### PR TITLE
Use app token for protected source pushes

### DIFF
--- a/.github/workflows/publish-sources.yml
+++ b/.github/workflows/publish-sources.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           # Release events check out the tag by default; we need main to commit to.
           ref: main
+          # The source push below uses a GitHub App token that can bypass the
+          # protected main ruleset. Do not leave checkout's GITHUB_TOKEN auth
+          # header in place, or Git may push as github-actions[bot] instead.
+          persist-credentials: false
 
       - name: Regenerate distribution sources
         env:
@@ -63,6 +67,7 @@ jobs:
             MSG="$MSG for $RELEASE_TAG"
           fi
           git commit -m "$MSG"
+          git config --local --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git pull --rebase origin main
           git push origin HEAD:main

--- a/.github/workflows/release-ipa-variants.yml
+++ b/.github/workflows/release-ipa-variants.yml
@@ -42,6 +42,10 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
+          # The source push at the end uses a GitHub App token that can bypass
+          # the protected main ruleset. Do not persist checkout's GITHUB_TOKEN
+          # auth header, or Git may push as github-actions[bot] instead.
+          persist-credentials: false
 
       - name: Install build dependencies
         run: brew install ldid dpkg make
@@ -216,6 +220,7 @@ jobs:
             exit 0
           fi
           git commit -m "Update distribution sources for ${{ steps.meta.outputs.tag_name }}"
+          git config --local --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git pull --rebase origin main
           git push origin HEAD:main


### PR DESCRIPTION
  ## Summary

  Fix source JSON publishing on protected `main` branches.

  The release/source workflows already create a GitHub App installation token before pushing updated source files, but `actions/checkout` persists the default
  `GITHUB_TOKEN` auth header in local git config. That can cause the final `git push` to authenticate as `github-actions[bot]` instead of the GitHub App, so branch
  protection rejects the push with:

  ```text
  GH013: Repository rule violations found for refs/heads/main
  - Changes must be made through a pull request.

  This updates both source-push paths to:

  - set persist-credentials: false on checkout
  - explicitly clear http.https://github.com/.extraheader before pushing
  - keep using the existing GitHub App token for the protected main push

  ## Validation

  Tested the failure mode on a protected fork main: the release was created, source files were generated and committed in the runner, but the final push was rejected by
  branch protection. After applying this fix and merging it into the fork, Publish distribution sources successfully pushed the generated source JSON update to protected
  main.