### PR TITLE
Add Liquid Glass icons-only variants

### DIFF
--- a/.github/workflows/release-ipa-variants.yml
+++ b/.github/workflows/release-ipa-variants.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   build-release:
-    name: Build four IPA variants
+    name: Build six IPA variants
     runs-on: macos-15
     permissions:
       contents: write
@@ -241,7 +241,8 @@ jobs:
         run: |
           git config user.name "apollo-source-updater[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add apps.json apps_noext.json apps_glass.json apps_noext_glass.json release-manifest.json
+          git add apps.json apps_noext.json apps_glass.json apps_noext_glass.json \
+                  apps_glass_icons.json apps_noext_glass_icons.json release-manifest.json
           if git diff --cached --quiet; then
             echo "No source JSON changes to commit."
             exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Add **GLASS Icons** and **No Extensions + GLASS Icons** distribution variants that bundle the Liquid Glass alternate icon catalog without opting the app into the iOS 26 UI runtime. The standard GLASS builds run `vtool -set-build-version ios 15.0 19.0`, which is what activates the new iOS 26 tab bar (whose horizontal swipe switches tabs); the icons-only variants skip that step so legacy UIKit behaviors — notably the bottom tab bar swipe-to-go-back/forward gesture — are preserved.
+- Add `--liquid-glass-icons` flag to `patch.sh` for producing the icons-only variant manually. `--liquid-glass` and `--liquid-glass-icons` are mutually exclusive.
+
 ## [v3.0.0] - 2026-05-29
 
 ### Features

--- a/distribution/config.json
+++ b/distribution/config.json
@@ -111,6 +111,38 @@
         "name": "Apollo for Reddit - No Extensions + GLASS",
         "subtitle": "Apollo-Reborn build without extensions and with Liquid Glass patch"
       }
+    },
+    {
+      "output": "apps_glass_icons.json",
+      "prefix": "GLASS-ICONS",
+      "notesLabel": "Liquid Glass icons-only build.",
+      "newsLabel": "GLASS Icons",
+      "source": {
+        "identifier": "app.apolloreborn.glassicons",
+        "name": "Apollo-Reborn - GLASS Icons",
+        "subtitle": "Apollo-Reborn source with the Liquid Glass icon catalog only",
+        "description": "GLASS Icons Apollo-Reborn source for AltStore Classic, SideStore, and Feather. Bundles the Liquid Glass alternate icon catalog without the iOS 26 UI runtime opt-in, so legacy UIKit behaviors (such as the bottom tab bar swipe gesture) are preserved. Not compatible with AltStore PAL."
+      },
+      "app": {
+        "name": "Apollo for Reddit - GLASS Icons",
+        "subtitle": "Apollo-Reborn build with the Liquid Glass icon catalog only"
+      }
+    },
+    {
+      "output": "apps_noext_glass_icons.json",
+      "prefix": "NO-EXTENSIONS_GLASS-ICONS",
+      "notesLabel": "No Extensions + Liquid Glass icons-only build.",
+      "newsLabel": "No Extensions + GLASS Icons",
+      "source": {
+        "identifier": "app.apolloreborn.noextensionsglassicons",
+        "name": "Apollo-Reborn - No Extensions + GLASS Icons",
+        "subtitle": "Apollo-Reborn source without extensions and with the Liquid Glass icon catalog only",
+        "description": "No Extensions + GLASS Icons Apollo-Reborn source for AltStore Classic, SideStore, and Feather. Uses 1 App ID and bundles the Liquid Glass alternate icon catalog without the iOS 26 UI runtime opt-in. Not compatible with AltStore PAL."
+      },
+      "app": {
+        "name": "Apollo for Reddit - No Extensions + GLASS Icons",
+        "subtitle": "Apollo-Reborn build without extensions and with the Liquid Glass icon catalog only"
+      }
     }
   ]
 }

--- a/patch.sh
+++ b/patch.sh
@@ -89,6 +89,7 @@ trap cleanup EXIT
 # Generic IPA patching script (DOES NOT inject the tweak)
 # Supports:
 # - Liquid Glass patch for iOS 26 (credit: @ryannair05)
