### PR TITLE
Declare full entitlement set in AltStore sources (#328)

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -146,12 +146,15 @@ overrides under each entry in `variants`. Notes on the model:
   example: `3.0.0 -> 286`, `3.0.1 -> 287`, `3.1.0 -> 288`. Do not reuse a
   build number, because AltStore/iOS use it to decide upgrade ordering.
 - **`appPermissions`**: AltStore validates a source's declared entitlements and
-  privacy strings against the downloaded IPA and refuses to install on a
-  mismatch, so these are required. The values were extracted from the Apollo
-  base IPA (`codesign -d --entitlements` for entitlements, `Info.plist` for the
-  `NS*UsageDescription` privacy strings) and are identical across all four
-  variants -- the decrypted base carries the same minimal entitlement set on the
-  main app and every extension, so stripping extensions does not change them.
+  privacy strings against the downloaded IPA and warns ("Install Anyway") or
+  refuses to install on a mismatch, so these must list the complete set the IPA
+  carries. The values are extracted from the Apollo base IPA
+  (`codesign -d --entitlements` across the main app and every `PlugIns/*.appex`
+  for entitlements, `Info.plist` for the `NS*UsageDescription` privacy strings).
+  `application-identifier` and `com.apple.developer.team-identifier` are
+  intentionally omitted per AltStore's guidance. The declared set is identical
+  across all four variants -- the main app binary carries the full entitlement
+  set, so stripping extensions or patching icons does not change it.
 - All four variants share Apollo's bundle identifier, so they cannot be combined
   into one source (the schema forbids duplicate bundle identifiers per source);
   one source per variant is required.

--- a/apps.json
+++ b/apps.json
@@ -20,8 +20,14 @@
       "localizedDescription": "Apollo-Reborn is the community-maintained Apollo sideload build powered by the Apollo-Reborn tweak.\n\nIt restores custom API support, media fixes, uploads, inline media, translation, saved categories, Liquid Glass support on iOS 26+, and the rest of the project’s ongoing fixes and enhancements.\n\nThese sources are intended for AltStore Classic, SideStore, and Feather. Apollo-Reborn is not compatible with AltStore PAL.\n\nChoose the source variant that matches how you sideload:\n\n• Standard: full app bundle with extensions intact\n• No Extensions: strips Apollo’s app extensions to reduce App ID usage on free Apple IDs\n• GLASS: adds the Liquid Glass iOS 26 patch and bundled Liquid Glass icon catalog\n• No Extensions + GLASS: combines both options\n\nThis project is not affiliated with Apollo or Christian Selig.",
       "appPermissions": {
         "entitlements": [
+          "com.apple.security.application-groups",
+          "com.apple.developer.associated-domains",
+          "com.apple.developer.group-session",
+          "com.apple.developer.icloud-container-identifiers",
+          "com.apple.developer.ubiquity-kvstore-identifier",
+          "keychain-access-groups",
           "aps-environment",
-          "keychain-access-groups"
+          "com.apple.developer.weatherkit"
         ],
         "privacy": {
           "NSCameraUsageDescription": "Used to take photos to upload for sharing.",

--- a/apps_glass.json
+++ b/apps_glass.json
@@ -20,8 +20,14 @@
       "localizedDescription": "Apollo-Reborn is the community-maintained Apollo sideload build powered by the Apollo-Reborn tweak.\n\nIt restores custom API support, media fixes, uploads, inline media, translation, saved categories, Liquid Glass support on iOS 26+, and the rest of the project’s ongoing fixes and enhancements.\n\nThese sources are intended for AltStore Classic, SideStore, and Feather. Apollo-Reborn is not compatible with AltStore PAL.\n\nChoose the source variant that matches how you sideload:\n\n• Standard: full app bundle with extensions intact\n• No Extensions: strips Apollo’s app extensions to reduce App ID usage on free Apple IDs\n• GLASS: adds the Liquid Glass iOS 26 patch and bundled Liquid Glass icon catalog\n• No Extensions + GLASS: combines both options\n\nThis project is not affiliated with Apollo or Christian Selig.",
       "appPermissions": {
         "entitlements": [
+          "com.apple.security.application-groups",
+          "com.apple.developer.associated-domains",
+          "com.apple.developer.group-session",
+          "com.apple.developer.icloud-container-identifiers",
+          "com.apple.developer.ubiquity-kvstore-identifier",
+          "keychain-access-groups",
           "aps-environment",
-          "keychain-access-groups"
+          "com.apple.developer.weatherkit"
         ],
         "privacy": {
           "NSCameraUsageDescription": "Used to take photos to upload for sharing.",

--- a/apps_noext.json
+++ b/apps_noext.json
@@ -20,8 +20,14 @@
       "localizedDescription": "Apollo-Reborn is the community-maintained Apollo sideload build powered by the Apollo-Reborn tweak.\n\nIt restores custom API support, media fixes, uploads, inline media, translation, saved categories, Liquid Glass support on iOS 26+, and the rest of the project’s ongoing fixes and enhancements.\n\nThese sources are intended for AltStore Classic, SideStore, and Feather. Apollo-Reborn is not compatible with AltStore PAL.\n\nChoose the source variant that matches how you sideload:\n\n• Standard: full app bundle with extensions intact\n• No Extensions: strips Apollo’s app extensions to reduce App ID usage on free Apple IDs\n• GLASS: adds the Liquid Glass iOS 26 patch and bundled Liquid Glass icon catalog\n• No Extensions + GLASS: combines both options\n\nThis project is not affiliated with Apollo or Christian Selig.",
       "appPermissions": {
         "entitlements": [
+          "com.apple.security.application-groups",
+          "com.apple.developer.associated-domains",
+          "com.apple.developer.group-session",
+          "com.apple.developer.icloud-container-identifiers",
+          "com.apple.developer.ubiquity-kvstore-identifier",
+          "keychain-access-groups",
           "aps-environment",
-          "keychain-access-groups"
+          "com.apple.developer.weatherkit"
         ],
         "privacy": {
           "NSCameraUsageDescription": "Used to take photos to upload for sharing.",

--- a/apps_noext_glass.json
+++ b/apps_noext_glass.json
@@ -20,8 +20,14 @@
       "localizedDescription": "Apollo-Reborn is the community-maintained Apollo sideload build powered by the Apollo-Reborn tweak.\n\nIt restores custom API support, media fixes, uploads, inline media, translation, saved categories, Liquid Glass support on iOS 26+, and the rest of the project’s ongoing fixes and enhancements.\n\nThese sources are intended for AltStore Classic, SideStore, and Feather. Apollo-Reborn is not compatible with AltStore PAL.\n\nChoose the source variant that matches how you sideload:\n\n• Standard: full app bundle with extensions intact\n• No Extensions: strips Apollo’s app extensions to reduce App ID usage on free Apple IDs\n• GLASS: adds the Liquid Glass iOS 26 patch and bundled Liquid Glass icon catalog\n• No Extensions + GLASS: combines both options\n\nThis project is not affiliated with Apollo or Christian Selig.",
       "appPermissions": {
         "entitlements": [
+          "com.apple.security.application-groups",
+          "com.apple.developer.associated-domains",
+          "com.apple.developer.group-session",
+          "com.apple.developer.icloud-container-identifiers",
+          "com.apple.developer.ubiquity-kvstore-identifier",
+          "keychain-access-groups",
           "aps-environment",
-          "keychain-access-groups"
+          "com.apple.developer.weatherkit"
         ],
         "privacy": {
           "NSCameraUsageDescription": "Used to take photos to upload for sharing.",

--- a/distribution/config.json
+++ b/distribution/config.json
@@ -30,8 +30,14 @@
     "localizedDescription": "Apollo-Reborn is the community-maintained Apollo sideload build powered by the Apollo-Reborn tweak.\n\nIt restores custom API support, media fixes, uploads, inline media, translation, saved categories, Liquid Glass support on iOS 26+, and the rest of the project’s ongoing fixes and enhancements.\n\nThese sources are intended for AltStore Classic, SideStore, and Feather. Apollo-Reborn is not compatible with AltStore PAL.\n\nChoose the source variant that matches how you sideload:\n\n• Standard: full app bundle with extensions intact\n• No Extensions: strips Apollo’s app extensions to reduce App ID usage on free Apple IDs\n• GLASS: adds the Liquid Glass iOS 26 patch and bundled Liquid Glass icon catalog\n• No Extensions + GLASS: combines both options\n\nThis project is not affiliated with Apollo or Christian Selig.",
     "appPermissions": {
       "entitlements": [
+        "com.apple.security.application-groups",
+        "com.apple.developer.associated-domains",
+        "com.apple.developer.group-session",
+        "com.apple.developer.icloud-container-identifiers",
+        "com.apple.developer.ubiquity-kvstore-identifier",
+        "keychain-access-groups",
         "aps-environment",
-        "keychain-access-groups"
+        "com.apple.developer.weatherkit"
       ],
       "privacy": {
         "NSCameraUsageDescription": "Used to take photos to upload for sharing.",


### PR DESCRIPTION
## Summary

Fixes the undeclared-permissions "Install Anyway" prompt reported in #328.

AltStore Classic compares a source's declared `appPermissions` against the downloaded IPA and warns (or shows "Install Anyway") when the IPA carries permissions the source didn't declare. Our sources declared only **2** entitlements (`aps-environment`, `keychain-access-groups`), but the Apollo base IPA's **main app** actually carries **8** declarable entitlements — so installs tripped the warning.

This adds the 6 missing entitlements to `distribution/config.json` (source of truth) and all four generated source files:

- `com.apple.security.application-groups`
- `com.apple.developer.associated-domains`
- `com.apple.developer.group-session`
- `com.apple.developer.icloud-container-identifiers`
- `com.apple.developer.ubiquity-kvstore-identifier`
- `com.apple.developer.weatherkit`

`application-identifier` and `com.apple.developer.team-identifier` are intentionally omitted per [AltStore's guidance](https://faq.altstore.io/developers/make-a-source). The resulting set matches what `codesign -d --entitlements` reports on the base IPA's main app and mirrors [Balackburn/Apollo](https://github.com/Balackburn/Apollo)'s declarations exactly.

The privacy `NS*UsageDescription` strings were already complete (they matched the IPA's `Info.plist`) and are unchanged. The same 8 entitlements live on the main app binary, so a single block is correct for all four variants (Standard, No Extensions, GLASS, No Extensions + GLASS) — stripping extensions or patching icons doesn't change them.

## Files changed

- `distribution/config.json` — `app.appPermissions.entitlements` → full 8-entry list
- `apps.json`, `apps_noext.json`, `apps_glass.json`, `apps_noext_glass.json` — mirrored the same list
- `DISTRIBUTION.md` — clarified the `appPermissions` note

## Verification done locally

- ✅ All source JSON files valid; each declares exactly 8 entitlements + 6 privacy keys.
- ✅ Parity check: extracted entitlements from `apollo-base.ipa`'s main app via `codesign -d --entitlements` (excluding `application-identifier`/`team-identifier`/`get-task-allow`) — exact match to the declared set, and identical to Balackburn's 8.
- ✅ Diff is limited to the entitlement lines + the doc note (no `news`/`versions`/manifest churn).

## 🙏 Needs a tester

I don't use AltStore myself, so I couldn't run the on-device step. **Would appreciate someone who uses AltStore Classic / SideStore to verify** that, after this change:

1. Adding the source and installing no longer shows the undeclared-permissions "Install Anyway" prompt (the repro in #328).
2. The displayed permission list matches Balackburn/Apollo (8 entitlements + 6 privacy strings).

Please test at least the **Standard** and **No Extensions** variants (those are the ones called out in the issue).

## Out of scope

#323 (switching the apolloreborn.app "Add to AltStore" link from `altstore://` to `altstore-classic://`) is a website-repo change and is **not** addressed here.

Closes #328