### PR TITLE
Additional Liquid Glass fixes, absolute `created_at` alert

### DIFF
--- a/ApolloCreatedAtAlert.xm
+++ b/ApolloCreatedAtAlert.xm
@@ -1,0 +1,292 @@
+// ApolloCreatedAtAlert
+//
+// Tap a comment/post timestamp ("2.8y") to reveal an alert with the absolute
+// creation date — mirrors Apollo's existing Edited-pencil alert.
+//
+// Wiring: the timestamp display nodes (CommentCellNode.ageNode,
+// PostInfoNode.ageButtonNode) are layer-backed, so addTarget: and per-node
+// gestures don't fire. We install one UITapGestureRecognizer on the cell's
+// own view (always view-backed) and hit-test the embedded node's CALayer
+// from shouldReceiveTouch:.
+//
+// Hooked cells: CommentCellNode (ageNode), CommentsHeaderCellNode /
+// LargePostCellNode / CompactPostCellNode (postInfoNode.ageButtonNode).
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+#import "ApolloCommon.h"
+#import "Tweak.h"
+#import "UIWindow+Apollo.h"
+
+// MARK: - AsyncDisplayKit minimal forward declarations
+
+@interface ApolloASDisplayNode : UIResponder
+@property (nonatomic, readonly) CALayer *layer;
+@property (nonatomic, readonly, nullable) UIView *view;
+@property (nonatomic, getter=isHidden) BOOL hidden;
+@property (nonatomic, readonly, nullable) UIViewController *closestViewController;
+@end
+
+// MARK: - RDKCreated accessor
+
+@interface RDKComment (ApolloCreatedAtAccessor)
+@property (nonatomic, readonly) NSDate *createdUTC;
+@end
+
+// MARK: - Helpers
+
+static const void *kApolloAgeTapGestureKey = &kApolloAgeTapGestureKey;
+// Marker on our own gesture so the shared shouldReceiveTouch: can identify it.
+static const void *kApolloAgeTapMarkerKey = &kApolloAgeTapMarkerKey;
+
+static NSDateFormatter *ApolloAbsoluteDateFormatter(void) {
+    static NSDateFormatter *fmt;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        fmt = [[NSDateFormatter alloc] init];
+        // Long date + short time matches Apollo's edited alert format.
+        fmt.dateStyle = NSDateFormatterLongStyle;
+        fmt.timeStyle = NSDateFormatterShortStyle;
+    });
+    return fmt;
+}
+
+static id ApolloIvarValueByName(id obj, const char *name) {
+    if (!obj || !name) return nil;
+    Class cls = object_getClass(obj);
+    while (cls) {
+        Ivar ivar = class_getInstanceVariable(cls, name);
+        if (ivar) {
+            return object_getIvar(obj, ivar);
+        }
+        cls = class_getSuperclass(cls);
+    }
+    return nil;
+}
+
+// Compact relative-time format matching Apollo's native ageNode/edited alert
+// (s/m/h/d/mo with 1-decimal y). <5s short-circuits to "Just now".
+static NSString *ApolloRelativeAgoString(NSDate *date) {
+    if (!date) return nil;
+    NSTimeInterval interval = fabs([date timeIntervalSinceNow]);
+    if (interval < 5.0)       return @"Just now";
+    if (interval < 60.0)      return [NSString stringWithFormat:@"%lds",  (long)interval];
+    if (interval < 3600.0)    return [NSString stringWithFormat:@"%ldm",  (long)(interval / 60.0)];
+    if (interval < 86400.0)   return [NSString stringWithFormat:@"%ldh",  (long)(interval / 3600.0)];
+    if (interval < 2592000.0) return [NSString stringWithFormat:@"%ldd",  (long)(interval / 86400.0)];
+    if (interval < 31536000.0) return [NSString stringWithFormat:@"%ldmo", (long)(interval / 2592000.0)];
+    return [NSString stringWithFormat:@"%.1fy", interval / 31556736.0];
+}
+
+static UIViewController *ApolloPresenterForNode(ApolloASDisplayNode *node) {
+    if (!node) return nil;
+
+    // Texture's closestViewController walks supernode → UIResponder chain.
+    UIViewController *vc = nil;
+    if ([node respondsToSelector:@selector(closestViewController)]) {
+        @try { vc = node.closestViewController; } @catch (__unused id e) {}
+    }
+    if (vc) return vc;
+
+    UIView *view = nil;
+    @try { view = node.view; } @catch (__unused id e) {}
+    UIWindow *window = view.window;
+    if (!window) {
+        for (UIWindow *w in [UIApplication sharedApplication].windows) {
+            if (w.isKeyWindow) { window = w; break; }
+        }
+    }
+    return [window visibleViewController];
+}
+
+static void ApolloPresentCreatedAtAlert(NSDate *createdAt, ApolloASDisplayNode *anchor, BOOL isComment) {
+    if (!createdAt || ![createdAt isKindOfClass:[NSDate class]]) return;
+    UIViewController *presenter = ApolloPresenterForNode(anchor);
+    if (!presenter) return;
+
+    NSString *verb = isComment ? @"Commented" : @"Posted";
+    NSString *relative = ApolloRelativeAgoString(createdAt) ?: @"Just now";
+    NSString *title;
+    if ([relative isEqualToString:@"Just now"]) {
+        title = [NSString stringWithFormat:@"%@ %@", verb, relative];
+    } else {
+        title = [NSString stringWithFormat:@"%@ %@ Ago", verb, relative];
+    }
+
+    NSString *message = nil;
+    if (fabs([createdAt timeIntervalSinceNow]) >= 5.0) {
+        message = [NSString stringWithFormat:@"%@ on %@", verb,
+                                              [ApolloAbsoluteDateFormatter() stringFromDate:createdAt]];
+    }
+
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title
+                                                                   message:message
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
+    [presenter presentViewController:alert animated:YES completion:nil];
+}
+
+// YES if `touch` falls inside `targetNode`'s layer (in containerView coords),
+// padded for comfortable touch targets. Works for layer-backed nodes too.
+static BOOL ApolloTouchHitsNode(ApolloASDisplayNode *targetNode, UIView *containerView, UITouch *touch) {
+    if (!targetNode || targetNode.isHidden || !containerView || !touch) return NO;
+
+    CALayer *targetLayer = nil;
+    @try { targetLayer = targetNode.layer; } @catch (__unused id e) {}
+    if (!targetLayer || !containerView.layer) return NO;
+
+    CGRect rect = [targetLayer convertRect:targetLayer.bounds toLayer:containerView.layer];
+    if (CGRectIsEmpty(rect) || CGRectIsNull(rect) || CGRectIsInfinite(rect)) return NO;
+
+    rect = CGRectInset(rect, -10.0, -8.0);
+    CGPoint pt = [touch locationInView:containerView];
+    return CGRectContainsPoint(rect, pt);
+}
+
+// Resolves the timestamp node for a cell. Comment cells expose ageNode
+// directly; post-style cells embed PostInfoNode which holds ageButtonNode.
+static ApolloASDisplayNode *ApolloAgeDisplayNodeForCell(id cell) {
+    if (!cell) return nil;
+
+    ApolloASDisplayNode *direct = ApolloIvarValueByName(cell, "ageNode");
+    if (direct) return direct;
+
+    id postInfoNode = ApolloIvarValueByName(cell, "postInfoNode");
+    if (postInfoNode) {
+        ApolloASDisplayNode *ageButtonNode = ApolloIvarValueByName(postInfoNode, "ageButtonNode");
+        if (ageButtonNode) return ageButtonNode;
+    }
+    return nil;
+}
+
+// Idempotent.
+static void ApolloInstallAgeTapOnCell(id cell, SEL handler) {
+    if (!cell) return;
+    if (objc_getAssociatedObject(cell, kApolloAgeTapGestureKey)) return;
+
+    UIView *cellView = nil;
+    @try { cellView = [(ApolloASDisplayNode *)cell view]; } @catch (__unused id e) {}
+    if (!cellView) return;
+
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:cell action:handler];
+    tap.cancelsTouchesInView = YES;
+    tap.delegate = (id<UIGestureRecognizerDelegate>)cell;
+    objc_setAssociatedObject(tap, kApolloAgeTapMarkerKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(cell, kApolloAgeTapGestureKey, tap, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [cellView addGestureRecognizer:tap];
+}
+
+// Only acts on our own gesture; defers to other delegate-routed gestures.
+static BOOL ApolloAgeTapShouldReceiveTouch(id cell, UIGestureRecognizer *gr, UITouch *touch) {
+    if (!objc_getAssociatedObject(gr, kApolloAgeTapMarkerKey)) return YES;
+
+    UIView *cellView = nil;
+    @try { cellView = [(ApolloASDisplayNode *)cell view]; } @catch (__unused id e) {}
+    ApolloASDisplayNode *ageNode = ApolloAgeDisplayNodeForCell(cell);
+    return ApolloTouchHitsNode(ageNode, cellView, touch);
+}
+
+static void ApolloAgeTapFired(id cell, UITapGestureRecognizer *tap) {
+    if (tap.state != UIGestureRecognizerStateRecognized) return;
+
+    // Comment cells carry an RDKComment; everything else is a post (RDKLink).
+    RDKComment *comment = ApolloIvarValueByName(cell, "comment");
+    NSDate *date = nil;
+    BOOL isComment = NO;
+    if (comment) {
+        NSDate *d = comment.createdUTC;
+        if ([d isKindOfClass:[NSDate class]]) {
+            date = d;
+            isComment = YES;
+        }
+    }
+    if (!date) {
+        RDKLink *link = ApolloIvarValueByName(cell, "link");
+        NSDate *d = link.createdUTC;
+        if ([d isKindOfClass:[NSDate class]]) date = d;
+    }
+    if (!date) return;
+
+    ApolloPresentCreatedAtAlert(date, (ApolloASDisplayNode *)cell, isComment);
+}
+
+// MARK: - Hooks
+
+%hook _TtC6Apollo15CommentCellNode
+
+- (void)didLoad {
+    %orig;
+    ApolloInstallAgeTapOnCell(self, @selector(apollo_ageTapFired:));
+}
+
+%new
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
+    return ApolloAgeTapShouldReceiveTouch(self, gestureRecognizer, touch);
+}
+
+%new
+- (void)apollo_ageTapFired:(UITapGestureRecognizer *)tap {
+    ApolloAgeTapFired(self, tap);
+}
+
+%end
+
+%hook _TtC6Apollo22CommentsHeaderCellNode
+
+- (void)didLoad {
+    %orig;
+    ApolloInstallAgeTapOnCell(self, @selector(apollo_ageTapFired:));
+}
+
+%new
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
+    return ApolloAgeTapShouldReceiveTouch(self, gestureRecognizer, touch);
+}
+
+%new
+- (void)apollo_ageTapFired:(UITapGestureRecognizer *)tap {
+    ApolloAgeTapFired(self, tap);
+}
+
+%end
+
+%hook _TtC6Apollo17LargePostCellNode
+
+- (void)didLoad {
+    %orig;
+    ApolloInstallAgeTapOnCell(self, @selector(apollo_ageTapFired:));
+}
+
+%new
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
+    return ApolloAgeTapShouldReceiveTouch(self, gestureRecognizer, touch);
+}
+
+%new
+- (void)apollo_ageTapFired:(UITapGestureRecognizer *)tap {
+    ApolloAgeTapFired(self, tap);
+}
+
+%end
+
+%hook _TtC6Apollo19CompactPostCellNode
+
+- (void)didLoad {
+    %orig;
+    ApolloInstallAgeTapOnCell(self, @selector(apollo_ageTapFired:));
+}
+
+%new
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
+    return ApolloAgeTapShouldReceiveTouch(self, gestureRecognizer, touch);
+}
+
+%new
+- (void)apollo_ageTapFired:(UITapGestureRecognizer *)tap {
+    ApolloAgeTapFired(self, tap);
+}
+
+%end

