### PR TITLE
Add Liquid Glass patch support for Liquid Glass .icons

### DIFF
--- a/CustomAPIViewController.m
+++ b/CustomAPIViewController.m
@@ -13,7 +13,6 @@ typedef NS_ENUM(NSInteger, SectionIndex) {
     SectionBackupRestore = 0,
     SectionAPIKeys,
     SectionGeneral,
-    SectionAppearance,
     SectionMedia,
     SectionSubreddits,
     SectionCredits,
@@ -34,11 +33,6 @@ typedef NS_ENUM(NSInteger, Tag) {
     TagTrendingLimit,
     TagReadPostMaxCount,
 };
-
-static NSString *const kLiquidGlassPrimaryIconIdentifier = @"jryng";
-static NSString *const kLiquidGlassAlternateIconIdentifierJryngAlt = @"jryng-alt";
-static NSString *const kLiquidGlassAlternateIconIdentifierIgerman00 = @"igerman00";
-static NSString *const kLiquidGlassAlternateIconIdentifierMetalnakls = @"metalnakls";
 
 #pragma mark - Helpers
 
@@ -192,135 +186,6 @@ static NSString *const kLiquidGlassAlternateIconIdentifierMetalnakls = @"metalna
     }
 }
 
-- (NSArray<NSDictionary<NSString *, NSString *> *> *)liquidGlassIconOptions {
-    return @[
-        @{@"id": kLiquidGlassPrimaryIconIdentifier, @"title": @"jryng"},
-        @{@"id": kLiquidGlassAlternateIconIdentifierJryngAlt, @"title": @"jryng-alt"},
-        @{@"id": kLiquidGlassAlternateIconIdentifierIgerman00, @"title": @"igerman00"},
-        @{@"id": kLiquidGlassAlternateIconIdentifierMetalnakls, @"title": @"metalnakls"},
-    ];
-}
-
-- (BOOL)shouldUseLiquidGlassIcon {
-    return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseLiquidGlassIcon];
-}
-
-- (NSString *)storedLiquidGlassIconIdentifier {
-    NSString *iconIdentifier = [[NSUserDefaults standardUserDefaults] stringForKey:UDKeyLiquidGlassSelectedIcon];
-    return iconIdentifier.length > 0 ? iconIdentifier : kLiquidGlassPrimaryIconIdentifier;
-}
-
-- (void)setStoredLiquidGlassIconIdentifier:(NSString *)iconIdentifier {
-    [[NSUserDefaults standardUserDefaults] setObject:iconIdentifier forKey:UDKeyLiquidGlassSelectedIcon];
-}
-
-- (NSString *)displayNameForLiquidGlassIconIdentifier:(NSString *)iconIdentifier {
-    for (NSDictionary<NSString *, NSString *> *option in [self liquidGlassIconOptions]) {
-        if ([option[@"id"] isEqualToString:iconIdentifier]) {
-            return option[@"title"];
-        }
-    }
-    return iconIdentifier;
-}
-
-- (NSString *)currentLiquidGlassIconText {
-    return [self displayNameForLiquidGlassIconIdentifier:[self storedLiquidGlassIconIdentifier]];
-}
-
-- (void)reloadLiquidGlassIconRow {
-    NSIndexSet *appearanceSection = [NSIndexSet indexSetWithIndex:SectionAppearance];
-    [self.tableView reloadSections:appearanceSection withRowAnimation:UITableViewRowAnimationAutomatic];
-}
-
-- (void)applyLiquidGlassIconStateEnabled:(BOOL)enabled iconIdentifier:(NSString *)iconIdentifier {
-    UIApplication *application = UIApplication.sharedApplication;
-    if (![application supportsAlternateIcons]) {
-        [self showAlertWithTitle:@"Unavailable" message:@"This Apollo build does not expose alternate app icons."];
-        return;
-    }
-
-    NSString *effectiveIconIdentifier = iconIdentifier.length > 0 ? iconIdentifier : [self storedLiquidGlassIconIdentifier];
-    NSString *requestedIconName = enabled ? effectiveIconIdentifier : nil;
-    NSString *storedIconIdentifier = [self storedLiquidGlassIconIdentifier];
-    BOOL storedEnabled = [self shouldUseLiquidGlassIcon];
-    BOOL isUnchanged = (storedEnabled == enabled) && (!enabled || [storedIconIdentifier isEqualToString:effectiveIconIdentifier]);
-    if (isUnchanged) {
-        if (enabled) {
-            [self setStoredLiquidGlassIconIdentifier:effectiveIconIdentifier];
-        }
-        [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:UDKeyUseLiquidGlassIcon];
-        [self reloadLiquidGlassIconRow];
-        return;
-    }
-
-    __weak __typeof__(self) weakSelf = self;
-    [application setAlternateIconName:requestedIconName completionHandler:^(NSError *error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            __strong __typeof__(weakSelf) strongSelf = weakSelf;
-            if (!strongSelf) return;
-
-            if (error) {
-                [strongSelf showAlertWithTitle:@"Couldn't Change Icon" message:error.localizedDescription ?: @"Unknown error."];
-                return;
-            }
-
-            [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:UDKeyUseLiquidGlassIcon];
-            if (enabled) {
-                [strongSelf setStoredLiquidGlassIconIdentifier:effectiveIconIdentifier];
-            }
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)),
-                           dispatch_get_main_queue(), ^{
-                [strongSelf reloadLiquidGlassIconRow];
-            });
-        });
-    }];
-}
-
-- (void)setLiquidGlassIconIdentifier:(NSString *)iconIdentifier {
-    [self applyLiquidGlassIconStateEnabled:YES iconIdentifier:iconIdentifier];
-}
-
-- (void)liquidGlassIconSwitchToggled:(UISwitch *)sender {
-    [self applyLiquidGlassIconStateEnabled:sender.isOn iconIdentifier:[self storedLiquidGlassIconIdentifier]];
-}
-
-- (void)presentLiquidGlassIconSheetFromSourceView:(UIView *)sourceView {
-    UIApplication *application = UIApplication.sharedApplication;
-    if (![application supportsAlternateIcons]) {
-        [self showAlertWithTitle:@"Unavailable" message:@"This Apollo build does not expose alternate app icons."];
-        return;
-    }
-
-    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Liquid Glass App Icon"
-                                                                   message:@"Choose which Liquid Glass icon Apollo should use."
-                                                            preferredStyle:UIAlertControllerStyleActionSheet];
-
-    NSString *currentIconIdentifier = [self storedLiquidGlassIconIdentifier];
-    for (NSDictionary<NSString *, NSString *> *option in [self liquidGlassIconOptions]) {
-        NSString *iconIdentifier = option[@"id"];
-        NSString *title = option[@"title"];
-        if ([iconIdentifier isEqualToString:currentIconIdentifier]) {
-            title = [title stringByAppendingString:@" (Current)"];
-        }
-
-        [sheet addAction:[UIAlertAction actionWithTitle:title
-                                                  style:UIAlertActionStyleDefault
-                                                handler:^(__unused UIAlertAction *action) {
-            [self setLiquidGlassIconIdentifier:iconIdentifier];
-        }]];
-    }
-
-    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
-
-    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
-    if (popover && sourceView) {
-        popover.sourceView = sourceView;
-        popover.sourceRect = sourceView.bounds;
-    }
-
-    [self presentViewController:sheet animated:YES completion:nil];
-}
-
 - (void)setImageUploadProvider:(NSInteger)provider {
     sImageUploadProvider = provider;
     [[NSUserDefaults standardUserDefaults] setInteger:sImageUploadProvider forKey:UDKeyImageUploadProvider];
@@ -365,11 +230,6 @@ static NSString *const kLiquidGlassAlternateIconIdentifierMetalnakls = @"metalna
     self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-    [self.tableView reloadData];
-}
-
 #pragma mark - UITableViewDataSource
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
@@ -381,7 +241,6 @@ static NSString *const kLiquidGlassAlternateIconIdentifierMetalnakls = @"metalna
         case SectionBackupRestore: return 2;
         case SectionAPIKeys: return 6; // 4 text fields + Can't sign in? + Instructions
         case SectionGeneral: return 8;
