### PR TITLE
Add top padding to account switcher popup on Liquid Glass

### DIFF
--- a/src/ApolloLiquidGlass.xm
+++ b/src/ApolloLiquidGlass.xm
@@ -820,6 +820,22 @@ static void ApolloRecenterTitleControl(UIView *titleControl) {
 
 %end
 
+// MARK: - AccountManagerViewController top padding fix for Liquid Glass
+// In Liquid Glass mode the account switcher popup has no built-in top margin,
+// so the X and Edit bar buttons touch the top edge.
+//
+// Fix: Add additional 12 pts top padding via additionalSafeAreaInsets if using liquid glass.
+
+%hook _TtC6Apollo28AccountManagerViewController
+
+- (void)viewDidLoad {
+    %orig;
+    if (!IsLiquidGlass()) return;
+    ((UIViewController *)self).additionalSafeAreaInsets = UIEdgeInsetsMake(12.0, 0, 0, 0);
+}
+
+%end
+
 %ctor {
     %init;
 }


### PR DESCRIPTION
Resolves #250:

# Summary

- Fix X and Edit buttons touching top of account switcher popup on Liquid Glass
- with liquid glass enabled, the X and Edit buttons in the account switcher modal were touching the top edge of the popup. Fixed by adding 12pt of top padding via additionalSafeAreaInsets on AccountManagerViewController.
- Only applies this additional padding when using Liquid Glass.

# Screenshots

### Before:
<img width="1206" height="207" alt="IMG_5680" src="https://github.com/user-attachments/assets/71b3773a-7eb4-4c7b-aad2-936d6c9c6bef" />

### After: 
<img width="1206" height="243" alt="IMG_5679" src="https://github.com/user-attachments/assets/f14c4d21-5c9a-4a0a-a235-1c9dac6bdcfc" />
