### PR TITLE
Bump distributable IPA bundle versions

### DIFF
--- a/.github/workflows/release-ipa-variants.yml
+++ b/.github/workflows/release-ipa-variants.yml
@@ -149,27 +149,43 @@ jobs:
 
       - name: Generate release notes
         run: |
-          cat > RELEASE_NOTES.md <<EOF
-          Apollo version: \`v${{ steps.meta.outputs.apollo_version }}\`
-          Apollo-Reborn version: \`v${{ steps.meta.outputs.tweak_version }}\`
+          python3 - <<'PY' > RELEASE_NOTES.md
+          from pathlib import Path
+          import os
+          import re
 
-          ## Included IPA variants
+          apollo_version = os.environ["APOLLO_VERSION"]
+          tweak_version = os.environ["TWEAK_VERSION"]
+          changelog_path = Path("CHANGELOG.md")
 
-          - Standard injected IPA
-          - No Extensions injected IPA
-          - Standard injected IPA + Liquid Glass patch
-          - No Extensions injected IPA + Liquid Glass patch
+          def changelog_entry(version: str) -> str | None:
+              if not changelog_path.exists():
+                  return None
+              text = changelog_path.read_text(encoding="utf-8")
+              heading_re = re.compile(
+                  rf"^## \[v?{re.escape(version)}\](?:\s+-\s+.+)?\s*$",
+                  re.MULTILINE,
+              )
+              match = heading_re.search(text)
+              if not match:
+                  return None
+              next_match = re.search(r"^## \[", text[match.end():], re.MULTILINE)
+              end = match.end() + next_match.start() if next_match else len(text)
+              entry = text[match.end():end].strip()
+              return entry or None
 
-          ## Included tweak packages
-
-          - Rootful `.deb`
-          - Rootless `.deb`
-
-          ## Variant notes
-
-          - **No Extensions** removes Apollo's bundled app extensions so the sideloaded app uses 1 App ID instead of 7.
-          - **GLASS** applies the iOS 26 Liquid Glass binary patch and installs the bundled Liquid Glass icon catalog from this repo.
-          EOF
+          notes = changelog_entry(tweak_version)
+          if notes:
+              print(notes)
+          else:
+              print(f"Apollo version: `v{apollo_version}`")
+              print(f"Apollo-Reborn version: `v{tweak_version}`")
+              print()
+              print("This release includes the standard, No Extensions, GLASS, and No Extensions + GLASS IPA variants.")
+          PY
+        env:
+          APOLLO_VERSION: ${{ steps.meta.outputs.apollo_version }}
+          TWEAK_VERSION: ${{ steps.meta.outputs.tweak_version }}
 
       - name: Create release
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8

--- a/.github/workflows/release-ipa-variants.yml
+++ b/.github/workflows/release-ipa-variants.yml
@@ -148,41 +148,7 @@ jobs:
           echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes
-        run: |
-          python3 - <<'PY' > RELEASE_NOTES.md
-          from pathlib import Path
-          import os
-          import re
-
-          apollo_version = os.environ["APOLLO_VERSION"]
-          tweak_version = os.environ["TWEAK_VERSION"]
-          changelog_path = Path("CHANGELOG.md")
-
-          def changelog_entry(version: str) -> str | None:
-              if not changelog_path.exists():
-                  return None
-              text = changelog_path.read_text(encoding="utf-8")
-              heading_re = re.compile(
-                  rf"^## \[v?{re.escape(version)}\](?:\s+-\s+.+)?\s*$",
-                  re.MULTILINE,
-              )
-              match = heading_re.search(text)
-              if not match:
-                  return None
-              next_match = re.search(r"^## \[", text[match.end():], re.MULTILINE)
-              end = match.end() + next_match.start() if next_match else len(text)
-              entry = text[match.end():end].strip()
-              return entry or None
-
-          notes = changelog_entry(tweak_version)
-          if notes:
-              print(notes)
-          else:
-              print(f"Apollo version: `v{apollo_version}`")
-              print(f"Apollo-Reborn version: `v{tweak_version}`")
-              print()
-              print("This release includes the standard, No Extensions, GLASS, and No Extensions + GLASS IPA variants.")
-          PY
+        run: python3 ./scripts/generate_release_notes.py > RELEASE_NOTES.md
         env:
           APOLLO_VERSION: ${{ steps.meta.outputs.apollo_version }}
           TWEAK_VERSION: ${{ steps.meta.outputs.tweak_version }}

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -121,12 +121,15 @@ Per-app metadata (icon, screenshots, description, `appPermissions`) lives in
 [distribution/config.json](distribution/config.json) under `app`, and per-variant
 overrides under each entry in `variants`. Notes on the model:
 
-- **Versioning**: each release entry uses `version` = the Apollo
-  `CFBundleShortVersionString` (e.g. `1.15.11`, which matches the installed
-  bundle so AltStore's update check behaves), while `buildVersion` and
-  `marketingVersion` carry the incrementing tweak version (e.g. `2.14.0`). The
-  tweak version is what users see and what makes each release a distinct entry,
-  so Feather/AltStore can list and re-download previous versions.
+- **Versioning**: the release pipeline rewrites the main app's
+  `CFBundleShortVersionString` to the Apollo-Reborn tweak version and
+  `CFBundleVersion` to the monotonic build number in
+  [distribution/config.json](distribution/config.json) (currently `286`). The
+  source generator mirrors those exact values in `version` and `buildVersion`
+  because AltStore validates them against the downloaded IPA before installing.
+  Historical IPAs used Apollo's original `1.15.11`/`285` values, so generated
+  sources advertise only the newest installable build while keeping older
+  release notes in `news`.
 - **`appPermissions`**: AltStore validates a source's declared entitlements and
   privacy strings against the downloaded IPA and refuses to install on a
   mismatch, so these are required. The values were extracted from the Apollo

--- a/distribution/config.json
+++ b/distribution/config.json
@@ -12,7 +12,7 @@
   },
   "app": {
     "bundleIdentifier": "com.christianselig.Apollo",
-    "buildVersion": "285",
+    "buildVersion": "286",
     "developerName": "Christian Selig (& Apollo-Reborn contributors)",
     "iconURL": "https://apolloreborn.app/assets/icon.png",
     "tintColor": "#F0542D",

--- a/scripts/build_release_variants.sh
+++ b/scripts/build_release_variants.sh
@@ -42,6 +42,51 @@ extract_apollo_version() {
     rm -f "$plist"
 }
 
+read_source_build_version() {
+    python3 - <<'PY'
+from pathlib import Path
+import json
+
+config = json.loads(Path("distribution/config.json").read_text(encoding="utf-8"))
+print(config["app"]["buildVersion"])
+PY
+}
+
+set_main_app_bundle_versions_in_ipa() {
+    local ipa="$1"
+    local short_version="$2"
+    local build_version="$3"
+    local work plist app_dir
+    work="$(mktemp -d)"
+
+    if ! (cd "$work" && unzip -q "$ipa"); then
+        echo "Warning: could not unzip IPA for version update; leaving as-is."
+        rm -rf "$work"
+        return 0
+    fi
+
+    plist="$(find "$work/Payload" -maxdepth 2 -name Info.plist -path '*.app/Info.plist' -print -quit)"
+    if [[ -z "$plist" || ! -f "$plist" ]]; then
+        echo "Warning: could not find main app Info.plist in $(basename "$ipa"); leaving as-is."
+        rm -rf "$work"
+        return 0
+    fi
+
+    plutil -replace CFBundleShortVersionString -string "$short_version" "$plist"
+    plutil -replace CFBundleVersion -string "$build_version" "$plist"
+
+    app_dir="$(dirname "$plist")"
+    rm -rf "$app_dir/_CodeSignature"
+
+    rm -f "$ipa"
+    (
+        cd "$work"
+        zip -qry "$ipa" Payload
+    )
+
+    rm -rf "$work"
+}
+
 strip_arm64e_from_substrate_in_ipa() {
     local ipa="$1"
     local work
@@ -170,6 +215,7 @@ if not match:
 print(match.group(1).replace("~", "-"))
 PY
 )"
+APP_BUILD_VERSION="$(read_source_build_version)"
 
 BASE_NAME="${NAME_PREFIX}-${APOLLO_VERSION}_Apollo-Reborn-${TWEAK_VERSION}"
 STANDARD_IPA="${OUTPUT_DIR}/${BASE_NAME}.ipa"
@@ -181,6 +227,7 @@ echo "Input IPA     : $IPA_PATH"
 echo "Tweak DEB     : $DEB_PATH"
 echo "Apollo version: $APOLLO_VERSION"
 echo "Tweak version : $TWEAK_VERSION"
+echo "Build version : $APP_BUILD_VERSION"
 echo "Output dir    : $OUTPUT_DIR"
 
 rm -f "$STANDARD_IPA" "$NOEXT_IPA" "$GLASS_IPA" "$NOEXT_GLASS_IPA"
@@ -188,19 +235,23 @@ rm -f "$STANDARD_IPA" "$NOEXT_IPA" "$GLASS_IPA" "$NOEXT_GLASS_IPA"
 echo ""
 echo "[1/4] Building standard injected IPA..."
 bash "${REPO_DIR}/build-ipa.sh" --ipa "$IPA_PATH" --deb "$DEB_PATH" -o "$STANDARD_IPA"
+set_main_app_bundle_versions_in_ipa "$STANDARD_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
 
 echo ""
 echo "[2/4] Building no-extensions injected IPA..."
 cyan -i "$IPA_PATH" -f "$DEB_PATH" -o "$NOEXT_IPA" -e
 strip_arm64e_from_substrate_in_ipa "$NOEXT_IPA"
+set_main_app_bundle_versions_in_ipa "$NOEXT_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
 
 echo ""
 echo "[3/4] Applying Liquid Glass patch to standard IPA..."
 bash "${REPO_DIR}/patch.sh" "$STANDARD_IPA" --liquid-glass -o "$GLASS_IPA"
+set_main_app_bundle_versions_in_ipa "$GLASS_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
 
 echo ""
 echo "[4/4] Applying Liquid Glass patch to no-extensions IPA..."
 bash "${REPO_DIR}/patch.sh" "$NOEXT_IPA" --liquid-glass -o "$NOEXT_GLASS_IPA"
+set_main_app_bundle_versions_in_ipa "$NOEXT_GLASS_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
 
 echo ""
 echo "Created:"

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Generate GitHub release notes from the changelog."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG_PATH = ROOT / "CHANGELOG.md"
+
+
+def changelog_entry(version: str) -> str | None:
+    if not CHANGELOG_PATH.exists():
+        return None
+
+    text = CHANGELOG_PATH.read_text(encoding="utf-8")
+    heading_re = re.compile(
+        rf"^## \[v?{re.escape(version)}\](?:\s+-\s+.+)?\s*$",
+        re.MULTILINE,
+    )
+    match = heading_re.search(text)
+    if not match:
+        return None
+
+    next_match = re.search(r"^## \[", text[match.end():], re.MULTILINE)
+    end = match.end() + next_match.start() if next_match else len(text)
+    entry = text[match.end():end].strip()
+    return entry or None
+
+
+def fallback_notes(apollo_version: str, tweak_version: str) -> str:
+    return "\n".join(
+        [
+            f"Apollo version: `v{apollo_version}`",
+            f"Apollo-Reborn version: `v{tweak_version}`",
+            "",
+            "This release includes the standard, No Extensions, GLASS, and No Extensions + GLASS IPA variants.",
+        ]
+    )
+
+
+def main() -> int:
+    apollo_version = os.environ.get("APOLLO_VERSION", "").strip()
+    tweak_version = os.environ.get("TWEAK_VERSION", "").strip()
+    if not apollo_version or not tweak_version:
+        print(
+            "APOLLO_VERSION and TWEAK_VERSION environment variables are required",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(changelog_entry(tweak_version) or fallback_notes(apollo_version, tweak_version))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_source_json.py
+++ b/scripts/update_source_json.py
@@ -98,14 +98,13 @@ def build_version_entry(
 
     apollo_version, tweak_version = parsed
     return {
-        # AltStore's VerifyAppOperation rejects an install when `version` does not
-        # equal the IPA's CFBundleShortVersionString, and (when present) when
-        # `buildVersion` does not equal its CFBundleVersion. Apollo's bundle is
-        # frozen, so both must mirror the IPA exactly: `version` is Apollo's
-        # 1.15.11 and `buildVersion` is its CFBundleVersion (from config). The
-        # incrementing tweak version surfaces via `marketingVersion`, which is
-        # display-only and is what clients show on the store page.
-        "version": apollo_version,
+        # AltStore's VerifyAppOperation rejects an install when `version` does
+        # not equal the IPA's CFBundleShortVersionString, and (when present)
+        # when `buildVersion` does not equal its CFBundleVersion. The release
+        # pipeline rewrites those fields to the tweak version and the source
+        # config's monotonic build number, so the source must mirror that exact
+        # pair.
+        "version": tweak_version,
         "buildVersion": build_version,
         "marketingVersion": tweak_version,
         "date": release.get("published_at"),
@@ -250,7 +249,6 @@ def update_source_json(
     app.update(variant["app"])
 
     build_version = config["app"].get("buildVersion")
-    seen: set[tuple[str, str | None]] = set()
     versions: list[dict[str, Any]] = []
     news: list[dict[str, Any]] = []
 
@@ -265,14 +263,11 @@ def update_source_json(
         )
         if not entry:
             continue
-        # Apollo's bundle is frozen, so every tweak release shares the same
-        # (version, buildVersion). AltStore requires version entries to be
-        # distinct on that pair, so we list only the newest installable build
-        # here (releases are iterated newest-first). The full per-release
-        # changelog lives in `news` below, which is keyed on the release tag.
-        key = (entry["version"], entry["buildVersion"])
-        if key not in seen:
-            seen.add(key)
+        # Historical IPAs were published before the bundle-version rewrite and
+        # still carry Apollo's original 1.15.11/285 plist values. The source
+        # config only knows the current build number, so advertise the newest
+        # installable asset while keeping the full release history in news.
+        if not versions:
             versions.append(entry)
         news.append(build_news_entry(release, config, variant.get("newsLabel")))
 

--- a/scripts/update_source_json.py
+++ b/scripts/update_source_json.py
@@ -55,8 +55,27 @@ def load_existing_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def markdown_to_plain_text(markdown: str) -> str:
+    text = markdown.strip()
+    if not text:
+        return ""
+
+    # AltStore/Feather version history renders descriptions as plain text, so
+    # remove the most visible Markdown syntax while keeping the curated wording.
+    text = re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    text = re.sub(r"\*\*([^*]+)\*\*", r"\1", text)
+    text = re.sub(r"__([^_]+)__", r"\1", text)
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1 (\2)", text)
+    text = re.sub(r"^#{2,6}\s+", "", text, flags=re.MULTILINE)
+    text = re.sub(r"^\s{2,}[-*]\s+", "  - ", text, flags=re.MULTILINE)
+    text = re.sub(r"^\s*[-*]\s+", "- ", text, flags=re.MULTILINE)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
 def format_release_notes(body: str, variant_name: str | None = None) -> str:
-    text = body.strip()
+    text = markdown_to_plain_text(body)
     if variant_name:
         return f"{variant_name}\n\n{text}" if text else variant_name
     return text


### PR DESCRIPTION
This reopens the work from #295 against the real `main` branch.

#295 was merged back into the old #286 source branch after #286 had already landed, so those commits never reached `main`.

## Changes

* Bumps distributable IPA bundle versions from the Apollo build version to the Apollo-Reborn tweak version
* Keeps `CFBundleVersion` monotonic via `distribution/config.json` `buildVersion`
* Uses `CHANGELOG.md` entries for release notes instead of the generated variant summary
* Keeps the release source generator aligned with the new version metadata

## Validation

```sh
python3 -m py_compile scripts/update_source_json.py
bash -n scripts/build_release_variants.sh
git diff --check origin/main..HEAD