### PR TITLE
Block Tracking and Analytics URLs

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -149,7 +149,8 @@ static NSString *const announcementUrl = @"apollogur.download/api/apollonounceme
 
 static NSArray *const blockedUrls = @[
     @"apollopushserver.xyz",
-    @"apolloreq.com/api/req_v2",
+    @"beta.apollonotifications.com",
+    @"apolloreq.com",
     @"notify.bugsnag.com",
     @"sessions.bugsnag.com",
     @"api.mixpanel.com",


### PR DESCRIPTION
Block:
* apolloreq.com (the worst offender)
* apollonotifications.com
* bugsnag.com
* mixpanel.com
* statsig.com

URLs taken from Little Snitch, FLEX debugger, and [ichitaso/ApolloPatcher/Tweak.xm](https://github.com/ichitaso/ApolloPatcher/blob/main/Tweak.xm).