+# - Liquid Glass icons only (icon catalog + plist metadata, no iOS 26 UI chrome)
 # - Custom URL schemes injection
 
 # --- Argument Parsing ---
@@ -96,6 +97,7 @@ INPUT_IPA=""
 OUTPUT_IPA="Apollo-Patched.ipa"
 REMOVE_CODE_SIGNATURE="false"
 LIQUID_GLASS="false"
+LIQUID_GLASS_ICONS_ONLY="false"
 URL_SCHEMES=""
 OUTPUT_IPA_PATH=""
 
@@ -106,11 +108,16 @@ print_usage() {
     echo "  -o, --output <file>           Output IPA filename (default: Apollo-Patched.ipa)"
     echo "  --remove-code-signature       Remove code signature from the binary"
     echo "  --liquid-glass                Apply Liquid Glass patch for iOS 26"
+    echo "  --liquid-glass-icons          Bundle the Liquid Glass icon catalog only,"
+    echo "                                without the iOS 26 UI chrome (no vtool"
+    echo "                                build-version bump). Cannot be combined"
+    echo "                                with --liquid-glass."
     echo "  --url-schemes <schemes>       Comma-separated list of URL schemes to add"
     echo "                                (e.g., 'custom,test,myapp')"
     echo ""
     echo "Examples:"
     echo "  $0 Apollo.ipa --liquid-glass"
+    echo "  $0 Apollo.ipa --liquid-glass-icons"
     echo "  $0 Apollo.ipa --url-schemes 'custom,test'"
     echo "  $0 Apollo.ipa --liquid-glass --url-schemes 'custom' -o MyApp.ipa"
 }
@@ -127,6 +134,10 @@ while [[ "$#" -gt 0 ]]; do
             ;;
         --liquid-glass)
             LIQUID_GLASS="true"
+            shift
+            ;;
+        --liquid-glass-icons)
+            LIQUID_GLASS_ICONS_ONLY="true"
             shift
             ;;
         --url-schemes)
@@ -155,6 +166,14 @@ if [ -z "$INPUT_IPA" ]; then
     exit 1
 fi
 
+# --liquid-glass and --liquid-glass-icons are mutually exclusive: the former
+# bumps LC_BUILD_VERSION to opt the app into the iOS 26 UI runtime, which is
+# the exact behavior the icons-only build is meant to avoid.
+if [ "${LIQUID_GLASS}" == "true" ] && [ "${LIQUID_GLASS_ICONS_ONLY}" == "true" ]; then
+    echo "Error: --liquid-glass and --liquid-glass-icons are mutually exclusive."
+    exit 1
+fi
+
 if [ ! -f "$INPUT_IPA" ]; then
     echo "Error: Input IPA file not found: $INPUT_IPA"
     exit 1
@@ -165,6 +184,7 @@ echo "Input IPA: ${INPUT_IPA}"
 echo "Output IPA: ${OUTPUT_IPA}"
 echo "Remove code signature: ${REMOVE_CODE_SIGNATURE}"
 echo "Liquid Glass patch: ${LIQUID_GLASS}"
