### PR TITLE
Block statsigapi.net (Statsig SDK exception endpoint missed by #124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Fix stale subreddit entries lingering after unfavouriting from Favourites section
 - Liquid Glass: fix separators blocking alphabet in subreddit list view
 - Update Custom API settings view to match app theme
+- Add statsigapi.net to the blocked URL list 
 
 ## [v2.12.0b] - 2026-05-16
 

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -156,6 +156,7 @@ static NSArray *const blockedUrls = @[
     @"sessions.bugsnag.com",
     @"api.mixpanel.com",
     @"api.statsig.com",
+    @"statsigapi.net",
     @"telemetrydeck.com",
     @"apollogur.download/api/easter_sale",
     @"apollogur.download/api/html_codes",


### PR DESCRIPTION
## Summary

- Adds `statsigapi.net` to the blocked URL list — the Statsig SDK's secondary endpoint, missed by #124 which only blocked `api.statsig.com`.

## Verification

`strings` on the shipped Apollo binary:

```
$ unzip -p GLASS_Apollo-1.15.11_ImprovedCustomApi-2.11.0.ipa Payload/Apollo.app/Apollo \
    | strings | grep -E 'statsig'
https://api.statsig.com                     ← blocked by #124
https://statsigapi.net/v1/sdk_exception     ← currently NOT blocked
```

With the current block list, the Statsig SDK can still report SDK exceptions to `statsigapi.net/v1/sdk_exception`. These typically include app version, OS version, device model, and an anonymous Statsig stable ID.

The substring `containsString:` match in `blockedUrls` catches every path under the domain, so a single entry covers it.

## Related

- #124 — original analytics URL block list