### PR TITLE
Change create release to make a draft release

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -72,6 +72,7 @@ jobs:
         env:
           TWEAK_VERSION: ${{ steps.parse_control.outputs.TWEAK_VERSION }}
         with:
+          draft: true
           tag_name: v${{ env.TWEAK_VERSION }}
           name: v${{ env.TWEAK_VERSION }}
           files: |


### PR DESCRIPTION
I notice you don't have it making a draft release so it releases it the emails go out to the watchers then you edit the changelog. If you made it a draft, you could edit the changelog before publishing it then publish it, so the changelog is shown in the emails to watchers, and you won't have to go back and edit it.