### PR TITLE
Tag Filters: blur NSFW/Spoiler posts in feeds

### DIFF
--- a/ApolloSettings.xm
+++ b/ApolloSettings.xm
@@ -5,6 +5,7 @@
 #import "CustomAPIViewController.h"
 #import "SavedCategoriesViewController.h"
 #import "TranslationSettingsViewController.h"
+#import "TagFiltersViewController.h"
 
 // MARK: - Settings View Controller (Custom API row injection)
 
@@ -56,7 +57,7 @@ static UIImage *createSettingsIcon(NSString *sfSymbolName, UIColor *bgColor) {
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    if (section == 1) return 3; // Custom API, Saved Categories, Translation
+    if (section == 1) return 4; // Custom API, Saved Categories, Translation, Tag Filters
     if (section > 1) return %orig(tableView, section - 1);
     return %orig;
 }
@@ -73,9 +74,12 @@ static UIImage *createSettingsIcon(NSString *sfSymbolName, UIColor *bgColor) {
         } else if (indexPath.row == 1) {
             cell.textLabel.text = @"Saved Categories";
             cell.imageView.image = createSettingsIcon(@"bookmark.fill", [UIColor systemOrangeColor]);
-        } else {
+        } else if (indexPath.row == 2) {
             cell.textLabel.text = @"Translation";
             cell.imageView.image = createSettingsIcon(@"globe", [UIColor systemIndigoColor]);
+        } else {
+            cell.textLabel.text = @"Tag Filters";
+            cell.imageView.image = createSettingsIcon(@"eye.slash.fill", [UIColor systemRedColor]);
         }
         return cell;
     }