-        case SectionAppearance: return [self shouldUseLiquidGlassIcon] ? 2 : 1;
         case SectionMedia: return 5;
         case SectionSubreddits: return 5;
         case SectionAbout: return 3; // GitHub repo link + version + export logs
@@ -395,7 +254,6 @@ static NSString *const kLiquidGlassAlternateIconIdentifierMetalnakls = @"metalna
         case SectionBackupRestore: return @"Backup / Restore";
         case SectionAPIKeys: return @"API Keys";
         case SectionGeneral: return @"General";
-        case SectionAppearance: return @"Appearance";
         case SectionMedia: return @"Media";
         case SectionSubreddits: return @"Subreddits";
         case SectionAbout: return @"About";
@@ -409,7 +267,6 @@ static NSString *const kLiquidGlassAlternateIconIdentifierMetalnakls = @"metalna
         case SectionBackupRestore: return [self backupRestoreCellForRow:indexPath.row tableView:tableView];
         case SectionAPIKeys: return [self apiKeyCellForRow:indexPath.row tableView:tableView];
         case SectionGeneral: return [self generalCellForRow:indexPath.row tableView:tableView];
-        case SectionAppearance: return [self appearanceCellForRow:indexPath.row tableView:tableView];
         case SectionMedia: return [self mediaCellForRow:indexPath.row tableView:tableView];
         case SectionSubreddits: return [self subredditCellForRow:indexPath.row tableView:tableView];
         case SectionAbout: return [self aboutCellForRow:indexPath.row tableView:tableView];
@@ -695,29 +552,6 @@ static NSString *const kLiquidGlassAlternateIconIdentifierMetalnakls = @"metalna
     }
 }
 
