### PR TITLE
Add rootless package support to Theos build workflow

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -46,7 +46,7 @@ jobs:
           submodules: recursive
 
       - name: Build package
-        run: make package FINALPACKAGE=1
+        run: make package FINALPACKAGE=1 THEOS_PACKAGE_SCHEME=rootless
 
         env:
           THEOS: ${{ github.workspace }}/theos

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -45,7 +45,13 @@ jobs:
           path: theos
           submodules: recursive
 
-      - name: Build package
+      - name: Build rootful package
+        run: make package FINALPACKAGE=1
+
+        env:
+          THEOS: ${{ github.workspace }}/theos
+
+      - name: Build rootless package
         run: make package FINALPACKAGE=1 THEOS_PACKAGE_SCHEME=rootless
 
         env:
@@ -59,5 +65,6 @@ jobs:
         with:
           tag_name: v${{ env.TWEAK_VERSION }}
           name: v${{ env.TWEAK_VERSION }}
-          files: packages/*.deb
+          files: |
+            packages/*.deb
           prerelease: ${{ inputs.prerelease }}


### PR DESCRIPTION
 added rootless package support to the Theos build workflow, which now allows for the creation of both rootful and rootless .deb packages. Since most modern jailbreaks are rootless, these rootless packages make installation much easier.

I tested the rootless build (version 1.1.7) on my iPhone 6s running iOS 15.8.x with the Dopamine jailbreak and Apollo version 1.15.11, and it’s working perfectly!