### PR TITLE
Translation feature

### DIFF
--- a/.github/workflows/build-injected-ipa.yml
+++ b/.github/workflows/build-injected-ipa.yml
@@ -1,0 +1,108 @@
+name: Build Injected IPA
+
+# Builds the tweak .deb AND injects it into a user-supplied decrypted Apollo IPA.
+# Output: a sideload-ready .ipa uploaded as a workflow artifact.
+#
+# IMPORTANT: The Apollo IPA URL you provide MUST point to a DECRYPTED IPA.
+# App Store IPAs are FairPlay-encrypted and will crash on launch after injection.
+
+on:
+  workflow_dispatch:
+    inputs:
+      apollo_ipa_url:
+        description: 'Direct URL to a DECRYPTED Apollo IPA'
+        required: true
+        type: string
+      output_name:
+        description: 'Output IPA filename (without .ipa extension)'
+        required: false
+        type: string
+        default: 'Apollo-ImprovedCustomApi'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build tweak and inject into IPA
+    runs-on: macos-15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Install build dependencies
+        run: brew install ldid dpkg make
+
+      - name: Add GNU make to PATH
+        run: echo "$(brew --prefix make)/libexec/gnubin" >> $GITHUB_PATH
+
+      - name: Setup Theos
+        uses: actions/checkout@v4
+        with:
+          repository: theos/theos
+          ref: master
+          path: theos
+          submodules: recursive
+
+      - name: Build rootful tweak package
+        run: make package FINALPACKAGE=1
+        env:
+          THEOS: ${{ github.workspace }}/theos
+
+      - name: Locate built .deb
+        id: locate_deb
+        run: |
+          DEB_PATH=$(ls -1t packages/*.deb | head -1)
+          if [ -z "$DEB_PATH" ]; then
+            echo "Error: no .deb produced by make package"
+            exit 1
+          fi
+          echo "deb_path=$DEB_PATH" >> $GITHUB_OUTPUT
+          echo "Built tweak: $DEB_PATH"
+
+      - name: Download Apollo IPA
+        run: |
+          echo "Downloading Apollo IPA..."
+          curl -L --fail --retry 3 "${{ github.event.inputs.apollo_ipa_url }}" -o Apollo.ipa
+          echo "Verifying archive integrity..."
+          if ! unzip -t Apollo.ipa > /dev/null; then
+            echo "Error: downloaded file is not a valid IPA / zip archive."
+            exit 1
+          fi
+          echo "Apollo.ipa size: $(wc -c < Apollo.ipa) bytes"
+
+      - name: Install cyan injector
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --pre cyan
+
+      - name: Inject tweak into IPA
+        id: inject
+        run: |
+          OUTPUT_NAME="${{ github.event.inputs.output_name }}"
+          if [ -z "$OUTPUT_NAME" ]; then
+            OUTPUT_NAME="Apollo-ImprovedCustomApi"
+          fi
+          OUTPUT_IPA="${OUTPUT_NAME}.ipa"
+          echo "Injecting ${{ steps.locate_deb.outputs.deb_path }} into Apollo.ipa..."
+          cyan -i Apollo.ipa -o "$OUTPUT_IPA" -f "${{ steps.locate_deb.outputs.deb_path }}"
+          if [ ! -f "$OUTPUT_IPA" ]; then
+            echo "Error: cyan did not produce $OUTPUT_IPA"
+            ls -la
+            exit 1
+          fi
+          echo "output_ipa=$OUTPUT_IPA" >> $GITHUB_OUTPUT
+          echo "Injected IPA: $OUTPUT_IPA ($(wc -c < $OUTPUT_IPA) bytes)"
+
+      - name: Upload injected IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.inject.outputs.output_ipa }}
+          path: ${{ steps.inject.outputs.output_ipa }}
+          retention-days: 30

--- a/ApolloSettings.xm
+++ b/ApolloSettings.xm
@@ -4,6 +4,7 @@
 #import "ApolloCommon.h"
 #import "CustomAPIViewController.h"
 #import "SavedCategoriesViewController.h"
+#import "TranslationSettingsViewController.h"
 
 // MARK: - Settings View Controller (Custom API row injection)
 
@@ -35,7 +36,7 @@ static UIImage *createSettingsIcon(NSString *sfSymbolName, UIColor *bgColor) {
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    if (section == 1) return 2; // Custom API, Saved Categories
+    if (section == 1) return 3; // Custom API, Saved Categories, Translation
     if (section > 1) return %orig(tableView, section - 1);
     return %orig;
 }
@@ -49,9 +50,12 @@ static UIImage *createSettingsIcon(NSString *sfSymbolName, UIColor *bgColor) {
         if (indexPath.row == 0) {
             cell.textLabel.text = @"Custom API";
             cell.imageView.image = createSettingsIcon(@"key.fill", [UIColor systemTealColor]);
-        } else {
+        } else if (indexPath.row == 1) {
             cell.textLabel.text = @"Saved Categories";
             cell.imageView.image = createSettingsIcon(@"bookmark.fill", [UIColor systemOrangeColor]);
+        } else {
+            cell.textLabel.text = @"Translation";
+            cell.imageView.image = createSettingsIcon(@"globe", [UIColor systemIndigoColor]);
         }
         return cell;
     }
@@ -68,8 +72,11 @@ static UIImage *createSettingsIcon(NSString *sfSymbolName, UIColor *bgColor) {
         if (indexPath.row == 0) {
             CustomAPIViewController *vc = [[CustomAPIViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
             [((UIViewController *)self).navigationController pushViewController:vc animated:YES];
-        } else {
+        } else if (indexPath.row == 1) {
             SavedCategoriesViewController *vc = [[SavedCategoriesViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
+            [((UIViewController *)self).navigationController pushViewController:vc animated:YES];
+        } else {
+            TranslationSettingsViewController *vc = [[TranslationSettingsViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
             [((UIViewController *)self).navigationController pushViewController:vc animated:YES];
         }
         return;

--- a/ApolloState.h
+++ b/ApolloState.h
@@ -19,3 +19,10 @@ extern NSInteger sReadPostMaxCount;
 extern NSInteger sUnmuteCommentsVideos;
 
 extern BOOL sProxyImgurDDG;
+
+extern BOOL sEnableBulkTranslation;
+extern BOOL sAutoTranslateOnAppear;
+extern NSString *sTranslationTargetLanguage;
+extern NSString *sTranslationProvider;
+extern NSString *sLibreTranslateURL;
+extern NSString *sLibreTranslateAPIKey;

--- a/ApolloState.m
+++ b/ApolloState.m
@@ -18,3 +18,10 @@ NSInteger sReadPostMaxCount = 0;
 NSInteger sUnmuteCommentsVideos = 0; // 0=Default, 1=Remember from Full Screen, 2=Always
 
 BOOL sProxyImgurDDG = NO;
+
+BOOL sEnableBulkTranslation = NO;
+BOOL sAutoTranslateOnAppear = YES;
+NSString *sTranslationTargetLanguage = nil;
+NSString *sTranslationProvider = nil;
+NSString *sLibreTranslateURL = nil;
+NSString *sLibreTranslateAPIKey = nil;

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -2180,7 +2180,7 @@ static void ApolloUpdateTranslationUIForController(id controller) {
         objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, translationItem, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
     translationItem.image = globeImage;
-    translationItem.imageInsets = UIEdgeInsetsMake(0.0, 6.0, 0.0, -6.0);
+    translationItem.imageInsets = UIEdgeInsetsMake(0.0, -6.0, 0.0, 6.0);
     translationItem.target = controller;
     translationItem.action = @selector(apollo_translationGlobeTapped);
     translationItem.menu = nil;

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -2083,6 +2083,62 @@ static BOOL ApolloRefreshVisibleTranslationAppliedForController(UIViewController
     return NO;
 }
 
+static UIColor *ApolloResolvedTintColor(UIColor *color, UITraitCollection *traitCollection) {
+    if (!color) return nil;
+    if (traitCollection && [color respondsToSelector:@selector(resolvedColorWithTraitCollection:)]) {
+        return [color resolvedColorWithTraitCollection:traitCollection];
+    }
+    return color;
+}
+
+static BOOL ApolloTintColorLooksLikeSystemBlue(UIColor *color, UITraitCollection *traitCollection) {
+    UIColor *resolvedColor = ApolloResolvedTintColor(color, traitCollection);
+    UIColor *resolvedBlue = ApolloResolvedTintColor([UIColor systemBlueColor], traitCollection);
+    CGFloat red = 0.0, green = 0.0, blue = 0.0, alpha = 0.0;
+    CGFloat blueRed = 0.0, blueGreen = 0.0, blueBlue = 0.0, blueAlpha = 0.0;
+    if (![resolvedColor getRed:&red green:&green blue:&blue alpha:&alpha]) return NO;
+    if (![resolvedBlue getRed:&blueRed green:&blueGreen blue:&blueBlue alpha:&blueAlpha]) return NO;
+
+    return fabs(red - blueRed) < 0.02 && fabs(green - blueGreen) < 0.02 && fabs(blue - blueBlue) < 0.02 && fabs(alpha - blueAlpha) < 0.02;
+}
+
+static UIColor *ApolloThemeTintCandidate(UIColor *color, UITraitCollection *traitCollection) {
+    if (!color || ApolloTintColorLooksLikeSystemBlue(color, traitCollection)) return nil;
+
+    CGFloat red = 0.0, green = 0.0, blue = 0.0, alpha = 1.0;
+    UIColor *resolvedColor = ApolloResolvedTintColor(color, traitCollection);
+    if ([resolvedColor getRed:&red green:&green blue:&blue alpha:&alpha] && alpha < 0.05) return nil;
+    return color;
+}
+
+static UIColor *ApolloThemeTintColorFromView(UIView *view, UITraitCollection *traitCollection, NSInteger depth) {
+    if (!view || depth < 0) return nil;
+
+    UIColor *candidate = ApolloThemeTintCandidate(view.tintColor, traitCollection);
+    if (candidate) return candidate;
+
+    for (UIView *subview in view.subviews) {
+        candidate = ApolloThemeTintColorFromView(subview, traitCollection, depth - 1);
+        if (candidate) return candidate;
+    }
+
+    return nil;
+}
+
+static UIColor *ApolloThemeTintColorFromNavigationItems(NSArray<UIBarButtonItem *> *items, UIBarButtonItem *translationItem, UITraitCollection *traitCollection) {
+    for (UIBarButtonItem *item in items) {
+        if (item == translationItem) continue;
+
+        UIColor *candidate = ApolloThemeTintCandidate(item.tintColor, traitCollection);
+        if (candidate) return candidate;
+
+        candidate = ApolloThemeTintColorFromView(item.customView, traitCollection, 4);
+        if (candidate) return candidate;
+    }
+
+    return nil;
+}
+
 static void ApolloUpdateTranslationUIForController(id controller) {
     UIViewController *vc = (UIViewController *)controller;
 
@@ -2127,9 +2183,15 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     translationItem.target = controller;
     translationItem.action = @selector(apollo_translationGlobeTapped);
     translationItem.menu = nil;
-    UIColor *themeTintColor = vc.view.tintColor;
+    UIColor *themeTintColor = ApolloThemeTintColorFromNavigationItems(items, translationItem, vc.traitCollection);
     if (!themeTintColor) {
-        themeTintColor = vc.navigationController.navigationBar.tintColor;
+        themeTintColor = ApolloThemeTintCandidate(vc.view.tintColor, vc.traitCollection);
+    }
+    if (!themeTintColor) {
+        themeTintColor = ApolloThemeTintCandidate(vc.navigationController.navigationBar.tintColor, vc.traitCollection);
+    }
+    if (!themeTintColor) {
+        themeTintColor = vc.view.tintColor ?: vc.navigationController.navigationBar.tintColor;
     }
     if (!themeTintColor) {
         themeTintColor = [UIColor systemBlueColor];

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -1,0 +1,813 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+#include <dlfcn.h>
+
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+#import "Tweak.h"
+
+static const void *kApolloOriginalAttributedTextKey = &kApolloOriginalAttributedTextKey;
+static const void *kApolloTranslatedTextNodeKey = &kApolloTranslatedTextNodeKey;
+static const void *kApolloCellTranslationKeyKey = &kApolloCellTranslationKeyKey;
+static const void *kApolloThreadTranslatedModeKey = &kApolloThreadTranslatedModeKey;
+static const void *kApolloTranslateBarButtonKey = &kApolloTranslateBarButtonKey;
+
+static NSString *const kApolloDefaultLibreTranslateURL = @"https://libretranslate.de/translate";
+
+static NSCache<NSString *, NSString *> *sTranslationCache;
+static NSMutableDictionary<NSString *, NSMutableArray *> *sPendingTranslationCallbacks;
+static __weak UIViewController *sVisibleCommentsViewController = nil;
+
+static id GetIvarObjectQuiet(id obj, const char *ivarName) {
+    if (!obj) return nil;
+    Ivar ivar = class_getInstanceVariable([obj class], ivarName);
+    return ivar ? object_getIvar(obj, ivar) : nil;
+}
+
+static UITableView *FindFirstTableViewInView(UIView *view) {
+    if (!view) return nil;
+    if ([view isKindOfClass:[UITableView class]]) {
+        return (UITableView *)view;
+    }
+
+    for (UIView *subview in view.subviews) {
+        UITableView *tableView = FindFirstTableViewInView(subview);
+        if (tableView) return tableView;
+    }
+
+    return nil;
+}
+
+static UITableView *GetCommentsTableView(UIViewController *viewController) {
+    id tableNode = GetIvarObjectQuiet(viewController, "tableNode");
+    if (tableNode) {
+        SEL viewSelector = NSSelectorFromString(@"view");
+        if ([tableNode respondsToSelector:viewSelector]) {
+            UIView *tableNodeView = ((id (*)(id, SEL))objc_msgSend)(tableNode, viewSelector);
+            if ([tableNodeView isKindOfClass:[UITableView class]]) {
+                return (UITableView *)tableNodeView;
+            }
+        }
+    }
+
+    return FindFirstTableViewInView(viewController.view);
+}
+
+static NSString *ApolloNormalizeLanguageCode(NSString *identifier) {
+    if (![identifier isKindOfClass:[NSString class]] || identifier.length == 0) return nil;
+
+    NSString *lower = [[identifier stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+    if (lower.length == 0) return nil;
+
+    NSRange dash = [lower rangeOfString:@"-"];
+    NSRange underscore = [lower rangeOfString:@"_"];
+    NSUInteger splitIndex = NSNotFound;
+    if (dash.location != NSNotFound) splitIndex = dash.location;
+    if (underscore.location != NSNotFound) {
+        splitIndex = (splitIndex == NSNotFound) ? underscore.location : MIN(splitIndex, underscore.location);
+    }
+    if (splitIndex != NSNotFound && splitIndex > 0) {
+        lower = [lower substringToIndex:splitIndex];
+    }
+
+    return lower.length > 0 ? lower : nil;
+}
+
+static NSString *ApolloResolvedTargetLanguageCode(void) {
+    NSString *override = ApolloNormalizeLanguageCode(sTranslationTargetLanguage);
+    if (override.length > 0) return override;
+
+    NSString *preferred = [NSLocale preferredLanguages].firstObject;
+    NSString *normalized = ApolloNormalizeLanguageCode(preferred);
+    return normalized ?: @"en";
+}
+
+static NSString *ApolloNormalizeTextForCompare(NSString *text) {
+    if (![text isKindOfClass:[NSString class]] || text.length == 0) return @"";
+
+    NSArray<NSString *> *parts = [text.lowercaseString componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    NSMutableArray<NSString *> *nonEmpty = [NSMutableArray arrayWithCapacity:parts.count];
+    for (NSString *part in parts) {
+        if (part.length > 0) [nonEmpty addObject:part];
+    }
+    return [nonEmpty componentsJoinedByString:@" "];
+}
+
+static NSString *ApolloDetectDominantLanguage(NSString *text) {
+    if (![text isKindOfClass:[NSString class]] || text.length < 12) return nil;
+
+    NSLinguisticTagger *tagger = [[NSLinguisticTagger alloc] initWithTagSchemes:@[NSLinguisticTagSchemeLanguage] options:0];
+    tagger.string = text;
+    NSString *language = [tagger dominantLanguage];
+    return ApolloNormalizeLanguageCode(language);
+}
+
+static NSString *ApolloTranslationCacheKey(NSString *text, NSString *targetLanguage) {
+    return [NSString stringWithFormat:@"%@|%lu", targetLanguage ?: @"en", (unsigned long)text.hash];
+}
+
+static BOOL ApolloThreadTranslationModeEnabledForVisibleCommentsVC(void) {
+    UIViewController *vc = sVisibleCommentsViewController;
+    if (!vc) return NO;
+    return [objc_getAssociatedObject(vc, kApolloThreadTranslatedModeKey) boolValue];
+}
+
+static BOOL ApolloShouldTranslateNow(BOOL forceTranslation) {
+    if (!sEnableBulkTranslation && !forceTranslation) return NO;
+    if (forceTranslation) return YES;
+    if (!sVisibleCommentsViewController) return NO;
+    return sAutoTranslateOnAppear || ApolloThreadTranslationModeEnabledForVisibleCommentsVC();
+}
+
+static BOOL ApolloActionTitleLooksTranslate(NSString *title) {
+    if (![title isKindOfClass:[NSString class]] || title.length == 0) return NO;
+
+    NSString *lower = [title lowercaseString];
+    NSArray<NSString *> *keywords = @[
+        @"translate",
+        @"traduz",
+        @"tradu",
+        @"übersetz",
+        @"перев",
+        @"翻译",
+        @"번역",
+        @"ترجم",
+    ];
+
+    for (NSString *keyword in keywords) {
+        if ([lower containsString:keyword]) return YES;
+    }
+    return NO;
+}
+
+static NSString *ApolloDecodeSwiftString(uint64_t w0, uint64_t w1) {
+    uint8_t disc = (uint8_t)(w1 >> 56);
+    if (disc >= 0xE0 && disc <= 0xEF) {
+        NSUInteger len = disc - 0xE0;
+        if (len == 0) return @"";
+
+        char buf[16] = {0};
+        memcpy(buf, &w0, 8);
+        uint64_t w1clean = w1 & 0x00FFFFFFFFFFFFFFULL;
+        memcpy(buf + 8, &w1clean, 7);
+        return [[NSString alloc] initWithBytes:buf length:len encoding:NSUTF8StringEncoding];
+    }
+
+    typedef NSString *(*BridgeFn)(uint64_t, uint64_t);
+    static BridgeFn sBridge = NULL;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sBridge = (BridgeFn)dlsym(RTLD_DEFAULT, "$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF");
+    });
+
+    return sBridge ? sBridge(w0, w1) : nil;
+}
+
+static NSUInteger ApolloRemoveNativeTranslateActions(id actionController) {
+    Class cls = object_getClass(actionController);
+    Ivar actionsIvar = class_getInstanceVariable(cls, "actions");
+    if (!actionsIvar) return 0;
+
+    uint8_t *acBase = (uint8_t *)(__bridge void *)actionController;
+    void *actionsBuffer = *(void **)(acBase + ivar_getOffset(actionsIvar));
+    if (!actionsBuffer) return 0;
+
+    int64_t count = *(int64_t *)((uint8_t *)actionsBuffer + 0x10);
+    if (count <= 0) return 0;
+
+    int64_t writeIndex = 0;
+    NSUInteger removedCount = 0;
+
+    for (int64_t readIndex = 0; readIndex < count; readIndex++) {
+        uint8_t *entry = (uint8_t *)actionsBuffer + 0x20 + (readIndex * 0x30);
+        NSString *title = ApolloDecodeSwiftString(*(uint64_t *)(entry + 0x08), *(uint64_t *)(entry + 0x10));
+        if (ApolloActionTitleLooksTranslate(title)) {
+            removedCount++;
+            continue;
+        }
+
+        if (writeIndex != readIndex) {
+            uint8_t *destination = (uint8_t *)actionsBuffer + 0x20 + (writeIndex * 0x30);
+            memmove(destination, entry, 0x30);
+        }
+        writeIndex++;
+    }
+
+    if (removedCount > 0) {
+        *(int64_t *)((uint8_t *)actionsBuffer + 0x10) = writeIndex;
+    }
+
+    return removedCount;
+}
+
+static void ApolloCollectAttributedTextNodes(id object,
+                                             NSInteger depth,
+                                             NSHashTable *visited,
+                                             NSMutableArray *nodes) {
+    if (!object || depth < 0 || [visited containsObject:object]) return;
+    [visited addObject:object];
+
+    if ([object respondsToSelector:@selector(attributedText)] &&
+        [object respondsToSelector:@selector(setAttributedText:)]) {
+        NSAttributedString *attr = ((id (*)(id, SEL))objc_msgSend)(object, @selector(attributedText));
+        if ([attr isKindOfClass:[NSAttributedString class]] && attr.string.length > 0) {
+            [nodes addObject:object];
+        }
+    }
+
+    if (depth == 0) return;
+
+    @try {
+        SEL subnodesSel = NSSelectorFromString(@"subnodes");
+        if ([object respondsToSelector:subnodesSel]) {
+            NSArray *subnodes = ((id (*)(id, SEL))objc_msgSend)(object, subnodesSel);
+            if ([subnodes isKindOfClass:[NSArray class]]) {
+                for (id subnode in subnodes) {
+                    ApolloCollectAttributedTextNodes(subnode, depth - 1, visited, nodes);
+                }
+            }
+        }
+    } @catch (__unused NSException *exception) {
+    }
+
+    for (Class cls = [object class]; cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
+        unsigned int count = 0;
+        Ivar *ivars = class_copyIvarList(cls, &count);
+        if (!ivars) continue;
+
+        for (unsigned int i = 0; i < count; i++) {
+            const char *type = ivar_getTypeEncoding(ivars[i]);
+            if (!type || type[0] != '@') continue;
+
+            id child = object_getIvar(object, ivars[i]);
+            if (!child || child == object) continue;
+
+            ApolloCollectAttributedTextNodes(child, depth - 1, visited, nodes);
+        }
+
+        free(ivars);
+    }
+}
+
+static NSInteger ApolloCandidateScore(NSAttributedString *candidateText, NSString *commentBody) {
+    if (![candidateText isKindOfClass:[NSAttributedString class]]) return NSIntegerMin;
+
+    NSString *candidate = ApolloNormalizeTextForCompare(candidateText.string);
+    if (candidate.length == 0) return NSIntegerMin;
+
+    NSString *body = ApolloNormalizeTextForCompare(commentBody ?: @"");
+    if (body.length == 0) return (NSInteger)candidate.length;
+
+    if ([candidate isEqualToString:body]) {
+        return 100000 + (NSInteger)candidate.length;
+    }
+
+    if ([candidate containsString:body] || [body containsString:candidate]) {
+        return 75000 + (NSInteger)MIN(candidate.length, body.length);
+    }
+
+    NSUInteger prefixLength = MIN((NSUInteger)20, MIN(candidate.length, body.length));
+    if (prefixLength >= 8) {
+        NSString *candidatePrefix = [candidate substringToIndex:prefixLength];
+        NSString *bodyPrefix = [body substringToIndex:prefixLength];
+        if ([candidatePrefix isEqualToString:bodyPrefix]) {
+            return 50000 + (NSInteger)candidate.length;
+        }
+    }
+
+    return (NSInteger)candidate.length;
+}
+
+static id ApolloBestCommentTextNode(id commentCellNode, RDKComment *comment) {
+    NSMutableArray *candidates = [NSMutableArray array];
+    NSHashTable *visited = [NSHashTable weakObjectsHashTable];
+    ApolloCollectAttributedTextNodes(commentCellNode, 4, visited, candidates);
+
+    id bestNode = nil;
+    NSInteger bestScore = NSIntegerMin;
+
+    for (id candidateNode in candidates) {
+        NSAttributedString *attr = ((id (*)(id, SEL))objc_msgSend)(candidateNode, @selector(attributedText));
+        NSInteger score = ApolloCandidateScore(attr, comment.body);
+        if (score > bestScore) {
+            bestScore = score;
+            bestNode = candidateNode;
+        }
+    }
+
+    return bestNode;
+}
+
+static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *comment, NSString *translatedText) {
+    if (!commentCellNode || ![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0) return;
+
+    id textNode = ApolloBestCommentTextNode(commentCellNode, comment);
+    if (!textNode) return;
+
+    NSAttributedString *current = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText));
+    if (![current isKindOfClass:[NSAttributedString class]]) return;
+
+    NSAttributedString *original = objc_getAssociatedObject(textNode, kApolloOriginalAttributedTextKey);
+    if (![original isKindOfClass:[NSAttributedString class]]) {
+        objc_setAssociatedObject(textNode, kApolloOriginalAttributedTextKey, [current copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    NSDictionary *attributes = nil;
+    if (current.length > 0) {
+        attributes = [current attributesAtIndex:0 effectiveRange:NULL];
+    }
+
+    NSAttributedString *translatedAttr = [[NSAttributedString alloc] initWithString:translatedText attributes:attributes ?: @{}];
+    ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), translatedAttr);
+
+    if ([textNode respondsToSelector:@selector(setNeedsLayout)]) {
+        ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsLayout));
+    }
+    if ([textNode respondsToSelector:@selector(setNeedsDisplay)]) {
+        ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsDisplay));
+    }
+
+    objc_setAssociatedObject(commentCellNode, kApolloTranslatedTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static void ApolloRestoreOriginalForCellNode(id commentCellNode, RDKComment *comment) {
+    if (!commentCellNode) return;
+
+    id textNode = objc_getAssociatedObject(commentCellNode, kApolloTranslatedTextNodeKey);
+    if (!textNode) {
+        textNode = ApolloBestCommentTextNode(commentCellNode, comment);
+    }
+    if (!textNode) return;
+
+    NSAttributedString *original = objc_getAssociatedObject(textNode, kApolloOriginalAttributedTextKey);
+    if (![original isKindOfClass:[NSAttributedString class]]) return;
+
+    ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), original);
+
+    if ([textNode respondsToSelector:@selector(setNeedsLayout)]) {
+        ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsLayout));
+    }
+    if ([textNode respondsToSelector:@selector(setNeedsDisplay)]) {
+        ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsDisplay));
+    }
+}
+
+static NSString *ApolloExtractGoogleTranslation(id jsonObject) {
+    if ([jsonObject isKindOfClass:[NSString class]]) {
+        return (NSString *)jsonObject;
+    }
+
+    if (![jsonObject isKindOfClass:[NSArray class]]) return nil;
+
+    NSArray *array = (NSArray *)jsonObject;
+    if (array.count == 0) return nil;
+
+    NSMutableString *joinedSegments = [NSMutableString string];
+    BOOL foundSegment = NO;
+
+    for (id item in array) {
+        if ([item isKindOfClass:[NSArray class]]) {
+            NSArray *segment = (NSArray *)item;
+            if (segment.count > 0 && [segment[0] isKindOfClass:[NSString class]]) {
+                [joinedSegments appendString:segment[0]];
+                foundSegment = YES;
+            }
+        }
+    }
+
+    if (foundSegment && joinedSegments.length > 0) {
+        return joinedSegments;
+    }
+
+    for (id item in array) {
+        NSString *nested = ApolloExtractGoogleTranslation(item);
+        if (nested.length > 0) return nested;
+    }
+
+    return nil;
+}
+
+static void ApolloTranslateViaGoogle(NSString *text,
+                                     NSString *targetLanguage,
+                                     void (^completion)(NSString *translated, NSError *error)) {
+    NSURLComponents *components = [[NSURLComponents alloc] init];
+    components.scheme = @"https";
+    components.host = @"translate.googleapis.com";
+    components.path = @"/translate_a/single";
+    components.queryItems = @[
+        [NSURLQueryItem queryItemWithName:@"client" value:@"gtx"],
+        [NSURLQueryItem queryItemWithName:@"sl" value:@"auto"],
+        [NSURLQueryItem queryItemWithName:@"tl" value:targetLanguage],
+        [NSURLQueryItem queryItemWithName:@"dt" value:@"t"],
+        [NSURLQueryItem queryItemWithName:@"q" value:text],
+    ];
+
+    NSURL *url = components.URL;
+    if (!url) {
+        NSError *error = [NSError errorWithDomain:@"ApolloTranslation" code:100 userInfo:@{NSLocalizedDescriptionKey: @"Failed to build Google Translate URL"}];
+        dispatch_async(dispatch_get_main_queue(), ^{ completion(nil, error); });
+        return;
+    }
+
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:12.0];
+    request.HTTPMethod = @"GET";
+
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        if (error) {
+            dispatch_async(dispatch_get_main_queue(), ^{ completion(nil, error); });
+            return;
+        }
+
+        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+        if (![httpResponse isKindOfClass:[NSHTTPURLResponse class]] || httpResponse.statusCode < 200 || httpResponse.statusCode >= 300) {
+            NSError *statusError = [NSError errorWithDomain:@"ApolloTranslation" code:101 userInfo:@{NSLocalizedDescriptionKey: @"Google Translate request failed"}];
+            dispatch_async(dispatch_get_main_queue(), ^{ completion(nil, statusError); });
+            return;
+        }
+
+        NSError *jsonError = nil;
+        id jsonObject = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
+        if (jsonError) {
+            dispatch_async(dispatch_get_main_queue(), ^{ completion(nil, jsonError); });
+            return;
+        }
+
+        NSString *translated = ApolloExtractGoogleTranslation(jsonObject);
+        if (![translated isKindOfClass:[NSString class]] || translated.length == 0) {
+            NSError *parseError = [NSError errorWithDomain:@"ApolloTranslation" code:102 userInfo:@{NSLocalizedDescriptionKey: @"Google Translate response parse error"}];
+            dispatch_async(dispatch_get_main_queue(), ^{ completion(nil, parseError); });
+            return;
+        }
+
+        dispatch_async(dispatch_get_main_queue(), ^{ completion(translated, nil); });
+    }];
+
+    [task resume];
+}
+
+static void ApolloTranslateViaLibre(NSString *text,
+                                    NSString *targetLanguage,
+                                    void (^completion)(NSString *translated, NSError *error)) {
+    NSString *urlString = [sLibreTranslateURL length] > 0 ? sLibreTranslateURL : kApolloDefaultLibreTranslateURL;
+    NSURL *url = [NSURL URLWithString:urlString];
+    if (!url) {
+        NSError *error = [NSError errorWithDomain:@"ApolloTranslation" code:200 userInfo:@{NSLocalizedDescriptionKey: @"Invalid LibreTranslate URL"}];
+        dispatch_async(dispatch_get_main_queue(), ^{ completion(nil, error); });
+        return;
+    }
+
+    NSMutableDictionary *payload = [@{
+        @"q": text,
+        @"source": @"auto",
+        @"target": targetLanguage,
+        @"format": @"text"
+    } mutableCopy];
+
+    if ([sLibreTranslateAPIKey length] > 0) {
+        payload[@"api_key"] = sLibreTranslateAPIKey;
+    }
+
+    NSError *jsonError = nil;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:payload options:0 error:&jsonError];
+    if (!jsonData) {
+        dispatch_async(dispatch_get_main_queue(), ^{ completion(nil, jsonError); });
+        return;
+    }
+
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:12.0];
+    request.HTTPMethod = @"POST";
+    [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+    request.HTTPBody = jsonData;
+
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        if (error) {
+            dispatch_async(dispatch_get_main_queue(), ^{ completion(nil, error); });
+            return;
+        }
+
+        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+        if (![httpResponse isKindOfClass:[NSHTTPURLResponse class]] || httpResponse.statusCode < 200 || httpResponse.statusCode >= 300) {
+            NSError *statusError = [NSError errorWithDomain:@"ApolloTranslation" code:201 userInfo:@{NSLocalizedDescriptionKey: @"LibreTranslate request failed"}];
+            dispatch_async(dispatch_get_main_queue(), ^{ completion(nil, statusError); });
+            return;
+        }
+
+        NSError *parseError = nil;
+        id jsonObject = [NSJSONSerialization JSONObjectWithData:data options:0 error:&parseError];
+        if (parseError) {
+            dispatch_async(dispatch_get_main_queue(), ^{ completion(nil, parseError); });
+            return;
+        }
+
+        NSString *translated = nil;
+        if ([jsonObject isKindOfClass:[NSDictionary class]]) {
+            translated = ((NSDictionary *)jsonObject)[@"translatedText"];
+        } else if ([jsonObject isKindOfClass:[NSArray class]]) {
+            id first = [(NSArray *)jsonObject firstObject];
+            if ([first isKindOfClass:[NSDictionary class]]) {
+                translated = ((NSDictionary *)first)[@"translatedText"];
+            }
+        }
+
+        if (![translated isKindOfClass:[NSString class]] || translated.length == 0) {
+            NSError *responseError = [NSError errorWithDomain:@"ApolloTranslation" code:202 userInfo:@{NSLocalizedDescriptionKey: @"LibreTranslate response parse error"}];
+            dispatch_async(dispatch_get_main_queue(), ^{ completion(nil, responseError); });
+            return;
+        }
+
+        dispatch_async(dispatch_get_main_queue(), ^{ completion(translated, nil); });
+    }];
+
+    [task resume];
+}
+
+static void ApolloTranslateTextWithFallback(NSString *text,
+                                            NSString *targetLanguage,
+                                            void (^completion)(NSString *translated, NSError *error)) {
+    NSString *primaryProvider = [sTranslationProvider isEqualToString:@"libre"] ? @"libre" : @"google";
+    BOOL googlePrimary = [primaryProvider isEqualToString:@"google"];
+
+    void (^fallback)(void) = ^{
+        if (googlePrimary) {
+            ApolloTranslateViaLibre(text, targetLanguage, completion);
+        } else {
+            ApolloTranslateViaGoogle(text, targetLanguage, completion);
+        }
+    };
+
+    void (^primaryCompletion)(NSString *, NSError *) = ^(NSString *translated, NSError *error) {
+        if ([translated isKindOfClass:[NSString class]] && translated.length > 0) {
+            completion(translated, nil);
+            return;
+        }
+        fallback();
+    };
+
+    if (googlePrimary) {
+        ApolloTranslateViaGoogle(text, targetLanguage, primaryCompletion);
+    } else {
+        ApolloTranslateViaLibre(text, targetLanguage, primaryCompletion);
+    }
+}
+
+static void ApolloRequestTranslation(NSString *cacheKey,
+                                     NSString *sourceText,
+                                     NSString *targetLanguage,
+                                     void (^completion)(NSString *translated, NSError *error)) {
+    NSString *cached = [sTranslationCache objectForKey:cacheKey];
+    if (cached.length > 0) {
+        completion(cached, nil);
+        return;
+    }
+
+    BOOL shouldStartRequest = NO;
+    @synchronized (sPendingTranslationCallbacks) {
+        NSMutableArray *callbacks = sPendingTranslationCallbacks[cacheKey];
+        if (!callbacks) {
+            callbacks = [NSMutableArray array];
+            sPendingTranslationCallbacks[cacheKey] = callbacks;
+            shouldStartRequest = YES;
+        }
+        [callbacks addObject:[completion copy]];
+    }
+
+    if (!shouldStartRequest) return;
+
+    ApolloTranslateTextWithFallback(sourceText, targetLanguage, ^(NSString *translated, NSError *error) {
+        NSArray *callbacks = nil;
+        @synchronized (sPendingTranslationCallbacks) {
+            callbacks = [sPendingTranslationCallbacks[cacheKey] copy] ?: @[];
+            [sPendingTranslationCallbacks removeObjectForKey:cacheKey];
+        }
+
+        if ([translated isKindOfClass:[NSString class]] && translated.length > 0) {
+            [sTranslationCache setObject:translated forKey:cacheKey];
+        }
+
+        for (id callbackObj in callbacks) {
+            void (^callback)(NSString *, NSError *) = callbackObj;
+            callback(translated, error);
+        }
+    });
+}
+
+static RDKComment *ApolloCommentFromCellNode(id commentCellNode) {
+    if (!commentCellNode) return nil;
+
+    Ivar commentIvar = class_getInstanceVariable([commentCellNode class], "comment");
+    if (!commentIvar) return nil;
+
+    id comment = object_getIvar(commentCellNode, commentIvar);
+    return [comment isKindOfClass:[RDKComment class]] ? (RDKComment *)comment : nil;
+}
+
+static void ApolloMaybeTranslateCommentCellNode(id commentCellNode, BOOL forceTranslation) {
+    if (!commentCellNode) return;
+    if (!ApolloShouldTranslateNow(forceTranslation)) return;
+
+    RDKComment *comment = ApolloCommentFromCellNode(commentCellNode);
+    if (!comment) return;
+
+    NSString *sourceText = [comment.body stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (sourceText.length == 0) return;
+
+    NSString *targetLanguage = ApolloResolvedTargetLanguageCode();
+    if (targetLanguage.length == 0) return;
+
+    if (!forceTranslation) {
+        NSString *detected = ApolloDetectDominantLanguage(sourceText);
+        if ([detected isEqualToString:targetLanguage]) {
+            return;
+        }
+    }
+
+    NSString *cacheKey = ApolloTranslationCacheKey(sourceText, targetLanguage);
+    objc_setAssociatedObject(commentCellNode, kApolloCellTranslationKeyKey, cacheKey, OBJC_ASSOCIATION_COPY_NONATOMIC);
+
+    __weak id weakCellNode = commentCellNode;
+    ApolloRequestTranslation(cacheKey, sourceText, targetLanguage, ^(NSString *translated, NSError *error) {
+        id strongCellNode = weakCellNode;
+        if (!strongCellNode) return;
+
+        NSString *currentKey = objc_getAssociatedObject(strongCellNode, kApolloCellTranslationKeyKey);
+        if (![currentKey isEqualToString:cacheKey]) return;
+
+        if (![translated isKindOfClass:[NSString class]] || translated.length == 0) {
+            if (error) {
+                ApolloLog(@"[Translation] Failed to translate comment: %@", error.localizedDescription ?: @"unknown error");
+            }
+            return;
+        }
+
+        if (!forceTranslation && !ApolloShouldTranslateNow(NO)) return;
+
+        RDKComment *strongComment = ApolloCommentFromCellNode(strongCellNode);
+        if (!strongComment) return;
+
+        ApolloApplyTranslationToCellNode(strongCellNode, strongComment, translated);
+    });
+}
+
+static void ApolloTranslateVisibleCommentsForController(UIViewController *viewController, BOOL forceTranslation) {
+    UITableView *tableView = GetCommentsTableView(viewController);
+    if (!tableView) return;
+
+    for (UITableViewCell *cell in [tableView visibleCells]) {
+        SEL nodeSelector = NSSelectorFromString(@"node");
+        if (![cell respondsToSelector:nodeSelector]) continue;
+
+        id cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSelector);
+        ApolloMaybeTranslateCommentCellNode(cellNode, forceTranslation);
+    }
+}
+
+static void ApolloRestoreVisibleCommentsForController(UIViewController *viewController) {
+    UITableView *tableView = GetCommentsTableView(viewController);
+    if (!tableView) return;
+
+    for (UITableViewCell *cell in [tableView visibleCells]) {
+        SEL nodeSelector = NSSelectorFromString(@"node");
+        if (![cell respondsToSelector:nodeSelector]) continue;
+
+        id cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSelector);
+        RDKComment *comment = ApolloCommentFromCellNode(cellNode);
+        ApolloRestoreOriginalForCellNode(cellNode, comment);
+    }
+}
+
+static void ApolloUpdateTranslationButtonForController(id controller) {
+    UIViewController *vc = (UIViewController *)controller;
+
+    UIBarButtonItem *translationItem = objc_getAssociatedObject(controller, kApolloTranslateBarButtonKey);
+    NSMutableArray<UIBarButtonItem *> *items = [vc.navigationItem.rightBarButtonItems mutableCopy] ?: [NSMutableArray array];
+
+    if (!sEnableBulkTranslation) {
+        if ([objc_getAssociatedObject(controller, kApolloThreadTranslatedModeKey) boolValue]) {
+            ApolloRestoreVisibleCommentsForController(vc);
+            objc_setAssociatedObject(controller, kApolloThreadTranslatedModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+
+        if (translationItem) {
+            [items removeObject:translationItem];
+            vc.navigationItem.rightBarButtonItems = items;
+            objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+        return;
+    }
+
+    if (!translationItem) {
+        translationItem = [[UIBarButtonItem alloc] initWithTitle:@"Translate"
+                                                           style:UIBarButtonItemStylePlain
+                                                          target:controller
+                                                          action:@selector(apollo_toggleThreadTranslation)];
+        objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, translationItem, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    BOOL translatedMode = [objc_getAssociatedObject(controller, kApolloThreadTranslatedModeKey) boolValue];
+    translationItem.title = translatedMode ? @"Original" : @"Translate";
+
+    if (![items containsObject:translationItem]) {
+        [items insertObject:translationItem atIndex:0];
+    }
+
+    vc.navigationItem.rightBarButtonItems = items;
+}
+
+%hook _TtC6Apollo15CommentCellNode
+
+- (void)didLoad {
+    %orig;
+
+    if (!sEnableBulkTranslation) return;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ApolloMaybeTranslateCommentCellNode((id)self, NO);
+    });
+}
+
+- (void)didEnterPreloadState {
+    %orig;
+
+    if (!sEnableBulkTranslation) return;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ApolloMaybeTranslateCommentCellNode((id)self, NO);
+    });
+}
+
+%end
+
+%hook _TtC6Apollo22CommentsViewController
+
+- (void)viewDidLoad {
+    %orig;
+    ApolloUpdateTranslationButtonForController(self);
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    %orig;
+    ApolloUpdateTranslationButtonForController(self);
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+
+    sVisibleCommentsViewController = (UIViewController *)self;
+
+    if (sEnableBulkTranslation && (sAutoTranslateOnAppear || [objc_getAssociatedObject((id)self, kApolloThreadTranslatedModeKey) boolValue])) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.12 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            ApolloTranslateVisibleCommentsForController((UIViewController *)self, NO);
+        });
+    }
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    %orig;
+
+    if (sVisibleCommentsViewController == (UIViewController *)self) {
+        sVisibleCommentsViewController = nil;
+    }
+}
+
+- (void)presentViewController:(UIViewController *)vc animated:(BOOL)animated completion:(void (^)(void))completion {
+    if (sEnableBulkTranslation && [vc isKindOfClass:objc_getClass("_TtC6Apollo16ActionController")]) {
+        NSUInteger removed = ApolloRemoveNativeTranslateActions(vc);
+        if (removed > 0) {
+            ApolloLog(@"[Translation] Removed %lu native Translate action(s)", (unsigned long)removed);
+        }
+    }
+    %orig;
+}
+
+%new
+- (void)apollo_toggleThreadTranslation {
+    BOOL translatedMode = [objc_getAssociatedObject((id)self, kApolloThreadTranslatedModeKey) boolValue];
+
+    if (translatedMode) {
+        ApolloRestoreVisibleCommentsForController((UIViewController *)self);
+        objc_setAssociatedObject((id)self, kApolloThreadTranslatedModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    } else {
+        ApolloTranslateVisibleCommentsForController((UIViewController *)self, YES);
+        objc_setAssociatedObject((id)self, kApolloThreadTranslatedModeKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    ApolloUpdateTranslationButtonForController(self);
+}
+
+%end
+
+%ctor {
+    sTranslationCache = [NSCache new];
+    sPendingTranslationCallbacks = [NSMutableDictionary dictionary];
+
+    [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidReceiveMemoryWarningNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(__unused NSNotification *note) {
+        [sTranslationCache removeAllObjects];
+    }];
+
+    %init;
+}

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -2178,7 +2178,7 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     }
     if (!globeButton) {
         globeButton = [UIButton buttonWithType:UIButtonTypeSystem];
-        globeButton.frame = CGRectMake(0.0, 0.0, 26.0, 32.0);
+        globeButton.frame = CGRectMake(0.0, 0.0, 18.0, 32.0);
         [globeButton addTarget:controller action:@selector(apollo_translationGlobeTapped) forControlEvents:UIControlEventTouchUpInside];
     }
     [globeButton setImage:globeImage forState:UIControlStateNormal];

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -2178,7 +2178,8 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     }
     if (!globeButton) {
         globeButton = [UIButton buttonWithType:UIButtonTypeSystem];
-        globeButton.frame = CGRectMake(0.0, 0.0, 10.0, 32.0);
+        globeButton.frame = CGRectMake(0.0, 0.0, 22.0, 32.0);
+        globeButton.imageEdgeInsets = UIEdgeInsetsMake(0.0, 14.0, 0.0, -14.0);
         [globeButton addTarget:controller action:@selector(apollo_translationGlobeTapped) forControlEvents:UIControlEventTouchUpInside];
     }
     [globeButton setImage:globeImage forState:UIControlStateNormal];

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -169,7 +169,6 @@ static BOOL ApolloCommentContainsCodeOrPreformatted(RDKComment *comment) {
 }
 
 static BOOL ApolloLinkContainsCodeOrPreformatted(RDKLink *link, NSString *visibleText) {
-    if (!link) return NO;
     return ApolloTextContainsMarkdownCode(link.selfText) ||
            ApolloHTMLContainsCode(link.selfTextHTML) ||
            ApolloTextContainsMarkdownCode(visibleText);
@@ -837,6 +836,14 @@ static NSString *ApolloVisibleTextFromNode(id textNode) {
     return [attr.string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 }
 
+static NSString *ApolloVisiblePostCacheKey(RDKLink *link, NSString *sourceText, NSString *targetLanguage) {
+    NSString *fullName = link.fullName;
+    if (fullName.length > 0) return fullName;
+    NSString *sourceNorm = ApolloNormalizeTextForCompare(sourceText ?: @"");
+    if (sourceNorm.length == 0) return nil;
+    return [NSString stringWithFormat:@"_visiblePost|%@|%lu", targetLanguage ?: @"en", (unsigned long)sourceNorm.hash];
+}
+
 // Picks the post-body text node by name first, then falls back to a scored
 // scan. If Apollo's model text is unavailable, choose the longest visible
 // body-like text node that is not title/byline/URL metadata.
@@ -872,7 +879,7 @@ static id ApolloBestPostBodyTextNode(id headerCellNode, RDKLink *link, NSString 
 }
 
 static void ApolloApplyTranslationToHeaderCellNode(id headerCellNode, RDKLink *link, NSString *sourceText, NSString *translatedText) {
-    if (!headerCellNode || ![(id)link isKindOfClass:NSClassFromString(@"RDKLink")]) return;
+    if (!headerCellNode) return;
     if (![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0) return;
     NSString *body = sourceText.length > 0 ? sourceText : ApolloPostBodyTextFromLink(link);
     if (![body isKindOfClass:[NSString class]] || body.length == 0) return;
@@ -1323,7 +1330,6 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
     if (!headerCellNode) return;
     RDKLink *link = ApolloLinkFromHeaderCellNode(headerCellNode);
     if (!link) link = fallbackLink;
-    if (!link) return;
     NSString *body = ApolloPostBodyTextFromLink(link);
     id visibleBodyNode = ApolloBestPostBodyTextNode(headerCellNode, link, body);
     NSString *visibleBody = ApolloVisibleTextFromNode(visibleBodyNode);
@@ -1358,9 +1364,9 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
     NSString *targetLanguage = ApolloResolvedTargetLanguageCode();
     if (targetLanguage.length == 0) return;
 
-    NSString *fullName = link.fullName;
-    if (fullName.length > 0) {
-        NSString *cached = [sLinkTranslationByFullName objectForKey:fullName];
+    NSString *cacheStoreKey = ApolloVisiblePostCacheKey(link, trimmed, targetLanguage);
+    if (cacheStoreKey.length > 0) {
+        NSString *cached = [sLinkTranslationByFullName objectForKey:cacheStoreKey];
         if (cached.length > 0) {
             ApolloApplyTranslationToHeaderCellNode(headerCellNode, link, trimmed, cached);
             return;
@@ -1382,8 +1388,8 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
             if (error) ApolloLog(@"[Translation] Failed to translate post body: %@", error.localizedDescription ?: @"unknown");
             return;
         }
-        if (fullName.length > 0) {
-            [sLinkTranslationByFullName setObject:translated forKey:fullName];
+        if (cacheStoreKey.length > 0) {
+            [sLinkTranslationByFullName setObject:translated forKey:cacheStoreKey];
         }
         if (!strongHeader) return;
         NSString *currentKey = objc_getAssociatedObject(strongHeader, kApolloHeaderCellTranslationKeyKey);
@@ -1392,7 +1398,6 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
 
         RDKLink *strongLink = ApolloLinkFromHeaderCellNode(strongHeader);
         if (!strongLink) strongLink = fallbackLink;
-        if (!strongLink) return;
         ApolloApplyTranslationToHeaderCellNode(strongHeader, strongLink, trimmed, translated);
     });
 }
@@ -1446,7 +1451,7 @@ static void ApolloRestoreVisibleCommentsForController(UIViewController *viewCont
     if (!tableView) return;
     RDKLink *controllerLink = ApolloLinkFromController(viewController);
 
-    if (tableView.tableHeaderView && controllerLink) {
+    if (tableView.tableHeaderView) {
         ApolloRestoreOriginalForHeaderCellNode(tableView.tableHeaderView, controllerLink);
     }
 
@@ -1465,7 +1470,7 @@ static void ApolloRestoreVisibleCommentsForController(UIViewController *viewCont
 
         // Header cell? Restore post body and skip the comment path.
         RDKLink *link = ApolloLinkFromHeaderCellNode(cellNode);
-        if (link || (!comment && controllerLink)) {
+        if (link || !comment) {
             if (!link) link = controllerLink;
             NSString *linkFullName = link.fullName;
             if (linkFullName.length > 0) {

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -600,7 +600,9 @@ static RDKComment *ApolloCommentFromCellNode(id commentCellNode) {
     if (!commentIvar) return nil;
 
     id comment = object_getIvar(commentCellNode, commentIvar);
-    return [comment isKindOfClass:[RDKComment class]] ? (RDKComment *)comment : nil;
+    Class rdkCommentClass = NSClassFromString(@"RDKComment");
+    if (!rdkCommentClass || ![comment isKindOfClass:rdkCommentClass]) return nil;
+    return (RDKComment *)comment;
 }
 
 static void ApolloMaybeTranslateCommentCellNode(id commentCellNode, BOOL forceTranslation) {

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -208,6 +208,84 @@ static NSString *ApolloTranslationCacheKey(NSString *text, NSString *targetLangu
     return [NSString stringWithFormat:@"%@|%lu", targetLanguage ?: @"en", (unsigned long)text.hash];
 }
 
+static NSString *ApolloTranslationLinkToken(NSUInteger index) {
+    return [NSString stringWithFormat:@"APOLLOTRANSLATIONLINK%luTOKEN", (unsigned long)index];
+}
+
+static NSRange ApolloRangeByTrimmingTrailingURLPunctuation(NSString *text, NSRange range) {
+    if (range.location == NSNotFound || NSMaxRange(range) > text.length) return range;
+
+    NSCharacterSet *trailingPunctuation = [NSCharacterSet characterSetWithCharactersInString:@".,!?;:"];
+    while (range.length > 0) {
+        unichar last = [text characterAtIndex:NSMaxRange(range) - 1];
+        if (![trailingPunctuation characterIsMember:last]) break;
+        range.length--;
+    }
+    return range;
+}
+
+static NSString *ApolloProtectTranslationLinks(NSString *sourceText, NSDictionary<NSString *, NSString *> **protectedLinksOut) {
+    if (protectedLinksOut) *protectedLinksOut = @{};
+    if (![sourceText isKindOfClass:[NSString class]] || sourceText.length == 0) return sourceText;
+
+    NSMutableString *protectedText = [sourceText mutableCopy];
+    NSMutableDictionary<NSString *, NSString *> *protectedLinks = [NSMutableDictionary dictionary];
+    __block NSUInteger nextTokenIndex = 0;
+
+    void (^replaceMatches)(NSRegularExpression *, BOOL) = ^(NSRegularExpression *regex, BOOL trimURLPunctuation) {
+        NSArray<NSTextCheckingResult *> *matches = [regex matchesInString:protectedText options:0 range:NSMakeRange(0, protectedText.length)];
+        for (NSTextCheckingResult *match in [matches reverseObjectEnumerator]) {
+            NSRange range = match.range;
+            if (trimURLPunctuation) {
+                range = ApolloRangeByTrimmingTrailingURLPunctuation(protectedText, range);
+            }
+            if (range.length == 0 || NSMaxRange(range) > protectedText.length) continue;
+
+            NSString *originalLink = [protectedText substringWithRange:range];
+            NSString *token = ApolloTranslationLinkToken(nextTokenIndex++);
+            protectedLinks[token] = originalLink;
+            [protectedText replaceCharactersInRange:range withString:token];
+        }
+    };
+
+    NSError *regexError = nil;
+    NSRegularExpression *markdownLinkRegex = [NSRegularExpression regularExpressionWithPattern:@"\\[[^\\]\\n]+\\]\\([^\\s)]+(?:\\s+\\\"[^\\\"]*\\\")?\\)"
+                                                                                       options:0
+                                                                                         error:&regexError];
+    if (!regexError && markdownLinkRegex) {
+        replaceMatches(markdownLinkRegex, NO);
+    }
+
+    regexError = nil;
+    NSRegularExpression *bareURLRegex = [NSRegularExpression regularExpressionWithPattern:@"(?i)\\bhttps?://[^\\s<>()\\[\\]{}\\\"']+"
+                                                                                options:0
+                                                                                  error:&regexError];
+    if (!regexError && bareURLRegex) {
+        replaceMatches(bareURLRegex, YES);
+    }
+
+    if (protectedLinksOut && protectedLinks.count > 0) {
+        *protectedLinksOut = [protectedLinks copy];
+    }
+    return protectedLinks.count > 0 ? [protectedText copy] : sourceText;
+}
+
+static NSString *ApolloRestoreTranslationLinks(NSString *translatedText, NSDictionary<NSString *, NSString *> *protectedLinks) {
+    if (![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0) return translatedText;
+    if (![protectedLinks isKindOfClass:[NSDictionary class]] || protectedLinks.count == 0) return translatedText;
+
+    NSMutableString *restoredText = [translatedText mutableCopy];
+    [protectedLinks enumerateKeysAndObjectsUsingBlock:^(NSString *token, NSString *originalLink, __unused BOOL *stop) {
+        if (![token isKindOfClass:[NSString class]] || token.length == 0) return;
+        if (![originalLink isKindOfClass:[NSString class]]) return;
+        [restoredText replaceOccurrencesOfString:token
+                                      withString:originalLink
+                                         options:0
+                                           range:NSMakeRange(0, restoredText.length)];
+    }];
+    return [restoredText copy];
+}
+
 static BOOL ApolloThreadTranslationModeEnabledForVisibleCommentsVC(void) __attribute__((unused));
 static BOOL ApolloThreadTranslationModeEnabledForVisibleCommentsVC(void) {
     UIViewController *vc = sVisibleCommentsViewController;
@@ -1299,20 +1377,24 @@ static void ApolloRequestTranslation(NSString *cacheKey,
 
     if (!shouldStartRequest) return;
 
-    ApolloTranslateTextWithFallback(sourceText, targetLanguage, ^(NSString *translated, NSError *error) {
+    NSDictionary<NSString *, NSString *> *protectedLinks = nil;
+    NSString *requestText = ApolloProtectTranslationLinks(sourceText, &protectedLinks);
+
+    ApolloTranslateTextWithFallback(requestText, targetLanguage, ^(NSString *translated, NSError *error) {
+        NSString *restoredTranslation = ApolloRestoreTranslationLinks(translated, protectedLinks);
         NSArray *callbacks = nil;
         @synchronized (sPendingTranslationCallbacks) {
             callbacks = [sPendingTranslationCallbacks[cacheKey] copy] ?: @[];
             [sPendingTranslationCallbacks removeObjectForKey:cacheKey];
         }
 
-        if ([translated isKindOfClass:[NSString class]] && translated.length > 0) {
-            [sTranslationCache setObject:translated forKey:cacheKey];
+        if ([restoredTranslation isKindOfClass:[NSString class]] && restoredTranslation.length > 0) {
+            [sTranslationCache setObject:restoredTranslation forKey:cacheKey];
         }
 
         for (id callbackObj in callbacks) {
             void (^callback)(NSString *, NSError *) = callbackObj;
-            callback(translated, error);
+            callback(restoredTranslation, error);
         }
     });
 }

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -2127,7 +2127,14 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     translationItem.target = controller;
     translationItem.action = @selector(apollo_translationGlobeTapped);
     translationItem.menu = nil;
-    translationItem.tintColor = visibleTranslationApplied ? [UIColor systemGreenColor] : [UIColor systemBlueColor];
+    UIColor *themeTintColor = vc.view.tintColor;
+    if (!themeTintColor) {
+        themeTintColor = vc.navigationController.navigationBar.tintColor;
+    }
+    if (!themeTintColor) {
+        themeTintColor = [UIColor systemBlueColor];
+    }
+    translationItem.tintColor = visibleTranslationApplied ? [UIColor systemGreenColor] : themeTintColor;
     translationItem.accessibilityLabel = translatedMode
         ? @"Translation: showing translated. Tap to show original."
         : [NSString stringWithFormat:@"Translation: showing original. Tap to translate to %@.", targetName];

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -34,6 +34,7 @@ static const void *kApolloTranslationBannerKey = &kApolloTranslationBannerKey;
 static const void *kApolloAppliedHeaderTranslationFullNameKey = &kApolloAppliedHeaderTranslationFullNameKey;
 static const void *kApolloHeaderTranslatedTextNodeKey = &kApolloHeaderTranslatedTextNodeKey;
 static const void *kApolloHeaderCellTranslationKeyKey = &kApolloHeaderCellTranslationKeyKey;
+static const void *kApolloPostBodyReapplyScheduledKey = &kApolloPostBodyReapplyScheduledKey;
 
 static NSString *const kApolloDefaultLibreTranslateURL = @"https://libretranslate.de/translate";
 
@@ -1596,6 +1597,23 @@ static void ApolloMaybeTranslatePostHeaderForController(UIViewController *viewCo
     ApolloMaybeTranslateVisiblePostBodyForController(viewController, tableView, forceTranslation);
 }
 
+static void ApolloSchedulePostBodyReapplyForController(UIViewController *viewController) {
+    if (!viewController || !sEnableBulkTranslation) return;
+    if (!ApolloControllerIsInTranslatedMode(viewController)) return;
+    if ([objc_getAssociatedObject(viewController, kApolloPostBodyReapplyScheduledKey) boolValue]) return;
+
+    objc_setAssociatedObject(viewController, kApolloPostBodyReapplyScheduledKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    __weak UIViewController *weakVC = viewController;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.22 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        UIViewController *strongVC = weakVC;
+        if (!strongVC) return;
+        objc_setAssociatedObject(strongVC, kApolloPostBodyReapplyScheduledKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        if (!sEnableBulkTranslation || !ApolloControllerIsInTranslatedMode(strongVC)) return;
+        ApolloMaybeTranslatePostHeaderForController(strongVC, NO);
+        ApolloUpdateTranslationUIForController(strongVC);
+    });
+}
+
 static void ApolloTranslateVisibleCommentsForController(UIViewController *viewController, BOOL forceTranslation) {
     UITableView *tableView = GetCommentsTableView(viewController);
     if (!tableView) return;
@@ -2017,6 +2035,12 @@ static NSAttributedString *ApolloRebuildTranslatedAttrPreservingAttrs(NSAttribut
 - (void)viewWillAppear:(BOOL)animated {
     %orig;
     ApolloUpdateTranslationUIForController(self);
+    ApolloSchedulePostBodyReapplyForController((UIViewController *)self);
+}
+
+- (void)viewDidLayoutSubviews {
+    %orig;
+    ApolloSchedulePostBodyReapplyForController((UIViewController *)self);
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -2030,6 +2054,7 @@ static NSAttributedString *ApolloRebuildTranslatedAttrPreservingAttrs(NSAttribut
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.12 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             ApolloTranslateVisibleCommentsForController((UIViewController *)self, NO);
             ApolloUpdateTranslationUIForController(self);
+            ApolloSchedulePostBodyReapplyForController((UIViewController *)self);
         });
     }
 }

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -12,14 +12,33 @@ static const void *kApolloOriginalAttributedTextKey = &kApolloOriginalAttributed
 static const void *kApolloTranslatedTextNodeKey = &kApolloTranslatedTextNodeKey;
 static const void *kApolloCellTranslationKeyKey = &kApolloCellTranslationKeyKey;
 static const void *kApolloThreadTranslatedModeKey = &kApolloThreadTranslatedModeKey;
+// Set when the user explicitly toggled away from a translated thread (so we
+// don't clobber the user's preference when sAutoTranslateOnAppear is on).
+static const void *kApolloThreadOriginalModeKey = &kApolloThreadOriginalModeKey;
 static const void *kApolloTranslateBarButtonKey = &kApolloTranslateBarButtonKey;
 static const void *kApolloAppliedTranslationFullNameKey = &kApolloAppliedTranslationFullNameKey;
+// Phase D — vote resilience. When we install a translated string into a text
+// node we tag the node with these associations. A global setAttributedText:
+// hook checks the marker and re-applies our translation if Apollo overwrites
+// the node (e.g. on vote, edit, score-flair refresh).
+static const void *kApolloTranslationOwnedTextNodeKey = &kApolloTranslationOwnedTextNodeKey;
+static const void *kApolloOwnedNodeOriginalBodyKey = &kApolloOwnedNodeOriginalBodyKey;
+static const void *kApolloOwnedNodeTranslatedTextKey = &kApolloOwnedNodeTranslatedTextKey;
+static const void *kApolloOwnedNodeReentrancyKey = &kApolloOwnedNodeReentrancyKey;
+// Phase B — status banner above comments.
+static const void *kApolloTranslationBannerKey = &kApolloTranslationBannerKey;
+// Phase C — post selftext translation.
+static const void *kApolloAppliedHeaderTranslationFullNameKey = &kApolloAppliedHeaderTranslationFullNameKey;
+static const void *kApolloHeaderTranslatedTextNodeKey = &kApolloHeaderTranslatedTextNodeKey;
+static const void *kApolloHeaderCellTranslationKeyKey = &kApolloHeaderCellTranslationKeyKey;
 
 static NSString *const kApolloDefaultLibreTranslateURL = @"https://libretranslate.de/translate";
 
 static NSCache<NSString *, NSString *> *sTranslationCache;
 // fullName ("t1_xxxxx") -> translated body text. Survives cell reuse / collapse.
 static NSCache<NSString *, NSString *> *sCommentTranslationByFullName;
+// fullName ("t3_xxxxx") -> translated post selftext. Same idea, for posts.
+static NSCache<NSString *, NSString *> *sLinkTranslationByFullName;
 static NSMutableDictionary<NSString *, NSMutableArray *> *sPendingTranslationCallbacks;
 static __weak UIViewController *sVisibleCommentsViewController = nil;
 
@@ -27,11 +46,10 @@ static __weak UIViewController *sVisibleCommentsViewController = nil;
 // stable derived key when the runtime doesn't expose `name` / `fullName`.
 static NSString *ApolloCommentFullName(RDKComment *comment) {
     if (!comment) return nil;
-    id commentObj = (id)comment;
     SEL sels[] = { @selector(name), NSSelectorFromString(@"fullName"), NSSelectorFromString(@"identifier"), NSSelectorFromString(@"id") };
     for (size_t i = 0; i < sizeof(sels) / sizeof(sels[0]); i++) {
-        if ([commentObj respondsToSelector:sels[i]]) {
-            id v = ((id (*)(id, SEL))objc_msgSend)(commentObj, sels[i]);
+        if ([(id)comment respondsToSelector:sels[i]]) {
+            id v = ((id (*)(id, SEL))objc_msgSend)(comment, sels[i]);
             if ([v isKindOfClass:[NSString class]] && [(NSString *)v length] > 0) return (NSString *)v;
         }
     }
@@ -128,17 +146,36 @@ static NSString *ApolloTranslationCacheKey(NSString *text, NSString *targetLangu
     return [NSString stringWithFormat:@"%@|%lu", targetLanguage ?: @"en", (unsigned long)text.hash];
 }
 
+static BOOL ApolloThreadTranslationModeEnabledForVisibleCommentsVC(void) __attribute__((unused));
 static BOOL ApolloThreadTranslationModeEnabledForVisibleCommentsVC(void) {
     UIViewController *vc = sVisibleCommentsViewController;
     if (!vc) return NO;
     return [objc_getAssociatedObject(vc, kApolloThreadTranslatedModeKey) boolValue];
 }
 
+// Returns YES if the controller is currently in translated mode considering
+// both the auto-translate setting AND the user's per-thread overrides:
+//   - Explicit "translate this thread" (kApolloThreadTranslatedModeKey = @YES)
+//     always wins.
+//   - sAutoTranslateOnAppear means default = translated, UNLESS the user has
+//     explicitly toggled to original on this thread
+//     (kApolloThreadOriginalModeKey = @YES).
+static BOOL ApolloControllerIsInTranslatedMode(UIViewController *vc) {
+    if (!vc) return NO;
+    if ([objc_getAssociatedObject(vc, kApolloThreadTranslatedModeKey) boolValue]) return YES;
+    if (sAutoTranslateOnAppear &&
+        ![objc_getAssociatedObject(vc, kApolloThreadOriginalModeKey) boolValue]) {
+        return YES;
+    }
+    return NO;
+}
+
 static BOOL ApolloShouldTranslateNow(BOOL forceTranslation) {
     if (!sEnableBulkTranslation && !forceTranslation) return NO;
     if (forceTranslation) return YES;
-    if (!sVisibleCommentsViewController) return NO;
-    return sAutoTranslateOnAppear || ApolloThreadTranslationModeEnabledForVisibleCommentsVC();
+    UIViewController *vc = sVisibleCommentsViewController;
+    if (!vc) return NO;
+    return ApolloControllerIsInTranslatedMode(vc);
 }
 
 static BOOL ApolloActionTitleLooksTranslate(NSString *title) {
@@ -451,6 +488,15 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
     }
 
     NSAttributedString *translatedAttr = [[NSAttributedString alloc] initWithString:translatedText attributes:attributes ?: @{}];
+
+    // Phase D — vote resilience. Mark this text node as ours BEFORE the
+    // setAttributedText: write below, so the global setter hook sees the
+    // marker and the swap-to-translated logic can trigger if Apollo later
+    // overwrites the node (e.g. on vote/score-flair refresh).
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [comment.body copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
     @try {
         ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), translatedAttr);
     } @catch (__unused NSException *e) {
@@ -484,6 +530,12 @@ static void ApolloRestoreOriginalForCellNode(id commentCellNode, RDKComment *com
     }
     if (!textNode) return;
 
+    // Drop ownership BEFORE writing original text back, otherwise the vote-
+    // resilience hook would swap the original right back to translated.
+    objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+
     NSAttributedString *original = objc_getAssociatedObject(textNode, kApolloOriginalAttributedTextKey);
     if (![original isKindOfClass:[NSAttributedString class]]) return;
 
@@ -501,6 +553,172 @@ static void ApolloRestoreOriginalForCellNode(id commentCellNode, RDKComment *com
     }
 
     objc_setAssociatedObject(commentCellNode, kApolloAppliedTranslationFullNameKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+#pragma mark - Phase C: post selftext (header cell) translation
+
+// Returns the post (RDKLink) ivar from a header-style cell node, or nil if
+// this cellNode isn't a post header. Searches a couple of common ivar names.
+static RDKLink *ApolloLinkFromHeaderCellNode(id cellNode) {
+    if (!cellNode) return nil;
+    static const char *kLinkIvarNames[] = { "link", "post", "_link", NULL };
+    Class rdkLink = NSClassFromString(@"RDKLink");
+    if (!rdkLink) return nil;
+    for (Class cls = [cellNode class]; cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
+        for (size_t i = 0; kLinkIvarNames[i]; i++) {
+            Ivar iv = class_getInstanceVariable(cls, kLinkIvarNames[i]);
+            if (!iv) continue;
+            const char *type = ivar_getTypeEncoding(iv);
+            if (!type || type[0] != '@') continue;
+            id v = nil;
+            @try { v = object_getIvar(cellNode, iv); } @catch (__unused NSException *e) { continue; }
+            if ([v isKindOfClass:rdkLink]) return (RDKLink *)v;
+        }
+    }
+    return nil;
+}
+
+// Same idea as ApolloKnownBodyTextNode but for post header cells.
+static id ApolloKnownPostBodyTextNode(id headerCellNode) {
+    if (!headerCellNode) return nil;
+    static const char *kCandidateNames[] = {
+        "selfTextNode",
+        "selfPostBodyNode",
+        "bodyTextNode",
+        "selfPostTextNode",
+        "selfTextTextNode",
+        "postBodyNode",
+        "postTextNode",
+        "bodyNode",
+        "markdownNode",
+        "attributedTextNode",
+        NULL,
+    };
+    for (Class cls = [headerCellNode class]; cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
+        for (size_t i = 0; kCandidateNames[i]; i++) {
+            Ivar iv = class_getInstanceVariable(cls, kCandidateNames[i]);
+            if (!iv) continue;
+            const char *type = ivar_getTypeEncoding(iv);
+            if (!type || type[0] != '@') continue;
+            id node = nil;
+            @try { node = object_getIvar(headerCellNode, iv); } @catch (__unused NSException *e) { continue; }
+            if (!node) continue;
+            if (![node respondsToSelector:@selector(attributedText)]) continue;
+            return node;
+        }
+    }
+    return nil;
+}
+
+// Picks the post-body text node by name first, then falls back to a scored
+// scan of the cell's subnode tree against link.selfText.
+static id ApolloBestPostBodyTextNode(id headerCellNode, RDKLink *link) {
+    id known = ApolloKnownPostBodyTextNode(headerCellNode);
+    if (known) {
+        // Sanity-check: if the named node's text isn't even close to selfText,
+        // fall through to scoring.
+        @try {
+            NSAttributedString *attr = ((id (*)(id, SEL))objc_msgSend)(known, @selector(attributedText));
+            if (ApolloCandidateScore(attr, link.selfText) > NSIntegerMin) return known;
+        } @catch (__unused NSException *e) { /* fall through */ }
+    }
+    NSMutableArray *candidates = [NSMutableArray array];
+    NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:64];
+    ApolloCollectAttributedTextNodes(headerCellNode, 5, visited, candidates);
+    id best = nil;
+    NSInteger bestScore = NSIntegerMin;
+    for (id n in candidates) {
+        NSAttributedString *attr = nil;
+        @try { attr = ((id (*)(id, SEL))objc_msgSend)(n, @selector(attributedText)); }
+        @catch (__unused NSException *e) { continue; }
+        NSInteger s = ApolloCandidateScore(attr, link.selfText);
+        if (s > bestScore) { bestScore = s; best = n; }
+    }
+    return best;
+}
+
+static void ApolloApplyTranslationToHeaderCellNode(id headerCellNode, RDKLink *link, NSString *translatedText) {
+    if (!headerCellNode || ![(id)link isKindOfClass:NSClassFromString(@"RDKLink")]) return;
+    if (![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0) return;
+    NSString *body = link.selfText;
+    if (![body isKindOfClass:[NSString class]] || body.length == 0) return;
+
+    id textNode = ApolloBestPostBodyTextNode(headerCellNode, link);
+    if (!textNode) return;
+
+    NSAttributedString *current = nil;
+    @try { current = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText)); }
+    @catch (__unused NSException *e) { return; }
+    if (![current isKindOfClass:[NSAttributedString class]]) return;
+
+    NSString *currentNorm = ApolloNormalizeTextForCompare(current.string);
+    NSString *bodyNorm = ApolloNormalizeTextForCompare(body);
+    NSString *translatedNorm = ApolloNormalizeTextForCompare(translatedText);
+    if (currentNorm.length == 0 || bodyNorm.length == 0) return;
+    BOOL textMatchesBody = [currentNorm isEqualToString:bodyNorm] ||
+                           [currentNorm containsString:bodyNorm] ||
+                           [bodyNorm containsString:currentNorm];
+    BOOL textMatchesTranslation = translatedNorm.length > 0 &&
+        ([currentNorm isEqualToString:translatedNorm] ||
+         [currentNorm containsString:translatedNorm] ||
+         [translatedNorm containsString:currentNorm]);
+    if (!textMatchesBody && !textMatchesTranslation) return;
+    if (textMatchesTranslation && !textMatchesBody) return;
+
+    NSAttributedString *originalSaved = objc_getAssociatedObject(textNode, kApolloOriginalAttributedTextKey);
+    if (![originalSaved isKindOfClass:[NSAttributedString class]]) {
+        objc_setAssociatedObject(textNode, kApolloOriginalAttributedTextKey, [current copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    NSDictionary *attrs = current.length > 0 ? [current attributesAtIndex:0 effectiveRange:NULL] : nil;
+    NSAttributedString *translatedAttr = [[NSAttributedString alloc] initWithString:translatedText attributes:attrs ?: @{}];
+
+    // Same vote-resilience marker pattern as comment cells.
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [body copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    @try { ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), translatedAttr); }
+    @catch (__unused NSException *e) { return; }
+
+    if ([textNode respondsToSelector:@selector(setNeedsLayout)]) {
+        ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsLayout));
+    }
+    if ([textNode respondsToSelector:@selector(setNeedsDisplay)]) {
+        ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsDisplay));
+    }
+
+    objc_setAssociatedObject(headerCellNode, kApolloHeaderTranslatedTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    NSString *fullName = link.fullName;
+    if (fullName.length > 0) {
+        [sLinkTranslationByFullName setObject:translatedText forKey:fullName];
+        objc_setAssociatedObject(headerCellNode, kApolloAppliedHeaderTranslationFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    }
+}
+
+static void ApolloRestoreOriginalForHeaderCellNode(id headerCellNode, RDKLink *link) {
+    if (!headerCellNode) return;
+    id textNode = objc_getAssociatedObject(headerCellNode, kApolloHeaderTranslatedTextNodeKey);
+    if (!textNode) textNode = ApolloBestPostBodyTextNode(headerCellNode, link);
+    if (!textNode) return;
+
+    objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+
+    NSAttributedString *original = objc_getAssociatedObject(textNode, kApolloOriginalAttributedTextKey);
+    if (![original isKindOfClass:[NSAttributedString class]]) return;
+    @try { ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), original); }
+    @catch (__unused NSException *e) { return; }
+
+    if ([textNode respondsToSelector:@selector(setNeedsLayout)]) {
+        ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsLayout));
+    }
+    if ([textNode respondsToSelector:@selector(setNeedsDisplay)]) {
+        ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsDisplay));
+    }
+    objc_setAssociatedObject(headerCellNode, kApolloAppliedHeaderTranslationFullNameKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 
 static NSString *ApolloExtractGoogleTranslation(id jsonObject) {
@@ -841,6 +1059,75 @@ static BOOL ApolloReapplyCachedTranslationForCellNode(id commentCellNode) {
     return YES;
 }
 
+#pragma mark - Phase C: post selftext translation driver
+
+static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, BOOL forceTranslation) {
+    if (!headerCellNode) return;
+    RDKLink *link = ApolloLinkFromHeaderCellNode(headerCellNode);
+    if (!link) return;
+    NSString *body = link.selfText;
+    if (![body isKindOfClass:[NSString class]]) return;
+    NSString *trimmed = [body stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (trimmed.length == 0) return;  // link/image post — nothing to translate
+
+    if (!ApolloShouldTranslateNow(forceTranslation)) return;
+
+    NSString *targetLanguage = ApolloResolvedTargetLanguageCode();
+    if (targetLanguage.length == 0) return;
+
+    NSString *fullName = link.fullName;
+    if (fullName.length > 0) {
+        NSString *cached = [sLinkTranslationByFullName objectForKey:fullName];
+        if (cached.length > 0) {
+            ApolloApplyTranslationToHeaderCellNode(headerCellNode, link, cached);
+            return;
+        }
+    }
+
+    if (!forceTranslation) {
+        NSString *detected = ApolloDetectDominantLanguage(trimmed);
+        if ([detected isEqualToString:targetLanguage]) return;
+    }
+
+    NSString *cacheKey = ApolloTranslationCacheKey(trimmed, targetLanguage);
+    objc_setAssociatedObject(headerCellNode, kApolloHeaderCellTranslationKeyKey, cacheKey, OBJC_ASSOCIATION_COPY_NONATOMIC);
+
+    __weak id weakHeader = headerCellNode;
+    ApolloRequestTranslation(cacheKey, trimmed, targetLanguage, ^(NSString *translated, NSError *error) {
+        id strongHeader = weakHeader;
+        if (![translated isKindOfClass:[NSString class]] || translated.length == 0) {
+            if (error) ApolloLog(@"[Translation] Failed to translate post body: %@", error.localizedDescription ?: @"unknown");
+            return;
+        }
+        if (fullName.length > 0) {
+            [sLinkTranslationByFullName setObject:translated forKey:fullName];
+        }
+        if (!strongHeader) return;
+        NSString *currentKey = objc_getAssociatedObject(strongHeader, kApolloHeaderCellTranslationKeyKey);
+        if (![currentKey isEqualToString:cacheKey]) return;
+        if (!forceTranslation && !ApolloShouldTranslateNow(NO)) return;
+
+        RDKLink *strongLink = ApolloLinkFromHeaderCellNode(strongHeader);
+        if (!strongLink) return;
+        ApolloApplyTranslationToHeaderCellNode(strongHeader, strongLink, translated);
+    });
+}
+
+// Walks the comments table looking for the post header cell (the one whose
+// cellNode has a `link` ivar instead of a `comment` ivar) and translates it.
+static void ApolloMaybeTranslatePostHeaderForController(UIViewController *viewController, BOOL forceTranslation) {
+    UITableView *tableView = GetCommentsTableView(viewController);
+    if (!tableView) return;
+    for (UITableViewCell *cell in [tableView visibleCells]) {
+        SEL nodeSelector = NSSelectorFromString(@"node");
+        if (![cell respondsToSelector:nodeSelector]) continue;
+        id cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSelector);
+        if (ApolloLinkFromHeaderCellNode(cellNode)) {
+            ApolloMaybeTranslatePostHeaderCellNode(cellNode, forceTranslation);
+        }
+    }
+}
+
 static void ApolloTranslateVisibleCommentsForController(UIViewController *viewController, BOOL forceTranslation) {
     UITableView *tableView = GetCommentsTableView(viewController);
     if (!tableView) return;
@@ -852,6 +1139,9 @@ static void ApolloTranslateVisibleCommentsForController(UIViewController *viewCo
         id cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSelector);
         ApolloMaybeTranslateCommentCellNode(cellNode, forceTranslation);
     }
+
+    // Phase C — also translate the post selftext (header cell) if present.
+    ApolloMaybeTranslatePostHeaderForController(viewController, forceTranslation);
 }
 
 static void ApolloRestoreVisibleCommentsForController(UIViewController *viewController) {
@@ -863,6 +1153,18 @@ static void ApolloRestoreVisibleCommentsForController(UIViewController *viewCont
         if (![cell respondsToSelector:nodeSelector]) continue;
 
         id cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSelector);
+
+        // Header cell? Restore post body and skip the comment path.
+        RDKLink *link = ApolloLinkFromHeaderCellNode(cellNode);
+        if (link) {
+            NSString *linkFullName = link.fullName;
+            if (linkFullName.length > 0) {
+                [sLinkTranslationByFullName removeObjectForKey:linkFullName];
+            }
+            ApolloRestoreOriginalForHeaderCellNode(cellNode, link);
+            continue;
+        }
+
         RDKComment *comment = ApolloCommentFromCellNode(cellNode);
 
         // Drop from the persistent fullName cache so cellNodeVisibilityEvent:
@@ -877,43 +1179,248 @@ static void ApolloRestoreVisibleCommentsForController(UIViewController *viewCont
     }
 }
 