--- a/ApolloLiquidGlass.xm
+++ b/ApolloLiquidGlass.xm
@@ -302,6 +302,92 @@ static void FixScrollEdgeEffectInversion(UIScrollView *scrollView) {
     }
 }
 
+// MARK: - ApolloNavigationController fixes for Liquid Glass
+
+@interface _TtC6Apollo26ApolloNavigationController : UINavigationController
+@end
+
+static Class ApolloTableVCClass(void) {
+    static Class cls = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ cls = objc_getClass("_TtC6Apollo25ApolloTableViewController"); });
+    return cls;
+}
+
+static Ivar ApolloTableVCTableViewIvar(void) {
+    static Ivar iv = NULL;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        Class c = ApolloTableVCClass();
+        if (c) iv = class_getInstanceVariable(c, "tableView");
+    });
+    return iv;
+}
+
+// Hide the translucent grey statusBarBackgroundView Apollo overlays on the window when
+// "Hide Bars on Scroll" is enabled. Pre-26 it blended with the opaque nav bar; on Liquid
+// Glass it shows through as a visible strip at the top of the screen.
+static void HideApolloStatusBarBackgroundView(UINavigationController *navController) {
+    if (!IsLiquidGlass() || !navController) return;
+
+    static Ivar sIvar = NULL;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class cls = objc_getClass("_TtC6Apollo26ApolloNavigationController");
+        if (cls) {
+            sIvar = class_getInstanceVariable(cls, "statusBarBackgroundView");
+        }
+    });
+    if (!sIvar) return;
+
+    UIView *bgView = object_getIvar(navController, sIvar);
+    if ([bgView isKindOfClass:[UIView class]] && !bgView.hidden) {
+        bgView.hidden = YES;
+        ApolloLog(@"[ApolloNavigationController] Hid statusBarBackgroundView for Liquid Glass");
+    }
+}
+
+%hook _TtC6Apollo26ApolloNavigationController
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    HideApolloStatusBarBackgroundView(self);
+}
+
+// Fix the first list row sitting under the translucent nav bar after hidesBarsOnSwipe
+// re-reveals it. Apollo's gesture handler applies a negative contentInset.top while the
+// bar is hidden but never resets it on reveal, leaving adjustedContentInset.top too small.
+// Pre-26 the opaque bar masked this; Liquid Glass exposes it.
+- (void)barHideOnSwipeGesturePanned:(UIPanGestureRecognizer *)gr {
+    %orig;
+    if (!IsLiquidGlass()) return;
+    if (gr.state != UIGestureRecognizerStateEnded) return;
+
+    // Only act when bar has settled fully on-screen — leave Apollo's negative inset alone
+    // while the bar is hidden (origin.y < 0).
+    if (self.navigationBar.frame.origin.y < 0) return;
+
+    Class apolloTblCls = ApolloTableVCClass();
+    Ivar tvIvar = ApolloTableVCTableViewIvar();
+    if (!apolloTblCls || !tvIvar) return;
+
+    UIViewController *topVC = self.topViewController;
+    if (![topVC isKindOfClass:apolloTblCls]) return;
+
+    UIScrollView *tv = object_getIvar(topVC, tvIvar);
+    if (![tv isKindOfClass:[UIScrollView class]]) return;
+
+    UIEdgeInsets ci = tv.contentInset;
+    if (ci.top >= 0) return;
+
+    CGFloat oldTop = ci.top;
+    ci.top = 0;
+    tv.contentInset = ci;
+    ApolloLog(@"[ApolloNavigationController] Reset stale contentInset.top %g→0 after bar reveal (Liquid Glass)", oldTop);
+}
+
+%end
+
 %hook _TtC6Apollo22MessagesCollectionView
 
 - (void)didMoveToWindow {

--- a/ApolloRecentlyRead.xm
+++ b/ApolloRecentlyRead.xm
@@ -521,9 +521,7 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
     if (elapsed < 2592000) return [NSString stringWithFormat:@"%ldd", (long)(elapsed / 86400)];
     double months = elapsed / 2592000.0;
     if (months < 12) return [NSString stringWithFormat:@"%.0fmo", months];
-    double years = elapsed / 31536000.0;
-    if (years >= 10) return [NSString stringWithFormat:@"%.0fy", years];
-    return [NSString stringWithFormat:@"%.1fy", years];
+    return [NSString stringWithFormat:@"%.1fy", elapsed / 31556736.0];
 }
 
 - (NSString *)compactScoreString:(NSInteger)score {

--- a/ApolloTranslation.xm
+++ b/ApolloTranslation.xm
@@ -2965,6 +2965,7 @@ static UIColor *ApolloThemeTintColorFromNavigationItems(NSArray<UIBarButtonItem 
 
 static void ApolloUpdateTranslationUIForController(id controller) {
     UIViewController *vc = (UIViewController *)controller;
+    if (!sEnableBulkTranslation) return;
 
     BOOL isFeedVC = [objc_getAssociatedObject(controller, kApolloFeedTranslationVCKey) boolValue];
     UIBarButtonItem *translationItem = objc_getAssociatedObject(controller, kApolloTranslateBarButtonKey);
@@ -4091,6 +4092,7 @@ static void ApolloScheduleFeedSettledTitleRefresh(UIViewController *vc) {
 
 static void ApolloFeedVCInstallGlobe(UIViewController *vc) {
     if (!vc) return;
+    if (!sEnableBulkTranslation) return;
     BOOL alreadyMarked = [objc_getAssociatedObject(vc, kApolloFeedTranslationVCKey) boolValue];
     objc_setAssociatedObject(vc, kApolloFeedTranslationVCKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     sLastInstalledFeedViewController = vc;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v2.6.0] - 2026-04-30
+- Bulk translation improvements (thanks @icpryde for continuing to refine this!)
+    - New **Don't Translate** languages list in **Settings > Translation** to keep selected languages untranslated
+    - New option to translate post titles in **Settings > Translation**
+    - Various bug fixes and stability improvements
+- Tap a comment or post's relative-time label (e.g. "2.8y") to show an alert with the absolute creation date and time, mirroring Apollo's existing "Edited" alert
+- Liquid Glass: fix tab bar not reappearing on scrolling up when "Hide Bars on Scroll" is enabled (thanks @icpryde for the fix!)
+- Liquid Glass: hide translucent status bar background strip that appears at the top of the screen when "Hide Bars on Scroll" is enabled
+- Liquid Glass: fix first list row being clipped under nav bar in subreddit list view when "Hide Bars on Scroll" is enabled
+
 ## [v2.5.0] - 2026-04-28
 
 - New bulk translation feature for comment threads and self posts (thanks @icpryde for implementing this feature!)
@@ -303,6 +313,7 @@ There are currently a few limitations:
 ## [v1.0.0] - 2023-10-13
 - Initial release
 
+[v2.6.0]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v2.5.0...v2.6.0
 [v2.5.0]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v2.4.0...v2.5.0
 [v2.4.0]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v2.3.0...v2.4.0
 [v2.3.0]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v2.2.1...v2.3.0

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ ApolloImprovedCustomApi_FILES = \
     ApolloTranslation.xm \
     ApolloVideoUnmute.xm \
     ApolloVideoSwipeFix.xm \
+    ApolloCreatedAtAlert.xm \
     CustomAPIViewController.m \
     TranslationSettingsViewController.m \
     SavedCategoriesViewController.m \

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ iOS tweak for [Apollo for Reddit app](https://apolloapp.io/) that lets you conti
 - **Custom Subreddit Sources**: Use external URLs for random and trending subreddits
 - **Recently Read Posts**: View all recently read posts from the Profile tab
 - **Editable Saved Categories**: Add, rename, and delete saved post categories (Settings > Saved Categories)
-- **Bulk inline translation**: Translate comment threads and self posts inline with configurable provider and target language (Settings > Translation)
+- **Bulk in-place translation**: Translate posts and comments in-place with configurable provider and target language (Settings > Translation)
+- **Tap timestamp for creation date**: Tap a comment or post's relative-time label to see the absolute creation date and time
 
 ## Known Issues
 

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: ca.jeffrey.apollo-improvedcustomapi
 Name: Apollo-ImprovedCustomApi
-Version: 2.5.0
+Version: 2.6.0
 Architecture: iphoneos-arm
 Description: Apollo for Reddit tweak with in-app configurable API keys
 Maintainer: JeffreyCA


### PR DESCRIPTION
Fixes #144

- Add early exits to bulk translation hooks when disabled
- Tap a comment or post's relative-time label (e.g. "2.8y") to show an alert with the absolute creation date and time, mirroring Apollo's existing "Edited" alert
- Liquid Glass: hide translucent status bar background strip that appears at the top of the screen when "Hide Bars on Scroll" is enabled
- Liquid Glass: fix first list row being clipped under nav bar in subreddit list view when "Hide Bars on Scroll" is enabled
