### PR TITLE
Translation: Don't Translate languages list + reliability fixes

### DIFF
--- a/ApolloSettings.xm
+++ b/ApolloSettings.xm
@@ -11,6 +11,26 @@
 @interface SettingsViewController : UIViewController
 @end
 
+@interface SettingsGeneralViewController : UIViewController
+@end
+
+// Apollo's native General > Other section contains an "Always Offer
+// Translate" row that is redundant and confusing now that we ship our
+// own Translation feature. Hide the row by collapsing its height to 0
+// and skipping selection. The underlying Apollo setting/code is
+// untouched — we just don't show the row.
+static NSString *const kApolloAlwaysOfferTranslateLabel = @"Always Offer Translate";
+static const void *kApolloHiddenRowsKey = &kApolloHiddenRowsKey;
+
+static NSMutableSet<NSIndexPath *> *ApolloHiddenRowsForTableView(UITableView *tableView) {
+    NSMutableSet *set = objc_getAssociatedObject(tableView, kApolloHiddenRowsKey);
+    if (!set) {
+        set = [NSMutableSet set];
+        objc_setAssociatedObject(tableView, kApolloHiddenRowsKey, set, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    return set;
+}
+
 static UIImage *createSettingsIcon(NSString *sfSymbolName, UIColor *bgColor) {
     CGSize size = CGSizeMake(29, 29);
     UIGraphicsBeginImageContextWithOptions(size, NO, 0);
@@ -115,6 +135,60 @@ static UIImage *createSettingsIcon(NSString *sfSymbolName, UIColor *bgColor) {
 
 %end
 
+%hook SettingsGeneralViewController
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = %orig;
+    NSString *text = cell.textLabel.text;
+    NSMutableSet *hidden = ApolloHiddenRowsForTableView(tableView);
+    if (text && [text isEqualToString:kApolloAlwaysOfferTranslateLabel]) {
+        [hidden addObject:indexPath];
+        cell.hidden = YES;
+        cell.contentView.hidden = YES;
+    } else {
+        if ([hidden containsObject:indexPath]) {
+            [hidden removeObject:indexPath];
+        }
+    }
+    return cell;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSMutableSet *hidden = ApolloHiddenRowsForTableView(tableView);
+    if ([hidden containsObject:indexPath]) {
+        return 0.0;
+    }
+    // Peek at the cell to discover whether it's the row we want to hide before height is finalized.
+    UITableViewCell *peek = [self tableView:tableView cellForRowAtIndexPath:indexPath];
+    NSString *text = peek.textLabel.text;
+    if (text && [text isEqualToString:kApolloAlwaysOfferTranslateLabel]) {
+        [hidden addObject:indexPath];
+        return 0.0;
+    }
+    return %orig;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSMutableSet *hidden = ApolloHiddenRowsForTableView(tableView);
+    if ([hidden containsObject:indexPath]) {
+        [tableView deselectRowAtIndexPath:indexPath animated:NO];
+        return;
+    }
+    %orig;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
+    %orig;
+    NSString *text = cell.textLabel.text;
+    if (text && [text isEqualToString:kApolloAlwaysOfferTranslateLabel]) {
+        cell.hidden = YES;
+        cell.contentView.hidden = YES;
+    }
+}
+
+%end
+
 %ctor {
-    %init(SettingsViewController=objc_getClass("_TtC6Apollo22SettingsViewController"));
+    %init(SettingsViewController=objc_getClass("_TtC6Apollo22SettingsViewController"),
+          SettingsGeneralViewController=objc_getClass("_TtC6Apollo29SettingsGeneralViewController"));
 }

--- a/ApolloState.h
+++ b/ApolloState.h
@@ -22,7 +22,10 @@ extern BOOL sProxyImgurDDG;
 
 extern BOOL sEnableBulkTranslation;
 extern BOOL sAutoTranslateOnAppear;
+extern BOOL sTranslatePostTitles;
 extern NSString *sTranslationTargetLanguage;
 extern NSString *sTranslationProvider;
 extern NSString *sLibreTranslateURL;
 extern NSString *sLibreTranslateAPIKey;
+// Lowercased 2-letter language codes the user has opted out of translating.
+extern NSArray<NSString *> *sTranslationSkipLanguages;

--- a/ApolloState.m
+++ b/ApolloState.m
@@ -21,7 +21,9 @@ BOOL sProxyImgurDDG = NO;
 
 BOOL sEnableBulkTranslation = NO;
 BOOL sAutoTranslateOnAppear = YES;
+BOOL sTranslatePostTitles = NO;
 NSString *sTranslationTargetLanguage = nil;
 NSString *sTranslationProvider = nil;
 NSString *sLibreTranslateURL = nil;
 NSString *sLibreTranslateAPIKey = nil;
+NSArray<NSString *> *sTranslationSkipLanguages = nil;

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -63,6 +63,11 @@ static NSCache<NSString *, NSString *> *sLinkTranslationByFullName;
 // on every visibility / scroll tick for the same comment. Reset whenever
 // the user changes the skip-language list (caches flushed).
 static NSMutableSet<NSString *> *sLoggedSkippedCommentFullNames;
+// Per-session set of post fullNames for which we already emitted the
+// "skipping structured post body" log. Prevents the same per-call flood as
+// above, since the post-body translate path runs on every viewDidAppear
+// retry / cell visibility event. Reset on skip-language changes.
+static NSMutableSet<NSString *> *sLoggedSkippedStructuredPostFullNames;
 // Mirrors of the two persistent caches above. NSCache hides its contents, so
 // we maintain plain NSMutableDictionaries alongside it for snapshot / disk
 // persistence on backgrounding. All writes go through helper macros below.
@@ -291,15 +296,175 @@ static BOOL ApolloHTMLContainsCode(NSString *html) {
            [lower containsString:@"</code"];
 }
 
+// Detects post bodies whose visual structure (markdown tables, headings,
+// many blank-line-separated paragraphs) does not survive a translator round-
+// trip. Our apply path collapses per-range attributes (bold headings,
+// monospace table cells, paragraph spacing) to a single base font, and the
+// translator commonly collapses `\n\n` to single newlines — together those
+// produce illegible output where most visible text disappears and only inline
+// emoji remain. Conservative: when in doubt, treat as structured and skip.
+// Only used for post bodies; comments don't trigger this and continue to
+// translate normally inside structured posts.
+static BOOL ApolloTextLooksLikeStructuredPostBody(NSString *text) {
+    if (![text isKindOfClass:[NSString class]] || text.length == 0) return NO;
+
+    NSArray<NSString *> *lines = [text componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+    NSCharacterSet *ws = [NSCharacterSet whitespaceCharacterSet];
+
+    NSUInteger pipeRowCount = 0;
+    NSUInteger atxHeadingCount = 0;
+    NSUInteger boldOnlyHeadingCount = 0;
+    BOOL sawTableSeparator = NO;
+
+    NSUInteger scanLimit = MIN(lines.count, (NSUInteger)200);
+    for (NSUInteger i = 0; i < scanLimit; i++) {
+        NSString *line = [lines[i] stringByTrimmingCharactersInSet:ws];
+        if (line.length == 0) continue;
+
+        // Markdown table separator row, e.g. "|---|---|" or "| --- | :---: |"
+        if (!sawTableSeparator && [line hasPrefix:@"|"] && [line hasSuffix:@"|"]) {
+            BOOL onlyDashesAndPipes = YES;
+            for (NSUInteger j = 0; j < line.length; j++) {
+                unichar c = [line characterAtIndex:j];
+                if (c != '|' && c != '-' && c != ':' && c != ' ' && c != '\t') { onlyDashesAndPipes = NO; break; }
+            }
+            if (onlyDashesAndPipes && [line rangeOfString:@"---"].location != NSNotFound) {
+                sawTableSeparator = YES;
+            }
+        }
+
+        // Markdown table content row: starts and ends with `|`.
+        if ([line hasPrefix:@"|"] && [line hasSuffix:@"|"] && line.length >= 3) {
+            pipeRowCount++;
+        }
+
+        // ATX heading: `#`, `##`, ... up to 6.
+        if ([line hasPrefix:@"#"]) {
+            NSUInteger hashCount = 0;
+            while (hashCount < line.length && hashCount < 6 && [line characterAtIndex:hashCount] == '#') hashCount++;
+            if (hashCount > 0 && hashCount < line.length && [line characterAtIndex:hashCount] == ' ') {
+                atxHeadingCount++;
+            }
+        }
+
+        // Bold-only heading lines like "**LINE-UPS**" or "**MATCH STATS**"
+        // — Reddit's post-match thread convention. Whole line wrapped in
+        // `**...**` and no other formatting.
+        if (line.length >= 5 && [line hasPrefix:@"**"] && [line hasSuffix:@"**"]) {
+            NSString *inner = [line substringWithRange:NSMakeRange(2, line.length - 4)];
+            if (inner.length > 0 && [inner rangeOfString:@"**"].location == NSNotFound) {
+                boldOnlyHeadingCount++;
+            }
+        }
+    }
+
+    if (sawTableSeparator) return YES;
+    if (pipeRowCount >= 3) return YES;
+    if (atxHeadingCount >= 1) return YES;
+    if (boldOnlyHeadingCount >= 2) return YES;
+
+    // Heavy paragraph structure: lots of blank-line breaks in a long body.
+    // Translator commonly collapses these and our flat re-render can't
+    // recover the section visuals. Bar lowered after the Shakhtar
+    // post-match thread case showed the visible-text path receives the
+    // rendered output (no `|`/`#`/`**`), so structural-only signals are
+    // gone — only the paragraph-break shape survives.
+    if (text.length >= 200) {
+        NSUInteger blankBreaks = 0;
+        NSRange searchRange = NSMakeRange(0, text.length);
+        while (searchRange.length > 0) {
+            NSRange found = [text rangeOfString:@"\n\n" options:0 range:searchRange];
+            if (found.location == NSNotFound) break;
+            blankBreaks++;
+            NSUInteger next = found.location + found.length;
+            if (next >= text.length) break;
+            searchRange = NSMakeRange(next, text.length - next);
+        }
+        if (blankBreaks >= 3) return YES;
+    }
+
+    // Many "Foo: bar" colon-terminated label lines (Venue:, Referee:,
+    // Manager:, Starting XI:, etc.) is a strong indicator of a structured
+    // post-match / spec-sheet style body even when no markdown survives.
+    NSUInteger labelLineCount = 0;
+    for (NSUInteger i = 0; i < scanLimit; i++) {
+        NSString *line = [lines[i] stringByTrimmingCharactersInSet:ws];
+        if (line.length < 4 || line.length > 80) continue;
+        NSRange colon = [line rangeOfString:@":"];
+        if (colon.location == NSNotFound) continue;
+        // "Word:" or "Word Word:" near start, with content after
+        if (colon.location >= 2 && colon.location <= 30) {
+            labelLineCount++;
+            if (labelLineCount >= 3) return YES;
+        }
+    }
+
+    return NO;
+}
+
 static BOOL ApolloCommentContainsCodeOrPreformatted(RDKComment *comment) {
     if (!comment) return NO;
     return ApolloTextContainsMarkdownCode(comment.body) || ApolloHTMLContainsCode(comment.bodyHTML);
 }
 
+// HTML-side companion to ApolloTextLooksLikeStructuredPostBody. Reddit
+// renders self-post bodies to HTML server-side, and Apollo's ASTextNode
+// pipeline consumes the markdown before our gate sees it — so checking
+// link.selfText / visibleText alone misses tables/headings/HRs whenever
+// the markdown source isn't available locally. The HTML form, however,
+// is reliably populated on RDKLink.selfTextHTML. Cheap case-insensitive
+// substring checks; conservative — any structural tag trips the skip.
+static BOOL ApolloHTMLLooksLikeStructuredPostBody(NSString *html) {
+    if (![html isKindOfClass:[NSString class]] || html.length == 0) return NO;
+    NSStringCompareOptions opts = NSCaseInsensitiveSearch;
+    if ([html rangeOfString:@"<table" options:opts].location != NSNotFound) return YES;
+    if ([html rangeOfString:@"<hr" options:opts].location != NSNotFound) return YES;
+    if ([html rangeOfString:@"<h1" options:opts].location != NSNotFound) return YES;
+    if ([html rangeOfString:@"<h2" options:opts].location != NSNotFound) return YES;
+    if ([html rangeOfString:@"<h3" options:opts].location != NSNotFound) return YES;
+    if ([html rangeOfString:@"<h4" options:opts].location != NSNotFound) return YES;
+    if ([html rangeOfString:@"<h5" options:opts].location != NSNotFound) return YES;
+    if ([html rangeOfString:@"<h6" options:opts].location != NSNotFound) return YES;
+
+    // Many <p> blocks => heavy paragraph structure (matches the >=4
+    // blank-line heuristic used on the markdown side).
+    NSUInteger pCount = 0;
+    NSRange searchRange = NSMakeRange(0, html.length);
+    while (searchRange.length > 0) {
+        NSRange found = [html rangeOfString:@"<p" options:opts range:searchRange];
+        if (found.location == NSNotFound) break;
+        pCount++;
+        if (pCount >= 4) return YES;
+        NSUInteger next = found.location + found.length;
+        if (next >= html.length) break;
+        searchRange = NSMakeRange(next, html.length - next);
+    }
+    return NO;
+}
+
 static BOOL ApolloLinkContainsCodeOrPreformatted(RDKLink *link, NSString *visibleText) {
     return ApolloTextContainsMarkdownCode(link.selfText) ||
            ApolloHTMLContainsCode(link.selfTextHTML) ||
-           ApolloTextContainsMarkdownCode(visibleText);
+           ApolloTextContainsMarkdownCode(visibleText) ||
+           ApolloTextLooksLikeStructuredPostBody(link.selfText) ||
+           ApolloTextLooksLikeStructuredPostBody(visibleText) ||
+           ApolloHTMLLooksLikeStructuredPostBody(link.selfTextHTML);
+}
+
+// One-shot diagnostic helper for post-body skips. The translate path runs
+// on every viewDidAppear retry / cell visibility event, so without a guard
+// the same skip line floods the log dozens of times per post.
+static void ApolloLogPostBodySkipOnce(RDKLink *link, NSString *reason) {
+    NSString *fullName = link.fullName;
+    if (fullName.length == 0) {
+        ApolloLog(@"[Translation] Skipping post body — %@", reason);
+        return;
+    }
+    @synchronized (sLoggedSkippedStructuredPostFullNames) {
+        if ([sLoggedSkippedStructuredPostFullNames containsObject:fullName]) return;
+        [sLoggedSkippedStructuredPostFullNames addObject:fullName];
+    }
+    ApolloLog(@"[Translation] Skipping post body fullName=%@ — %@", fullName, reason);
 }
 
 static BOOL ApolloTranslatedTextDiffersFromSource(NSString *sourceText, NSString *translatedText) {
@@ -2104,6 +2269,30 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
     NSString *trimmed = [body stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     if (trimmed.length == 0) return;  // link/image post — nothing to translate
 
+    // One-shot diagnostic so we can see exactly why a post body did or did
+    // not get gated. Logs once per fullName per session.
+    {
+        NSString *fn = link.fullName ?: @"<no-link>";
+        static NSMutableSet<NSString *> *sLoggedDiag;
+        static dispatch_once_t onceTok;
+        dispatch_once(&onceTok, ^{ sLoggedDiag = [NSMutableSet set]; });
+        BOOL shouldLog = NO;
+        @synchronized (sLoggedDiag) {
+            if (![sLoggedDiag containsObject:fn]) { [sLoggedDiag addObject:fn]; shouldLog = YES; }
+        }
+        if (shouldLog) {
+            BOOL hasLink = (link != nil);
+            NSUInteger selfTextLen = link.selfText.length;
+            NSUInteger selfHTMLLen = link.selfTextHTML.length;
+            NSUInteger trimmedLen = trimmed.length;
+            BOOL textHit = ApolloTextLooksLikeStructuredPostBody(trimmed) || ApolloTextLooksLikeStructuredPostBody(link.selfText);
+            BOOL htmlHit = ApolloHTMLLooksLikeStructuredPostBody(link.selfTextHTML);
+            BOOL codeHit = ApolloTextContainsMarkdownCode(link.selfText) || ApolloHTMLContainsCode(link.selfTextHTML) || ApolloTextContainsMarkdownCode(trimmed);
+            ApolloLog(@"[Translation] post-body diag fn=%@ hasLink=%d selfText=%lu selfHTML=%lu trimmed=%lu textHit=%d htmlHit=%d codeHit=%d",
+                      fn, hasLink, (unsigned long)selfTextLen, (unsigned long)selfHTMLLen, (unsigned long)trimmedLen, textHit, htmlHit, codeHit);
+        }
+    }
+
     if (ApolloLinkContainsCodeOrPreformatted(link, trimmed)) {
         NSString *linkFullName = link.fullName;
         if (linkFullName.length > 0) {
@@ -2111,7 +2300,12 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
             ApolloMirrorRemoveLink(linkFullName);
         }
         ApolloRestoreOriginalForHeaderCellNode(headerCellNode, link);
-        ApolloLog(@"[Translation] Skipping post body with code/preformatted content");
+        NSString *reason = (ApolloTextLooksLikeStructuredPostBody(trimmed) ||
+                            ApolloTextLooksLikeStructuredPostBody(link.selfText) ||
+                            ApolloHTMLLooksLikeStructuredPostBody(link.selfTextHTML))
+            ? @"structured content (table / heading / multi-paragraph)"
+            : @"code/preformatted content";
+        ApolloLogPostBodySkipOnce(link, reason);
         return;
     }
 
@@ -2169,7 +2363,11 @@ static void ApolloMaybeTranslateVisiblePostBodyForController(UIViewController *v
     id textNode = ApolloBestVisiblePostBodyTextNodeForController(viewController, tableView, link);
     NSString *sourceText = ApolloVisibleTextFromNode(textNode);
     if (sourceText.length == 0) return;
-    if (ApolloLinkContainsCodeOrPreformatted(link, sourceText)) return;
+    if (ApolloLinkContainsCodeOrPreformatted(link, sourceText)) {
+        // Companion to the header-cell skip just above — same rule, no log
+        // here (header-cell path already logged once for this fullName).
+        return;
+    }
 
     NSString *targetLanguage = ApolloResolvedTargetLanguageCode();
     if (targetLanguage.length == 0) return;
@@ -2397,12 +2595,54 @@ static void ApolloTranslateVisibleCommentsForController(UIViewController *viewCo
     ApolloForceVisibleCommentsTableRelayoutForController(viewController);
 }
 
+// Associated key + helper used to defer the table-level begin/endUpdates pass
+// when the comments table is mid-scroll. Calling [tableView beginUpdates]/
+// [tableView endUpdates] while the table is tracking/dragging/decelerating on
+// iOS 26 collides with UITableView's internal scroll state machine and can
+// leave the table's panGestureRecognizer wedged — the table area stops
+// responding to touches while the back button + bottom toolbar still work.
+// See user-reported "freeze on bottom overscroll with translation on" bug.
+static const void *kApolloTableRelayoutDeferScheduledKey = &kApolloTableRelayoutDeferScheduledKey;
+
+static void ApolloDeferTableRelayoutUntilScrollIdle(UIViewController *viewController, NSUInteger remainingRetries) {
+    if (!viewController) return;
+    if ([objc_getAssociatedObject(viewController, kApolloTableRelayoutDeferScheduledKey) boolValue]) return;
+    objc_setAssociatedObject(viewController, kApolloTableRelayoutDeferScheduledKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    __weak UIViewController *weakVC = viewController;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        UIViewController *strongVC = weakVC;
+        if (!strongVC) return;
+        objc_setAssociatedObject(strongVC, kApolloTableRelayoutDeferScheduledKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        if (!strongVC.isViewLoaded) return;
+
+        UITableView *tableView = GetCommentsTableView(strongVC);
+        if (!tableView) return;
+
+        if (tableView.isTracking || tableView.isDragging || tableView.isDecelerating) {
+            if (remainingRetries > 0) {
+                ApolloDeferTableRelayoutUntilScrollIdle(strongVC, remainingRetries - 1);
+            } else {
+                ApolloLog(@"[Translation] Relayout deferred — gave up after retry budget exhausted");
+            }
+            return;
+        }
+
+        ApolloForceVisibleCommentsTableRelayoutForController(strongVC);
+    });
+}
+
 static void ApolloForceVisibleCommentsTableRelayoutForController(UIViewController *viewController) {
     UITableView *tableView = GetCommentsTableView(viewController);
     if (!tableView) return;
 
+    BOOL tableIsScrolling = tableView.isTracking || tableView.isDragging || tableView.isDecelerating;
+
     @try {
         [UIView performWithoutAnimation:^{
+            // Per-cell layout is always safe — it doesn't touch UITableView's
+            // gesture/scroll state. Visible cells need this to measure
+            // freshly-applied translated text correctly.
             for (UITableViewCell *cell in [tableView visibleCells]) {
                 [cell setNeedsLayout];
                 [cell.contentView setNeedsLayout];
@@ -2413,12 +2653,27 @@ static void ApolloForceVisibleCommentsTableRelayoutForController(UIViewControlle
                     ApolloForceRelayoutForTextNodeAndOwner(cellNode, nil);
                 }
             }
+
+            // Table-level begin/endUpdates is what wedges the pan gesture
+            // when the table is mid-bounce. Defer it until the scroll settles.
+            if (tableIsScrolling) {
+                ApolloLog(@"[Translation] Relayout deferred — table is scrolling (tracking=%d dragging=%d decelerating=%d)",
+                          tableView.isTracking, tableView.isDragging, tableView.isDecelerating);
+                return;
+            }
+
             [tableView beginUpdates];
             [tableView endUpdates];
             [tableView setNeedsLayout];
             [tableView layoutIfNeeded];
         }];
     } @catch (__unused NSException *e) {}
+
+    if (tableIsScrolling) {
+        // Up to 40 retries × 50ms ≈ 2s ceiling — well past any realistic
+        // bounce-back deceleration window.
+        ApolloDeferTableRelayoutUntilScrollIdle(viewController, 40);
+    }
 }
 
 static void ApolloRestoreVisibleCommentsForController(UIViewController *viewController) {
@@ -4396,6 +4651,7 @@ static void ApolloReapplyTranslationOnAppResume(void) {
     sLinkTranslationByFullName = [NSCache new];
     sLinkTranslationByFullName.countLimit = 256;
     sLoggedSkippedCommentFullNames = [NSMutableSet set];
+    sLoggedSkippedStructuredPostFullNames = [NSMutableSet set];
     sCommentTranslationMirror = [NSMutableDictionary dictionary];
     sLinkTranslationMirror = [NSMutableDictionary dictionary];
     sPendingTranslationCallbacks = [NSMutableDictionary dictionary];
@@ -4452,6 +4708,9 @@ static void ApolloReapplyTranslationOnAppResume(void) {
         [sLinkTranslationByFullName removeAllObjects];
         @synchronized (sLoggedSkippedCommentFullNames) {
             [sLoggedSkippedCommentFullNames removeAllObjects];
+        }
+        @synchronized (sLoggedSkippedStructuredPostFullNames) {
+            [sLoggedSkippedStructuredPostFullNames removeAllObjects];
         }
         ApolloLog(@"[Translation] Skip-languages changed; flushed translation caches");
 

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import <NaturalLanguage/NaturalLanguage.h>
 #import <objc/runtime.h>
 #import <objc/message.h>
 #include <dlfcn.h>
@@ -27,6 +28,16 @@ static const void *kApolloTranslationOwnedTextNodeKey = &kApolloTranslationOwned
 static const void *kApolloOwnedNodeOriginalBodyKey = &kApolloOwnedNodeOriginalBodyKey;
 static const void *kApolloOwnedNodeTranslatedTextKey = &kApolloOwnedNodeTranslatedTextKey;
 static const void *kApolloOwnedNodeReentrancyKey = &kApolloOwnedNodeReentrancyKey;
+// Marker for title text nodes. Title nodes live outside the comments view
+// controller (feeds, search, profiles) so they must bypass the
+// `ApolloControllerIsInTranslatedMode` check used by the comment-thread
+// ownership system. Set in addition to kApolloTranslationOwnedTextNodeKey.
+static const void *kApolloTitleOwnedTextNodeKey = &kApolloTitleOwnedTextNodeKey;
+// Marks a UIViewController as a feed-style VC (Posts/LitePosts/SearchResults).
+// The globe-installation code uses this to gate visibility on
+// sTranslatePostTitles in addition to sEnableBulkTranslation.
+static const void *kApolloFeedTranslationVCKey = &kApolloFeedTranslationVCKey;
+static const void *kApolloFeedSettledTitleRefreshScheduledKey = &kApolloFeedSettledTitleRefreshScheduledKey;
 static const void *kApolloReapplyScheduledKey = &kApolloReapplyScheduledKey;
 // Phase B — status banner above comments.
 static const void *kApolloTranslationBannerKey = &kApolloTranslationBannerKey;
@@ -35,6 +46,10 @@ static const void *kApolloAppliedHeaderTranslationFullNameKey = &kApolloAppliedH
 static const void *kApolloHeaderTranslatedTextNodeKey = &kApolloHeaderTranslatedTextNodeKey;
 static const void *kApolloHeaderCellTranslationKeyKey = &kApolloHeaderCellTranslationKeyKey;
 static const void *kApolloPostBodyReapplyScheduledKey = &kApolloPostBodyReapplyScheduledKey;
+// Per-VC monotonic counter bumped in viewWillDisappear:. Pending toggle
+// reconciles capture this at scheduling time and bail out if it changed,
+// so we don't run multi-pass restore work mid swipe-back.
+static const void *kApolloReconcileGenerationKey = &kApolloReconcileGenerationKey;
 
 static NSString *const kApolloDefaultLibreTranslateURL = @"https://libretranslate.de/translate";
 
@@ -43,11 +58,54 @@ static NSCache<NSString *, NSString *> *sTranslationCache;
 static NSCache<NSString *, NSString *> *sCommentTranslationByFullName;
 // fullName ("t3_xxxxx") -> translated post selftext. Same idea, for posts.
 static NSCache<NSString *, NSString *> *sLinkTranslationByFullName;
+// Per-session set of comment fullNames for which we already emitted the
+// "detected language matches target" skip log. Prevents the log from firing
+// on every visibility / scroll tick for the same comment. Reset whenever
+// the user changes the skip-language list (caches flushed).
+static NSMutableSet<NSString *> *sLoggedSkippedCommentFullNames;
+// Mirrors of the two persistent caches above. NSCache hides its contents, so
+// we maintain plain NSMutableDictionaries alongside it for snapshot / disk
+// persistence on backgrounding. All writes go through helper macros below.
+static NSMutableDictionary<NSString *, NSString *> *sCommentTranslationMirror = nil;
+static NSMutableDictionary<NSString *, NSString *> *sLinkTranslationMirror = nil;
+static inline void ApolloMirrorSetComment(NSString *key, NSString *value) {
+    if (!key || !value) return;
+    @synchronized (sCommentTranslationMirror) { sCommentTranslationMirror[key] = value; }
+}
+static inline void ApolloMirrorRemoveComment(NSString *key) {
+    if (!key) return;
+    @synchronized (sCommentTranslationMirror) { [sCommentTranslationMirror removeObjectForKey:key]; }
+}
+static inline void ApolloMirrorSetLink(NSString *key, NSString *value) {
+    if (!key || !value) return;
+    @synchronized (sLinkTranslationMirror) { sLinkTranslationMirror[key] = value; }
+}
+static inline void ApolloMirrorRemoveLink(NSString *key) {
+    if (!key) return;
+    @synchronized (sLinkTranslationMirror) { [sLinkTranslationMirror removeObjectForKey:key]; }
+}
 static NSMutableDictionary<NSString *, NSMutableArray *> *sPendingTranslationCallbacks;
 static __weak UIViewController *sVisibleCommentsViewController = nil;
+// Weak set of every text node we've stamped with the ownership marker. Lets
+// us walk *all* off-screen / preloaded text nodes on toggle-off, instead of
+// only those whose UITableViewCells happen to be in `visibleCells`.
+static NSHashTable<id> *sOwnedTextNodes = nil;
+static dispatch_queue_t sOwnedTextNodesQueue = NULL;
+static BOOL sPendingVisibleFeedTitleApplied = NO;
+static NSMutableDictionary<NSString *, NSNumber *> *sFeedTitleModeByFeedKey = nil;
+static BOOL sLastFeedTitleModeKnown = NO;
+static BOOL sLastFeedTitleTranslatedMode = YES;
+static __weak UIViewController *sLastInstalledFeedViewController = nil;
 
 static void ApolloUpdateTranslationUIForController(id controller);
 static RDKComment *ApolloCommentFromCellNode(id commentCellNode);
+static void ApolloRegisterOwnedTextNode(id textNode);
+static void ApolloRestoreAllOwnedTextNodes(void);
+static void ApolloRescanTitleNodesForController(UIViewController *vc);
+static UIViewController *ApolloEnclosingViewControllerForNode(id node);
+static BOOL ApolloControllerIsInTranslatedMode(UIViewController *vc);
+static BOOL ApolloRefreshVisibleTranslationAppliedForController(UIViewController *vc);
+static BOOL ApolloRefreshFeedTitleTranslationAppliedForController(UIViewController *vc);
 
 // Returns the Reddit fullName ("t1_xxxxx") for a comment. Falls back to a
 // stable derived key when the runtime doesn't expose `name` / `fullName`.
@@ -254,8 +312,73 @@ static void ApolloMarkVisibleTranslationApplied(NSString *sourceText, NSString *
     if (!ApolloTranslatedTextDiffersFromSource(sourceText, translatedText)) return;
     UIViewController *vc = sVisibleCommentsViewController;
     if (!vc) return;
+    if (!ApolloControllerIsInTranslatedMode(vc)) return;
     objc_setAssociatedObject(vc, kApolloVisibleTranslationAppliedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloUpdateTranslationUIForController(vc);
+}
+
+// Mark a specific (non-comments) controller as having visible translated
+// content so its globe icon turns green. Used by the feed/title path where
+// `sVisibleCommentsViewController` is nil.
+//
+// Strategy (after multiple failed attempts at responder-chain walks): just
+// find the topmost visible feed VC in the key window that we've installed
+// the globe on. The user is only ever looking at one feed at a time, so the
+// "right" target is always the visible one. This avoids all the parent /
+// child / nav-stack indirection that fails on Home (where the title node's
+// responder chain doesn't reach the marked feed VC).
+static UIViewController *ApolloFindTopmostVisibleFeedVC(void) {
+    UIWindow *keyWindow = nil;
+    for (UIWindowScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if (![scene isKindOfClass:[UIWindowScene class]]) continue;
+        if (scene.activationState != UISceneActivationStateForegroundActive) continue;
+        for (UIWindow *w in scene.windows) {
+            if (w.isKeyWindow) { keyWindow = w; break; }
+        }
+        if (keyWindow) break;
+    }
+    if (!keyWindow) return nil;
+
+    // BFS from the root, return the deepest VC marked with the feed key
+    // that is currently visible (view in window, not hidden).
+    NSMutableArray<UIViewController *> *queue = [NSMutableArray array];
+    UIViewController *root = keyWindow.rootViewController;
+    if (root) [queue addObject:root];
+    UIViewController *bestMatch = nil;
+    NSUInteger guard = 0;
+    while (queue.count > 0 && guard++ < 256) {
+        UIViewController *vc = queue.firstObject;
+        [queue removeObjectAtIndex:0];
+        if ([objc_getAssociatedObject(vc, kApolloFeedTranslationVCKey) boolValue]) {
+            if (vc.isViewLoaded && vc.view.window == keyWindow && !vc.view.hidden) {
+                bestMatch = vc;  // Keep walking; deeper match wins.
+            }
+        }
+        for (UIViewController *child in vc.childViewControllers) [queue addObject:child];
+        if (vc.presentedViewController) [queue addObject:vc.presentedViewController];
+    }
+    return bestMatch;
+}
+
+static void ApolloMarkVisibleFeedTitleApplied(NSString *sourceText, NSString *translatedText) {
+    if (!ApolloTranslatedTextDiffersFromSource(sourceText, translatedText)) return;
+
+    UIViewController *feedVC = ApolloFindTopmostVisibleFeedVC();
+    if (!feedVC) feedVC = sLastInstalledFeedViewController;
+    if (feedVC && [objc_getAssociatedObject(feedVC, kApolloFeedTranslationVCKey) boolValue] && ApolloControllerIsInTranslatedMode(feedVC)) {
+        // Only log on the NO->YES transition; otherwise this fires per
+        // translated title (many per scroll) and floods the log.
+        BOOL wasApplied = [objc_getAssociatedObject(feedVC, kApolloVisibleTranslationAppliedKey) boolValue];
+        objc_setAssociatedObject(feedVC, kApolloVisibleTranslationAppliedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloUpdateTranslationUIForController(feedVC);
+        sPendingVisibleFeedTitleApplied = NO;
+        if (!wasApplied) {
+            ApolloLog(@"[Translation] MarkFeedTitleApplied direct class=%@ ptr=%p", NSStringFromClass([feedVC class]), feedVC);
+        }
+        return;
+    }
+
+    sPendingVisibleFeedTitleApplied = YES;
 }
 
 static void ApolloClearVisibleTranslationApplied(UIViewController *vc) {
@@ -263,13 +386,32 @@ static void ApolloClearVisibleTranslationApplied(UIViewController *vc) {
     objc_setAssociatedObject(vc, kApolloVisibleTranslationAppliedKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-static NSString *ApolloDetectDominantLanguage(NSString *text) {
-    if (![text isKindOfClass:[NSString class]] || text.length < 12) return nil;
+static BOOL ApolloRefreshFeedTranslationStateForController(UIViewController *vc) {
+    if (!vc) return NO;
+    if (![objc_getAssociatedObject(vc, kApolloFeedTranslationVCKey) boolValue]) {
+        return ApolloRefreshVisibleTranslationAppliedForController(vc);
+    }
 
-    NSLinguisticTagger *tagger = [[NSLinguisticTagger alloc] initWithTagSchemes:@[NSLinguisticTagSchemeLanguage] options:0];
-    tagger.string = text;
-    NSString *language = [tagger dominantLanguage];
-    return ApolloNormalizeLanguageCode(language);
+    if (!sEnableBulkTranslation || !sTranslatePostTitles || !ApolloControllerIsInTranslatedMode(vc)) {
+        ApolloClearVisibleTranslationApplied(vc);
+        ApolloUpdateTranslationUIForController(vc);
+        return NO;
+    }
+
+    BOOL applied = ApolloRefreshVisibleTranslationAppliedForController(vc);
+    if (!applied) applied = ApolloRefreshFeedTitleTranslationAppliedForController(vc);
+    ApolloUpdateTranslationUIForController(vc);
+    return applied;
+}
+
+static void ApolloScheduleFeedTranslationStateRefresh(UIViewController *vc, NSTimeInterval delay) {
+    if (!vc) return;
+    __weak UIViewController *weakVC = vc;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        UIViewController *strongVC = weakVC;
+        if (!strongVC || !strongVC.isViewLoaded || !strongVC.view.window) return;
+        ApolloRefreshFeedTranslationStateForController(strongVC);
+    });
 }
 
 static NSString *ApolloTranslationCacheKey(NSString *text, NSString *targetLanguage) {
@@ -820,8 +962,70 @@ static id ApolloBestCommentTextNode(id commentCellNode, RDKComment *comment) {
     return bestNode;
 }
 
+static void ApolloForceRelayoutForTextNodeAndOwner(id owner, id textNode) {
+    SEL invalidateSel = NSSelectorFromString(@"invalidateCalculatedLayout");
+    SEL supernodeSel = NSSelectorFromString(@"supernode");
+    SEL transitionSel = NSSelectorFromString(@"transitionLayoutWithAnimation:shouldMeasureAsync:measurementCompletion:");
+
+    void (^nudgeObject)(id) = ^(id object) {
+        if (!object) return;
+        @try {
+            if ([object respondsToSelector:invalidateSel]) {
+                ((void (*)(id, SEL))objc_msgSend)(object, invalidateSel);
+            }
+            if ([object respondsToSelector:@selector(setNeedsLayout)]) {
+                ((void (*)(id, SEL))objc_msgSend)(object, @selector(setNeedsLayout));
+            }
+            if ([object respondsToSelector:@selector(setNeedsDisplay)]) {
+                ((void (*)(id, SEL))objc_msgSend)(object, @selector(setNeedsDisplay));
+            }
+            if ([object isKindOfClass:[UIView class]]) {
+                UIView *view = (UIView *)object;
+                [view setNeedsLayout];
+                [view layoutIfNeeded];
+            }
+        } @catch (__unused NSException *e) {}
+    };
+
+    nudgeObject(textNode);
+    nudgeObject(owner);
+
+    id current = textNode;
+    id cellNode = nil;
+    for (int hops = 0; current && hops < 8; hops++) {
+        nudgeObject(current);
+        const char *className = class_getName([current class]);
+        if (!cellNode && className && strstr(className, "CellNode")) {
+            cellNode = current;
+        }
+        if (![current respondsToSelector:supernodeSel]) break;
+        @try { current = ((id (*)(id, SEL))objc_msgSend)(current, supernodeSel); }
+        @catch (__unused NSException *e) { break; }
+    }
+    if (!cellNode) cellNode = owner;
+
+    @try {
+        if ([cellNode respondsToSelector:transitionSel]) {
+            NSMethodSignature *sig = [cellNode methodSignatureForSelector:transitionSel];
+            if (sig) {
+                NSInvocation *inv = [NSInvocation invocationWithMethodSignature:sig];
+                inv.target = cellNode;
+                inv.selector = transitionSel;
+                BOOL animated = NO;
+                BOOL async = NO;
+                void (^completion)(void) = nil;
+                [inv setArgument:&animated atIndex:2];
+                [inv setArgument:&async atIndex:3];
+                [inv setArgument:&completion atIndex:4];
+                [inv invoke];
+            }
+        }
+    } @catch (__unused NSException *e) {}
+}
+
 static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *comment, NSString *translatedText) {
     if (!commentCellNode || ![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0) return;
+    if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) return;
 
     id textNode = ApolloBestCommentTextNode(commentCellNode, comment);
     if (!textNode) return;
@@ -867,6 +1071,7 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
     objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [comment.body copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloRegisterOwnedTextNode(textNode);
 
     @try {
         ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), translatedAttr);
@@ -880,6 +1085,7 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
     if ([textNode respondsToSelector:@selector(setNeedsDisplay)]) {
         ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsDisplay));
     }
+    ApolloForceRelayoutForTextNodeAndOwner(commentCellNode, textNode);
 
     objc_setAssociatedObject(commentCellNode, kApolloTranslatedTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
@@ -888,6 +1094,7 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
     NSString *fullName = ApolloCommentFullName(comment);
     if (fullName.length > 0) {
         [sCommentTranslationByFullName setObject:translatedText forKey:fullName];
+        ApolloMirrorSetComment(fullName, translatedText);
         objc_setAssociatedObject(commentCellNode, kApolloAppliedTranslationFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
     }
     ApolloMarkVisibleTranslationApplied(comment.body, translatedText);
@@ -896,11 +1103,18 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
 static void ApolloRestoreOriginalForCellNode(id commentCellNode, RDKComment *comment) {
     if (!commentCellNode) return;
 
-    id textNode = objc_getAssociatedObject(commentCellNode, kApolloTranslatedTextNodeKey);
-    if (!textNode) {
-        textNode = ApolloBestCommentTextNode(commentCellNode, comment);
-    }
+    id currentBodyNode = ApolloBestCommentTextNode(commentCellNode, comment);
+    id associatedNode = objc_getAssociatedObject(commentCellNode, kApolloTranslatedTextNodeKey);
+    id textNode = currentBodyNode ?: associatedNode;
     if (!textNode) return;
+
+    // Capture the cached translated body BEFORE clearing ownership keys, so
+    // we can decide below whether the textNode actually still shows our
+    // translation (safe to write saved-original) or has been reused for a
+    // different comment (must NOT overwrite — the saved original would be
+    // stale and would clobber the new comment's correct text).
+    NSString *cachedTranslatedBody = objc_getAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey);
+    NSString *cachedOriginalBody = objc_getAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey);
 
     // Drop ownership BEFORE writing original text back, otherwise the vote-
     // resilience hook would swap the original right back to translated.
@@ -908,8 +1122,48 @@ static void ApolloRestoreOriginalForCellNode(id commentCellNode, RDKComment *com
     objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
 
+    // Reuse-safety gate: only write the saved-original if the textNode
+    // currently shows our cached translated body (i.e. the textNode really
+    // is still displaying our stale translation). If the textNode has been
+    // reused for a different comment, leave Apollo's freshly-rendered text
+    // alone — clearing the ownership keys above is enough to prevent the
+    // global setAttributedText hook from re-translating it.
+    NSAttributedString *currentAttr = nil;
+    @try {
+        currentAttr = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText));
+    } @catch (__unused NSException *e) {
+        return;
+    }
+    if (![currentAttr isKindOfClass:[NSAttributedString class]]) return;
+
     NSAttributedString *original = objc_getAssociatedObject(textNode, kApolloOriginalAttributedTextKey);
-    if (![original isKindOfClass:[NSAttributedString class]]) return;
+    BOOL originalFromCommentModel = NO;
+    if (![original isKindOfClass:[NSAttributedString class]]) {
+        NSString *modelBody = [comment.body stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        if (modelBody.length == 0) return;
+        original = ApolloTranslatedAttributedStringPreservingVisualLinks(currentAttr, modelBody);
+        originalFromCommentModel = [original isKindOfClass:[NSAttributedString class]];
+        if (!originalFromCommentModel) return;
+    }
+    NSString *currentText = [currentAttr isKindOfClass:[NSAttributedString class]] ? currentAttr.string : nil;
+    BOOL displaysOurTranslation = NO;
+    if ([cachedTranslatedBody isKindOfClass:[NSString class]] && cachedTranslatedBody.length > 0 && currentText.length > 0) {
+        displaysOurTranslation = ApolloTextQualifiesAsBodyCandidate(currentText, cachedTranslatedBody);
+    }
+    // Also accept the case where the current text already matches the saved
+    // original (idempotent restore — will be a no-op write but harmless).
+    BOOL displaysSavedOriginal = NO;
+    if (!displaysOurTranslation && [cachedOriginalBody isKindOfClass:[NSString class]] && cachedOriginalBody.length > 0 && currentText.length > 0) {
+        displaysSavedOriginal = ApolloTextQualifiesAsBodyCandidate(currentText, cachedOriginalBody);
+    }
+    BOOL shouldForceModelOriginal = NO;
+    if (!displaysOurTranslation && !displaysSavedOriginal && originalFromCommentModel && currentText.length > 0) {
+        shouldForceModelOriginal = !ApolloTextQualifiesAsBodyCandidate(currentText, comment.body);
+    }
+    if (!displaysOurTranslation && !displaysSavedOriginal && !shouldForceModelOriginal) {
+        ApolloLog(@"[Translation] Restore skipped: textNode no longer shows our translation (likely reused)");
+        return;
+    }
 
     @try {
         ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), original);
@@ -923,6 +1177,7 @@ static void ApolloRestoreOriginalForCellNode(id commentCellNode, RDKComment *com
     if ([textNode respondsToSelector:@selector(setNeedsDisplay)]) {
         ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsDisplay));
     }
+    ApolloForceRelayoutForTextNodeAndOwner(commentCellNode, textNode);
 
     objc_setAssociatedObject(commentCellNode, kApolloAppliedTranslationFullNameKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
@@ -1238,6 +1493,7 @@ static id ApolloBestPostBodyTextNode(id headerCellNode, RDKLink *link, NSString 
 static void ApolloApplyTranslationToHeaderCellNode(id headerCellNode, RDKLink *link, NSString *sourceText, NSString *translatedText) {
     if (!headerCellNode) return;
     if (![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0) return;
+    if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) return;
     NSString *body = sourceText.length > 0 ? sourceText : ApolloPostBodyTextFromLink(link);
     if (![body isKindOfClass:[NSString class]] || body.length == 0) return;
 
@@ -1274,6 +1530,7 @@ static void ApolloApplyTranslationToHeaderCellNode(id headerCellNode, RDKLink *l
     objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [body copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloRegisterOwnedTextNode(textNode);
 
     @try { ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), translatedAttr); }
     @catch (__unused NSException *e) { return; }
@@ -1290,6 +1547,7 @@ static void ApolloApplyTranslationToHeaderCellNode(id headerCellNode, RDKLink *l
     NSString *fullName = link.fullName;
     if (fullName.length > 0) {
         [sLinkTranslationByFullName setObject:translatedText forKey:fullName];
+        ApolloMirrorSetLink(fullName, translatedText);
         objc_setAssociatedObject(headerCellNode, kApolloAppliedHeaderTranslationFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
     }
     ApolloMarkVisibleTranslationApplied(body, translatedText);
@@ -1299,6 +1557,7 @@ static void ApolloApplyTranslationToPostTextNode(id owner, id textNode, NSString
     if (!owner || !textNode) return;
     if (![sourceText isKindOfClass:[NSString class]] || sourceText.length == 0) return;
     if (![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0) return;
+    if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) return;
 
     NSAttributedString *current = nil;
     @try { current = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText)); }
@@ -1328,6 +1587,7 @@ static void ApolloApplyTranslationToPostTextNode(id owner, id textNode, NSString
     objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [sourceText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloRegisterOwnedTextNode(textNode);
 
     @try { ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), translatedAttr); }
     @catch (__unused NSException *e) { return; }
@@ -1536,33 +1796,94 @@ static void ApolloTranslateViaLibre(NSString *text,
     [task resume];
 }
 
+static NSString *ApolloDetectDominantLanguage(NSString *text) {
+    if (![text isKindOfClass:[NSString class]]) return nil;
+    NSString *trimmed = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    // Short strings produce unreliable detections ("lol", "wow", etc.). Skip them.
+    if (trimmed.length < 8) return nil;
+    if (@available(iOS 12.0, *)) {
+        NLLanguageRecognizer *recognizer = [[NLLanguageRecognizer alloc] init];
+        [recognizer processString:trimmed];
+        NSDictionary<NLLanguage, NSNumber *> *hyps = [recognizer languageHypothesesWithMaximum:1];
+        NSString *dominant = nil;
+        double bestProb = 0.0;
+        for (NLLanguage lang in hyps) {
+            double p = hyps[lang].doubleValue;
+            if (p > bestProb) { bestProb = p; dominant = (NSString *)lang; }
+        }
+        // Require reasonable confidence so we don't accidentally skip ambiguous text.
+        if (bestProb < 0.55 || dominant.length == 0) return nil;
+        return ApolloNormalizeLanguageCode(dominant);
+    }
+    return nil;
+}
+
+// Returns YES if the user has asked us not to translate text in `detectedLang`.
+// We intentionally do NOT short-circuit when detected == target: many comments are
+// mixed-language (e.g. mostly English with embedded Japanese), and NLLanguageRecognizer
+// will return only the dominant language. Letting the provider see the full text means
+// the embedded foreign chunks still get translated.
+static BOOL ApolloShouldSkipTranslationForText(NSString *text, NSString *targetLanguage) {
+    (void)targetLanguage;
+    NSArray<NSString *> *skip = sTranslationSkipLanguages;
+    if (![skip isKindOfClass:[NSArray class]] || skip.count == 0) return NO;
+
+    NSString *detected = ApolloDetectDominantLanguage(text);
+    if (detected.length == 0) return NO;
+
+    for (NSString *code in skip) {
+        if (![code isKindOfClass:[NSString class]]) continue;
+        if ([code.lowercaseString isEqualToString:detected]) return YES;
+    }
+    return NO;
+}
+
 static void ApolloTranslateTextWithFallback(NSString *text,
                                             NSString *targetLanguage,
                                             void (^completion)(NSString *translated, NSError *error)) {
-    NSString *primaryProvider = [sTranslationProvider isEqualToString:@"libre"] ? @"libre" : @"google";
-    BOOL googlePrimary = [primaryProvider isEqualToString:@"google"];
+    // User-controlled skip: if the source language is in the skip list, or already
+    // matches the target, return the original text untouched. Downstream callers
+    // treat this as a successful no-op (cache will store source==translation,
+    // making future hits instant).
+    if (ApolloShouldSkipTranslationForText(text, targetLanguage)) {
+        if (completion) {
+            dispatch_async(dispatch_get_main_queue(), ^{ completion(text, nil); });
+        }
+        return;
+    }
 
+    // Provider can be: "google" or "libre". Anything unrecognized defaults to Google.
+    // Primary = user's choice; fallback = the other one.
+    NSString *primaryProvider = sTranslationProvider;
+    if (![primaryProvider isEqualToString:@"libre"] &&
+        ![primaryProvider isEqualToString:@"google"]) {
+        primaryProvider = @"google";
+    }
+
+    void (^callPrimary)(void (^)(NSString *, NSError *)) = ^(void (^cb)(NSString *, NSError *)) {
+        if ([primaryProvider isEqualToString:@"libre"]) {
+            ApolloTranslateViaLibre(text, targetLanguage, cb);
+        } else {
+            ApolloTranslateViaGoogle(text, targetLanguage, cb);
+        }
+    };
+
+    // If the primary provider fails, fall back to the other one.
     void (^fallback)(void) = ^{
-        if (googlePrimary) {
+        if ([primaryProvider isEqualToString:@"google"]) {
             ApolloTranslateViaLibre(text, targetLanguage, completion);
         } else {
             ApolloTranslateViaGoogle(text, targetLanguage, completion);
         }
     };
 
-    void (^primaryCompletion)(NSString *, NSError *) = ^(NSString *translated, NSError *error) {
+    callPrimary(^(NSString *translated, NSError *error) {
         if ([translated isKindOfClass:[NSString class]] && translated.length > 0) {
             completion(translated, nil);
             return;
         }
         fallback();
-    };
-
-    if (googlePrimary) {
-        ApolloTranslateViaGoogle(text, targetLanguage, primaryCompletion);
-    } else {
-        ApolloTranslateViaLibre(text, targetLanguage, primaryCompletion);
-    }
+    });
 }
 
 static void ApolloRequestTranslation(NSString *cacheKey,
@@ -1639,6 +1960,7 @@ static void ApolloMaybeTranslateCommentCellNode(id commentCellNode, BOOL forceTr
     if (ApolloCommentContainsCodeOrPreformatted(comment)) {
         if (fullName.length > 0) {
             [sCommentTranslationByFullName removeObjectForKey:fullName];
+            ApolloMirrorRemoveComment(fullName);
         }
         ApolloRestoreOriginalForCellNode(commentCellNode, comment);
         ApolloLog(@"[Translation] Skipping comment with code/preformatted content");
@@ -1657,8 +1979,31 @@ static void ApolloMaybeTranslateCommentCellNode(id commentCellNode, BOOL forceTr
     }
 
     if (!forceTranslation) {
-        NSString *detected = ApolloDetectDominantLanguage(sourceText);
+        // Detect on link-stripped text so URLs / markdown link targets don't
+        // pollute the signal. A comment like "[title](https://record.pt/...)
+        // body in Portuguese" would otherwise feed NLLanguageRecognizer a
+        // big chunk of URL path that can pull detection toward English /
+        // generic and skip translation.
+        NSString *detectionText = ApolloProtectTranslationLinks(sourceText, NULL);
+        NSString *detected = ApolloDetectDominantLanguage(detectionText);
         if ([detected isEqualToString:targetLanguage]) {
+            // Log only once per fullName per session — this path is hit on
+            // every visibility / scroll tick for the same cell otherwise.
+            NSString *logKey = fullName.length > 0 ? fullName : nil;
+            BOOL shouldLog = YES;
+            if (logKey) {
+                @synchronized (sLoggedSkippedCommentFullNames) {
+                    if ([sLoggedSkippedCommentFullNames containsObject:logKey]) {
+                        shouldLog = NO;
+                    } else {
+                        [sLoggedSkippedCommentFullNames addObject:logKey];
+                    }
+                }
+            }
+            if (shouldLog) {
+                ApolloLog(@"[Translation] Skipping comment fullName=%@ — detected language matches target (%@)",
+                          logKey ?: @"(none)", targetLanguage);
+            }
             return;
         }
     }
@@ -1674,6 +2019,7 @@ static void ApolloMaybeTranslateCommentCellNode(id commentCellNode, BOOL forceTr
             // re-displayed cell for this comment picks it up instantly.
             if ([translated isKindOfClass:[NSString class]] && translated.length > 0 && fullName.length > 0) {
                 [sCommentTranslationByFullName setObject:translated forKey:fullName];
+                ApolloMirrorSetComment(fullName, translated);
             }
             return;
         }
@@ -1692,6 +2038,7 @@ static void ApolloMaybeTranslateCommentCellNode(id commentCellNode, BOOL forceTr
         // it, so a future re-display gets it for free.
         if (fullName.length > 0) {
             [sCommentTranslationByFullName setObject:translated forKey:fullName];
+            ApolloMirrorSetComment(fullName, translated);
         }
 
         if (!forceTranslation && !ApolloShouldTranslateNow(NO)) return;
@@ -1761,6 +2108,7 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
         NSString *linkFullName = link.fullName;
         if (linkFullName.length > 0) {
             [sLinkTranslationByFullName removeObjectForKey:linkFullName];
+            ApolloMirrorRemoveLink(linkFullName);
         }
         ApolloRestoreOriginalForHeaderCellNode(headerCellNode, link);
         ApolloLog(@"[Translation] Skipping post body with code/preformatted content");
@@ -1782,7 +2130,9 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
     }
 
     if (!forceTranslation) {
-        NSString *detected = ApolloDetectDominantLanguage(trimmed);
+        // Strip links so URLs don't pollute language detection.
+        NSString *detectionText = ApolloProtectTranslationLinks(trimmed, NULL);
+        NSString *detected = ApolloDetectDominantLanguage(detectionText);
         if ([detected isEqualToString:targetLanguage]) return;
     }
 
@@ -1798,6 +2148,7 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
         }
         if (cacheStoreKey.length > 0) {
             [sLinkTranslationByFullName setObject:translated forKey:cacheStoreKey];
+            ApolloMirrorSetLink(cacheStoreKey, translated);
         }
         if (!strongHeader) return;
         NSString *currentKey = objc_getAssociatedObject(strongHeader, kApolloHeaderCellTranslationKeyKey);
@@ -1833,7 +2184,9 @@ static void ApolloMaybeTranslateVisiblePostBodyForController(UIViewController *v
     }
 
     if (!forceTranslation) {
-        NSString *detected = ApolloDetectDominantLanguage(sourceText);
+        // Strip links so URLs don't pollute language detection.
+        NSString *detectionText = ApolloProtectTranslationLinks(sourceText, NULL);
+        NSString *detected = ApolloDetectDominantLanguage(detectionText);
         if ([detected isEqualToString:targetLanguage]) return;
     }
 
@@ -1855,6 +2208,7 @@ static void ApolloMaybeTranslateVisiblePostBodyForController(UIViewController *v
 
         if (cacheStoreKey.length > 0) {
             [sLinkTranslationByFullName setObject:translated forKey:cacheStoreKey];
+            ApolloMirrorSetLink(cacheStoreKey, translated);
         }
         ApolloApplyTranslationToPostTextNode(strongVC.view, strongTextNode, sourceText, translated);
     });
@@ -1907,6 +2261,119 @@ static void ApolloSchedulePostBodyReapplyForController(UIViewController *viewCon
     });
 }
 
+static void ApolloReapplyCommentCellNodesInTree(id object, NSInteger depth, NSHashTable *visited, BOOL forceTranslation) {
+    if (!object || depth < 0) return;
+    if (visited.count >= 2048) return;
+    if ([visited containsObject:object]) return;
+    [visited addObject:object];
+
+    Class displayNodeCls = NSClassFromString(@"ASDisplayNode");
+    BOOL isDisplayNode = displayNodeCls && [object isKindOfClass:displayNodeCls];
+    BOOL isView = [object isKindOfClass:[UIView class]];
+    if (!isDisplayNode && !isView) return;
+
+    if (isDisplayNode) {
+        RDKComment *comment = ApolloCommentFromCellNode(object);
+        if (comment) {
+            if (!ApolloReapplyCachedTranslationForCellNode(object)) {
+                ApolloMaybeTranslateCommentCellNode(object, forceTranslation);
+            }
+        }
+    }
+
+    @try {
+        SEL nodeSelectors[] = { NSSelectorFromString(@"asyncdisplaykit_node"), NSSelectorFromString(@"node") };
+        for (size_t i = 0; i < sizeof(nodeSelectors) / sizeof(nodeSelectors[0]); i++) {
+            SEL selector = nodeSelectors[i];
+            if (![object respondsToSelector:selector]) continue;
+            id node = ((id (*)(id, SEL))objc_msgSend)(object, selector);
+            if (node && node != object) ApolloReapplyCommentCellNodesInTree(node, depth - 1, visited, forceTranslation);
+        }
+    } @catch (__unused NSException *e) {}
+
+    @try {
+        SEL subnodesSel = NSSelectorFromString(@"subnodes");
+        if ([object respondsToSelector:subnodesSel]) {
+            NSArray *subnodes = ((id (*)(id, SEL))objc_msgSend)(object, subnodesSel);
+            if ([subnodes isKindOfClass:[NSArray class]]) {
+                for (id subnode in subnodes) ApolloReapplyCommentCellNodesInTree(subnode, depth - 1, visited, forceTranslation);
+            }
+        }
+    } @catch (__unused NSException *e) {}
+
+    @try {
+        if ([object respondsToSelector:@selector(subviews)]) {
+            NSArray *subviews = ((id (*)(id, SEL))objc_msgSend)(object, @selector(subviews));
+            if ([subviews isKindOfClass:[NSArray class]]) {
+                for (id subview in subviews) ApolloReapplyCommentCellNodesInTree(subview, depth - 1, visited, forceTranslation);
+            }
+        }
+    } @catch (__unused NSException *e) {}
+}
+
+static void ApolloReapplyVisibleCommentCellNodesForController(UIViewController *viewController, BOOL forceTranslation) {
+    if (!viewController || !viewController.isViewLoaded) return;
+    if (!sEnableBulkTranslation || !ApolloControllerIsInTranslatedMode(viewController)) return;
+    NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:512];
+    ApolloReapplyCommentCellNodesInTree(viewController.view, 18, visited, forceTranslation);
+}
+
+static void ApolloRestoreCommentCellNodesInTree(id object, NSInteger depth, NSHashTable *visited) {
+    if (!object || depth < 0) return;
+    if (visited.count >= 2048) return;
+    if ([visited containsObject:object]) return;
+    [visited addObject:object];
+
+    Class displayNodeCls = NSClassFromString(@"ASDisplayNode");
+    BOOL isDisplayNode = displayNodeCls && [object isKindOfClass:displayNodeCls];
+    BOOL isView = [object isKindOfClass:[UIView class]];
+    if (!isDisplayNode && !isView) return;
+
+    if (isDisplayNode) {
+        RDKComment *comment = ApolloCommentFromCellNode(object);
+        if (comment) {
+            ApolloRestoreOriginalForCellNode(object, comment);
+        }
+    }
+
+    @try {
+        SEL nodeSelectors[] = { NSSelectorFromString(@"asyncdisplaykit_node"), NSSelectorFromString(@"node") };
+        for (size_t i = 0; i < sizeof(nodeSelectors) / sizeof(nodeSelectors[0]); i++) {
+            SEL selector = nodeSelectors[i];
+            if (![object respondsToSelector:selector]) continue;
+            id node = ((id (*)(id, SEL))objc_msgSend)(object, selector);
+            if (node && node != object) ApolloRestoreCommentCellNodesInTree(node, depth - 1, visited);
+        }
+    } @catch (__unused NSException *e) {}
+
+    @try {
+        SEL subnodesSel = NSSelectorFromString(@"subnodes");
+        if ([object respondsToSelector:subnodesSel]) {
+            NSArray *subnodes = ((id (*)(id, SEL))objc_msgSend)(object, subnodesSel);
+            if ([subnodes isKindOfClass:[NSArray class]]) {
+                for (id subnode in subnodes) ApolloRestoreCommentCellNodesInTree(subnode, depth - 1, visited);
+            }
+        }
+    } @catch (__unused NSException *e) {}
+
+    @try {
+        if ([object respondsToSelector:@selector(subviews)]) {
+            NSArray *subviews = ((id (*)(id, SEL))objc_msgSend)(object, @selector(subviews));
+            if ([subviews isKindOfClass:[NSArray class]]) {
+                for (id subview in subviews) ApolloRestoreCommentCellNodesInTree(subview, depth - 1, visited);
+            }
+        }
+    } @catch (__unused NSException *e) {}
+}
+
+static void ApolloRestoreVisibleCommentCellNodesForController(UIViewController *viewController) {
+    if (!viewController || !viewController.isViewLoaded) return;
+    NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:512];
+    ApolloRestoreCommentCellNodesInTree(viewController.view, 18, visited);
+}
+
+static void ApolloForceVisibleCommentsTableRelayoutForController(UIViewController *viewController);
+
 static void ApolloTranslateVisibleCommentsForController(UIViewController *viewController, BOOL forceTranslation) {
     UITableView *tableView = GetCommentsTableView(viewController);
     if (!tableView) return;
@@ -1919,8 +2386,39 @@ static void ApolloTranslateVisibleCommentsForController(UIViewController *viewCo
         ApolloMaybeTranslateCommentCellNode(cellNode, forceTranslation);
     }
 
+    // Texture can keep some visible/preloaded comment cell nodes out of
+    // UITableView.visibleCells until a visibility event (collapse/reopen,
+    // screenshot/app snapshot, tiny scroll) wakes them. Walk the loaded node
+    // tree too and hit the same cached-reapply path those events use.
+    ApolloReapplyVisibleCommentCellNodesForController(viewController, forceTranslation);
+
     // Phase C — also translate the post selftext (header cell) if present.
     ApolloMaybeTranslatePostHeaderForController(viewController, forceTranslation);
+    ApolloForceVisibleCommentsTableRelayoutForController(viewController);
+}
+
+static void ApolloForceVisibleCommentsTableRelayoutForController(UIViewController *viewController) {
+    UITableView *tableView = GetCommentsTableView(viewController);
+    if (!tableView) return;
+
+    @try {
+        [UIView performWithoutAnimation:^{
+            for (UITableViewCell *cell in [tableView visibleCells]) {
+                [cell setNeedsLayout];
+                [cell.contentView setNeedsLayout];
+                [cell layoutIfNeeded];
+                SEL nodeSelector = NSSelectorFromString(@"node");
+                if ([cell respondsToSelector:nodeSelector]) {
+                    id cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSelector);
+                    ApolloForceRelayoutForTextNodeAndOwner(cellNode, nil);
+                }
+            }
+            [tableView beginUpdates];
+            [tableView endUpdates];
+            [tableView setNeedsLayout];
+            [tableView layoutIfNeeded];
+        }];
+    } @catch (__unused NSException *e) {}
 }
 
 static void ApolloRestoreVisibleCommentsForController(UIViewController *viewController) {
@@ -1950,30 +2448,22 @@ static void ApolloRestoreVisibleCommentsForController(UIViewController *viewCont
         RDKLink *link = ApolloLinkFromHeaderCellNode(cellNode);
         if (link || !comment) {
             if (!link) link = controllerLink;
-            NSString *linkFullName = link.fullName;
-            if (linkFullName.length > 0) {
-                [sLinkTranslationByFullName removeObjectForKey:linkFullName];
-            }
             ApolloRestoreOriginalForHeaderCellNode(cellNode, link);
             continue;
         }
 
-        // Drop from the persistent fullName cache so cellNodeVisibilityEvent:
-        // / didEnterDisplayState don't re-apply it after the user asked for
-        // the original text.
-        NSString *fullName = ApolloCommentFullName(comment);
-        if (fullName.length > 0) {
-            [sCommentTranslationByFullName removeObjectForKey:fullName];
-        }
-
         ApolloRestoreOriginalForCellNode(cellNode, comment);
     }
+    ApolloRestoreVisibleCommentCellNodesForController(viewController);
+    ApolloForceVisibleCommentsTableRelayoutForController(viewController);
 }
 
 #pragma mark - Phase A/B: nav-bar globe icon + status banner
 
 // Forward declaration so the globe bar button action can call it.
 static void ApolloToggleThreadTranslationForController(UIViewController *vc);
+static void ApolloToggleFeedTitleTranslationForController(UIViewController *vc);
+static void ApolloScheduleThreadTranslationReconcileForController(UIViewController *vc, BOOL translatedMode);
 
 // Returns a localized human name for the active target language (e.g. "en"
 // → "English"). Falls back to the uppercased code.
@@ -2056,6 +2546,7 @@ static BOOL ApolloTextMatchesTranslatedDisplayText(NSString *visibleText, NSStri
 
 static BOOL ApolloRefreshVisibleTranslationAppliedForController(UIViewController *vc) {
     if (!vc || !ApolloControllerIsInTranslatedMode(vc)) return NO;
+    BOOL isFeedVC = [objc_getAssociatedObject(vc, kApolloFeedTranslationVCKey) boolValue];
 
     NSMutableArray *nodes = [NSMutableArray array];
     NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:128];
@@ -2063,6 +2554,7 @@ static BOOL ApolloRefreshVisibleTranslationAppliedForController(UIViewController
 
     for (id node in nodes) {
         if (![objc_getAssociatedObject(node, kApolloTranslationOwnedTextNodeKey) boolValue]) continue;
+        if (!isFeedVC && [objc_getAssociatedObject(node, kApolloTitleOwnedTextNodeKey) boolValue]) continue;
 
         NSString *originalBody = objc_getAssociatedObject(node, kApolloOwnedNodeOriginalBodyKey);
         NSString *translatedText = objc_getAssociatedObject(node, kApolloOwnedNodeTranslatedTextKey);
@@ -2081,6 +2573,83 @@ static BOOL ApolloRefreshVisibleTranslationAppliedForController(UIViewController
     }
 
     return NO;
+}
+
+static BOOL ApolloFindVisibleTranslatedTitleOwnedTextNodeInTree(id object, NSInteger depth, NSHashTable *visited) {
+    if (!object || depth < 0) return NO;
+    if (visited.count >= 2048) return NO;
+
+    Class displayNodeCls = NSClassFromString(@"ASDisplayNode");
+    BOOL isDisplayNode = displayNodeCls && [object isKindOfClass:displayNodeCls];
+    BOOL isView = [object isKindOfClass:[UIView class]];
+    if (!isDisplayNode && !isView) return NO;
+    if ([visited containsObject:object]) return NO;
+    [visited addObject:object];
+
+    @try {
+        if ([object respondsToSelector:@selector(attributedText)] &&
+            [objc_getAssociatedObject(object, kApolloTranslationOwnedTextNodeKey) boolValue] &&
+            [objc_getAssociatedObject(object, kApolloTitleOwnedTextNodeKey) boolValue]) {
+            NSString *originalBody = objc_getAssociatedObject(object, kApolloOwnedNodeOriginalBodyKey);
+            NSString *translatedText = objc_getAssociatedObject(object, kApolloOwnedNodeTranslatedTextKey);
+            if ([originalBody isKindOfClass:[NSString class]] &&
+                [translatedText isKindOfClass:[NSString class]] &&
+                ApolloTranslatedTextDiffersFromSource(originalBody, translatedText)) {
+                NSAttributedString *attr = ((id (*)(id, SEL))objc_msgSend)(object, @selector(attributedText));
+                if ([attr isKindOfClass:[NSAttributedString class]] &&
+                    ApolloTextMatchesTranslatedDisplayText(attr.string, translatedText)) {
+                    return YES;
+                }
+            }
+        }
+    } @catch (__unused NSException *e) {}
+
+    @try {
+        SEL nodeSelectors[] = { NSSelectorFromString(@"asyncdisplaykit_node"), NSSelectorFromString(@"node") };
+        for (size_t i = 0; i < sizeof(nodeSelectors) / sizeof(nodeSelectors[0]); i++) {
+            SEL selector = nodeSelectors[i];
+            if (![object respondsToSelector:selector]) continue;
+            id node = ((id (*)(id, SEL))objc_msgSend)(object, selector);
+            if (node && node != object && ApolloFindVisibleTranslatedTitleOwnedTextNodeInTree(node, depth - 1, visited)) return YES;
+        }
+    } @catch (__unused NSException *e) {}
+
+    @try {
+        SEL subnodesSel = NSSelectorFromString(@"subnodes");
+        if ([object respondsToSelector:subnodesSel]) {
+            NSArray *subnodes = ((id (*)(id, SEL))objc_msgSend)(object, subnodesSel);
+            if ([subnodes isKindOfClass:[NSArray class]]) {
+                for (id subnode in subnodes) {
+                    if (ApolloFindVisibleTranslatedTitleOwnedTextNodeInTree(subnode, depth - 1, visited)) return YES;
+                }
+            }
+        }
+    } @catch (__unused NSException *e) {}
+
+    @try {
+        if ([object respondsToSelector:@selector(subviews)]) {
+            NSArray *subviews = ((id (*)(id, SEL))objc_msgSend)(object, @selector(subviews));
+            if ([subviews isKindOfClass:[NSArray class]]) {
+                for (id subview in subviews) {
+                    if (ApolloFindVisibleTranslatedTitleOwnedTextNodeInTree(subview, depth - 1, visited)) return YES;
+                }
+            }
+        }
+    } @catch (__unused NSException *e) {}
+
+    return NO;
+}
+
+static BOOL ApolloRefreshFeedTitleTranslationAppliedForController(UIViewController *vc) {
+    if (!vc || !vc.isViewLoaded) return NO;
+    if (![objc_getAssociatedObject(vc, kApolloFeedTranslationVCKey) boolValue]) return NO;
+    if (!sEnableBulkTranslation || !sTranslatePostTitles || !ApolloControllerIsInTranslatedMode(vc)) return NO;
+
+    NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:512];
+    if (!ApolloFindVisibleTranslatedTitleOwnedTextNodeInTree(vc.view, 20, visited)) return NO;
+
+    objc_setAssociatedObject(vc, kApolloVisibleTranslationAppliedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return YES;
 }
 
 static UIColor *ApolloResolvedTintColor(UIColor *color, UITraitCollection *traitCollection) {
@@ -2142,14 +2711,21 @@ static UIColor *ApolloThemeTintColorFromNavigationItems(NSArray<UIBarButtonItem 
 static void ApolloUpdateTranslationUIForController(id controller) {
     UIViewController *vc = (UIViewController *)controller;
 
+    BOOL isFeedVC = [objc_getAssociatedObject(controller, kApolloFeedTranslationVCKey) boolValue];
     UIBarButtonItem *translationItem = objc_getAssociatedObject(controller, kApolloTranslateBarButtonKey);
     NSMutableArray<UIBarButtonItem *> *items = [vc.navigationItem.rightBarButtonItems mutableCopy] ?: [NSMutableArray array];
-    if (!sEnableBulkTranslation) {
+    // Comments VCs require sEnableBulkTranslation.
+    // Feed VCs additionally require sTranslatePostTitles — the only thing
+    // they translate is post titles, so when titles are disabled the globe
+    // shouldn't appear.
+    BOOL gateOK = sEnableBulkTranslation && (!isFeedVC || sTranslatePostTitles);
+    if (!gateOK) {
         // Feature flipped off: revert any active translation, drop the bar
         // button + hide the banner. Do not leak associations.
         if (ApolloControllerIsInTranslatedMode(vc)) {
-            ApolloRestoreVisibleCommentsForController(vc);
+            if (!isFeedVC) ApolloRestoreVisibleCommentsForController(vc);
         }
+        ApolloRestoreAllOwnedTextNodes();
         ApolloClearVisibleTranslationApplied(vc);
         objc_setAssociatedObject(controller, kApolloThreadTranslatedModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(controller, kApolloThreadOriginalModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -2159,7 +2735,7 @@ static void ApolloUpdateTranslationUIForController(id controller) {
             vc.navigationItem.rightBarButtonItems = items;
             objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         }
-        ApolloUpdateBannerForController(vc);
+        if (!isFeedVC) ApolloUpdateBannerForController(vc);
         return;
     }
 
@@ -2221,7 +2797,7 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     }
     vc.navigationItem.rightBarButtonItems = items;
 
-    ApolloUpdateBannerForController(vc);
+    if (!isFeedVC) ApolloUpdateBannerForController(vc);
 }
 
 static void ApolloToggleThreadTranslationForController(UIViewController *vc) {
@@ -2230,15 +2806,134 @@ static void ApolloToggleThreadTranslationForController(UIViewController *vc) {
     if (wasTranslated) {
         // Switch to original.
         ApolloRestoreVisibleCommentsForController(vc);
+        // Off-screen / preloaded text nodes never went through the visible-
+        // cells walk above. Restore every node we still own globally so the
+        // user sees originals as soon as they scroll back, without waiting
+        // for cellNodeVisibilityEvent (which has timing issues for cells
+        // already cached in ASDK's preload range).
+        ApolloRestoreAllOwnedTextNodes();
         ApolloClearVisibleTranslationApplied(vc);
+        sPendingVisibleFeedTitleApplied = NO;
         objc_setAssociatedObject(vc, kApolloThreadTranslatedModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(vc, kApolloThreadOriginalModeKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloScheduleThreadTranslationReconcileForController(vc, NO);
     } else {
         // Switch to translated.
         ApolloClearVisibleTranslationApplied(vc);
         objc_setAssociatedObject(vc, kApolloThreadTranslatedModeKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(vc, kApolloThreadOriginalModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         ApolloTranslateVisibleCommentsForController(vc, YES);
+        ApolloRescanTitleNodesForController(vc);
+        ApolloScheduleThreadTranslationReconcileForController(vc, YES);
+    }
+    ApolloUpdateTranslationUIForController(vc);
+}
+
+static NSString *ApolloFeedTitleModeKeyForController(UIViewController *vc) {
+    if (!vc) return nil;
+    NSString *title = vc.navigationItem.title ?: vc.title ?: @"";
+    return [NSString stringWithFormat:@"%@|%@", NSStringFromClass([vc class]), title.length > 0 ? title : @"(untitled)"];
+}
+
+static NSNumber *ApolloStoredFeedTitleModeForController(UIViewController *vc) {
+    NSString *key = ApolloFeedTitleModeKeyForController(vc);
+    if (key.length == 0) return nil;
+    return sFeedTitleModeByFeedKey[key];
+}
+
+static void ApolloStoreFeedTitleModeForController(UIViewController *vc, BOOL translated) {
+    NSString *key = ApolloFeedTitleModeKeyForController(vc);
+    if (key.length == 0) return;
+    if (!sFeedTitleModeByFeedKey) sFeedTitleModeByFeedKey = [NSMutableDictionary dictionary];
+    sFeedTitleModeByFeedKey[key] = @(translated);
+    sLastFeedTitleModeKnown = YES;
+    sLastFeedTitleTranslatedMode = translated;
+}
+
+static BOOL ApolloFeedTitlesShouldShowTranslated(UIViewController *feedVC) {
+    if (feedVC) {
+        BOOL translated = ApolloControllerIsInTranslatedMode(feedVC);
+        sLastFeedTitleModeKnown = YES;
+        sLastFeedTitleTranslatedMode = translated;
+        return translated;
+    }
+    return !sLastFeedTitleModeKnown || sLastFeedTitleTranslatedMode;
+}
+
+static BOOL ApolloClassLooksLikeCommentsViewController(Class cls) {
+    if (!cls) return NO;
+    const char *name = class_getName(cls);
+    return name && strstr(name, "CommentsViewController");
+}
+
+static BOOL ApolloTitleOwnedNodeShouldShowTranslated(UIViewController *enclosingVC) {
+    if (enclosingVC && ApolloClassLooksLikeCommentsViewController([enclosingVC class])) {
+        return ApolloControllerIsInTranslatedMode(enclosingVC);
+    }
+    UIViewController *feedVC = ApolloFindTopmostVisibleFeedVC();
+    if (!feedVC && sVisibleCommentsViewController) {
+        return ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController);
+    }
+    return ApolloFeedTitlesShouldShowTranslated(feedVC);
+}
+
+static void ApolloScheduleThreadTranslationReconcileForController(UIViewController *vc, BOOL translatedMode) {
+    if (!vc) return;
+    // Capture the cancel generation at scheduling time. viewWillDisappear
+    // bumps this counter; any reconcile pass that fires after the user has
+    // started swiping back will see a mismatch and bail out before it walks
+    // the owned-textnode registry / forces table relayouts.
+    NSNumber *generationAtSchedule = objc_getAssociatedObject(vc, kApolloReconcileGenerationKey);
+    NSUInteger schedGen = generationAtSchedule.unsignedIntegerValue;
+    NSArray<NSNumber *> *delays = @[ @0.12, @0.35, @0.8 ];
+    for (NSNumber *delayNumber in delays) {
+        __weak UIViewController *weakVC = vc;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayNumber.doubleValue * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            UIViewController *strongVC = weakVC;
+            if (!strongVC || !strongVC.isViewLoaded || !strongVC.view.window) return;
+            // Cancelled by viewWillDisappear: \u2014 don't run mid-pop.
+            NSNumber *currentGen = objc_getAssociatedObject(strongVC, kApolloReconcileGenerationKey);
+            if (currentGen.unsignedIntegerValue != schedGen) return;
+            if (ApolloControllerIsInTranslatedMode(strongVC) != translatedMode) return;
+            if (translatedMode) {
+                ApolloTranslateVisibleCommentsForController(strongVC, NO);
+                ApolloRescanTitleNodesForController(strongVC);
+                ApolloRefreshVisibleTranslationAppliedForController(strongVC);
+                ApolloForceVisibleCommentsTableRelayoutForController(strongVC);
+            } else {
+                ApolloRestoreVisibleCommentsForController(strongVC);
+                // Skip the global restore walk when nothing remains to
+                // restore \u2014 avoids the four-deep storm of full-registry walks
+                // per toggle that the user sees as swipe-back / toggle lag.
+                if (sOwnedTextNodes && sOwnedTextNodes.count > 0) {
+                    ApolloRestoreAllOwnedTextNodes();
+                }
+                ApolloClearVisibleTranslationApplied(strongVC);
+                ApolloForceVisibleCommentsTableRelayoutForController(strongVC);
+            }
+            ApolloUpdateTranslationUIForController(strongVC);
+        });
+    }
+}
+
+static void ApolloToggleFeedTitleTranslationForController(UIViewController *vc) {
+    if (!vc) return;
+    BOOL wasTranslated = ApolloControllerIsInTranslatedMode(vc);
+    if (wasTranslated) {
+        ApolloRestoreAllOwnedTextNodes();
+        ApolloClearVisibleTranslationApplied(vc);
+        sPendingVisibleFeedTitleApplied = NO;
+        objc_setAssociatedObject(vc, kApolloThreadTranslatedModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(vc, kApolloThreadOriginalModeKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloStoreFeedTitleModeForController(vc, NO);
+        ApolloRescanTitleNodesForController(vc);
+        ApolloRefreshFeedTranslationStateForController(vc);
+    } else {
+        ApolloClearVisibleTranslationApplied(vc);
+        objc_setAssociatedObject(vc, kApolloThreadTranslatedModeKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(vc, kApolloThreadOriginalModeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloStoreFeedTitleModeForController(vc, YES);
+        ApolloRescanTitleNodesForController(vc);
     }
     ApolloUpdateTranslationUIForController(vc);
 }
@@ -2264,8 +2959,188 @@ static BOOL ApolloTextMatchesSourceOrVisualDisplay(NSString *incomingText, NSStr
 
 static void ApolloClearTranslationOwnershipForTextNode(id textNode) {
     objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloTitleOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    if (textNode && sOwnedTextNodes) {
+        dispatch_sync(sOwnedTextNodesQueue, ^{
+            [sOwnedTextNodes removeObject:textNode];
+        });
+    }
+}
+
+// Add `textNode` to the global weak registry. Called from
+// ApolloApplyTranslationToCellNode / ApolloApplyTranslationToHeaderCellNode
+// every time we stamp a node with the ownership marker, so the toggle-off
+// walk below can find every owned node — even those whose backing
+// UITableViewCell is currently off-screen.
+static void ApolloRegisterOwnedTextNode(id textNode) {
+    if (!textNode || !sOwnedTextNodes) return;
+    dispatch_sync(sOwnedTextNodesQueue, ^{
+        [sOwnedTextNodes addObject:textNode];
+    });
+}
+
+// Walk every text node we've ever stamped with the ownership marker and
+// restore each one to its saved original attributedText. Used by the toggle-
+// off path so cells that scrolled off-screen while translated immediately
+// revert — instead of waiting for cellNodeVisibilityEvent (which doesn't
+// always fire reliably for cells already cached in ASDK's preload range).
+static void ApolloRestoreAllOwnedTextNodes(void) {
+    if (!sOwnedTextNodes) return;
+    // Cheap fast-path: nothing's been stamped, nothing to do. Avoids the
+    // hashtable snapshot + full log line on every gateOK=NO refresh of
+    // ApolloUpdateTranslationUIForController and on toggle reconciles after
+    // the immediate pass already drained the registry.
+    if (sOwnedTextNodes.count == 0) return;
+    NSArray *snapshot = nil;
+    {
+        __block NSArray *capture = nil;
+        dispatch_sync(sOwnedTextNodesQueue, ^{
+            capture = [sOwnedTextNodes allObjects];
+        });
+        snapshot = capture;
+    }
+    NSUInteger restored = 0, skippedNoOriginal = 0, skippedReuse = 0, skippedTitleStaleReuse = 0;
+    for (id textNode in snapshot) {
+        if (!textNode) continue;
+        // Only act if still tagged.
+        if (![objc_getAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey) boolValue]) continue;
+
+        BOOL isTitleOwned = [objc_getAssociatedObject(textNode, kApolloTitleOwnedTextNodeKey) boolValue];
+        NSString *cachedTranslated = objc_getAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey);
+        NSAttributedString *savedOriginal = objc_getAssociatedObject(textNode, kApolloOriginalAttributedTextKey);
+
+        // Drop ownership keys FIRST so the global setAttributedText: hook
+        // won't re-swap when we write the original below.
+        objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(textNode, kApolloTitleOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+        objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+
+        if (![savedOriginal isKindOfClass:[NSAttributedString class]]) { skippedNoOriginal++; continue; }
+
+        // Reuse-safety: only write if the node currently shows our cached
+        // translation. If it now shows something else (reused for a
+        // different comment), leave it alone — clearing ownership is
+        // sufficient.
+        NSAttributedString *currentAttr = nil;
+        @try {
+            currentAttr = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText));
+        } @catch (__unused NSException *e) {
+            continue;
+        }
+        NSString *currentText = [currentAttr isKindOfClass:[NSAttributedString class]] ? currentAttr.string : nil;
+        if (currentText.length == 0) { skippedReuse++; continue; }
+
+        BOOL shouldRestore = NO;
+        if (isTitleOwned) {
+            // Title-owned: be permissive. The strict body-candidate check
+            // (which requires ≥60% length overlap or shared 12+ char prefix)
+            // rejects many short translated titles whose normalized form
+            // doesn't perfectly equal the cached translated string. For
+            // titles, just compare normalized forms for equality OR check
+            // that the saved-original text differs from currentText (i.e.
+            // we haven't already restored). If the cell got reused for a
+            // different post the next setAttributedText: from Apollo will
+            // overwrite our restored stale text — no worse than leaving
+            // stale translated text.
+            NSString *currentNorm = ApolloNormalizeTextForCompare(currentText);
+            NSString *cachedNorm = ApolloNormalizeTextForCompare(cachedTranslated);
+            NSString *origNorm = ApolloNormalizeTextForCompare(savedOriginal.string);
+            if (cachedNorm.length > 0 && [currentNorm isEqualToString:cachedNorm]) {
+                shouldRestore = YES;
+            } else if (origNorm.length > 0 && ![currentNorm isEqualToString:origNorm]) {
+                // Currently showing something other than the saved original
+                // — likely still translated text but with slight format diff.
+                shouldRestore = YES;
+            } else {
+                skippedTitleStaleReuse++;
+            }
+        } else if ([cachedTranslated isKindOfClass:[NSString class]] && cachedTranslated.length > 0) {
+            shouldRestore = ApolloTextQualifiesAsBodyCandidate(currentText, cachedTranslated);
+            if (!shouldRestore) skippedReuse++;
+        } else {
+            skippedReuse++;
+        }
+        if (!shouldRestore) continue;
+
+        @try {
+            ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), savedOriginal);
+        } @catch (__unused NSException *e) {
+            continue;
+        }
+        restored++;
+        if ([textNode respondsToSelector:@selector(setNeedsLayout)]) {
+            ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsLayout));
+        }
+        if ([textNode respondsToSelector:@selector(setNeedsDisplay)]) {
+            ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsDisplay));
+        }
+        // ---- Restore-side cell relayout ----
+        // Same problem as the apply path: the enclosing ASCellNode caches
+        // the (longer) translated layout, so without an explicit transition
+        // the original text gets truncated to "Benfica..." until you scroll.
+        SEL invalidateSel = NSSelectorFromString(@"invalidateCalculatedLayout");
+        SEL supernodeSel = NSSelectorFromString(@"supernode");
+        @try {
+            if ([textNode respondsToSelector:invalidateSel]) {
+                ((void (*)(id, SEL))objc_msgSend)(textNode, invalidateSel);
+            }
+            id supernode = nil;
+            if ([textNode respondsToSelector:supernodeSel]) {
+                supernode = ((id (*)(id, SEL))objc_msgSend)(textNode, supernodeSel);
+            }
+            int hops = 0;
+            id cellNode = nil;
+            while (supernode && hops < 8) {
+                if ([supernode respondsToSelector:invalidateSel]) {
+                    ((void (*)(id, SEL))objc_msgSend)(supernode, invalidateSel);
+                }
+                if ([supernode respondsToSelector:@selector(setNeedsLayout)]) {
+                    ((void (*)(id, SEL))objc_msgSend)(supernode, @selector(setNeedsLayout));
+                }
+                if (!cellNode) {
+                    const char *snName = class_getName([supernode class]);
+                    if (snName && strstr(snName, "CellNode")) cellNode = supernode;
+                }
+                if (![supernode respondsToSelector:supernodeSel]) break;
+                supernode = ((id (*)(id, SEL))objc_msgSend)(supernode, supernodeSel);
+                hops++;
+            }
+            if (cellNode) {
+                SEL transitionSel = NSSelectorFromString(@"transitionLayoutWithAnimation:shouldMeasureAsync:measurementCompletion:");
+                if ([cellNode respondsToSelector:transitionSel]) {
+                    NSMethodSignature *sig = [cellNode methodSignatureForSelector:transitionSel];
+                    if (sig) {
+                        NSInvocation *inv = [NSInvocation invocationWithMethodSignature:sig];
+                        inv.target = cellNode;
+                        inv.selector = transitionSel;
+                        BOOL animated = NO;
+                        BOOL async = NO;
+                        void (^completion)(void) = nil;
+                        [inv setArgument:&animated atIndex:2];
+                        [inv setArgument:&async atIndex:3];
+                        [inv setArgument:&completion atIndex:4];
+                        @try { [inv invoke]; } @catch (__unused NSException *e) {}
+                    }
+                }
+            }
+        } @catch (__unused NSException *e) {}
+    }
+
+    // Drain dead weak entries.
+    dispatch_sync(sOwnedTextNodesQueue, ^{
+        // NSHashTable handles weak entries automatically; a no-op iteration
+        // suffices to compact in some implementations. Nothing else needed.
+        (void)[sOwnedTextNodes count];
+    });
+    ApolloLog(@"[Translation] RestoreAllOwnedTextNodes total=%lu restored=%lu skippedNoOriginal=%lu skippedReuse=%lu skippedTitleStaleReuse=%lu",
+              (unsigned long)snapshot.count,
+              (unsigned long)restored,
+              (unsigned long)skippedNoOriginal,
+              (unsigned long)skippedReuse,
+              (unsigned long)skippedTitleStaleReuse);
 }
 
 static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
@@ -2312,6 +3187,33 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
         return;
     }
 
+    // Title-owned nodes live outside the comments controller (feeds, search,
+    // profile, etc.) — they must bypass the per-thread translated-mode gate.
+    BOOL isTitleOwned = [objc_getAssociatedObject(self, kApolloTitleOwnedTextNodeKey) boolValue];
+
+    // Title-owned toggle-off gate: if the topmost-visible feed VC is in
+    // original mode, drop ownership and let Apollo's incoming text through.
+    if (isTitleOwned) {
+        UIViewController *enclosingVC = ApolloEnclosingViewControllerForNode((id)self);
+        if (!ApolloTitleOwnedNodeShouldShowTranslated(enclosingVC)) {
+            ApolloClearTranslationOwnershipForTextNode(self);
+            %orig;
+            return;
+        }
+    }
+
+    // Toggle-off gate: if the controller is no longer in translated mode,
+    // drop our ownership marker and let Apollo's incoming (original) text
+    // through unchanged. Without this, off-screen text nodes that still
+    // carry the ownership marker would re-swap to translated as soon as
+    // Apollo touches them again on cell reuse / scroll-back, which is the
+    // "translated text persists after toggling off" bug.
+    if (!isTitleOwned && !ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) {
+        ApolloClearTranslationOwnershipForTextNode(self);
+        %orig;
+        return;
+    }
+
     // Re-entrancy guard: when WE call %orig with a substituted string, the
     // hook re-fires. Skip the swap on the inner call.
     if ([objc_getAssociatedObject(self, kApolloOwnedNodeReentrancyKey) boolValue]) {
@@ -2324,6 +3226,16 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
         objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         @try { %orig(swap); } @catch (__unused NSException *e) {}
         objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        if (isTitleOwned) {
+            NSString *originalBody = objc_getAssociatedObject(self, kApolloOwnedNodeOriginalBodyKey);
+            NSString *translatedText = objc_getAssociatedObject(self, kApolloOwnedNodeTranslatedTextKey);
+            UIViewController *enclosingVC = ApolloEnclosingViewControllerForNode((id)self);
+            if (ApolloClassLooksLikeCommentsViewController([enclosingVC class])) {
+                ApolloMarkVisibleTranslationApplied(originalBody, translatedText);
+            } else {
+                ApolloMarkVisibleFeedTitleApplied(originalBody, translatedText);
+            }
+        }
         return;
     }
 
@@ -2340,6 +3252,24 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
         return;
     }
 
+    BOOL isTitleOwned = [objc_getAssociatedObject(self, kApolloTitleOwnedTextNodeKey) boolValue];
+
+    if (isTitleOwned) {
+        UIViewController *enclosingVC = ApolloEnclosingViewControllerForNode((id)self);
+        if (!ApolloTitleOwnedNodeShouldShowTranslated(enclosingVC)) {
+            ApolloClearTranslationOwnershipForTextNode(self);
+            %orig;
+            return;
+        }
+    }
+
+    // Toggle-off gate (mirror of ASTextNode hook above).
+    if (!isTitleOwned && !ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) {
+        ApolloClearTranslationOwnershipForTextNode(self);
+        %orig;
+        return;
+    }
+
     if ([objc_getAssociatedObject(self, kApolloOwnedNodeReentrancyKey) boolValue]) {
         %orig;
         return;
@@ -2350,10 +3280,761 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
         objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         @try { %orig(swap); } @catch (__unused NSException *e) {}
         objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        if (isTitleOwned) {
+            NSString *originalBody = objc_getAssociatedObject(self, kApolloOwnedNodeOriginalBodyKey);
+            NSString *translatedText = objc_getAssociatedObject(self, kApolloOwnedNodeTranslatedTextKey);
+            UIViewController *enclosingVC = ApolloEnclosingViewControllerForNode((id)self);
+            if (ApolloClassLooksLikeCommentsViewController([enclosingVC class])) {
+                ApolloMarkVisibleTranslationApplied(originalBody, translatedText);
+            } else {
+                ApolloMarkVisibleFeedTitleApplied(originalBody, translatedText);
+            }
+        }
         return;
     }
 
     %orig;
+}
+
+%end
+
+// ---------------------------------------------------------------------------
+// Post title translation (PostTitleNode / PostTitleURLNode)
+// ---------------------------------------------------------------------------
+//
+// Title translation runs in *every* feed surface (subreddit feed, home feed,
+// search results, profile, and the post-detail header). Title nodes are
+// produced and reused by AsyncDisplayKit *outside* the comments controller,
+// so they bypass the per-thread translated-mode gate via the
+// `kApolloTitleOwnedTextNodeKey` marker (see ASTextNode setAttributedText
+// hooks above).
+//
+// CRITICAL: do NOT hook setNeedsLayout / setNeedsDisplay on title nodes.
+// `setAttributedText:` internally invokes both, so hooking those methods to
+// re-translate would cause unbounded recursion and a stack-overflow crash.
+// (This was the v17 bug that caused the launch-time crash loop.)
+// Re-application on cell reuse, vote refresh, edit, etc. is handled by the
+// global ASTextNode/ASTextNode2 setAttributedText: swap hooks, keyed on
+// `kApolloTranslationOwnedTextNodeKey`.
+
+// Walks up an ASDisplayNode's supernode chain looking for one with a loaded
+// view, then walks the UIView responder chain to find the enclosing
+// UIViewController. Returns nil if the node isn't yet attached to a view
+// hierarchy (e.g. during preload before the cell view is loaded).
+static void ApolloMaybeTranslatePostTitleNode(id titleNode);
+
+static UIViewController *ApolloEnclosingViewControllerForNode(id node) {
+    if (!node) return nil;
+    SEL supernodeSel = NSSelectorFromString(@"supernode");
+    SEL isLoadedSel = NSSelectorFromString(@"isNodeLoaded");
+    SEL viewSel = @selector(view);
+
+    id current = node;
+    int hops = 0;
+    while (current && hops < 16) {
+        @try {
+            BOOL viewLoaded = NO;
+            if ([current respondsToSelector:isLoadedSel]) {
+                viewLoaded = ((BOOL (*)(id, SEL))objc_msgSend)(current, isLoadedSel);
+            }
+            if (viewLoaded && [current respondsToSelector:viewSel]) {
+                UIView *v = ((id (*)(id, SEL))objc_msgSend)(current, viewSel);
+                if ([v isKindOfClass:[UIView class]]) {
+                    UIResponder *r = v.nextResponder;
+                    while (r) {
+                        if ([r isKindOfClass:[UIViewController class]]) {
+                            return (UIViewController *)r;
+                        }
+                        r = r.nextResponder;
+                    }
+                }
+            }
+        } @catch (__unused NSException *e) {}
+        if (![current respondsToSelector:supernodeSel]) break;
+        @try {
+            current = ((id (*)(id, SEL))objc_msgSend)(current, supernodeSel);
+        } @catch (__unused NSException *e) { break; }
+        hops++;
+    }
+    return nil;
+}
+
+// Returns YES if the controller has been confirmed-set to original-mode
+// (either via the per-thread toggle, or via auto-translate-off). Returns NO
+// when the VC is nil or its mode is unknown \u2014 callers use that to *defer*
+// destructive actions (like restoring originals) until viewDidAppear has
+// claimed `sVisibleCommentsViewController`.
+static BOOL ApolloControllerIsConfirmedOriginalMode(UIViewController *vc) {
+    if (!vc) return NO;
+    if ([objc_getAssociatedObject(vc, kApolloThreadOriginalModeKey) boolValue]) return YES;
+    // No explicit per-thread override: the VC follows global auto-translate.
+    // If auto-translate is OFF, mode == original. If ON, the translated-mode
+    // path handles things; we report NO here so callers don't mistakenly
+    // restore originals on a translated thread.
+    if (!sAutoTranslateOnAppear) return YES;
+    return NO;
+}
+
+// Best-effort \"which CommentsViewController owns this cell node?\". Tries the
+// global pointer first (covers the common case); falls back to walking the
+// ASDisplayNode tree so cell-visibility hooks that fire BEFORE viewDidAppear:
+// can still find their owning VC. Returns nil if the cell isn't attached to
+// a view hierarchy yet.
+static UIViewController *ApolloOwningCommentsVCForCellNode(id cellNode) {
+    UIViewController *vc = sVisibleCommentsViewController;
+    if (vc && vc.isViewLoaded && vc.view.window) return vc;
+    UIViewController *enclosing = ApolloEnclosingViewControllerForNode(cellNode);
+    if (enclosing) return enclosing;
+    return vc; // may be nil; callers handle that
+}
+
+
+// when toggling the feed/thread globe on so that already-visible cells get
+// translated immediately (the didLoad/preload/display hooks only fire on
+// new cells).
+static void ApolloRescanTitleNodesInTree(id object, NSInteger depth, NSHashTable *visited) {
+    if (!object || depth < 0) return;
+    if (visited.count >= 2048) return;
+    if ([visited containsObject:object]) return;
+    [visited addObject:object];
+
+    Class displayNodeCls = NSClassFromString(@"ASDisplayNode");
+    BOOL isDisplayNode = displayNodeCls && [object isKindOfClass:displayNodeCls];
+
+    if (isDisplayNode) {
+        const char *clsName = class_getName([object class]);
+        if (clsName && (strstr(clsName, "PostTitleNode") || strstr(clsName, "PostTitleURLNode"))) {
+            ApolloMaybeTranslatePostTitleNode(object);
+            // Don't return — title nodes might contain other PostTitleNodes
+            // (e.g. crossposts), but practically we can stop descending.
+        }
+    }
+
+    @try {
+        SEL nodeSelectors[] = { NSSelectorFromString(@"asyncdisplaykit_node"), NSSelectorFromString(@"node") };
+        for (size_t i = 0; i < sizeof(nodeSelectors) / sizeof(nodeSelectors[0]); i++) {
+            SEL sel = nodeSelectors[i];
+            if (![object respondsToSelector:sel]) continue;
+            id n = ((id (*)(id, SEL))objc_msgSend)(object, sel);
+            if (n && n != object) ApolloRescanTitleNodesInTree(n, depth - 1, visited);
+        }
+    } @catch (__unused NSException *e) {}
+
+    @try {
+        SEL subnodesSel = NSSelectorFromString(@"subnodes");
+        if ([object respondsToSelector:subnodesSel]) {
+            NSArray *subs = ((id (*)(id, SEL))objc_msgSend)(object, subnodesSel);
+            if ([subs isKindOfClass:[NSArray class]]) {
+                for (id s in subs) ApolloRescanTitleNodesInTree(s, depth - 1, visited);
+            }
+        }
+    } @catch (__unused NSException *e) {}
+
+    @try {
+        if ([object respondsToSelector:@selector(subviews)]) {
+            NSArray *subviews = ((id (*)(id, SEL))objc_msgSend)(object, @selector(subviews));
+            if ([subviews isKindOfClass:[NSArray class]]) {
+                for (id s in subviews) ApolloRescanTitleNodesInTree(s, depth - 1, visited);
+            }
+        }
+    } @catch (__unused NSException *e) {}
+}
+
+static void ApolloRescanTitleNodesForController(UIViewController *vc) {
+    if (!vc || !vc.isViewLoaded) return;
+    if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
+    BOOL isFeedVC = [objc_getAssociatedObject(vc, kApolloFeedTranslationVCKey) boolValue];
+    NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:256];
+    ApolloRescanTitleNodesInTree(vc.view, 16, visited);
+    if (isFeedVC) ApolloRefreshFeedTranslationStateForController(vc);
+
+    // Some cells haven't fully laid out their title node yet at the moment
+    // the user taps the globe (e.g. cells just scrolled into view, or the
+    // first toggle right after viewDidAppear). Schedule retries so those
+    // late-arriving title nodes still get translated without the user having
+    // to scroll, then repaint the globe from the visible title state.
+    __weak UIViewController *weakVC = vc;
+    void (^scheduleTranslatedRescan)(NSTimeInterval) = ^(NSTimeInterval delay) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            UIViewController *strongVC = weakVC;
+            if (!strongVC || !strongVC.isViewLoaded) return;
+            if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
+            if (!ApolloControllerIsInTranslatedMode(strongVC)) return;
+            NSHashTable *visited2 = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:256];
+            ApolloRescanTitleNodesInTree(strongVC.view, 16, visited2);
+            if ([objc_getAssociatedObject(strongVC, kApolloFeedTranslationVCKey) boolValue]) {
+                ApolloRefreshFeedTranslationStateForController(strongVC);
+            }
+        });
+    };
+    scheduleTranslatedRescan(0.15);
+    scheduleTranslatedRescan(0.6);
+}
+
+static id ApolloTitleTextNodeFromTitleNode(id titleNode) {
+    if (!titleNode) return nil;
+
+    // Most likely path: PostTitleNode IS an ASTextNode subclass.
+    if ([titleNode respondsToSelector:@selector(attributedText)]) {
+        @try {
+            NSAttributedString *attr = ((id (*)(id, SEL))objc_msgSend)(titleNode, @selector(attributedText));
+            if ([attr isKindOfClass:[NSAttributedString class]] && attr.length > 0) {
+                return titleNode;
+            }
+        } @catch (__unused NSException *e) {}
+    }
+
+    // Fallback: scan child text nodes and pick the longest non-empty one.
+    NSMutableArray *candidates = [NSMutableArray array];
+    NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:16];
+    ApolloCollectAttributedTextNodes(titleNode, 3, visited, candidates);
+
+    id best = nil;
+    NSUInteger bestLen = 0;
+    for (id n in candidates) {
+        NSAttributedString *attr = nil;
+        @try { attr = ((id (*)(id, SEL))objc_msgSend)(n, @selector(attributedText)); }
+        @catch (__unused NSException *e) { continue; }
+        if (![attr isKindOfClass:[NSAttributedString class]]) continue;
+        if (attr.length > bestLen) { bestLen = attr.length; best = n; }
+    }
+    return best;
+}
+
+static void ApolloApplyTranslationToTitleNode(id titleNode, id textNode, NSString *sourceText, NSString *translatedText) {
+    if (!titleNode || !textNode) return;
+    if (![sourceText isKindOfClass:[NSString class]] || sourceText.length == 0) return;
+    if (![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0) return;
+
+    NSAttributedString *current = nil;
+    @try { current = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText)); }
+    @catch (__unused NSException *e) { return; }
+    if (![current isKindOfClass:[NSAttributedString class]]) return;
+
+    NSString *currentNorm = ApolloNormalizeTextForCompare(current.string);
+    NSString *sourceNorm = ApolloNormalizeTextForCompare(sourceText);
+    NSString *translatedNorm = ApolloNormalizeTextForCompare(translatedText);
+    if (currentNorm.length == 0 || sourceNorm.length == 0) return;
+
+    BOOL textMatchesSource = [currentNorm isEqualToString:sourceNorm] ||
+                             [currentNorm containsString:sourceNorm] ||
+                             [sourceNorm containsString:currentNorm];
+    BOOL textMatchesTranslation = translatedNorm.length > 0 &&
+        ([currentNorm isEqualToString:translatedNorm] ||
+         [currentNorm containsString:translatedNorm] ||
+         [translatedNorm containsString:currentNorm]);
+
+    // Already showing translation, or showing something unrelated (cell
+    // recycled to a different post mid-flight) — nothing to do.
+    if (!textMatchesSource && !textMatchesTranslation) return;
+    if (textMatchesTranslation && !textMatchesSource) return;
+
+    // Save original on first apply for this node so toggle-off / restore can
+    // recover. Subsequent applies for the same node keep the first-seen
+    // original.
+    NSAttributedString *originalSaved = objc_getAssociatedObject(textNode, kApolloOriginalAttributedTextKey);
+    if (![originalSaved isKindOfClass:[NSAttributedString class]]) {
+        objc_setAssociatedObject(textNode, kApolloOriginalAttributedTextKey, [current copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    NSAttributedString *translatedAttr = ApolloTranslatedAttributedStringPreservingVisualLinks(current, translatedText);
+
+    // Vote-resilience / cell-reuse markers (same scheme as comment cells +
+    // post bodies). The title-owned marker tells the global swap hook to
+    // bypass the per-thread translated-mode gate.
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [sourceText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloTitleOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloRegisterOwnedTextNode(textNode);
+
+    @try { ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), translatedAttr); }
+    @catch (__unused NSException *e) { return; }
+
+    // Turn the feed/thread globe green now that we've actually swapped a
+    // visible title to the translated string.
+    UIViewController *enclosingVC = ApolloEnclosingViewControllerForNode(titleNode);
+    if (ApolloClassLooksLikeCommentsViewController([enclosingVC class])) {
+        ApolloMarkVisibleTranslationApplied(sourceText, translatedText);
+    } else {
+        ApolloMarkVisibleFeedTitleApplied(sourceText, translatedText);
+    }
+
+    // ---- Tag overlap fix ----
+    // PostTitleNode / PostTitleURLNode lay out subnodes (title text + tag
+    // pills + URL hostname) using ASDK's flexbox with positions that depend
+    // on the title text's calculated intrinsic size. When we replace the
+    // attributed string in-place, ASDK doesn't always re-flow the parent
+    // automatically — tag pills overlap the (longer) translated title until
+    // a scroll-out / scroll-in forces a fresh layout pass.
+    //
+    // Force a fresh layout pass on both the text node AND its enclosing
+    // title node. We do this from a static helper (NOT a hook), so even
+    // though setNeedsLayout / invalidateCalculatedLayout normally trigger
+    // ASDK relayout work, this never re-enters our translation code path.
+    //
+    // CRITICAL: do NOT install %hooks for setNeedsLayout / setNeedsDisplay
+    // on PostTitleNode — setAttributedText: internally calls them, and
+    // hooking those to invoke maybe-translate is what caused the v17 stack-
+    // overflow crash. Calling them ourselves from this un-hooked function
+    // is safe.
+    SEL invalidateSel = NSSelectorFromString(@"invalidateCalculatedLayout");
+    @try {
+        if ([textNode respondsToSelector:invalidateSel]) {
+            ((void (*)(id, SEL))objc_msgSend)(textNode, invalidateSel);
+        }
+        if (titleNode != textNode) {
+            if ([titleNode respondsToSelector:invalidateSel]) {
+                ((void (*)(id, SEL))objc_msgSend)(titleNode, invalidateSel);
+            }
+            if ([titleNode respondsToSelector:@selector(setNeedsLayout)]) {
+                ((void (*)(id, SEL))objc_msgSend)(titleNode, @selector(setNeedsLayout));
+            }
+        }
+        // Bubble up: the cell node containing the title also caches layout
+        // based on the title's old size. Invalidate the chain of supernodes
+        // until we hit the table/collection node.
+        id supernode = nil;
+        SEL supernodeSel = NSSelectorFromString(@"supernode");
+        if ([titleNode respondsToSelector:supernodeSel]) {
+            supernode = ((id (*)(id, SEL))objc_msgSend)(titleNode, supernodeSel);
+        }
+        int hops = 0;
+        id cellNode = nil;
+        while (supernode && hops < 8) {
+            if ([supernode respondsToSelector:invalidateSel]) {
+                ((void (*)(id, SEL))objc_msgSend)(supernode, invalidateSel);
+            }
+            if ([supernode respondsToSelector:@selector(setNeedsLayout)]) {
+                ((void (*)(id, SEL))objc_msgSend)(supernode, @selector(setNeedsLayout));
+            }
+            // Remember the first ASCellNode we encounter — we trigger an
+            // explicit transition layout on it below so the table view
+            // recalculates the row height around the now-larger title.
+            if (!cellNode) {
+                const char *snName = class_getName([supernode class]);
+                if (snName && strstr(snName, "CellNode")) {
+                    cellNode = supernode;
+                }
+            }
+            if (![supernode respondsToSelector:supernodeSel]) break;
+            supernode = ((id (*)(id, SEL))objc_msgSend)(supernode, supernodeSel);
+            hops++;
+        }
+        // Without a real ASCellNode transition, the table view keeps using
+        // the cached row height for the original (shorter) title — that's
+        // what causes the "Benfica em Roma" -> "Benfica..." truncation.
+        if (cellNode) {
+            SEL transitionSel = NSSelectorFromString(@"transitionLayoutWithAnimation:shouldMeasureAsync:measurementCompletion:");
+            if ([cellNode respondsToSelector:transitionSel]) {
+                NSMethodSignature *sig = [cellNode methodSignatureForSelector:transitionSel];
+                if (sig) {
+                    NSInvocation *inv = [NSInvocation invocationWithMethodSignature:sig];
+                    inv.target = cellNode;
+                    inv.selector = transitionSel;
+                    BOOL animated = NO;
+                    BOOL async = NO;
+                    void (^completion)(void) = nil;
+                    [inv setArgument:&animated atIndex:2];
+                    [inv setArgument:&async atIndex:3];
+                    [inv setArgument:&completion atIndex:4];
+                    @try { [inv invoke]; } @catch (__unused NSException *e) {}
+                }
+            }
+        }
+    } @catch (__unused NSException *e) {}
+}
+
+static void ApolloMaybeTranslatePostTitleNode(id titleNode) {
+    if (!titleNode) return;
+    if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
+
+    id textNode = ApolloTitleTextNodeFromTitleNode(titleNode);
+    if (!textNode) return;
+
+    NSString *titleText = ApolloVisibleTextFromNode(textNode);
+    if (!titleText || titleText.length < 3) return;
+
+    // ---- Per-VC translated-mode gate ----
+    // The user's contract: title translation in a feed/thread is gated by
+    // that VC's globe state. Use the topmost-visible feed VC (the one the
+    // user is actually looking at) instead of walking the title node's
+    // responder chain — the responder chain often surfaces a child
+    // container VC that doesn't carry the translated-mode flag, which
+    // caused tap-on-after-tap-off to silently restore everything.
+    UIViewController *enclosingVC = ApolloEnclosingViewControllerForNode(titleNode);
+    UIViewController *gateVC = ApolloClassLooksLikeCommentsViewController([enclosingVC class]) ? enclosingVC : ApolloFindTopmostVisibleFeedVC();
+    if (!ApolloTitleOwnedNodeShouldShowTranslated(enclosingVC)) {
+        // Visible feed is in original mode — restore if we previously
+        // translated this node and bail.
+        if ([objc_getAssociatedObject(textNode, kApolloTitleOwnedTextNodeKey) boolValue]) {
+            NSAttributedString *original = objc_getAssociatedObject(textNode, kApolloOriginalAttributedTextKey);
+            ApolloClearTranslationOwnershipForTextNode(textNode);
+            if ([original isKindOfClass:[NSAttributedString class]]) {
+                @try { ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), original); }
+                @catch (__unused NSException *e) {}
+            }
+        }
+        return;
+    }
+
+    // Already owned title nodes can be in either display state after a
+    // toggle cycle: translated (nothing to do) or original (reapply the
+    // cached translation immediately, no network). Do not assume ownership
+    // means the node is currently showing translated text.
+    if ([objc_getAssociatedObject(textNode, kApolloTitleOwnedTextNodeKey) boolValue]) {
+        NSString *ownedTranslated = objc_getAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey);
+        NSString *ownedSource = objc_getAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey);
+        NSString *currentNorm = ApolloNormalizeTextForCompare(titleText);
+        NSString *ownedSourceNorm = ApolloNormalizeTextForCompare(ownedSource);
+        NSString *ownedTranslatedNorm = ApolloNormalizeTextForCompare(ownedTranslated);
+        if ([ownedTranslated isKindOfClass:[NSString class]] && ownedTranslated.length > 0 &&
+            ownedTranslatedNorm.length > 0 && [currentNorm isEqualToString:ownedTranslatedNorm]) {
+            if (ApolloClassLooksLikeCommentsViewController([gateVC class])) {
+                ApolloMarkVisibleTranslationApplied(ownedSource, ownedTranslated);
+            } else {
+                ApolloMarkVisibleFeedTitleApplied(ownedSource, ownedTranslated);
+            }
+            return;
+        }
+        if ([ownedSource isKindOfClass:[NSString class]] && ownedSource.length > 0 &&
+            [ownedTranslated isKindOfClass:[NSString class]] && ownedTranslated.length > 0 &&
+            ownedSourceNorm.length > 0 && [currentNorm isEqualToString:ownedSourceNorm]) {
+            ApolloApplyTranslationToTitleNode(titleNode, textNode, ownedSource, ownedTranslated);
+            return;
+        }
+        // Title text changed (cell reuse for a new post). Drop ownership and
+        // fall through to translate the new text.
+        ApolloClearTranslationOwnershipForTextNode(textNode);
+    }
+
+    NSString *targetLanguage = ApolloResolvedTargetLanguageCode();
+    if (targetLanguage.length == 0) return;
+
+    // Strip links so URLs don't pollute language detection.
+    NSString *detectionText = ApolloProtectTranslationLinks(titleText, NULL);
+    NSString *detected = ApolloDetectDominantLanguage(detectionText);
+    if ([detected isEqualToString:targetLanguage]) return;
+
+    NSString *cacheKey = ApolloTranslationCacheKey(titleText, targetLanguage);
+    __weak id weakTitleNode = titleNode;
+    __weak id weakTextNode = textNode;
+    ApolloRequestTranslation(cacheKey, titleText, targetLanguage, ^(NSString *translated, NSError *error) {
+        if (![translated isKindOfClass:[NSString class]] || translated.length == 0) {
+            if (error) ApolloLog(@"[Translation] Title translate failed: %@", error.localizedDescription ?: @"unknown");
+            return;
+        }
+        if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
+        id strongTitleNode = weakTitleNode;
+        id strongTextNode = weakTextNode;
+        if (!strongTitleNode || !strongTextNode) return;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            // Re-check the visible feed VC mode after async translate — user
+            // may have toggled the globe off while the request was in
+            // flight. Use topmost-visible feed VC (NOT enclosing) for the
+            // same reason as the pre-check above.
+            UIViewController *enclosing = ApolloEnclosingViewControllerForNode(strongTitleNode);
+            UIViewController *vc = ApolloClassLooksLikeCommentsViewController([enclosing class]) ? enclosing : ApolloFindTopmostVisibleFeedVC();
+            if (ApolloClassLooksLikeCommentsViewController([vc class])) {
+                if (!ApolloControllerIsInTranslatedMode(vc)) return;
+            } else if (!ApolloFeedTitlesShouldShowTranslated(vc)) {
+                return;
+            }
+            ApolloApplyTranslationToTitleNode(strongTitleNode, strongTextNode, titleText, translated);
+        });
+    });
+}
+
+%hook _TtC6Apollo13PostTitleNode
+
+- (void)didLoad {
+    %orig;
+    if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
+    __weak id weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{ ApolloMaybeTranslatePostTitleNode(weakSelf); });
+}
+
+- (void)didEnterPreloadState {
+    %orig;
+    if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
+    __weak id weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{ ApolloMaybeTranslatePostTitleNode(weakSelf); });
+}
+
+- (void)didEnterDisplayState {
+    %orig;
+    if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
+    __weak id weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{ ApolloMaybeTranslatePostTitleNode(weakSelf); });
+}
+
+%end
+
+%hook _TtC6Apollo16PostTitleURLNode
+
+- (void)didLoad {
+    %orig;
+    if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
+    __weak id weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{ ApolloMaybeTranslatePostTitleNode(weakSelf); });
+}
+
+- (void)didEnterPreloadState {
+    %orig;
+    if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
+    __weak id weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{ ApolloMaybeTranslatePostTitleNode(weakSelf); });
+}
+
+- (void)didEnterDisplayState {
+    %orig;
+    if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
+    __weak id weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{ ApolloMaybeTranslatePostTitleNode(weakSelf); });
+}
+
+%end
+
+// ---------------------------------------------------------------------------
+// Feed view controllers (Posts / LitePosts / PostsSearchResults / Saved)
+// ---------------------------------------------------------------------------
+//
+// When sTranslatePostTitles is on, install a globe button on each feed VC
+// matching the existing thread-globe behaviour. The globe controls a
+// per-VC translated mode (kApolloThreadTranslatedModeKey) that gates
+// title translation in `ApolloMaybeTranslatePostTitleNode` via
+// `ApolloEnclosingViewControllerForNode`.
+//
+// Settings/UI gating contract per user requirements:
+//   - Settings titles OFF -> globe never shown, no titles translated.
+//   - Settings titles ON  -> globe shown on every feed VC (and existing
+//                            thread VC). Tapping toggles green/grey.
+//   - Globe ON            -> titles translated as cells become visible.
+//   - Globe OFF           -> titles restored to original.
+//
+// We rely entirely on the existing per-VC mode marker + the title hooks'
+// per-VC gate. No additional re-entrant hooks on PostTitleNode.
+
+static void ApolloScheduleFeedSettledTitleRefresh(UIViewController *vc) {
+    if (!vc || !vc.isViewLoaded) return;
+    if (!sEnableBulkTranslation || !sTranslatePostTitles || !ApolloControllerIsInTranslatedMode(vc)) return;
+    if ([objc_getAssociatedObject(vc, kApolloFeedSettledTitleRefreshScheduledKey) boolValue]) return;
+    objc_setAssociatedObject(vc, kApolloFeedSettledTitleRefreshScheduledKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    __weak UIViewController *weakVC = vc;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        UIViewController *strongVC = weakVC;
+        if (!strongVC) return;
+        objc_setAssociatedObject(strongVC, kApolloFeedSettledTitleRefreshScheduledKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        if (!strongVC.isViewLoaded || !strongVC.view.window) return;
+        if (!sEnableBulkTranslation || !sTranslatePostTitles || !ApolloControllerIsInTranslatedMode(strongVC)) return;
+        NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:512];
+        ApolloRescanTitleNodesInTree(strongVC.view, 20, visited);
+        ApolloRefreshFeedTranslationStateForController(strongVC);
+    });
+}
+
+static void ApolloFeedVCInstallGlobe(UIViewController *vc) {
+    if (!vc) return;
+    BOOL alreadyMarked = [objc_getAssociatedObject(vc, kApolloFeedTranslationVCKey) boolValue];
+    objc_setAssociatedObject(vc, kApolloFeedTranslationVCKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    sLastInstalledFeedViewController = vc;
+    // Feed VCs default to "translated mode" so post titles auto-translate
+    // the moment a non-English title scrolls into view (matches user
+    // expectation: settings titles ON => feeds always translate by default).
+    // The globe is a per-VC override the user can flip off.
+    NSNumber *storedMode = ApolloStoredFeedTitleModeForController(vc);
+    if ([storedMode isKindOfClass:[NSNumber class]]) {
+        BOOL translated = storedMode.boolValue;
+        objc_setAssociatedObject(vc, kApolloThreadTranslatedModeKey, @(translated), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(vc, kApolloThreadOriginalModeKey, @(!translated), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        sLastFeedTitleModeKnown = YES;
+        sLastFeedTitleTranslatedMode = translated;
+        if (!translated) {
+            ApolloClearVisibleTranslationApplied(vc);
+            sPendingVisibleFeedTitleApplied = NO;
+        }
+    } else if (![objc_getAssociatedObject(vc, kApolloThreadTranslatedModeKey) boolValue] &&
+               ![objc_getAssociatedObject(vc, kApolloThreadOriginalModeKey) boolValue]) {
+        objc_setAssociatedObject(vc, kApolloThreadTranslatedModeKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        sLastFeedTitleModeKnown = YES;
+        sLastFeedTitleTranslatedMode = YES;
+    } else {
+        sLastFeedTitleModeKnown = YES;
+        sLastFeedTitleTranslatedMode = ApolloControllerIsInTranslatedMode(vc);
+    }
+    if (!alreadyMarked) {
+        ApolloLog(@"[Translation] InstallGlobe class=%@ ptr=%p title='%@'",
+                  NSStringFromClass([vc class]), vc, vc.navigationItem.title ?: vc.title ?: @"(none)");
+    }
+    if (sPendingVisibleFeedTitleApplied && ApolloControllerIsInTranslatedMode(vc)) {
+        objc_setAssociatedObject(vc, kApolloVisibleTranslationAppliedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        sPendingVisibleFeedTitleApplied = NO;
+    }
+    ApolloRefreshFeedTranslationStateForController(vc);
+    ApolloScheduleFeedTranslationStateRefresh(vc, 0.05);
+    ApolloScheduleFeedTranslationStateRefresh(vc, 0.2);
+    ApolloScheduleFeedTranslationStateRefresh(vc, 0.75);
+    ApolloScheduleFeedTranslationStateRefresh(vc, 1.5);
+    ApolloScheduleFeedSettledTitleRefresh(vc);
+    if (ApolloControllerIsInTranslatedMode(vc)) {
+        __weak UIViewController *weakVC = vc;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.35 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            UIViewController *strongVC = weakVC;
+            if (!strongVC || !strongVC.isViewLoaded || !strongVC.view.window) return;
+            if (!ApolloControllerIsInTranslatedMode(strongVC)) return;
+            ApolloRescanTitleNodesForController(strongVC);
+        });
+    }
+}
+
+// Universal globe-tap selector. The original implementation declared this
+// %new on each Swift feed VC class we hook; that broke whenever Home (or
+// any future feed surface) was hosted by a class we hadn't hooked, because
+// the action selector was silently missing on the target. A category on
+// UIViewController guarantees the selector exists on every controller, so
+// taps always reach our toggle code regardless of host class.
+@interface UIViewController (ApolloTranslationGlobe)
+- (void)apollo_translationGlobeTapped;
+@end
+
+@implementation UIViewController (ApolloTranslationGlobe)
+- (void)apollo_translationGlobeTapped {
+    ApolloLog(@"[Translation] GlobeTapped class=%@ ptr=%p", NSStringFromClass([self class]), self);
+    if ([objc_getAssociatedObject(self, kApolloFeedTranslationVCKey) boolValue]) {
+        ApolloToggleFeedTitleTranslationForController(self);
+    } else {
+        ApolloToggleThreadTranslationForController(self);
+    }
+}
+@end
+
+%hook _TtC6Apollo19PostsViewController
+
+- (void)viewDidLoad {
+    %orig;
+    ApolloFeedVCInstallGlobe((UIViewController *)self);
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    %orig;
+    ApolloFeedVCInstallGlobe((UIViewController *)self);
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    ApolloFeedVCInstallGlobe((UIViewController *)self);
+    if (sEnableBulkTranslation && sTranslatePostTitles && ApolloControllerIsInTranslatedMode((UIViewController *)self)) {
+        // Re-translate any visible titles in case the user came back to a
+        // feed that was previously in translated mode.
+        ApolloRescanTitleNodesForController((UIViewController *)self);
+    }
+}
+
+- (void)viewDidLayoutSubviews {
+    %orig;
+    ApolloScheduleFeedSettledTitleRefresh((UIViewController *)self);
+}
+
+%new
+- (void)apollo_translationGlobeTapped {
+    ApolloToggleFeedTitleTranslationForController((UIViewController *)self);
+}
+
+%end
+
+%hook _TtC6Apollo23LitePostsViewController
+
+- (void)viewDidLoad {
+    %orig;
+    ApolloFeedVCInstallGlobe((UIViewController *)self);
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    %orig;
+    ApolloFeedVCInstallGlobe((UIViewController *)self);
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    ApolloFeedVCInstallGlobe((UIViewController *)self);
+    if (sEnableBulkTranslation && sTranslatePostTitles && ApolloControllerIsInTranslatedMode((UIViewController *)self)) {
+        ApolloRescanTitleNodesForController((UIViewController *)self);
+    }
+}
+
+- (void)viewDidLayoutSubviews {
+    %orig;
+    ApolloScheduleFeedSettledTitleRefresh((UIViewController *)self);
+}
+
+%new
+- (void)apollo_translationGlobeTapped {
+    ApolloToggleFeedTitleTranslationForController((UIViewController *)self);
+}
+
+%end
+
+%hook _TtC6Apollo32PostsSearchResultsViewController
+
+- (void)viewDidLoad {
+    %orig;
+    ApolloFeedVCInstallGlobe((UIViewController *)self);
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    %orig;
+    ApolloFeedVCInstallGlobe((UIViewController *)self);
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    ApolloFeedVCInstallGlobe((UIViewController *)self);
+    if (sEnableBulkTranslation && sTranslatePostTitles && ApolloControllerIsInTranslatedMode((UIViewController *)self)) {
+        ApolloRescanTitleNodesForController((UIViewController *)self);
+    }
+}
+
+- (void)viewDidLayoutSubviews {
+    %orig;
+    ApolloScheduleFeedSettledTitleRefresh((UIViewController *)self);
+}
+
+%new
+- (void)apollo_translationGlobeTapped {
+    ApolloToggleFeedTitleTranslationForController((UIViewController *)self);
+}
+
+%end
+
+%hook _TtC6Apollo25MultiredditViewController
+
+- (void)viewDidLoad {
+    %orig;
+    ApolloFeedVCInstallGlobe((UIViewController *)self);
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    %orig;
+    ApolloFeedVCInstallGlobe((UIViewController *)self);
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    ApolloFeedVCInstallGlobe((UIViewController *)self);
+    if (sEnableBulkTranslation && sTranslatePostTitles && ApolloControllerIsInTranslatedMode((UIViewController *)self)) {
+        ApolloRescanTitleNodesForController((UIViewController *)self);
+    }
+}
+
+- (void)viewDidLayoutSubviews {
+    %orig;
+    ApolloScheduleFeedSettledTitleRefresh((UIViewController *)self);
+}
+
+%new
+- (void)apollo_translationGlobeTapped {
+    ApolloToggleFeedTitleTranslationForController((UIViewController *)self);
 }
 
 %end
@@ -2397,25 +4078,54 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
     // a cached translation for this comment, re-apply instantly — no network,
     // no language detection. This fixes the "translation lost on
     // collapse/uncollapse" report.
-    if (sEnableBulkTranslation) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+    //
+    // BUT: only do this when the controller is currently in translated mode.
+    // If the user toggled translation OFF, off-screen cells still hold the
+    // translated attributedText on their text nodes (they were never re-laid-
+    // out while we restored visible cells). Force-restore those here so the
+    // original text reappears as the cell scrolls back into view.
+    if (!sEnableBulkTranslation) return;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *owningVC = ApolloOwningCommentsVCForCellNode((id)self);
+        if (ApolloControllerIsInTranslatedMode(owningVC)) {
             if (!ApolloReapplyCachedTranslationForCellNode((id)self)) {
                 ApolloMaybeTranslateCommentCellNode((id)self, NO);
             }
-        });
-    }
+        } else if (ApolloControllerIsConfirmedOriginalMode(owningVC)) {
+            // Only restore if the owning VC is confirmed to be in original
+            // mode. If the VC is unknown (lifecycle race), defer — the
+            // viewDidAppear retries will translate the cell shortly.
+            RDKComment *comment = ApolloCommentFromCellNode((id)self);
+            if (comment) {
+                ApolloRestoreOriginalForCellNode((id)self, comment);
+            }
+        }
+    });
 }
 
 - (void)cellNodeVisibilityEvent:(NSInteger)event {
     %orig;
 
     // Event 0 = "will become visible". Re-apply cached translation as soon as
-    // possible so the original text never flashes when re-displaying.
-    if (sEnableBulkTranslation && event == 0) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+    // possible so the original text never flashes when re-displaying — but
+    // only while the thread is in translated mode. If translation was toggled
+    // off, restore the original to defeat any stale translated attributedText
+    // that's still sitting on the text node from before the toggle-off.
+    if (!sEnableBulkTranslation || event != 0) return;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *owningVC = ApolloOwningCommentsVCForCellNode((id)self);
+        if (ApolloControllerIsInTranslatedMode(owningVC)) {
             ApolloReapplyCachedTranslationForCellNode((id)self);
-        });
-    }
+        } else if (ApolloControllerIsConfirmedOriginalMode(owningVC)) {
+            // Same defer-on-unknown rule as didEnterDisplayState above.
+            RDKComment *comment = ApolloCommentFromCellNode((id)self);
+            if (comment) {
+                ApolloRestoreOriginalForCellNode((id)self, comment);
+            }
+        }
+    });
 }
 
 %end