+echo "Liquid Glass icons only: ${LIQUID_GLASS_ICONS_ONLY}"
 echo "URL schemes: ${URL_SCHEMES:-none}"
 
 if [[ "${OUTPUT_IPA}" = /* ]]; then
@@ -225,6 +245,27 @@ if [ "${LIQUID_GLASS}" == "true" ]; then
         install_name_tool -delete_rpath "@executable_path/Frameworks" "${EXECUTABLE_NAME}"
         echo "Duplicate LC_RPATH entry removed"
     fi
+
+    if [ ! -f "${LIQUID_GLASS_ASSETS_CAR}" ]; then
+        echo "Error: Liquid Glass asset catalog not found at ${LIQUID_GLASS_ASSETS_CAR}"
+        exit 1
+    fi
+
+    echo "Replacing Assets.car with prebuilt Liquid Glass asset catalog..."
+    cp "${LIQUID_GLASS_ASSETS_CAR}" "Assets.car"
+
+    echo "Updating app icon metadata for Liquid Glass multi-icon catalog..."
+    ensure_liquid_glass_icon_metadata
+fi
+
+# --- 2a-icons. Liquid Glass icons-only Patch ---
+# Same Assets.car + plist work as --liquid-glass, but skip the vtool
+# build-version bump. That bump is what opts the app into the iOS 26 Liquid
+# Glass UI runtime, which replaces several legacy UIKit behaviors (notably
+# the bottom-tab horizontal swipe gesture). Users who want the new icon
+# catalog without that runtime swap can use this variant instead.
+if [ "${LIQUID_GLASS_ICONS_ONLY}" == "true" ]; then
+    echo "Applying Liquid Glass icons-only patch (no iOS 26 UI chrome)..."
 
     if [ ! -f "${LIQUID_GLASS_ASSETS_CAR}" ]; then
         echo "Error: Liquid Glass asset catalog not found at ${LIQUID_GLASS_ASSETS_CAR}"

--- a/scripts/build_release_variants.sh
+++ b/scripts/build_release_variants.sh
@@ -12,11 +12,13 @@ NAME_PREFIX="Apollo"
 usage() {
     echo "Usage: $0 --ipa <Apollo.ipa> [--deb <packages/*.deb>] [--output-dir <dir>] [--name-prefix <name>]"
     echo ""
-    echo "Builds the four distributable IPA variants used by AltStore/SideStore/Feather:"
+    echo "Builds the six distributable IPA variants used by AltStore/SideStore/Feather:"
     echo "  1. standard"
     echo "  2. no-extensions"
     echo "  3. standard + Liquid Glass"
     echo "  4. no-extensions + Liquid Glass"
+    echo "  5. standard + Liquid Glass icons-only"
+    echo "  6. no-extensions + Liquid Glass icons-only"
 }
 
 absolute_path() {
@@ -224,6 +226,8 @@ STANDARD_IPA="${OUTPUT_DIR}/${BASE_NAME}.ipa"
 NOEXT_IPA="${OUTPUT_DIR}/${BASE_NAME}-NOEXTENSIONS.ipa"
 GLASS_IPA="${OUTPUT_DIR}/${BASE_NAME}-GLASS.ipa"
 NOEXT_GLASS_IPA="${OUTPUT_DIR}/${BASE_NAME}-GLASS-NOEXTENSIONS.ipa"
+GLASS_ICONS_IPA="${OUTPUT_DIR}/${BASE_NAME}-GLASSICONS.ipa"
+NOEXT_GLASS_ICONS_IPA="${OUTPUT_DIR}/${BASE_NAME}-GLASSICONS-NOEXTENSIONS.ipa"
 
 echo "Input IPA     : $IPA_PATH"
 echo "Tweak DEB     : $DEB_PATH"
@@ -232,29 +236,41 @@ echo "Tweak version : $TWEAK_VERSION"
 echo "Build version : $APP_BUILD_VERSION"
 echo "Output dir    : $OUTPUT_DIR"
 
-rm -f "$STANDARD_IPA" "$NOEXT_IPA" "$GLASS_IPA" "$NOEXT_GLASS_IPA"
+rm -f "$STANDARD_IPA" "$NOEXT_IPA" "$GLASS_IPA" "$NOEXT_GLASS_IPA" \
+      "$GLASS_ICONS_IPA" "$NOEXT_GLASS_ICONS_IPA"
 
 echo ""
-echo "[1/4] Building standard injected IPA..."
+echo "[1/6] Building standard injected IPA..."
 bash "${REPO_DIR}/build-ipa.sh" --ipa "$IPA_PATH" --deb "$DEB_PATH" -o "$STANDARD_IPA"
 set_main_app_bundle_versions_in_ipa "$STANDARD_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
 
 echo ""
-echo "[2/4] Building no-extensions injected IPA..."
+echo "[2/6] Building no-extensions injected IPA..."
 cyan -i "$IPA_PATH" -f "$DEB_PATH" -o "$NOEXT_IPA" -e
 strip_arm64e_from_substrate_in_ipa "$NOEXT_IPA"
 set_main_app_bundle_versions_in_ipa "$NOEXT_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
 
 echo ""
-echo "[3/4] Applying Liquid Glass patch to standard IPA..."
+echo "[3/6] Applying Liquid Glass patch to standard IPA..."
 bash "${REPO_DIR}/patch.sh" "$STANDARD_IPA" --liquid-glass -o "$GLASS_IPA"
 set_main_app_bundle_versions_in_ipa "$GLASS_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
 
 echo ""
-echo "[4/4] Applying Liquid Glass patch to no-extensions IPA..."
+echo "[4/6] Applying Liquid Glass patch to no-extensions IPA..."
 bash "${REPO_DIR}/patch.sh" "$NOEXT_IPA" --liquid-glass -o "$NOEXT_GLASS_IPA"
 set_main_app_bundle_versions_in_ipa "$NOEXT_GLASS_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
 
 echo ""
+echo "[5/6] Applying Liquid Glass icons-only patch to standard IPA..."
+bash "${REPO_DIR}/patch.sh" "$STANDARD_IPA" --liquid-glass-icons -o "$GLASS_ICONS_IPA"
+set_main_app_bundle_versions_in_ipa "$GLASS_ICONS_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
+
+echo ""
+echo "[6/6] Applying Liquid Glass icons-only patch to no-extensions IPA..."
+bash "${REPO_DIR}/patch.sh" "$NOEXT_IPA" --liquid-glass-icons -o "$NOEXT_GLASS_ICONS_IPA"
+set_main_app_bundle_versions_in_ipa "$NOEXT_GLASS_ICONS_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
+
+echo ""
 echo "Created:"
-printf '  %s\n' "$STANDARD_IPA" "$NOEXT_IPA" "$GLASS_IPA" "$NOEXT_GLASS_IPA"
+printf '  %s\n' "$STANDARD_IPA" "$NOEXT_IPA" "$GLASS_IPA" "$NOEXT_GLASS_IPA" \
+                "$GLASS_ICONS_IPA" "$NOEXT_GLASS_ICONS_IPA"

--- a/scripts/update_source_json.py
+++ b/scripts/update_source_json.py
@@ -18,14 +18,20 @@ LEGACY_ASSET_RE = re.compile(
     r"^(?:(?P<prefix>NO-EXTENSIONS_GLASS|NO-EXTENSIONS|GLASS)_)?"
     r"Apollo-(?P<apollo>[^_]+)_Apollo-Reborn-(?P<tweak>.+)\.ipa$"
 )
+# Longest alternatives first so e.g. "GLASSICONS-NOEXTENSIONS" matches as a
+# whole instead of "GLASSICONS" with "-NOEXTENSIONS" left dangling.
 REBORN_ASSET_RE = re.compile(
-    r"^Apollo-Reborn-(?P<tweak>.+?)(?:-(?P<suffix>GLASS-NOEXTENSIONS|NOEXTENSIONS|GLASS))?\.ipa$"
+    r"^Apollo-Reborn-(?P<tweak>.+?)"
+    r"(?:-(?P<suffix>GLASSICONS-NOEXTENSIONS|GLASS-NOEXTENSIONS|GLASSICONS|NOEXTENSIONS|GLASS))?"
+    r"\.ipa$"
 )
 REBORN_SUFFIX_TO_PREFIX = {
     None: "",
     "GLASS": "GLASS",
     "NOEXTENSIONS": "NO-EXTENSIONS",
     "GLASS-NOEXTENSIONS": "NO-EXTENSIONS_GLASS",
+    "GLASSICONS": "GLASS-ICONS",
+    "GLASSICONS-NOEXTENSIONS": "NO-EXTENSIONS_GLASS-ICONS",
 }
 
 
@@ -54,6 +60,8 @@ def build_variant_key(prefix: str | None) -> str:
         "GLASS": "glass",
         "NO-EXTENSIONS": "noExtensions",
         "NO-EXTENSIONS_GLASS": "noExtensionsGlass",
+        "GLASS-ICONS": "glassIcons",
+        "NO-EXTENSIONS_GLASS-ICONS": "noExtensionsGlassIcons",
     }
     return mapping[prefix]
 


### PR DESCRIPTION
## Summary

Adds two new distribution variants — **GLASS Icons** and **No Extensions + GLASS Icons** — that bundle the Liquid Glass alternate icon catalog *without* bumping the binary's `LC_BUILD_VERSION`.

## Motivation

The current `--liquid-glass` patch runs:

```
vtool -set-build-version ios 15.0 19.0
```

on the Apollo executable. That bump is what opts the app into the iOS 26 UI runtime. Among other UIKit behavior changes, it replaces the legacy bottom tab bar — whose horizontal swipe triggers Apollo's back/forward navigation — with the new Liquid Glass tab bar, whose horizontal swipe just switches tabs. The existing GLASS builds therefore force users who want the icon catalog to also give up that swipe gesture.

The icons-only variants do the `Assets.car` swap and `CFBundleAlternateIcons` plist work, but skip the `vtool` step entirely, so the legacy UIKit behaviors are preserved.

## Changes

- **`patch.sh`** — new `--liquid-glass-icons` flag. Mutually exclusive with `--liquid-glass`.
- **`distribution/config.json`** — two new variant entries (`GLASS-ICONS`, `NO-EXTENSIONS_GLASS-ICONS`) emitting `apps_glass_icons.json` and `apps_noext_glass_icons.json`.
- **`scripts/build_release_variants.sh`** — adds steps [5/6] and [6/6] for `Apollo-Reborn-<ver>-GLASSICONS.ipa` and `Apollo-Reborn-<ver>-GLASSICONS-NOEXTENSIONS.ipa`.
- **`scripts/update_source_json.py`** — extends `REBORN_ASSET_RE`, `REBORN_SUFFIX_TO_PREFIX`, and `build_variant_key` for the new suffixes. Existing 4-variant releases stay parseable.
- **`.github/workflows/release-ipa-variants.yml`** — adds the two new `apps_*.json` to the source-update `git add` list; job name is now "Build six IPA variants".
- **`CHANGELOG.md`** — entry under `[Unreleased]`.

## Test plan

Verified end-to-end against the published `Apollo-1.15.11_ImprovedCustomApi-2.14.0` IPA, using the repo's `Assets.car` (pulled via `git lfs`):

- [x] `bash -n patch.sh` syntax OK
- [x] `patch.sh --liquid-glass --liquid-glass-icons` rejects with mutex error
- [x] `patch.sh --liquid-glass-icons` produces an IPA with:
  - [x] `Assets.car` replaced (39MB → 60MB; the new 47-icon catalog)
  - [x] All 48 icon ids from `liquid-glass/icons.json` present in `CFBundleIcons:CFBundleAlternateIcons` (+ `CFBundleIcons~ipad:CFBundleAlternateIcons`), preserving the 155 stock alternates for a total of 203
  - [x] `LC_BUILD_VERSION` unchanged (`minos 15.0 / sdk 16.2`, same as the input IPA — `--liquid-glass` would bump it to `sdk 19.0`)
- [x] `update_source_json.py` regex/mapping unit-tested against all six asset-name shapes; existing four still parse correctly
- [x] `python3 -c "import scripts.update_source_json"` imports cleanly

Not tested locally: a full release-pipeline dry-run on macOS-15 with `cyan` and `ldid`. The script changes mirror the existing GLASS path 1:1 (same `patch.sh` invocation pattern, same `set_main_app_bundle_versions_in_ipa`, same naming convention), so it should compose with the rest of the pipeline without surprises, but a maintainer trigger of `Build and release IPA variants` against a draft tag would be the right way to confirm.