### PR TITLE
Fix crash after sharing content

### DIFF
--- a/src/ApolloMarkdownToolbarGif.xm
+++ b/src/ApolloMarkdownToolbarGif.xm
@@ -20,7 +20,7 @@ NSRegularExpression *ApolloNativeGiphyMarkdownTokenRegex(void) {
 static char kApolloMarkdownGifToolbarLastAttemptKey;
 static char kApolloMarkdownGifLoggedDiscoveryKey;
 static char kApolloMarkdownGifLoggedFailureKey;
-static char kApolloMarkdownGifActiveComposeKey;
+static __weak UIViewController *sApolloMarkdownGifActiveComposeController = nil;
 static char kApolloMarkdownGifToolbarRootKey;
 static char kApolloMarkdownGifSessionInjectedKey;
 static char kApolloMarkdownGifLayoutLoggedKey;
@@ -1107,11 +1107,16 @@ static void ApolloMarkdownGifPresentMissingAPIKeyAlert(UIViewController *compose
 }
 
 static UIViewController *ApolloMarkdownGifActiveComposeController(void) {
-    return objc_getAssociatedObject([UIApplication sharedApplication], &kApolloMarkdownGifActiveComposeKey);
+    // Stored weakly so the pointer auto-nils when the compose controller
+    // deallocates (e.g. after sharing content and dismissing). Using an
+    // OBJC_ASSOCIATION_ASSIGN associated object here previously left a dangling
+    // raw pointer that crashed in objc_retain when a deferred injection block
+    // read it back.
+    return sApolloMarkdownGifActiveComposeController;
 }
 
 static void ApolloMarkdownGifSetActiveComposeController(UIViewController *controller) {
-    objc_setAssociatedObject([UIApplication sharedApplication], &kApolloMarkdownGifActiveComposeKey, controller, OBJC_ASSOCIATION_ASSIGN);
+    sApolloMarkdownGifActiveComposeController = controller;
 }
 
 static void ApolloMarkdownGifScheduleInjection(UIViewController *composeController, NSString *reason) {


### PR DESCRIPTION
Fix #333

This fixes an `EXC_BAD_ACCESS` crash that occurred after sharing a post or comment (e.g. to Messages) from the Markdown GIF compose toolbar.

## Details

- The "active compose controller" was stored on `UIApplication` via an unsafe-unretained associated object (`OBJC_ASSOCIATION_ASSIGN`). After the compose controller deallocated, the association kept a dangling raw pointer.
- `ApolloMarkdownGifScheduleInjection` schedules deferred injection blocks up to 2.5s out. When one fired after the controller was gone, ARC retained the dangling `id` return value of `ApolloMarkdownGifActiveComposeController()`, crashing in `objc_retain`.
- Replaced the associated object with a `__weak` static variable, which auto-nils on dealloc, so the getter safely returns `nil` and deferred blocks no-op.