@@ -2429,6 +4139,16 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
 
 - (void)viewWillAppear:(BOOL)animated {
     %orig;
+    // Claim ownership AS EARLY AS POSSIBLE. Cell visibility events
+    // (`cellNodeVisibilityEvent:`, `didEnterDisplayState`) often fire
+    // *before* `viewDidAppear:` on iOS 26, and those handlers gate their
+    // translate-vs-restore decision on `sVisibleCommentsViewController`.
+    // If we wait until `viewDidAppear:` (as we used to), the global pointer
+    // is still nil/stale when those cells arrive, so they take the
+    // restore-original branch and the thread renders untranslated until
+    // the user scrolls. Setting it here closes that race.
+    sVisibleCommentsViewController = (UIViewController *)self;
+
     ApolloRefreshVisibleTranslationAppliedForController((UIViewController *)self);
     ApolloUpdateTranslationUIForController(self);
     ApolloSchedulePostBodyReapplyForController((UIViewController *)self);
@@ -2447,13 +4167,37 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
     if (sEnableBulkTranslation && ApolloControllerIsInTranslatedMode((UIViewController *)self)) {
         ApolloRefreshVisibleTranslationAppliedForController((UIViewController *)self);
         ApolloUpdateTranslationUIForController(self);
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.12 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            ApolloTranslateVisibleCommentsForController((UIViewController *)self, NO);
-            ApolloRefreshVisibleTranslationAppliedForController((UIViewController *)self);
-            ApolloUpdateTranslationUIForController(self);
-            ApolloSchedulePostBodyReapplyForController((UIViewController *)self);
-        });
+        // Staggered retries: comments may not be loaded at +0.12s on slower
+        // threads (network fetch still in flight, no visible cells yet → the
+        // walk is a no-op and the user is left with original-language
+        // content). Re-walk a few times so late-arriving cells get picked up
+        // without forcing the user to scroll.
+        NSArray<NSNumber *> *retryDelays = @[ @0.12, @0.4, @0.9, @1.8 ];
+        for (NSNumber *delayNumber in retryDelays) {
+            __weak UIViewController *weakSelf = (UIViewController *)self;
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayNumber.doubleValue * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                UIViewController *strongSelf = weakSelf;
+                if (!strongSelf || !strongSelf.isViewLoaded || !strongSelf.view.window) return;
+                if (!sEnableBulkTranslation || !ApolloControllerIsInTranslatedMode(strongSelf)) return;
+                ApolloTranslateVisibleCommentsForController(strongSelf, NO);
+                ApolloRefreshVisibleTranslationAppliedForController(strongSelf);
+                ApolloUpdateTranslationUIForController(strongSelf);
+                ApolloSchedulePostBodyReapplyForController(strongSelf);
+            });
+        }
     }
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    %orig;
+    // Bump the cancel generation so any pending toggle reconciles bail out
+    // instead of running mid-swipe. Each call to ApolloRestoreAllOwnedTextNodes
+    // walks the entire owned-textnode registry and forces cell relayouts —
+    // doing that 3× during an interactive pop is the swipe-back lag the user
+    // sees.
+    NSNumber *cur = objc_getAssociatedObject((id)self, kApolloReconcileGenerationKey);
+    NSUInteger next = cur.unsignedIntegerValue + 1;
+    objc_setAssociatedObject((id)self, kApolloReconcileGenerationKey, @(next), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
@@ -2481,21 +4225,308 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
 
 %end
 
+// ---- Disk persistence for the per-comment / per-post translation caches ----
+//
+// Background: when the user momentarily backgrounds Apollo (swipes home, opens
+// Control Center, locks the device) and returns, AsyncDisplayKit can drop the
+// attributed text on visible cells, and iOS frequently fires a memory warning
+// while the app is suspended. Without persistence the caches that drive the
+// re-apply path are empty when the user comes back, and the thread reverts
+// to the original language.
+//
+// We snapshot `sCommentTranslationByFullName` / `sLinkTranslationByFullName`
+// to a plist on `DidEnterBackground` and re-hydrate them on launch. Entries
+// are tagged with the provider + target language at write time so toggling
+// providers or switching language never serves stale text.
+
+static const NSTimeInterval kApolloTranslationDiskCacheTTL = 60 * 60; // 1 hour
+static const NSUInteger kApolloTranslationDiskCacheMaxEntries = 2048;
+static NSString *const kApolloTranslationDiskCacheVersion = @"v1";
+
+static NSURL *ApolloTranslationDiskCacheURL(void) {
+    NSURL *dir = [[[NSFileManager defaultManager] URLsForDirectory:NSCachesDirectory inDomains:NSUserDomainMask] firstObject];
+    if (!dir) return nil;
+    return [dir URLByAppendingPathComponent:@"apollo-translation-cache-v1.plist"];
+}
+
+static NSString *ApolloCurrentTranslationTag(void) {
+    NSString *provider = sTranslationProvider.length > 0 ? sTranslationProvider : @"google";
+    NSString *language = sTranslationTargetLanguage.length > 0 ? sTranslationTargetLanguage : @"auto";
+    return [NSString stringWithFormat:@"%@|%@", provider, language];
+}
+
+static void ApolloPersistTranslationCachesToDisk(void) {
+    NSURL *url = ApolloTranslationDiskCacheURL();
+    if (!url) return;
+
+    NSString *tag = ApolloCurrentTranslationTag();
+    NSDate *now = [NSDate date];
+
+    // NSCache doesn't expose its contents — we maintain mirror dictionaries
+    // alongside the caches that hold the same data while the app is alive.
+    NSDictionary *commentSnapshot = nil;
+    NSDictionary *linkSnapshot = nil;
+    @synchronized (sCommentTranslationMirror) {
+        commentSnapshot = [sCommentTranslationMirror copy];
+    }
+    @synchronized (sLinkTranslationMirror) {
+        linkSnapshot = [sLinkTranslationMirror copy];
+    }
+
+    NSMutableArray *commentEntries = [NSMutableArray array];
+    NSUInteger written = 0;
+    for (NSString *key in commentSnapshot) {
+        if (written++ >= kApolloTranslationDiskCacheMaxEntries) break;
+        NSString *text = commentSnapshot[key];
+        if (![key isKindOfClass:[NSString class]] || ![text isKindOfClass:[NSString class]]) continue;
+        [commentEntries addObject:@{ @"k": key, @"v": text, @"t": now, @"tag": tag }];
+    }
+    NSMutableArray *linkEntries = [NSMutableArray array];
+    written = 0;
+    for (NSString *key in linkSnapshot) {
+        if (written++ >= kApolloTranslationDiskCacheMaxEntries) break;
+        NSString *text = linkSnapshot[key];
+        if (![key isKindOfClass:[NSString class]] || ![text isKindOfClass:[NSString class]]) continue;
+        [linkEntries addObject:@{ @"k": key, @"v": text, @"t": now, @"tag": tag }];
+    }
+
+    NSDictionary *root = @{
+        @"version": kApolloTranslationDiskCacheVersion,
+        @"comments": commentEntries,
+        @"links": linkEntries,
+    };
+    NSError *err = nil;
+    NSData *data = [NSPropertyListSerialization dataWithPropertyList:root format:NSPropertyListBinaryFormat_v1_0 options:0 error:&err];
+    if (!data) {
+        ApolloLog(@"[translation/persist] serialize failed: %@", err);
+        return;
+    }
+    if (![data writeToURL:url options:NSDataWritingAtomic error:&err]) {
+        ApolloLog(@"[translation/persist] write failed: %@", err);
+        return;
+    }
+    ApolloLog(@"[translation/persist] wrote %lu comment + %lu link entries", (unsigned long)commentEntries.count, (unsigned long)linkEntries.count);
+}
+
+static void ApolloHydrateTranslationCachesFromDisk(void) {
+    NSURL *url = ApolloTranslationDiskCacheURL();
+    if (!url) return;
+    NSData *data = [NSData dataWithContentsOfURL:url];
+    if (!data) return;
+
+    NSError *err = nil;
+    id root = [NSPropertyListSerialization propertyListWithData:data options:NSPropertyListImmutable format:NULL error:&err];
+    if (![root isKindOfClass:[NSDictionary class]]) {
+        ApolloLog(@"[translation/hydrate] bad plist: %@", err);
+        return;
+    }
+    NSString *version = root[@"version"];
+    if (![version isEqualToString:kApolloTranslationDiskCacheVersion]) return;
+
+    NSString *currentTag = ApolloCurrentTranslationTag();
+    NSDate *now = [NSDate date];
+
+    NSUInteger restored = 0;
+    for (NSDictionary *entry in (NSArray *)root[@"comments"]) {
+        if (![entry isKindOfClass:[NSDictionary class]]) continue;
+        NSString *key = entry[@"k"];
+        NSString *text = entry[@"v"];
+        NSDate *t = entry[@"t"];
+        NSString *tag = entry[@"tag"];
+        if (![key isKindOfClass:[NSString class]] || ![text isKindOfClass:[NSString class]]) continue;
+        if (![tag isEqualToString:currentTag]) continue;
+        if (![t isKindOfClass:[NSDate class]] || [now timeIntervalSinceDate:t] > kApolloTranslationDiskCacheTTL) continue;
+        [sCommentTranslationByFullName setObject:text forKey:key];
+        ApolloMirrorSetComment(key, text);
+        restored++;
+    }
+    NSUInteger restoredLinks = 0;
+    for (NSDictionary *entry in (NSArray *)root[@"links"]) {
+        if (![entry isKindOfClass:[NSDictionary class]]) continue;
+        NSString *key = entry[@"k"];
+        NSString *text = entry[@"v"];
+        NSDate *t = entry[@"t"];
+        NSString *tag = entry[@"tag"];
+        if (![key isKindOfClass:[NSString class]] || ![text isKindOfClass:[NSString class]]) continue;
+        if (![tag isEqualToString:currentTag]) continue;
+        if (![t isKindOfClass:[NSDate class]] || [now timeIntervalSinceDate:t] > kApolloTranslationDiskCacheTTL) continue;
+        [sLinkTranslationByFullName setObject:text forKey:key];
+        ApolloMirrorSetLink(key, text);
+        restoredLinks++;
+    }
+    ApolloLog(@"[translation/hydrate] restored %lu comments + %lu links (tag=%@)", (unsigned long)restored, (unsigned long)restoredLinks, currentTag);
+}
+
+// Re-runs the cache-only translation reapply path for the currently-visible
+// comments controller. Used when the app returns to foreground and ASDK has
+// dropped the attributed text on visible cells. Per-thread translated-mode
+// state is stored as an associated object on the VC and survives backgrounding
+// (the VC isn't dealloc'd while the app is suspended), so we just re-render
+// from cache (force=NO — never burns a network round-trip on resume).
+static void ApolloReapplyTranslationOnAppResume(void) {
+    UIViewController *vc = sVisibleCommentsViewController;
+    if (!vc) return;
+    if (!ApolloControllerIsInTranslatedMode(vc)) return;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *current = sVisibleCommentsViewController;
+        if (!current || !ApolloControllerIsInTranslatedMode(current)) return;
+        ApolloRefreshVisibleTranslationAppliedForController(current);
+        ApolloUpdateTranslationUIForController(current);
+        ApolloTranslateVisibleCommentsForController(current, NO);
+        ApolloSchedulePostBodyReapplyForController(current);
+    });
+
+    // Belt-and-suspenders second pass after ASDK has had a beat to rehydrate
+    // its own display state. force=NO, so this is cheap if everything's
+    // already correct.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        UIViewController *current = sVisibleCommentsViewController;
+        if (!current || !ApolloControllerIsInTranslatedMode(current)) return;
+        ApolloRefreshVisibleTranslationAppliedForController(current);
+        ApolloTranslateVisibleCommentsForController(current, NO);
+        ApolloSchedulePostBodyReapplyForController(current);
+    });
+}
+
 %ctor {
     sTranslationCache = [NSCache new];
     sCommentTranslationByFullName = [NSCache new];
     sCommentTranslationByFullName.countLimit = 2048;
     sLinkTranslationByFullName = [NSCache new];
     sLinkTranslationByFullName.countLimit = 256;
+    sLoggedSkippedCommentFullNames = [NSMutableSet set];
+    sCommentTranslationMirror = [NSMutableDictionary dictionary];
+    sLinkTranslationMirror = [NSMutableDictionary dictionary];
     sPendingTranslationCallbacks = [NSMutableDictionary dictionary];
+    sFeedTitleModeByFeedKey = [NSMutableDictionary dictionary];
+    sOwnedTextNodes = [NSHashTable hashTableWithOptions:(NSPointerFunctionsWeakMemory | NSPointerFunctionsObjectPointerPersonality)];
+    sOwnedTextNodesQueue = dispatch_queue_create("ca.jeffrey.apollo.translation.ownednodes", DISPATCH_QUEUE_SERIAL);
 
+    // Hydrate disk cache early so any cells laid out during the first frame
+    // already see translations.
+    ApolloHydrateTranslationCachesFromDisk();
+
+    // Memory-warning handler: only drop the raw key->text cache (cheap to
+    // recompute via the persistent fullName caches). Do NOT wipe the
+    // per-comment / per-post caches — iOS sends memory warnings when the app
+    // is backgrounded, and clearing them caused translated threads to revert
+    // to the original language as soon as the user returned to Apollo.
     [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidReceiveMemoryWarningNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(__unused NSNotification *note) {
+        [sTranslationCache removeAllObjects];
+    }];
+
+    // App lifecycle: snapshot caches when going to background; re-apply the
+    // active thread's translation on return.
+    [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidEnterBackgroundNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(__unused NSNotification *note) {
+        ApolloPersistTranslationCachesToDisk();
+    }];
+    [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationWillEnterForegroundNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(__unused NSNotification *note) {
+        ApolloReapplyTranslationOnAppResume();
+    }];
+    [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidBecomeActiveNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(__unused NSNotification *note) {
+        ApolloReapplyTranslationOnAppResume();
+    }];
+
+    // When the user changes the "Don't Translate" language list, blow away every
+    // translation cache so previously-skipped (and cached as source==translation)
+    // text gets a fresh provider call on the next view.
+    [[NSNotificationCenter defaultCenter] addObserverForName:@"ApolloTranslationSkipLanguagesChanged"
                                                       object:nil
                                                        queue:[NSOperationQueue mainQueue]
                                                   usingBlock:^(__unused NSNotification *note) {
         [sTranslationCache removeAllObjects];
         [sCommentTranslationByFullName removeAllObjects];
         [sLinkTranslationByFullName removeAllObjects];
+        @synchronized (sLoggedSkippedCommentFullNames) {
+            [sLoggedSkippedCommentFullNames removeAllObjects];
+        }
+        ApolloLog(@"[Translation] Skip-languages changed; flushed translation caches");
+
+        // Actively re-translate visible comments now (instead of waiting for
+        // the next scroll/reuse). If the user just *removed* a language from
+        // the skip list, the visible cells will pick up translations within
+        // ~100ms instead of feeling laggy. If they *added* a language, the
+        // skip-detect inside the per-comment translator path will short-circuit.
+        UIViewController *visibleCommentsVC = sVisibleCommentsViewController;
+        if (visibleCommentsVC && visibleCommentsVC.isViewLoaded && visibleCommentsVC.view.window
+            && ApolloControllerIsInTranslatedMode(visibleCommentsVC)) {
+            ApolloLog(@"[Translation] Re-translating visible comments after skip-languages change");
+            ApolloTranslateVisibleCommentsForController(visibleCommentsVC, NO);
+        }
+
+        // Same idea for the visible feed VC: rescan titles so newly-allowed
+        // languages translate now, AND clear the cached "applied" flag so the
+        // green globe accurately reflects the current visible state. If the
+        // user just added the dominant feed language to the skip list,
+        // nothing visible will translate and the globe should drop back to
+        // its un-applied appearance.
+        UIViewController *visibleFeedVC = ApolloFindTopmostVisibleFeedVC();
+        if (visibleFeedVC && visibleFeedVC.isViewLoaded && visibleFeedVC.view.window
+            && [objc_getAssociatedObject(visibleFeedVC, kApolloFeedTranslationVCKey) boolValue]
+            && ApolloControllerIsInTranslatedMode(visibleFeedVC)) {
+            ApolloLog(@"[Translation] Refreshing visible feed titles after skip-languages change");
+            ApolloClearVisibleTranslationApplied(visibleFeedVC);
+            sPendingVisibleFeedTitleApplied = NO;
+            ApolloRescanTitleNodesForController(visibleFeedVC);
+            // Re-evaluate after the rescan has had time to issue/complete
+            // translations \u2014 if anything came back translated, the globe
+            // flips back to applied; if nothing did, it stays cleared.
+            ApolloScheduleFeedTranslationStateRefresh(visibleFeedVC, 0.6);
+            ApolloScheduleFeedTranslationStateRefresh(visibleFeedVC, 1.5);
+        }
+    }];
+
+    // Live-update when the user toggles "Translate Post Titles" in settings:
+    // refresh the topmost UIViewController so the feed-VC globe is added or
+    // removed immediately and any owned title nodes are restored.
+    [[NSNotificationCenter defaultCenter] addObserverForName:@"ApolloTranslatePostTitlesChanged"
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(__unused NSNotification *note) {
+        if (!sTranslatePostTitles) {
+            // Restore every title node we still own.
+            ApolloRestoreAllOwnedTextNodes();
+            [sFeedTitleModeByFeedKey removeAllObjects];
+            sPendingVisibleFeedTitleApplied = NO;
+            sLastFeedTitleModeKnown = NO;
+            sLastFeedTitleTranslatedMode = YES;
+        }
+        // Walk the keyWindow's VC tree and update any feed VC.
+        UIWindow *keyWindow = nil;
+        for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+            if ([scene isKindOfClass:[UIWindowScene class]] && scene.activationState == UISceneActivationStateForegroundActive) {
+                for (UIWindow *w in ((UIWindowScene *)scene).windows) {
+                    if (w.isKeyWindow) { keyWindow = w; break; }
+                }
+                if (keyWindow) break;
+            }
+        }
+        if (!keyWindow) return;
+        UIViewController *root = keyWindow.rootViewController;
+        NSMutableArray *queue = [NSMutableArray array];
+        if (root) [queue addObject:root];
+        while (queue.count) {
+            UIViewController *vc = queue.firstObject;
+            [queue removeObjectAtIndex:0];
+            if ([objc_getAssociatedObject(vc, kApolloFeedTranslationVCKey) boolValue]) {
+                ApolloUpdateTranslationUIForController(vc);
+            }
+            for (UIViewController *child in vc.childViewControllers) [queue addObject:child];
+            if (vc.presentedViewController) [queue addObject:vc.presentedViewController];
+        }
     }];
 
     %init;