-- (UITableViewCell *)appearanceCellForRow:(NSInteger)row tableView:(UITableView *)tableView {
-    switch (row) {
-        case 0:
-            return [self switchCellWithIdentifier:@"Cell_Appearance_UseLiquidGlass"
-                                            label:@"Use Liquid Glass Icon"
-                                               on:[self shouldUseLiquidGlassIcon]
-                                           action:@selector(liquidGlassIconSwitchToggled:)];
-        case 1: {
-            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Gen_LiquidGlassIcon"];
-            if (!cell) {
-                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Gen_LiquidGlassIcon"];
-                cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-            }
-            cell.textLabel.text = @"Liquid Glass App Icon";
-            cell.detailTextLabel.text = [self currentLiquidGlassIconText];
-            cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
-            return cell;
-        }
-        default: return [[UITableViewCell alloc] init];
-    }
-}
-
 - (UITableViewCell *)mediaCellForRow:(NSInteger)row tableView:(UITableView *)tableView {
     switch (row) {
         case 0: {
@@ -986,11 +820,6 @@ static NSString *const kLiquidGlassAlternateIconIdentifierMetalnakls = @"metalna
         } else if (indexPath.row == 1) {
             [self exportLogs];
         }
-    } else if (indexPath.section == SectionAppearance) {
-        if (indexPath.row == 1) {
-            UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
-            [self presentLiquidGlassIconSheetFromSourceView:cell];
-        }
     } else if (indexPath.section == SectionMedia) {
         UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
         if (indexPath.row == 0) {
@@ -1018,7 +847,6 @@ static NSString *const kLiquidGlassAlternateIconIdentifierMetalnakls = @"metalna
 - (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.section == SectionBackupRestore) return YES;
     if (indexPath.section == SectionAPIKeys && (indexPath.row == 4 || indexPath.row == 5)) return YES;
-    if (indexPath.section == SectionAppearance && indexPath.row == 1) return YES;
     if (indexPath.section == SectionMedia && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2)) return YES;
     if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1)) return YES;
     if (indexPath.section == SectionCredits) return YES;

--- a/CustomAPIViewController.m
+++ b/CustomAPIViewController.m
@@ -39,7 +39,6 @@ static NSString *const kLiquidGlassPrimaryIconIdentifier = @"jryng";
 static NSString *const kLiquidGlassAlternateIconIdentifierJryngAlt = @"jryng-alt";
 static NSString *const kLiquidGlassAlternateIconIdentifierIgerman00 = @"igerman00";
 static NSString *const kLiquidGlassAlternateIconIdentifierMetalnakls = @"metalnakls";
-static NSString *const kLiquidGlassDefaultApolloIdentifier = @"__default_apollo__";
 
 #pragma mark - Helpers
 
@@ -195,7 +194,6 @@ static NSString *const kLiquidGlassDefaultApolloIdentifier = @"__default_apollo_
 
 - (NSArray<NSDictionary<NSString *, NSString *> *> *)liquidGlassIconOptions {
     return @[
-        @{@"id": kLiquidGlassDefaultApolloIdentifier, @"title": @"Default Apollo"},
         @{@"id": kLiquidGlassPrimaryIconIdentifier, @"title": @"jryng"},
         @{@"id": kLiquidGlassAlternateIconIdentifierJryngAlt, @"title": @"jryng-alt"},
         @{@"id": kLiquidGlassAlternateIconIdentifierIgerman00, @"title": @"igerman00"},
@@ -203,9 +201,13 @@ static NSString *const kLiquidGlassDefaultApolloIdentifier = @"__default_apollo_
     ];
 }
 
+- (BOOL)shouldUseLiquidGlassIcon {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseLiquidGlassIcon];
+}
+
 - (NSString *)storedLiquidGlassIconIdentifier {
     NSString *iconIdentifier = [[NSUserDefaults standardUserDefaults] stringForKey:UDKeyLiquidGlassSelectedIcon];
-    return iconIdentifier.length > 0 ? iconIdentifier : kLiquidGlassDefaultApolloIdentifier;
+    return iconIdentifier.length > 0 ? iconIdentifier : kLiquidGlassPrimaryIconIdentifier;
 }
 
 - (void)setStoredLiquidGlassIconIdentifier:(NSString *)iconIdentifier {
@@ -226,23 +228,27 @@ static NSString *const kLiquidGlassDefaultApolloIdentifier = @"__default_apollo_
 }
 
 - (void)reloadLiquidGlassIconRow {
-    [self.tableView reloadData];
+    NSIndexSet *appearanceSection = [NSIndexSet indexSetWithIndex:SectionAppearance];
+    [self.tableView reloadSections:appearanceSection withRowAnimation:UITableViewRowAnimationAutomatic];
 }
 
-- (void)setLiquidGlassIconIdentifier:(NSString *)iconIdentifier {
+- (void)applyLiquidGlassIconStateEnabled:(BOOL)enabled iconIdentifier:(NSString *)iconIdentifier {
     UIApplication *application = UIApplication.sharedApplication;
     if (![application supportsAlternateIcons]) {
         [self showAlertWithTitle:@"Unavailable" message:@"This Apollo build does not expose alternate app icons."];
         return;
     }
 
-    NSString *requestedIconName = [iconIdentifier isEqualToString:kLiquidGlassDefaultApolloIdentifier] ? nil : iconIdentifier;
-    NSString *currentIconName = application.alternateIconName;
-    BOOL isUnchanged =
-        (requestedIconName == nil && currentIconName == nil) ||
-        [currentIconName isEqualToString:requestedIconName];
+    NSString *effectiveIconIdentifier = iconIdentifier.length > 0 ? iconIdentifier : [self storedLiquidGlassIconIdentifier];
+    NSString *requestedIconName = enabled ? effectiveIconIdentifier : nil;
+    NSString *storedIconIdentifier = [self storedLiquidGlassIconIdentifier];
+    BOOL storedEnabled = [self shouldUseLiquidGlassIcon];
+    BOOL isUnchanged = (storedEnabled == enabled) && (!enabled || [storedIconIdentifier isEqualToString:effectiveIconIdentifier]);
     if (isUnchanged) {
-        [self setStoredLiquidGlassIconIdentifier:iconIdentifier];
+        if (enabled) {
+            [self setStoredLiquidGlassIconIdentifier:effectiveIconIdentifier];
+        }
+        [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:UDKeyUseLiquidGlassIcon];
         [self reloadLiquidGlassIconRow];
         return;
     }
@@ -258,13 +264,24 @@ static NSString *const kLiquidGlassDefaultApolloIdentifier = @"__default_apollo_
                 return;
             }
 
-            [strongSelf setStoredLiquidGlassIconIdentifier:iconIdentifier];
+            [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:UDKeyUseLiquidGlassIcon];
+            if (enabled) {
+                [strongSelf setStoredLiquidGlassIconIdentifier:effectiveIconIdentifier];
+            }
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)),
                            dispatch_get_main_queue(), ^{
                 [strongSelf reloadLiquidGlassIconRow];
             });
         });
     }];
