### PR TITLE
Perf/reliability improvements

### DIFF
--- a/ApolloAutoHideTabBar.xm
+++ b/ApolloAutoHideTabBar.xm
@@ -50,11 +50,23 @@ typedef NS_ENUM(NSInteger, ApolloTabBarMinimizeBehavior) {
 static char kApolloRequestedHidesBarsOnSwipeKey;
 static char kApolloAppliedMinimizeBehaviorKey;
 static char kApolloIdleRevealTimerKey;
+static char kApolloIdleRevealTimerScheduledAtKey;
 static char kApolloUpwardRevealDistanceKey;
+static char kApolloDownwardCollapseDistanceKey;
+static char kApolloScrollViewTabBarControllerBoxKey;
 
 static NSString *const ApolloAutoHideTabBarShowOnIdleChangedNotification = @"ApolloAutoHideTabBarShowOnIdleChangedNotification";
 static const NSTimeInterval ApolloIdleRevealDelaySeconds = 30.0;
+static const NSTimeInterval ApolloIdleRevealRescheduleInterval = 0.25;
 static const CGFloat ApolloUpwardRevealDistanceThreshold = 120.0;
+static const CGFloat ApolloDownwardCollapseDistanceThreshold = 48.0;
+
+@interface ApolloAutoHideWeakTabBarControllerBox : NSObject
+@property (nonatomic, weak) UITabBarController *controller;
+@end
+
+@implementation ApolloAutoHideWeakTabBarControllerBox
+@end
 
 static SEL ApolloMinimizeBehaviorSetter(void) {
     return NSSelectorFromString(@"setTabBarMinimizeBehavior:");
@@ -113,6 +125,22 @@ static void ApolloSetUpwardRevealDistance(UITabBarController *tbc, CGFloat dista
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+static CGFloat ApolloDownwardCollapseDistance(UITabBarController *tbc) {
+    NSNumber *distance = objc_getAssociatedObject(tbc, &kApolloDownwardCollapseDistanceKey);
+    if ([distance isKindOfClass:[NSNumber class]]) {
+        return (CGFloat)distance.doubleValue;
+    }
+    return 0.0;
+}
+
+static void ApolloSetDownwardCollapseDistance(UITabBarController *tbc, CGFloat distance) {
+    if (!tbc) return;
+    objc_setAssociatedObject(tbc,
+                             &kApolloDownwardCollapseDistanceKey,
+                             distance > 0.0 ? @(distance) : nil,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 // Walk only the parentViewController chain so modally-presented nav controllers
 // (share sheets, document pickers, etc.) are skipped — mirroring their hidden
 // state onto the main tab bar would spuriously hide it.
@@ -159,6 +187,7 @@ static void ApolloCancelIdleRevealTimer(UITabBarController *tbc) {
     if (!timer) return;
     dispatch_source_cancel(timer);
     objc_setAssociatedObject(tbc, &kApolloIdleRevealTimerKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(tbc, &kApolloIdleRevealTimerScheduledAtKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 static void ApolloReapplyNativeMinimizeBehavior(UITabBarController *tbc, NSString *reason) {
@@ -263,7 +292,23 @@ static void ApolloHideTabBar(UITabBarController *tbc, BOOL animated) {
 
 static void ApolloScheduleIdleRevealTimer(UITabBarController *tbc) {
     if (!tbc || !sAutoHideTabBarShowOnIdle || !ApolloTabBarControllerWantsNativeMinimize(tbc)) return;
-    ApolloCancelIdleRevealTimer(tbc);
+
+    NSTimeInterval now = CACurrentMediaTime();
+    NSNumber *lastScheduled = objc_getAssociatedObject(tbc, &kApolloIdleRevealTimerScheduledAtKey);
+    dispatch_source_t existingTimer = objc_getAssociatedObject(tbc, &kApolloIdleRevealTimerKey);
+    if (existingTimer && [lastScheduled isKindOfClass:[NSNumber class]] &&
+        now - lastScheduled.doubleValue < ApolloIdleRevealRescheduleInterval) {
+        return;
+    }
+
+    if (existingTimer) {
+        dispatch_source_set_timer(existingTimer,
+                                  dispatch_time(DISPATCH_TIME_NOW, (int64_t)(ApolloIdleRevealDelaySeconds * NSEC_PER_SEC)),
+                                  DISPATCH_TIME_FOREVER,
+                                  (uint64_t)(50 * NSEC_PER_MSEC));
+        objc_setAssociatedObject(tbc, &kApolloIdleRevealTimerScheduledAtKey, @(now), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return;
+    }
 
     dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
     if (!timer) return;
@@ -277,6 +322,7 @@ static void ApolloScheduleIdleRevealTimer(UITabBarController *tbc) {
         UITabBarController *strongTBC = weakTBC;
         if (!strongTBC) return;
         objc_setAssociatedObject(strongTBC, &kApolloIdleRevealTimerKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(strongTBC, &kApolloIdleRevealTimerScheduledAtKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         if (!sAutoHideTabBarShowOnIdle || !ApolloTabBarControllerWantsNativeMinimize(strongTBC)) return;
         ApolloApplyMinimizeBehavior(strongTBC, ApolloTabBarMinimizeBehaviorNever);
         __weak UITabBarController *rearmTBC = strongTBC;
@@ -288,18 +334,26 @@ static void ApolloScheduleIdleRevealTimer(UITabBarController *tbc) {
         });
     });
     objc_setAssociatedObject(tbc, &kApolloIdleRevealTimerKey, timer, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(tbc, &kApolloIdleRevealTimerScheduledAtKey, @(now), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     dispatch_resume(timer);
 }
 
 static UITabBarController *ApolloTabBarControllerForScrollView(UIScrollView *scrollView) {
     if (!scrollView) return nil;
+    ApolloAutoHideWeakTabBarControllerBox *cachedBox = objc_getAssociatedObject(scrollView, &kApolloScrollViewTabBarControllerBoxKey);
+    UITabBarController *cachedTBC = cachedBox.controller;
+    if (cachedTBC) return cachedTBC;
+
     UIResponder *responder = scrollView;
     while ((responder = responder.nextResponder)) {
         if (![responder isKindOfClass:[UIViewController class]]) continue;
         UIViewController *vc = (UIViewController *)responder;
         while (vc) {
             if ([vc isKindOfClass:[UITabBarController class]]) {
-                return (UITabBarController *)vc;
+                ApolloAutoHideWeakTabBarControllerBox *box = [ApolloAutoHideWeakTabBarControllerBox new];
+                box.controller = (UITabBarController *)vc;
+                objc_setAssociatedObject(scrollView, &kApolloScrollViewTabBarControllerBoxKey, box, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                return box.controller;
             }
             vc = vc.parentViewController;
         }
@@ -418,32 +472,55 @@ static void ApolloMirrorNavBarStateToTabBar(UINavigationController *nav, BOOL na
 
 %hook UIScrollView
 
+- (void)didMoveToWindow {
+    %orig;
+    objc_setAssociatedObject((UIScrollView *)self, &kApolloScrollViewTabBarControllerBoxKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 - (void)setContentOffset:(CGPoint)contentOffset {
+    if (!sAutoHideTabBarShowOnIdle || !ApolloSupportsNativeTabBarMinimize() || !self.window ||
+        !(self.tracking || self.dragging || self.decelerating)) {
+        %orig(contentOffset);
+        return;
+    }
+
     CGPoint oldOffset = self.contentOffset;
     CGFloat deltaY = contentOffset.y - oldOffset.y;
     UITabBarController *tbc = nil;
     BOOL shouldScheduleIdleReveal = NO;
 
-    if (sAutoHideTabBarShowOnIdle && ApolloSupportsNativeTabBarMinimize() && self.window &&
-        (self.tracking || self.dragging || self.decelerating) && fabs(deltaY) >= 0.5) {
+    if (fabs(deltaY) >= 0.5) {
         tbc = ApolloTabBarControllerForScrollView(self);
         if (ApolloTabBarControllerWantsNativeMinimize(tbc)) {
-            // Re-arm before UIKit processes this offset. If we wait until after
-            // %orig, a fast fling can spend its first scroll update in .never
-            // and miss the native Liquid Glass collapse threshold.
-            if (deltaY > 0.0) {
-                ApolloSetUpwardRevealDistance(tbc, 0.0);
-                if (ApolloLastAppliedMinimizeBehavior(tbc) == ApolloTabBarMinimizeBehaviorNever) {
-                    ApolloApplyMinimizeBehavior(tbc, ApolloTabBarMinimizeBehaviorOnScrollDown);
-                }
-            } else {
-                CGFloat upwardDistance = ApolloUpwardRevealDistance(tbc) + fabs(deltaY);
-                if (upwardDistance >= ApolloUpwardRevealDistanceThreshold) {
+            BOOL userDriven = self.tracking || self.dragging;
+            if (userDriven) {
+                // Re-arm before UIKit processes a deliberate downward drag. Use
+                // hysteresis so rubber-band/reversal noise doesn't thrash safe areas.
+                if (deltaY > 0.0) {
                     ApolloSetUpwardRevealDistance(tbc, 0.0);
-                    ApolloApplyMinimizeBehavior(tbc, ApolloTabBarMinimizeBehaviorNever);
+                    CGFloat downwardDistance = ApolloDownwardCollapseDistance(tbc) + deltaY;
+                    if (ApolloLastAppliedMinimizeBehavior(tbc) != ApolloTabBarMinimizeBehaviorNever ||
+                        downwardDistance >= ApolloDownwardCollapseDistanceThreshold) {
+                        ApolloSetDownwardCollapseDistance(tbc, 0.0);
+                        if (ApolloLastAppliedMinimizeBehavior(tbc) == ApolloTabBarMinimizeBehaviorNever) {
+                            ApolloApplyMinimizeBehavior(tbc, ApolloTabBarMinimizeBehaviorOnScrollDown);
+                        }
+                    } else {
+                        ApolloSetDownwardCollapseDistance(tbc, downwardDistance);
+                    }
                 } else {
-                    ApolloSetUpwardRevealDistance(tbc, upwardDistance);
+                    ApolloSetDownwardCollapseDistance(tbc, 0.0);
+                    CGFloat upwardDistance = ApolloUpwardRevealDistance(tbc) + fabs(deltaY);
+                    if (upwardDistance >= ApolloUpwardRevealDistanceThreshold) {
+                        ApolloSetUpwardRevealDistance(tbc, 0.0);
+                        ApolloApplyMinimizeBehavior(tbc, ApolloTabBarMinimizeBehaviorNever);
+                    } else {
+                        ApolloSetUpwardRevealDistance(tbc, upwardDistance);
+                    }
                 }
+            } else if (deltaY > 0.0) {
+                ApolloSetUpwardRevealDistance(tbc, 0.0);
+                ApolloSetDownwardCollapseDistance(tbc, 0.0);
             }
             shouldScheduleIdleReveal = YES;
         }

--- a/ApolloInlineLinkPreviewURLHiding.xm
+++ b/ApolloInlineLinkPreviewURLHiding.xm
@@ -263,6 +263,11 @@ static void ApolloLPInstallURLHidingObserver(void) {
 %hook ASTextNode
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
+    if (!ApolloLPURLHidingEnabled()) {
+        %orig;
+        return;
+    }
+
     if ([objc_getAssociatedObject(self, kApolloLPURLHidingReentrancyKey) boolValue] || !ApolloLPURLHidingShouldProcessTextNode(self)) {
         %orig;
         return;
@@ -287,6 +292,11 @@ static void ApolloLPInstallURLHidingObserver(void) {
 %hook ASTextNode2
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
+    if (!ApolloLPURLHidingEnabled()) {
+        %orig;
+        return;
+    }
+
     if ([objc_getAssociatedObject(self, kApolloLPURLHidingReentrancyKey) boolValue] || !ApolloLPURLHidingShouldProcessTextNode(self)) {
         %orig;
         return;

--- a/ApolloInlineLinkPreviews.xm
+++ b/ApolloInlineLinkPreviews.xm
@@ -103,6 +103,7 @@ static char kApolloLinkPreviewFetchInFlightKey;
 static char kApolloLinkPreviewOriginalHostShellKey;
 static char kApolloLinkPreviewRenderedPlaceholderKey;
 static char kApolloLinkPreviewBackgroundColorPresetKey;
+static char kApolloLinkPreviewAreaKey;
 
 static NSHashTable<id> *sApolloLPRegisteredLinkNodes = nil;
 static dispatch_queue_t sApolloLPRegisteredLinkNodesQueue = NULL;
@@ -482,6 +483,11 @@ static NSInteger ApolloLPModeForArea(ApolloLPArea area) {
     return (area == ApolloLPAreaComments) ? sLinkPreviewCommentsMode : sLinkPreviewBodyMode;
 }
 
+static BOOL ApolloLPAllModesDisabled(void) {
+    return sLinkPreviewBodyMode == ApolloLinkPreviewModeOff &&
+        sLinkPreviewCommentsMode == ApolloLinkPreviewModeOff;
+}
+
 static ApolloLPContext ApolloLPContextForMode(NSInteger mode, ApolloLinkPreview *preview) {
     if (mode == ApolloLinkPreviewModeCompact) return ApolloLPContextCompact;
     if (preview.imageIsFallbackIcon) return ApolloLPContextCompact;
@@ -549,9 +555,17 @@ static id ApolloLPModelFromNodeIvar(ASDisplayNode *node, const char *ivarName) {
 }
 
 static ApolloLPArea ApolloLPAreaForLinkButton(ASDisplayNode *linkButtonNode) {
+    NSNumber *cachedArea = objc_getAssociatedObject(linkButtonNode, &kApolloLinkPreviewAreaKey);
+    if ([cachedArea isKindOfClass:[NSNumber class]]) {
+        return (ApolloLPArea)cachedArea.unsignedIntegerValue;
+    }
+
     for (ASDisplayNode *node = linkButtonNode; node; node = node.supernode) {
         id comment = ApolloLPModelFromNodeIvar(node, "comment");
-        if (comment) return ApolloLPAreaComments;
+        if (comment) {
+            objc_setAssociatedObject(linkButtonNode, &kApolloLinkPreviewAreaKey, @(ApolloLPAreaComments), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            return ApolloLPAreaComments;
+        }
     }
     return ApolloLPAreaBody;
 }
@@ -1560,6 +1574,11 @@ static NSString *ApolloLPVariant(ApolloLPArea area, NSInteger mode, ApolloLPCont
 %hook _TtC6Apollo14LinkButtonNode
 
 - (id)layoutSpecThatFits:(struct CDStruct_90e057aa)constrainedSize {
+    if (ApolloLPAllModesDisabled()) {
+        ApolloLPRestoreHostShell((ASDisplayNode *)self);
+        return %orig;
+    }
+
     NSString *urlString = ApolloGetLinkButtonNodeURLString(self);
     NSURL *url = urlString.length > 0 ? [NSURL URLWithString:urlString] : nil;
     if (!url) {

--- a/ApolloPhotoPostComposerScrollFix.xm
+++ b/ApolloPhotoPostComposerScrollFix.xm
@@ -984,6 +984,23 @@ static BOOL ApolloPhotoComposerClassLooksLikeComposer(NSString *className) {
     return ApolloPhotoComposerStringContains(className, @"ComposePostViewController");
 }
 
+static BOOL ApolloPhotoComposerControllerHasDirectScopeSignal(UIViewController *controller) {
+    if (![controller isKindOfClass:[UIViewController class]]) return NO;
+    if (controller == sApolloMediaComposerActiveBodyController || controller == sApolloMediaComposerLastBodyOwnerController) return YES;
+    if (objc_getAssociatedObject(controller, &kApolloPhotoComposerLoggedControllerKey) ||
+        objc_getAssociatedObject(controller, &kApolloMediaComposerBodyContainerKey) ||
+        objc_getAssociatedObject(controller, &kApolloMediaComposerBodyNativeEditorActiveKey)) {
+        return YES;
+    }
+
+    NSString *className = NSStringFromClass(controller.class);
+    if (ApolloPhotoComposerClassLooksLikeComposer(className)) return YES;
+
+    NSString *title = controller.navigationItem.title ?: controller.title;
+    return ApolloPhotoComposerStringContains(title, @"Photo Post") ||
+        ApolloPhotoComposerStringContains(title, @"Media Post");
+}
+
 static NSString *ApolloPhotoComposerTextForView(UIView *view) {
     if ([view isKindOfClass:[UILabel class]]) return ((UILabel *)view).text;
     if ([view isKindOfClass:[UITextField class]]) return ((UITextField *)view).text;
@@ -1814,6 +1831,7 @@ static void ApolloMediaComposerConfigureTitleBodyControl(UITableViewCell *cell, 
 static BOOL ApolloMediaComposerControllerLooksLikeNativeTextEditor(UIViewController *controller) {
     NSString *title = controller.navigationItem.title ?: controller.title;
     if (ApolloPhotoComposerStringContains(title, @"Post Text")) return YES;
+    if (!sApolloMediaComposerActiveBodyController) return NO;
     return controller.isViewLoaded && ApolloPhotoComposerViewContainsText(controller.view, @"Post Text");
 }
 
@@ -3030,6 +3048,8 @@ static void ApolloPhotoComposerApplyScrollFix(UICollectionView *collectionView) 
 }
 
 static void ApolloPhotoComposerRepairController(UIViewController *controller, NSString *reason) {
+    if (!ApolloPhotoComposerControllerHasDirectScopeSignal(controller)) return;
+
     UIViewController *bodyController = ApolloMediaComposerCanonicalBodyController(controller);
     if (!ApolloPhotoComposerControllerIsInScope(controller)) {
         ApolloMediaComposerRemoveBodyEditor(bodyController ?: controller);
@@ -3052,6 +3072,8 @@ static void ApolloPhotoComposerRepairController(UIViewController *controller, NS
 }
 
 static void ApolloPhotoComposerRepairControllerSoon(UIViewController *controller, NSString *reason) {
+    if (!ApolloPhotoComposerControllerHasDirectScopeSignal(controller)) return;
+
     __weak UIViewController *weakController = controller;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.40 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         UIViewController *strongController = weakController;
@@ -3060,6 +3082,8 @@ static void ApolloPhotoComposerRepairControllerSoon(UIViewController *controller
 }
 
 static void ApolloPhotoComposerRepairControllerAfterDelay(UIViewController *controller, NSString *reason, NSTimeInterval delay) {
+    if (!ApolloPhotoComposerControllerHasDirectScopeSignal(controller)) return;
+
     __weak UIViewController *weakController = controller;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         UIViewController *strongController = weakController;

--- a/ApolloSubredditIndexPolish.xm
+++ b/ApolloSubredditIndexPolish.xm
@@ -28,6 +28,7 @@ static const CGFloat ApolloSubredditIndexSlotHeight = 14.0;
 static const CGFloat ApolloSubredditIndexTouchWidth = 56.0;
 static const CGFloat ApolloSubredditIndexGestureWidth = 34.0;
 static const CGFloat ApolloSubredditIndexRightInset = 38.0;
+static const CGFloat ApolloSubredditStarHitWidth = 60.0;
 static const CGFloat ApolloSubredditRowBalancedLeadingMargin = 18.0;
 static const CGFloat ApolloSubredditRowIconTextGap = 12.0;
 static const CGFloat ApolloSubredditRowStandardIconTextTrim = 2.0;
@@ -46,6 +47,8 @@ static NSInteger sApolloFavoriteMutationOriginalLastRow = NSNotFound;
 @property (nonatomic, strong) UISelectionFeedbackGenerator *selectionFeedbackGenerator;
 @property (nonatomic) NSInteger activeIndex;
 @property (nonatomic) NSInteger lastScrolledIndex;
+- (void)apollo_applyThemeTintToLabels;
+- (void)apollo_scheduleDeferredThemeTintRefresh;
 - (void)updateWithTableView:(UITableView *)tableView titles:(NSArray<NSString *> *)titles;
 @end
 
@@ -121,6 +124,18 @@ static UIColor *ApolloSubredditIndexThemeListBackgroundColor(UITableView *tableV
     return [UIColor clearColor];
 }
 
+static BOOL ApolloSubredditIndexOwningTitleLooksLikeSubreddits(UITableView *tableView) {
+    UIViewController *vc = ApolloSubredditIndexOwningViewController(tableView);
+    NSString *title = vc.navigationItem.title ?: vc.title;
+    return [title isEqualToString:@"Subreddits"];
+}
+
+static BOOL ApolloSubredditIndexShouldInspectTable(UITableView *tableView) {
+    if (!tableView) return NO;
+    if ([objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue]) return YES;
+    return ApolloSubredditIndexOwningTitleLooksLikeSubreddits(tableView);
+}
+
 static NSArray<NSString *> *ApolloSubredditIndexTitlesForTable(UITableView *tableView) {
     id<UITableViewDataSource> dataSource = tableView.dataSource;
     if (!dataSource || ![dataSource respondsToSelector:@selector(sectionIndexTitlesForTableView:)]) return nil;
@@ -138,9 +153,7 @@ static NSArray<NSString *> *ApolloSubredditIndexTitlesForTable(UITableView *tabl
 }
 
 static BOOL ApolloSubredditIndexLooksLikeSubredditsTable(UITableView *tableView, NSArray<NSString *> *titles) {
-    UIViewController *vc = ApolloSubredditIndexOwningViewController(tableView);
-    NSString *title = vc.navigationItem.title ?: vc.title;
-    if (![title isEqualToString:@"Subreddits"]) return NO;
+    if (!ApolloSubredditIndexOwningTitleLooksLikeSubreddits(tableView)) return NO;
     if (titles.count < 10) return NO;
 
     BOOL hasA = [titles containsObject:@"A"];
@@ -226,15 +239,25 @@ static UITableViewCell *ApolloSubredditIndexCellForView(UIView *view) {
     return nil;
 }
 
+static Class ApolloSubredditIndexRedditListTableViewCellClass(void) {
+    static Class cls = Nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        cls = NSClassFromString(@"_TtC6Apollo23RedditListTableViewCell");
+    });
+    return cls;
+}
+
 static UIControl *ApolloSubredditIndexRedditListAccessoryButton(UITableViewCell *cell) {
     static Ivar accessoryButtonIvar = NULL;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        Class cls = NSClassFromString(@"_TtC6Apollo23RedditListTableViewCell");
+        Class cls = ApolloSubredditIndexRedditListTableViewCellClass();
         if (cls) accessoryButtonIvar = class_getInstanceVariable(cls, "accessoryButton");
     });
 
-    if (!accessoryButtonIvar || ![cell isKindOfClass:NSClassFromString(@"_TtC6Apollo23RedditListTableViewCell")]) return nil;
+    Class cellClass = ApolloSubredditIndexRedditListTableViewCellClass();
+    if (!accessoryButtonIvar || !cellClass || ![cell isKindOfClass:cellClass]) return nil;
 
     id value = object_getIvar(cell, accessoryButtonIvar);
     return [value isKindOfClass:[UIControl class]] ? (UIControl *)value : nil;
@@ -379,7 +402,7 @@ static BOOL ApolloSubredditIndexStringLooksLikeSubredditName(NSString *string) {
 static BOOL ApolloSubredditIndexStringLooksLikeHeaderTitle(NSString *string) {
     NSString *trimmed = [string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     if (trimmed.length == 0) return NO;
-    if ([trimmed isEqualToString:@"FAVORITES"] || [trimmed isEqualToString:@"MODERATOR"]) return YES;
+    if ([trimmed isEqualToString:@"FAVORITES"] || [trimmed isEqualToString:@"MODERATOR"] || [trimmed isEqualToString:@"MULTIREDDITS"]) return YES;
     if (trimmed.length == 1) {
         unichar ch = [trimmed characterAtIndex:0];
         if ([[NSCharacterSet uppercaseLetterCharacterSet] characterIsMember:ch]) return YES;
@@ -390,6 +413,8 @@ static BOOL ApolloSubredditIndexStringLooksLikeHeaderTitle(NSString *string) {
 }
 
 static UILabel *ApolloSubredditIndexHeaderLabelInView(UIView *view) {
+    if (!view) return nil;
+
     NSMutableArray<UIView *> *stack = [NSMutableArray arrayWithObject:view];
     while (stack.count > 0) {
         UIView *candidate = stack.lastObject;
@@ -439,6 +464,8 @@ static UITableView *ApolloSubredditIndexTableForView(UIView *view) {
 }
 
 static UILabel *ApolloSubredditIndexBestTitleLabelInView(UIView *view, UITableViewCell *cell) {
+    if (!view || !cell) return nil;
+
     UILabel *bestLabel = nil;
     CGFloat bestScore = -CGFLOAT_MAX;
     NSMutableArray<UIView *> *stack = [NSMutableArray arrayWithObject:view];
@@ -470,6 +497,8 @@ static UILabel *ApolloSubredditIndexBestTitleLabelInView(UIView *view, UITableVi
 }
 
 static NSString *ApolloSubredditIndexCellTitle(UITableViewCell *cell) {
+    if (!cell) return nil;
+
     NSString *title = cell.textLabel.text;
     title = [title stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     if (ApolloSubredditIndexStringLooksLikeSubredditName(title)) return title;
@@ -562,27 +591,15 @@ static void ApolloSubredditIndexClearStarChrome(UIControl *control) {
 static CGRect ApolloSubredditIndexProxyFrameForCell(UITableViewCell *cell, UIControl *nativeControl) {
     CGFloat cellWidth = CGRectGetWidth(cell.bounds);
     CGFloat cellHeight = CGRectGetHeight(cell.bounds);
+    CGFloat width = MIN(ApolloSubredditStarHitWidth, MAX(cellWidth, 0.0));
 
-    // Anchor a comfortable, symmetric hit area on the native star control
-    // while still avoiding the index bar's gesture strip.
     if (!nativeControl) {
-        CGFloat fallbackWidth = 52.0;
-        return CGRectMake(MAX(cellWidth - fallbackWidth - 16.0, 0.0), 0.0, fallbackWidth, cellHeight);
+        return CGRectMake(MAX(cellWidth - width, 0.0), 0.0, width, cellHeight);
     }
 
     CGRect nativeFrame = [cell convertRect:nativeControl.bounds fromView:nativeControl];
-    CGFloat leftPadding = 46.0;
-    CGFloat rightPadding = 46.0;
-    CGFloat indexAvoidanceWidth = ApolloSubredditIndexGestureWidth + 4.0;
-    CGFloat maxX = MIN(CGRectGetMaxX(nativeFrame) + rightPadding, cellWidth - indexAvoidanceWidth);
-    CGFloat minX = MAX(0.0, CGRectGetMinX(nativeFrame) - leftPadding);
-    if (maxX <= CGRectGetMinX(nativeFrame)) {
-        maxX = MIN(cellWidth, CGRectGetMaxX(nativeFrame) + rightPadding);
-    }
-    CGFloat width = MAX(maxX - minX, 70.0);
-    if (minX + width > cellWidth) {
-        minX = MAX(0.0, cellWidth - width);
-    }
+    CGFloat minX = CGRectGetMidX(nativeFrame) - (width / 2.0);
+    minX = MIN(MAX(minX, 0.0), MAX(cellWidth - width, 0.0));
     return CGRectMake(minX, 0.0, width, cellHeight);
 }
 
@@ -692,6 +709,25 @@ static void ApolloSubredditIndexRemoveStarProxyFromCell(UITableViewCell *cell) {
     [self apollo_applyThemeTintToLabels];
 }
 
+- (void)didMoveToWindow {
+    [super didMoveToWindow];
+    [self apollo_applyThemeTintToLabels];
+    [self apollo_scheduleDeferredThemeTintRefresh];
+}
+
+- (void)apollo_scheduleDeferredThemeTintRefresh {
+    __weak ApolloSubredditIndexOverlayView *weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ApolloSubredditIndexOverlayView *strongSelf = weakSelf;
+        [strongSelf apollo_applyThemeTintToLabels];
+    });
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.20 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        ApolloSubredditIndexOverlayView *strongSelf = weakSelf;
+        [strongSelf apollo_applyThemeTintToLabels];
+    });
+}
+
 - (void)updateWithTableView:(UITableView *)tableView titles:(NSArray<NSString *> *)titles {
     self.tableView = tableView;
     self.titles = titles ?: @[];
@@ -721,6 +757,7 @@ static void ApolloSubredditIndexRemoveStarProxyFromCell(UITableViewCell *cell) {
     }
 
     [self apollo_applyThemeTintToLabels];
+    [self apollo_scheduleDeferredThemeTintRefresh];
     [self setNeedsLayout];
     [self applyMagnificationForIndex:self.activeIndex animated:NO];
 }
@@ -1027,6 +1064,8 @@ static void ApolloSubredditIndexInstallStarProxyForCell(UITableViewCell *cell, U
 }
 
 static void ApolloSubredditIndexInstallOrUpdate(UITableView *tableView) {
+    if (!ApolloSubredditIndexShouldInspectTable(tableView)) return;
+
     NSArray<NSString *> *titles = ApolloSubredditIndexTitlesForTable(tableView);
     if (!ApolloSubredditIndexLooksLikeSubredditsTable(tableView, titles)) return;
 
@@ -1052,12 +1091,19 @@ static void ApolloSubredditIndexInstallOrUpdate(UITableView *tableView) {
     CGFloat visibleHeight = MAX(CGRectGetHeight(tableFrame) - tableView.adjustedContentInset.top - tableView.adjustedContentInset.bottom - 8.0, 44.0);
     CGFloat desiredHeight = MIN(MAX(titles.count * ApolloSubredditIndexSlotHeight + 8.0, 240.0), visibleHeight);
     CGFloat originY = visibleTop + ((visibleHeight - desiredHeight) / 2.0);
-    overlay.frame = CGRectMake(CGRectGetMaxX(tableFrame) - width - rightPadding,
-                               originY,
-                               width,
-                               desiredHeight);
+    CGRect overlayFrame = CGRectMake(CGRectGetMaxX(tableFrame) - width - rightPadding,
+                                     originY,
+                                     width,
+                                     desiredHeight);
+    if (!CGRectEqualToRect(overlay.frame, overlayFrame)) {
+        overlay.frame = overlayFrame;
+    }
     [container bringSubviewToFront:overlay];
-    [overlay updateWithTableView:tableView titles:titles];
+    if (overlay.tableView != tableView || ![overlay.titles isEqualToArray:titles] || overlay.labels.count != titles.count) {
+        [overlay updateWithTableView:tableView titles:titles];
+    } else {
+        [overlay apollo_applyThemeTintToLabels];
+    }
 
     if (![objc_getAssociatedObject(tableView, &kApolloSubredditIndexLoggedKey) boolValue]) {
         objc_setAssociatedObject(tableView, &kApolloSubredditIndexLoggedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -1073,19 +1119,20 @@ static void ApolloSubredditIndexRefreshTablesInView(UIView *view) {
 
     if ([view isKindOfClass:[UITableView class]]) {
         UITableView *tableView = (UITableView *)view;
-        NSArray<NSString *> *titles = ApolloSubredditIndexTitlesForTable(tableView);
-        BOOL isSubredditTable = [objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue] ||
-                                ApolloSubredditIndexLooksLikeSubredditsTable(tableView, titles);
-        if (isSubredditTable) {
-            objc_setAssociatedObject(tableView, &kApolloSubredditIndexTableKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            NSDictionary *anchor = ApolloSubredditIndexCaptureScrollAnchor(tableView);
-            ApolloSubredditIndexApplySeparatorInsets(tableView);
-            [UIView performWithoutAnimation:^{
-                [tableView reloadData];
-                [tableView layoutIfNeeded];
-                ApolloSubredditIndexInstallOrUpdate(tableView);
-                ApolloSubredditIndexRestoreScrollAnchor(tableView, anchor);
-            }];
+        if (ApolloSubredditIndexShouldInspectTable(tableView)) {
+            NSArray<NSString *> *titles = ApolloSubredditIndexTitlesForTable(tableView);
+            BOOL isSubredditTable = ApolloSubredditIndexLooksLikeSubredditsTable(tableView, titles);
+            if (isSubredditTable) {
+                objc_setAssociatedObject(tableView, &kApolloSubredditIndexTableKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                NSDictionary *anchor = ApolloSubredditIndexCaptureScrollAnchor(tableView);
+                ApolloSubredditIndexApplySeparatorInsets(tableView);
+                [UIView performWithoutAnimation:^{
+                    [tableView reloadData];
+                    [tableView layoutIfNeeded];
+                    ApolloSubredditIndexInstallOrUpdate(tableView);
+                    ApolloSubredditIndexRestoreScrollAnchor(tableView, anchor);
+                }];
+            }
         }
     }
 
@@ -1103,6 +1150,7 @@ static void ApolloSubredditIndexRefreshAllVisibleTables(void) {
 static BOOL ApolloSubredditIndexEnsureSubredditTable(UITableView *tableView) {
     if (!tableView) return NO;
     if ([objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue]) return YES;
+    if (!ApolloSubredditIndexShouldInspectTable(tableView)) return NO;
 
     NSArray<NSString *> *titles = ApolloSubredditIndexTitlesForTable(tableView);
     if (!ApolloSubredditIndexLooksLikeSubredditsTable(tableView, titles)) return NO;
@@ -1116,7 +1164,8 @@ static void ApolloSubredditIndexPrepareCellForDisplay(UITableView *tableView, UI
 
     ApolloSubredditIndexApplySeparatorInsets(tableView);
     ApolloSubredditIndexApplyCellMarginsOnce(cell);
-    if ([cell isKindOfClass:NSClassFromString(@"_TtC6Apollo23RedditListTableViewCell")]) {
+    Class redditListCellClass = ApolloSubredditIndexRedditListTableViewCellClass();
+    if (redditListCellClass && [cell isKindOfClass:redditListCellClass]) {
         ApolloSubredditIndexApplyRedditListCellPolishOnce(cell);
     }
 }
@@ -1124,6 +1173,7 @@ static void ApolloSubredditIndexPrepareCellForDisplay(UITableView *tableView, UI
 static void ApolloSubredditIndexStyleHeaderView(UIView *header, UITableView *tableView) {
     if (!header || !tableView) return;
     if (![objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue]) {
+        if (!ApolloSubredditIndexShouldInspectTable(tableView)) return;
         NSArray<NSString *> *titles = ApolloSubredditIndexTitlesForTable(tableView);
         if (!ApolloSubredditIndexLooksLikeSubredditsTable(tableView, titles)) return;
         objc_setAssociatedObject(tableView, &kApolloSubredditIndexTableKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -1358,6 +1408,9 @@ static void ApolloSubredditIndexInstallHeaderLayoutHook(void) {
 
 - (void)layoutSubviews {
     %orig;
+    Class redditListCellClass = ApolloSubredditIndexRedditListTableViewCellClass();
+    if (!redditListCellClass || ![(UITableViewCell *)self isKindOfClass:redditListCellClass]) return;
+
     UITableView *tableView = ApolloSubredditIndexTableForCell((UITableViewCell *)self);
     if ([objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue]) {
         ApolloSubredditIndexInstallStarProxyForCell((UITableViewCell *)self, tableView);
@@ -1366,6 +1419,9 @@ static void ApolloSubredditIndexInstallHeaderLayoutHook(void) {
 
 - (void)setEditing:(BOOL)editing animated:(BOOL)animated {
     %orig;
+    Class redditListCellClass = ApolloSubredditIndexRedditListTableViewCellClass();
+    if (!redditListCellClass || ![(UITableViewCell *)self isKindOfClass:redditListCellClass]) return;
+
     UITableView *tableView = ApolloSubredditIndexTableForCell((UITableViewCell *)self);
     if ([objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue]) {
         ApolloSubredditIndexInstallStarProxyForCell((UITableViewCell *)self, tableView);
@@ -1378,7 +1434,7 @@ static UIStackView *ApolloSubredditIndexRedditListMainStackView(UITableViewCell 
     static Ivar mainStackIvar = NULL;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        Class cls = NSClassFromString(@"_TtC6Apollo23RedditListTableViewCell");
+        Class cls = ApolloSubredditIndexRedditListTableViewCellClass();
         if (cls) mainStackIvar = class_getInstanceVariable(cls, "mainStackView");
     });
     if (!mainStackIvar) return nil;

--- a/ApolloUserAvatars.xm
+++ b/ApolloUserAvatars.xm
@@ -47,6 +47,7 @@ static const void *kApolloProfileUsernameCopyMissLoggedKey = &kApolloProfileUser
 static const void *kApolloProfileTabOriginalImageKey = &kApolloProfileTabOriginalImageKey;
 static const void *kApolloProfileTabOriginalSelectedImageKey = &kApolloProfileTabOriginalSelectedImageKey;
 static const void *kApolloProfileTabAppliedUsernameKey = &kApolloProfileTabAppliedUsernameKey;
+static const void *kApolloProfileTabAppliedImageKey = &kApolloProfileTabAppliedImageKey;
 
 @interface ApolloProfileHeaderView : UIView
 @property(nonatomic, strong) UIImageView *bannerImageView;
@@ -76,6 +77,7 @@ static void ApolloProfileLoadImages(ApolloProfileHeaderView *header, NSString *u
 static void ApolloProfileRefreshControllersForUsername(NSString *username);
 static void ApolloProfileApplyTabAvatarForController(UITabBarController *tabBarController);
 static void ApolloProfileApplyTabAvatarForVisibleWindows(void);
+static void ApolloProfileScheduleTabAvatarRefresh(NSString *reason);
 
 @implementation ApolloProfileHeaderView
 
@@ -946,6 +948,7 @@ static NSUInteger sApolloInlineAvatarAppliedLogCount = 0;
 static NSUInteger sApolloInlineAvatarGaveUpLogCount = 0;
 static NSUInteger sApolloInlineAvatarLateReapplyLogCount = 0;
 static NSUInteger sApolloInlineAvatarRewriteLogCount = 0;
+static BOOL sApolloProfileTabSyncingView = NO;
 
 static BOOL ApolloInlineAvatarShouldLog(NSUInteger *counter) {
     if (!counter || *counter >= ApolloInlineAvatarLogLimit) return NO;
@@ -1685,11 +1688,111 @@ static void ApolloProfileRestoreTabAvatarItem(UITabBarItem *item) {
     objc_setAssociatedObject(item, kApolloProfileTabOriginalImageKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(item, kApolloProfileTabOriginalSelectedImageKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(item, kApolloProfileTabAppliedUsernameKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(item, kApolloProfileTabAppliedImageKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 static UIImage *ApolloProfileTabAvatarImage(UIImage *sourceImage) {
     UIImage *avatar = ApolloCircularAvatarImage(sourceImage, ApolloProfileTabAvatarDiameter);
     return [avatar imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+}
+
+static UIImage *ApolloProfileTabOriginalRenderingImage(UIImage *image) {
+    if (!image) return nil;
+    return image.renderingMode == UIImageRenderingModeAlwaysOriginal ? image : [image imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+}
+
+static UIImage *ApolloProfileTabAppliedAvatarForItem(UITabBarItem *item) {
+    if (!item || ![objc_getAssociatedObject(item, ApolloProfileTabAvatarActiveKey()) boolValue]) return nil;
+    return ApolloProfileTabOriginalRenderingImage(objc_getAssociatedObject(item, kApolloProfileTabAppliedImageKey));
+}
+
+static void ApolloProfileDisableSystemTemplateTreatment(UIImageView *imageView) {
+    if (![imageView isKindOfClass:[UIImageView class]]) return;
+
+    imageView.image = ApolloProfileTabOriginalRenderingImage(imageView.image);
+    imageView.highlightedImage = ApolloProfileTabOriginalRenderingImage(imageView.highlightedImage);
+
+    SEL setEnableMonochromaticTreatment = NSSelectorFromString(@"_setEnableMonochromaticTreatment:");
+    if ([imageView respondsToSelector:setEnableMonochromaticTreatment]) {
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(imageView, setEnableMonochromaticTreatment, NO);
+    }
+}
+
+static UITabBarItem *ApolloProfileTabItemForTabBarButton(id button) {
+    if (!button || ![button respondsToSelector:@selector(tabBar)]) return nil;
+    UITabBar *tabBar = ((UITabBar *(*)(id, SEL))objc_msgSend)(button, @selector(tabBar));
+    if (![tabBar isKindOfClass:[UITabBar class]]) return nil;
+
+    SEL tabBarButtonSelector = NSSelectorFromString(@"_tabBarButton");
+    for (UITabBarItem *item in tabBar.items) {
+        if (![item respondsToSelector:tabBarButtonSelector]) continue;
+        id tabBarButton = ((id (*)(id, SEL))objc_msgSend)(item, tabBarButtonSelector);
+        if (tabBarButton == button) return item;
+    }
+    return nil;
+}
+
+static UITabBarItem *ApolloProfileTabItemFromFloatingItem(id item) {
+    if ([item isKindOfClass:[UITabBarItem class]]) return item;
+
+    NSArray<NSString *> *selectors = @[@"_linkedTabBarItem", @"tabBarItem"];
+    for (NSString *selectorName in selectors) {
+        SEL selector = NSSelectorFromString(selectorName);
+        if (![item respondsToSelector:selector]) continue;
+        id linkedItem = ((id (*)(id, SEL))objc_msgSend)(item, selector);
+        if ([linkedItem isKindOfClass:[UITabBarItem class]]) return linkedItem;
+    }
+    return nil;
+}
+
+static void ApolloProfileSyncLegacyTabButtonAvatar(id button) {
+    if (sApolloProfileTabSyncingView) return;
+    UITabBarItem *item = ApolloProfileTabItemForTabBarButton(button);
+    UIImage *avatar = ApolloProfileTabAppliedAvatarForItem(item);
+    if (!avatar) return;
+
+    id imageView = ApolloObjectIvarValue(button, @"_imageView");
+    sApolloProfileTabSyncingView = YES;
+    @try {
+        if ([imageView respondsToSelector:@selector(setImage:)]) {
+            ((void (*)(id, SEL, UIImage *))objc_msgSend)(imageView, @selector(setImage:), avatar);
+        }
+        SEL setAlternateImage = NSSelectorFromString(@"setAlternateImage:");
+        if ([imageView respondsToSelector:setAlternateImage]) {
+            ((void (*)(id, SEL, UIImage *))objc_msgSend)(imageView, setAlternateImage, avatar);
+        }
+        ApolloProfileDisableSystemTemplateTreatment((UIImageView *)imageView);
+    } @finally {
+        sApolloProfileTabSyncingView = NO;
+    }
+}
+
+static void ApolloProfileSyncFloatingTabItemViewAvatar(id itemView) {
+    if (sApolloProfileTabSyncingView) return;
+    if (!itemView || ![itemView respondsToSelector:@selector(item)]) return;
+    id floatingItem = ((id (*)(id, SEL))objc_msgSend)(itemView, @selector(item));
+    UITabBarItem *item = ApolloProfileTabItemFromFloatingItem(floatingItem);
+    UIImage *avatar = ApolloProfileTabAppliedAvatarForItem(item);
+    if (!avatar) return;
+
+    UIImageView *imageView = nil;
+    if ([itemView respondsToSelector:@selector(imageView)]) {
+        id value = ((id (*)(id, SEL))objc_msgSend)(itemView, @selector(imageView));
+        if ([value isKindOfClass:[UIImageView class]]) imageView = value;
+    }
+    if (!imageView) {
+        imageView = (UIImageView *)ApolloObjectIvarValue(itemView, @"_imageView");
+    }
+    if (![imageView isKindOfClass:[UIImageView class]]) return;
+
+    sApolloProfileTabSyncingView = YES;
+    @try {
+        imageView.image = avatar;
+        imageView.highlightedImage = avatar;
+        ApolloProfileDisableSystemTemplateTreatment(imageView);
+    } @finally {
+        sApolloProfileTabSyncingView = NO;
+    }
 }
 
 static void ApolloProfileSetTabAvatarImage(UITabBarItem *item, UIImage *sourceImage, NSString *username) {
@@ -1704,6 +1807,7 @@ static void ApolloProfileSetTabAvatarImage(UITabBarItem *item, UIImage *sourceIm
     item.image = avatar;
     item.selectedImage = avatar;
     objc_setAssociatedObject(item, kApolloProfileTabAppliedUsernameKey, username, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(item, kApolloProfileTabAppliedImageKey, avatar, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 static void ApolloProfileApplyTabAvatarForController(UITabBarController *tabBarController) {
@@ -1768,10 +1872,27 @@ static void ApolloProfileApplyTabAvatarForVisibleWindows(void) {
     });
 }
 
+static void ApolloProfileScheduleTabAvatarRefresh(NSString *reason) {
+    if (!sUseProfileAvatarTabIcon) return;
+
+    ApolloProfileApplyTabAvatarForVisibleWindows();
+    NSArray<NSNumber *> *delays = @[@0.10, @0.50, @1.25];
+    for (NSNumber *delayNumber in delays) {
+        NSTimeInterval delay = delayNumber.doubleValue;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            if (!sUseProfileAvatarTabIcon) return;
+            ApolloProfileApplyTabAvatarForVisibleWindows();
+        });
+    }
+
+    if (reason.length > 0) {
+        ApolloLog(@"[UserAvatars] Scheduled profile tab avatar refresh after %@", reason);
+    }
+}
+
 static void ApolloProfileScheduleAccountChangeTabAvatarRefresh(NSString *reason) {
     if (!sUseProfileAvatarTabIcon) return;
-    ApolloProfileApplyTabAvatarForVisibleWindows();
-    ApolloLog(@"[UserAvatars] Scheduled profile tab avatar refresh after %@", reason ?: @"account change");
+    ApolloProfileScheduleTabAvatarRefresh(reason ?: @"account change");
 }
 
 static void ApolloProfileOpenURL(NSURL *url) {
@@ -1788,6 +1909,11 @@ static void ApolloProfileOpenRedditProfileEditor(void) {
 %hook ASTextNode
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
+    if (!sShowUserAvatars) {
+        %orig;
+        return;
+    }
+
     if ([objc_getAssociatedObject(self, kApolloAvatarApplyingTextKey) boolValue]) {
         %orig;
         return;
@@ -1813,6 +1939,11 @@ static void ApolloProfileOpenRedditProfileEditor(void) {
 %hook ASTextNode2
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
+    if (!sShowUserAvatars) {
+        %orig;
+        return;
+    }
+
     if ([objc_getAssociatedObject(self, kApolloAvatarApplyingTextKey) boolValue]) {
         %orig;
         return;
@@ -1839,6 +1970,7 @@ static void ApolloProfileOpenRedditProfileEditor(void) {
 
 - (void)didLoad {
     %orig;
+    if (!sShowUserAvatars) return;
     ApolloApplyAvatarToCellWithDiameter(self, ApolloUsernameFromCell(self, @"comment"), ApolloCommentInlineAvatarDiameter);
 }
 
@@ -1848,6 +1980,7 @@ static void ApolloProfileOpenRedditProfileEditor(void) {
 
 - (void)didLoad {
     %orig;
+    if (!sShowUserAvatars) return;
     ApolloApplyAvatarToCellWithDiameter(self, ApolloUsernameFromCell(self, @"link"), ApolloFeedInlineAvatarDiameter);
 }
 
@@ -1857,6 +1990,7 @@ static void ApolloProfileOpenRedditProfileEditor(void) {
 
 - (void)didLoad {
     %orig;
+    if (!sShowUserAvatars) return;
     ApolloApplyAvatarToCellWithDiameter(self, ApolloUsernameFromCell(self, @"link"), ApolloFeedInlineAvatarDiameter);
 }
 
@@ -1866,6 +2000,7 @@ static void ApolloProfileOpenRedditProfileEditor(void) {
 
 - (void)didLoad {
     %orig;
+    if (!sShowUserAvatars) return;
     ApolloApplyAvatarToCellWithDiameter(self, ApolloUsernameFromCell(self, @"link"), ApolloFeedInlineAvatarDiameter);
 }
 
@@ -1931,6 +2066,16 @@ static void ApolloProfileOpenRedditProfileEditor(void) {
     ApolloProfileApplyTabAvatarForController(self);
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+    %orig(animated);
+    ApolloProfileApplyTabAvatarForController(self);
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    %orig(previousTraitCollection);
+    ApolloProfileScheduleTabAvatarRefresh(nil);
+}
+
 - (void)setViewControllers:(NSArray<UIViewController *> *)viewControllers {
     %orig(viewControllers);
     ApolloProfileApplyTabAvatarForController(self);
@@ -1939,6 +2084,87 @@ static void ApolloProfileOpenRedditProfileEditor(void) {
 - (void)setViewControllers:(NSArray<UIViewController *> *)viewControllers animated:(BOOL)animated {
     %orig(viewControllers, animated);
     ApolloProfileApplyTabAvatarForController(self);
+}
+
+%end
+
+%hook UITabBar
+
+- (void)didMoveToWindow {
+    %orig;
+    ApolloProfileScheduleTabAvatarRefresh(nil);
+}
+
+- (void)tintColorDidChange {
+    %orig;
+    ApolloProfileScheduleTabAvatarRefresh(nil);
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    %orig(previousTraitCollection);
+    ApolloProfileScheduleTabAvatarRefresh(nil);
+}
+
+%end
+
+%hook UITabBarButton
+
+- (void)_updateToMatchCurrentState {
+    %orig;
+    ApolloProfileSyncLegacyTabButtonAvatar(self);
+}
+
+- (void)setItemAppearanceData:(id)data {
+    %orig(data);
+    ApolloProfileSyncLegacyTabButtonAvatar(self);
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    %orig(previousTraitCollection);
+    ApolloProfileSyncLegacyTabButtonAvatar(self);
+}
+
+%end
+
+%hook UITabBarSwappableImageView
+
+- (void)setImage:(UIImage *)image {
+    %orig(image);
+    ApolloProfileSyncLegacyTabButtonAvatar(((UIView *)self).superview);
+}
+
+- (void)setAlternateImage:(UIImage *)image {
+    %orig(image);
+    ApolloProfileSyncLegacyTabButtonAvatar(((UIView *)self).superview);
+}
+
+- (void)setCurrentImage {
+    %orig;
+    ApolloProfileSyncLegacyTabButtonAvatar(((UIView *)self).superview);
+}
+
+%end
+
+%hook _UIFloatingTabBarItemView
+
+- (void)reloadItemView {
+    %orig;
+    ApolloProfileSyncFloatingTabItemViewAvatar(self);
+}
+
+- (void)_updateImage {
+    %orig;
+    ApolloProfileSyncFloatingTabItemViewAvatar(self);
+}
+
+- (void)_updateFontAndColors {
+    %orig;
+    ApolloProfileSyncFloatingTabItemViewAvatar(self);
+}
+
+- (void)setHasSelectionHighlight:(BOOL)hasSelectionHighlight {
+    %orig(hasSelectionHighlight);
+    ApolloProfileSyncFloatingTabItemViewAvatar(self);
 }
 
 %end
@@ -2002,12 +2228,30 @@ static void ApolloProfileOpenRedditProfileEditor(void) {
                                                       object:nil
                                                        queue:[NSOperationQueue mainQueue]
                                                   usingBlock:^(__unused NSNotification *note) {
-        ApolloProfileApplyTabAvatarForVisibleWindows();
+        ApolloProfileScheduleTabAvatarRefresh(@"setting toggle");
     }];
     [[NSNotificationCenter defaultCenter] addObserverForName:ApolloUserProfileInfoUpdatedNotification
                                                       object:nil
                                                        queue:[NSOperationQueue mainQueue]
                                                   usingBlock:^(__unused NSNotification *note) {
-        ApolloProfileApplyTabAvatarForVisibleWindows();
+        ApolloProfileScheduleTabAvatarRefresh(@"profile info update");
+    }];
+    [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationWillEnterForegroundNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(__unused NSNotification *note) {
+        ApolloProfileScheduleTabAvatarRefresh(@"app foreground");
+    }];
+    [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidBecomeActiveNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(__unused NSNotification *note) {
+        ApolloProfileScheduleTabAvatarRefresh(@"app active");
+    }];
+    [[NSNotificationCenter defaultCenter] addObserverForName:@"com.christianselig.ApolloSpecificThemeChanged"
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(__unused NSNotification *note) {
+        ApolloProfileScheduleTabAvatarRefresh(@"Apollo theme change");
     }];
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [v2.14.0] - 2026-05-20
 
-- Optional **Notification Backend** support: point Apollo at your own forked self-hosted [apollo-backend](https://github.com/nickclyde/apollo-backend) instance so push registrations, watchers, and inbox checks route there instead of being silently dropped. Configure in **Settings > Custom API > Notification Backend** with the backend URL and optional registration token. Leave empty to keep current blocking behavior. APNs delivery still requires a paid Apple Developer account on the signing side.
-- New **Reddit API Secret** field in **Settings > Custom API > API Keys** so per-account Reddit credentials can be forwarded to a self-hosted notification backend that performs token refreshes server-side. Usually left empty for installed-app Reddit credentials.
+### Features
+
+- **Notification Backend** support (requires paid Apple Developer account): point Apollo at your own forked self-hosted [apollo-backend](https://github.com/nickclyde/apollo-backend) instance so push registrations, watchers, and inbox checks route there instead of being silently dropped. (Thanks @nickclyde!)
+    - Configure in **Settings > Custom API > Notification Backend** with the backend URL and optional registration token. Leave empty to keep current blocking behavior.
+    - APNs delivery still requires a paid Apple Developer account on the signing side. 
+- New **Reddit API Secret** field in **Settings > Custom API > API Keys** so per-account Reddit credentials can be forwarded to a self-hosted notification backend that performs token refreshes server-side. Usually left empty for installed-app Reddit credentials. (Thanks @nickclyde!)
+
+### Fixes
+
+- Improve **Profile Picture Tab Icon** reliability across Liquid Glass tab bar refreshes, theme changes, and app foregrounding.
+- Refine Liquid Glass **Hide Bars on Scroll** idle behavior with smoother re-collapse/re-expand handling and disable the idle setting on unsupported iOS versions.
+- Improve performance and stability across subreddit list polish, rich link previews, and the media post composer.
 
 ## [v2.13.0] - 2026-05-19
 
@@ -419,6 +429,7 @@ There are currently a few limitations:
 ## [v1.0.0] - 2023-10-13
 - Initial release
 
+[v2.14.0]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v2.13.0...v2.14.0
 [v2.13.0]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v2.12.0b...v2.13.0
 [v2.12.0b]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v2.11.0...v2.12.0b
 [v2.11.0]: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/compare/v2.10.0...v2.11.0

--- a/CustomAPIViewController.m
+++ b/CustomAPIViewController.m
@@ -201,6 +201,20 @@ typedef NS_ENUM(NSInteger, Tag) {
     return (sPreferredGIFFallbackFormat == 0) ? @"GIF" : @"MP4";
 }
 
+- (BOOL)apollo_supportsAutoHideTabBarIdleSetting {
+    return IsLiquidGlass() &&
+        [UITabBarController instancesRespondToSelector:NSSelectorFromString(@"setTabBarMinimizeBehavior:")];
+}
+
+- (void)apollo_disableAutoHideTabBarIdleIfUnsupported {
+    if ([self apollo_supportsAutoHideTabBarIdleSetting]) return;
+    if (!sAutoHideTabBarShowOnIdle && ![[NSUserDefaults standardUserDefaults] boolForKey:UDKeyAutoHideTabBarShowOnIdle]) return;
+
+    sAutoHideTabBarShowOnIdle = NO;
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:UDKeyAutoHideTabBarShowOnIdle];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloAutoHideTabBarShowOnIdleChangedNotification" object:nil];
+}
+
 - (void)setPreferredGIFFallbackFormat:(NSInteger)format {
     sPreferredGIFFallbackFormat = (format == 0) ? 0 : 1;
     [[NSUserDefaults standardUserDefaults] setInteger:sPreferredGIFFallbackFormat forKey:UDKeyPreferredGIFFallbackFormat];
@@ -537,6 +551,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 
     self.title = @"Custom API";
     self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
+    [self apollo_disableAutoHideTabBarIdleIfUnsupported];
     [self apollo_applyTheme];
 }
 
@@ -791,6 +806,29 @@ typedef NS_ENUM(NSInteger, Tag) {
     return cell;
 }
 
+- (UITableViewCell *)switchCellWithIdentifier:(NSString *)identifier
+                                        label:(NSString *)label
+                                       detail:(NSString *)detail
+                                           on:(BOOL)on
+                                       action:(SEL)action {
+    UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:identifier];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:identifier];
+        cell.selectionStyle = UITableViewCellSelectionStyleNone;
+        cell.textLabel.numberOfLines = 0;
+        cell.detailTextLabel.numberOfLines = 0;
+        cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+
+        UISwitch *toggleSwitch = [[UISwitch alloc] init];
+        [toggleSwitch addTarget:self action:action forControlEvents:UIControlEventValueChanged];
+        cell.accessoryView = toggleSwitch;
+    }
+    cell.textLabel.text = label;
+    cell.detailTextLabel.text = detail;
+    ((UISwitch *)cell.accessoryView).on = on;
+    return cell;
+}
+
 - (UITableViewCell *)apiKeyCellForRow:(NSInteger)row tableView:(UITableView *)tableView {
     switch (row) {
         case 0:
@@ -902,11 +940,19 @@ typedef NS_ENUM(NSInteger, Tag) {
                                             label:@"Open Steam Links in App"
                                                on:[defaults boolForKey:UDKeyOpenLinksInSteamApp]
                                            action:@selector(steamAppSwitchToggled:)];
-        case 7:
-            return [self switchCellWithIdentifier:@"Cell_Gen_TabBarIdle"
-                                            label:@"Tab Bar Re-Expands When Idle"
-                                               on:[defaults boolForKey:UDKeyAutoHideTabBarShowOnIdle]
-                                           action:@selector(autoHideTabBarShowOnIdleSwitchToggled:)];
+        case 7: {
+            BOOL idleSupported = [self apollo_supportsAutoHideTabBarIdleSetting];
+            UITableViewCell *cell = [self switchCellWithIdentifier:@"Cell_Gen_TabBarIdle"
+                                                             label:@"Tab Bar Re-Expands When Idle"
+                                                            detail:@"Requires Liquid Glass and Hide Bars on Scroll in General settings."
+                                                                on:idleSupported && [defaults boolForKey:UDKeyAutoHideTabBarShowOnIdle]
+                                                            action:@selector(autoHideTabBarShowOnIdleSwitchToggled:)];
+            UISwitch *toggleSwitch = [cell.accessoryView isKindOfClass:[UISwitch class]] ? (UISwitch *)cell.accessoryView : nil;
+            toggleSwitch.enabled = idleSupported;
+            cell.textLabel.enabled = idleSupported;
+            cell.detailTextLabel.enabled = idleSupported;
+            return cell;
+        }
         default: return [[UITableViewCell alloc] init];
     }
 }
@@ -1668,6 +1714,14 @@ typedef NS_ENUM(NSInteger, Tag) {
 }
 
 - (void)autoHideTabBarShowOnIdleSwitchToggled:(UISwitch *)sender {
+    if (![self apollo_supportsAutoHideTabBarIdleSetting]) {
+        sender.on = NO;
+        sAutoHideTabBarShowOnIdle = NO;
+        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:UDKeyAutoHideTabBarShowOnIdle];
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloAutoHideTabBarShowOnIdleChangedNotification" object:nil];
+        return;
+    }
+
     sAutoHideTabBarShowOnIdle = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sAutoHideTabBarShowOnIdle forKey:UDKeyAutoHideTabBarShowOnIdle];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloAutoHideTabBarShowOnIdleChangedNotification" object:nil];

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ Thank you to these wonderful people:
       <td align="center" valign="top" width="14.29%"><a href="https://github.com/ryannair05"><img src="https://avatars.githubusercontent.com/u/23365226?v=4&amp;s=100" width="100px;" height="100px;" style="object-fit: cover;" alt="ryannair05"/></a><br /><sub><b>ryannair05</b></sub><br /><a href="https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/commits?author=ryannair05" title="Code">Code</a></td>
       <td align="center" valign="top" width="14.29%"><a href="https://github.com/ichitaso"><img src="https://avatars.githubusercontent.com/u/980215?v=4&amp;s=100" width="100px;" height="100px;" style="object-fit: cover;" alt="ichitaso"/></a><br /><sub><b>ichitaso</b></sub><br /><a href="https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/commits?author=ichitaso" title="Code">Code</a></td>
     </tr>
+    <tr>
+      <td align="center" valign="top" width="14.29%"><a href="https://github.com/epheterson"><img src="https://avatars.githubusercontent.com/u/151483?v=4&amp;s=100" width="100px;" height="100px;" style="object-fit: cover;" alt="epheterson"/></a><br /><sub><b>epheterson</b></sub><br /><a href="https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/commits?author=epheterson" title="Code">Code</a></td>
+      <td align="center" valign="top" width="14.29%"><a href="https://github.com/nickclyde"><img src="https://avatars.githubusercontent.com/u/9121162?v=4&amp;s=100" width="100px;" height="100px;" style="object-fit: cover;" alt="nickclyde"/></a><br /><sub><b>nickclyde</b></sub><br /><a href="https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/commits?author=nickclyde" title="Code">Code</a></td>
+    </tr>
   </tbody>
 </table>
 

--- a/contributors.json
+++ b/contributors.json
@@ -60,6 +60,14 @@
       "github": "ichitaso"
     },
     {
+      "role": "code",
+      "github": "epheterson"
+    },
+    {
+      "role": "code",
+      "github": "nickclyde"
+    },
+    {
       "role": "design",
       "github": "iGerman00"
     },

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: ca.jeffrey.apollo-improvedcustomapi
 Name: Apollo-ImprovedCustomApi
-Version: 2.13.0
+Version: 2.14.0
 Architecture: iphoneos-arm
 Description: Apollo for Reddit tweak with in-app configurable API keys
 Maintainer: JeffreyCA


### PR DESCRIPTION
Fixes #247

Improves polish and stability across several UI tweaks:

 - Makes profile tab avatars more reliable across Liquid Glass refreshes, theme changes, and app foregrounding.
 - Refines Liquid Glass tab bar idle/re-collapse behavior and gates unsupported settings.
 - Optimizes subreddit list, rich link preview, and media composer hot paths while fixing subreddit star/index edge cases.