### PR TITLE
Add Bosnian to Don't Translate list

### DIFF
--- a/TranslationSettingsViewController.m
+++ b/TranslationSettingsViewController.m
@@ -52,6 +52,7 @@ static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguag
             @{@"code": @"cs", @"name": @"Czech"},
             @{@"code": @"ro", @"name": @"Romanian"},
             @{@"code": @"hu", @"name": @"Hungarian"},
+            @{@"code": @"bs", @"name": @"Bosnian"},
         ];
     });
     return options;


### PR DESCRIPTION
Adds Bosnian (`bs`) to the "Don't Translate" language list in `TranslationSettingsViewController.m`, so users can exclude Bosnian from automatic translation.