### PR TITLE
Restore logged-in accounts on settings restore

### DIFF
--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -1425,7 +1425,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 
     if (section == SectionBackupRestore) {
         text = [[NSMutableAttributedString alloc]
-            initWithString:@"Restore does not affect accounts or existing ones. The backup .zip contains an accounts.txt with all account usernames for reference."
+            initWithString:@"Restore also signs you back into the accounts saved in the backup. The backup .zip contains your login credentials — anyone with the file can sign in as you, so keep it private. It also includes an accounts.txt listing the saved usernames."
             attributes:plainAttrs];
     } else if (section == SectionAPIKeys) {
         text = [[NSMutableAttributedString alloc]
@@ -2175,7 +2175,7 @@ static NSString *const kGroupSuiteName = @"group.com.christianselig.apollo";
 
     if (!_isRestoreOperation) {
         NSString *filename = urls.firstObject.lastPathComponent;
-        NSString *message = [NSString stringWithFormat:@"Settings saved as: %@", filename];
+        NSString *message = [NSString stringWithFormat:@"Settings saved as: %@\n\nThis file contains your logged-in account credentials. Keep it private.", filename];
         [self showAlertWithTitle:@"Backup Complete" message:message];
         return;
     }
@@ -2186,7 +2186,7 @@ static NSString *const kGroupSuiteName = @"group.com.christianselig.apollo";
 
 - (void)confirmRestoreWithURL:(NSURL *)zipURL {
     UIAlertController *confirmAlert = [UIAlertController alertControllerWithTitle:@"Confirm Restore"
-        message:@"This will replace all existing settings with the backup. This cannot be undone."
+        message:@"This will replace all existing settings and logged-in accounts with the backup. This cannot be undone."
         preferredStyle:UIAlertControllerStyleAlert];
 
     UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
@@ -2289,7 +2289,20 @@ static NSString *const kGroupSuiteName = @"group.com.christianselig.apollo";
     NSString *libreAPIKey = [defaults stringForKey:UDKeyLibreTranslateAPIKey];
     sLibreTranslateAPIKey = libreAPIKey.length > 0 ? libreAPIKey : nil;
 
-    // Restore group preferences, preserving account state from current install
+    // Restore group preferences, including logged-in accounts.
+    //
+    // The account keys (RedditAccounts2, RedditApplicationOnlyAccount2,
+    // CurrentRedditAccountIndex, LoggedInAccountDetails) hold the Reddit OAuth tokens as
+    // self-contained NSKeyedArchiver blobs (RDKClient -> RDKOAuthCredential ->
+    // RDKAccessToken). They carry no keychain dependency and no device binding, so writing
+    // them here and relaunching (exit(0) below) lets AccountManager reload them on next
+    // launch — the user is signed back in without reauthenticating. The restored API keys
+    // (main prefs) match the keys the tokens were minted under, keeping token refresh
+    // consistent.
+    //
+    // Non-destructive by design: only keys present in the backup are written. A backup made
+    // while logged out has no account keys, so the current install's accounts are left
+    // intact rather than wiped.
     NSString *groupPlistBackupPath = [extractDir stringByAppendingPathComponent:kGroupPlistFilename];
     if ([fileManager fileExistsAtPath:groupPlistBackupPath]) {
         NSDictionary *groupPrefs = [NSDictionary dictionaryWithContentsOfFile:groupPlistBackupPath];
@@ -2297,12 +2310,6 @@ static NSString *const kGroupSuiteName = @"group.com.christianselig.apollo";
             NSUserDefaults *groupDefaults = [[NSUserDefaults alloc] initWithSuiteName:kGroupSuiteName];
 
             for (NSString *key in groupPrefs) {
-                if ([key isEqualToString:@"LoggedInAccountDetails"] ||
-                    [key isEqualToString:@"CurrentRedditAccountIndex"] ||
-                    [key isEqualToString:@"RedditAccounts2"] ||
-                    [key isEqualToString:@"RedditApplicationOnlyAccount2"]) {
-                    continue;
-                }
                 [groupDefaults setObject:groupPrefs[key] forKey:key];
             }
             [groupDefaults synchronize];


### PR DESCRIPTION
## What

Restoring a backup now also signs you back into the Reddit accounts that were logged in when the backup was made. After deleting/reinstalling the app and restoring, **reauthentication is no longer required**.

## Why

Previously, restore brought back all settings but deliberately skipped accounts, so every reinstall meant re-logging into each account.

It turns out the account data was *already* in every backup — `backupSettings` copies the entire `group.com.christianselig.apollo.plist`, which contains the account keys. The restore was the only thing preventing reuse: it explicitly skipped `RedditAccounts2`, `RedditApplicationOnlyAccount2`, `CurrentRedditAccountIndex`, and `LoggedInAccountDetails`.

Those keys hold the Reddit OAuth tokens as self-contained `NSKeyedArchiver` blobs (`RDKClient` → `RDKOAuthCredential` → `RDKAccessToken`) with no keychain dependency and no device binding. Writing them on restore and letting the existing `exit(0)` relaunch reload `AccountManager` is enough to sign the user back in. The restored API keys (main prefs) match the keys the tokens were minted under, so token refresh stays consistent.

## Changes (`src/CustomAPIViewController.m`)

- **Restore accounts** — `restoreFromZipURL:` no longer skips the four account keys; the group-prefs loop writes them all. Non-destructive by design: only keys present in the backup are written, so restoring a logged-out backup won't wipe current accounts.
- **Restore confirmation** — now warns that logged-in accounts will also be replaced.
- **Backup/Restore footer** — replaced the now-false "Restore does not affect accounts" text with one noting that backups contain login credentials and should be kept private.
- **Backup-complete alert** — appends a "keep it private" credentials warning.

## Security note

Backups already contained these unencrypted OAuth tokens (the whole group plist was copied) — this PR just makes them usable on restore. The UI now clearly warns that a backup `.zip` is a credential file. Encryption was considered but intentionally left out of scope (warn-only).

## Testing

Verified manually on device: logged into accounts, backed up, cleared accounts, restored → accounts return usable with no reauthentication and the correct active account.

### Known limitations
- **Cross-version backups:** a `RedditAccounts2` blob from a very different Apollo schema may fail to decode at launch and fall back to re-login (not a crash).
- **Revoked authorization:** if the app's Reddit authorization was revoked during the gap, refresh fails and that account needs re-login (outside our control).
- **API-key consistency:** tokens refresh against the restored client ID/secret; backups capture both together, so the normal flow stays consistent.