+}
+
+- (void)setLiquidGlassIconIdentifier:(NSString *)iconIdentifier {
+    [self applyLiquidGlassIconStateEnabled:YES iconIdentifier:iconIdentifier];
+}
+
+- (void)liquidGlassIconSwitchToggled:(UISwitch *)sender {
+    [self applyLiquidGlassIconStateEnabled:sender.isOn iconIdentifier:[self storedLiquidGlassIconIdentifier]];
 }
 
 - (void)presentLiquidGlassIconSheetFromSourceView:(UIView *)sourceView {
@@ -364,7 +381,7 @@ static NSString *const kLiquidGlassDefaultApolloIdentifier = @"__default_apollo_
         case SectionBackupRestore: return 2;
         case SectionAPIKeys: return 6; // 4 text fields + Can't sign in? + Instructions
         case SectionGeneral: return 8;
-        case SectionAppearance: return 1;
+        case SectionAppearance: return [self shouldUseLiquidGlassIcon] ? 2 : 1;
         case SectionMedia: return 5;
         case SectionSubreddits: return 5;
         case SectionAbout: return 3; // GitHub repo link + version + export logs
@@ -680,7 +697,12 @@ static NSString *const kLiquidGlassDefaultApolloIdentifier = @"__default_apollo_
 
 - (UITableViewCell *)appearanceCellForRow:(NSInteger)row tableView:(UITableView *)tableView {
     switch (row) {
-        case 0: {
+        case 0:
+            return [self switchCellWithIdentifier:@"Cell_Appearance_UseLiquidGlass"
+                                            label:@"Use Liquid Glass Icon"
+                                               on:[self shouldUseLiquidGlassIcon]
+                                           action:@selector(liquidGlassIconSwitchToggled:)];
+        case 1: {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Gen_LiquidGlassIcon"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Gen_LiquidGlassIcon"];
@@ -965,7 +987,7 @@ static NSString *const kLiquidGlassDefaultApolloIdentifier = @"__default_apollo_
             [self exportLogs];
         }
     } else if (indexPath.section == SectionAppearance) {
-        if (indexPath.row == 0) {
+        if (indexPath.row == 1) {
             UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
             [self presentLiquidGlassIconSheetFromSourceView:cell];
         }
@@ -996,7 +1018,7 @@ static NSString *const kLiquidGlassDefaultApolloIdentifier = @"__default_apollo_
 - (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.section == SectionBackupRestore) return YES;
     if (indexPath.section == SectionAPIKeys && (indexPath.row == 4 || indexPath.row == 5)) return YES;
-    if (indexPath.section == SectionAppearance && indexPath.row == 0) return YES;
+    if (indexPath.section == SectionAppearance && indexPath.row == 1) return YES;
     if (indexPath.section == SectionMedia && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2)) return YES;
     if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1)) return YES;
     if (indexPath.section == SectionCredits) return YES;

--- a/CustomAPIViewController.m
+++ b/CustomAPIViewController.m
@@ -13,6 +13,7 @@ typedef NS_ENUM(NSInteger, SectionIndex) {
     SectionBackupRestore = 0,
     SectionAPIKeys,
     SectionGeneral,
+    SectionAppearance,
     SectionMedia,
     SectionSubreddits,
     SectionCredits,
@@ -33,6 +34,12 @@ typedef NS_ENUM(NSInteger, Tag) {
     TagTrendingLimit,
     TagReadPostMaxCount,
 };
+
+static NSString *const kLiquidGlassPrimaryIconIdentifier = @"jryng";
+static NSString *const kLiquidGlassAlternateIconIdentifierJryngAlt = @"jryng-alt";
+static NSString *const kLiquidGlassAlternateIconIdentifierIgerman00 = @"igerman00";
+static NSString *const kLiquidGlassAlternateIconIdentifierMetalnakls = @"metalnakls";
+static NSString *const kLiquidGlassDefaultApolloIdentifier = @"__default_apollo__";
 
 #pragma mark - Helpers
 
@@ -186,6 +193,117 @@ typedef NS_ENUM(NSInteger, Tag) {
     }
 }
 
+- (NSArray<NSDictionary<NSString *, NSString *> *> *)liquidGlassIconOptions {
+    return @[
+        @{@"id": kLiquidGlassDefaultApolloIdentifier, @"title": @"Default Apollo"},
+        @{@"id": kLiquidGlassPrimaryIconIdentifier, @"title": @"jryng"},
+        @{@"id": kLiquidGlassAlternateIconIdentifierJryngAlt, @"title": @"jryng-alt"},
+        @{@"id": kLiquidGlassAlternateIconIdentifierIgerman00, @"title": @"igerman00"},
+        @{@"id": kLiquidGlassAlternateIconIdentifierMetalnakls, @"title": @"metalnakls"},
+    ];
+}
+
+- (NSString *)storedLiquidGlassIconIdentifier {
+    NSString *iconIdentifier = [[NSUserDefaults standardUserDefaults] stringForKey:UDKeyLiquidGlassSelectedIcon];
+    return iconIdentifier.length > 0 ? iconIdentifier : kLiquidGlassDefaultApolloIdentifier;
+}
+
+- (void)setStoredLiquidGlassIconIdentifier:(NSString *)iconIdentifier {
+    [[NSUserDefaults standardUserDefaults] setObject:iconIdentifier forKey:UDKeyLiquidGlassSelectedIcon];
+}
+
+- (NSString *)displayNameForLiquidGlassIconIdentifier:(NSString *)iconIdentifier {
+    for (NSDictionary<NSString *, NSString *> *option in [self liquidGlassIconOptions]) {
+        if ([option[@"id"] isEqualToString:iconIdentifier]) {
+            return option[@"title"];
+        }
+    }
+    return iconIdentifier;
+}
+
+- (NSString *)currentLiquidGlassIconText {
+    return [self displayNameForLiquidGlassIconIdentifier:[self storedLiquidGlassIconIdentifier]];
+}
+
+- (void)reloadLiquidGlassIconRow {
+    [self.tableView reloadData];
+}
+
+- (void)setLiquidGlassIconIdentifier:(NSString *)iconIdentifier {
+    UIApplication *application = UIApplication.sharedApplication;
+    if (![application supportsAlternateIcons]) {
+        [self showAlertWithTitle:@"Unavailable" message:@"This Apollo build does not expose alternate app icons."];
+        return;
+    }
+
+    NSString *requestedIconName = [iconIdentifier isEqualToString:kLiquidGlassDefaultApolloIdentifier] ? nil : iconIdentifier;
+    NSString *currentIconName = application.alternateIconName;
+    BOOL isUnchanged =
+        (requestedIconName == nil && currentIconName == nil) ||
+        [currentIconName isEqualToString:requestedIconName];
+    if (isUnchanged) {
+        [self setStoredLiquidGlassIconIdentifier:iconIdentifier];
+        [self reloadLiquidGlassIconRow];
+        return;
+    }
+
+    __weak __typeof__(self) weakSelf = self;
+    [application setAlternateIconName:requestedIconName completionHandler:^(NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            __strong __typeof__(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf) return;
+
+            if (error) {
+                [strongSelf showAlertWithTitle:@"Couldn't Change Icon" message:error.localizedDescription ?: @"Unknown error."];
+                return;
+            }
+
+            [strongSelf setStoredLiquidGlassIconIdentifier:iconIdentifier];
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)),
+                           dispatch_get_main_queue(), ^{
+                [strongSelf reloadLiquidGlassIconRow];
+            });
+        });
+    }];
+}
+
+- (void)presentLiquidGlassIconSheetFromSourceView:(UIView *)sourceView {
+    UIApplication *application = UIApplication.sharedApplication;
+    if (![application supportsAlternateIcons]) {
+        [self showAlertWithTitle:@"Unavailable" message:@"This Apollo build does not expose alternate app icons."];
+        return;
+    }
+
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Liquid Glass App Icon"
+                                                                   message:@"Choose which Liquid Glass icon Apollo should use."
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+
+    NSString *currentIconIdentifier = [self storedLiquidGlassIconIdentifier];
+    for (NSDictionary<NSString *, NSString *> *option in [self liquidGlassIconOptions]) {
+        NSString *iconIdentifier = option[@"id"];
+        NSString *title = option[@"title"];
+        if ([iconIdentifier isEqualToString:currentIconIdentifier]) {
+            title = [title stringByAppendingString:@" (Current)"];
+        }
+
+        [sheet addAction:[UIAlertAction actionWithTitle:title
+                                                  style:UIAlertActionStyleDefault
+                                                handler:^(__unused UIAlertAction *action) {
+            [self setLiquidGlassIconIdentifier:iconIdentifier];
+        }]];
+    }
+
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    if (popover && sourceView) {
+        popover.sourceView = sourceView;
+        popover.sourceRect = sourceView.bounds;
+    }
+
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
 - (void)setImageUploadProvider:(NSInteger)provider {
     sImageUploadProvider = provider;
     [[NSUserDefaults standardUserDefaults] setInteger:sImageUploadProvider forKey:UDKeyImageUploadProvider];
@@ -230,6 +348,11 @@ typedef NS_ENUM(NSInteger, Tag) {
     self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.tableView reloadData];
+}
+
 #pragma mark - UITableViewDataSource
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
@@ -241,6 +364,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionBackupRestore: return 2;
         case SectionAPIKeys: return 6; // 4 text fields + Can't sign in? + Instructions
         case SectionGeneral: return 8;
+        case SectionAppearance: return 1;
         case SectionMedia: return 5;
         case SectionSubreddits: return 5;
         case SectionAbout: return 3; // GitHub repo link + version + export logs
@@ -254,6 +378,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionBackupRestore: return @"Backup / Restore";
         case SectionAPIKeys: return @"API Keys";
         case SectionGeneral: return @"General";
+        case SectionAppearance: return @"Appearance";
         case SectionMedia: return @"Media";
         case SectionSubreddits: return @"Subreddits";
         case SectionAbout: return @"About";
@@ -267,6 +392,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionBackupRestore: return [self backupRestoreCellForRow:indexPath.row tableView:tableView];
         case SectionAPIKeys: return [self apiKeyCellForRow:indexPath.row tableView:tableView];
         case SectionGeneral: return [self generalCellForRow:indexPath.row tableView:tableView];
+        case SectionAppearance: return [self appearanceCellForRow:indexPath.row tableView:tableView];
         case SectionMedia: return [self mediaCellForRow:indexPath.row tableView:tableView];
         case SectionSubreddits: return [self subredditCellForRow:indexPath.row tableView:tableView];
         case SectionAbout: return [self aboutCellForRow:indexPath.row tableView:tableView];
@@ -552,6 +678,24 @@ typedef NS_ENUM(NSInteger, Tag) {
     }
 }
 
