### PR TITLE
Fix getting 3 pixel pals food on every launch

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -35,7 +35,6 @@ static NSString *ValetOverrideValue(NSString *account) {
             @"meganotifs":              @"affirmative", // Ultra
             @"seconds_since2":          @"1473982",     // Pro
             @"rep_seconds_since2":      @"1473982",     // Pro (alternate?)
-            @"pixelpalfoodtokensgiven": @"affirmative", // Community icons
             @"rep_seconds_after2":      @"1482118",     // SPCA Animals icon pack
         };
     });


### PR DESCRIPTION
Every time you launch Apollo, the app gives 3 food in Pixel Pals. This is due to the Valet override for `pixelpalfoodtokensgiven`, which is currently labeled for unlocking community icons. I removed that override, and I no longer get 3 food every time, and I tested and confirmed that you can still select community icons, so it is likely being incorrectly overridden.