### PR TITLE
Fix Imgur multi-image uploads and add link to discussion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.2.3] - 2025-04-07
+
+- Fix issue with Imgur multi-image uploads failing. Note that multi-image uploads still fail on the first attempt but should succeed on the next attempt.
+- Update Custom API settings with link to [GitHub discussion](https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/discussions/60) where you can share your own subreddit sources.
+
 ## [v1.2.2] - 2025-01-16
 
 - Fix video downloads failing on certain v.redd.it videos

--- a/CustomAPIViewController.m
+++ b/CustomAPIViewController.m
@@ -166,6 +166,12 @@ typedef NS_ENUM(NSInteger, Tag) {
     UIStackView *trendingSubredditsLimitStackView = [self createLabeledStackViewWithLabelText:@"Limit trending subreddits to:" placeholder:@"(unlimited)" text:sTrendingSubredditsLimit tag:TagTrendingLimit isNumerical:YES];
     [stackView addArrangedSubview:trendingSubredditsLimitStackView];
 
+    UIButton *communitySourcesButton = [UIButton systemButtonWithPrimaryAction:[UIAction actionWithTitle:@"Community Subreddit Sources" image:nil identifier:nil handler:^(UIAction * action) {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/discussions/60"] options:@{} completionHandler:nil];
+    }]];
+    communitySourcesButton.titleLabel.font = [UIFont systemFontOfSize:16.0];
+    [stackView addArrangedSubview:communitySourcesButton];
+
     UIStackView *trendingSourceStackView = [self createLabeledStackViewWithLabelText:@"Trending subreddits source:" placeholder:defaultTrendingSubredditsSource text:sTrendingSubredditsSource tag:TagTrendingSubredditsSource];
     [stackView addArrangedSubview:trendingSourceStackView];
 
@@ -198,8 +204,8 @@ typedef NS_ENUM(NSInteger, Tag) {
         @"4. Enter the **Client ID** (not the client secret) above.\n"
         @"\n"
         @"**Providing custom subreddit sources:**\n"
-        @"You can provide custom subreddit sources by specifying a URL to a plaintext file with a list of line-separated subreddit names (without the `/r/`). ([Example file](https://jeffreyca.github.io/subreddits/popular.txt))\n"
-        @"**Tip:** You can host the file on services like Pastebin or GitHub.\n"
+        @"You can provide custom subreddit sources by specifying a URL to a plaintext file with a list of line-separated subreddit names (without the `/r/`). ([Example file](https://jeffreyca.github.io/subreddits/popular.txt))\n\n"
+        @"**Tip:** You can host the file on GitHub or pastebin sites."
 
     options:markdownOptions baseURL:nil error:nil];
 

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: ca.jeffrey.apollo-improvedcustomapi
 Name: Apollo-ImprovedCustomApi
-Version: 1.2.2
+Version: 1.2.3
 Architecture: iphoneos-arm
 Description: Apollo for Reddit tweak with in-app configurable API keys
 Maintainer: JeffreyCA


### PR DESCRIPTION
Fixes #51 and adds link to https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/discussions/60 in the Custom API settings.

Imgur's [Un-authed Album Creation API endpoint](https://apidocs.imgur.com/#8f89bd41-28a1-4624-9393-95e12cec509a) (`https://api.imgur.com/3/album`) appears to only accept the request body in JSON or multipart/form-data where previously application/x-www-form-urlencoded was allowed.