### PR TITLE
Fix v.redd.it video downloads

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
     path = Tweaks/FLEXing
     url = https://github.com/PoomSmart/FLEXing
     branch = rootless
+[submodule "ffmpeg-kit"]
+	path = ffmpeg-kit
+	url = https://github.com/JeffreyCA/ffmpeg-kit-ios

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.2.2] - 2025-01-16
+
+- Fix video downloads failing on certain v.redd.it videos
+    - Note that the `.deb` file is significantly larger (several MB) because of new external dependencies needed to fix the issue (FFmpegKit)
+
 ## [v1.2.1] - 2024-12-19
 
 - Custom random and trending subreddits - you can now specify an external URL to use as the source for random and trending subreddits (in Settings > General > Custom API)
@@ -109,6 +114,7 @@ There are currently a few limitations:
 ## [v1.0.0] - 2023-10-13
 - Initial release
 
+[v1.2.2]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v1.2.1...v1.2.2
 [v1.2.1]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v1.1.8...v1.2.1
 [v1.1.8]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v1.1.7b...v1.1.8
 [v1.1.7b]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v1.1.7...v1.1.7b

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ ApolloImprovedCustomApi_FILES = Tweak.xm CustomAPIViewController.m DefaultSubred
 ApolloImprovedCustomApi_FRAMEWORKS = UIKit
 ApolloImprovedCustomApi_CFLAGS = -fobjc-arc -Wno-unguarded-availability-new -Wno-module-import-in-extern-c
 
+ApolloImprovedCustomApi_OBJ_FILES = $(shell find ffmpeg-kit -name '*.a')
+
 SUBPROJECTS += Tweaks/FLEXing/libflex
 
 CONTROL_FILE = $(THEOS_PROJECT_DIR)/control

--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ Apollo for Reddit with in-app configurable API keys and several fixes and improv
 - Working Imgur integration (view, delete, and upload single images and multi-image albums) 
 - Handle x.com links as Twitter links so that they can be opened in the Twitter app
 - Suppress unwanted messages on app startup (wallpaper popup, in-app announcements, etc)
-- Support new share link format (reddit.com/r/subreddit/s/xxxxxx) so they open like any other post and not in a browser
-- Support media share links (reddit.com/media?url=)
+- Support /s/ share links (reddit.com/r/subreddit/s/xxxxxx) natively
+- Support media share links (reddit.com/media?url=) natively
 - **Fully working** "New Comments Highlightifier" Ultra feature
 - Use generic user agent for requests to Reddit
-- Support FLEX debugging
-- Use custom external sources for random and trending subreddits
+- FLEX debugging
+- Support custom external sources for random and trending subreddits
+- Working v.redd.it video downloads
 
 ## Known issues
 - Apollo Ultra features may cause app to crash 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ Recommended configuration:
 ### Requirements
 - [Theos](https://github.com/theos/theos)
 
-1. `git clone`
-2. `git submodule update --init --recursive`
-2. `make package` or `make package THEOS_PACKAGE_SCHEME=rootless` for rootless variant
+1. `git clone https://github.com/JeffreyCA/Apollo-ImprovedCustomApi`
+2. `cd Apollo-ImprovedCustomApi`
+3. `git submodule update --init --recursive`
+4. `make package` or `make package THEOS_PACKAGE_SCHEME=rootless` for rootless variant
 
 ## Credits
 - [Apollo-CustomApiCredentials](https://github.com/EthanArbuckle/Apollo-CustomApiCredentials) by [@EthanArbuckle](https://github.com/EthanArbuckle)

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: ca.jeffrey.apollo-improvedcustomapi
 Name: Apollo-ImprovedCustomApi
-Version: 1.2.1
+Version: 1.2.2
 Architecture: iphoneos-arm
 Description: Apollo for Reddit tweak with in-app configurable API keys
 Maintainer: JeffreyCA


### PR DESCRIPTION
Fixes #25

The Reddit videos Apollo has trouble downloading have AAC audio streams that use the MPEG-TS container format, which Apollo doesn't support. The fix here is to use FFmpeg (specifically FFmpegKit for iOS `arm64`) to convert them to ADTS, which older videos seem to use and is supported by Apollo.

The added dependency does make the `.deb` significantly larger than previous releases.

FFmpegKit source code: https://github.com/JeffreyCA/ffmpeg-kit
Prebuilt lib files using [Actions](https://github.com/JeffreyCA/ffmpeg-kit-ios/blob/main/.github/workflows/build.yml): https://github.com/JeffreyCA/ffmpeg-kit-ios