### PR TITLE
Add support for resolving Reddit media share links

### DIFF
--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: ca.jeffrey.apollo-improvedcustomapi
 Name: Apollo-ImprovedCustomApi
-Version: 1.0.5
+Version: 1.0.6
 Architecture: iphoneos-arm
 Description: Apollo for Reddit tweak with in-app configurable API keys
 Maintainer: JeffreyCA


### PR DESCRIPTION
There's a few occasional links with the following format:

    https://www.reddit.com/media?url=https%3A%2F%2Fi.redd.it%2Fpdnxq8dj0w881.jpg

for example, in [this](https://reddit.com/r/TikTokCringe/comments/18cyek4/_/kce86er/?context=1) comment which in their current form redirect to a random post from 12 years ago. 

This PR adds support for replacing these links by a direct link to the image by performing the following:

1. Adding a regex pattern for such links
2. Replacing matching the direct image url
3. Percent decoding the match
4. Build a new NSURL and return this instead of the original URL