### PR TITLE
Fix v.redd.it downloads for videos using CMAF format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.2.6] - 2025-11-08
+
+- Fix video downloads failing on certain v.redd.it videos
+    - Recently, Reddit started using [CMAF media format](https://developer.apple.com/documentation/http-live-streaming/about-the-common-media-application-format-with-http-live-streaming-hls) for serving video content, which Apollo does not natively support downloading for.
+
 ## [v1.2.5] - 2025-10-18
 
 - Fix occassional crashes when scrolling on iOS 26 with Liquid Glass patch (thanks @dankrichtofen for the original implementation)
@@ -130,6 +135,7 @@ There are currently a few limitations:
 ## [v1.0.0] - 2023-10-13
 - Initial release
 
+[v1.2.6]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v1.2.5...v1.2.6
 [v1.2.5]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v1.2.4...v1.2.5
 [v1.2.4]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v1.2.3...v1.2.4
 [v1.2.3]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v1.2.2...v1.2.3

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: ca.jeffrey.apollo-improvedcustomapi
 Name: Apollo-ImprovedCustomApi
-Version: 1.2.5
+Version: 1.2.6
 Architecture: iphoneos-arm
 Description: Apollo for Reddit tweak with in-app configurable API keys
 Maintainer: JeffreyCA


### PR DESCRIPTION
Fixes #75

Recently, Reddit started using [CMAF media format](https://developer.apple.com/documentation/http-live-streaming/about-the-common-media-application-format-with-http-live-streaming-hls) for serving video content, which Apollo does not natively support downloading for

| Issue | Fix |
|-------|-----|
| Apollo uses regex that only matches `HLS_AUDIO` pattern in .m3u8 manifests | Update regex to match both `HLS_AUDIO` and `CMAF_AUDIO` patterns |
| CMAF .m3u8 manifests list audio in descending bitrate order, causing Apollo to download the lower quality audio track by default | Reorder CMAF audio tracks by ascending bitrate so Apollo downloads highest quality track |
| When downloading videos, Apollo assumes audio tracks have `.aac` extension but CMAF uses `.mp4` | Update audio download logic to use `.mp4` extension instead of `.aac` for CMAF media |
| Apollo's video export implementation does not support joining CMAF audio and video streams | Convert CMAF audio to ADTS format using FFmpeg |