-static void ApolloUpdateTranslationButtonForController(id controller) {
+#pragma mark - Phase A/B: nav-bar globe icon + status banner
+
+// Forward declaration so the menu's UIAction handler can call it.
+static void ApolloToggleThreadTranslationForController(UIViewController *vc);
+
+// Returns a localized human name for the active target language (e.g. "en"
+// → "English"). Falls back to the uppercased code.
+static NSString *ApolloLocalizedTargetLanguageName(void) {
+    NSString *code = ApolloResolvedTargetLanguageCode();
+    NSString *name = [[NSLocale currentLocale] localizedStringForLanguageCode:code];
+    if (name.length == 0) return [code uppercaseString];
+    // Capitalize first letter for nicer display.
+    return [[name substringToIndex:1].localizedUppercaseString stringByAppendingString:[name substringFromIndex:1]];
+}
+
+// Lazily install a thin status label pinned to the controller view's safe-area
+// top. Hidden by default; the UI updater shows/hides + recolors.
+static UILabel *ApolloEnsureBannerForController(UIViewController *vc) {
+    UILabel *banner = objc_getAssociatedObject(vc, kApolloTranslationBannerKey);
+    if (banner && banner.superview) return banner;
+
+    banner = [[UILabel alloc] init];
+    banner.translatesAutoresizingMaskIntoConstraints = NO;
+    banner.font = [UIFont systemFontOfSize:11.0 weight:UIFontWeightMedium];
+    banner.textAlignment = NSTextAlignmentLeft;
+    banner.backgroundColor = [UIColor clearColor];
+    banner.numberOfLines = 1;
+    banner.adjustsFontSizeToFitWidth = YES;
+    banner.minimumScaleFactor = 0.85;
+    banner.userInteractionEnabled = NO;
+    banner.hidden = YES;
+    [vc.view addSubview:banner];
+
+    UILayoutGuide *safe = vc.view.safeAreaLayoutGuide;
+    [NSLayoutConstraint activateConstraints:@[
+        [banner.topAnchor constraintEqualToAnchor:safe.topAnchor constant:2.0],
+        [banner.leadingAnchor constraintEqualToAnchor:safe.leadingAnchor constant:14.0],
+        [banner.trailingAnchor constraintEqualToAnchor:safe.trailingAnchor constant:-14.0],
+        [banner.heightAnchor constraintEqualToConstant:14.0],
+    ]];
+    objc_setAssociatedObject(vc, kApolloTranslationBannerKey, banner, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return banner;
+}
+
+// Builds (or rebuilds) the UIMenu attached to the globe bar button. The menu
+// has one action whose title reflects what tapping it will DO — "Translate
+// to English" when currently showing original, "Show original" when currently
+// translated. This addresses the user's "feels backwards" complaint with the
+// previous text-label button.
+static UIMenu *ApolloBuildTranslationMenuForController(UIViewController *vc) {
+    BOOL translatedMode = ApolloControllerIsInTranslatedMode(vc);
+    NSString *targetName = ApolloLocalizedTargetLanguageName();
+
+    NSString *title = translatedMode
+        ? @"Show original"
+        : [NSString stringWithFormat:@"Translate to %@", targetName];
+
+    UIImage *image = [UIImage systemImageNamed:translatedMode ? @"text.bubble" : @"globe"];
+
+    __weak UIViewController *weakVC = vc;
+    UIAction *toggle = [UIAction actionWithTitle:title
+                                           image:image
+                                      identifier:nil
+                                         handler:^(__kindof UIAction * _Nonnull action) {
+        UIViewController *strong = weakVC;
+        if (!strong) return;
+        ApolloToggleThreadTranslationForController(strong);
+    }];
+
+    return [UIMenu menuWithTitle:@"" children:@[toggle]];
+}
+
+static void ApolloUpdateTranslationUIForController(id controller) {
     UIViewController *vc = (UIViewController *)controller;
 
     UIBarButtonItem *translationItem = objc_getAssociatedObject(controller, kApolloTranslateBarButtonKey);
     NSMutableArray<UIBarButtonItem *> *items = [vc.navigationItem.rightBarButtonItems mutableCopy] ?: [NSMutableArray array];
+    UILabel *banner = objc_getAssociatedObject(controller, kApolloTranslationBannerKey);
 
     if (!sEnableBulkTranslation) {
-        if ([objc_getAssociatedObject(controller, kApolloThreadTranslatedModeKey) boolValue]) {
+        // Feature flipped off: revert any active translation, drop the bar
+        // button + hide the banner. Do not leak associations.
+        if (ApolloControllerIsInTranslatedMode(vc)) {
             ApolloRestoreVisibleCommentsForController(vc);
-            objc_setAssociatedObject(controller, kApolloThreadTranslatedModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         }
+        objc_setAssociatedObject(controller, kApolloThreadTranslatedModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(controller, kApolloThreadOriginalModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
         if (translationItem) {
             [items removeObject:translationItem];
             vc.navigationItem.rightBarButtonItems = items;
             objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         }
+        if (banner) banner.hidden = YES;
         return;
     }
 
+    BOOL translatedMode = ApolloControllerIsInTranslatedMode(vc);
+    NSString *targetName = ApolloLocalizedTargetLanguageName();
+
+    // Compact globe icon — same width as the existing nav buttons, so the
+    // central pill (sort/3-dots) is not pushed out of place.
+    UIImage *globeImage = [UIImage systemImageNamed:@"globe"];
     if (!translationItem) {
-        translationItem = [[UIBarButtonItem alloc] initWithTitle:@"Translate"
+        translationItem = [[UIBarButtonItem alloc] initWithImage:globeImage
                                                            style:UIBarButtonItemStylePlain
-                                                          target:controller
-                                                          action:@selector(apollo_toggleThreadTranslation)];
+                                                          target:nil
+                                                          action:nil];
+        // Slight visual hint when translated mode is on — same image, distinct
+        // tint so the user sees at a glance.
         objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, translationItem, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
-
-    BOOL translatedMode = [objc_getAssociatedObject(controller, kApolloThreadTranslatedModeKey) boolValue];
-    translationItem.title = translatedMode ? @"Original" : @"Translate";
+    translationItem.image = globeImage;
+    translationItem.tintColor = translatedMode ? [UIColor systemGreenColor] : nil;
+    translationItem.menu = ApolloBuildTranslationMenuForController(vc);
+    translationItem.accessibilityLabel = translatedMode
+        ? @"Translation: showing translated. Tap to show original."
+        : [NSString stringWithFormat:@"Translation: showing original. Tap to translate to %@.", targetName];
 
     if (![items containsObject:translationItem]) {
+        // Insert at the front of the right-side stack so it sits at the far
+        // right edge (Apollo's existing rightBarButtonItems are ordered
+        // right-to-left).
         [items insertObject:translationItem atIndex:0];
     }
-
     vc.navigationItem.rightBarButtonItems = items;
+
+    // Phase B — banner.
+    UILabel *b = ApolloEnsureBannerForController(vc);
+    BOOL userInteracted = [objc_getAssociatedObject(controller, kApolloThreadTranslatedModeKey) boolValue] ||
+                          [objc_getAssociatedObject(controller, kApolloThreadOriginalModeKey) boolValue];
+    BOOL showBanner = userInteracted || sAutoTranslateOnAppear;
+    if (!showBanner) {
+        b.hidden = YES;
+    } else {
+        b.hidden = NO;
+        if (translatedMode) {
+            b.text = [NSString stringWithFormat:@"Translated to %@", targetName];
+            b.textColor = [UIColor systemGreenColor];
+        } else {
+            b.text = @"Showing original";
+            b.textColor = [UIColor systemBlueColor];
+        }
+    }
 }
+
+static void ApolloToggleThreadTranslationForController(UIViewController *vc) {
+    if (!vc) return;
+    BOOL wasTranslated = ApolloControllerIsInTranslatedMode(vc);
+    if (wasTranslated) {
+        // Switch to original.
+        ApolloRestoreVisibleCommentsForController(vc);
+        objc_setAssociatedObject(vc, kApolloThreadTranslatedModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(vc, kApolloThreadOriginalModeKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    } else {
+        // Switch to translated.
+        objc_setAssociatedObject(vc, kApolloThreadTranslatedModeKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(vc, kApolloThreadOriginalModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloTranslateVisibleCommentsForController(vc, YES);
+    }
+    ApolloUpdateTranslationUIForController(vc);
+}
+
+#pragma mark - Phase D: vote / redisplay resilience
+
+// Helper: rebuild a translated NSAttributedString preserving the attributes of
+// `incoming` (which carries Apollo's freshly-computed score color, font size,
+// link styles, etc.) but using our cached translated string.
+static NSAttributedString *ApolloRebuildTranslatedAttrPreservingAttrs(NSAttributedString *incoming, NSString *translatedText) {
+    NSDictionary *attrs = nil;
+    if ([incoming isKindOfClass:[NSAttributedString class]] && incoming.length > 0) {
+        attrs = [incoming attributesAtIndex:0 effectiveRange:NULL];
+    }
+    return [[NSAttributedString alloc] initWithString:translatedText attributes:attrs ?: @{}];
+}
+
+// Global setAttributedText: hook on ASTextNode. Strict no-op for any node we
+// haven't tagged with kApolloTranslationOwnedTextNodeKey. For tagged nodes:
+// if Apollo is overwriting back to the original `comment.body`, swap to our
+// cached translated string. This catches vote/score-color refresh, edit, and
+// any other "Apollo rewrites the body without going through cell reuse"
+// pathway in a single chokepoint.
+%hook ASTextNode
+
+- (void)setAttributedText:(NSAttributedString *)attributedText {
+    if (![objc_getAssociatedObject(self, kApolloTranslationOwnedTextNodeKey) boolValue]) {
+        %orig;
+        return;
+    }
+
+    // Re-entrancy guard: when WE call %orig with a substituted string, the
+    // hook re-fires. Skip the swap on the inner call.
+    if ([objc_getAssociatedObject(self, kApolloOwnedNodeReentrancyKey) boolValue]) {
+        %orig;
+        return;
+    }
+
+    NSString *originalBody = objc_getAssociatedObject(self, kApolloOwnedNodeOriginalBodyKey);
+    NSString *translatedText = objc_getAssociatedObject(self, kApolloOwnedNodeTranslatedTextKey);
+
+    if (![originalBody isKindOfClass:[NSString class]] || originalBody.length == 0 ||
+        ![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0 ||
+        ![attributedText isKindOfClass:[NSAttributedString class]]) {
+        %orig;
+        return;
+    }
+
+    NSString *incomingNorm = ApolloNormalizeTextForCompare(attributedText.string);
+    NSString *originalNorm = ApolloNormalizeTextForCompare(originalBody);
+    NSString *translatedNorm = ApolloNormalizeTextForCompare(translatedText);
+
+    // If the incoming string already matches our translation, pass through.
+    if (translatedNorm.length > 0 &&
+        ([incomingNorm isEqualToString:translatedNorm] ||
+         [incomingNorm containsString:translatedNorm] ||
+         [translatedNorm containsString:incomingNorm])) {
+        %orig;
+        return;
+    }
+
+    // If the incoming string matches the original body, Apollo is reverting
+    // (e.g. after vote / score color refresh). Substitute the cached
+    // translation, preserving incoming attributes (color, font, links).
+    BOOL incomingIsOriginal = [incomingNorm isEqualToString:originalNorm] ||
+                              [incomingNorm containsString:originalNorm] ||
+                              [originalNorm containsString:incomingNorm];
+    if (incomingIsOriginal) {
+        NSAttributedString *swap = ApolloRebuildTranslatedAttrPreservingAttrs(attributedText, translatedText);
+        objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        @try { %orig(swap); } @catch (__unused NSException *e) {}
+        objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return;
+    }
+
+    // Unknown content (some other text Apollo wants to display). Pass
+    // through unchanged — and clear the marker so this node is no longer
+    // considered ours.
+    objc_setAssociatedObject(self, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    %orig;
+}
+
+%end
 
 %hook _TtC6Apollo15CommentCellNode
 
@@ -971,12 +1478,12 @@ static void ApolloUpdateTranslationButtonForController(id controller) {
 
 - (void)viewDidLoad {
     %orig;
-    ApolloUpdateTranslationButtonForController(self);
+    ApolloUpdateTranslationUIForController(self);
 }
 
 - (void)viewWillAppear:(BOOL)animated {
     %orig;
-    ApolloUpdateTranslationButtonForController(self);
+    ApolloUpdateTranslationUIForController(self);
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -984,9 +1491,10 @@ static void ApolloUpdateTranslationButtonForController(id controller) {
 
     sVisibleCommentsViewController = (UIViewController *)self;
 
-    if (sEnableBulkTranslation && (sAutoTranslateOnAppear || [objc_getAssociatedObject((id)self, kApolloThreadTranslatedModeKey) boolValue])) {
+    if (sEnableBulkTranslation && ApolloControllerIsInTranslatedMode((UIViewController *)self)) {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.12 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             ApolloTranslateVisibleCommentsForController((UIViewController *)self, NO);
+            ApolloUpdateTranslationUIForController(self);
         });
     }
 }
@@ -1009,27 +1517,14 @@ static void ApolloUpdateTranslationButtonForController(id controller) {
     %orig;
 }
 
-%new
-- (void)apollo_toggleThreadTranslation {
-    BOOL translatedMode = [objc_getAssociatedObject((id)self, kApolloThreadTranslatedModeKey) boolValue];
-
-    if (translatedMode) {
-        ApolloRestoreVisibleCommentsForController((UIViewController *)self);
-        objc_setAssociatedObject((id)self, kApolloThreadTranslatedModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    } else {
-        ApolloTranslateVisibleCommentsForController((UIViewController *)self, YES);
-        objc_setAssociatedObject((id)self, kApolloThreadTranslatedModeKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    }
-
-    ApolloUpdateTranslationButtonForController(self);
-}
-
 %end
 
 %ctor {
     sTranslationCache = [NSCache new];
     sCommentTranslationByFullName = [NSCache new];
     sCommentTranslationByFullName.countLimit = 2048;
+    sLinkTranslationByFullName = [NSCache new];
+    sLinkTranslationByFullName.countLimit = 256;
     sPendingTranslationCallbacks = [NSMutableDictionary dictionary];
 
     [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidReceiveMemoryWarningNotification
@@ -1038,6 +1533,7 @@ static void ApolloUpdateTranslationButtonForController(id controller) {
                                                   usingBlock:^(__unused NSNotification *note) {
         [sTranslationCache removeAllObjects];
         [sCommentTranslationByFullName removeAllObjects];
+        [sLinkTranslationByFullName removeAllObjects];
     }];
 
     %init;

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -27,10 +27,11 @@ static __weak UIViewController *sVisibleCommentsViewController = nil;
 // stable derived key when the runtime doesn't expose `name` / `fullName`.
 static NSString *ApolloCommentFullName(RDKComment *comment) {
     if (!comment) return nil;
+    id commentObj = (id)comment;
     SEL sels[] = { @selector(name), NSSelectorFromString(@"fullName"), NSSelectorFromString(@"identifier"), NSSelectorFromString(@"id") };
     for (size_t i = 0; i < sizeof(sels) / sizeof(sels[0]); i++) {
-        if ([comment respondsToSelector:sels[i]]) {
-            id v = ((id (*)(id, SEL))objc_msgSend)(comment, sels[i]);
+        if ([commentObj respondsToSelector:sels[i]]) {
+            id v = ((id (*)(id, SEL))objc_msgSend)(commentObj, sels[i]);
             if ([v isKindOfClass:[NSString class]] && [(NSString *)v length] > 0) return (NSString *)v;
         }
     }

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -2178,7 +2178,7 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     }
     if (!globeButton) {
         globeButton = [UIButton buttonWithType:UIButtonTypeSystem];
-        globeButton.frame = CGRectMake(0.0, 0.0, 18.0, 32.0);
+        globeButton.frame = CGRectMake(0.0, 0.0, 10.0, 32.0);
         [globeButton addTarget:controller action:@selector(apollo_translationGlobeTapped) forControlEvents:UIControlEventTouchUpInside];
     }
     [globeButton setImage:globeImage forState:UIControlStateNormal];

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -17,6 +17,7 @@ static const void *kApolloThreadTranslatedModeKey = &kApolloThreadTranslatedMode
 // don't clobber the user's preference when sAutoTranslateOnAppear is on).
 static const void *kApolloThreadOriginalModeKey = &kApolloThreadOriginalModeKey;
 static const void *kApolloTranslateBarButtonKey = &kApolloTranslateBarButtonKey;
+static const void *kApolloTranslateNegativeSpacerKey = &kApolloTranslateNegativeSpacerKey;
 static const void *kApolloVisibleTranslationAppliedKey = &kApolloVisibleTranslationAppliedKey;
 static const void *kApolloAppliedTranslationFullNameKey = &kApolloAppliedTranslationFullNameKey;
 // Phase D — vote resilience. When we install a translated string into a text
@@ -2154,10 +2155,13 @@ static void ApolloUpdateTranslationUIForController(id controller) {
         objc_setAssociatedObject(controller, kApolloThreadTranslatedModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(controller, kApolloThreadOriginalModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-        if (translationItem) {
-            [items removeObject:translationItem];
+        UIBarButtonItem *spacer = objc_getAssociatedObject(controller, kApolloTranslateNegativeSpacerKey);
+        if (translationItem || spacer) {
+            if (translationItem) [items removeObject:translationItem];
+            if (spacer) [items removeObject:spacer];
             vc.navigationItem.rightBarButtonItems = items;
             objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            objc_setAssociatedObject(controller, kApolloTranslateNegativeSpacerKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         }
         ApolloUpdateBannerForController(vc);
         return;
@@ -2180,7 +2184,6 @@ static void ApolloUpdateTranslationUIForController(id controller) {
         objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, translationItem, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
     translationItem.image = globeImage;
-    translationItem.imageInsets = UIEdgeInsetsMake(0.0, -6.0, 0.0, 6.0);
     translationItem.target = controller;
     translationItem.action = @selector(apollo_translationGlobeTapped);
     translationItem.menu = nil;
@@ -2202,12 +2205,21 @@ static void ApolloUpdateTranslationUIForController(id controller) {
         ? @"Translation: showing translated. Tap to show original."
         : [NSString stringWithFormat:@"Translation: showing original. Tap to translate to %@.", targetName];
 
-    if (![items containsObject:translationItem]) {
-        // Apollo's rightBarButtonItems are displayed right-to-left. Adding at
-        // the END places the globe on the LEFT side of the existing pill,
-        // keeping the three-dots / sort controls in their original slots.
-        [items addObject:translationItem];
+    // Pull the globe closer to Apollo's existing nav pill. rightBarButtonItems
+    // are laid out right-to-left, so a negative-width fixed-space placed just
+    // before the globe (one index earlier) shrinks the visual gap between the
+    // globe and the items to its right.
+    UIBarButtonItem *negativeSpacer = objc_getAssociatedObject(controller, kApolloTranslateNegativeSpacerKey);
+    if (!negativeSpacer) {
+        negativeSpacer = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
+        objc_setAssociatedObject(controller, kApolloTranslateNegativeSpacerKey, negativeSpacer, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
+    negativeSpacer.width = -10.0;
+
+    [items removeObject:translationItem];
+    [items removeObject:negativeSpacer];
+    [items addObject:negativeSpacer];
+    [items addObject:translationItem];
     vc.navigationItem.rightBarButtonItems = items;
 
     ApolloUpdateBannerForController(vc);

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -25,6 +25,7 @@ static const void *kApolloTranslationOwnedTextNodeKey = &kApolloTranslationOwned
 static const void *kApolloOwnedNodeOriginalBodyKey = &kApolloOwnedNodeOriginalBodyKey;
 static const void *kApolloOwnedNodeTranslatedTextKey = &kApolloOwnedNodeTranslatedTextKey;
 static const void *kApolloOwnedNodeReentrancyKey = &kApolloOwnedNodeReentrancyKey;
+static const void *kApolloReapplyScheduledKey = &kApolloReapplyScheduledKey;
 // Phase B — status banner above comments.
 static const void *kApolloTranslationBannerKey = &kApolloTranslationBannerKey;
 // Phase C — post selftext translation.
@@ -558,12 +559,20 @@ static void ApolloRestoreOriginalForCellNode(id commentCellNode, RDKComment *com
 #pragma mark - Phase C: post selftext (header cell) translation
 
 // Returns the post (RDKLink) ivar from a header-style cell node, or nil if
-// this cellNode isn't a post header. Searches a couple of common ivar names.
+// this cellNode isn't a post header. Searches a couple of common ivar names,
+// then falls back to scanning ALL `@`-typed ivars in the class hierarchy
+// (cheap — there are only a handful per class) so we catch Apollo's actual
+// ivar name even if it doesn't match our wishlist.
 static RDKLink *ApolloLinkFromHeaderCellNode(id cellNode) {
     if (!cellNode) return nil;
-    static const char *kLinkIvarNames[] = { "link", "post", "_link", NULL };
     Class rdkLink = NSClassFromString(@"RDKLink");
     if (!rdkLink) return nil;
+
+    // Fast path — common names.
+    static const char *kLinkIvarNames[] = {
+        "link", "post", "_link", "_post", "currentLink", "model", "data",
+        "headerLink", "linkModel", "postModel", NULL
+    };
     for (Class cls = [cellNode class]; cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
         for (size_t i = 0; kLinkIvarNames[i]; i++) {
             Ivar iv = class_getInstanceVariable(cls, kLinkIvarNames[i]);
@@ -574,6 +583,63 @@ static RDKLink *ApolloLinkFromHeaderCellNode(id cellNode) {
             @try { v = object_getIvar(cellNode, iv); } @catch (__unused NSException *e) { continue; }
             if ([v isKindOfClass:rdkLink]) return (RDKLink *)v;
         }
+    }
+
+    // Fallback — scan every `@`-typed ivar in the class hierarchy and return
+    // the first RDKLink we find. Bounded by the small number of ivars per
+    // class, so cheap; this is the path that catches Swift-mangled names.
+    for (Class cls = [cellNode class]; cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
+        unsigned int count = 0;
+        Ivar *ivars = class_copyIvarList(cls, &count);
+        if (!ivars) continue;
+        for (unsigned int i = 0; i < count; i++) {
+            const char *type = ivar_getTypeEncoding(ivars[i]);
+            if (!type || type[0] != '@') continue;
+            id v = nil;
+            @try { v = object_getIvar(cellNode, ivars[i]); } @catch (__unused NSException *e) { continue; }
+            if ([v isKindOfClass:rdkLink]) {
+                free(ivars);
+                return (RDKLink *)v;
+            }
+        }
+        free(ivars);
+    }
+    return nil;
+}
+
+static RDKLink *ApolloLinkFromController(UIViewController *vc) {
+    if (!vc) return nil;
+    Class rdkLink = NSClassFromString(@"RDKLink");
+    if (!rdkLink) return nil;
+    static const char *kNames[] = {
+        "link", "post", "thing", "currentLink", "currentPost", "_link", "_post", NULL
+    };
+    for (Class cls = [vc class]; cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
+        for (size_t i = 0; kNames[i]; i++) {
+            Ivar iv = class_getInstanceVariable(cls, kNames[i]);
+            if (!iv) continue;
+            const char *type = ivar_getTypeEncoding(iv);
+            if (!type || type[0] != '@') continue;
+            id v = nil;
+            @try { v = object_getIvar(vc, iv); } @catch (__unused NSException *e) { continue; }
+            if ([v isKindOfClass:rdkLink]) return (RDKLink *)v;
+        }
+    }
+    for (Class cls = [vc class]; cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
+        unsigned int count = 0;
+        Ivar *ivars = class_copyIvarList(cls, &count);
+        if (!ivars) continue;
+        for (unsigned int i = 0; i < count; i++) {
+            const char *type = ivar_getTypeEncoding(ivars[i]);
+            if (!type || type[0] != '@') continue;
+            id v = nil;
+            @try { v = object_getIvar(vc, ivars[i]); } @catch (__unused NSException *e) { continue; }
+            if ([v isKindOfClass:rdkLink]) {
+                free(ivars);
+                return (RDKLink *)v;
+            }
+        }
+        free(ivars);
     }
     return nil;
 }
@@ -1059,11 +1125,26 @@ static BOOL ApolloReapplyCachedTranslationForCellNode(id commentCellNode) {
     return YES;
 }
 
+static void ApolloScheduleCachedTranslationReapplyForCellNode(id commentCellNode) {
+    if (!commentCellNode || !sEnableBulkTranslation) return;
+    if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) return;
+    if ([objc_getAssociatedObject(commentCellNode, kApolloReapplyScheduledKey) boolValue]) return;
+    objc_setAssociatedObject(commentCellNode, kApolloReapplyScheduledKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    __weak id weakNode = commentCellNode;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.06 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        id strong = weakNode;
+        if (!strong) return;
+        objc_setAssociatedObject(strong, kApolloReapplyScheduledKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloReapplyCachedTranslationForCellNode(strong);
+    });
+}
+
 #pragma mark - Phase C: post selftext translation driver
 
-static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, BOOL forceTranslation) {
+static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *fallbackLink, BOOL forceTranslation) {
     if (!headerCellNode) return;
     RDKLink *link = ApolloLinkFromHeaderCellNode(headerCellNode);
+    if (!link) link = fallbackLink;
     if (!link) return;
     NSString *body = link.selfText;
     if (![body isKindOfClass:[NSString class]]) return;
@@ -1108,6 +1189,7 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, BOOL force
         if (!forceTranslation && !ApolloShouldTranslateNow(NO)) return;
 
         RDKLink *strongLink = ApolloLinkFromHeaderCellNode(strongHeader);
+        if (!strongLink) strongLink = fallbackLink;
         if (!strongLink) return;
         ApolloApplyTranslationToHeaderCellNode(strongHeader, strongLink, translated);
     });
@@ -1118,12 +1200,13 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, BOOL force
 static void ApolloMaybeTranslatePostHeaderForController(UIViewController *viewController, BOOL forceTranslation) {
     UITableView *tableView = GetCommentsTableView(viewController);
     if (!tableView) return;
+    RDKLink *controllerLink = ApolloLinkFromController(viewController);
     for (UITableViewCell *cell in [tableView visibleCells]) {
         SEL nodeSelector = NSSelectorFromString(@"node");
         if (![cell respondsToSelector:nodeSelector]) continue;
         id cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSelector);
-        if (ApolloLinkFromHeaderCellNode(cellNode)) {
-            ApolloMaybeTranslatePostHeaderCellNode(cellNode, forceTranslation);
+        if (ApolloLinkFromHeaderCellNode(cellNode) || (!ApolloCommentFromCellNode(cellNode) && controllerLink)) {
+            ApolloMaybeTranslatePostHeaderCellNode(cellNode, controllerLink, forceTranslation);
         }
     }
 }
@@ -1147,16 +1230,19 @@ static void ApolloTranslateVisibleCommentsForController(UIViewController *viewCo
 static void ApolloRestoreVisibleCommentsForController(UIViewController *viewController) {
     UITableView *tableView = GetCommentsTableView(viewController);
     if (!tableView) return;
+    RDKLink *controllerLink = ApolloLinkFromController(viewController);
 
     for (UITableViewCell *cell in [tableView visibleCells]) {
         SEL nodeSelector = NSSelectorFromString(@"node");
         if (![cell respondsToSelector:nodeSelector]) continue;
 
         id cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSelector);
+        RDKComment *comment = ApolloCommentFromCellNode(cellNode);
 
         // Header cell? Restore post body and skip the comment path.
         RDKLink *link = ApolloLinkFromHeaderCellNode(cellNode);
-        if (link) {
+        if (link || (!comment && controllerLink)) {
+            if (!link) link = controllerLink;
             NSString *linkFullName = link.fullName;
             if (linkFullName.length > 0) {
                 [sLinkTranslationByFullName removeObjectForKey:linkFullName];
@@ -1164,8 +1250,6 @@ static void ApolloRestoreVisibleCommentsForController(UIViewController *viewCont
             ApolloRestoreOriginalForHeaderCellNode(cellNode, link);
             continue;
         }
-
-        RDKComment *comment = ApolloCommentFromCellNode(cellNode);
 
         // Drop from the persistent fullName cache so cellNodeVisibilityEvent:
         // / didEnterDisplayState don't re-apply it after the user asked for
@@ -1181,7 +1265,7 @@ static void ApolloRestoreVisibleCommentsForController(UIViewController *viewCont
 
 #pragma mark - Phase A/B: nav-bar globe icon + status banner
 
-// Forward declaration so the menu's UIAction handler can call it.
+// Forward declaration so the globe bar button action can call it.
 static void ApolloToggleThreadTranslationForController(UIViewController *vc);
 
 // Returns a localized human name for the active target language (e.g. "en"
@@ -1194,61 +1278,81 @@ static NSString *ApolloLocalizedTargetLanguageName(void) {
     return [[name substringToIndex:1].localizedUppercaseString stringByAppendingString:[name substringFromIndex:1]];
 }
 
-// Lazily install a thin status label pinned to the controller view's safe-area
-// top. Hidden by default; the UI updater shows/hides + recolors.
-static UILabel *ApolloEnsureBannerForController(UIViewController *vc) {
-    UILabel *banner = objc_getAssociatedObject(vc, kApolloTranslationBannerKey);
-    if (banner && banner.superview) return banner;
+// Lazily install our small status caption inside the POST HEADER cell view
+// (the cell that shows the post title / author / score / age). Pinned to
+// the bottom-trailing edge of the cell so it sits on the same row as the
+// "100% 2h" metadata — exactly where the user wants it. Returns the label
+// (creating it if necessary) or nil if the header cell view isn't loaded.
+static UILabel *ApolloEnsureBannerInHeaderCellView(UIView *headerCellView) {
+    if (!headerCellView) return nil;
+    UILabel *banner = objc_getAssociatedObject(headerCellView, kApolloTranslationBannerKey);
+    if (banner && banner.superview == headerCellView) return banner;
 
     banner = [[UILabel alloc] init];
     banner.translatesAutoresizingMaskIntoConstraints = NO;
-    banner.font = [UIFont systemFontOfSize:11.0 weight:UIFontWeightMedium];
-    banner.textAlignment = NSTextAlignmentLeft;
+    banner.font = [UIFont systemFontOfSize:11.0 weight:UIFontWeightSemibold];
+    banner.textAlignment = NSTextAlignmentRight;
     banner.backgroundColor = [UIColor clearColor];
     banner.numberOfLines = 1;
     banner.adjustsFontSizeToFitWidth = YES;
     banner.minimumScaleFactor = 0.85;
     banner.userInteractionEnabled = NO;
     banner.hidden = YES;
-    [vc.view addSubview:banner];
+    [headerCellView addSubview:banner];
 
-    UILayoutGuide *safe = vc.view.safeAreaLayoutGuide;
+    // Pin trailing/bottom inside the header cell. Bottom is anchored a bit up
+    // from the divider so it visually aligns with the metadata row baseline.
     [NSLayoutConstraint activateConstraints:@[
-        [banner.topAnchor constraintEqualToAnchor:safe.topAnchor constant:2.0],
-        [banner.leadingAnchor constraintEqualToAnchor:safe.leadingAnchor constant:14.0],
-        [banner.trailingAnchor constraintEqualToAnchor:safe.trailingAnchor constant:-14.0],
+        [banner.trailingAnchor constraintEqualToAnchor:headerCellView.trailingAnchor constant:-14.0],
+        [banner.bottomAnchor constraintEqualToAnchor:headerCellView.bottomAnchor constant:-44.0],
         [banner.heightAnchor constraintEqualToConstant:14.0],
+        [banner.widthAnchor constraintLessThanOrEqualToAnchor:headerCellView.widthAnchor multiplier:0.6],
     ]];
-    objc_setAssociatedObject(vc, kApolloTranslationBannerKey, banner, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(headerCellView, kApolloTranslationBannerKey, banner, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     return banner;
 }
 
-// Builds (or rebuilds) the UIMenu attached to the globe bar button. The menu
-// has one action whose title reflects what tapping it will DO — "Translate
-// to English" when currently showing original, "Show original" when currently
-// translated. This addresses the user's "feels backwards" complaint with the
-// previous text-label button.
-static UIMenu *ApolloBuildTranslationMenuForController(UIViewController *vc) {
+// Finds the post header cell's view (if visible), returns nil otherwise.
+static UIView *ApolloFindPostHeaderCellViewForController(UIViewController *vc) {
+    UITableView *tableView = GetCommentsTableView(vc);
+    if (!tableView) return nil;
+    RDKLink *controllerLink = ApolloLinkFromController(vc);
+    for (UITableViewCell *cell in [tableView visibleCells]) {
+        SEL nodeSelector = NSSelectorFromString(@"node");
+        if (![cell respondsToSelector:nodeSelector]) continue;
+        id cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSelector);
+        if (ApolloLinkFromHeaderCellNode(cellNode) || (!ApolloCommentFromCellNode(cellNode) && controllerLink)) {
+            return cell.contentView ?: cell;
+        }
+    }
+    return nil;
+}
+
+static void ApolloUpdateBannerForController(UIViewController *vc) {
+    if (!vc) return;
+    UIView *headerView = ApolloFindPostHeaderCellViewForController(vc);
+    if (!headerView) return;  // header off-screen, nothing to do
+
+    UILabel *banner = ApolloEnsureBannerInHeaderCellView(headerView);
+    if (!banner) return;
+
+    if (!sEnableBulkTranslation) {
+        banner.hidden = YES;
+        return;
+    }
+
     BOOL translatedMode = ApolloControllerIsInTranslatedMode(vc);
     NSString *targetName = ApolloLocalizedTargetLanguageName();
 
-    NSString *title = translatedMode
-        ? @"Show original"
-        : [NSString stringWithFormat:@"Translate to %@", targetName];
-
-    UIImage *image = [UIImage systemImageNamed:translatedMode ? @"text.bubble" : @"globe"];
-
-    __weak UIViewController *weakVC = vc;
-    UIAction *toggle = [UIAction actionWithTitle:title
-                                           image:image
-                                      identifier:nil
-                                         handler:^(__kindof UIAction * _Nonnull action) {
-        UIViewController *strong = weakVC;
-        if (!strong) return;
-        ApolloToggleThreadTranslationForController(strong);
-    }];
-
-    return [UIMenu menuWithTitle:@"" children:@[toggle]];
+    banner.hidden = NO;
+    if (translatedMode) {
+        banner.text = [NSString stringWithFormat:@"Translated to %@", targetName];
+        banner.textColor = [UIColor systemGreenColor];
+    } else {
+        banner.text = @"Original language";
+        banner.textColor = [UIColor systemBlueColor];
+    }
+    [banner.superview bringSubviewToFront:banner];
 }
 
 static void ApolloUpdateTranslationUIForController(id controller) {
@@ -1256,8 +1360,6 @@ static void ApolloUpdateTranslationUIForController(id controller) {
 
     UIBarButtonItem *translationItem = objc_getAssociatedObject(controller, kApolloTranslateBarButtonKey);
     NSMutableArray<UIBarButtonItem *> *items = [vc.navigationItem.rightBarButtonItems mutableCopy] ?: [NSMutableArray array];
-    UILabel *banner = objc_getAssociatedObject(controller, kApolloTranslationBannerKey);
-
     if (!sEnableBulkTranslation) {
         // Feature flipped off: revert any active translation, drop the bar
         // button + hide the banner. Do not leak associations.
@@ -1272,7 +1374,7 @@ static void ApolloUpdateTranslationUIForController(id controller) {
             vc.navigationItem.rightBarButtonItems = items;
             objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         }
-        if (banner) banner.hidden = YES;
+        ApolloUpdateBannerForController(vc);
         return;
     }
 
@@ -1285,44 +1387,30 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     if (!translationItem) {
         translationItem = [[UIBarButtonItem alloc] initWithImage:globeImage
                                                            style:UIBarButtonItemStylePlain
-                                                          target:nil
-                                                          action:nil];
+                                                          target:controller
+                                                          action:@selector(apollo_translationGlobeTapped)];
         // Slight visual hint when translated mode is on — same image, distinct
         // tint so the user sees at a glance.
         objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, translationItem, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
     translationItem.image = globeImage;
-    translationItem.tintColor = translatedMode ? [UIColor systemGreenColor] : nil;
-    translationItem.menu = ApolloBuildTranslationMenuForController(vc);
+    translationItem.target = controller;
+    translationItem.action = @selector(apollo_translationGlobeTapped);
+    translationItem.menu = nil;
+    translationItem.tintColor = translatedMode ? [UIColor systemGreenColor] : [UIColor systemBlueColor];
     translationItem.accessibilityLabel = translatedMode
         ? @"Translation: showing translated. Tap to show original."
         : [NSString stringWithFormat:@"Translation: showing original. Tap to translate to %@.", targetName];
 
     if (![items containsObject:translationItem]) {
-        // Insert at the front of the right-side stack so it sits at the far
-        // right edge (Apollo's existing rightBarButtonItems are ordered
-        // right-to-left).
-        [items insertObject:translationItem atIndex:0];
+        // Apollo's rightBarButtonItems are displayed right-to-left. Adding at
+        // the END places the globe on the LEFT side of the existing pill,
+        // keeping the three-dots / sort controls in their original slots.
+        [items addObject:translationItem];
     }
     vc.navigationItem.rightBarButtonItems = items;
 
-    // Phase B — banner.
-    UILabel *b = ApolloEnsureBannerForController(vc);
-    BOOL userInteracted = [objc_getAssociatedObject(controller, kApolloThreadTranslatedModeKey) boolValue] ||
-                          [objc_getAssociatedObject(controller, kApolloThreadOriginalModeKey) boolValue];
-    BOOL showBanner = userInteracted || sAutoTranslateOnAppear;
-    if (!showBanner) {
-        b.hidden = YES;
-    } else {
-        b.hidden = NO;
-        if (translatedMode) {
-            b.text = [NSString stringWithFormat:@"Translated to %@", targetName];
-            b.textColor = [UIColor systemGreenColor];
-        } else {
-            b.text = @"Showing original";
-            b.textColor = [UIColor systemBlueColor];
-        }
-    }
+    ApolloUpdateBannerForController(vc);
 }
 
 static void ApolloToggleThreadTranslationForController(UIViewController *vc) {
@@ -1422,7 +1510,69 @@ static NSAttributedString *ApolloRebuildTranslatedAttrPreservingAttrs(NSAttribut
 
 %end
 
+%hook ASTextNode2
+
+- (void)setAttributedText:(NSAttributedString *)attributedText {
+    if (![objc_getAssociatedObject(self, kApolloTranslationOwnedTextNodeKey) boolValue]) {
+        %orig;
+        return;
+    }
+
+    if ([objc_getAssociatedObject(self, kApolloOwnedNodeReentrancyKey) boolValue]) {
+        %orig;
+        return;
+    }
+
+    NSString *originalBody = objc_getAssociatedObject(self, kApolloOwnedNodeOriginalBodyKey);
+    NSString *translatedText = objc_getAssociatedObject(self, kApolloOwnedNodeTranslatedTextKey);
+
+    if (![originalBody isKindOfClass:[NSString class]] || originalBody.length == 0 ||
+        ![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0 ||
+        ![attributedText isKindOfClass:[NSAttributedString class]]) {
+        %orig;
+        return;
+    }
+
+    NSString *incomingNorm = ApolloNormalizeTextForCompare(attributedText.string);
+    NSString *originalNorm = ApolloNormalizeTextForCompare(originalBody);
+    NSString *translatedNorm = ApolloNormalizeTextForCompare(translatedText);
+
+    if (translatedNorm.length > 0 &&
+        ([incomingNorm isEqualToString:translatedNorm] ||
+         [incomingNorm containsString:translatedNorm] ||
+         [translatedNorm containsString:incomingNorm])) {
+        %orig;
+        return;
+    }
+
+    BOOL incomingIsOriginal = [incomingNorm isEqualToString:originalNorm] ||
+                              [incomingNorm containsString:originalNorm] ||
+                              [originalNorm containsString:incomingNorm];
+    if (incomingIsOriginal) {
+        NSAttributedString *swap = ApolloRebuildTranslatedAttrPreservingAttrs(attributedText, translatedText);
+        objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        @try { %orig(swap); } @catch (__unused NSException *e) {}
+        objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return;
+    }
+
+    objc_setAssociatedObject(self, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    %orig;
+}
+
+%end
+
 %hook _TtC6Apollo15CommentCellNode
+
+- (void)setNeedsLayout {
+    %orig;
+    ApolloScheduleCachedTranslationReapplyForCellNode((id)self);
+}
+
+- (void)setNeedsDisplay {
+    %orig;
+    ApolloScheduleCachedTranslationReapplyForCellNode((id)self);
+}
 
 - (void)didLoad {
     %orig;
@@ -1515,6 +1665,11 @@ static NSAttributedString *ApolloRebuildTranslatedAttrPreservingAttrs(NSAttribut
         }
     }
     %orig;
+}
+
+%new
+- (void)apollo_translationGlobeTapped {
+    ApolloToggleThreadTranslationForController((UIViewController *)self);
 }
 
 %end

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -140,6 +140,74 @@ static NSString *ApolloNormalizeTextForCompare(NSString *text) {
     return [nonEmpty componentsJoinedByString:@" "];
 }
 
+static NSString *ApolloTrimmedString(NSString *text) {
+    if (![text isKindOfClass:[NSString class]]) return @"";
+    return [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
+static BOOL ApolloTextLooksLikeURLPreview(NSString *text) {
+    NSString *trimmed = ApolloTrimmedString(text);
+    if (trimmed.length == 0) return NO;
+
+    NSString *lower = trimmed.lowercaseString;
+    if ([lower hasPrefix:@"http://"] || [lower hasPrefix:@"https://"] || [lower hasPrefix:@"www."]) return YES;
+
+    NSRange firstWhitespace = [lower rangeOfCharacterFromSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    NSString *firstToken = firstWhitespace.location == NSNotFound ? lower : [lower substringToIndex:firstWhitespace.location];
+    if ([firstToken containsString:@"."] && ([firstToken containsString:@"/"] || [firstToken hasSuffix:@"…"] || [firstToken hasSuffix:@"..."])) {
+        return YES;
+    }
+
+    return NO;
+}
+
+static BOOL ApolloTextLooksLikePreviewExcerptOfBody(NSString *candidateText, NSString *bodyText) {
+    NSString *candidate = ApolloTrimmedString(candidateText);
+    NSString *body = ApolloTrimmedString(bodyText);
+    if (candidate.length == 0 || body.length == 0 || candidate.length >= body.length) return NO;
+
+    NSString *candidateNorm = ApolloNormalizeTextForCompare(candidate);
+    NSString *bodyNorm = ApolloNormalizeTextForCompare(body);
+    if (candidateNorm.length == 0 || bodyNorm.length == 0 || ![bodyNorm containsString:candidateNorm]) return NO;
+
+    BOOL visiblyTruncated = [candidate containsString:@"..."] || [candidate containsString:@"…"];
+    BOOL markdownExcerpt = ([candidate containsString:@"**"] || [candidate containsString:@"*"]) && visiblyTruncated;
+    CGFloat ratio = (CGFloat)candidateNorm.length / (CGFloat)bodyNorm.length;
+    return ApolloTextLooksLikeURLPreview(candidate) || markdownExcerpt || ratio < 0.60;
+}
+
+static BOOL ApolloTextQualifiesAsBodyCandidate(NSString *candidateText, NSString *bodyText) {
+    NSString *candidateNorm = ApolloNormalizeTextForCompare(candidateText);
+    NSString *bodyNorm = ApolloNormalizeTextForCompare(bodyText);
+    if (candidateNorm.length == 0 || bodyNorm.length == 0) return NO;
+    if ([candidateNorm isEqualToString:bodyNorm]) return YES;
+
+    if (ApolloTextLooksLikeURLPreview(candidateText) || ApolloTextLooksLikePreviewExcerptOfBody(candidateText, bodyText)) return NO;
+
+    if ([candidateNorm containsString:bodyNorm]) return YES;
+    if ([bodyNorm containsString:candidateNorm]) {
+        CGFloat ratio = (CGFloat)candidateNorm.length / (CGFloat)bodyNorm.length;
+        return ratio >= 0.60 || candidateNorm.length >= 160;
+    }
+
+    NSUInteger prefixLength = MIN((NSUInteger)24, MIN(candidateNorm.length, bodyNorm.length));
+    if (prefixLength >= 12) {
+        NSString *candidatePrefix = [candidateNorm substringToIndex:prefixLength];
+        NSString *bodyPrefix = [bodyNorm substringToIndex:prefixLength];
+        if ([candidatePrefix isEqualToString:bodyPrefix]) {
+            CGFloat ratio = (CGFloat)candidateNorm.length / (CGFloat)bodyNorm.length;
+            return ratio >= 0.60 || candidateNorm.length >= 160;
+        }
+    }
+
+    return NO;
+}
+
+static BOOL ApolloTextIsSubstantiveForOwnershipCleanup(NSString *text) {
+    NSString *norm = ApolloNormalizeTextForCompare(text);
+    return norm.length >= 3;
+}
+
 static BOOL ApolloTextContainsMarkdownCode(NSString *text) {
     if (![text isKindOfClass:[NSString class]] || text.length == 0) return NO;
     NSString *lower = text.lowercaseString;
@@ -361,7 +429,11 @@ static NSString *ApolloDisplayStringByConvertingMarkdownLinks(NSString *text, NS
         NSRange urlRange = [match rangeAtIndex:2];
         NSString *title = (titleRange.location != NSNotFound && NSMaxRange(titleRange) <= text.length) ? [text substringWithRange:titleRange] : nil;
         NSString *urlString = (urlRange.location != NSNotFound && NSMaxRange(urlRange) <= text.length) ? [text substringWithRange:urlRange] : nil;
-        if (title.length == 0) title = [text substringWithRange:match.range];
+        if (title.length == 0 || urlString.length == 0) {
+            [display appendString:[text substringWithRange:match.range]];
+            cursor = NSMaxRange(match.range);
+            continue;
+        }
 
         NSRange displayRange = NSMakeRange(display.length, title.length);
         [display appendString:title];
@@ -698,19 +770,17 @@ static NSInteger ApolloCandidateScore(NSAttributedString *candidateText, NSStrin
         return 100000 + (NSInteger)candidate.length;
     }
 
-    if ([candidate containsString:body] || [body containsString:candidate]) {
+    if (ApolloTextQualifiesAsBodyCandidate(candidateText.string, commentBody)) {
         // Require the overlap to be a meaningful chunk, not just a stray word.
         NSUInteger overlap = MIN(candidate.length, body.length);
-        if (overlap >= 12 || overlap == body.length || overlap == candidate.length) {
-            return 75000 + (NSInteger)overlap;
-        }
+        return 75000 + (NSInteger)overlap;
     }
 
     NSUInteger prefixLength = MIN((NSUInteger)24, MIN(candidate.length, body.length));
     if (prefixLength >= 12) {
         NSString *candidatePrefix = [candidate substringToIndex:prefixLength];
         NSString *bodyPrefix = [body substringToIndex:prefixLength];
-        if ([candidatePrefix isEqualToString:bodyPrefix]) {
+        if ([candidatePrefix isEqualToString:bodyPrefix] && ApolloTextQualifiesAsBodyCandidate(candidateText.string, commentBody)) {
             return 50000 + (NSInteger)candidate.length;
         }
     }
@@ -772,13 +842,8 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
     NSString *bodyNorm = ApolloNormalizeTextForCompare(comment.body);
     NSString *translatedNorm = ApolloNormalizeTextForCompare(translatedText);
     if (currentNorm.length == 0 || bodyNorm.length == 0) return;
-    BOOL textMatchesBody = [currentNorm isEqualToString:bodyNorm] ||
-                           [currentNorm containsString:bodyNorm] ||
-                           [bodyNorm containsString:currentNorm];
-    BOOL textMatchesTranslation = translatedNorm.length > 0 &&
-        ([currentNorm isEqualToString:translatedNorm] ||
-         [currentNorm containsString:translatedNorm] ||
-         [translatedNorm containsString:currentNorm]);
+    BOOL textMatchesBody = ApolloTextQualifiesAsBodyCandidate(current.string, comment.body);
+    BOOL textMatchesTranslation = translatedNorm.length > 0 && ApolloTextQualifiesAsBodyCandidate(current.string, translatedText);
     if (!textMatchesBody && !textMatchesTranslation) {
         ApolloLog(@"[Translation] Skipping write — chosen node text does not match body or translation");
         return;
@@ -2068,34 +2133,14 @@ static NSAttributedString *ApolloRebuildTranslatedAttrPreservingAttrs(NSAttribut
     return ApolloTranslatedAttributedStringPreservingVisualLinks(incoming, translatedText);
 }
 
-static BOOL ApolloNormalizedTextMatchesVariant(NSString *incomingNorm, NSString *targetNorm) {
-    if (incomingNorm.length == 0 || targetNorm.length == 0) return NO;
-    if ([incomingNorm isEqualToString:targetNorm]) return YES;
-
-    BOOL contains = [incomingNorm containsString:targetNorm] || [targetNorm containsString:incomingNorm];
-    if (contains) {
-        NSUInteger overlap = MIN(incomingNorm.length, targetNorm.length);
-        if (overlap >= 12) return YES;
-    }
-
-    NSUInteger prefixLength = MIN((NSUInteger)24, MIN(incomingNorm.length, targetNorm.length));
-    if (prefixLength >= 12) {
-        NSString *incomingPrefix = [incomingNorm substringToIndex:prefixLength];
-        NSString *targetPrefix = [targetNorm substringToIndex:prefixLength];
-        if ([incomingPrefix isEqualToString:targetPrefix]) return YES;
-    }
-
-    return NO;
-}
-
 static BOOL ApolloTextMatchesSourceOrVisualDisplay(NSString *incomingText, NSString *targetText) {
-    NSString *incomingNorm = ApolloNormalizeTextForCompare(incomingText);
     NSString *targetNorm = ApolloNormalizeTextForCompare(targetText);
-    if (ApolloNormalizedTextMatchesVariant(incomingNorm, targetNorm)) return YES;
+    if (targetNorm.length == 0) return NO;
+    if (ApolloTextQualifiesAsBodyCandidate(incomingText, targetText)) return YES;
 
     NSString *targetDisplay = ApolloDisplayStringByConvertingMarkdownLinks(targetText, nil);
     NSString *targetDisplayNorm = ApolloNormalizeTextForCompare(targetDisplay);
-    return ![targetDisplayNorm isEqualToString:targetNorm] && ApolloNormalizedTextMatchesVariant(incomingNorm, targetDisplayNorm);
+    return ![targetDisplayNorm isEqualToString:targetNorm] && ApolloTextQualifiesAsBodyCandidate(incomingText, targetDisplay);
 }
 
 static void ApolloClearTranslationOwnershipForTextNode(id textNode) {
@@ -2128,7 +2173,7 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
         return YES;
     }
 
-    if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) {
+    if (ApolloTextIsSubstantiveForOwnershipCleanup(incomingText)) {
         ApolloClearTranslationOwnershipForTextNode(textNode);
     }
     return NO;

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -17,7 +17,6 @@ static const void *kApolloThreadTranslatedModeKey = &kApolloThreadTranslatedMode
 // don't clobber the user's preference when sAutoTranslateOnAppear is on).
 static const void *kApolloThreadOriginalModeKey = &kApolloThreadOriginalModeKey;
 static const void *kApolloTranslateBarButtonKey = &kApolloTranslateBarButtonKey;
-static const void *kApolloTranslateNegativeSpacerKey = &kApolloTranslateNegativeSpacerKey;
 static const void *kApolloVisibleTranslationAppliedKey = &kApolloVisibleTranslationAppliedKey;
 static const void *kApolloAppliedTranslationFullNameKey = &kApolloAppliedTranslationFullNameKey;
 // Phase D — vote resilience. When we install a translated string into a text
@@ -2155,13 +2154,10 @@ static void ApolloUpdateTranslationUIForController(id controller) {
         objc_setAssociatedObject(controller, kApolloThreadTranslatedModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(controller, kApolloThreadOriginalModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-        UIBarButtonItem *spacer = objc_getAssociatedObject(controller, kApolloTranslateNegativeSpacerKey);
-        if (translationItem || spacer) {
-            if (translationItem) [items removeObject:translationItem];
-            if (spacer) [items removeObject:spacer];
+        if (translationItem) {
+            [items removeObject:translationItem];
             vc.navigationItem.rightBarButtonItems = items;
             objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            objc_setAssociatedObject(controller, kApolloTranslateNegativeSpacerKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         }
         ApolloUpdateBannerForController(vc);
         return;
@@ -2171,21 +2167,28 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     BOOL visibleTranslationApplied = [objc_getAssociatedObject(vc, kApolloVisibleTranslationAppliedKey) boolValue];
     NSString *targetName = ApolloLocalizedTargetLanguageName();
 
-    // Compact globe icon — same width as the existing nav buttons, so the
-    // central pill (sort/3-dots) is not pushed out of place.
-    UIImage *globeImage = [UIImage systemImageNamed:@"globe"];
-    if (!translationItem) {
-        translationItem = [[UIBarButtonItem alloc] initWithImage:globeImage
-                                                           style:UIBarButtonItemStylePlain
-                                                          target:controller
-                                                          action:@selector(apollo_translationGlobeTapped)];
-        // Slight visual hint when translated mode is on — same image, distinct
-        // tint so the user sees at a glance.
-        objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, translationItem, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    // Compact globe icon — backed by a UIButton in a custom view so we can
+    // shrink its slot below UIKit's default ~44pt and keep it grouped in the
+    // same bubble as Apollo's sort/3-dots items (any fixed-space item would
+    // split that bubble).
+    UIImage *globeImage = [[UIImage systemImageNamed:@"globe"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    UIButton *globeButton = nil;
+    if (translationItem && [translationItem.customView isKindOfClass:[UIButton class]]) {
+        globeButton = (UIButton *)translationItem.customView;
     }
-    translationItem.image = globeImage;
-    translationItem.target = controller;
-    translationItem.action = @selector(apollo_translationGlobeTapped);
+    if (!globeButton) {
+        globeButton = [UIButton buttonWithType:UIButtonTypeSystem];
+        globeButton.frame = CGRectMake(0.0, 0.0, 26.0, 32.0);
+        [globeButton addTarget:controller action:@selector(apollo_translationGlobeTapped) forControlEvents:UIControlEventTouchUpInside];
+    }
+    [globeButton setImage:globeImage forState:UIControlStateNormal];
+
+    if (!translationItem) {
+        translationItem = [[UIBarButtonItem alloc] initWithCustomView:globeButton];
+        objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, translationItem, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    } else if (translationItem.customView != globeButton) {
+        translationItem.customView = globeButton;
+    }
     translationItem.menu = nil;
     UIColor *themeTintColor = ApolloThemeTintColorFromNavigationItems(items, translationItem, vc.traitCollection);
     if (!themeTintColor) {
@@ -2200,26 +2203,20 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     if (!themeTintColor) {
         themeTintColor = [UIColor systemBlueColor];
     }
-    translationItem.tintColor = visibleTranslationApplied ? [UIColor systemGreenColor] : themeTintColor;
-    translationItem.accessibilityLabel = translatedMode
+    UIColor *resolvedTint = visibleTranslationApplied ? [UIColor systemGreenColor] : themeTintColor;
+    translationItem.tintColor = resolvedTint;
+    globeButton.tintColor = resolvedTint;
+    globeButton.accessibilityLabel = translatedMode
         ? @"Translation: showing translated. Tap to show original."
         : [NSString stringWithFormat:@"Translation: showing original. Tap to translate to %@.", targetName];
+    translationItem.accessibilityLabel = globeButton.accessibilityLabel;
 
-    // Pull the globe closer to Apollo's existing nav pill. rightBarButtonItems
-    // are laid out right-to-left, so a negative-width fixed-space placed just
-    // before the globe (one index earlier) shrinks the visual gap between the
-    // globe and the items to its right.
-    UIBarButtonItem *negativeSpacer = objc_getAssociatedObject(controller, kApolloTranslateNegativeSpacerKey);
-    if (!negativeSpacer) {
-        negativeSpacer = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
-        objc_setAssociatedObject(controller, kApolloTranslateNegativeSpacerKey, negativeSpacer, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (![items containsObject:translationItem]) {
+        // Apollo's rightBarButtonItems are laid out right-to-left. Adding to
+        // the end places the globe just to the left of Apollo's sort/3-dots
+        // pill — same bubble, tighter spacing thanks to the narrower frame.
+        [items addObject:translationItem];
     }
-    negativeSpacer.width = -10.0;
-
-    [items removeObject:translationItem];
-    [items removeObject:negativeSpacer];
-    [items addObject:negativeSpacer];
-    [items addObject:translationItem];
     vc.navigationItem.rightBarButtonItems = items;
 
     ApolloUpdateBannerForController(vc);

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -2045,6 +2045,44 @@ static void ApolloUpdateBannerForController(UIViewController *vc) {
     banner.hidden = YES;
 }
 
+static BOOL ApolloTextMatchesTranslatedDisplayText(NSString *visibleText, NSString *translatedText) {
+    if (ApolloTextQualifiesAsBodyCandidate(visibleText, translatedText)) return YES;
+
+    NSString *translatedDisplay = ApolloDisplayStringByConvertingMarkdownLinks(translatedText, nil);
+    NSString *translatedNorm = ApolloNormalizeTextForCompare(translatedText);
+    NSString *displayNorm = ApolloNormalizeTextForCompare(translatedDisplay);
+    return displayNorm.length > 0 && ![displayNorm isEqualToString:translatedNorm] && ApolloTextQualifiesAsBodyCandidate(visibleText, translatedDisplay);
+}
+
+static BOOL ApolloRefreshVisibleTranslationAppliedForController(UIViewController *vc) {
+    if (!vc || !ApolloControllerIsInTranslatedMode(vc)) return NO;
+
+    NSMutableArray *nodes = [NSMutableArray array];
+    NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:128];
+    ApolloCollectAttributedTextNodes(vc.view, 8, visited, nodes);
+
+    for (id node in nodes) {
+        if (![objc_getAssociatedObject(node, kApolloTranslationOwnedTextNodeKey) boolValue]) continue;
+
+        NSString *originalBody = objc_getAssociatedObject(node, kApolloOwnedNodeOriginalBodyKey);
+        NSString *translatedText = objc_getAssociatedObject(node, kApolloOwnedNodeTranslatedTextKey);
+        if (![originalBody isKindOfClass:[NSString class]] || ![translatedText isKindOfClass:[NSString class]]) continue;
+        if (!ApolloTranslatedTextDiffersFromSource(originalBody, translatedText)) continue;
+
+        NSAttributedString *attr = nil;
+        @try { attr = ((id (*)(id, SEL))objc_msgSend)(node, @selector(attributedText)); }
+        @catch (__unused NSException *e) { continue; }
+        if (![attr isKindOfClass:[NSAttributedString class]] || attr.string.length == 0) continue;
+
+        if (ApolloTextMatchesTranslatedDisplayText(attr.string, translatedText)) {
+            objc_setAssociatedObject(vc, kApolloVisibleTranslationAppliedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
 static void ApolloUpdateTranslationUIForController(id controller) {
     UIViewController *vc = (UIViewController *)controller;
 
@@ -2310,6 +2348,7 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
 
 - (void)viewWillAppear:(BOOL)animated {
     %orig;
+    ApolloRefreshVisibleTranslationAppliedForController((UIViewController *)self);
     ApolloUpdateTranslationUIForController(self);
     ApolloSchedulePostBodyReapplyForController((UIViewController *)self);
 }
@@ -2325,10 +2364,11 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
     sVisibleCommentsViewController = (UIViewController *)self;
 
     if (sEnableBulkTranslation && ApolloControllerIsInTranslatedMode((UIViewController *)self)) {
-        ApolloClearVisibleTranslationApplied((UIViewController *)self);
+        ApolloRefreshVisibleTranslationAppliedForController((UIViewController *)self);
         ApolloUpdateTranslationUIForController(self);
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.12 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             ApolloTranslateVisibleCommentsForController((UIViewController *)self, NO);
+            ApolloRefreshVisibleTranslationAppliedForController((UIViewController *)self);
             ApolloUpdateTranslationUIForController(self);
             ApolloSchedulePostBodyReapplyForController((UIViewController *)self);
         });

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -286,6 +286,159 @@ static NSString *ApolloRestoreTranslationLinks(NSString *translatedText, NSDicti
     return [restoredText copy];
 }
 
+static NSDictionary *ApolloAttributesWithoutLinkAttribute(NSDictionary *attributes) {
+    if (![attributes isKindOfClass:[NSDictionary class]] || attributes.count == 0) return @{};
+    NSMutableDictionary *filteredAttributes = [attributes mutableCopy];
+    [filteredAttributes removeObjectForKey:NSLinkAttributeName];
+    return [filteredAttributes copy];
+}
+
+static NSDictionary *ApolloVisualBaseAttributesFromAttributedString(NSAttributedString *attributedText) {
+    if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return @{};
+
+    __block NSDictionary *firstAttributes = nil;
+    __block NSDictionary *firstNonLinkAttributes = nil;
+    [attributedText enumerateAttributesInRange:NSMakeRange(0, attributedText.length)
+                                       options:0
+                                    usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attrs, __unused NSRange range, BOOL *stop) {
+        if (!firstAttributes) firstAttributes = attrs;
+        if (!attrs[NSLinkAttributeName]) {
+            firstNonLinkAttributes = attrs;
+            *stop = YES;
+        }
+    }];
+
+    return ApolloAttributesWithoutLinkAttribute(firstNonLinkAttributes ?: firstAttributes ?: @{});
+}
+
+static NSDictionary *ApolloFirstLinkAttributesFromAttributedString(NSAttributedString *attributedText) {
+    if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return nil;
+
+    __block NSDictionary *linkAttributes = nil;
+    [attributedText enumerateAttributesInRange:NSMakeRange(0, attributedText.length)
+                                       options:0
+                                    usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attrs, __unused NSRange range, BOOL *stop) {
+        if (attrs[NSLinkAttributeName]) {
+            linkAttributes = attrs;
+            *stop = YES;
+        }
+    }];
+    return linkAttributes;
+}
+
+static id ApolloLinkAttributeValueForURLString(NSString *urlString) {
+    if (![urlString isKindOfClass:[NSString class]] || urlString.length == 0) return nil;
+    NSURL *url = [NSURL URLWithString:urlString];
+    return url ?: urlString;
+}
+
+static BOOL ApolloRangeIntersectsRange(NSRange lhs, NSRange rhs) {
+    if (lhs.location == NSNotFound || rhs.location == NSNotFound) return NO;
+    return NSIntersectionRange(lhs, rhs).length > 0;
+}
+
+static NSString *ApolloDisplayStringByConvertingMarkdownLinks(NSString *text, NSMutableArray<NSDictionary *> **markdownLinksOut) {
+    if (markdownLinksOut) *markdownLinksOut = [NSMutableArray array];
+    if (![text isKindOfClass:[NSString class]] || text.length == 0) return text;
+
+    NSError *regexError = nil;
+    NSRegularExpression *markdownLinkRegex = [NSRegularExpression regularExpressionWithPattern:@"\\[([^\\]\\n]+)\\]\\((https?://[^\\s)]+)(?:\\s+\\\"[^\\\"]*\\\")?\\)"
+                                                                                       options:NSRegularExpressionCaseInsensitive
+                                                                                         error:&regexError];
+    if (regexError || !markdownLinkRegex) return text;
+
+    NSArray<NSTextCheckingResult *> *matches = [markdownLinkRegex matchesInString:text options:0 range:NSMakeRange(0, text.length)];
+    if (matches.count == 0) return text;
+
+    NSMutableString *display = [NSMutableString string];
+    NSMutableArray<NSDictionary *> *markdownLinks = markdownLinksOut ? *markdownLinksOut : nil;
+    NSUInteger cursor = 0;
+    for (NSTextCheckingResult *match in matches) {
+        if (match.range.location < cursor || NSMaxRange(match.range) > text.length) continue;
+        [display appendString:[text substringWithRange:NSMakeRange(cursor, match.range.location - cursor)]];
+
+        NSRange titleRange = [match rangeAtIndex:1];
+        NSRange urlRange = [match rangeAtIndex:2];
+        NSString *title = (titleRange.location != NSNotFound && NSMaxRange(titleRange) <= text.length) ? [text substringWithRange:titleRange] : nil;
+        NSString *urlString = (urlRange.location != NSNotFound && NSMaxRange(urlRange) <= text.length) ? [text substringWithRange:urlRange] : nil;
+        if (title.length == 0) title = [text substringWithRange:match.range];
+
+        NSRange displayRange = NSMakeRange(display.length, title.length);
+        [display appendString:title];
+        if (markdownLinks && urlString.length > 0 && displayRange.length > 0) {
+            [markdownLinks addObject:@{@"range": [NSValue valueWithRange:displayRange], @"url": urlString}];
+        }
+        cursor = NSMaxRange(match.range);
+    }
+    if (cursor < text.length) {
+        [display appendString:[text substringFromIndex:cursor]];
+    }
+    return [display copy];
+}
+
+static void ApolloApplyLinkAttributes(NSMutableAttributedString *attributedString,
+                                      NSRange range,
+                                      NSString *urlString,
+                                      NSDictionary *baseAttributes,
+                                      NSDictionary *sourceLinkAttributes) {
+    if (![attributedString isKindOfClass:[NSMutableAttributedString class]]) return;
+    if (range.location == NSNotFound || range.length == 0 || NSMaxRange(range) > attributedString.length) return;
+    id linkValue = ApolloLinkAttributeValueForURLString(urlString);
+    if (!linkValue) return;
+
+    NSMutableDictionary *attributes = [NSMutableDictionary dictionaryWithDictionary:baseAttributes ?: @{}];
+    if ([sourceLinkAttributes isKindOfClass:[NSDictionary class]]) {
+        [attributes addEntriesFromDictionary:sourceLinkAttributes];
+    }
+    attributes[NSLinkAttributeName] = linkValue;
+    [attributedString addAttributes:attributes range:range];
+}
+
+static NSAttributedString *ApolloTranslatedAttributedStringPreservingVisualLinks(NSAttributedString *visualBase,
+                                                                                 NSString *translatedText) {
+    if (![translatedText isKindOfClass:[NSString class]]) translatedText = @"";
+
+    NSMutableArray<NSDictionary *> *markdownLinks = nil;
+    NSString *displayText = ApolloDisplayStringByConvertingMarkdownLinks(translatedText, &markdownLinks);
+    NSDictionary *baseAttributes = ApolloVisualBaseAttributesFromAttributedString(visualBase);
+    NSDictionary *sourceLinkAttributes = ApolloFirstLinkAttributesFromAttributedString(visualBase);
+    NSMutableAttributedString *attributed = [[NSMutableAttributedString alloc] initWithString:displayText ?: @"" attributes:baseAttributes ?: @{}];
+
+    for (NSDictionary *linkInfo in markdownLinks) {
+        NSValue *rangeValue = linkInfo[@"range"];
+        NSString *urlString = linkInfo[@"url"];
+        if (![rangeValue isKindOfClass:[NSValue class]] || ![urlString isKindOfClass:[NSString class]]) continue;
+        ApolloApplyLinkAttributes(attributed, rangeValue.rangeValue, urlString, baseAttributes, sourceLinkAttributes);
+    }
+
+    NSError *regexError = nil;
+    NSRegularExpression *bareURLRegex = [NSRegularExpression regularExpressionWithPattern:@"(?i)\\bhttps?://[^\\s<>()\\[\\]{}\\\"']+"
+                                                                                options:0
+                                                                                  error:&regexError];
+    if (!regexError && bareURLRegex && attributed.length > 0) {
+        NSArray<NSTextCheckingResult *> *matches = [bareURLRegex matchesInString:attributed.string options:0 range:NSMakeRange(0, attributed.length)];
+        for (NSTextCheckingResult *match in matches) {
+            NSRange range = ApolloRangeByTrimmingTrailingURLPunctuation(attributed.string, match.range);
+            if (range.length == 0 || NSMaxRange(range) > attributed.length) continue;
+
+            BOOL overlapsMarkdownLink = NO;
+            for (NSDictionary *linkInfo in markdownLinks) {
+                NSValue *rangeValue = linkInfo[@"range"];
+                if ([rangeValue isKindOfClass:[NSValue class]] && ApolloRangeIntersectsRange(range, rangeValue.rangeValue)) {
+                    overlapsMarkdownLink = YES;
+                    break;
+                }
+            }
+            if (overlapsMarkdownLink) continue;
+
+            NSString *urlString = [attributed.string substringWithRange:range];
+            ApolloApplyLinkAttributes(attributed, range, urlString, baseAttributes, sourceLinkAttributes);
+        }
+    }
+
+    return [attributed copy];
+}
+
 static BOOL ApolloThreadTranslationModeEnabledForVisibleCommentsVC(void) __attribute__((unused));
 static BOOL ApolloThreadTranslationModeEnabledForVisibleCommentsVC(void) {
     UIViewController *vc = sVisibleCommentsViewController;
@@ -640,12 +793,7 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
         objc_setAssociatedObject(textNode, kApolloOriginalAttributedTextKey, [current copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
 
-    NSDictionary *attributes = nil;
-    if (current.length > 0) {
-        attributes = [current attributesAtIndex:0 effectiveRange:NULL];
-    }
-
-    NSAttributedString *translatedAttr = [[NSAttributedString alloc] initWithString:translatedText attributes:attributes ?: @{}];
+    NSAttributedString *translatedAttr = ApolloTranslatedAttributedStringPreservingVisualLinks(current, translatedText);
 
     // Phase D — vote resilience. Mark this text node as ours BEFORE the
     // setAttributedText: write below, so the global setter hook sees the
@@ -1055,8 +1203,7 @@ static void ApolloApplyTranslationToHeaderCellNode(id headerCellNode, RDKLink *l
         objc_setAssociatedObject(textNode, kApolloOriginalAttributedTextKey, [current copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
 
-    NSDictionary *attrs = current.length > 0 ? [current attributesAtIndex:0 effectiveRange:NULL] : nil;
-    NSAttributedString *translatedAttr = [[NSAttributedString alloc] initWithString:translatedText attributes:attrs ?: @{}];
+    NSAttributedString *translatedAttr = ApolloTranslatedAttributedStringPreservingVisualLinks(current, translatedText);
 
     // Same vote-resilience marker pattern as comment cells.
     objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [body copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
@@ -1112,8 +1259,7 @@ static void ApolloApplyTranslationToPostTextNode(id owner, id textNode, NSString
         objc_setAssociatedObject(textNode, kApolloOriginalAttributedTextKey, [current copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
 
-    NSDictionary *attrs = current.length > 0 ? [current attributesAtIndex:0 effectiveRange:NULL] : nil;
-    NSAttributedString *translatedAttr = [[NSAttributedString alloc] initWithString:translatedText attributes:attrs ?: @{}];
+    NSAttributedString *translatedAttr = ApolloTranslatedAttributedStringPreservingVisualLinks(current, translatedText);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [sourceText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -1513,7 +1659,7 @@ static void ApolloScheduleCachedTranslationReapplyForCellNode(id commentCellNode
     if ([objc_getAssociatedObject(commentCellNode, kApolloReapplyScheduledKey) boolValue]) return;
     objc_setAssociatedObject(commentCellNode, kApolloReapplyScheduledKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     __weak id weakNode = commentCellNode;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.06 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         id strong = weakNode;
         if (!strong) return;
         objc_setAssociatedObject(strong, kApolloReapplyScheduledKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -1919,11 +2065,73 @@ static void ApolloToggleThreadTranslationForController(UIViewController *vc) {
 // `incoming` (which carries Apollo's freshly-computed score color, font size,
 // link styles, etc.) but using our cached translated string.
 static NSAttributedString *ApolloRebuildTranslatedAttrPreservingAttrs(NSAttributedString *incoming, NSString *translatedText) {
-    NSDictionary *attrs = nil;
-    if ([incoming isKindOfClass:[NSAttributedString class]] && incoming.length > 0) {
-        attrs = [incoming attributesAtIndex:0 effectiveRange:NULL];
+    return ApolloTranslatedAttributedStringPreservingVisualLinks(incoming, translatedText);
+}
+
+static BOOL ApolloNormalizedTextMatchesVariant(NSString *incomingNorm, NSString *targetNorm) {
+    if (incomingNorm.length == 0 || targetNorm.length == 0) return NO;
+    if ([incomingNorm isEqualToString:targetNorm]) return YES;
+
+    BOOL contains = [incomingNorm containsString:targetNorm] || [targetNorm containsString:incomingNorm];
+    if (contains) {
+        NSUInteger overlap = MIN(incomingNorm.length, targetNorm.length);
+        if (overlap >= 12) return YES;
     }
-    return [[NSAttributedString alloc] initWithString:translatedText attributes:attrs ?: @{}];
+
+    NSUInteger prefixLength = MIN((NSUInteger)24, MIN(incomingNorm.length, targetNorm.length));
+    if (prefixLength >= 12) {
+        NSString *incomingPrefix = [incomingNorm substringToIndex:prefixLength];
+        NSString *targetPrefix = [targetNorm substringToIndex:prefixLength];
+        if ([incomingPrefix isEqualToString:targetPrefix]) return YES;
+    }
+
+    return NO;
+}
+
+static BOOL ApolloTextMatchesSourceOrVisualDisplay(NSString *incomingText, NSString *targetText) {
+    NSString *incomingNorm = ApolloNormalizeTextForCompare(incomingText);
+    NSString *targetNorm = ApolloNormalizeTextForCompare(targetText);
+    if (ApolloNormalizedTextMatchesVariant(incomingNorm, targetNorm)) return YES;
+
+    NSString *targetDisplay = ApolloDisplayStringByConvertingMarkdownLinks(targetText, nil);
+    NSString *targetDisplayNorm = ApolloNormalizeTextForCompare(targetDisplay);
+    return ![targetDisplayNorm isEqualToString:targetNorm] && ApolloNormalizedTextMatchesVariant(incomingNorm, targetDisplayNorm);
+}
+
+static void ApolloClearTranslationOwnershipForTextNode(id textNode) {
+    objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
+                                                   NSAttributedString *incomingAttributedText,
+                                                   NSAttributedString **swapOut) {
+    if (swapOut) *swapOut = nil;
+
+    NSString *originalBody = objc_getAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey);
+    NSString *translatedText = objc_getAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey);
+
+    if (![originalBody isKindOfClass:[NSString class]] || originalBody.length == 0 ||
+        ![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0 ||
+        ![incomingAttributedText isKindOfClass:[NSAttributedString class]]) {
+        return NO;
+    }
+
+    NSString *incomingText = incomingAttributedText.string;
+    if (ApolloTextMatchesSourceOrVisualDisplay(incomingText, translatedText)) {
+        return NO;
+    }
+
+    if (ApolloTextMatchesSourceOrVisualDisplay(incomingText, originalBody)) {
+        if (swapOut) *swapOut = ApolloRebuildTranslatedAttrPreservingAttrs(incomingAttributedText, translatedText);
+        return YES;
+    }
+
+    if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) {
+        ApolloClearTranslationOwnershipForTextNode(textNode);
+    }
+    return NO;
 }
 
 // Global setAttributedText: hook on ASTextNode. Strict no-op for any node we
@@ -1947,47 +2155,14 @@ static NSAttributedString *ApolloRebuildTranslatedAttrPreservingAttrs(NSAttribut
         return;
     }
 
-    NSString *originalBody = objc_getAssociatedObject(self, kApolloOwnedNodeOriginalBodyKey);
-    NSString *translatedText = objc_getAssociatedObject(self, kApolloOwnedNodeTranslatedTextKey);
-
-    if (![originalBody isKindOfClass:[NSString class]] || originalBody.length == 0 ||
-        ![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0 ||
-        ![attributedText isKindOfClass:[NSAttributedString class]]) {
-        %orig;
-        return;
-    }
-
-    NSString *incomingNorm = ApolloNormalizeTextForCompare(attributedText.string);
-    NSString *originalNorm = ApolloNormalizeTextForCompare(originalBody);
-    NSString *translatedNorm = ApolloNormalizeTextForCompare(translatedText);
-
-    // If the incoming string already matches our translation, pass through.
-    if (translatedNorm.length > 0 &&
-        ([incomingNorm isEqualToString:translatedNorm] ||
-         [incomingNorm containsString:translatedNorm] ||
-         [translatedNorm containsString:incomingNorm])) {
-        %orig;
-        return;
-    }
-
-    // If the incoming string matches the original body, Apollo is reverting
-    // (e.g. after vote / score color refresh). Substitute the cached
-    // translation, preserving incoming attributes (color, font, links).
-    BOOL incomingIsOriginal = [incomingNorm isEqualToString:originalNorm] ||
-                              [incomingNorm containsString:originalNorm] ||
-                              [originalNorm containsString:incomingNorm];
-    if (incomingIsOriginal) {
-        NSAttributedString *swap = ApolloRebuildTranslatedAttrPreservingAttrs(attributedText, translatedText);
+    NSAttributedString *swap = nil;
+    if (ApolloPrepareTranslatedSwapForTextNode(self, attributedText, &swap)) {
         objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         @try { %orig(swap); } @catch (__unused NSException *e) {}
         objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         return;
     }
 
-    // Unknown content (some other text Apollo wants to display). Pass
-    // through unchanged — and clear the marker so this node is no longer
-    // considered ours.
-    objc_setAssociatedObject(self, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     %orig;
 }
 
@@ -2006,40 +2181,14 @@ static NSAttributedString *ApolloRebuildTranslatedAttrPreservingAttrs(NSAttribut
         return;
     }
 
-    NSString *originalBody = objc_getAssociatedObject(self, kApolloOwnedNodeOriginalBodyKey);
-    NSString *translatedText = objc_getAssociatedObject(self, kApolloOwnedNodeTranslatedTextKey);
-
-    if (![originalBody isKindOfClass:[NSString class]] || originalBody.length == 0 ||
-        ![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0 ||
-        ![attributedText isKindOfClass:[NSAttributedString class]]) {
-        %orig;
-        return;
-    }
-
-    NSString *incomingNorm = ApolloNormalizeTextForCompare(attributedText.string);
-    NSString *originalNorm = ApolloNormalizeTextForCompare(originalBody);
-    NSString *translatedNorm = ApolloNormalizeTextForCompare(translatedText);
-
-    if (translatedNorm.length > 0 &&
-        ([incomingNorm isEqualToString:translatedNorm] ||
-         [incomingNorm containsString:translatedNorm] ||
-         [translatedNorm containsString:incomingNorm])) {
-        %orig;
-        return;
-    }
-
-    BOOL incomingIsOriginal = [incomingNorm isEqualToString:originalNorm] ||
-                              [incomingNorm containsString:originalNorm] ||
-                              [originalNorm containsString:incomingNorm];
-    if (incomingIsOriginal) {
-        NSAttributedString *swap = ApolloRebuildTranslatedAttrPreservingAttrs(attributedText, translatedText);
+    NSAttributedString *swap = nil;
+    if (ApolloPrepareTranslatedSwapForTextNode(self, attributedText, &swap)) {
         objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         @try { %orig(swap); } @catch (__unused NSException *e) {}
         objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         return;
     }
 
-    objc_setAssociatedObject(self, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     %orig;
 }
 

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -46,6 +46,7 @@ static NSMutableDictionary<NSString *, NSMutableArray *> *sPendingTranslationCal
 static __weak UIViewController *sVisibleCommentsViewController = nil;
 
 static void ApolloUpdateTranslationUIForController(id controller);
+static RDKComment *ApolloCommentFromCellNode(id commentCellNode);
 
 // Returns the Reddit fullName ("t1_xxxxx") for a comment. Falls back to a
 // stable derived key when the runtime doesn't expose `name` / `fullName`.
@@ -836,6 +837,70 @@ static NSString *ApolloVisibleTextFromNode(id textNode) {
     return [attr.string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 }
 
+static UIView *ApolloViewForTextObject(id object) {
+    if ([object isKindOfClass:[UIView class]]) return (UIView *)object;
+    @try {
+        SEL isLoadedSel = NSSelectorFromString(@"isNodeLoaded");
+        if ([object respondsToSelector:isLoadedSel] && !((BOOL (*)(id, SEL))objc_msgSend)(object, isLoadedSel)) {
+            return nil;
+        }
+        if ([object respondsToSelector:@selector(view)]) {
+            id view = ((id (*)(id, SEL))objc_msgSend)(object, @selector(view));
+            if ([view isKindOfClass:[UIView class]]) return (UIView *)view;
+        }
+    } @catch (__unused NSException *e) {
+    }
+    return nil;
+}
+
+static CGFloat ApolloFirstVisibleCommentTopY(UIViewController *viewController, UITableView *tableView) {
+    CGFloat top = CGFLOAT_MAX;
+    for (UITableViewCell *cell in [tableView visibleCells]) {
+        SEL nodeSelector = NSSelectorFromString(@"node");
+        if (![cell respondsToSelector:nodeSelector]) continue;
+        id cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSelector);
+        if (!ApolloCommentFromCellNode(cellNode)) continue;
+        CGRect frame = [cell convertRect:cell.bounds toView:viewController.view];
+        top = MIN(top, CGRectGetMinY(frame));
+    }
+    return top;
+}
+
+static id ApolloBestVisiblePostBodyTextNodeForController(UIViewController *viewController, UITableView *tableView, RDKLink *link) {
+    if (!viewController.view) return nil;
+    NSMutableArray *candidates = [NSMutableArray array];
+    NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:128];
+    ApolloCollectAttributedTextNodes(viewController.view, 8, visited, candidates);
+
+    CGFloat firstCommentTop = ApolloFirstVisibleCommentTopY(viewController, tableView);
+    if (firstCommentTop == CGFLOAT_MAX) firstCommentTop = CGRectGetHeight(viewController.view.bounds);
+
+    id best = nil;
+    NSInteger bestScore = NSIntegerMin;
+    for (id candidate in candidates) {
+        NSString *text = ApolloVisibleTextFromNode(candidate);
+        if (text.length == 0 || ApolloPostTextLooksLikeMetadata(text, link)) continue;
+
+        UIView *view = ApolloViewForTextObject(candidate);
+        if (!view || view.hidden || view.alpha < 0.01) continue;
+        CGRect frame = [view convertRect:view.bounds toView:viewController.view];
+        if (CGRectIsEmpty(frame) || CGRectGetMaxY(frame) <= 0) continue;
+
+        // Post body sits above the first comment. Avoid accidentally grabbing
+        // translated comment text lower in the table while still allowing long
+        // selftext that scrolls near the first comment boundary.
+        if (CGRectGetMinY(frame) >= firstCommentTop - 8.0) continue;
+
+        NSInteger score = (NSInteger)text.length;
+        if (CGRectGetMaxY(frame) < firstCommentTop) score += 1000;
+        if (score > bestScore) {
+            bestScore = score;
+            best = candidate;
+        }
+    }
+    return best;
+}
+
 static NSString *ApolloVisiblePostCacheKey(RDKLink *link, NSString *sourceText, NSString *targetLanguage) {
     NSString *fullName = link.fullName;
     if (fullName.length > 0) return fullName;
@@ -937,6 +1002,55 @@ static void ApolloApplyTranslationToHeaderCellNode(id headerCellNode, RDKLink *l
         objc_setAssociatedObject(headerCellNode, kApolloAppliedHeaderTranslationFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
     }
     ApolloMarkVisibleTranslationApplied(body, translatedText);
+}
+
+static void ApolloApplyTranslationToPostTextNode(id owner, id textNode, NSString *sourceText, NSString *translatedText) {
+    if (!owner || !textNode) return;
+    if (![sourceText isKindOfClass:[NSString class]] || sourceText.length == 0) return;
+    if (![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0) return;
+
+    NSAttributedString *current = nil;
+    @try { current = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText)); }
+    @catch (__unused NSException *e) { return; }
+    if (![current isKindOfClass:[NSAttributedString class]]) return;
+
+    NSString *currentNorm = ApolloNormalizeTextForCompare(current.string);
+    NSString *sourceNorm = ApolloNormalizeTextForCompare(sourceText);
+    NSString *translatedNorm = ApolloNormalizeTextForCompare(translatedText);
+    if (currentNorm.length == 0 || sourceNorm.length == 0) return;
+    BOOL textMatchesSource = [currentNorm isEqualToString:sourceNorm] ||
+                             [currentNorm containsString:sourceNorm] ||
+                             [sourceNorm containsString:currentNorm];
+    BOOL textMatchesTranslation = translatedNorm.length > 0 &&
+        ([currentNorm isEqualToString:translatedNorm] ||
+         [currentNorm containsString:translatedNorm] ||
+         [translatedNorm containsString:currentNorm]);
+    if (!textMatchesSource && !textMatchesTranslation) return;
+    if (textMatchesTranslation && !textMatchesSource) return;
+
+    NSAttributedString *originalSaved = objc_getAssociatedObject(textNode, kApolloOriginalAttributedTextKey);
+    if (![originalSaved isKindOfClass:[NSAttributedString class]]) {
+        objc_setAssociatedObject(textNode, kApolloOriginalAttributedTextKey, [current copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    NSDictionary *attrs = current.length > 0 ? [current attributesAtIndex:0 effectiveRange:NULL] : nil;
+    NSAttributedString *translatedAttr = [[NSAttributedString alloc] initWithString:translatedText attributes:attrs ?: @{}];
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [sourceText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    @try { ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), translatedAttr); }
+    @catch (__unused NSException *e) { return; }
+
+    if ([textNode respondsToSelector:@selector(setNeedsLayout)]) {
+        ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsLayout));
+    }
+    if ([textNode respondsToSelector:@selector(setNeedsDisplay)]) {
+        ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsDisplay));
+    }
+
+    objc_setAssociatedObject(owner, kApolloHeaderTranslatedTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloMarkVisibleTranslationApplied(sourceText, translatedText);
 }
 
 static void ApolloRestoreOriginalForHeaderCellNode(id headerCellNode, RDKLink *link) {
@@ -1402,6 +1516,56 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
     });
 }
 
+static void ApolloMaybeTranslateVisiblePostBodyForController(UIViewController *viewController, UITableView *tableView, BOOL forceTranslation) {
+    if (!viewController || !tableView) return;
+    if (!ApolloShouldTranslateNow(forceTranslation)) return;
+
+    RDKLink *link = ApolloLinkFromController(viewController);
+    id textNode = ApolloBestVisiblePostBodyTextNodeForController(viewController, tableView, link);
+    NSString *sourceText = ApolloVisibleTextFromNode(textNode);
+    if (sourceText.length == 0) return;
+    if (ApolloLinkContainsCodeOrPreformatted(link, sourceText)) return;
+
+    NSString *targetLanguage = ApolloResolvedTargetLanguageCode();
+    if (targetLanguage.length == 0) return;
+
+    NSString *cacheStoreKey = ApolloVisiblePostCacheKey(link, sourceText, targetLanguage);
+    if (cacheStoreKey.length > 0) {
+        NSString *cached = [sLinkTranslationByFullName objectForKey:cacheStoreKey];
+        if (cached.length > 0) {
+            ApolloApplyTranslationToPostTextNode(viewController.view, textNode, sourceText, cached);
+            return;
+        }
+    }
+
+    if (!forceTranslation) {
+        NSString *detected = ApolloDetectDominantLanguage(sourceText);
+        if ([detected isEqualToString:targetLanguage]) return;
+    }
+
+    NSString *cacheKey = ApolloTranslationCacheKey(sourceText, targetLanguage);
+    objc_setAssociatedObject(viewController.view, kApolloHeaderCellTranslationKeyKey, cacheKey, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    __weak UIViewController *weakVC = viewController;
+    __weak id weakTextNode = textNode;
+    ApolloRequestTranslation(cacheKey, sourceText, targetLanguage, ^(NSString *translated, NSError *error) {
+        UIViewController *strongVC = weakVC;
+        id strongTextNode = weakTextNode;
+        if (![translated isKindOfClass:[NSString class]] || translated.length == 0) {
+            if (error) ApolloLog(@"[Translation] Failed to translate visible post body: %@", error.localizedDescription ?: @"unknown");
+            return;
+        }
+        if (!strongVC || !strongTextNode) return;
+        NSString *currentKey = objc_getAssociatedObject(strongVC.view, kApolloHeaderCellTranslationKeyKey);
+        if (![currentKey isEqualToString:cacheKey]) return;
+        if (!forceTranslation && !ApolloShouldTranslateNow(NO)) return;
+
+        if (cacheStoreKey.length > 0) {
+            [sLinkTranslationByFullName setObject:translated forKey:cacheStoreKey];
+        }
+        ApolloApplyTranslationToPostTextNode(strongVC.view, strongTextNode, sourceText, translated);
+    });
+}
+
 // Walks the comments table looking for post header roots. Apollo can render
 // the post body as a cell node, a tableHeaderView, or a plain contentView
 // wrapper depending on post type/media layout, so cover those surfaces.
@@ -1428,6 +1592,8 @@ static void ApolloMaybeTranslatePostHeaderForController(UIViewController *viewCo
             ApolloMaybeTranslatePostHeaderCellNode(cellNode, controllerLink, forceTranslation);
         }
     }
+
+    ApolloMaybeTranslateVisiblePostBodyForController(viewController, tableView, forceTranslation);
 }
 
 static void ApolloTranslateVisibleCommentsForController(UIViewController *viewController, BOOL forceTranslation) {
@@ -1454,6 +1620,7 @@ static void ApolloRestoreVisibleCommentsForController(UIViewController *viewCont
     if (tableView.tableHeaderView) {
         ApolloRestoreOriginalForHeaderCellNode(tableView.tableHeaderView, controllerLink);
     }
+    ApolloRestoreOriginalForHeaderCellNode(viewController.view, controllerLink);
 
     for (UITableViewCell *cell in [tableView visibleCells]) {
         SEL nodeSelector = NSSelectorFromString(@"node");

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -2178,8 +2178,9 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     }
     if (!globeButton) {
         globeButton = [UIButton buttonWithType:UIButtonTypeSystem];
-        globeButton.frame = CGRectMake(0.0, 0.0, 22.0, 32.0);
-        globeButton.imageEdgeInsets = UIEdgeInsetsMake(0.0, 14.0, 0.0, -14.0);
+        globeButton.frame = CGRectMake(0.0, 0.0, 36.0, 32.0);
+        globeButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
+        globeButton.imageEdgeInsets = UIEdgeInsetsZero;
         [globeButton addTarget:controller action:@selector(apollo_translationGlobeTapped) forControlEvents:UIControlEventTouchUpInside];
     }
     [globeButton setImage:globeImage forState:UIControlStateNormal];

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -3,6 +3,7 @@
 #import <objc/runtime.h>
 #import <objc/message.h>
 #include <dlfcn.h>
+#include <string.h>
 
 #import "ApolloCommon.h"
 #import "ApolloState.h"
@@ -16,6 +17,7 @@ static const void *kApolloThreadTranslatedModeKey = &kApolloThreadTranslatedMode
 // don't clobber the user's preference when sAutoTranslateOnAppear is on).
 static const void *kApolloThreadOriginalModeKey = &kApolloThreadOriginalModeKey;
 static const void *kApolloTranslateBarButtonKey = &kApolloTranslateBarButtonKey;
+static const void *kApolloVisibleTranslationAppliedKey = &kApolloVisibleTranslationAppliedKey;
 static const void *kApolloAppliedTranslationFullNameKey = &kApolloAppliedTranslationFullNameKey;
 // Phase D — vote resilience. When we install a translated string into a text
 // node we tag the node with these associations. A global setAttributedText:
@@ -42,6 +44,8 @@ static NSCache<NSString *, NSString *> *sCommentTranslationByFullName;
 static NSCache<NSString *, NSString *> *sLinkTranslationByFullName;
 static NSMutableDictionary<NSString *, NSMutableArray *> *sPendingTranslationCallbacks;
 static __weak UIViewController *sVisibleCommentsViewController = nil;
+
+static void ApolloUpdateTranslationUIForController(id controller);
 
 // Returns the Reddit fullName ("t1_xxxxx") for a comment. Falls back to a
 // stable derived key when the runtime doesn't expose `name` / `fullName`.
@@ -132,6 +136,25 @@ static NSString *ApolloNormalizeTextForCompare(NSString *text) {
         if (part.length > 0) [nonEmpty addObject:part];
     }
     return [nonEmpty componentsJoinedByString:@" "];
+}
+
+static BOOL ApolloTranslatedTextDiffersFromSource(NSString *sourceText, NSString *translatedText) {
+    NSString *sourceNorm = ApolloNormalizeTextForCompare(sourceText ?: @"");
+    NSString *translatedNorm = ApolloNormalizeTextForCompare(translatedText ?: @"");
+    return sourceNorm.length > 0 && translatedNorm.length > 0 && ![sourceNorm isEqualToString:translatedNorm];
+}
+
+static void ApolloMarkVisibleTranslationApplied(NSString *sourceText, NSString *translatedText) {
+    if (!ApolloTranslatedTextDiffersFromSource(sourceText, translatedText)) return;
+    UIViewController *vc = sVisibleCommentsViewController;
+    if (!vc) return;
+    objc_setAssociatedObject(vc, kApolloVisibleTranslationAppliedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloUpdateTranslationUIForController(vc);
+}
+
+static void ApolloClearVisibleTranslationApplied(UIViewController *vc) {
+    if (!vc) return;
+    objc_setAssociatedObject(vc, kApolloVisibleTranslationAppliedKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 static NSString *ApolloDetectDominantLanguage(NSString *text) {
@@ -520,6 +543,7 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
         [sCommentTranslationByFullName setObject:translatedText forKey:fullName];
         objc_setAssociatedObject(commentCellNode, kApolloAppliedTranslationFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
     }
+    ApolloMarkVisibleTranslationApplied(comment.body, translatedText);
 }
 
 static void ApolloRestoreOriginalForCellNode(id commentCellNode, RDKComment *comment) {
@@ -644,6 +668,65 @@ static RDKLink *ApolloLinkFromController(UIViewController *vc) {
     return nil;
 }
 
+static NSString *ApolloPlainTextFromHTMLString(NSString *html) {
+    if (![html isKindOfClass:[NSString class]] || html.length == 0) return nil;
+    NSData *data = [html dataUsingEncoding:NSUTF8StringEncoding];
+    if (!data) return nil;
+    NSDictionary *options = @{
+        NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType,
+        NSCharacterEncodingDocumentAttribute: @(NSUTF8StringEncoding),
+    };
+    NSAttributedString *attr = [[NSAttributedString alloc] initWithData:data options:options documentAttributes:nil error:nil];
+    NSString *plain = attr.string;
+    return [plain isKindOfClass:[NSString class]] ? [plain stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] : nil;
+}
+
+static NSString *ApolloPostBodyTextFromLink(RDKLink *link) {
+    if (!link) return nil;
+    NSMutableArray<NSString *> *candidates = [NSMutableArray array];
+    SEL stringSelectors[] = {
+        @selector(selfText),
+        NSSelectorFromString(@"selftext"),
+        NSSelectorFromString(@"body"),
+        NSSelectorFromString(@"text"),
+        NSSelectorFromString(@"content"),
+    };
+    for (size_t i = 0; i < sizeof(stringSelectors) / sizeof(stringSelectors[0]); i++) {
+        if ([(id)link respondsToSelector:stringSelectors[i]]) {
+            id value = ((id (*)(id, SEL))objc_msgSend)((id)link, stringSelectors[i]);
+            if ([value isKindOfClass:[NSString class]]) [candidates addObject:value];
+        }
+    }
+    if ([(id)link respondsToSelector:@selector(selfTextHTML)]) {
+        NSString *htmlPlain = ApolloPlainTextFromHTMLString(link.selfTextHTML);
+        if (htmlPlain.length > 0) [candidates addObject:htmlPlain];
+    }
+    static const char *kBodyIvarNames[] = {
+        "selfText", "selftext", "_selfText", "_selftext", "body", "_body",
+        "text", "_text", "content", "_content", "selfTextHTML", "_selfTextHTML", NULL
+    };
+    for (Class cls = [(id)link class]; cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
+        for (size_t i = 0; kBodyIvarNames[i]; i++) {
+            Ivar iv = class_getInstanceVariable(cls, kBodyIvarNames[i]);
+            if (!iv) continue;
+            const char *type = ivar_getTypeEncoding(iv);
+            if (!type || type[0] != '@') continue;
+            id value = nil;
+            @try { value = object_getIvar(link, iv); } @catch (__unused NSException *e) { continue; }
+            if ([value isKindOfClass:[NSString class]]) {
+                NSString *string = (NSString *)value;
+                if (strstr(kBodyIvarNames[i], "HTML")) string = ApolloPlainTextFromHTMLString(string) ?: string;
+                [candidates addObject:string];
+            }
+        }
+    }
+    for (NSString *candidate in candidates) {
+        NSString *trimmed = [candidate stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        if (trimmed.length > 0) return trimmed;
+    }
+    return nil;
+}
+
 // Same idea as ApolloKnownBodyTextNode but for post header cells.
 static id ApolloKnownPostBodyTextNode(id headerCellNode) {
     if (!headerCellNode) return nil;
@@ -676,17 +759,44 @@ static id ApolloKnownPostBodyTextNode(id headerCellNode) {
     return nil;
 }
 
+static BOOL ApolloPostTextLooksLikeMetadata(NSString *text, RDKLink *link) {
+    NSString *norm = ApolloNormalizeTextForCompare(text ?: @"");
+    if (norm.length == 0) return YES;
+    NSString *titleNorm = ApolloNormalizeTextForCompare(link.title ?: @"");
+    NSString *authorNorm = ApolloNormalizeTextForCompare(link.author ?: @"");
+    NSString *subredditNorm = ApolloNormalizeTextForCompare(link.subreddit ?: @"");
+    if (titleNorm.length > 0 && ([norm isEqualToString:titleNorm] || [titleNorm containsString:norm])) return YES;
+    if (authorNorm.length > 0 && [norm containsString:authorNorm]) return YES;
+    if (subredditNorm.length > 0 && [norm containsString:subredditNorm]) return YES;
+    if ([norm hasPrefix:@"http://"] || [norm hasPrefix:@"https://"]) return YES;
+    if (norm.length < 18) return YES;
+    return NO;
+}
+
+static NSString *ApolloVisibleTextFromNode(id textNode) {
+    if (!textNode) return nil;
+    NSAttributedString *attr = nil;
+    @try { attr = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText)); }
+    @catch (__unused NSException *e) { return nil; }
+    if (![attr isKindOfClass:[NSAttributedString class]]) return nil;
+    return [attr.string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
 // Picks the post-body text node by name first, then falls back to a scored
-// scan of the cell's subnode tree against link.selfText.
-static id ApolloBestPostBodyTextNode(id headerCellNode, RDKLink *link) {
+// scan. If Apollo's model text is unavailable, choose the longest visible
+// body-like text node that is not title/byline/URL metadata.
+static id ApolloBestPostBodyTextNode(id headerCellNode, RDKLink *link, NSString *bodyText) {
     id known = ApolloKnownPostBodyTextNode(headerCellNode);
     if (known) {
-        // Sanity-check: if the named node's text isn't even close to selfText,
-        // fall through to scoring.
-        @try {
-            NSAttributedString *attr = ((id (*)(id, SEL))objc_msgSend)(known, @selector(attributedText));
-            if (ApolloCandidateScore(attr, link.selfText) > NSIntegerMin) return known;
-        } @catch (__unused NSException *e) { /* fall through */ }
+        NSString *knownText = ApolloVisibleTextFromNode(known);
+        if (bodyText.length > 0) {
+            @try {
+                NSAttributedString *attr = ((id (*)(id, SEL))objc_msgSend)(known, @selector(attributedText));
+                if (ApolloCandidateScore(attr, bodyText) > NSIntegerMin) return known;
+            } @catch (__unused NSException *e) { /* fall through */ }
+        } else if (!ApolloPostTextLooksLikeMetadata(knownText, link)) {
+            return known;
+        }
     }
     NSMutableArray *candidates = [NSMutableArray array];
     NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:64];
@@ -697,19 +807,22 @@ static id ApolloBestPostBodyTextNode(id headerCellNode, RDKLink *link) {
         NSAttributedString *attr = nil;
         @try { attr = ((id (*)(id, SEL))objc_msgSend)(n, @selector(attributedText)); }
         @catch (__unused NSException *e) { continue; }
-        NSInteger s = ApolloCandidateScore(attr, link.selfText);
+        NSInteger s = bodyText.length > 0 ? ApolloCandidateScore(attr, bodyText) : NSIntegerMin;
+        if (s == NSIntegerMin && !ApolloPostTextLooksLikeMetadata(attr.string, link)) {
+            s = (NSInteger)attr.string.length;
+        }
         if (s > bestScore) { bestScore = s; best = n; }
     }
     return best;
 }
 
-static void ApolloApplyTranslationToHeaderCellNode(id headerCellNode, RDKLink *link, NSString *translatedText) {
+static void ApolloApplyTranslationToHeaderCellNode(id headerCellNode, RDKLink *link, NSString *sourceText, NSString *translatedText) {
     if (!headerCellNode || ![(id)link isKindOfClass:NSClassFromString(@"RDKLink")]) return;
     if (![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0) return;
-    NSString *body = link.selfText;
+    NSString *body = sourceText.length > 0 ? sourceText : ApolloPostBodyTextFromLink(link);
     if (![body isKindOfClass:[NSString class]] || body.length == 0) return;
 
-    id textNode = ApolloBestPostBodyTextNode(headerCellNode, link);
+    id textNode = ApolloBestPostBodyTextNode(headerCellNode, link, body);
     if (!textNode) return;
 
     NSAttributedString *current = nil;
@@ -761,12 +874,13 @@ static void ApolloApplyTranslationToHeaderCellNode(id headerCellNode, RDKLink *l
         [sLinkTranslationByFullName setObject:translatedText forKey:fullName];
         objc_setAssociatedObject(headerCellNode, kApolloAppliedHeaderTranslationFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
     }
+    ApolloMarkVisibleTranslationApplied(body, translatedText);
 }
 
 static void ApolloRestoreOriginalForHeaderCellNode(id headerCellNode, RDKLink *link) {
     if (!headerCellNode) return;
     id textNode = objc_getAssociatedObject(headerCellNode, kApolloHeaderTranslatedTextNodeKey);
-    if (!textNode) textNode = ApolloBestPostBodyTextNode(headerCellNode, link);
+    if (!textNode) textNode = ApolloBestPostBodyTextNode(headerCellNode, link, ApolloPostBodyTextFromLink(link));
     if (!textNode) return;
 
     objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -1146,7 +1260,11 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
     RDKLink *link = ApolloLinkFromHeaderCellNode(headerCellNode);
     if (!link) link = fallbackLink;
     if (!link) return;
-    NSString *body = link.selfText;
+    NSString *body = ApolloPostBodyTextFromLink(link);
+    if (![body isKindOfClass:[NSString class]] || body.length == 0) {
+        id visibleBodyNode = ApolloBestPostBodyTextNode(headerCellNode, link, nil);
+        body = ApolloVisibleTextFromNode(visibleBodyNode);
+    }
     if (![body isKindOfClass:[NSString class]]) return;
     NSString *trimmed = [body stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     if (trimmed.length == 0) return;  // link/image post — nothing to translate
@@ -1160,7 +1278,7 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
     if (fullName.length > 0) {
         NSString *cached = [sLinkTranslationByFullName objectForKey:fullName];
         if (cached.length > 0) {
-            ApolloApplyTranslationToHeaderCellNode(headerCellNode, link, cached);
+            ApolloApplyTranslationToHeaderCellNode(headerCellNode, link, trimmed, cached);
             return;
         }
     }
@@ -1191,7 +1309,7 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
         RDKLink *strongLink = ApolloLinkFromHeaderCellNode(strongHeader);
         if (!strongLink) strongLink = fallbackLink;
         if (!strongLink) return;
-        ApolloApplyTranslationToHeaderCellNode(strongHeader, strongLink, translated);
+        ApolloApplyTranslationToHeaderCellNode(strongHeader, strongLink, trimmed, translated);
     });
 }
 
@@ -1335,24 +1453,7 @@ static void ApolloUpdateBannerForController(UIViewController *vc) {
 
     UILabel *banner = ApolloEnsureBannerInHeaderCellView(headerView);
     if (!banner) return;
-
-    if (!sEnableBulkTranslation) {
-        banner.hidden = YES;
-        return;
-    }
-
-    BOOL translatedMode = ApolloControllerIsInTranslatedMode(vc);
-    NSString *targetName = ApolloLocalizedTargetLanguageName();
-
-    banner.hidden = NO;
-    if (translatedMode) {
-        banner.text = [NSString stringWithFormat:@"Translated to %@", targetName];
-        banner.textColor = [UIColor systemGreenColor];
-    } else {
-        banner.text = @"Original language";
-        banner.textColor = [UIColor systemBlueColor];
-    }
-    [banner.superview bringSubviewToFront:banner];
+    banner.hidden = YES;
 }
 
 static void ApolloUpdateTranslationUIForController(id controller) {
@@ -1366,6 +1467,7 @@ static void ApolloUpdateTranslationUIForController(id controller) {
         if (ApolloControllerIsInTranslatedMode(vc)) {
             ApolloRestoreVisibleCommentsForController(vc);
         }
+        ApolloClearVisibleTranslationApplied(vc);
         objc_setAssociatedObject(controller, kApolloThreadTranslatedModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(controller, kApolloThreadOriginalModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
@@ -1379,6 +1481,7 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     }
 
     BOOL translatedMode = ApolloControllerIsInTranslatedMode(vc);
+    BOOL visibleTranslationApplied = [objc_getAssociatedObject(vc, kApolloVisibleTranslationAppliedKey) boolValue];
     NSString *targetName = ApolloLocalizedTargetLanguageName();
 
     // Compact globe icon — same width as the existing nav buttons, so the
@@ -1397,7 +1500,7 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     translationItem.target = controller;
     translationItem.action = @selector(apollo_translationGlobeTapped);
     translationItem.menu = nil;
-    translationItem.tintColor = translatedMode ? [UIColor systemGreenColor] : [UIColor systemBlueColor];
+    translationItem.tintColor = visibleTranslationApplied ? [UIColor systemGreenColor] : [UIColor systemBlueColor];
     translationItem.accessibilityLabel = translatedMode
         ? @"Translation: showing translated. Tap to show original."
         : [NSString stringWithFormat:@"Translation: showing original. Tap to translate to %@.", targetName];
@@ -1419,10 +1522,12 @@ static void ApolloToggleThreadTranslationForController(UIViewController *vc) {
     if (wasTranslated) {
         // Switch to original.
         ApolloRestoreVisibleCommentsForController(vc);
+        ApolloClearVisibleTranslationApplied(vc);
         objc_setAssociatedObject(vc, kApolloThreadTranslatedModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(vc, kApolloThreadOriginalModeKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     } else {
         // Switch to translated.
+        ApolloClearVisibleTranslationApplied(vc);
         objc_setAssociatedObject(vc, kApolloThreadTranslatedModeKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(vc, kApolloThreadOriginalModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         ApolloTranslateVisibleCommentsForController(vc, YES);
@@ -1642,6 +1747,8 @@ static NSAttributedString *ApolloRebuildTranslatedAttrPreservingAttrs(NSAttribut
     sVisibleCommentsViewController = (UIViewController *)self;
 
     if (sEnableBulkTranslation && ApolloControllerIsInTranslatedMode((UIViewController *)self)) {
+        ApolloClearVisibleTranslationApplied((UIViewController *)self);
+        ApolloUpdateTranslationUIForController(self);
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.12 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             ApolloTranslateVisibleCommentsForController((UIViewController *)self, NO);
             ApolloUpdateTranslationUIForController(self);

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -2180,6 +2180,7 @@ static void ApolloUpdateTranslationUIForController(id controller) {
         objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, translationItem, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
     translationItem.image = globeImage;
+    translationItem.imageInsets = UIEdgeInsetsMake(0.0, 6.0, 0.0, -6.0);
     translationItem.target = controller;
     translationItem.action = @selector(apollo_translationGlobeTapped);
     translationItem.menu = nil;

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -320,6 +320,24 @@ static void ApolloCollectAttributedTextNodes(id object,
     } @catch (__unused NSException *exception) {
     }
 
+    // Texture/AsyncDisplayKit views often keep the real ASDisplayNode behind
+    // a private category accessor. When the post body lives in the table
+    // header view, walking UIView subviews alone can stop at an _ASDisplayView;
+    // hop back to the backing node so the normal subnode traversal can find
+    // ASTextNode/ASTextNode2 children.
+    @try {
+        SEL nodeSelectors[] = { NSSelectorFromString(@"asyncdisplaykit_node"), NSSelectorFromString(@"node") };
+        for (size_t i = 0; i < sizeof(nodeSelectors) / sizeof(nodeSelectors[0]); i++) {
+            SEL selector = nodeSelectors[i];
+            if (![object respondsToSelector:selector]) continue;
+            id node = ((id (*)(id, SEL))objc_msgSend)(object, selector);
+            if (node && node != object) {
+                ApolloCollectAttributedTextNodes(node, depth - 1, visited, nodes);
+            }
+        }
+    } @catch (__unused NSException *exception) {
+    }
+
     if (depth == 0) return;
 
     @try {
@@ -1261,9 +1279,19 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
     if (!link) link = fallbackLink;
     if (!link) return;
     NSString *body = ApolloPostBodyTextFromLink(link);
+    id visibleBodyNode = ApolloBestPostBodyTextNode(headerCellNode, link, body);
+    NSString *visibleBody = ApolloVisibleTextFromNode(visibleBodyNode);
     if (![body isKindOfClass:[NSString class]] || body.length == 0) {
-        id visibleBodyNode = ApolloBestPostBodyTextNode(headerCellNode, link, nil);
-        body = ApolloVisibleTextFromNode(visibleBodyNode);
+        body = visibleBody;
+    } else if (visibleBody.length > 0 && !ApolloPostTextLooksLikeMetadata(visibleBody, link)) {
+        NSString *bodyNorm = ApolloNormalizeTextForCompare(body);
+        NSString *visibleNorm = ApolloNormalizeTextForCompare(visibleBody);
+        BOOL visibleMatchesModel = [visibleNorm isEqualToString:bodyNorm] ||
+                                   [visibleNorm containsString:bodyNorm] ||
+                                   [bodyNorm containsString:visibleNorm];
+        if (!visibleMatchesModel) {
+            body = visibleBody;
+        }
     }
     if (![body isKindOfClass:[NSString class]]) return;
     NSString *trimmed = [body stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
@@ -1313,16 +1341,28 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
     });
 }
 
-// Walks the comments table looking for the post header cell (the one whose
-// cellNode has a `link` ivar instead of a `comment` ivar) and translates it.
+// Walks the comments table looking for post header roots. Apollo can render
+// the post body as a cell node, a tableHeaderView, or a plain contentView
+// wrapper depending on post type/media layout, so cover those surfaces.
 static void ApolloMaybeTranslatePostHeaderForController(UIViewController *viewController, BOOL forceTranslation) {
     UITableView *tableView = GetCommentsTableView(viewController);
     if (!tableView) return;
     RDKLink *controllerLink = ApolloLinkFromController(viewController);
+
+    if (tableView.tableHeaderView) {
+        ApolloMaybeTranslatePostHeaderCellNode(tableView.tableHeaderView, controllerLink, forceTranslation);
+    }
+
     for (UITableViewCell *cell in [tableView visibleCells]) {
         SEL nodeSelector = NSSelectorFromString(@"node");
-        if (![cell respondsToSelector:nodeSelector]) continue;
-        id cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSelector);
+        id cellNode = nil;
+        if ([cell respondsToSelector:nodeSelector]) {
+            cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSelector);
+        }
+        if (!cellNode && controllerLink) {
+            cellNode = cell.contentView ?: cell;
+        }
+        if (!cellNode) continue;
         if (ApolloLinkFromHeaderCellNode(cellNode) || (!ApolloCommentFromCellNode(cellNode) && controllerLink)) {
             ApolloMaybeTranslatePostHeaderCellNode(cellNode, controllerLink, forceTranslation);
         }
@@ -1350,11 +1390,21 @@ static void ApolloRestoreVisibleCommentsForController(UIViewController *viewCont
     if (!tableView) return;
     RDKLink *controllerLink = ApolloLinkFromController(viewController);
 
+    if (tableView.tableHeaderView && controllerLink) {
+        ApolloRestoreOriginalForHeaderCellNode(tableView.tableHeaderView, controllerLink);
+    }
+
     for (UITableViewCell *cell in [tableView visibleCells]) {
         SEL nodeSelector = NSSelectorFromString(@"node");
-        if (![cell respondsToSelector:nodeSelector]) continue;
+        id cellNode = nil;
+        if ([cell respondsToSelector:nodeSelector]) {
+            cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSelector);
+        }
+        if (!cellNode && controllerLink) {
+            cellNode = cell.contentView ?: cell;
+        }
+        if (!cellNode) continue;
 
-        id cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSelector);
         RDKComment *comment = ApolloCommentFromCellNode(cellNode);
 
         // Header cell? Restore post body and skip the comment path.

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -138,6 +138,43 @@ static NSString *ApolloNormalizeTextForCompare(NSString *text) {
     return [nonEmpty componentsJoinedByString:@" "];
 }
 
+static BOOL ApolloTextContainsMarkdownCode(NSString *text) {
+    if (![text isKindOfClass:[NSString class]] || text.length == 0) return NO;
+    NSString *lower = text.lowercaseString;
+    if ([lower containsString:@"```"] || [lower containsString:@"~~~"] || [lower containsString:@"`"]) return YES;
+
+    NSArray<NSString *> *lines = [text componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+    NSUInteger indentedCodeLines = 0;
+    for (NSString *line in lines) {
+        if (line.length == 0) continue;
+        if ([line hasPrefix:@"    "] || [line hasPrefix:@"\t"]) {
+            indentedCodeLines++;
+        }
+    }
+    return indentedCodeLines > 0;
+}
+
+static BOOL ApolloHTMLContainsCode(NSString *html) {
+    if (![html isKindOfClass:[NSString class]] || html.length == 0) return NO;
+    NSString *lower = html.lowercaseString;
+    return [lower containsString:@"<pre"] ||
+           [lower containsString:@"</pre"] ||
+           [lower containsString:@"<code"] ||
+           [lower containsString:@"</code"];
+}
+
+static BOOL ApolloCommentContainsCodeOrPreformatted(RDKComment *comment) {
+    if (!comment) return NO;
+    return ApolloTextContainsMarkdownCode(comment.body) || ApolloHTMLContainsCode(comment.bodyHTML);
+}
+
+static BOOL ApolloLinkContainsCodeOrPreformatted(RDKLink *link, NSString *visibleText) {
+    if (!link) return NO;
+    return ApolloTextContainsMarkdownCode(link.selfText) ||
+           ApolloHTMLContainsCode(link.selfTextHTML) ||
+           ApolloTextContainsMarkdownCode(visibleText);
+}
+
 static BOOL ApolloTranslatedTextDiffersFromSource(NSString *sourceText, NSString *translatedText) {
     NSString *sourceNorm = ApolloNormalizeTextForCompare(sourceText ?: @"");
     NSString *translatedNorm = ApolloNormalizeTextForCompare(translatedText ?: @"");
@@ -1183,10 +1220,19 @@ static void ApolloMaybeTranslateCommentCellNode(id commentCellNode, BOOL forceTr
     NSString *targetLanguage = ApolloResolvedTargetLanguageCode();
     if (targetLanguage.length == 0) return;
 
+    NSString *fullName = ApolloCommentFullName(comment);
+    if (ApolloCommentContainsCodeOrPreformatted(comment)) {
+        if (fullName.length > 0) {
+            [sCommentTranslationByFullName removeObjectForKey:fullName];
+        }
+        ApolloRestoreOriginalForCellNode(commentCellNode, comment);
+        ApolloLog(@"[Translation] Skipping comment with code/preformatted content");
+        return;
+    }
+
     // Fast path 1: we already translated this exact comment in this session.
     // Re-apply from the fullName cache without going to the network. This
     // makes collapse/expand and cell reuse re-show the translation immediately.
-    NSString *fullName = ApolloCommentFullName(comment);
     if (fullName.length > 0) {
         NSString *cachedTranslation = [sCommentTranslationByFullName objectForKey:fullName];
         if (cachedTranslation.length > 0) {
@@ -1296,6 +1342,16 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
     if (![body isKindOfClass:[NSString class]]) return;
     NSString *trimmed = [body stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     if (trimmed.length == 0) return;  // link/image post — nothing to translate
+
+    if (ApolloLinkContainsCodeOrPreformatted(link, trimmed)) {
+        NSString *linkFullName = link.fullName;
+        if (linkFullName.length > 0) {
+            [sLinkTranslationByFullName removeObjectForKey:linkFullName];
+        }
+        ApolloRestoreOriginalForHeaderCellNode(headerCellNode, link);
+        ApolloLog(@"[Translation] Skipping post body with code/preformatted content");
+        return;
+    }
 
     if (!ApolloShouldTranslateNow(forceTranslation)) return;
 

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -13,12 +13,31 @@ static const void *kApolloTranslatedTextNodeKey = &kApolloTranslatedTextNodeKey;
 static const void *kApolloCellTranslationKeyKey = &kApolloCellTranslationKeyKey;
 static const void *kApolloThreadTranslatedModeKey = &kApolloThreadTranslatedModeKey;
 static const void *kApolloTranslateBarButtonKey = &kApolloTranslateBarButtonKey;
+static const void *kApolloAppliedTranslationFullNameKey = &kApolloAppliedTranslationFullNameKey;
 
 static NSString *const kApolloDefaultLibreTranslateURL = @"https://libretranslate.de/translate";
 
 static NSCache<NSString *, NSString *> *sTranslationCache;
+// fullName ("t1_xxxxx") -> translated body text. Survives cell reuse / collapse.
+static NSCache<NSString *, NSString *> *sCommentTranslationByFullName;
 static NSMutableDictionary<NSString *, NSMutableArray *> *sPendingTranslationCallbacks;
 static __weak UIViewController *sVisibleCommentsViewController = nil;
+
+// Returns the Reddit fullName ("t1_xxxxx") for a comment. Falls back to a
+// stable derived key when the runtime doesn't expose `name` / `fullName`.
+static NSString *ApolloCommentFullName(RDKComment *comment) {
+    if (!comment) return nil;
+    SEL sels[] = { @selector(name), NSSelectorFromString(@"fullName"), NSSelectorFromString(@"identifier"), NSSelectorFromString(@"id") };
+    for (size_t i = 0; i < sizeof(sels) / sizeof(sels[0]); i++) {
+        if ([comment respondsToSelector:sels[i]]) {
+            id v = ((id (*)(id, SEL))objc_msgSend)(comment, sels[i]);
+            if ([v isKindOfClass:[NSString class]] && [(NSString *)v length] > 0) return (NSString *)v;
+        }
+    }
+    NSString *body = comment.body;
+    if (body.length > 0) return [NSString stringWithFormat:@"_body|%lu|%lu", (unsigned long)body.length, (unsigned long)body.hash];
+    return nil;
+}
 
 static id GetIvarObjectQuiet(id obj, const char *ivarName) {
     if (!obj) return nil;
@@ -202,19 +221,41 @@ static NSUInteger ApolloRemoveNativeTranslateActions(id actionController) {
     return removedCount;
 }
 
+// Walks ONLY the ASDisplayNode subnode tree (and, lazily, UIView subviews when
+// a view is loaded). We deliberately do NOT enumerate arbitrary `@`-typed
+// ivars: many of those are __weak / __unsafe_unretained references to objects
+// (delegates, model objects, captured cells) that may be deallocated during
+// cell reuse — touching them ARC-retains a zombie and crashes (the original
+// `objc_retain + 8` crash reported by users).
+//
+// Caps: depth and a hard visited-node ceiling, so even a misbehaving subtree
+// can't blow the stack or burn unbounded CPU on the main thread.
+static const NSUInteger kApolloMaxVisitedNodes = 256;
+
 static void ApolloCollectAttributedTextNodes(id object,
                                              NSInteger depth,
                                              NSHashTable *visited,
                                              NSMutableArray *nodes) {
-    if (!object || depth < 0 || [visited containsObject:object]) return;
+    if (!object || depth < 0) return;
+    if (visited.count >= kApolloMaxVisitedNodes) return;
+
+    Class displayNodeCls = NSClassFromString(@"ASDisplayNode");
+    BOOL isDisplayNode = displayNodeCls && [object isKindOfClass:displayNodeCls];
+    BOOL isView = [object isKindOfClass:[UIView class]];
+    if (!isDisplayNode && !isView) return;
+
+    if ([visited containsObject:object]) return;
     [visited addObject:object];
 
-    if ([object respondsToSelector:@selector(attributedText)] &&
-        [object respondsToSelector:@selector(setAttributedText:)]) {
-        NSAttributedString *attr = ((id (*)(id, SEL))objc_msgSend)(object, @selector(attributedText));
-        if ([attr isKindOfClass:[NSAttributedString class]] && attr.string.length > 0) {
-            [nodes addObject:object];
+    @try {
+        if ([object respondsToSelector:@selector(attributedText)] &&
+            [object respondsToSelector:@selector(setAttributedText:)]) {
+            NSAttributedString *attr = ((id (*)(id, SEL))objc_msgSend)(object, @selector(attributedText));
+            if ([attr isKindOfClass:[NSAttributedString class]] && attr.string.length > 0) {
+                [nodes addObject:object];
+            }
         }
+    } @catch (__unused NSException *exception) {
     }
 
     if (depth == 0) return;
@@ -225,6 +266,7 @@ static void ApolloCollectAttributedTextNodes(id object,
             NSArray *subnodes = ((id (*)(id, SEL))objc_msgSend)(object, subnodesSel);
             if ([subnodes isKindOfClass:[NSArray class]]) {
                 for (id subnode in subnodes) {
+                    if (visited.count >= kApolloMaxVisitedNodes) break;
                     ApolloCollectAttributedTextNodes(subnode, depth - 1, visited, nodes);
                 }
             }
@@ -232,25 +274,68 @@ static void ApolloCollectAttributedTextNodes(id object,
     } @catch (__unused NSException *exception) {
     }
 
-    for (Class cls = [object class]; cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
-        unsigned int count = 0;
-        Ivar *ivars = class_copyIvarList(cls, &count);
-        if (!ivars) continue;
-
-        for (unsigned int i = 0; i < count; i++) {
-            const char *type = ivar_getTypeEncoding(ivars[i]);
-            if (!type || type[0] != '@') continue;
-
-            id child = object_getIvar(object, ivars[i]);
-            if (!child || child == object) continue;
-
-            ApolloCollectAttributedTextNodes(child, depth - 1, visited, nodes);
+    // Only descend into UIView subviews when the node already has its view
+    // loaded — querying `-view` would force-load and is wrong off-main anyway.
+    @try {
+        SEL isViewLoadedSel = NSSelectorFromString(@"isNodeLoaded");
+        BOOL viewLoaded = isView;
+        if (!viewLoaded && [object respondsToSelector:isViewLoadedSel]) {
+            viewLoaded = ((BOOL (*)(id, SEL))objc_msgSend)(object, isViewLoadedSel);
         }
-
-        free(ivars);
+        if (viewLoaded && [object respondsToSelector:@selector(subviews)]) {
+            NSArray *subviews = ((id (*)(id, SEL))objc_msgSend)(object, @selector(subviews));
+            if ([subviews isKindOfClass:[NSArray class]]) {
+                for (id sub in subviews) {
+                    if (visited.count >= kApolloMaxVisitedNodes) break;
+                    ApolloCollectAttributedTextNodes(sub, depth - 1, visited, nodes);
+                }
+            }
+        }
+    } @catch (__unused NSException *exception) {
     }
 }
 
+// Returns the ASTextNode (or compatible) holding the comment body, by reading
+// well-known body ivar names directly off the cell node. This is the safe
+// fast path: it can't accidentally pick up the username / upvote / byline
+// nodes because we ask the cell explicitly for the body slot.
+static id ApolloKnownBodyTextNode(id commentCellNode) {
+    if (!commentCellNode) return nil;
+    static const char *kCandidateNames[] = {
+        "bodyTextNode",
+        "commentTextNode",
+        "commentBodyNode",
+        "bodyNode",
+        "markdownNode",
+        "commentMarkdownNode",
+        "attributedTextNode",
+        "textNode",
+        "commentBodyTextNode",
+        "bodyMarkdownNode",
+        NULL,
+    };
+    for (Class cls = [commentCellNode class]; cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
+        for (size_t i = 0; kCandidateNames[i]; i++) {
+            Ivar iv = class_getInstanceVariable(cls, kCandidateNames[i]);
+            if (!iv) continue;
+            const char *type = ivar_getTypeEncoding(iv);
+            if (!type || type[0] != '@') continue;
+            id node = nil;
+            @try { node = object_getIvar(commentCellNode, iv); } @catch (__unused NSException *e) { continue; }
+            if (!node) continue;
+            if (![node respondsToSelector:@selector(attributedText)]) continue;
+            return node;
+        }
+    }
+    return nil;
+}
+
+// Score a candidate text node's attributedString against the comment body.
+// Returns NSIntegerMin when the candidate is clearly NOT the body — this is
+// critical: previously we'd fall back to `(NSInteger)candidate.length` which
+// let unrelated nodes (username, upvote count, byline, "X minutes ago", etc.)
+// win the race and get overwritten with the translation. Now only real
+// matches qualify.
 static NSInteger ApolloCandidateScore(NSAttributedString *candidateText, NSString *commentBody) {
     if (![candidateText isKindOfClass:[NSAttributedString class]]) return NSIntegerMin;
 
@@ -258,18 +343,22 @@ static NSInteger ApolloCandidateScore(NSAttributedString *candidateText, NSStrin
     if (candidate.length == 0) return NSIntegerMin;
 
     NSString *body = ApolloNormalizeTextForCompare(commentBody ?: @"");
-    if (body.length == 0) return (NSInteger)candidate.length;
+    if (body.length == 0) return NSIntegerMin;
 
     if ([candidate isEqualToString:body]) {
         return 100000 + (NSInteger)candidate.length;
     }
 
     if ([candidate containsString:body] || [body containsString:candidate]) {
-        return 75000 + (NSInteger)MIN(candidate.length, body.length);
+        // Require the overlap to be a meaningful chunk, not just a stray word.
+        NSUInteger overlap = MIN(candidate.length, body.length);
+        if (overlap >= 12 || overlap == body.length || overlap == candidate.length) {
+            return 75000 + (NSInteger)overlap;
+        }
     }
 
-    NSUInteger prefixLength = MIN((NSUInteger)20, MIN(candidate.length, body.length));
-    if (prefixLength >= 8) {
+    NSUInteger prefixLength = MIN((NSUInteger)24, MIN(candidate.length, body.length));
+    if (prefixLength >= 12) {
         NSString *candidatePrefix = [candidate substringToIndex:prefixLength];
         NSString *bodyPrefix = [body substringToIndex:prefixLength];
         if ([candidatePrefix isEqualToString:bodyPrefix]) {
@@ -277,19 +366,31 @@ static NSInteger ApolloCandidateScore(NSAttributedString *candidateText, NSStrin
         }
     }
 
-    return (NSInteger)candidate.length;
+    return NSIntegerMin;
 }
 
 static id ApolloBestCommentTextNode(id commentCellNode, RDKComment *comment) {
+    // Fast path: ask the cell directly via well-known ivar names. This avoids
+    // both the crash exposure and the wrong-node selection bug.
+    id known = ApolloKnownBodyTextNode(commentCellNode);
+    if (known) return known;
+
     NSMutableArray *candidates = [NSMutableArray array];
-    NSHashTable *visited = [NSHashTable weakObjectsHashTable];
-    ApolloCollectAttributedTextNodes(commentCellNode, 4, visited, candidates);
+    // Pointer-identity hash table — does NOT retain visited objects, which
+    // would otherwise resurrect zombies during cell teardown.
+    NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:64];
+    ApolloCollectAttributedTextNodes(commentCellNode, 5, visited, candidates);
 
     id bestNode = nil;
     NSInteger bestScore = NSIntegerMin;
 
     for (id candidateNode in candidates) {
-        NSAttributedString *attr = ((id (*)(id, SEL))objc_msgSend)(candidateNode, @selector(attributedText));
+        NSAttributedString *attr = nil;
+        @try {
+            attr = ((id (*)(id, SEL))objc_msgSend)(candidateNode, @selector(attributedText));
+        } @catch (__unused NSException *e) {
+            continue;
+        }
         NSInteger score = ApolloCandidateScore(attr, comment.body);
         if (score > bestScore) {
             bestScore = score;
@@ -306,8 +407,37 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
     id textNode = ApolloBestCommentTextNode(commentCellNode, comment);
     if (!textNode) return;
 
-    NSAttributedString *current = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText));
+    NSAttributedString *current = nil;
+    @try {
+        current = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText));
+    } @catch (__unused NSException *e) {
+        return;
+    }
     if (![current isKindOfClass:[NSAttributedString class]]) return;
+
+    // Pre-write match guard: re-verify the chosen node's current text really
+    // is the comment body. If `ApolloBestCommentTextNode` somehow returned a
+    // wrong node (e.g. mid-reuse, body cleared), skip the write rather than
+    // overwriting a username / upvote / byline label.
+    NSString *currentNorm = ApolloNormalizeTextForCompare(current.string);
+    NSString *bodyNorm = ApolloNormalizeTextForCompare(comment.body);
+    NSString *translatedNorm = ApolloNormalizeTextForCompare(translatedText);
+    if (currentNorm.length == 0 || bodyNorm.length == 0) return;
+    BOOL textMatchesBody = [currentNorm isEqualToString:bodyNorm] ||
+                           [currentNorm containsString:bodyNorm] ||
+                           [bodyNorm containsString:currentNorm];
+    BOOL textMatchesTranslation = translatedNorm.length > 0 &&
+        ([currentNorm isEqualToString:translatedNorm] ||
+         [currentNorm containsString:translatedNorm] ||
+         [translatedNorm containsString:currentNorm]);
+    if (!textMatchesBody && !textMatchesTranslation) {
+        ApolloLog(@"[Translation] Skipping write — chosen node text does not match body or translation");
+        return;
+    }
+    // Already showing the translation? No-op.
+    if (textMatchesTranslation && !textMatchesBody) {
+        return;
+    }
 
     NSAttributedString *original = objc_getAssociatedObject(textNode, kApolloOriginalAttributedTextKey);
     if (![original isKindOfClass:[NSAttributedString class]]) {
@@ -320,7 +450,11 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
     }
 
     NSAttributedString *translatedAttr = [[NSAttributedString alloc] initWithString:translatedText attributes:attributes ?: @{}];
-    ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), translatedAttr);
+    @try {
+        ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), translatedAttr);
+    } @catch (__unused NSException *e) {
+        return;
+    }
 
     if ([textNode respondsToSelector:@selector(setNeedsLayout)]) {
         ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsLayout));
@@ -330,6 +464,14 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
     }
 
     objc_setAssociatedObject(commentCellNode, kApolloTranslatedTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    // Persist the translation by Reddit fullName so we can re-apply after
+    // collapse/expand or cell reuse without hitting the network again.
+    NSString *fullName = ApolloCommentFullName(comment);
+    if (fullName.length > 0) {
+        [sCommentTranslationByFullName setObject:translatedText forKey:fullName];
+        objc_setAssociatedObject(commentCellNode, kApolloAppliedTranslationFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    }
 }
 
 static void ApolloRestoreOriginalForCellNode(id commentCellNode, RDKComment *comment) {
@@ -344,7 +486,11 @@ static void ApolloRestoreOriginalForCellNode(id commentCellNode, RDKComment *com
     NSAttributedString *original = objc_getAssociatedObject(textNode, kApolloOriginalAttributedTextKey);
     if (![original isKindOfClass:[NSAttributedString class]]) return;
 
-    ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), original);
+    @try {
+        ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), original);
+    } @catch (__unused NSException *e) {
+        return;
+    }
 
     if ([textNode respondsToSelector:@selector(setNeedsLayout)]) {
         ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsLayout));
@@ -352,6 +498,8 @@ static void ApolloRestoreOriginalForCellNode(id commentCellNode, RDKComment *com
     if ([textNode respondsToSelector:@selector(setNeedsDisplay)]) {
         ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsDisplay));
     }
+
+    objc_setAssociatedObject(commentCellNode, kApolloAppliedTranslationFullNameKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 
 static NSString *ApolloExtractGoogleTranslation(id jsonObject) {
@@ -618,6 +766,18 @@ static void ApolloMaybeTranslateCommentCellNode(id commentCellNode, BOOL forceTr
     NSString *targetLanguage = ApolloResolvedTargetLanguageCode();
     if (targetLanguage.length == 0) return;
 
+    // Fast path 1: we already translated this exact comment in this session.
+    // Re-apply from the fullName cache without going to the network. This
+    // makes collapse/expand and cell reuse re-show the translation immediately.
+    NSString *fullName = ApolloCommentFullName(comment);
+    if (fullName.length > 0) {
+        NSString *cachedTranslation = [sCommentTranslationByFullName objectForKey:fullName];
+        if (cachedTranslation.length > 0) {
+            ApolloApplyTranslationToCellNode(commentCellNode, comment, cachedTranslation);
+            return;
+        }
+    }
+
     if (!forceTranslation) {
         NSString *detected = ApolloDetectDominantLanguage(sourceText);
         if ([detected isEqualToString:targetLanguage]) {
@@ -631,7 +791,14 @@ static void ApolloMaybeTranslateCommentCellNode(id commentCellNode, BOOL forceTr
     __weak id weakCellNode = commentCellNode;
     ApolloRequestTranslation(cacheKey, sourceText, targetLanguage, ^(NSString *translated, NSError *error) {
         id strongCellNode = weakCellNode;
-        if (!strongCellNode) return;
+        if (!strongCellNode) {
+            // Cell gone, but stash the translation by fullName so the next
+            // re-displayed cell for this comment picks it up instantly.
+            if ([translated isKindOfClass:[NSString class]] && translated.length > 0 && fullName.length > 0) {
+                [sCommentTranslationByFullName setObject:translated forKey:fullName];
+            }
+            return;
+        }
 
         NSString *currentKey = objc_getAssociatedObject(strongCellNode, kApolloCellTranslationKeyKey);
         if (![currentKey isEqualToString:cacheKey]) return;
@@ -643,6 +810,12 @@ static void ApolloMaybeTranslateCommentCellNode(id commentCellNode, BOOL forceTr
             return;
         }
 
+        // Stash by fullName even if the cell is no longer eligible to render
+        // it, so a future re-display gets it for free.
+        if (fullName.length > 0) {
+            [sCommentTranslationByFullName setObject:translated forKey:fullName];
+        }
+
         if (!forceTranslation && !ApolloShouldTranslateNow(NO)) return;
 
         RDKComment *strongComment = ApolloCommentFromCellNode(strongCellNode);
@@ -650,6 +823,21 @@ static void ApolloMaybeTranslateCommentCellNode(id commentCellNode, BOOL forceTr
 
         ApolloApplyTranslationToCellNode(strongCellNode, strongComment, translated);
     });
+}
+
+// Re-applies a previously-translated body from the fullName cache, without
+// hitting the network or re-running language detection. Used when a cell
+// re-enters display (collapse/expand, scroll-back, reuse).
+static BOOL ApolloReapplyCachedTranslationForCellNode(id commentCellNode) {
+    if (!commentCellNode) return NO;
+    RDKComment *comment = ApolloCommentFromCellNode(commentCellNode);
+    if (!comment) return NO;
+    NSString *fullName = ApolloCommentFullName(comment);
+    if (fullName.length == 0) return NO;
+    NSString *cached = [sCommentTranslationByFullName objectForKey:fullName];
+    if (cached.length == 0) return NO;
+    ApolloApplyTranslationToCellNode(commentCellNode, comment, cached);
+    return YES;
 }
 
 static void ApolloTranslateVisibleCommentsForController(UIViewController *viewController, BOOL forceTranslation) {
@@ -675,6 +863,15 @@ static void ApolloRestoreVisibleCommentsForController(UIViewController *viewCont
 
         id cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSelector);
         RDKComment *comment = ApolloCommentFromCellNode(cellNode);
+
+        // Drop from the persistent fullName cache so cellNodeVisibilityEvent:
+        // / didEnterDisplayState don't re-apply it after the user asked for
+        // the original text.
+        NSString *fullName = ApolloCommentFullName(comment);
+        if (fullName.length > 0) {
+            [sCommentTranslationByFullName removeObjectForKey:fullName];
+        }
+
         ApolloRestoreOriginalForCellNode(cellNode, comment);
     }
 }
@@ -737,6 +934,34 @@ static void ApolloUpdateTranslationButtonForController(id controller) {
     dispatch_async(dispatch_get_main_queue(), ^{
         ApolloMaybeTranslateCommentCellNode((id)self, NO);
     });
+}
+
+- (void)didEnterDisplayState {
+    %orig;
+
+    // Cell coming on-screen (scroll-back, collapse→expand, reuse). If we have
+    // a cached translation for this comment, re-apply instantly — no network,
+    // no language detection. This fixes the "translation lost on
+    // collapse/uncollapse" report.
+    if (sEnableBulkTranslation) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (!ApolloReapplyCachedTranslationForCellNode((id)self)) {
+                ApolloMaybeTranslateCommentCellNode((id)self, NO);
+            }
+        });
+    }
+}
+
+- (void)cellNodeVisibilityEvent:(NSInteger)event {
+    %orig;
+
+    // Event 0 = "will become visible". Re-apply cached translation as soon as
+    // possible so the original text never flashes when re-displaying.
+    if (sEnableBulkTranslation && event == 0) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            ApolloReapplyCachedTranslationForCellNode((id)self);
+        });
+    }
 }
 
 %end
@@ -802,6 +1027,8 @@ static void ApolloUpdateTranslationButtonForController(id controller) {
 
 %ctor {
     sTranslationCache = [NSCache new];
+    sCommentTranslationByFullName = [NSCache new];
+    sCommentTranslationByFullName.countLimit = 2048;
     sPendingTranslationCallbacks = [NSMutableDictionary dictionary];
 
     [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidReceiveMemoryWarningNotification
@@ -809,6 +1036,7 @@ static void ApolloUpdateTranslationButtonForController(id controller) {
                                                        queue:[NSOperationQueue mainQueue]
                                                   usingBlock:^(__unused NSNotification *note) {
         [sTranslationCache removeAllObjects];
+        [sCommentTranslationByFullName removeAllObjects];
     }];
 
     %init;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Translation: also scan the comments table header view / plain content view wrappers for post body text, covering post layouts where the selftext is not exposed through a visible cell node.
 - Translation: skip comments and post bodies that contain Markdown/HTML code or preformatted blocks so code snippets stay visible and are not replaced by plain translated text.
 - Translation: allow post body translation from visible header text even when Apollo does not expose an `RDKLink` model for that header layout.
+- Translation: add a controller-view fallback that translates the visible selftext node above the first comment when Apollo renders the post body outside the comments table/header node path.
 
 ## [v2.4.0] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Translation: broaden post-body translation again by falling back to the visible body text node when Apollo does not expose matching selftext through `RDKLink.selfText`.
 - Translation: also scan the comments table header view / plain content view wrappers for post body text, covering post layouts where the selftext is not exposed through a visible cell node.
 - Translation: skip comments and post bodies that contain Markdown/HTML code or preformatted blocks so code snippets stay visible and are not replaced by plain translated text.
+- Translation: allow post body translation from visible header text even when Apollo does not expose an `RDKLink` model for that header layout.
 
 ## [v2.4.0] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Translation: skip comments and post bodies that contain Markdown/HTML code or preformatted blocks so code snippets stay visible and are not replaced by plain translated text.
 - Translation: allow post body translation from visible header text even when Apollo does not expose an `RDKLink` model for that header layout.
 - Translation: add a controller-view fallback that translates the visible selftext node above the first comment when Apollo renders the post body outside the comments table/header node path.
+- Translation: re-apply cached post body translation after pull-to-refresh/layout rebuilds so the body stays translated while comments and the globe remain in translated mode.
 
 ## [v2.4.0] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Translation: preserve visual link display while translated by rebuilding translated attributed strings with base styling and reapplying link attributes only to restored Markdown/bare URL ranges.
+- Translation: stop the original-language flash after upvote/downvote redraws by synchronously swapping Apollo's refreshed original text back to the cached translated attributed text.
 - Translation: preserve exact Markdown link and bare URL strings during translation so URLs do not get localized or rewritten by the translation provider.
 - Translation: fix random crashes when opening a comment thread or tapping Translate / Original (was caused by recursing into weak ivars on partially-deallocated cell nodes; the body-text-node walker now stays inside the ASDisplayNode subnode tree and uses pointer-identity visited tracking).
 - Translation: fix username / upvote count occasionally being overwritten with the translated comment body (now finds the body via well-known ivar names and only writes when the chosen node's text really matches the comment body).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Translation: keep the globe blue until visible text is actually changed by translation. English/default-language threads no longer show a green globe just because auto-translate mode is enabled.
 - Translation: broaden post-body translation again by falling back to the visible body text node when Apollo does not expose matching selftext through `RDKLink.selfText`.
 - Translation: also scan the comments table header view / plain content view wrappers for post body text, covering post layouts where the selftext is not exposed through a visible cell node.
+- Translation: skip comments and post bodies that contain Markdown/HTML code or preformatted blocks so code snippets stay visible and are not replaced by plain translated text.
 
 ## [v2.4.0] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Translation: fix v12 translated-mode link preview/card display duplication and stale text-node ownership while preserving the upvote/downvote anti-flash behavior.
 - Translation: preserve visual link display while translated by rebuilding translated attributed strings with base styling and reapplying link attributes only to restored Markdown/bare URL ranges.
 - Translation: stop the original-language flash after upvote/downvote redraws by synchronously swapping Apollo's refreshed original text back to the cached translated attributed text.
 - Translation: preserve exact Markdown link and bare URL strings during translation so URLs do not get localized or rewritten by the translation provider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 - Translation: move the translation status caption into the visible post header cell near the metadata row. It now shows green "Translated to <language>" in translated mode and blue "Original language" in original/default-language mode.
 - Translation: also translate the post selftext (post body above comments), not just the comment cells. Post lookup now scans header cell and controller ivars so it still works when Apollo stores the `RDKLink` outside the visible cell node.
 - Translation: voting (up/downvote) on a translated comment is more resilient against Apollo redraws. Text-node interception now covers both `ASTextNode` and `ASTextNode2`, with a throttled cell redraw backstop that re-applies cached translations after score / vote-state refreshes.
+- Translation: keep the globe blue until visible text is actually changed by translation. English/default-language threads no longer show a green globe just because auto-translate mode is enabled.
+- Translation: broaden post-body translation again by falling back to the visible body text node when Apollo does not expose matching selftext through `RDKLink.selfText`.
 
 ## [v2.4.0] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Translation: keep the globe icon green after opening a Reddit/link preview and swiping back when the thread is still visibly translated.
 - Translation: fix v12 translated-mode link preview/card display duplication and stale text-node ownership while preserving the upvote/downvote anti-flash behavior.
 - Translation: preserve visual link display while translated by rebuilding translated attributed strings with base styling and reapplying link attributes only to restored Markdown/bare URL ranges.
 - Translation: stop the original-language flash after upvote/downvote redraws by synchronously swapping Apollo's refreshed original text back to the cached translated attributed text.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Translation: fix random crashes when opening a comment thread or tapping Translate / Original (was caused by recursing into weak ivars on partially-deallocated cell nodes; the body-text-node walker now stays inside the ASDisplayNode subnode tree and uses pointer-identity visited tracking).
+- Translation: fix username / upvote count occasionally being overwritten with the translated comment body (now finds the body via well-known ivar names and only writes when the chosen node's text really matches the comment body).
+- Translation: keep the translated text in place after a comment is collapsed and re-expanded, and after the cell is recycled by scrolling away and back (translations now persist by Reddit fullName and re-apply on `cellNodeVisibilityEvent:` / `didEnterDisplayState`).
+
 ## [v2.4.0] - 2026-04-18
 
 - Add option to proxy Imgur images through DuckDuckGo (Settings > General > Custom API > Media)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ All notable changes to this project will be documented in this file.
 - Translation: fix random crashes when opening a comment thread or tapping Translate / Original (was caused by recursing into weak ivars on partially-deallocated cell nodes; the body-text-node walker now stays inside the ASDisplayNode subnode tree and uses pointer-identity visited tracking).
 - Translation: fix username / upvote count occasionally being overwritten with the translated comment body (now finds the body via well-known ivar names and only writes when the chosen node's text really matches the comment body).
 - Translation: keep the translated text in place after a comment is collapsed and re-expanded, and after the cell is recycled by scrolling away and back (translations now persist by Reddit fullName and re-apply on `cellNodeVisibilityEvent:` / `didEnterDisplayState`).
-- Translation: replace the wide "Translate" / "Original" navigation-bar button with a compact globe icon that opens a single-action menu; this no longer pushes the existing sort / hamburger pill out of place. The menu wording always describes the action ("Translate to English" or "Show original") so it's no longer confusing.
-- Translation: add a small status caption at the top of the comments view — green "Translated to <language>" when in translated mode, blue "Showing original" when reverted. Hidden when bulk translation is off and the user hasn't interacted yet.
-- Translation: also translate the post selftext (post body above comments), not just the comment cells. Cached by post fullName so collapse / scroll keep the translation.
-- Translation: voting (up/downvote) on a translated comment no longer reverts that comment to the original language. A narrow `setAttributedText:` interception on text nodes we own re-applies the cached translation when Apollo rewrites the body for vote / score-color refresh.
+- Translation: replace the wide "Translate" / "Original" navigation-bar button with a compact globe icon placed to the left of Apollo's existing right-side controls. The globe is blue while showing original text and green while showing translated text.
+- Translation: move the translation status caption into the visible post header cell near the metadata row. It now shows green "Translated to <language>" in translated mode and blue "Original language" in original/default-language mode.
+- Translation: also translate the post selftext (post body above comments), not just the comment cells. Post lookup now scans header cell and controller ivars so it still works when Apollo stores the `RDKLink` outside the visible cell node.
+- Translation: voting (up/downvote) on a translated comment is more resilient against Apollo redraws. Text-node interception now covers both `ASTextNode` and `ASTextNode2`, with a throttled cell redraw backstop that re-applies cached translations after score / vote-state refreshes.
 
 ## [v2.4.0] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 - Translation: fix random crashes when opening a comment thread or tapping Translate / Original (was caused by recursing into weak ivars on partially-deallocated cell nodes; the body-text-node walker now stays inside the ASDisplayNode subnode tree and uses pointer-identity visited tracking).
 - Translation: fix username / upvote count occasionally being overwritten with the translated comment body (now finds the body via well-known ivar names and only writes when the chosen node's text really matches the comment body).
 - Translation: keep the translated text in place after a comment is collapsed and re-expanded, and after the cell is recycled by scrolling away and back (translations now persist by Reddit fullName and re-apply on `cellNodeVisibilityEvent:` / `didEnterDisplayState`).
+- Translation: replace the wide "Translate" / "Original" navigation-bar button with a compact globe icon that opens a single-action menu; this no longer pushes the existing sort / hamburger pill out of place. The menu wording always describes the action ("Translate to English" or "Show original") so it's no longer confusing.
+- Translation: add a small status caption at the top of the comments view — green "Translated to <language>" when in translated mode, blue "Showing original" when reverted. Hidden when bulk translation is off and the user hasn't interacted yet.
+- Translation: also translate the post selftext (post body above comments), not just the comment cells. Cached by post fullName so collapse / scroll keep the translation.
+- Translation: voting (up/downvote) on a translated comment no longer reverts that comment to the original language. A narrow `setAttributedText:` interception on text nodes we own re-applies the cached translation when Apollo rewrites the body for vote / score-color refresh.
 
 ## [v2.4.0] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Translation: preserve exact Markdown link and bare URL strings during translation so URLs do not get localized or rewritten by the translation provider.
 - Translation: fix random crashes when opening a comment thread or tapping Translate / Original (was caused by recursing into weak ivars on partially-deallocated cell nodes; the body-text-node walker now stays inside the ASDisplayNode subnode tree and uses pointer-identity visited tracking).
 - Translation: fix username / upvote count occasionally being overwritten with the translated comment body (now finds the body via well-known ivar names and only writes when the chosen node's text really matches the comment body).
 - Translation: keep the translated text in place after a comment is collapsed and re-expanded, and after the cell is recycled by scrolling away and back (translations now persist by Reddit fullName and re-apply on `cellNodeVisibilityEvent:` / `didEnterDisplayState`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Translation: voting (up/downvote) on a translated comment is more resilient against Apollo redraws. Text-node interception now covers both `ASTextNode` and `ASTextNode2`, with a throttled cell redraw backstop that re-applies cached translations after score / vote-state refreshes.
 - Translation: keep the globe blue until visible text is actually changed by translation. English/default-language threads no longer show a green globe just because auto-translate mode is enabled.
 - Translation: broaden post-body translation again by falling back to the visible body text node when Apollo does not expose matching selftext through `RDKLink.selfText`.
+- Translation: also scan the comments table header view / plain content view wrappers for post body text, covering post layouts where the selftext is not exposed through a visible cell node.
 
 ## [v2.4.0] - 2026-04-18
 

--- a/CustomAPIViewController.m
+++ b/CustomAPIViewController.m
@@ -1246,6 +1246,20 @@ static NSString *const kGroupSuiteName = @"group.com.christianselig.apollo";
     sShowRecentlyReadThumbnails = [defaults boolForKey:UDKeyShowRecentlyReadThumbnails];
     sPreferredGIFFallbackFormat = ([defaults integerForKey:UDKeyPreferredGIFFallbackFormat] == 0) ? 0 : 1;
     sUnmuteCommentsVideos = [defaults integerForKey:UDKeyUnmuteCommentsVideos];
+    sEnableBulkTranslation = [defaults boolForKey:UDKeyEnableBulkTranslation];
+    sAutoTranslateOnAppear = [defaults boolForKey:UDKeyAutoTranslateOnAppear];
+
+    NSString *targetLanguage = [defaults stringForKey:UDKeyTranslationTargetLanguage];
+    sTranslationTargetLanguage = targetLanguage.length > 0 ? targetLanguage : nil;
+
+    NSString *provider = [defaults stringForKey:UDKeyTranslationProvider];
+    sTranslationProvider = ([provider isEqualToString:@"libre"] || [provider isEqualToString:@"google"]) ? provider : @"google";
+
+    NSString *libreURL = [defaults stringForKey:UDKeyLibreTranslateURL];
+    sLibreTranslateURL = libreURL.length > 0 ? libreURL : @"https://libretranslate.de/translate";
+
+    NSString *libreAPIKey = [defaults stringForKey:UDKeyLibreTranslateAPIKey];
+    sLibreTranslateAPIKey = libreAPIKey.length > 0 ? libreAPIKey : nil;
 
     // Restore group preferences, preserving account state from current install
     NSString *groupPlistBackupPath = [extractDir stringByAppendingPathComponent:kGroupPlistFilename];

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,11 @@ ApolloImprovedCustomApi_FILES = \
     ApolloSettings.xm \
     ApolloRecentlyRead.xm \
     ApolloSavedCategories.xm \
+    ApolloTranslation.xm \
     ApolloVideoUnmute.xm \
     ApolloVideoSwipeFix.xm \
     CustomAPIViewController.m \
+    TranslationSettingsViewController.m \
     SavedCategoriesViewController.m \
     Defaults.m \
     UIWindow+Apollo.m \

--- a/README.md
+++ b/README.md
@@ -109,6 +109,25 @@ Recommended configuration:
     - **Substitute**: *unchecked*
     - **Sideload Spoofer**: *unchecked*
 
+## Build Injected IPA Locally
+
+You can build the tweak `.deb` and inject it into a stock Apollo IPA using `build-ipa.sh`.
+
+```bash
+make package
+./build-ipa.sh --ipa ./Apollo.ipa
+```
+
+Optional arguments:
+
+```bash
+./build-ipa.sh --ipa ./Apollo.ipa --deb ./packages/<your_tweak>.deb -o ./packages/Apollo-Translated.ipa
+```
+
+Notes:
+- The script expects either `azule` or `cyan` to be installed on your machine.
+- This is a local helper workflow for testing; final signing/sideloading is still done with your preferred signer.
+
 ## Build
 
 **Requirements:**

--- a/TranslationSettingsViewController.h
+++ b/TranslationSettingsViewController.h
@@ -1,0 +1,4 @@
+#import <UIKit/UIKit.h>
+
+@interface TranslationSettingsViewController : UITableViewController <UITextFieldDelegate>
+@end

--- a/TranslationSettingsViewController.m
+++ b/TranslationSettingsViewController.m
@@ -1,0 +1,443 @@
+#import "TranslationSettingsViewController.h"
+
+#import "ApolloState.h"
+#import "UserDefaultConstants.h"
+
+typedef NS_ENUM(NSInteger, TranslationSettingsSection) {
+    TranslationSettingsSectionGeneral = 0,
+    TranslationSettingsSectionLibre,
+    TranslationSettingsSectionCount,
+};
+
+typedef NS_ENUM(NSInteger, TranslationTextFieldTag) {
+    TranslationTextFieldTagLibreURL = 0,
+    TranslationTextFieldTagLibreAPIKey,
+};
+
+static NSString *const kDefaultLibreTranslateURL = @"https://libretranslate.de/translate";
+
+static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguageOptions(void) {
+    static NSArray<NSDictionary<NSString *, NSString *> *> *options;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        options = @[
+            @{@"code": @"", @"name": @"Device Default"},
+            @{@"code": @"en", @"name": @"English"},
+            @{@"code": @"es", @"name": @"Spanish"},
+            @{@"code": @"pt", @"name": @"Portuguese"},
+            @{@"code": @"fr", @"name": @"French"},
+            @{@"code": @"de", @"name": @"German"},
+            @{@"code": @"it", @"name": @"Italian"},
+            @{@"code": @"nl", @"name": @"Dutch"},
+            @{@"code": @"ru", @"name": @"Russian"},
+            @{@"code": @"uk", @"name": @"Ukrainian"},
+            @{@"code": @"pl", @"name": @"Polish"},
+            @{@"code": @"tr", @"name": @"Turkish"},
+            @{@"code": @"ar", @"name": @"Arabic"},
+            @{@"code": @"he", @"name": @"Hebrew"},
+            @{@"code": @"hi", @"name": @"Hindi"},
+            @{@"code": @"bn", @"name": @"Bengali"},
+            @{@"code": @"ja", @"name": @"Japanese"},
+            @{@"code": @"ko", @"name": @"Korean"},
+            @{@"code": @"zh", @"name": @"Chinese"},
+            @{@"code": @"vi", @"name": @"Vietnamese"},
+            @{@"code": @"id", @"name": @"Indonesian"},
+            @{@"code": @"th", @"name": @"Thai"},
+            @{@"code": @"el", @"name": @"Greek"},
+            @{@"code": @"sv", @"name": @"Swedish"},
+            @{@"code": @"fi", @"name": @"Finnish"},
+            @{@"code": @"da", @"name": @"Danish"},
+            @{@"code": @"no", @"name": @"Norwegian"},
+            @{@"code": @"cs", @"name": @"Czech"},
+            @{@"code": @"ro", @"name": @"Romanian"},
+            @{@"code": @"hu", @"name": @"Hungarian"},
+        ];
+    });
+    return options;
+}
+
+@implementation TranslationSettingsViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.title = @"Translation";
+    self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
+}
+
+#pragma mark - Helpers
+
+- (NSString *)normalizedLanguageCodeFromIdentifier:(NSString *)identifier {
+    if (![identifier isKindOfClass:[NSString class]] || identifier.length == 0) return nil;
+
+    NSString *lower = [[identifier stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+    if (lower.length == 0) return nil;
+
+    NSRange dash = [lower rangeOfString:@"-"];
+    NSRange underscore = [lower rangeOfString:@"_"];
+    NSUInteger splitIndex = NSNotFound;
+    if (dash.location != NSNotFound) splitIndex = dash.location;
+    if (underscore.location != NSNotFound) {
+        splitIndex = (splitIndex == NSNotFound) ? underscore.location : MIN(splitIndex, underscore.location);
+    }
+    if (splitIndex != NSNotFound && splitIndex > 0) {
+        lower = [lower substringToIndex:splitIndex];
+    }
+    return lower.length > 0 ? lower : nil;
+}
+
+- (NSString *)deviceLanguageCode {
+    NSString *preferred = [NSLocale preferredLanguages].firstObject;
+    NSString *normalized = [self normalizedLanguageCodeFromIdentifier:preferred];
+    return normalized ?: @"en";
+}
+
+- (NSString *)displayNameForLanguageCode:(NSString *)code {
+    NSString *normalized = [self normalizedLanguageCodeFromIdentifier:code];
+    if (!normalized || normalized.length == 0) return @"Device Default";
+
+    for (NSDictionary<NSString *, NSString *> *option in ApolloTranslationLanguageOptions()) {
+        if ([option[@"code"] isEqualToString:normalized]) {
+            return option[@"name"];
+        }
+    }
+
+    NSString *localized = [[NSLocale currentLocale] localizedStringForLanguageCode:normalized];
+    if ([localized isKindOfClass:[NSString class]] && localized.length > 0) {
+        return localized.capitalizedString;
+    }
+
+    return normalized.uppercaseString;
+}
+
+- (NSString *)currentTargetLanguageDetailText {
+    NSString *overrideCode = [self normalizedLanguageCodeFromIdentifier:sTranslationTargetLanguage];
+    if (overrideCode.length > 0) {
+        return [self displayNameForLanguageCode:overrideCode];
+    }
+
+    NSString *deviceCode = [self deviceLanguageCode];
+    NSString *deviceName = [self displayNameForLanguageCode:deviceCode];
+    return [NSString stringWithFormat:@"Device Default (%@)", deviceName];
+}
+
+- (NSString *)currentProvider {
+    if ([sTranslationProvider isEqualToString:@"libre"]) {
+        return @"libre";
+    }
+    return @"google";
+}
+
+- (NSString *)providerDetailText {
+    return [[self currentProvider] isEqualToString:@"libre"] ? @"LibreTranslate" : @"Google";
+}
+
+- (void)setTargetLanguageCode:(NSString *)code {
+    NSString *normalized = [self normalizedLanguageCodeFromIdentifier:code];
+
+    if (normalized.length == 0) {
+        sTranslationTargetLanguage = nil;
+        [[NSUserDefaults standardUserDefaults] setObject:@"" forKey:UDKeyTranslationTargetLanguage];
+    } else {
+        sTranslationTargetLanguage = [normalized copy];
+        [[NSUserDefaults standardUserDefaults] setObject:sTranslationTargetLanguage forKey:UDKeyTranslationTargetLanguage];
+    }
+
+    NSIndexPath *path = [NSIndexPath indexPathForRow:2 inSection:TranslationSettingsSectionGeneral];
+    [self.tableView reloadRowsAtIndexPaths:@[path] withRowAnimation:UITableViewRowAnimationNone];
+}
+
+- (void)setProvider:(NSString *)provider {
+    NSString *normalized = [[provider stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+    if (![normalized isEqualToString:@"libre"]) normalized = @"google";
+
+    sTranslationProvider = [normalized copy];
+    [[NSUserDefaults standardUserDefaults] setObject:sTranslationProvider forKey:UDKeyTranslationProvider];
+
+    NSIndexPath *providerPath = [NSIndexPath indexPathForRow:3 inSection:TranslationSettingsSectionGeneral];
+    [self.tableView reloadRowsAtIndexPaths:@[providerPath] withRowAnimation:UITableViewRowAnimationNone];
+}
+
+- (UITableViewCell *)switchCellWithIdentifier:(NSString *)identifier
+                                        label:(NSString *)label
+                                           on:(BOOL)on
+                                       action:(SEL)action {
+    UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:identifier];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:identifier];
+        cell.selectionStyle = UITableViewCellSelectionStyleNone;
+
+        UISwitch *toggleSwitch = [[UISwitch alloc] init];
+        [toggleSwitch addTarget:self action:action forControlEvents:UIControlEventValueChanged];
+        cell.accessoryView = toggleSwitch;
+    }
+
+    cell.textLabel.text = label;
+    ((UISwitch *)cell.accessoryView).on = on;
+    return cell;
+}
+
+- (UITableViewCell *)valueCellWithIdentifier:(NSString *)identifier
+                                       label:(NSString *)label
+                                      detail:(NSString *)detail {
+    UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:identifier];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:identifier];
+        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+        cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+    }
+
+    cell.textLabel.text = label;
+    cell.detailTextLabel.text = detail;
+    return cell;
+}
+
+- (UITableViewCell *)textFieldCellWithIdentifier:(NSString *)identifier
+                                           label:(NSString *)label
+                                     placeholder:(NSString *)placeholder
+                                            text:(NSString *)text
+                                             tag:(NSInteger)tag
+                                     secureEntry:(BOOL)secureEntry {
+    UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:identifier];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:identifier];
+        cell.selectionStyle = UITableViewCellSelectionStyleNone;
+        cell.textLabel.text = label;
+
+        UITextField *textField = [[UITextField alloc] init];
+        textField.placeholder = placeholder;
+        textField.tag = tag;
+        textField.delegate = self;
+        textField.textAlignment = NSTextAlignmentRight;
+        textField.clearButtonMode = UITextFieldViewModeWhileEditing;
+        textField.font = [UIFont systemFontOfSize:16];
+        textField.secureTextEntry = secureEntry;
+        textField.autocorrectionType = UITextAutocorrectionTypeNo;
+        textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+        textField.returnKeyType = UIReturnKeyDone;
+        textField.translatesAutoresizingMaskIntoConstraints = NO;
+
+        [cell.contentView addSubview:textField];
+        [NSLayoutConstraint activateConstraints:@[
+            [textField.trailingAnchor constraintEqualToAnchor:cell.contentView.layoutMarginsGuide.trailingAnchor],
+            [textField.centerYAnchor constraintEqualToAnchor:cell.contentView.centerYAnchor],
+            [textField.widthAnchor constraintEqualToAnchor:cell.contentView.widthAnchor multiplier:0.60],
+        ]];
+    }
+
+    UITextField *textField = nil;
+    for (UIView *subview in cell.contentView.subviews) {
+        if ([subview isKindOfClass:[UITextField class]]) {
+            textField = (UITextField *)subview;
+            break;
+        }
+    }
+
+    cell.textLabel.text = label;
+    textField.placeholder = placeholder;
+    textField.text = text;
+    textField.secureTextEntry = secureEntry;
+
+    return cell;
+}
+
+- (void)presentTargetLanguageSheetFromSourceView:(UIView *)sourceView {
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Target Language"
+                                                                   message:nil
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+
+    NSString *currentOverride = [self normalizedLanguageCodeFromIdentifier:sTranslationTargetLanguage] ?: @"";
+
+    for (NSDictionary<NSString *, NSString *> *option in ApolloTranslationLanguageOptions()) {
+        NSString *code = option[@"code"];
+        NSString *name = option[@"name"];
+        BOOL isCurrent = [code isEqualToString:currentOverride];
+        NSString *title = isCurrent ? [NSString stringWithFormat:@"%@ (Current)", name] : name;
+
+        [sheet addAction:[UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+            [self setTargetLanguageCode:code];
+        }]];
+    }
+
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    if (popover && sourceView) {
+        popover.sourceView = sourceView;
+        popover.sourceRect = sourceView.bounds;
+    }
+
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+- (void)presentProviderSheetFromSourceView:(UIView *)sourceView {
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Primary Provider"
+                                                                   message:nil
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+
+    NSString *currentProvider = [self currentProvider];
+    NSString *googleTitle = [currentProvider isEqualToString:@"google"] ? @"Google (Current)" : @"Google";
+    NSString *libreTitle = [currentProvider isEqualToString:@"libre"] ? @"LibreTranslate (Current)" : @"LibreTranslate";
+
+    [sheet addAction:[UIAlertAction actionWithTitle:googleTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self setProvider:@"google"];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:libreTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self setProvider:@"libre"];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    if (popover && sourceView) {
+        popover.sourceView = sourceView;
+        popover.sourceRect = sourceView.bounds;
+    }
+
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+#pragma mark - UITableViewDataSource
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return TranslationSettingsSectionCount;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    switch (section) {
+        case TranslationSettingsSectionGeneral: return 4;
+        case TranslationSettingsSectionLibre: return 2;
+        default: return 0;
+    }
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
+    switch (section) {
+        case TranslationSettingsSectionGeneral: return @"General";
+        case TranslationSettingsSectionLibre: return @"LibreTranslate";
+        default: return nil;
+    }
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
+    switch (section) {
+        case TranslationSettingsSectionGeneral:
+            return @"When enabled, loaded comments are translated in-place. The native per-comment Translate action is hidden to avoid duplicate flows.";
+        case TranslationSettingsSectionLibre:
+            return @"Google is the default primary provider. If it fails, the tweak automatically falls back to LibreTranslate using this URL and optional API key.";
+        default:
+            return nil;
+    }
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == TranslationSettingsSectionGeneral) {
+        switch (indexPath.row) {
+            case 0:
+                return [self switchCellWithIdentifier:@"Cell_Translation_Enabled"
+                                                label:@"Enable Bulk Translation"
+                                                   on:sEnableBulkTranslation
+                                               action:@selector(enableBulkTranslationSwitchToggled:)];
+            case 1: {
+                UITableViewCell *cell = [self switchCellWithIdentifier:@"Cell_Translation_Auto"
+                                                                 label:@"Auto Translate on Scroll"
+                                                                    on:sAutoTranslateOnAppear
+                                                                action:@selector(autoTranslateSwitchToggled:)];
+                cell.textLabel.enabled = sEnableBulkTranslation;
+                ((UISwitch *)cell.accessoryView).enabled = sEnableBulkTranslation;
+                return cell;
+            }
+            case 2:
+                return [self valueCellWithIdentifier:@"Cell_Translation_TargetLanguage"
+                                               label:@"Target Language"
+                                              detail:[self currentTargetLanguageDetailText]];
+            case 3:
+                return [self valueCellWithIdentifier:@"Cell_Translation_Provider"
+                                               label:@"Primary Provider"
+                                              detail:[self providerDetailText]];
+            default:
+                return [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+        }
+    }
+
+    if (indexPath.section == TranslationSettingsSectionLibre) {
+        switch (indexPath.row) {
+            case 0:
+                return [self textFieldCellWithIdentifier:@"Cell_Translation_LibreURL"
+                                                   label:@"API URL"
+                                             placeholder:kDefaultLibreTranslateURL
+                                                    text:sLibreTranslateURL ?: kDefaultLibreTranslateURL
+                                                     tag:TranslationTextFieldTagLibreURL
+                                             secureEntry:NO];
+            case 1:
+                return [self textFieldCellWithIdentifier:@"Cell_Translation_LibreAPIKey"
+                                                   label:@"API Key"
+                                             placeholder:@"Optional"
+                                                    text:sLibreTranslateAPIKey ?: @""
+                                                     tag:TranslationTextFieldTagLibreAPIKey
+                                             secureEntry:YES];
+            default:
+                return [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+        }
+    }
+
+    return [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+}
+
+#pragma mark - UITableViewDelegate
+
+- (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
+    return indexPath.section == TranslationSettingsSectionGeneral && (indexPath.row == 2 || indexPath.row == 3);
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+
+    if (indexPath.section != TranslationSettingsSectionGeneral) return;
+
+    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+    if (indexPath.row == 2) {
+        [self presentTargetLanguageSheetFromSourceView:cell];
+    } else if (indexPath.row == 3) {
+        [self presentProviderSheetFromSourceView:cell];
+    }
+}
+
+#pragma mark - UITextFieldDelegate
+
+- (BOOL)textFieldShouldReturn:(UITextField *)textField {
+    [textField resignFirstResponder];
+    return YES;
+}
+
+- (void)textFieldDidEndEditing:(UITextField *)textField {
+    NSString *value = [textField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+
+    if (textField.tag == TranslationTextFieldTagLibreURL) {
+        if (value.length == 0) value = kDefaultLibreTranslateURL;
+
+        sLibreTranslateURL = [value copy];
+        [[NSUserDefaults standardUserDefaults] setObject:sLibreTranslateURL forKey:UDKeyLibreTranslateURL];
+        textField.text = sLibreTranslateURL;
+    } else if (textField.tag == TranslationTextFieldTagLibreAPIKey) {
+        sLibreTranslateAPIKey = value.length > 0 ? [value copy] : nil;
+        [[NSUserDefaults standardUserDefaults] setObject:(sLibreTranslateAPIKey ?: @"") forKey:UDKeyLibreTranslateAPIKey];
+        textField.text = sLibreTranslateAPIKey ?: @"";
+    }
+}
+
+#pragma mark - Switch Actions
+
+- (void)enableBulkTranslationSwitchToggled:(UISwitch *)sender {
+    sEnableBulkTranslation = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sEnableBulkTranslation forKey:UDKeyEnableBulkTranslation];
+
+    NSIndexPath *autoPath = [NSIndexPath indexPathForRow:1 inSection:TranslationSettingsSectionGeneral];
+    [self.tableView reloadRowsAtIndexPaths:@[autoPath] withRowAnimation:UITableViewRowAnimationNone];
+}
+
+- (void)autoTranslateSwitchToggled:(UISwitch *)sender {
+    sAutoTranslateOnAppear = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sAutoTranslateOnAppear forKey:UDKeyAutoTranslateOnAppear];
+}
+
+@end

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -755,7 +755,13 @@ static void initializeRandomSources() {
                                     UDKeyShowRecentlyReadThumbnails: @YES,
                                     UDKeyPreferredGIFFallbackFormat: @1,
                                     UDKeyUnmuteCommentsVideos: @0,
-                                    UDKeyProxyImgurDDG: @NO};
+                                    UDKeyProxyImgurDDG: @NO,
+                                    UDKeyEnableBulkTranslation: @NO,
+                                    UDKeyAutoTranslateOnAppear: @YES,
+                                    UDKeyTranslationTargetLanguage: @"",
+                                    UDKeyTranslationProvider: @"google",
+                                    UDKeyLibreTranslateURL: @"https://libretranslate.de/translate",
+                                    UDKeyLibreTranslateAPIKey: @""};
     [[NSUserDefaults standardUserDefaults] registerDefaults:defaultValues];
 
     sRedditClientId = (NSString *)[[[NSUserDefaults standardUserDefaults] objectForKey:UDKeyRedditClientId] ?: @"" copy];
@@ -768,6 +774,24 @@ static void initializeRandomSources() {
     sReadPostMaxCount = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyReadPostMaxCount];
     sUnmuteCommentsVideos = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyUnmuteCommentsVideos];
     sProxyImgurDDG = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyProxyImgurDDG];
+    sEnableBulkTranslation = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableBulkTranslation];
+    sAutoTranslateOnAppear = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyAutoTranslateOnAppear];
+
+    NSString *targetLanguage = (NSString *)[[NSUserDefaults standardUserDefaults] objectForKey:UDKeyTranslationTargetLanguage];
+    sTranslationTargetLanguage = [targetLanguage length] > 0 ? [targetLanguage copy] : nil;
+
+    NSString *provider = (NSString *)[[NSUserDefaults standardUserDefaults] objectForKey:UDKeyTranslationProvider];
+    if ([provider isEqualToString:@"libre"] || [provider isEqualToString:@"google"]) {
+        sTranslationProvider = [provider copy];
+    } else {
+        sTranslationProvider = @"google";
+    }
+
+    NSString *libreURL = (NSString *)[[NSUserDefaults standardUserDefaults] objectForKey:UDKeyLibreTranslateURL];
+    sLibreTranslateURL = [libreURL length] > 0 ? [libreURL copy] : @"https://libretranslate.de/translate";
+
+    NSString *libreAPIKey = (NSString *)[[NSUserDefaults standardUserDefaults] objectForKey:UDKeyLibreTranslateAPIKey];
+    sLibreTranslateAPIKey = [libreAPIKey length] > 0 ? [libreAPIKey copy] : nil;
 
     // Trim ReadPostIDs if over configured max
     if (sReadPostMaxCount > 0) {

--- a/UserDefaultConstants.h
+++ b/UserDefaultConstants.h
@@ -18,3 +18,11 @@ static NSString *const UDKeyOpenLinksInSteamApp = @"OpenLinksInSteamApp";
 static NSString *const UDKeyCollapsePinnedComments = @"CollapsePinnedComments";
 static NSString *const UDKeyFilterNSFWRecentlyRead = @"FilterNSFWRecentlyRead";
 static NSString *const UDKeyProxyImgurDDG = @"ProxyImgurDDG";
+
+// Bulk translation feature
+static NSString *const UDKeyEnableBulkTranslation = @"EnableBulkTranslation";
+static NSString *const UDKeyAutoTranslateOnAppear = @"AutoTranslateOnAppear";
+static NSString *const UDKeyTranslationTargetLanguage = @"TranslationTargetLanguage";
+static NSString *const UDKeyTranslationProvider = @"TranslationProvider"; // google | libre
+static NSString *const UDKeyLibreTranslateURL = @"LibreTranslateURL";
+static NSString *const UDKeyLibreTranslateAPIKey = @"LibreTranslateAPIKey";

--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -euo pipefail
+
+IPA_PATH=""
+DEB_PATH=""
+OUTPUT_IPA="Apollo-Translated.ipa"
+
+usage() {
+    echo "Usage: $0 --ipa <Apollo.ipa> [--deb <packages/*.deb>] [-o <output.ipa>]"
+    echo ""
+    echo "Options:"
+    echo "  --ipa <file>      Path to base Apollo IPA (required)"
+    echo "  --deb <file>      Path to tweak .deb (default: newest in packages/)"
+    echo "  -o, --output      Output IPA filename (default: Apollo-Translated.ipa)"
+    echo "  -h, --help        Show this help"
+    echo ""
+    echo "Examples:"
+    echo "  $0 --ipa ./Apollo.ipa"
+    echo "  $0 --ipa ./Apollo.ipa --deb ./packages/com.jeffreyca.apolloimprovedcustomapi_*.deb -o ./packages/Apollo-Translated.ipa"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ipa)
+            IPA_PATH="$2"
+            shift 2
+            ;;
+        --deb)
+            DEB_PATH="$2"
+            shift 2
+            ;;
+        -o|--output)
+            OUTPUT_IPA="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$IPA_PATH" ]]; then
+    echo "Error: --ipa is required"
+    usage
+    exit 1
+fi
+
+if [[ ! -f "$IPA_PATH" ]]; then
+    echo "Error: IPA not found: $IPA_PATH"
+    exit 1
+fi
+
+if [[ -z "$DEB_PATH" ]]; then
+    latest_deb=$(ls -1t packages/*.deb 2>/dev/null | head -1 || true)
+    if [[ -z "$latest_deb" ]]; then
+        echo "Error: No .deb found in packages/. Run 'make package' first or pass --deb."
+        exit 1
+    fi
+    DEB_PATH="$latest_deb"
+fi
+
+if [[ ! -f "$DEB_PATH" ]]; then
+    echo "Error: .deb not found: $DEB_PATH"
+    exit 1
+fi
+
+echo "Base IPA : $IPA_PATH"
+echo "Tweak DEB: $DEB_PATH"
+echo "Output   : $OUTPUT_IPA"
+
+if command -v azule >/dev/null 2>&1; then
+    echo "Using azule for injection..."
+
+    if azule -i "$IPA_PATH" -f "$DEB_PATH" -o "$OUTPUT_IPA"; then
+        echo "Injected IPA created at: $OUTPUT_IPA"
+        exit 0
+    fi
+
+    echo "azule command failed with -o syntax, retrying fallback syntax..."
+    azule -i "$IPA_PATH" -f "$DEB_PATH"
+
+    generated=$(ls -1t ./*.ipa 2>/dev/null | head -1 || true)
+    if [[ -z "$generated" ]]; then
+        echo "Error: azule did not produce an IPA."
+        exit 1
+    fi
+
+    if [[ "$generated" != "$OUTPUT_IPA" ]]; then
+        mv -f "$generated" "$OUTPUT_IPA"
+    fi
+
+    echo "Injected IPA created at: $OUTPUT_IPA"
+    exit 0
+fi
+
+if command -v cyan >/dev/null 2>&1; then
+    echo "Using cyan for injection..."
+
+    if cyan -i "$IPA_PATH" -d "$DEB_PATH" -o "$OUTPUT_IPA"; then
+        echo "Injected IPA created at: $OUTPUT_IPA"
+        exit 0
+    fi
+
+    echo "Error: cyan injection failed."
+    exit 1
+fi
+
+echo "Error: Neither 'azule' nor 'cyan' is installed."
+echo "Install one of them, then rerun this script."
+exit 1


### PR DESCRIPTION
updating the translation feature on apollo so comments can translate and load in the langauge you want inside the comment section so you can see all the loaded comments in the language you want instead of having to  translate 1 comment at a time which is super inefficient. 

If anyone wants to test this out and see how it works, in settings the translate option if off will default to the traditional way to translate leaving the one built into apollo as is if you turn it on then it will use this version.