### PR TITLE
Fix Recently Read not loading due to Reddit API change

### DIFF
--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -746,6 +746,25 @@ static NSURLRequest *ApolloLocalFastFailRequest(NSString *path) {
         NSMutableURLRequest *mutableRequest = [request mutableCopy];
         NSString *customUA = [sUserAgent length] > 0 ? sUserAgent : defaultUserAgent;
         [mutableRequest setValue:customUA forHTTPHeaderField:@"User-Agent"];
+
+        // Reddit now returns 403 for unauthenticated www.reddit.com/api/info.json
+        // requests, which Apollo issues natively to populate the Recently Read list
+        // (no Authorization header, browser UA). Reroute those to the authenticated
+        // oauth.reddit.com host with the captured bearer token so the list loads.
+        if ([requestURL.host isEqualToString:@"www.reddit.com"]
+            && [requestURL.path containsString:@"/api/info"]
+            && sLatestRedditBearerToken.length > 0
+            && [[request valueForHTTPHeaderField:@"Authorization"] length] == 0) {
+            NSURLComponents *components = [NSURLComponents componentsWithURL:requestURL resolvingAgainstBaseURL:NO];
+            components.host = @"oauth.reddit.com";
+            NSURL *oauthURL = components.URL;
+            if (oauthURL) {
+                [mutableRequest setURL:oauthURL];
+                [mutableRequest setValue:[@"Bearer " stringByAppendingString:sLatestRedditBearerToken] forHTTPHeaderField:@"Authorization"];
+                ApolloLog(@"[RecentlyRead] Rerouted unauthenticated info.json to oauth.reddit.com");
+            }
+        }
+
         [self setValue:mutableRequest forKey:@"_originalRequest"];
         [self setValue:mutableRequest forKey:@"_currentRequest"];
     } else if (sProxyImgurDDG


### PR DESCRIPTION
Recently Read stopped showing any posts. Apollo populates the list via `-[RDKClient thingsByFullNames:completion:]`, which natively issues `GET https://www.reddit.com/api/info.json?...` with **no `Authorization` header** and a browser User-Agent. Reddit now returns **403 Forbidden** for that unauthenticated request, so the listing parses to nothing and the list shows empty (logs: `[RecentlyRead] Fetch error: (null)`).

## Fix
In `_onqueue_resume` (`src/Tweak.xm`), reroute these requests to the authenticated host: when a `www.reddit.com` request targets `/api/info`, has no `Authorization` header, and we have a captured bearer token, rewrite the host to `oauth.reddit.com` and attach `Authorization: Bearer <token>`.

- Tightly scoped to unauthenticated `www.reddit.com` info.json requests — other flows are untouched.
- Reuses the already-captured `sLatestRedditBearerToken` and the existing User-Agent path.
- Native `RDKLink` parsing/rendering pipeline is unchanged.

## Testing
- `make package` builds cleanly.
- Manually verified Recently Read populates again.