+- (UITableViewCell *)appearanceCellForRow:(NSInteger)row tableView:(UITableView *)tableView {
+    switch (row) {
+        case 0: {
+            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Gen_LiquidGlassIcon"];
+            if (!cell) {
+                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Gen_LiquidGlassIcon"];
+                cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+            }
+            cell.textLabel.text = @"Liquid Glass App Icon";
+            cell.detailTextLabel.text = [self currentLiquidGlassIconText];
+            cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+            return cell;
+        }
+        default: return [[UITableViewCell alloc] init];
+    }
+}
+
 - (UITableViewCell *)mediaCellForRow:(NSInteger)row tableView:(UITableView *)tableView {
     switch (row) {
         case 0: {
@@ -820,6 +964,11 @@ typedef NS_ENUM(NSInteger, Tag) {
         } else if (indexPath.row == 1) {
             [self exportLogs];
         }
+    } else if (indexPath.section == SectionAppearance) {
+        if (indexPath.row == 0) {
+            UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+            [self presentLiquidGlassIconSheetFromSourceView:cell];
+        }
     } else if (indexPath.section == SectionMedia) {
         UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
         if (indexPath.row == 0) {
@@ -847,6 +996,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 - (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.section == SectionBackupRestore) return YES;
     if (indexPath.section == SectionAPIKeys && (indexPath.row == 4 || indexPath.row == 5)) return YES;
+    if (indexPath.section == SectionAppearance && indexPath.row == 0) return YES;
     if (indexPath.section == SectionMedia && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2)) return YES;
     if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1)) return YES;
     if (indexPath.section == SectionCredits) return YES;

--- a/UserDefaultConstants.h
+++ b/UserDefaultConstants.h
@@ -20,8 +20,6 @@ static NSString *const UDKeyFilterNSFWRecentlyRead = @"FilterNSFWRecentlyRead";
 static NSString *const UDKeyProxyImgurDDG = @"ProxyImgurDDG";
 static NSString *const UDKeyImageUploadProvider = @"ImageUploadProvider";
 static NSString *const UDKeyHideNextParentButton = @"HideNextParentButton";
-static NSString *const UDKeyUseLiquidGlassIcon = @"UseLiquidGlassIcon";
-static NSString *const UDKeyLiquidGlassSelectedIcon = @"LiquidGlassSelectedIcon";
 // Render image URLs (i.redd.it, preview.redd.it, i.imgur.com, generic .png/.jpg/.jpeg/.webp)
 // inline within post selftext and comments instead of leaving them as plain text links.
 static NSString *const UDKeyEnableInlineImages = @"EnableInlineImages";

--- a/UserDefaultConstants.h
+++ b/UserDefaultConstants.h
@@ -20,6 +20,7 @@ static NSString *const UDKeyFilterNSFWRecentlyRead = @"FilterNSFWRecentlyRead";
 static NSString *const UDKeyProxyImgurDDG = @"ProxyImgurDDG";
 static NSString *const UDKeyImageUploadProvider = @"ImageUploadProvider";
 static NSString *const UDKeyHideNextParentButton = @"HideNextParentButton";
+static NSString *const UDKeyLiquidGlassSelectedIcon = @"LiquidGlassSelectedIcon";
 // Render image URLs (i.redd.it, preview.redd.it, i.imgur.com, generic .png/.jpg/.jpeg/.webp)
 // inline within post selftext and comments instead of leaving them as plain text links.
 static NSString *const UDKeyEnableInlineImages = @"EnableInlineImages";

--- a/UserDefaultConstants.h
+++ b/UserDefaultConstants.h
@@ -20,6 +20,7 @@ static NSString *const UDKeyFilterNSFWRecentlyRead = @"FilterNSFWRecentlyRead";
 static NSString *const UDKeyProxyImgurDDG = @"ProxyImgurDDG";
 static NSString *const UDKeyImageUploadProvider = @"ImageUploadProvider";
 static NSString *const UDKeyHideNextParentButton = @"HideNextParentButton";
+static NSString *const UDKeyUseLiquidGlassIcon = @"UseLiquidGlassIcon";
 static NSString *const UDKeyLiquidGlassSelectedIcon = @"LiquidGlassSelectedIcon";
 // Render image URLs (i.redd.it, preview.redd.it, i.imgur.com, generic .png/.jpg/.jpeg/.webp)
 // inline within post selftext and comments instead of leaving them as plain text links.

--- a/patch-assets/liquid-glass/ApolloLiquidGlass/asset-info.plist
+++ b/patch-assets/liquid-glass/ApolloLiquidGlass/asset-info.plist
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIcons</key>
+	<dict>
+		<key>CFBundleAlternateIcons</key>
+		<dict>
+			<key>igerman00</key>
+			<dict>
+				<key>CFBundleIconName</key>
+				<string>igerman00</string>
+			</dict>
+			<key>jryng-alt</key>
+			<dict>
+				<key>CFBundleIconName</key>
+				<string>jryng-alt</string>
+			</dict>
+			<key>metalnakls</key>
+			<dict>
+				<key>CFBundleIconName</key>
+				<string>metalnakls</string>
+			</dict>
+		</dict>
+		<key>CFBundlePrimaryIcon</key>
+		<dict>
+			<key>CFBundleIconFiles</key>
+			<array>
+				<string>jryng60x60</string>
+			</array>
+			<key>CFBundleIconName</key>
+			<string>jryng</string>
+		</dict>
+	</dict>
+	<key>CFBundleIcons~ipad</key>
+	<dict>
+		<key>CFBundleAlternateIcons</key>
+		<dict>
+			<key>igerman00</key>
+			<dict>
+				<key>CFBundleIconName</key>
+				<string>igerman00</string>
+			</dict>
+			<key>jryng-alt</key>
+			<dict>
+				<key>CFBundleIconName</key>
+				<string>jryng-alt</string>
+			</dict>
+			<key>metalnakls</key>
+			<dict>
+				<key>CFBundleIconName</key>
+				<string>metalnakls</string>
+			</dict>
+		</dict>
+		<key>CFBundlePrimaryIcon</key>
+		<dict>
+			<key>CFBundleIconFiles</key>
+			<array>
+				<string>jryng60x60</string>
+				<string>jryng76x76</string>
+			</array>
+			<key>CFBundleIconName</key>
+			<string>jryng</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/patch.sh
+++ b/patch.sh
@@ -3,7 +3,64 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LIQUID_GLASS_ASSETS_CAR="${SCRIPT_DIR}/patch-assets/liquid-glass/ApolloLiquidGlass/Assets.car"
-LIQUID_GLASS_ICON_NAME="ApolloLiquidGlass"
+LIQUID_GLASS_ICON_NAME="AppIcon"
+LIQUID_GLASS_IPAD_ICON_FILES=("AppIcon60x60" "AppIcon76x76")
+LIQUID_GLASS_IPHONE_ICON_FILES=("AppIcon60x60")
+LIQUID_GLASS_ALTERNATE_ICONS=("jryng" "jryng-alt" "igerman00" "metalnakls")
+
+plist_set_string() {
+    local path="$1"
+    local value="$2"
+
+    if /usr/libexec/PlistBuddy -c "Print :${path}" "Info.plist" &>/dev/null; then
+        /usr/libexec/PlistBuddy -c "Set :${path} ${value}" "Info.plist"
+    else
+        /usr/libexec/PlistBuddy -c "Add :${path} string ${value}" "Info.plist"
+    fi
+}
+
+plist_ensure_dict() {
+    local path="$1"
+
+    if ! /usr/libexec/PlistBuddy -c "Print :${path}" "Info.plist" &>/dev/null; then
+        /usr/libexec/PlistBuddy -c "Add :${path} dict" "Info.plist"
+    fi
+}
+
+plist_replace_string_array() {
+    local path="$1"
+    shift
+
+    if /usr/libexec/PlistBuddy -c "Print :${path}" "Info.plist" &>/dev/null; then
+        /usr/libexec/PlistBuddy -c "Delete :${path}" "Info.plist"
+    fi
+    /usr/libexec/PlistBuddy -c "Add :${path} array" "Info.plist"
+
+    for value in "$@"; do
+        /usr/libexec/PlistBuddy -c "Add :${path}: string ${value}" "Info.plist"
+    done
+}
+
+ensure_liquid_glass_icon_metadata() {
+    plist_ensure_dict "CFBundleIcons"
+    plist_ensure_dict "CFBundleIcons:CFBundlePrimaryIcon"
+    plist_ensure_dict "CFBundleIcons:CFBundleAlternateIcons"
+    plist_ensure_dict "CFBundleIcons~ipad"
+    plist_ensure_dict "CFBundleIcons~ipad:CFBundlePrimaryIcon"
+    plist_ensure_dict "CFBundleIcons~ipad:CFBundleAlternateIcons"
+
+    plist_set_string "CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconName" "${LIQUID_GLASS_ICON_NAME}"
+    plist_set_string "CFBundleIcons~ipad:CFBundlePrimaryIcon:CFBundleIconName" "${LIQUID_GLASS_ICON_NAME}"
+    plist_replace_string_array "CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconFiles" "${LIQUID_GLASS_IPHONE_ICON_FILES[@]}"
+    plist_replace_string_array "CFBundleIcons~ipad:CFBundlePrimaryIcon:CFBundleIconFiles" "${LIQUID_GLASS_IPAD_ICON_FILES[@]}"
+
+    for icon_name in "${LIQUID_GLASS_ALTERNATE_ICONS[@]}"; do
+        plist_ensure_dict "CFBundleIcons:CFBundleAlternateIcons:${icon_name}"
+        plist_ensure_dict "CFBundleIcons~ipad:CFBundleAlternateIcons:${icon_name}"
+        plist_set_string "CFBundleIcons:CFBundleAlternateIcons:${icon_name}:CFBundleIconName" "${icon_name}"
+        plist_set_string "CFBundleIcons~ipad:CFBundleAlternateIcons:${icon_name}:CFBundleIconName" "${icon_name}"
+    done
+}
 
 # Cleanup on exit (success or failure)
 cleanup() {
@@ -24,6 +81,7 @@ OUTPUT_IPA="Apollo-Patched.ipa"
 REMOVE_CODE_SIGNATURE="false"
 LIQUID_GLASS="false"
 URL_SCHEMES=""
+OUTPUT_IPA_PATH=""
 
 print_usage() {
     echo "Usage: $0 <path_to_ipa> [options]"
@@ -93,6 +151,12 @@ echo "Remove code signature: ${REMOVE_CODE_SIGNATURE}"
 echo "Liquid Glass patch: ${LIQUID_GLASS}"
 echo "URL schemes: ${URL_SCHEMES:-none}"
 
+if [[ "${OUTPUT_IPA}" = /* ]]; then
+    OUTPUT_IPA_PATH="${OUTPUT_IPA}"
+else
+    OUTPUT_IPA_PATH="../${OUTPUT_IPA}"
+fi
+
 # --- 1. Extract IPA ---
 echo "Extracting ${INPUT_IPA}..."
 rm -rf extract_temp
@@ -154,12 +218,8 @@ if [ "${LIQUID_GLASS}" == "true" ]; then
     echo "Replacing Assets.car with prebuilt Liquid Glass asset catalog..."
     cp "${LIQUID_GLASS_ASSETS_CAR}" "Assets.car"
 
-    echo "Updating primary app icon name to ${LIQUID_GLASS_ICON_NAME}..."
-    /usr/libexec/PlistBuddy -c "Set :CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconName ${LIQUID_GLASS_ICON_NAME}" "Info.plist"
-
-    if /usr/libexec/PlistBuddy -c "Print :CFBundleIcons~ipad:CFBundlePrimaryIcon:CFBundleIconName" "Info.plist" &>/dev/null; then
-        /usr/libexec/PlistBuddy -c "Set :CFBundleIcons~ipad:CFBundlePrimaryIcon:CFBundleIconName ${LIQUID_GLASS_ICON_NAME}" "Info.plist"
-    fi
+    echo "Updating app icon metadata for Liquid Glass multi-icon catalog..."
+    ensure_liquid_glass_icon_metadata
 fi
 
 # --- 2b. URL Schemes Patch ---
@@ -237,14 +297,14 @@ cd ../.. # Back to extract_temp directory
 
 # --- 3. Repackage IPA ---
 echo "Repackaging modified IPA..."
-zip -qr "../${OUTPUT_IPA}" Payload/
+zip -qr "${OUTPUT_IPA_PATH}" Payload/
 cd .. # Back to original directory
 
 # Note: Cleanup handled by trap on EXIT
 
 # --- 5. Final Verification ---
-file_size=$(wc -c < "${OUTPUT_IPA}")
-echo "Patched IPA created: ${OUTPUT_IPA} (Size: ${file_size} bytes)"
+file_size=$(wc -c < "${OUTPUT_IPA_PATH}")
+echo "Patched IPA created: ${OUTPUT_IPA_PATH} (Size: ${file_size} bytes)"
 
 # Output the name for the workflow
-echo "${OUTPUT_IPA}"
+echo "${OUTPUT_IPA_PATH}"


### PR DESCRIPTION
## What changed

  - update the Liquid Glass patching flow to use stock Apollo as the base icon
  - package all four Liquid Glass icon variants into the patched `Assets.car`
  - update `patch.sh` so the patch step installs the Liquid Glass asset catalog and rewrites the app icon metadata accordingly
  - include the generated `asset-info.plist` for the new multi-icon catalog

  ## Why

  This keeps the patch flow focused on the IPA-side Liquid Glass icon work. The app-side icon picker is being handled separately in Apollo’s native icon selector, so this
  PR only covers the patching changes needed to ship the Liquid Glass icon assets correctly.

  ## Impact

  - patched IPAs can expose the Liquid Glass icon set without replacing Apollo’s default icon permanently
  - the patch flow stays deterministic for CI and local IPA patching
  - the Liquid Glass assets are bundled in a single compiled catalog containing all four variants

  ## Validation

  - rebuilt the multi-icon Liquid Glass `Assets.car`
  - patched a local Apollo 1.15.11 IPA
  - verified the resulting IPA contains the updated app icon metadata