### PR TITLE
patch: include prebuilt Liquid Glass asset catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ You can use `patch.sh` or the GitHub action mentioned below to add URL schemes.
 
 `patch.sh` and the **Patch IPA** GitHub Action can apply optional patches (Liquid Glass for iOS 26, custom URL schemes) to Apollo IPAs. These do **not** inject the tweak itself.
 
+The Liquid Glass patch now also replaces Apollo's compiled `Assets.car` with a prebuilt catalog that includes the `ApolloLiquidGlass` app icon, and updates the primary app icon name in `Info.plist`.
+
 ```bash
 ./patch.sh <path_to_ipa> [--liquid-glass] [--url-schemes <schemes>] [--remove-code-signature] [-o <output>]
 ```

--- a/patch.sh
+++ b/patch.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIQUID_GLASS_ASSETS_CAR="${SCRIPT_DIR}/patch-assets/liquid-glass/ApolloLiquidGlass/Assets.car"
+LIQUID_GLASS_ICON_NAME="ApolloLiquidGlass"
+
 # Cleanup on exit (success or failure)
 cleanup() {
     if [ -d "extract_temp" ]; then
@@ -140,6 +144,21 @@ if [ "${LIQUID_GLASS}" == "true" ]; then
         echo "Removing duplicate @executable_path/Frameworks LC_RPATH entry..."
         install_name_tool -delete_rpath "@executable_path/Frameworks" "${EXECUTABLE_NAME}"
         echo "Duplicate LC_RPATH entry removed"
+    fi
+
+    if [ ! -f "${LIQUID_GLASS_ASSETS_CAR}" ]; then
+        echo "Error: Liquid Glass asset catalog not found at ${LIQUID_GLASS_ASSETS_CAR}"
+        exit 1
+    fi
+
+    echo "Replacing Assets.car with prebuilt Liquid Glass asset catalog..."
+    cp "${LIQUID_GLASS_ASSETS_CAR}" "Assets.car"
+
+    echo "Updating primary app icon name to ${LIQUID_GLASS_ICON_NAME}..."
+    /usr/libexec/PlistBuddy -c "Set :CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconName ${LIQUID_GLASS_ICON_NAME}" "Info.plist"
+
+    if /usr/libexec/PlistBuddy -c "Print :CFBundleIcons~ipad:CFBundlePrimaryIcon:CFBundleIconName" "Info.plist" &>/dev/null; then
+        /usr/libexec/PlistBuddy -c "Set :CFBundleIcons~ipad:CFBundlePrimaryIcon:CFBundleIconName ${LIQUID_GLASS_ICON_NAME}" "Info.plist"
     fi
 fi
 


### PR DESCRIPTION
  ## Summary

  This extends the existing `--liquid-glass` patch flow so it also enables Apollo's new Liquid Glass app icon on iOS 26.

  The icon was built with Apple's Icon Composer and compiled into a prebuilt `Assets.car`, which is now swapped into the app bundle as part of the Liquid Glass patch path.

  `.icon` source provided by @iGerman00.

  ## What this does

  When `--liquid-glass` is used, the patch now also:

  - replaces Apollo's compiled `Assets.car` with a prebuilt catalog containing the Liquid Glass app icon
  - updates the primary app icon name in `Info.plist` to `ApolloLiquidGlass` for iPhone
  - updates the primary app icon name in `Info.plist` to `ApolloLiquidGlass` for iPad when present

  This means Liquid Glass builds now get the matching iOS 26-style app icon automatically, without requiring any extra manual steps.

  ## Why this approach

  This keeps the feature easy to use for both end users and CI:

  - no Icon Composer setup required
  - no `.icon` compilation step required during patching
  - no asset reconstruction workflow required
  - no additional workflow flags needed

  The repo already exposes `--liquid-glass` as the user-facing switch, so bundling the icon/catalog change into that path keeps the behavior straightforward.

  ## Scope

  This PR is intentionally narrow:

  - adds the prebuilt Liquid Glass asset catalog artifact
  - updates `patch.sh` to install it during `--liquid-glass`
  - updates README documentation

  It does not change:

  - tweak injection logic
  - workflow structure
  - signing behavior
  - the existing non-Liquid-Glass patch path

  ## Attribution

  - `.icon` source provided by @iGerman00

  ## Local verification

  Tested locally against a clean Apollo IPA and verified that:

  - `patch.sh --liquid-glass` completes successfully
  - the patched IPA embeds the committed prebuilt `Assets.car`
  - both primary app icon plist entries are updated to `ApolloLiquidGlass`

## Video


https://github.com/user-attachments/assets/a352c695-f700-4138-afa6-7bcd2a1aa06c