--- a/ApolloVideoUnmute.xm
+++ b/ApolloVideoUnmute.xm
@@ -558,6 +558,10 @@ static void HandleCommentsRichMediaVisibilityEvent(id visibilityOwner,
                   withCellFrame:(CGRect)frame {
     %orig;
     id richMediaNode = GetIvarObject(self, "richMediaNode");
+    // event=1 (VisibleRectChanged) fires on every layout tick during scroll.
+    // Skip the verbose path entirely — the icon-sync inside SyncMuteButtonIcon
+    // is a no-op when state already matches, but the log line itself floods.
+    if (event == 1) return;
     HandleCommentsRichMediaVisibilityEvent(self, richMediaNode, event,
                                            @"comments header video");
 }
@@ -570,6 +574,10 @@ static void HandleCommentsRichMediaVisibilityEvent(id visibilityOwner,
                    inScrollView:(id)scrollView
                   withCellFrame:(CGRect)frame {
     %orig;
+
+    // event=1 (VisibleRectChanged) fires on every layout tick during scroll.
+    // Skip entirely — nothing for us to do on rect-change ticks.
+    if (event == 1) return;
 
     id richMediaNode = GetCrosspostRichMediaNodeFromOwner(self);
     if (!richMediaNode) return;

--- a/CustomAPIViewController.m
+++ b/CustomAPIViewController.m
@@ -1,5 +1,6 @@
 #import "CustomAPIViewController.h"
 #import "ApolloCommon.h"
+#import "ApolloState.h"
 #import "UserDefaultConstants.h"
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <objc/runtime.h>
@@ -1253,7 +1254,16 @@ static NSString *const kGroupSuiteName = @"group.com.christianselig.apollo";
     sTranslationTargetLanguage = targetLanguage.length > 0 ? targetLanguage : nil;
 
     NSString *provider = [defaults stringForKey:UDKeyTranslationProvider];
-    sTranslationProvider = ([provider isEqualToString:@"libre"] || [provider isEqualToString:@"google"]) ? provider : @"google";
+    if ([provider isEqualToString:@"libre"]) {
+        sTranslationProvider = @"libre";
+    } else if ([provider isEqualToString:@"google"]) {
+        sTranslationProvider = @"google";
+    } else {
+        // Unset, unrecognized, or legacy "apple" — default to Google.
+        sTranslationProvider = @"google";
+        [defaults setObject:sTranslationProvider forKey:UDKeyTranslationProvider];
+        [defaults setBool:NO forKey:UDKeyTranslationProviderUserSelected];
+    }
 
     NSString *libreURL = [defaults stringForKey:UDKeyLibreTranslateURL];
     sLibreTranslateURL = libreURL.length > 0 ? libreURL : @"https://libretranslate.de/translate";

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ApolloImprovedCustomApi_FILES = \
     UIWindow+Apollo.m \
     fishhook.c \
     $(SSZIPARCHIVE_FILES)
-ApolloImprovedCustomApi_FRAMEWORKS = UIKit Security AVFoundation OSLog
+ApolloImprovedCustomApi_FRAMEWORKS = UIKit Security AVFoundation OSLog NaturalLanguage
 ApolloImprovedCustomApi_LIBRARIES = z iconv
 ApolloImprovedCustomApi_CFLAGS = -fobjc-arc -Wno-unguarded-availability-new -Wno-module-import-in-extern-c -IZipArchive/SSZipArchive -IZipArchive/SSZipArchive/minizip -DHAVE_ARC4RANDOM_BUF -DHAVE_ICONV -DHAVE_INTTYPES_H -DHAVE_PKCRYPT -DHAVE_STDINT_H -DHAVE_WZAES -DHAVE_ZLIB -DZLIB_COMPAT
 

--- a/TranslationSettingsViewController.m
+++ b/TranslationSettingsViewController.m
@@ -5,6 +5,7 @@
 
 typedef NS_ENUM(NSInteger, TranslationSettingsSection) {
     TranslationSettingsSectionGeneral = 0,
+    TranslationSettingsSectionSkip,
     TranslationSettingsSectionLibre,
     TranslationSettingsSectionCount,
 };
@@ -129,7 +130,9 @@ static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguag
 }
 
 - (NSString *)providerDetailText {
-    return [[self currentProvider] isEqualToString:@"libre"] ? @"LibreTranslate" : @"Google";
+    NSString *current = [self currentProvider];
+    if ([current isEqualToString:@"libre"]) return @"LibreTranslate";
+    return @"Google";
 }
 
 - (void)setTargetLanguageCode:(NSString *)code {
@@ -143,19 +146,23 @@ static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguag
         [[NSUserDefaults standardUserDefaults] setObject:sTranslationTargetLanguage forKey:UDKeyTranslationTargetLanguage];
     }
 
-    NSIndexPath *path = [NSIndexPath indexPathForRow:2 inSection:TranslationSettingsSectionGeneral];
+    NSIndexPath *path = [NSIndexPath indexPathForRow:3 inSection:TranslationSettingsSectionGeneral];
     [self.tableView reloadRowsAtIndexPaths:@[path] withRowAnimation:UITableViewRowAnimationNone];
 }
 
 - (void)setProvider:(NSString *)provider {
     NSString *normalized = [[provider stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
-    if (![normalized isEqualToString:@"libre"]) normalized = @"google";
+    if (![normalized isEqualToString:@"libre"]) {
+        normalized = @"google";
+    }
 
     sTranslationProvider = [normalized copy];
     [[NSUserDefaults standardUserDefaults] setObject:sTranslationProvider forKey:UDKeyTranslationProvider];
+    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:UDKeyTranslationProviderUserSelected];
 
-    NSIndexPath *providerPath = [NSIndexPath indexPathForRow:3 inSection:TranslationSettingsSectionGeneral];
-    [self.tableView reloadRowsAtIndexPaths:@[providerPath] withRowAnimation:UITableViewRowAnimationNone];
+    NSIndexPath *providerPath = [NSIndexPath indexPathForRow:4 inSection:TranslationSettingsSectionGeneral];
+    NSIndexPath *langPath = [NSIndexPath indexPathForRow:3 inSection:TranslationSettingsSectionGeneral];
+    [self.tableView reloadRowsAtIndexPaths:@[langPath, providerPath] withRowAnimation:UITableViewRowAnimationNone];
 }
 
 - (UITableViewCell *)switchCellWithIdentifier:(NSString *)identifier
@@ -241,6 +248,109 @@ static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguag
     return cell;
 }
 
+#pragma mark - Skip Languages
+
+- (NSArray<NSString *> *)skipLanguageCodes {
+    NSArray *raw = sTranslationSkipLanguages;
+    if (![raw isKindOfClass:[NSArray class]]) return @[];
+    return raw;
+}
+
+- (void)persistSkipLanguageCodes:(NSArray<NSString *> *)codes {
+    NSMutableArray<NSString *> *clean = [NSMutableArray array];
+    for (NSString *code in codes) {
+        NSString *norm = [self normalizedLanguageCodeFromIdentifier:code];
+        if (norm.length > 0 && ![clean containsObject:norm]) [clean addObject:norm];
+    }
+    sTranslationSkipLanguages = [clean copy];
+    [[NSUserDefaults standardUserDefaults] setObject:sTranslationSkipLanguages
+                                              forKey:UDKeyTranslationSkipLanguages];
+    // Tell ApolloTranslation.xm to flush its caches so removed languages
+    // start translating again on the next view (and added languages stop
+    // returning previously-cached translations).
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloTranslationSkipLanguagesChanged" object:nil];
+}
+
+- (void)addSkipLanguageCode:(NSString *)code {
+    NSString *norm = [self normalizedLanguageCodeFromIdentifier:code];
+    if (norm.length == 0) return;
+    NSArray<NSString *> *current = [self skipLanguageCodes];
+    if ([current containsObject:norm]) return;
+    NSMutableArray *next = [current mutableCopy];
+    [next addObject:norm];
+    [self persistSkipLanguageCodes:next];
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:TranslationSettingsSectionSkip]
+                  withRowAnimation:UITableViewRowAnimationAutomatic];
+}
+
+- (void)removeSkipLanguageCode:(NSString *)code {
+    NSString *norm = [self normalizedLanguageCodeFromIdentifier:code];
+    if (norm.length == 0) return;
+    NSMutableArray *next = [[self skipLanguageCodes] mutableCopy];
+    NSUInteger idx = [next indexOfObject:norm];
+    if (idx == NSNotFound) return;
+    [next removeObjectAtIndex:idx];
+    [self persistSkipLanguageCodes:next];
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:TranslationSettingsSectionSkip]
+                  withRowAnimation:UITableViewRowAnimationAutomatic];
+}
+
+- (void)skipLanguageTrashTapped:(UIButton *)sender {
+    NSArray<NSString *> *codes = [self skipLanguageCodes];
+    NSInteger idx = sender.tag;
+    if (idx < 0 || (NSUInteger)idx >= codes.count) return;
+    [self presentRemoveSkipLanguageConfirmForCode:codes[idx] sourceView:sender];
+}
+
+- (void)presentRemoveSkipLanguageConfirmForCode:(NSString *)code sourceView:(UIView *)sourceView {
+    if (code.length == 0) return;
+    NSString *name = [self displayNameForLanguageCode:code] ?: code.uppercaseString;
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:nil
+                                                                   message:[NSString stringWithFormat:@"Remove %@ from Don't Translate?", name]
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Remove" style:UIAlertActionStyleDestructive handler:^(__unused UIAlertAction *a) {
+        [self removeSkipLanguageCode:code];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    if (popover && sourceView) {
+        popover.sourceView = sourceView;
+        popover.sourceRect = sourceView.bounds;
+    }
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+- (void)presentSkipLanguageSheetFromSourceView:(UIView *)sourceView {
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Don't Translate"
+                                                                   message:@"Pick a language to leave untranslated."
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+
+    NSArray<NSString *> *current = [self skipLanguageCodes];
+    NSUInteger added = 0;
+    for (NSDictionary<NSString *, NSString *> *option in ApolloTranslationLanguageOptions()) {
+        NSString *code = option[@"code"];
+        if (code.length == 0) continue;            // skip "Device Default"
+        if ([current containsObject:code]) continue; // already added
+        NSString *name = option[@"name"];
+        [sheet addAction:[UIAlertAction actionWithTitle:name style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+            [self addSkipLanguageCode:code];
+        }]];
+        added++;
+    }
+    if (added == 0) {
+        [sheet addAction:[UIAlertAction actionWithTitle:@"All available languages already added"
+                                                  style:UIAlertActionStyleDefault handler:nil]];
+    }
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    if (popover && sourceView) {
+        popover.sourceView = sourceView;
+        popover.sourceRect = sourceView.bounds;
+    }
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
 - (void)presentTargetLanguageSheetFromSourceView:(UIView *)sourceView {
     UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Target Language"
                                                                    message:nil
@@ -277,7 +387,7 @@ static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguag
 
     NSString *currentProvider = [self currentProvider];
     NSString *googleTitle = [currentProvider isEqualToString:@"google"] ? @"Google (Current)" : @"Google";
-    NSString *libreTitle = [currentProvider isEqualToString:@"libre"] ? @"LibreTranslate (Current)" : @"LibreTranslate";
+    NSString *libreTitle  = [currentProvider isEqualToString:@"libre"]  ? @"LibreTranslate (Current)" : @"LibreTranslate";
 
     [sheet addAction:[UIAlertAction actionWithTitle:googleTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
         [self setProvider:@"google"];
@@ -304,7 +414,8 @@ static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguag
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     switch (section) {
-        case TranslationSettingsSectionGeneral: return 4;
+        case TranslationSettingsSectionGeneral: return 5;
+        case TranslationSettingsSectionSkip: return (NSInteger)[self skipLanguageCodes].count + 1; // entries + "Add Language…"
         case TranslationSettingsSectionLibre: return 2;
         default: return 0;
     }
@@ -313,6 +424,7 @@ static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguag
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
     switch (section) {
         case TranslationSettingsSectionGeneral: return @"General";
+        case TranslationSettingsSectionSkip: return @"Don't Translate";
         case TranslationSettingsSectionLibre: return @"LibreTranslate";
         default: return nil;
     }
@@ -321,9 +433,11 @@ static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguag
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
     switch (section) {
         case TranslationSettingsSectionGeneral:
-            return @"When enabled, loaded comments are translated in-place. The native per-comment Translate action is hidden to avoid duplicate flows.";
+            return @"When enabled, loaded comments are translated in-place. You can optionally translate post titles in feeds and thread headers. The native per-comment Translate action is hidden to avoid duplicate flows.";
+        case TranslationSettingsSectionSkip:
+            return @"Posts and comments detected as one of these languages will be left in their original form. Mixed-language text is still translated so embedded foreign words come through.";
         case TranslationSettingsSectionLibre:
-            return @"Google is the default primary provider. If it fails, the tweak automatically falls back to LibreTranslate using this URL and optional API key.";
+            return @"Google is the default provider. If the chosen provider fails, the tweak automatically falls back to the other one. The settings below configure the LibreTranslate endpoint.";
         default:
             return nil;
     }
@@ -346,17 +460,64 @@ static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguag
                 ((UISwitch *)cell.accessoryView).enabled = sEnableBulkTranslation;
                 return cell;
             }
-            case 2:
+            case 2: {
+                UITableViewCell *cell = [self switchCellWithIdentifier:@"Cell_Translation_Titles"
+                                                                 label:@"Translate Post Titles"
+                                                                    on:sTranslatePostTitles
+                                                                action:@selector(translatePostTitlesSwitchToggled:)];
+                cell.textLabel.enabled = sEnableBulkTranslation;
+                ((UISwitch *)cell.accessoryView).enabled = sEnableBulkTranslation;
+                return cell;
+            }
+            case 3:
                 return [self valueCellWithIdentifier:@"Cell_Translation_TargetLanguage"
                                                label:@"Target Language"
                                               detail:[self currentTargetLanguageDetailText]];
-            case 3:
+            case 4:
                 return [self valueCellWithIdentifier:@"Cell_Translation_Provider"
                                                label:@"Primary Provider"
                                               detail:[self providerDetailText]];
             default:
                 return [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
         }
+    }
+
+    if (indexPath.section == TranslationSettingsSectionSkip) {
+        NSArray<NSString *> *codes = [self skipLanguageCodes];
+        if ((NSUInteger)indexPath.row < codes.count) {
+            NSString *code = codes[indexPath.row];
+            // Use a fresh cell each time so the accessoryView (trash button) gets the right indexPath captured.
+            UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:nil];
+            cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+            cell.textLabel.text = [self displayNameForLanguageCode:code];
+            cell.detailTextLabel.text = code.uppercaseString;
+            UIButton *trash = [UIButton buttonWithType:UIButtonTypeSystem];
+            if (@available(iOS 13.0, *)) {
+                [trash setImage:[UIImage systemImageNamed:@"trash"] forState:UIControlStateNormal];
+                trash.tintColor = [UIColor systemRedColor];
+            } else {
+                [trash setTitle:@"Remove" forState:UIControlStateNormal];
+                [trash setTitleColor:[UIColor systemRedColor] forState:UIControlStateNormal];
+            }
+            trash.tag = indexPath.row;
+            [trash addTarget:self action:@selector(skipLanguageTrashTapped:) forControlEvents:UIControlEventTouchUpInside];
+            [trash sizeToFit];
+            CGRect f = trash.frame;
+            f.size.width = MAX(44.0, f.size.width + 12.0);
+            f.size.height = MAX(44.0, f.size.height);
+            trash.frame = f;
+            cell.accessoryView = trash;
+            return cell;
+        }
+        UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Translation_SkipAdd"];
+        if (!cell) {
+            cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell_Translation_SkipAdd"];
+            cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+        }
+        cell.textLabel.text = @"Add Language…";
+        cell.textLabel.textColor = [UIColor systemBlueColor];
+        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+        return cell;
     }
 
     if (indexPath.section == TranslationSettingsSectionLibre) {
@@ -386,20 +547,75 @@ static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguag
 #pragma mark - UITableViewDelegate
 
 - (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
-    return indexPath.section == TranslationSettingsSectionGeneral && (indexPath.row == 2 || indexPath.row == 3);
+    if (indexPath.section == TranslationSettingsSectionGeneral) {
+        return indexPath.row == 3 || indexPath.row == 4;
+    }
+    if (indexPath.section == TranslationSettingsSectionSkip) {
+        return YES; // both "Add" row and existing-language rows tappable
+    }
+    return NO;
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 
+    if (indexPath.section == TranslationSettingsSectionSkip) {
+        NSArray<NSString *> *codes = [self skipLanguageCodes];
+        UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+        if ((NSUInteger)indexPath.row == codes.count) {
+            [self presentSkipLanguageSheetFromSourceView:cell];
+        } else if ((NSUInteger)indexPath.row < codes.count) {
+            [self presentRemoveSkipLanguageConfirmForCode:codes[indexPath.row] sourceView:cell];
+        }
+        return;
+    }
+
     if (indexPath.section != TranslationSettingsSectionGeneral) return;
 
     UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
-    if (indexPath.row == 2) {
+    if (indexPath.row == 3) {
         [self presentTargetLanguageSheetFromSourceView:cell];
-    } else if (indexPath.row == 3) {
+    } else if (indexPath.row == 4) {
         [self presentProviderSheetFromSourceView:cell];
     }
+}
+
+- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
+    return indexPath.section == TranslationSettingsSectionSkip
+        && (NSUInteger)indexPath.row < [self skipLanguageCodes].count;
+}
+
+- (UITableViewCellEditingStyle)tableView:(UITableView *)tableView editingStyleForRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == TranslationSettingsSectionSkip
+        && (NSUInteger)indexPath.row < [self skipLanguageCodes].count) {
+        return UITableViewCellEditingStyleDelete;
+    }
+    return UITableViewCellEditingStyleNone;
+}
+
+- (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (editingStyle != UITableViewCellEditingStyleDelete) return;
+    if (indexPath.section != TranslationSettingsSectionSkip) return;
+    NSArray<NSString *> *codes = [self skipLanguageCodes];
+    if ((NSUInteger)indexPath.row >= codes.count) return;
+    [self removeSkipLanguageCode:codes[indexPath.row]];
+}
+
+- (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath API_AVAILABLE(ios(11.0)) {
+    if (indexPath.section != TranslationSettingsSectionSkip) return nil;
+    NSArray<NSString *> *codes = [self skipLanguageCodes];
+    if ((NSUInteger)indexPath.row >= codes.count) return nil;
+    NSString *code = codes[indexPath.row];
+    __weak typeof(self) weakSelf = self;
+    UIContextualAction *delete = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleDestructive
+                                                                         title:@"Remove"
+                                                                       handler:^(__unused UIContextualAction *action, __unused UIView *sourceView, void (^completion)(BOOL)) {
+        [weakSelf removeSkipLanguageCode:code];
+        if (completion) completion(YES);
+    }];
+    UISwipeActionsConfiguration *config = [UISwipeActionsConfiguration configurationWithActions:@[delete]];
+    config.performsFirstActionWithFullSwipe = YES;
+    return config;
 }
 
 #pragma mark - UITextFieldDelegate