@@ -95,8 +99,11 @@ static UIImage *createSettingsIcon(NSString *sfSymbolName, UIColor *bgColor) {
         } else if (indexPath.row == 1) {
             SavedCategoriesViewController *vc = [[SavedCategoriesViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
             [((UIViewController *)self).navigationController pushViewController:vc animated:YES];
-        } else {
+        } else if (indexPath.row == 2) {
             TranslationSettingsViewController *vc = [[TranslationSettingsViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
+            [((UIViewController *)self).navigationController pushViewController:vc animated:YES];
+        } else {
+            TagFiltersViewController *vc = [[TagFiltersViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
             [((UIViewController *)self).navigationController pushViewController:vc animated:YES];
         }
         return;

--- a/ApolloState.h
+++ b/ApolloState.h
@@ -29,3 +29,12 @@ extern NSString *sLibreTranslateURL;
 extern NSString *sLibreTranslateAPIKey;
 // Lowercased 2-letter language codes the user has opted out of translating.
 extern NSArray<NSString *> *sTranslationSkipLanguages;
+
+// Tag filter feature (NSFW / Spoiler).
+extern BOOL sTagFilterEnabled;
+extern NSString *sTagFilterMode;          // @"hide" or @"blur"
+extern BOOL sTagFilterNSFW;
+extern BOOL sTagFilterSpoiler;
+// Lowercased subreddit name -> dictionary with optional keys:
+//   nsfw (NSNumber BOOL), spoiler (NSNumber BOOL), mode (NSString).
+extern NSDictionary<NSString *, NSDictionary *> *sTagFilterSubredditOverrides;

--- a/ApolloState.m
+++ b/ApolloState.m
@@ -27,3 +27,9 @@ NSString *sTranslationProvider = nil;
 NSString *sLibreTranslateURL = nil;
 NSString *sLibreTranslateAPIKey = nil;
 NSArray<NSString *> *sTranslationSkipLanguages = nil;
+
+BOOL sTagFilterEnabled = NO;
+NSString *sTagFilterMode = @"blur";
+BOOL sTagFilterNSFW = YES;
+BOOL sTagFilterSpoiler = YES;
+NSDictionary<NSString *, NSDictionary *> *sTagFilterSubredditOverrides = nil;

--- a/ApolloTagFilters.xm
+++ b/ApolloTagFilters.xm
@@ -331,54 +331,6 @@ static void ApolloTagRevealCell(id cell) {
     }
 }
 
-static void ApolloTagSimulateCellSelection(id cell) {
-    if (!cell) return;
-    UIViewController *presenter = ApolloTagPresenterForCell(cell);
-    if (!presenter) return;
-
-    // Walk up to find the nearest tableNode-based VC and its tableNode delegate.
-    // Apollo's PostsViewController acts as its own ASTableNode delegate, so the
-    // closestViewController already implements tableNode:didSelectRowAtIndexPath:.
-    UIView *cellView = ApolloTagCellView(cell);
-    if (!cellView) return;
-
-    // Find ASTableView (subclass of UITableView) up the view hierarchy.
-    UIView *cursor = cellView;
-    UITableView *tableView = nil;
-    while (cursor) {
-        if ([cursor isKindOfClass:[UITableView class]]) {
-            tableView = (UITableView *)cursor;
-            break;
-        }
-        cursor = cursor.superview;
-    }
-
-    NSIndexPath *indexPath = nil;
-    if (tableView) {
-        // Convert cellView center to tableView coords; ASTableView accepts UITableView API.
-        CGPoint center = [cellView.superview convertPoint:cellView.center toView:tableView];
-        indexPath = [tableView indexPathForRowAtPoint:center];
-    }
-
-    if (!indexPath) return;
-
-    // Try ASTableNode delegate selector first, then UITableView delegate.
-    SEL tableNodeSel = NSSelectorFromString(@"tableNode:didSelectRowAtIndexPath:");
-    if ([presenter respondsToSelector:tableNodeSel]) {
-        // Need the tableNode (not tableView). Fetch via tableView.delegate which
-        // for ASTableNode is the VC; the tableNode is held on the VC. Easiest:
-        // call the UITableView delegate, which Apollo also implements via ASDK.
-    }
-    SEL tableViewSel = @selector(tableView:didSelectRowAtIndexPath:);
-    if (tableView && [presenter respondsToSelector:tableViewSel]) {
-        ((void (*)(id, SEL, UITableView *, NSIndexPath *))objc_msgSend)(presenter, tableViewSel, tableView, indexPath);
-        return;
-    }
-
-    // Fallback: synthesize a tap on the cell (Apollo will react via its own gestures).
-    [tableView selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
-}
-
 static void ApolloTagPresentConfirmAlertForCell(id cell) {
     UIViewController *presenter = ApolloTagPresenterForCell(cell);
     if (!presenter) {
@@ -392,11 +344,8 @@ static void ApolloTagPresentConfirmAlertForCell(id cell) {
                                                             preferredStyle:UIAlertControllerStyleAlert];
     [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
     [alert addAction:[UIAlertAction actionWithTitle:@"View" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+        // Reveal only — leave navigation to the user's next tap on the now-visible cell.
         ApolloTagRevealCell(cell);
-        // Slight delay so the reveal animation completes before navigation.
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.18 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            ApolloTagSimulateCellSelection(cell);
-        });
     }]];
     [presenter presentViewController:alert animated:YES completion:nil];
 }

--- a/ApolloTagFilters.xm
+++ b/ApolloTagFilters.xm
@@ -1,0 +1,480 @@
+// ApolloTagFilters
+//
+// Hide or blur posts in the Apollo feed based on Reddit's built-in tags
+// (NSFW / Spoiler). Per-subreddit overrides take precedence over global
+// settings; missing per-sub keys fall back to global.
+//
+// Strategy: hook the post cell nodes (LargePostCellNode + CompactPostCellNode)
+// at didLoad and on layoutSpecThatFits: re-evaluate. If the link is filtered:
+//   - "hide" mode → set the cell view hidden + collapse the cell node's
+//     calculatedSize to zero (keeps Apollo's data array intact, no
+//     pagination desync).
+//   - "blur" mode → install a UIVisualEffectView overlay with a small
+//     "NSFW" / "Spoiler" pill. First long-press while blurred reveals the
+//     cell (next long-press behaves normally). Tap on a blurred cell shows
+//     a "Are you sure?" alert before navigating.
+//
+// Live updates: observers of ApolloTagFiltersChanged trigger a refresh on
+// all visible cell nodes.
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+#import "Tweak.h"
+#import "UIWindow+Apollo.h"
+#import "UserDefaultConstants.h"
+
+extern NSString *const ApolloTagFiltersChangedNotification;
+
+// MARK: - Minimal AsyncDisplayKit forward declarations
+
+@interface ApolloTagDisplayNode : UIResponder
+@property (nonatomic, readonly) CALayer *layer;
+@property (nonatomic, readonly, nullable) UIView *view;
+@property (nonatomic, readonly) BOOL isNodeLoaded;
+@property (nonatomic, getter=isHidden) BOOL hidden;
+@property (nonatomic, readonly, nullable) UIViewController *closestViewController;
+@property (nonatomic) CGSize calculatedSize;
+- (void)setNeedsLayout;
+- (void)invalidateCalculatedLayout;
+@end
+
+// MARK: - Helpers
+
+static const void *kApolloTagDecisionKey = &kApolloTagDecisionKey;       // NSString @"hide"|@"blur"|@"none"
+static const void *kApolloTagOverlaysKey = &kApolloTagOverlaysKey;        // NSArray<UIVisualEffectView *>
+static const void *kApolloTagRevealedKey = &kApolloTagRevealedKey;        // NSNumber BOOL
+static const void *kApolloTagAppliedLinkKey = &kApolloTagAppliedLinkKey;  // NSValue (non-retained pointer to current link, used to detect cell reuse)
+
+static id ApolloTagIvarValueByName(id obj, const char *name) {
+    if (!obj || !name) return nil;
+    Class cls = object_getClass(obj);
+    while (cls) {
+        Ivar ivar = class_getInstanceVariable(cls, name);
+        if (ivar) {
+            return object_getIvar(obj, ivar);
+        }
+        cls = class_getSuperclass(cls);
+    }
+    return nil;
+}
+
+static RDKLink *ApolloTagLinkFromCell(id cell) {
+    if (!cell) return nil;
+    id v = ApolloTagIvarValueByName(cell, "link");
+    if ([v isKindOfClass:objc_getClass("RDKLink")]) return (RDKLink *)v;
+    return nil;
+}
+
+// Returns @"hide", @"blur", or @"none" given a link and (optional) subreddit context.
+// Per-subreddit overrides take precedence over global settings on a per-tag basis;
+// mode is also overridable per-sub.
+static NSString *ApolloTagFilterDecisionForLink(RDKLink *link) {
+    if (!sTagFilterEnabled || !link) return @"none";
+    if (![(id)link respondsToSelector:@selector(isNSFW)] && ![(id)link respondsToSelector:@selector(isSpoiler)]) return @"none";
+
+    BOOL isNSFW = NO;
+    BOOL isSpoiler = NO;
+    @try { isNSFW = link.isNSFW; } @catch (__unused id e) {}
+    @try { isSpoiler = link.isSpoiler; } @catch (__unused id e) {}
+    if (!isNSFW && !isSpoiler) return @"none";
+
+    NSString *sub = nil;
+    @try { sub = link.subreddit; } @catch (__unused id e) {}
+    NSString *subKey = [sub isKindOfClass:[NSString class]] ? sub.lowercaseString : nil;
+    NSDictionary *override = (subKey.length > 0) ? sTagFilterSubredditOverrides[subKey] : nil;
+
+    BOOL filterNSFW = sTagFilterNSFW;
+    BOOL filterSpoiler = sTagFilterSpoiler;
+    if ([override isKindOfClass:[NSDictionary class]]) {
+        id n = override[@"nsfw"];
+        if ([n isKindOfClass:[NSNumber class]]) filterNSFW = [(NSNumber *)n boolValue];
+        id s = override[@"spoiler"];
+        if ([s isKindOfClass:[NSNumber class]]) filterSpoiler = [(NSNumber *)s boolValue];
+    }
+
+    BOOL match = (isNSFW && filterNSFW) || (isSpoiler && filterSpoiler);
+    if (!match) return @"none";
+
+    // Hide mode was removed; everything filtered now blurs.
+    return @"blur";
+}
+
+// MARK: - Blur overlays (scoped to content subnodes)
+
+static NSArray<UIVisualEffectView *> *ApolloTagOverlaysForCell(id cell) {
+    NSArray *arr = objc_getAssociatedObject(cell, kApolloTagOverlaysKey);
+    return [arr isKindOfClass:[NSArray class]] ? arr : nil;
+}
+
+static UIView *ApolloTagCellView(id cell) {
+    if (!cell) return nil;
+    @try {
+        ApolloTagDisplayNode *node = (ApolloTagDisplayNode *)cell;
+        if (node.isNodeLoaded) return node.view;
+    } @catch (__unused id e) {}
+    return nil;
+}
+
+// Returns the UIView for a given ASDisplayNode-ish ivar value, if loaded.
+static UIView *ApolloTagViewForNode(id node) {
+    if (!node) return nil;
+    if ([node respondsToSelector:@selector(view)]) {
+        @try { return [(ApolloTagDisplayNode *)node view]; } @catch (__unused id e) {}
+    }
+    return nil;
+}
+
+// Collect the subviews we want to blur for a given cell.
+// Compact cells: thumbnailNode + titleNode (Apollo already blurs spoiler video
+//   thumbnails natively; our blur on top is harmless and keeps things consistent).
+// Large cells: crosspostNode contains title + rich media + body for both regular
+//   posts and crossposts. If unavailable, fall back to titleNode + thumbnailNode.
+static NSArray<UIView *> *ApolloTagBlurTargetsForCell(id cell) {
+    NSMutableArray<UIView *> *targets = [NSMutableArray array];
+    Class compactCls = objc_getClass("_TtC6Apollo19CompactPostCellNode");
+    BOOL isCompact = compactCls && [cell isKindOfClass:compactCls];
+
+    if (!isCompact) {
+        id cross = ApolloTagIvarValueByName(cell, "crosspostNode");
+        UIView *cv = ApolloTagViewForNode(cross);
+        if (cv && !cv.isHidden && cv.bounds.size.width > 4 && cv.bounds.size.height > 4) {
+            [targets addObject:cv];
+            return targets;
+        }
+    }
+
+    for (NSString *name in @[@"thumbnailNode", @"titleNode"]) {
+        id node = ApolloTagIvarValueByName(cell, name.UTF8String);
+        UIView *v = ApolloTagViewForNode(node);
+        if (v && !v.isHidden && v.bounds.size.width > 4 && v.bounds.size.height > 4) {
+            [targets addObject:v];
+        }
+    }
+    return targets;
+}
+
+static UIVisualEffectView *ApolloTagBuildBlurOverlay(void) {
+    UIBlurEffect *effect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleSystemMaterialDark];
+    UIVisualEffectView *overlay = [[UIVisualEffectView alloc] initWithEffect:effect];
+    overlay.userInteractionEnabled = YES;
+    overlay.layer.cornerRadius = 8;
+    overlay.layer.masksToBounds = YES;
+    return overlay;
+}
+
+// Pill: NSFW = red bg / white text. SPOILER = grey bg / white text.
+// NSFW+SPOILER together: NSFW wins (red).
+static UILabel *ApolloTagBuildPillForLink(RDKLink *link) {
+    BOOL isNSFW = NO, isSpoiler = NO;
+    @try { isNSFW = link.isNSFW; } @catch (__unused id e) {}
+    @try { isSpoiler = [(id)link respondsToSelector:@selector(isSpoiler)] ? link.isSpoiler : NO; } @catch (__unused id e) {}
+    NSString *text;
+    UIColor *bg;
+    if (isNSFW) {
+        text = @"NSFW";
+        bg = [UIColor colorWithRed:0.85 green:0.10 blue:0.10 alpha:0.95];
+    } else if (isSpoiler) {
+        text = @"SPOILER";
+        bg = [UIColor colorWithWhite:0.35 alpha:0.95];
+    } else {
+        return nil;
+    }
+    UILabel *pill = [[UILabel alloc] init];
+    pill.text = [NSString stringWithFormat:@"  %@  ", text];
+    pill.font = [UIFont systemFontOfSize:13 weight:UIFontWeightSemibold];
+    pill.textColor = [UIColor whiteColor];
+    pill.backgroundColor = bg;
+    pill.layer.cornerRadius = 6;
+    pill.layer.masksToBounds = YES;
+    pill.translatesAutoresizingMaskIntoConstraints = NO;
+    return pill;
+}
+
+static void ApolloTagInstallBlurOverlay(id cell, RDKLink *link) {
+    UIView *cellView = ApolloTagCellView(cell);
+    if (!cellView) return;
+
+    NSArray<UIView *> *targets = ApolloTagBlurTargetsForCell(cell);
+    if (targets.count == 0) {
+        // Defer: layout may not have produced subviews yet. We'll retry on next layout pass.
+        return;
+    }
+
+    NSArray<UIVisualEffectView *> *existing = ApolloTagOverlaysForCell(cell);
+    if (existing.count == targets.count) {
+        // Reuse existing overlays; just resync frames + ensure pill stays on top.
+        for (NSUInteger i = 0; i < targets.count; i++) {
+            UIView *target = targets[i];
+            UIVisualEffectView *ov = existing[i];
+            CGRect f = [target.superview convertRect:target.frame toView:cellView];
+            ov.frame = f;
+            ov.hidden = NO;
+            [cellView bringSubviewToFront:ov];
+        }
+        return;
+    }
+
+    // Tear down and rebuild if count changed.
+    for (UIVisualEffectView *ov in existing) [ov removeFromSuperview];
+
+    // Pick the largest target for the pill so it lands on the title area for
+    // both layouts (large: crosspostNode body; compact: titleNode is wider than thumbnail).
+    NSUInteger pillIndex = 0;
+    CGFloat bestArea = 0;
+    for (NSUInteger i = 0; i < targets.count; i++) {
+        CGSize sz = targets[i].bounds.size;
+        CGFloat area = sz.width * sz.height;
+        if (area > bestArea) { bestArea = area; pillIndex = i; }
+    }
+
+    NSMutableArray<UIVisualEffectView *> *fresh = [NSMutableArray arrayWithCapacity:targets.count];
+    for (NSUInteger i = 0; i < targets.count; i++) {
+        UIView *target = targets[i];
+        UIVisualEffectView *overlay = ApolloTagBuildBlurOverlay();
+        CGRect f = [target.superview convertRect:target.frame toView:cellView];
+        overlay.frame = f;
+        if (i == pillIndex) {
+            UILabel *pill = ApolloTagBuildPillForLink(link);
+            if (pill) {
+                [overlay.contentView addSubview:pill];
+                [NSLayoutConstraint activateConstraints:@[
+                    [pill.centerXAnchor constraintEqualToAnchor:overlay.contentView.centerXAnchor],
+                    [pill.centerYAnchor constraintEqualToAnchor:overlay.contentView.centerYAnchor],
+                    [pill.heightAnchor constraintEqualToConstant:24],
+                ]];
+            }
+        }
+        UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:cell action:@selector(apollo_tagFilterCellTapped:)];
+        [overlay addGestureRecognizer:tap];
+        [cellView addSubview:overlay];
+        [cellView bringSubviewToFront:overlay];
+        [fresh addObject:overlay];
+    }
+    objc_setAssociatedObject(cell, kApolloTagOverlaysKey, [fresh copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static void ApolloTagRemoveBlurOverlay(id cell) {
+    NSArray<UIVisualEffectView *> *overlays = ApolloTagOverlaysForCell(cell);
+    for (UIVisualEffectView *ov in overlays) [ov removeFromSuperview];
+    objc_setAssociatedObject(cell, kApolloTagOverlaysKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+// MARK: - Apply / refresh decision
+
+static void ApolloTagApplyDecisionToCell(id cell) {
+    if (!cell) return;
+    RDKLink *link = ApolloTagLinkFromCell(cell);
+    NSString *decision = ApolloTagFilterDecisionForLink(link);
+
+    // Reset reveal flag if cell was reused for a different link.
+    void *appliedLinkPtr = (__bridge void *)link;
+    NSValue *prevValue = objc_getAssociatedObject(cell, kApolloTagAppliedLinkKey);
+    void *prevPtr = prevValue ? [prevValue pointerValue] : NULL;
+    if (prevPtr != appliedLinkPtr) {
+        objc_setAssociatedObject(cell, kApolloTagRevealedKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(cell, kApolloTagAppliedLinkKey,
+                                 [NSValue valueWithPointer:appliedLinkPtr],
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    BOOL revealed = [objc_getAssociatedObject(cell, kApolloTagRevealedKey) boolValue];
+    if (revealed) {
+        // User long-pressed; treat as no decision until cell is reused.
+        decision = @"none";
+    }
+
+    objc_setAssociatedObject(cell, kApolloTagDecisionKey, decision, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    UIView *cellView = ApolloTagCellView(cell);
+    if ([decision isEqualToString:@"blur"]) {
+        if (cellView) cellView.hidden = NO;
+        ApolloTagInstallBlurOverlay(cell, link);
+    } else {
+        if (cellView) cellView.hidden = NO;
+        ApolloTagRemoveBlurOverlay(cell);
+    }
+}
+
+// MARK: - Tap / long-press handlers (added via %new on cell hooks)
+
+static UIViewController *ApolloTagPresenterForCell(id cell) {
+    if (!cell) return nil;
+    @try {
+        UIViewController *vc = [(ApolloTagDisplayNode *)cell closestViewController];
+        if (vc) return vc;
+    } @catch (__unused id e) {}
+    UIView *view = ApolloTagCellView(cell);
+    UIWindow *window = view.window;
+    if (!window) {
+        for (UIWindow *w in [UIApplication sharedApplication].windows) {
+            if (w.isKeyWindow) { window = w; break; }
+        }
+    }
+    return [window visibleViewController];
+}
+
+static void ApolloTagRevealCell(id cell) {
+    objc_setAssociatedObject(cell, kApolloTagRevealedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(cell, kApolloTagDecisionKey, @"none", OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    NSArray<UIVisualEffectView *> *overlays = ApolloTagOverlaysForCell(cell);
+    if (overlays.count > 0) {
+        [UIView animateWithDuration:0.18 animations:^{
+            for (UIVisualEffectView *ov in overlays) ov.alpha = 0.0;
+        } completion:^(BOOL finished) {
+            ApolloTagRemoveBlurOverlay(cell);
+        }];
+    }
+}
+
+static void ApolloTagSimulateCellSelection(id cell) {
+    if (!cell) return;
+    UIViewController *presenter = ApolloTagPresenterForCell(cell);
+    if (!presenter) return;
+
+    // Walk up to find the nearest tableNode-based VC and its tableNode delegate.
+    // Apollo's PostsViewController acts as its own ASTableNode delegate, so the
+    // closestViewController already implements tableNode:didSelectRowAtIndexPath:.
+    UIView *cellView = ApolloTagCellView(cell);
+    if (!cellView) return;
+
+    // Find ASTableView (subclass of UITableView) up the view hierarchy.
+    UIView *cursor = cellView;
+    UITableView *tableView = nil;
+    while (cursor) {
+        if ([cursor isKindOfClass:[UITableView class]]) {
+            tableView = (UITableView *)cursor;
+            break;
+        }
+        cursor = cursor.superview;
+    }
+
+    NSIndexPath *indexPath = nil;
+    if (tableView) {
+        // Convert cellView center to tableView coords; ASTableView accepts UITableView API.
+        CGPoint center = [cellView.superview convertPoint:cellView.center toView:tableView];
+        indexPath = [tableView indexPathForRowAtPoint:center];
+    }
+
+    if (!indexPath) return;
+
+    // Try ASTableNode delegate selector first, then UITableView delegate.
+    SEL tableNodeSel = NSSelectorFromString(@"tableNode:didSelectRowAtIndexPath:");
+    if ([presenter respondsToSelector:tableNodeSel]) {
+        // Need the tableNode (not tableView). Fetch via tableView.delegate which
+        // for ASTableNode is the VC; the tableNode is held on the VC. Easiest:
+        // call the UITableView delegate, which Apollo also implements via ASDK.
+    }
+    SEL tableViewSel = @selector(tableView:didSelectRowAtIndexPath:);
+    if (tableView && [presenter respondsToSelector:tableViewSel]) {
+        ((void (*)(id, SEL, UITableView *, NSIndexPath *))objc_msgSend)(presenter, tableViewSel, tableView, indexPath);
+        return;
+    }
+
+    // Fallback: synthesize a tap on the cell (Apollo will react via its own gestures).
+    [tableView selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
+}
+
+static void ApolloTagPresentConfirmAlertForCell(id cell) {
+    UIViewController *presenter = ApolloTagPresenterForCell(cell);
+    if (!presenter) {
+        // No presenter — just reveal as a fallback.
+        ApolloTagRevealCell(cell);
+        return;
+    }
+
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"View hidden post?"
+                                                                   message:@"This post is filtered by your tag-filter settings. Open it anyway?"
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"View" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+        ApolloTagRevealCell(cell);
+        // Slight delay so the reveal animation completes before navigation.
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.18 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            ApolloTagSimulateCellSelection(cell);
+        });
+    }]];
+    [presenter presentViewController:alert animated:YES completion:nil];
+}
+
+// MARK: - Live updates
+
+static void ApolloTagRefreshAllVisibleCells(void) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        void (^__block walk)(UIView *) = nil;
+        void (^localWalk)(UIView *) = ^(UIView *root) {
+            if ([root isKindOfClass:[UITableView class]]) {
+                UITableView *tv = (UITableView *)root;
+                @try { [tv reloadData]; } @catch (__unused id e) {}
+            }
+            for (UIView *sub in root.subviews) walk(sub);
+        };
+        walk = localWalk;
+        for (UIWindow *window in [UIApplication sharedApplication].windows) {
+            walk(window);
+        }
+        walk = nil;
+    });
+}
+
+// MARK: - Cell hooks
+
+%hook _TtC6Apollo17LargePostCellNode
+
+- (void)didLoad {
+    %orig;
+    ApolloTagApplyDecisionToCell(self);
+}
+
+- (void)layout {
+    %orig;
+    // Re-apply on every layout (handles cell reuse, link changes, and the
+    // common case where subnode views aren't sized yet during didLoad).
+    ApolloTagApplyDecisionToCell(self);
+}
+
+%new
+- (void)apollo_tagFilterCellTapped:(UITapGestureRecognizer *)tap {
+    if (tap.state != UIGestureRecognizerStateRecognized) return;
+    ApolloTagPresentConfirmAlertForCell(self);
+}
+
+%end
+
+%hook _TtC6Apollo19CompactPostCellNode
+
+- (void)didLoad {
+    %orig;
+    ApolloTagApplyDecisionToCell(self);
+}
+
+- (void)layout {
+    %orig;
+    ApolloTagApplyDecisionToCell(self);
+}
+
+%new
+- (void)apollo_tagFilterCellTapped:(UITapGestureRecognizer *)tap {
+    if (tap.state != UIGestureRecognizerStateRecognized) return;
+    ApolloTagPresentConfirmAlertForCell(self);
+}
+
+%end
+
+// MARK: - Constructor
+
+%ctor {
+    %init(_TtC6Apollo17LargePostCellNode = objc_getClass("_TtC6Apollo17LargePostCellNode"),
+          _TtC6Apollo19CompactPostCellNode = objc_getClass("_TtC6Apollo19CompactPostCellNode"));
+
+    [[NSNotificationCenter defaultCenter] addObserverForName:ApolloTagFiltersChangedNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(NSNotification *note) {
+        ApolloTagRefreshAllVisibleCells();
+    }];
+}

--- a/ApolloTagFilters.xm
+++ b/ApolloTagFilters.xm
@@ -45,10 +45,11 @@ extern NSString *const ApolloTagFiltersChangedNotification;
 
 // MARK: - Helpers
 
-static const void *kApolloTagDecisionKey = &kApolloTagDecisionKey;       // NSString @"hide"|@"blur"|@"none"
+static const void *kApolloTagDecisionKey = &kApolloTagDecisionKey;        // NSString @"hide"|@"blur"|@"none"
 static const void *kApolloTagOverlaysKey = &kApolloTagOverlaysKey;        // NSArray<UIVisualEffectView *>
-static const void *kApolloTagRevealedKey = &kApolloTagRevealedKey;        // NSNumber BOOL
+static const void *kApolloTagRevealedKindsKey = &kApolloTagRevealedKindsKey; // NSMutableSet<NSString *> of revealed kinds (@"title", @"media")
 static const void *kApolloTagAppliedLinkKey = &kApolloTagAppliedLinkKey;  // NSValue (non-retained pointer to current link, used to detect cell reuse)
+static const void *kApolloTagOverlayKindKey = &kApolloTagOverlayKindKey;  // NSString on overlay: @"title" or @"media"
 
 static id ApolloTagIvarValueByName(id obj, const char *name) {
     if (!obj || !name) return nil;
@@ -129,42 +130,176 @@ static UIView *ApolloTagViewForNode(id node) {
     return nil;
 }
 
-// Collect the subviews we want to blur for a given cell.
-// Compact cells: thumbnailNode + titleNode (Apollo already blurs spoiler video
-//   thumbnails natively; our blur on top is harmless and keeps things consistent).
-// Large cells: crosspostNode contains title + rich media + body for both regular
-//   posts and crossposts. If unavailable, fall back to titleNode + thumbnailNode.
-static NSArray<UIView *> *ApolloTagBlurTargetsForCell(id cell) {
-    NSMutableArray<UIView *> *targets = [NSMutableArray array];
+// MARK: - Blur target geometry
+//
+// Compact cells: blur thumbnailNode + titleNode separately (these are already
+//   the only on-screen content above the action row, and Apollo natively blurs
+//   spoiler video thumbnails so a harmless extra blur on top is fine).
+//
+// Large cells: build TWO overlays — one over the title area, one over the
+//   media area — so users can tap-reveal either independently. Each overlay
+//   gets its own "kind" (@"title" / @"media"); tapping reveals only that part.
+//
+//   For SPOILER-only posts whose media is a video, Apollo already shows its
+//   own native "Spoiler — Contains spoiler – tap to watch" overlay on the
+//   video, so the media overlay is suppressed (only the title is covered).
+//   For NSFW posts, we always cover both regardless of media type.
+//
+//   Coverage uses the actual subnode frames (richMediaNode / thumbnailNode /
+//   crosspostNode→richMediaNode) extended horizontally to the cell width so
+//   gallery thumbnails that scroll past the cell edges don't bleed through.
+
+// Returns the title subnode's view, if loaded and visible.
+static UIView *ApolloTagTitleViewForCell(id cell) {
+    id node = ApolloTagIvarValueByName(cell, "titleNode");
+    UIView *v = ApolloTagViewForNode(node);
+    if (v && !v.isHidden && v.bounds.size.width > 4 && v.bounds.size.height > 4) return v;
+    return nil;
+}
+
+// Returns the media subnode's view (gallery / image / video container) and
+// optionally the underlying richMediaNode (for video detection). Tries the
+// richMediaNode-bearing ivars first, then falls back to thumbnailNode.
+static UIView *ApolloTagMediaViewForCell(id cell, id *outRichMediaNode) {
+    if (outRichMediaNode) *outRichMediaNode = nil;
+    id richMedia = ApolloTagIvarValueByName(cell, "richMediaNode");
+    if (!richMedia) {
+        id cross = ApolloTagIvarValueByName(cell, "crosspostNode");
+        if (cross) richMedia = ApolloTagIvarValueByName(cross, "richMediaNode");
+    }
+    if (richMedia) {
+        UIView *v = ApolloTagViewForNode(richMedia);
+        if (v && !v.isHidden && v.bounds.size.width > 4 && v.bounds.size.height > 4) {
+            if (outRichMediaNode) *outRichMediaNode = richMedia;
+            return v;
+        }
+    }
+    // Large Thumbnails / link-card variants: media lives on thumbnailNode.
+    id thumb = ApolloTagIvarValueByName(cell, "thumbnailNode");
+    UIView *tv = ApolloTagViewForNode(thumb);
+    if (tv && !tv.isHidden && tv.bounds.size.width > 4 && tv.bounds.size.height > 4) {
+        return tv;
+    }
+    return nil;
+}
+
+// Detect whether the rich media node currently represents a video. Apollo
+// populates the videoNode ivar on RichMediaNode for v.redd.it / Streamable /
+// hosted video / GIF posts.
+static BOOL ApolloTagMediaIsVideo(id richMediaNode) {
+    if (!richMediaNode) return NO;
+    id vn = ApolloTagIvarValueByName(richMediaNode, "videoNode");
+    return vn != nil;
+}
+
+// Returns an array of NSDictionary entries: @{ @"rect": NSValue<CGRect>, @"kind": NSString }.
+// Rects are in cellView coordinates. `kind` is one of @"title" or @"media".
+static NSArray<NSDictionary *> *ApolloTagBlurEntriesForCell(id cell, RDKLink *link) {
+    UIView *cellView = ApolloTagCellView(cell);
+    if (!cellView || cellView.bounds.size.width < 8 || cellView.bounds.size.height < 8) return @[];
+
     Class compactCls = objc_getClass("_TtC6Apollo19CompactPostCellNode");
     BOOL isCompact = compactCls && [cell isKindOfClass:compactCls];
 
-    if (!isCompact) {
-        id cross = ApolloTagIvarValueByName(cell, "crosspostNode");
-        UIView *cv = ApolloTagViewForNode(cross);
-        if (cv && !cv.isHidden && cv.bounds.size.width > 4 && cv.bounds.size.height > 4) {
-            [targets addObject:cv];
-            return targets;
+    NSMutableArray<NSDictionary *> *entries = [NSMutableArray array];
+
+    if (isCompact) {
+        // Compact: blur titleNode + (usually) thumbnailNode at their actual
+        // frames. Pill only on the title (the thumbnail is too small to wear
+        // it). For SPOILER-only posts the thumbnail is suppressed because
+        // Apollo already natively blurs spoiler thumbnails in compact mode;
+        // covering it again would just stack two grey rectangles. NSFW posts
+        // always get both.
+        BOOL compactIsNSFW = NO, compactIsSpoiler = NO;
+        @try { compactIsNSFW = link.isNSFW; } @catch (__unused id e) {}
+        @try { compactIsSpoiler = link.isSpoiler; } @catch (__unused id e) {}
+        BOOL skipCompactThumb = (!compactIsNSFW && compactIsSpoiler);
+        for (NSString *name in @[@"thumbnailNode", @"titleNode"]) {
+            BOOL isTitle = [name isEqualToString:@"titleNode"];
+            if (!isTitle && skipCompactThumb) continue;
+            id node = ApolloTagIvarValueByName(cell, name.UTF8String);
+            UIView *v = ApolloTagViewForNode(node);
+            if (v && !v.isHidden && v.bounds.size.width > 4 && v.bounds.size.height > 4) {
+                CGRect f = [v.superview convertRect:v.frame toView:cellView];
+                NSString *kind = isTitle ? @"title" : @"media";
+                [entries addObject:@{ @"rect": [NSValue valueWithCGRect:f],
+                                      @"kind": kind,
+                                      @"corner": @8.0,
+                                      @"pill": @(isTitle) }];
+            }
+        }
+        return entries;
+    }
+
+    // Large path.
+    BOOL isNSFW = NO, isSpoiler = NO;
+    @try { isNSFW = link.isNSFW; } @catch (__unused id e) {}
+    @try { isSpoiler = link.isSpoiler; } @catch (__unused id e) {}
+
+    UIView *titleView = ApolloTagTitleViewForCell(cell);
+    id richMediaNode = nil;
+    UIView *mediaView = ApolloTagMediaViewForCell(cell, &richMediaNode);
+
+    // Title overlay: title's frame stretched to full cell width so any
+    // trailing tag pills are also covered. Rounded corners look right here
+    // because the title sits inside the card padding.
+    if (titleView) {
+        CGRect tf = [titleView.superview convertRect:titleView.frame toView:cellView];
+        const CGFloat vPad = 4.0;
+        CGRect rect = CGRectMake(0,
+                                 MAX(0, CGRectGetMinY(tf) - vPad),
+                                 cellView.bounds.size.width,
+                                 CGRectGetHeight(tf) + 2 * vPad);
+        if (rect.size.width >= 40 && rect.size.height >= 16) {
+            [entries addObject:@{ @"rect": [NSValue valueWithCGRect:rect],
+                                  @"kind": @"title",
+                                  @"corner": @8.0,
+                                  @"pill": @YES }];
         }
     }
 
-    for (NSString *name in @[@"thumbnailNode", @"titleNode"]) {
-        id node = ApolloTagIvarValueByName(cell, name.UTF8String);
-        UIView *v = ApolloTagViewForNode(node);
-        if (v && !v.isHidden && v.bounds.size.width > 4 && v.bounds.size.height > 4) {
-            [targets addObject:v];
+    // Media overlay: only build it unless this is a SPOILER-only video post
+    // (Apollo's native spoiler overlay already covers the player). Square
+    // corners — the media area runs edge-to-edge and any rounding leaves a
+    // sliver of the underlying image visible in the corners.
+    BOOL skipMedia = (!isNSFW && isSpoiler && ApolloTagMediaIsVideo(richMediaNode));
+    if (!skipMedia && mediaView) {
+        CGRect mf = [mediaView.superview convertRect:mediaView.frame toView:cellView];
+        // Stretch horizontally to full cell width so a horizontally-scrollable
+        // gallery doesn't bleed past the overlay edges.
+        CGRect rect = CGRectMake(0,
+                                 CGRectGetMinY(mf),
+                                 cellView.bounds.size.width,
+                                 CGRectGetHeight(mf));
+        if (rect.size.width >= 40 && rect.size.height >= 40) {
+            [entries addObject:@{ @"rect": [NSValue valueWithCGRect:rect],
+                                  @"kind": @"media",
+                                  @"corner": @0.0,
+                                  @"pill": @YES }];
         }
     }
-    return targets;
+
+    return entries;
 }
 
-static UIVisualEffectView *ApolloTagBuildBlurOverlay(void) {
+static UIVisualEffectView *ApolloTagBuildBlurOverlay(CGFloat cornerRadius) {
     UIBlurEffect *effect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleSystemMaterialDark];
     UIVisualEffectView *overlay = [[UIVisualEffectView alloc] initWithEffect:effect];
     overlay.userInteractionEnabled = YES;
-    overlay.layer.cornerRadius = 8;
-    overlay.layer.masksToBounds = YES;
+    overlay.layer.cornerRadius = cornerRadius;
+    overlay.layer.masksToBounds = (cornerRadius > 0);
     return overlay;
+}
+
+// Returns the set of kinds (@"title" / @"media") the user has individually
+// revealed on this cell. Lazily created.
+static NSMutableSet<NSString *> *ApolloTagRevealedKindsForCell(id cell, BOOL create) {
+    NSMutableSet *set = objc_getAssociatedObject(cell, kApolloTagRevealedKindsKey);
+    if (!set && create) {
+        set = [NSMutableSet set];
+        objc_setAssociatedObject(cell, kApolloTagRevealedKindsKey, set, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    return set;
 }
 
 // Pill: NSFW = red bg / white text. SPOILER = grey bg / white text.
@@ -199,46 +334,59 @@ static void ApolloTagInstallBlurOverlay(id cell, RDKLink *link) {
     UIView *cellView = ApolloTagCellView(cell);
     if (!cellView) return;
 
-    NSArray<UIView *> *targets = ApolloTagBlurTargetsForCell(cell);
-    if (targets.count == 0) {
+    NSArray<NSDictionary *> *entries = ApolloTagBlurEntriesForCell(cell, link);
+    if (entries.count == 0) {
         // Defer: layout may not have produced subviews yet. We'll retry on next layout pass.
         return;
     }
 
+    // Suppress kinds the user has already individually revealed.
+    NSSet<NSString *> *revealedKinds = [ApolloTagRevealedKindsForCell(cell, NO) copy] ?: [NSSet set];
+    if (revealedKinds.count > 0) {
+        NSMutableArray<NSDictionary *> *filtered = [NSMutableArray arrayWithCapacity:entries.count];
+        for (NSDictionary *e in entries) {
+            if (![revealedKinds containsObject:e[@"kind"]]) [filtered addObject:e];
+        }
+        entries = filtered;
+    }
+    if (entries.count == 0) {
+        // Everything is revealed — tear down anything we still have on the cell.
+        NSArray<UIVisualEffectView *> *existing = ApolloTagOverlaysForCell(cell);
+        for (UIVisualEffectView *ov in existing) [ov removeFromSuperview];
+        objc_setAssociatedObject(cell, kApolloTagOverlaysKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return;
+    }
+
+    // Reuse path: same set of kinds → just resync frames.
     NSArray<UIVisualEffectView *> *existing = ApolloTagOverlaysForCell(cell);
-    if (existing.count == targets.count) {
-        // Reuse existing overlays; just resync frames + ensure pill stays on top.
-        for (NSUInteger i = 0; i < targets.count; i++) {
-            UIView *target = targets[i];
+    BOOL canReuse = (existing.count == entries.count);
+    if (canReuse) {
+        for (NSUInteger i = 0; i < entries.count; i++) {
+            NSString *existingKind = objc_getAssociatedObject(existing[i], kApolloTagOverlayKindKey);
+            if (![existingKind isEqualToString:entries[i][@"kind"]]) { canReuse = NO; break; }
+        }
+    }
+    if (canReuse) {
+        for (NSUInteger i = 0; i < entries.count; i++) {
             UIVisualEffectView *ov = existing[i];
-            CGRect f = [target.superview convertRect:target.frame toView:cellView];
-            ov.frame = f;
+            ov.frame = [entries[i][@"rect"] CGRectValue];
             ov.hidden = NO;
             [cellView bringSubviewToFront:ov];
         }
         return;
     }
 
-    // Tear down and rebuild if count changed.
+    // Tear down and rebuild.
     for (UIVisualEffectView *ov in existing) [ov removeFromSuperview];
 
-    // Pick the largest target for the pill so it lands on the title area for
-    // both layouts (large: crosspostNode body; compact: titleNode is wider than thumbnail).
-    NSUInteger pillIndex = 0;
-    CGFloat bestArea = 0;
-    for (NSUInteger i = 0; i < targets.count; i++) {
-        CGSize sz = targets[i].bounds.size;
-        CGFloat area = sz.width * sz.height;
-        if (area > bestArea) { bestArea = area; pillIndex = i; }
-    }
-
-    NSMutableArray<UIVisualEffectView *> *fresh = [NSMutableArray arrayWithCapacity:targets.count];
-    for (NSUInteger i = 0; i < targets.count; i++) {
-        UIView *target = targets[i];
-        UIVisualEffectView *overlay = ApolloTagBuildBlurOverlay();
-        CGRect f = [target.superview convertRect:target.frame toView:cellView];
-        overlay.frame = f;
-        if (i == pillIndex) {
+    NSMutableArray<UIVisualEffectView *> *fresh = [NSMutableArray arrayWithCapacity:entries.count];
+    for (NSUInteger i = 0; i < entries.count; i++) {
+        NSDictionary *entry = entries[i];
+        CGFloat corner = [entry[@"corner"] doubleValue];
+        UIVisualEffectView *overlay = ApolloTagBuildBlurOverlay(corner);
+        overlay.frame = [entry[@"rect"] CGRectValue];
+        objc_setAssociatedObject(overlay, kApolloTagOverlayKindKey, entry[@"kind"], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        if ([entry[@"pill"] boolValue]) {
             UILabel *pill = ApolloTagBuildPillForLink(link);
             if (pill) {
                 [overlay.contentView addSubview:pill];
@@ -271,21 +419,15 @@ static void ApolloTagApplyDecisionToCell(id cell) {
     RDKLink *link = ApolloTagLinkFromCell(cell);
     NSString *decision = ApolloTagFilterDecisionForLink(link);
 
-    // Reset reveal flag if cell was reused for a different link.
+    // Reset per-overlay revealed kinds if cell was reused for a different link.
     void *appliedLinkPtr = (__bridge void *)link;
     NSValue *prevValue = objc_getAssociatedObject(cell, kApolloTagAppliedLinkKey);
     void *prevPtr = prevValue ? [prevValue pointerValue] : NULL;
     if (prevPtr != appliedLinkPtr) {
-        objc_setAssociatedObject(cell, kApolloTagRevealedKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(cell, kApolloTagRevealedKindsKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(cell, kApolloTagAppliedLinkKey,
                                  [NSValue valueWithPointer:appliedLinkPtr],
                                  OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    }
-
-    BOOL revealed = [objc_getAssociatedObject(cell, kApolloTagRevealedKey) boolValue];
-    if (revealed) {
-        // User long-pressed; treat as no decision until cell is reused.
-        decision = @"none";
     }
 
     objc_setAssociatedObject(cell, kApolloTagDecisionKey, decision, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -318,34 +460,61 @@ static UIViewController *ApolloTagPresenterForCell(id cell) {
     return [window visibleViewController];
 }
 
-static void ApolloTagRevealCell(id cell) {
-    objc_setAssociatedObject(cell, kApolloTagRevealedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    objc_setAssociatedObject(cell, kApolloTagDecisionKey, @"none", OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    NSArray<UIVisualEffectView *> *overlays = ApolloTagOverlaysForCell(cell);
-    if (overlays.count > 0) {
+// Reveal a single overlay (by kind). The kind is added to the cell's revealed
+// set so cell-reuse / re-layout passes won't put it back. Other overlays on the
+// same cell remain.
+static void ApolloTagRevealOverlay(id cell, UIVisualEffectView *overlay, NSString *kind) {
+    if (kind.length > 0) {
+        NSMutableSet *revealed = ApolloTagRevealedKindsForCell(cell, YES);
+        [revealed addObject:kind];
+    }
+    if (overlay) {
         [UIView animateWithDuration:0.18 animations:^{
-            for (UIVisualEffectView *ov in overlays) ov.alpha = 0.0;
+            overlay.alpha = 0.0;
         } completion:^(BOOL finished) {
-            ApolloTagRemoveBlurOverlay(cell);
+            [overlay removeFromSuperview];
+            // Drop it from the cached overlays array.
+            NSArray<UIVisualEffectView *> *existing = ApolloTagOverlaysForCell(cell);
+            if (existing) {
+                NSMutableArray *remaining = [existing mutableCopy];
+                [remaining removeObject:overlay];
+                objc_setAssociatedObject(cell, kApolloTagOverlaysKey,
+                                         remaining.count > 0 ? [remaining copy] : nil,
+                                         OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            }
+            // If nothing's covered anymore, downgrade decision so future
+            // layouts don't re-evaluate as "blur" pointlessly.
+            NSArray<UIVisualEffectView *> *after = ApolloTagOverlaysForCell(cell);
+            if (after.count == 0) {
+                objc_setAssociatedObject(cell, kApolloTagDecisionKey, @"none", OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            }
         }];
     }
 }
 
-static void ApolloTagPresentConfirmAlertForCell(id cell) {
+static void ApolloTagPresentConfirmAlertForOverlay(id cell, UIVisualEffectView *overlay) {
+    NSString *kind = objc_getAssociatedObject(overlay, kApolloTagOverlayKindKey);
     UIViewController *presenter = ApolloTagPresenterForCell(cell);
     if (!presenter) {
         // No presenter — just reveal as a fallback.
-        ApolloTagRevealCell(cell);
+        ApolloTagRevealOverlay(cell, overlay, kind);
         return;
     }
 
-    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"View hidden post?"
-                                                                   message:@"This post is filtered by your tag-filter settings. Open it anyway?"
+    NSString *title = @"View hidden post?";
+    NSString *message = @"This post is filtered by your tag-filter settings. Reveal it anyway?";
+    if ([kind isEqualToString:@"title"]) {
+        message = @"Reveal the title of this filtered post?";
+    } else if ([kind isEqualToString:@"media"]) {
+        message = @"Reveal the media of this filtered post?";
+    }
+
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title
+                                                                   message:message
                                                             preferredStyle:UIAlertControllerStyleAlert];
     [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
-    [alert addAction:[UIAlertAction actionWithTitle:@"View" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
-        // Reveal only — leave navigation to the user's next tap on the now-visible cell.
-        ApolloTagRevealCell(cell);
+    [alert addAction:[UIAlertAction actionWithTitle:@"Reveal" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+        ApolloTagRevealOverlay(cell, overlay, kind);
     }]];
     [presenter presentViewController:alert animated:YES completion:nil];
 }
@@ -389,7 +558,9 @@ static void ApolloTagRefreshAllVisibleCells(void) {
 %new
 - (void)apollo_tagFilterCellTapped:(UITapGestureRecognizer *)tap {
     if (tap.state != UIGestureRecognizerStateRecognized) return;
-    ApolloTagPresentConfirmAlertForCell(self);
+    UIVisualEffectView *overlay = nil;
+    if ([tap.view isKindOfClass:[UIVisualEffectView class]]) overlay = (UIVisualEffectView *)tap.view;
+    ApolloTagPresentConfirmAlertForOverlay(self, overlay);
 }
 
 %end
@@ -409,7 +580,9 @@ static void ApolloTagRefreshAllVisibleCells(void) {
 %new
 - (void)apollo_tagFilterCellTapped:(UITapGestureRecognizer *)tap {
     if (tap.state != UIGestureRecognizerStateRecognized) return;
-    ApolloTagPresentConfirmAlertForCell(self);
+    UIVisualEffectView *overlay = nil;
+    if ([tap.view isKindOfClass:[UIVisualEffectView class]]) overlay = (UIVisualEffectView *)tap.view;
+    ApolloTagPresentConfirmAlertForOverlay(self, overlay);
 }
 
 %end

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,11 @@ ApolloImprovedCustomApi_FILES = \
     ApolloTranslation.xm \
     ApolloVideoUnmute.xm \
     ApolloVideoSwipeFix.xm \
-    ApolloCreatedAtAlert.xm \
+    ApolloTagFilters.xm \
     CustomAPIViewController.m \
     TranslationSettingsViewController.m \
     SavedCategoriesViewController.m \
+    TagFiltersViewController.m \
     Defaults.m \
     UIWindow+Apollo.m \
     fishhook.c \

--- a/TagFiltersViewController.h
+++ b/TagFiltersViewController.h
@@ -1,0 +1,4 @@
+#import <UIKit/UIKit.h>
+
+@interface TagFiltersViewController : UITableViewController
+@end

--- a/TagFiltersViewController.m
+++ b/TagFiltersViewController.m
@@ -1,0 +1,345 @@
+#import "TagFiltersViewController.h"
+
+#import "ApolloState.h"
+#import "UserDefaultConstants.h"
+
+extern NSString *const ApolloTagFiltersChangedNotification;
+NSString *const ApolloTagFiltersChangedNotification = @"ApolloTagFiltersChangedNotification";
+
+typedef NS_ENUM(NSInteger, TagFiltersSection) {
+    TagFiltersSectionGeneral = 0,    // Enable / Mode / NSFW / Spoiler
+    TagFiltersSectionOverrides,      // Per-subreddit list + "Add Subreddit…"
+    TagFiltersSectionCount,
+};
+
+#pragma mark - Per-subreddit detail VC
+
+@interface TagFilterSubredditDetailViewController : UITableViewController
+@property (nonatomic, copy) NSString *subredditName;   // lowercased
+@property (nonatomic, copy) void (^onChange)(void);
+@end
+
+@implementation TagFilterSubredditDetailViewController
+
+- (instancetype)initWithSubreddit:(NSString *)subreddit {
+    self = [super initWithStyle:UITableViewStyleInsetGrouped];
+    if (self) {
+        _subredditName = [[subreddit stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+    }
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = [NSString stringWithFormat:@"r/%@", self.subredditName];
+}
+
+- (NSDictionary *)currentOverride {
+    NSDictionary *all = sTagFilterSubredditOverrides;
+    NSDictionary *o = all[self.subredditName];
+    return [o isKindOfClass:[NSDictionary class]] ? o : @{};
+}
+
+- (void)updateOverrideWithBlock:(void (^)(NSMutableDictionary *override))block {
+    NSMutableDictionary *all = [(sTagFilterSubredditOverrides ?: @{}) mutableCopy];
+    NSMutableDictionary *o = [([self currentOverride] ?: @{}) mutableCopy];
+    if (block) block(o);
+    if (o.count > 0) {
+        all[self.subredditName] = [o copy];
+    } else {
+        [all removeObjectForKey:self.subredditName];
+    }
+    sTagFilterSubredditOverrides = [all copy];
+    [[NSUserDefaults standardUserDefaults] setObject:sTagFilterSubredditOverrides forKey:UDKeyTagFilterSubredditOverrides];
+    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloTagFiltersChangedNotification object:nil];
+    if (self.onChange) self.onChange();
+}
+
+- (BOOL)effectiveBoolForKey:(NSString *)key globalDefault:(BOOL)globalDefault {
+    NSDictionary *o = [self currentOverride];
+    id v = o[key];
+    if ([v isKindOfClass:[NSNumber class]]) return [(NSNumber *)v boolValue];
+    return globalDefault;
+}
+
+#pragma mark - Table
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView { return 3; }
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    if (section == 0) return 2; // NSFW, Spoiler
+    if (section == 1) return 1; // Reset
+    return 1;                   // Delete
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
+    if (section == 0) return @"Filter";
+    return nil;
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
+    if (section == 0) return @"Per-subreddit settings override the global defaults. Toggles match what you'd set globally.";
+    if (section == 1) return @"Reset clears overrides for this subreddit (it will follow global settings again).";
+    return nil;
+}
+
+- (UITableViewCell *)switchCellLabel:(NSString *)label on:(BOOL)on action:(SEL)action {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+    cell.textLabel.text = label;
+    UISwitch *sw = [[UISwitch alloc] init];
+    sw.on = on;
+    [sw addTarget:self action:action forControlEvents:UIControlEventValueChanged];
+    cell.accessoryView = sw;
+    return cell;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == 0) {
+        if (indexPath.row == 0) return [self switchCellLabel:@"NSFW"
+                                                          on:[self effectiveBoolForKey:@"nsfw" globalDefault:sTagFilterNSFW]
+                                                      action:@selector(nsfwChanged:)];
+        return [self switchCellLabel:@"Spoiler"
+                                  on:[self effectiveBoolForKey:@"spoiler" globalDefault:sTagFilterSpoiler]
+                              action:@selector(spoilerChanged:)];
+    }
+    if (indexPath.section == 1) {
+        UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+        cell.textLabel.text = @"Reset to Global Defaults";
+        cell.textLabel.textColor = [UIColor systemBlueColor];
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
+        return cell;
+    }
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    cell.textLabel.text = @"Remove Subreddit Override";
+    cell.textLabel.textColor = [UIColor systemRedColor];
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
+    return cell;
+}
+
+- (void)nsfwChanged:(UISwitch *)sw {
+    [self updateOverrideWithBlock:^(NSMutableDictionary *o) { o[@"nsfw"] = @(sw.on); }];
+}
+
+- (void)spoilerChanged:(UISwitch *)sw {
+    [self updateOverrideWithBlock:^(NSMutableDictionary *o) { o[@"spoiler"] = @(sw.on); }];
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    if (indexPath.section == 1) {
+        [self updateOverrideWithBlock:^(NSMutableDictionary *o) {
+            [o removeAllObjects];
+        }];
+        [self.tableView reloadData];
+        return;
+    }
+    if (indexPath.section == 2) {
+        [self updateOverrideWithBlock:^(NSMutableDictionary *o) {
+            [o removeAllObjects];
+        }];
+        [self.navigationController popViewControllerAnimated:YES];
+    }
+}
+
+@end
+
+#pragma mark - Main TagFiltersViewController
+
+@interface TagFiltersViewController () <UITextFieldDelegate>
+@end
+
+@implementation TagFiltersViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Tag Filters";
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.tableView reloadData];
+}
+
+#pragma mark - Helpers
+
+- (NSArray<NSString *> *)overrideSubreddits {
+    NSDictionary *all = sTagFilterSubredditOverrides ?: @{};
+    return [[all allKeys] sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
+}
+
+- (void)postChange {
+    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloTagFiltersChangedNotification object:nil];
+}
+
+#pragma mark - Section / row counts
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView { return TagFiltersSectionCount; }
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    if (section == TagFiltersSectionGeneral) return 3;  // Enable / NSFW / Spoiler
+    if (section == TagFiltersSectionOverrides) return [self overrideSubreddits].count + 1; // + "Add"
+    return 0;
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
+    if (section == TagFiltersSectionGeneral) return @"General";
+    if (section == TagFiltersSectionOverrides) return @"Per-Subreddit Overrides";
+    return nil;
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
+    if (section == TagFiltersSectionGeneral) {
+        return @"Filtered posts are covered with a frosted blur over the post's title and thumbnail. Tap the blur to confirm and reveal the post. Brand Affiliate is unavailable because Apollo does not store that tag.";
+    }
+    if (section == TagFiltersSectionOverrides) {
+        return @"Per-subreddit settings override the global defaults. Add a subreddit to customize behavior for it.";
+    }
+    return nil;
+}
+
+#pragma mark - Cells
+
+- (UITableViewCell *)switchCellLabel:(NSString *)label on:(BOOL)on enabled:(BOOL)enabled action:(SEL)action {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+    cell.textLabel.text = label;
+    cell.textLabel.enabled = enabled;
+    UISwitch *sw = [[UISwitch alloc] init];
+    sw.on = on;
+    sw.enabled = enabled;
+    [sw addTarget:self action:action forControlEvents:UIControlEventValueChanged];
+    cell.accessoryView = sw;
+    return cell;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == TagFiltersSectionGeneral) {
+        switch (indexPath.row) {
+            case 0:
+                return [self switchCellLabel:@"Enable Tag Filters" on:sTagFilterEnabled enabled:YES action:@selector(enableChanged:)];
+            case 1: return [self switchCellLabel:@"NSFW" on:sTagFilterNSFW enabled:sTagFilterEnabled action:@selector(nsfwChanged:)];
+            case 2: return [self switchCellLabel:@"Spoiler" on:sTagFilterSpoiler enabled:sTagFilterEnabled action:@selector(spoilerChanged:)];
+        }
+    }
+
+    if (indexPath.section == TagFiltersSectionOverrides) {
+        NSArray<NSString *> *subs = [self overrideSubreddits];
+        if ((NSUInteger)indexPath.row < subs.count) {
+            NSString *sub = subs[indexPath.row];
+            UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:nil];
+            cell.textLabel.text = [NSString stringWithFormat:@"r/%@", sub];
+            cell.detailTextLabel.text = [self summaryForOverride:sub];
+            cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+            return cell;
+        }
+        UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+        cell.textLabel.text = @"Add Subreddit…";
+        cell.textLabel.textColor = [UIColor systemBlueColor];
+        return cell;
+    }
+
+    return [[UITableViewCell alloc] init];
+}
+
+- (NSString *)summaryForOverride:(NSString *)sub {
+    NSDictionary *o = sTagFilterSubredditOverrides[sub];
+    if (![o isKindOfClass:[NSDictionary class]]) return @"(no overrides)";
+    NSMutableArray<NSString *> *parts = [NSMutableArray array];
+    if ([o[@"nsfw"] isKindOfClass:[NSNumber class]]) [parts addObject:[NSString stringWithFormat:@"NSFW: %@", [o[@"nsfw"] boolValue] ? @"on" : @"off"]];
+    if ([o[@"spoiler"] isKindOfClass:[NSNumber class]]) [parts addObject:[NSString stringWithFormat:@"Spoiler: %@", [o[@"spoiler"] boolValue] ? @"on" : @"off"]];
+    if (parts.count == 0) return @"(uses global)";
+    return [parts componentsJoinedByString:@" · "];
+}
+
+#pragma mark - Switch handlers
+
+- (void)enableChanged:(UISwitch *)sw {
+    sTagFilterEnabled = sw.on;
+    [[NSUserDefaults standardUserDefaults] setBool:sw.on forKey:UDKeyTagFilterEnabled];
+    [self postChange];
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:TagFiltersSectionGeneral] withRowAnimation:UITableViewRowAnimationNone];
+}
+
+- (void)nsfwChanged:(UISwitch *)sw {
+    sTagFilterNSFW = sw.on;
+    [[NSUserDefaults standardUserDefaults] setBool:sw.on forKey:UDKeyTagFilterNSFW];
+    [self postChange];
+}
+
+- (void)spoilerChanged:(UISwitch *)sw {
+    sTagFilterSpoiler = sw.on;
+    [[NSUserDefaults standardUserDefaults] setBool:sw.on forKey:UDKeyTagFilterSpoiler];
+    [self postChange];
+}
+
+#pragma mark - Selection
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+
+    if (indexPath.section == TagFiltersSectionOverrides) {
+        NSArray<NSString *> *subs = [self overrideSubreddits];
+        if ((NSUInteger)indexPath.row < subs.count) {
+            TagFilterSubredditDetailViewController *detail = [[TagFilterSubredditDetailViewController alloc] initWithSubreddit:subs[indexPath.row]];
+            __weak typeof(self) wself = self;
+            detail.onChange = ^{ [wself.tableView reloadData]; };
+            [self.navigationController pushViewController:detail animated:YES];
+        } else {
+            [self presentAddSubredditPrompt];
+        }
+    }
+}
+
+- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section != TagFiltersSectionOverrides) return NO;
+    return (NSUInteger)indexPath.row < [self overrideSubreddits].count;
+}
+
+- (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (editingStyle != UITableViewCellEditingStyleDelete) return;
+    NSArray<NSString *> *subs = [self overrideSubreddits];
+    if ((NSUInteger)indexPath.row >= subs.count) return;
+    NSString *sub = subs[indexPath.row];
+    NSMutableDictionary *all = [(sTagFilterSubredditOverrides ?: @{}) mutableCopy];
+    [all removeObjectForKey:sub];
+    sTagFilterSubredditOverrides = [all copy];
+    [[NSUserDefaults standardUserDefaults] setObject:all forKey:UDKeyTagFilterSubredditOverrides];
+    [self postChange];
+    [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+}
+
+- (void)presentAddSubredditPrompt {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Add Subreddit"
+                                                                   message:@"Enter the subreddit name (without r/)."
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField *tf) {
+        tf.placeholder = @"funny";
+        tf.autocapitalizationType = UITextAutocapitalizationTypeNone;
+        tf.autocorrectionType = UITextAutocorrectionTypeNo;
+    }];
+    __weak UIAlertController *weakAlert = alert;
+    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Add" style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) {
+        UITextField *tf = weakAlert.textFields.firstObject;
+        NSString *raw = [tf.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        if ([raw hasPrefix:@"r/"] || [raw hasPrefix:@"R/"]) raw = [raw substringFromIndex:2];
+        if ([raw hasPrefix:@"/"]) raw = [raw substringFromIndex:1];
+        NSString *sub = raw.lowercaseString;
+        if (sub.length == 0) return;
+        NSMutableDictionary *all = [(sTagFilterSubredditOverrides ?: @{}) mutableCopy];
+        if (!all[sub]) all[sub] = @{}; // empty overrides; opens detail to configure
+        sTagFilterSubredditOverrides = [all copy];
+        [[NSUserDefaults standardUserDefaults] setObject:all forKey:UDKeyTagFilterSubredditOverrides];
+        [self postChange];
+        [self.tableView reloadData];
+        TagFilterSubredditDetailViewController *detail = [[TagFilterSubredditDetailViewController alloc] initWithSubreddit:sub];
+        __weak typeof(self) wself = self;
+        detail.onChange = ^{ [wself.tableView reloadData]; };
+        [self.navigationController pushViewController:detail animated:YES];
+    }]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+@end

--- a/Tweak.h
+++ b/Tweak.h
@@ -27,6 +27,7 @@
 @property(nonatomic) NSInteger totalComments;
 @property(nonatomic, strong) NSDate *createdUTC;
 @property(nonatomic, getter=isNSFW) BOOL NSFW;
+@property(nonatomic, getter=isSpoiler) BOOL spoiler;
 @property(nonatomic, getter=isSelfPost) BOOL selfPost;
 @property(retain, nonatomic) NSDictionary *mediaMetadata;
 @property(retain, nonatomic) RDKLinkPreviewMedia *previewMedia;

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -763,7 +763,12 @@ static void initializeRandomSources() {
                                     UDKeyTranslationProviderUserSelected: @NO,
                                     UDKeyLibreTranslateURL: @"https://libretranslate.de/translate",
                                     UDKeyLibreTranslateAPIKey: @"",
-                                    UDKeyTranslationSkipLanguages: @[]};
+                                    UDKeyTranslationSkipLanguages: @[],
+                                    UDKeyTagFilterEnabled: @NO,
+                                    UDKeyTagFilterMode: @"blur",
+                                    UDKeyTagFilterNSFW: @YES,
+                                    UDKeyTagFilterSpoiler: @YES,
+                                    UDKeyTagFilterSubredditOverrides: @{}};
     [[NSUserDefaults standardUserDefaults] registerDefaults:defaultValues];
 
     sRedditClientId = (NSString *)[[[NSUserDefaults standardUserDefaults] objectForKey:UDKeyRedditClientId] ?: @"" copy];
@@ -826,6 +831,34 @@ static void initializeRandomSources() {
             }
         }
         sTranslationSkipLanguages = [clean copy];
+    }
+
+    // Tag filter feature hydration.
+    sTagFilterEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyTagFilterEnabled];
+    sTagFilterNSFW = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyTagFilterNSFW];
+    sTagFilterSpoiler = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyTagFilterSpoiler];
+    {
+        NSString *mode = (NSString *)[[NSUserDefaults standardUserDefaults] objectForKey:UDKeyTagFilterMode];
+        if ([mode isKindOfClass:[NSString class]] && ([mode isEqualToString:@"hide"] || [mode isEqualToString:@"blur"])) {
+            sTagFilterMode = [mode copy];
+        } else {
+            sTagFilterMode = @"blur";
+        }
+    }
+    {
+        id raw = [[NSUserDefaults standardUserDefaults] objectForKey:UDKeyTagFilterSubredditOverrides];
+        NSMutableDictionary<NSString *, NSDictionary *> *clean = [NSMutableDictionary dictionary];
+        if ([raw isKindOfClass:[NSDictionary class]]) {
+            for (id key in (NSDictionary *)raw) {
+                if (![key isKindOfClass:[NSString class]]) continue;
+                NSString *sub = [(NSString *)key stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].lowercaseString;
+                if (sub.length == 0) continue;
+                id v = ((NSDictionary *)raw)[key];
+                if (![v isKindOfClass:[NSDictionary class]]) continue;
+                clean[sub] = (NSDictionary *)v;
+            }
+        }
+        sTagFilterSubredditOverrides = [clean copy];
     }
 
     // Trim ReadPostIDs if over configured max

--- a/UserDefaultConstants.h
+++ b/UserDefaultConstants.h
@@ -30,3 +30,18 @@ static NSString *const UDKeyLibreTranslateURL = @"LibreTranslateURL";
 static NSString *const UDKeyLibreTranslateAPIKey = @"LibreTranslateAPIKey";
 // Array<String> of 2-letter language codes to leave untranslated (detected source language).
 static NSString *const UDKeyTranslationSkipLanguages = @"TranslationSkipLanguages";
+
+// Tag filters (NSFW / Spoiler) — hide or blur posts in the feed based on
+// Reddit's built-in tags. Brand Affiliate is intentionally absent because
+// Apollo's RDKLink does not deserialize that field.
+static NSString *const UDKeyTagFilterEnabled = @"TagFilterEnabled";        // master switch
+static NSString *const UDKeyTagFilterMode = @"TagFilterMode";              // "hide" | "blur"
+static NSString *const UDKeyTagFilterNSFW = @"TagFilterNSFW";              // global NSFW
+static NSString *const UDKeyTagFilterSpoiler = @"TagFilterSpoiler";        // global Spoiler
+// Per-subreddit overrides: dictionary keyed by lowercased subreddit name.
+// Each value is a dictionary with optional keys:
+//   "nsfw"    -> NSNumber BOOL  (overrides global NSFW for this sub)
+//   "spoiler" -> NSNumber BOOL  (overrides global Spoiler for this sub)
+//   "mode"    -> NSString       ("hide" | "blur"; overrides global mode)
+// Missing keys fall back to global settings.
+static NSString *const UDKeyTagFilterSubredditOverrides = @"TagFilterSubredditOverrides";

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: ca.jeffrey.apollo-improvedcustomapi
 Name: Apollo-ImprovedCustomApi
-Version: 2.6.1
+Version: 2.6.6
 Architecture: iphoneos-arm
 Description: Apollo for Reddit tweak with in-app configurable API keys
 Maintainer: JeffreyCA


### PR DESCRIPTION
Adds a new **Tag Filters** screen under Settings that frosts a blur over NSFW and/or Spoiler posts in any feed (home, subreddit, search, profile). Tap the blur for a small confirm-and-reveal alert ("View hidden post?"). Per-subreddit overrides let you flip NSFW or Spoiler on/off for individual subs.

## How this is different from the existing NSFW setting

Apollo's existing **"Hide NSFW in Recently Read"** toggle (added by `ApolloRecentlyRead.xm`) only affects the in-app *Recently Read* history list. It doesn't touch what shows up in actual feeds.

This Tag Filter feature is the opposite: it doesn't touch Recently Read at all, it covers posts in the live feed listings as you browse. The two settings are independent and can be used together.

It also doesn't fight Apollo's native NSFW splash on the media viewer — that's left alone, the blur is purely a feed-level cover.

## What it does

- Settings -> **Tag Filters** (red `eye.slash.fill` icon, sits with the other custom rows)
- Three global rows: **Enable**, **NSFW**, **Spoiler**
- A **Per-subreddit overrides** section where you can add a sub and override either tag
- In feeds, matching posts get a `UIBlurEffectStyleSystemMaterialDark` overlay scoped to the post's content (thumbnail + title for compact, the rich-media node for large), with a small **NSFW** (red) or **SPOILER** (grey) pill centered on the largest covered area. NSFW wins when both apply.
- Tap the blur -> "View hidden post?" alert -> "View" reveals just that post (next tap on the now-visible cell opens it normally).

## Why blur and not hide

An earlier draft included a "hide" mode that fully removed filtered cells. ASTableNode caches its row sizes outside the standard `UITableView` delegate path, so collapsing a single cell mid-feed left a stubborn empty gap. Blur sidesteps the layout problem entirely and keeps the feed scroll position stable, so that's the only mode shipped here.

## Implementation notes

All new code:
- `ApolloTagFilters.xm` — hooks `_TtC6Apollo17LargePostCellNode` and `_TtC6Apollo19CompactPostCellNode` (`didLoad` + `layout`), reads `nsfw` / `spoiler` off `RDKLink`, builds the overlays, manages the tap gesture, drives reveal.
- `TagFiltersViewController.{h,m}` — the settings screen + per-sub override editor, stores into the existing app-group `NSUserDefaults`.
- `ApolloSettings.xm` — injects the new row into Apollo's Settings table, alongside the other custom rows.
- `ApolloState.{h,m}` + `UserDefaultConstants.h` + `Tweak.xm` `%ctor` — hydrates the global flags + per-sub overrides dictionary on launch and on a `Darwin` change notification posted by the settings VC, so toggles take effect without an app restart.
- `Makefile` — registers the two new sources.

No new entitlements, no network, no changes to existing behavior when the master toggle is off.



