### PR TITLE
Guard patch.sh against un-pulled Git LFS Assets.car pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Resulting `Info.plist` entry:
 
 Available patches:
 
-- **`--liquid-glass`** - enables the iOS 26 Liquid Glass UI and installs a pack of Liquid Glass icons that can be switched between in the tweak's in-app icon picker.
+- **`--liquid-glass`** - enables the iOS 26 Liquid Glass UI and installs a pack of Liquid Glass icons that can be switched between in the tweak's in-app icon picker. Requires the Git LFS asset to be pulled first (`git lfs install && git lfs pull`); see the [Build](#build) note. `patch.sh` will refuse to run with an un-pulled pointer.
 - **`--url-schemes <list>`** - adds comma-separated URL schemes to `CFBundleURLTypes` (see [Custom Redirect URI](#custom-redirect-uri)).
 - **`--remove-code-signature`** - strips the existing code signature.
 
@@ -151,8 +151,12 @@ For the in-house four-variant IPA release flow, AltStore Classic/SideStore/Feath
 **Instructions:**
 1. `git clone https://github.com/Apollo-Reborn/Apollo-Reborn`
 2. `cd Apollo-Reborn`
-3. `git submodule update --init --recursive`
-4. `make package` or `make package THEOS_PACKAGE_SCHEME=rootless` for rootless variant
+3. `git lfs install && git lfs pull` (see the note below)
+4. `git submodule update --init --recursive`
+5. `make package` or `make package THEOS_PACKAGE_SCHEME=rootless` for rootless variant
+
+> [!IMPORTANT]
+> The prebuilt Liquid Glass asset catalog (`liquid-glass/prebuilt/Assets.car`) is stored with [Git LFS](https://git-lfs.com). A plain `git clone` without git-lfs installed leaves a tiny text pointer in its place instead of the real ~80 MB file, which makes `patch.sh --liquid-glass` produce a broken IPA that crashes on launch. Run `git lfs install` (one-time per machine) followed by `git lfs pull` to fetch the real asset. Verify with `git lfs ls-files` — a `*` next to the file means it's present.
 
 ## Contributors ✨
 

--- a/patch.sh
+++ b/patch.sh
@@ -231,6 +231,21 @@ if [ "${LIQUID_GLASS}" == "true" ]; then
         exit 1
     fi
 
+    # Guard against an un-pulled Git LFS pointer. Assets.car is stored via Git
+    # LFS, so a plain `git clone` without git-lfs installed leaves a tiny text
+    # pointer in its place. Patching with that stub silently produces a broken
+    # IPA that crashes on launch (see issue #314), so fail early with a fix.
+    asset_size=$(wc -c < "${LIQUID_GLASS_ASSETS_CAR}" | tr -d ' ')
+    if head -c 64 "${LIQUID_GLASS_ASSETS_CAR}" | grep -q "git-lfs" || [ "${asset_size}" -lt 4096 ]; then
+        echo "Error: ${LIQUID_GLASS_ASSETS_CAR} looks like an un-pulled Git LFS pointer (${asset_size} bytes), not the real asset catalog."
+        echo "       Fetch the LFS content, then re-run this command:"
+        echo ""
+        echo "         git lfs install   # one-time per machine"
+        echo "         git lfs pull"
+        echo ""
+        exit 1
+    fi
+
     echo "Replacing Assets.car with prebuilt Liquid Glass asset catalog..."
     cp "${LIQUID_GLASS_ASSETS_CAR}" "Assets.car"
 


### PR DESCRIPTION
## What

Makes `patch.sh --liquid-glass` fail fast (with a fix) when `liquid-glass/prebuilt/Assets.car` is an un-pulled Git LFS pointer instead of the real asset catalog, and documents the LFS requirement in the README.

## Why

`Assets.car` is stored via Git LFS. A plain `git clone` on a machine without git-lfs installed leaves a tiny text pointer (<1 KB) in its place. `patch.sh` happily copied that stub into the IPA, producing a build that crashes on launch with no obvious cause — exactly what was reported in #314.

## Changes

- **`patch.sh`**: after the existing existence check, detect an LFS pointer (matches the `git-lfs` signature in the file header, or an implausibly small size < 4 KB) and exit early with instructions to run `git lfs install && git lfs pull`.
- **`README.md`**: add a Git LFS step to the build instructions plus an IMPORTANT callout, and note the requirement on the `--liquid-glass` patch description.

Keeping LFS for now (the file is ~80 MB, under GitHub's 100 MB limit, so dropping LFS remains an option if the guard + docs don't reduce confusion).

## Testing

- `bash -n patch.sh` passes.
- Verified the guard ACCEPTS the real 81 MB `Assets.car` and REJECTS a simulated LFS pointer file.

Closes #314