@@ -432,12 +648,21 @@ static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguag
     [[NSUserDefaults standardUserDefaults] setBool:sEnableBulkTranslation forKey:UDKeyEnableBulkTranslation];
 
     NSIndexPath *autoPath = [NSIndexPath indexPathForRow:1 inSection:TranslationSettingsSectionGeneral];
-    [self.tableView reloadRowsAtIndexPaths:@[autoPath] withRowAnimation:UITableViewRowAnimationNone];
+    NSIndexPath *titlesPath = [NSIndexPath indexPathForRow:2 inSection:TranslationSettingsSectionGeneral];
+    [self.tableView reloadRowsAtIndexPaths:@[autoPath, titlesPath] withRowAnimation:UITableViewRowAnimationNone];
 }
 
 - (void)autoTranslateSwitchToggled:(UISwitch *)sender {
     sAutoTranslateOnAppear = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sAutoTranslateOnAppear forKey:UDKeyAutoTranslateOnAppear];
+}
+
+- (void)translatePostTitlesSwitchToggled:(UISwitch *)sender {
+    sTranslatePostTitles = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sTranslatePostTitles forKey:UDKeyTranslatePostTitles];
+    // Notify ApolloTranslation.xm so the feed-VC globe is added/removed live
+    // and any currently-translated title nodes get restored when this is OFF.
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloTranslatePostTitlesChanged" object:nil];
 }
 
 @end

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -758,10 +758,12 @@ static void initializeRandomSources() {
                                     UDKeyProxyImgurDDG: @NO,
                                     UDKeyEnableBulkTranslation: @NO,
                                     UDKeyAutoTranslateOnAppear: @YES,
+                                    UDKeyTranslatePostTitles: @NO,
                                     UDKeyTranslationTargetLanguage: @"",
-                                    UDKeyTranslationProvider: @"google",
+                                    UDKeyTranslationProviderUserSelected: @NO,
                                     UDKeyLibreTranslateURL: @"https://libretranslate.de/translate",
-                                    UDKeyLibreTranslateAPIKey: @""};
+                                    UDKeyLibreTranslateAPIKey: @"",
+                                    UDKeyTranslationSkipLanguages: @[]};
     [[NSUserDefaults standardUserDefaults] registerDefaults:defaultValues];
 
     sRedditClientId = (NSString *)[[[NSUserDefaults standardUserDefaults] objectForKey:UDKeyRedditClientId] ?: @"" copy];
@@ -776,15 +778,28 @@ static void initializeRandomSources() {
     sProxyImgurDDG = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyProxyImgurDDG];
     sEnableBulkTranslation = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableBulkTranslation];
     sAutoTranslateOnAppear = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyAutoTranslateOnAppear];
+    sTranslatePostTitles = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyTranslatePostTitles];
 
     NSString *targetLanguage = (NSString *)[[NSUserDefaults standardUserDefaults] objectForKey:UDKeyTranslationTargetLanguage];
     sTranslationTargetLanguage = [targetLanguage length] > 0 ? [targetLanguage copy] : nil;
 
-    NSString *provider = (NSString *)[[NSUserDefaults standardUserDefaults] objectForKey:UDKeyTranslationProvider];
-    if ([provider isEqualToString:@"libre"] || [provider isEqualToString:@"google"]) {
-        sTranslationProvider = [provider copy];
-    } else {
+    // Provider: only "google" or "libre" are supported. Migrate any older
+    // "apple" value to "google" so existing users land on a working provider.
+    NSUserDefaults *standardDefaults = [NSUserDefaults standardUserDefaults];
+    NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
+    NSDictionary *persistentDomain = bundleID.length > 0 ? [standardDefaults persistentDomainForName:bundleID] : nil;
+    id providerValue = [persistentDomain objectForKey:UDKeyTranslationProvider];
+    NSString *provider = [providerValue isKindOfClass:[NSString class]] ? (NSString *)providerValue : nil;
+
+    if ([provider isEqualToString:@"libre"]) {
+        sTranslationProvider = @"libre";
+    } else if ([provider isEqualToString:@"google"]) {
         sTranslationProvider = @"google";
+    } else {
+        // Unset, unrecognized, or legacy "apple" — default to Google.
+        sTranslationProvider = @"google";
+        [standardDefaults setObject:sTranslationProvider forKey:UDKeyTranslationProvider];
+        [standardDefaults setBool:NO forKey:UDKeyTranslationProviderUserSelected];
     }
 
     NSString *libreURL = (NSString *)[[NSUserDefaults standardUserDefaults] objectForKey:UDKeyLibreTranslateURL];
@@ -792,6 +807,26 @@ static void initializeRandomSources() {
 
     NSString *libreAPIKey = (NSString *)[[NSUserDefaults standardUserDefaults] objectForKey:UDKeyLibreTranslateAPIKey];
     sLibreTranslateAPIKey = [libreAPIKey length] > 0 ? [libreAPIKey copy] : nil;
+
+    {
+        id raw = [[NSUserDefaults standardUserDefaults] objectForKey:UDKeyTranslationSkipLanguages];
+        NSMutableArray<NSString *> *clean = [NSMutableArray array];
+        if ([raw isKindOfClass:[NSArray class]]) {
+            for (id v in (NSArray *)raw) {
+                if (![v isKindOfClass:[NSString class]]) continue;
+                NSString *s = [(NSString *)v stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].lowercaseString;
+                if (s.length == 0) continue;
+                NSRange dash = [s rangeOfString:@"-"];
+                NSRange under = [s rangeOfString:@"_"];
+                NSUInteger split = NSNotFound;
+                if (dash.location != NSNotFound) split = dash.location;
+                if (under.location != NSNotFound) split = (split == NSNotFound) ? under.location : MIN(split, under.location);
+                if (split != NSNotFound && split > 0) s = [s substringToIndex:split];
+                if (s.length > 0 && ![clean containsObject:s]) [clean addObject:s];
+            }
+        }
+        sTranslationSkipLanguages = [clean copy];
+    }
 
     // Trim ReadPostIDs if over configured max
     if (sReadPostMaxCount > 0) {

--- a/UserDefaultConstants.h
+++ b/UserDefaultConstants.h
@@ -22,7 +22,11 @@ static NSString *const UDKeyProxyImgurDDG = @"ProxyImgurDDG";
 // Bulk translation feature
 static NSString *const UDKeyEnableBulkTranslation = @"EnableBulkTranslation";
 static NSString *const UDKeyAutoTranslateOnAppear = @"AutoTranslateOnAppear";
+static NSString *const UDKeyTranslatePostTitles = @"TranslatePostTitles";
 static NSString *const UDKeyTranslationTargetLanguage = @"TranslationTargetLanguage";
 static NSString *const UDKeyTranslationProvider = @"TranslationProvider"; // google | libre
+static NSString *const UDKeyTranslationProviderUserSelected = @"TranslationProviderUserSelected";
 static NSString *const UDKeyLibreTranslateURL = @"LibreTranslateURL";
 static NSString *const UDKeyLibreTranslateAPIKey = @"LibreTranslateAPIKey";
+// Array<String> of 2-letter language codes to leave untranslated (detected source language).
+static NSString *const UDKeyTranslationSkipLanguages = @"TranslationSkipLanguages";


### PR DESCRIPTION
Replaces the Apple Translation work previously on this branch with a more reliable Google + LibreTranslate setup. Apple's framework caused too many issues and slowdowns — Google ended up being way more reliable and easier to work with.

## What's new

- **Title translations.** Translate post titles right in your feed, with a globe toggle to turn them on/off per feed.
- **"Don't Translate" languages.** Add the languages you don't want translated and they stay in their native form while everything else still translates normally. Mixed-language text is still translated — only the dominant detected language matters.
- **Lots of fixes and stability improvements.** Translations now persist across backgrounding, swipe-back/lifecycle races are gone, and changing settings updates the visible feed/thread immediately instead of waiting for scroll.

---

## Technical details

### "Don't Translate" languages

- Settings UI manages the list, persisted to NSUserDefaults under the existing app group.
- Detection runs on a URL/markdown-stripped copy of the source so a comment like `[title](https://record.pt/...)` doesn't pull `NLLanguageRecognizer` toward English.
- Changing the list posts `ApolloTranslationSkipLanguagesChanged`, which actively flushes all 3 translation caches AND re-runs translation on visible comments + visible feed titles, so the new behavior shows up within ~hundreds of ms instead of needing a scroll. Globe "applied" state on the visible feed VC is also re-evaluated so the green indicator accurately reflects the new outcome.

### Reliability & polish

- **Persistence across backgrounding.** Translations are mirrored to a plain dictionary alongside the `NSCache` and persisted to disk on `applicationWillResignActive`, hydrated on launch. Translated threads no longer revert to source after backgrounding.
- **Feed/subreddit globe.** Globe injected on `Apollo.PostsViewController` and re-installed across nav transitions; tap toggles all titles in the visible feed; "applied" state cached per-VC and refreshed on cell reuse + scroll-to-translate sweeps.
- **Hide native per-comment Translate row.** Avoids the duplicate-flow problem where users could trigger Apollo's native translate sheet on top of our in-place translation.
- **Lifecycle / swipe-back hardening.** Reconcile passes capture a per-VC generation counter at scheduling time; `viewWillDisappear` bumps the counter so deferred passes that fire mid-pop bail out before walking the owned-textnode registry. Resolves intermittent flicker / stale-text reports during interactive pop.
- **URL-aware language detection** applied to comment cells, post header cells, post body, and feed-title translation paths.
- **Selective memory-warning handling.** Only the cheap key→text cache is dropped; the per-comment / per-post fullName caches are preserved (iOS sends memory warnings on backgrounding, and wiping these caused threads to revert when the user returned).

### VideoUnmute log cleanup (small drive-by)

Suppresses the per-layout-tick `event=1 (VisibleRectChanged)` log spam from both `RichMediaHeaderCellNode.cellNodeVisibilityEvent:` and `CommentsHeaderCellNode.cellNodeVisibilityEvent:`. Pure noise reduction — the rect-change ticks fire constantly during scroll and the handler was already a no-op for them.

## Notes

- All translation paths go through the Google + LibreTranslate provider chain; no new providers.
- `AppleTranslationBridge.swift` and the Translation/SwiftUI weak-link Makefile entries from earlier commits on this branch are removed.
- Manually validated on iOS 26 with Portuguese↔English in long comment threads and feed scrolling.
