### PR TITLE
Fix GIFs not autoplaying on cellular connection

### DIFF
--- a/src/ApolloMediaAutoplay.h
+++ b/src/ApolloMediaAutoplay.h
@@ -14,7 +14,7 @@ BOOL ApolloShouldAutoplayInlineGIF(void);
 /// Invalidated when settings, reachability, or Low Power Mode changes.
 BOOL ApolloShouldAutoplayInlineGIFCached(void);
 
-/// Current AutoplayGIFs raw string (never / only-on-wifi / always / automatic).
+/// Current AutoplayGIFs raw string (never / only-on-wifi / always).
 NSString *ApolloAutoplayGIFModeString(void);
 
 /// YES for URLs that are typically animated GIFs (not static JPEG/PNG/WebP).

--- a/src/ApolloMediaAutoplay.m
+++ b/src/ApolloMediaAutoplay.m
@@ -7,7 +7,6 @@
 #import <objc/runtime.h>
 
 static NSString *const kApolloAutoplayGIFsKey = @"AutoplayGIFs";
-static NSString *const kApolloAutoplayGIFsOverCellularKey = @"AutoplayGifsOverCellular";
 static NSString *const kApolloGroupSuiteName = @"group.com.christianselig.apollo";
 
 static const void *kApolloInlineAnimatedGIFViewKey = &kApolloInlineAnimatedGIFViewKey;
@@ -69,8 +68,7 @@ static void ApolloAutoplaySettingsDidChange(void) {
     (void)object;
     (void)change;
     (void)context;
-    if ([keyPath isEqualToString:kApolloAutoplayGIFsKey] ||
-        [keyPath isEqualToString:kApolloAutoplayGIFsOverCellularKey]) {
+    if ([keyPath isEqualToString:kApolloAutoplayGIFsKey]) {
         ApolloAutoplaySettingsDidChange();
     }
 }
@@ -81,15 +79,13 @@ static ApolloAutoplayDefaultsObserver *sAutoplayDefaultsObserver = nil;
 
 static void ApolloInstallAutoplayDefaultsKVO(NSUserDefaults *defaults) {
     if (!defaults || !sAutoplayDefaultsObserver) return;
-    for (NSString *key in @[kApolloAutoplayGIFsKey, kApolloAutoplayGIFsOverCellularKey]) {
-        @try {
-            [defaults addObserver:sAutoplayDefaultsObserver
-                       forKeyPath:key
-                          options:NSKeyValueObservingOptionNew
-                          context:NULL];
-        } @catch (__unused NSException *exception) {
-            ApolloLog(@"[AutoplayGIF] KVO unavailable for defaults key=%@", key);
-        }
+    @try {
+        [defaults addObserver:sAutoplayDefaultsObserver
+                   forKeyPath:kApolloAutoplayGIFsKey
+                      options:NSKeyValueObservingOptionNew
+                      context:NULL];
+    } @catch (__unused NSException *exception) {
+        ApolloLog(@"[AutoplayGIF] KVO unavailable for defaults key=%@", kApolloAutoplayGIFsKey);
     }
 }
 
@@ -108,20 +104,10 @@ static BOOL ApolloComputeShouldAutoplayInlineGIF(NSString **outMode) {
 
     if ([mode isEqualToString:@"never"]) {
         shouldPlay = NO;
-    } else if ([mode isEqualToString:@"only-on-wifi"] || [mode isEqualToString:@"automatic"]) {
+    } else if ([mode isEqualToString:@"only-on-wifi"]) {
         shouldPlay = ApolloNetworkIsOnWiFi();
     } else if ([mode isEqualToString:@"always"]) {
-        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-        BOOL overCellular = [defaults boolForKey:kApolloAutoplayGIFsOverCellularKey];
-        if (!overCellular) {
-            NSUserDefaults *groupDefaults = [[NSUserDefaults alloc] initWithSuiteName:kApolloGroupSuiteName];
-            overCellular = [groupDefaults boolForKey:kApolloAutoplayGIFsOverCellularKey];
-        }
-        if (ApolloNetworkIsOnCellular() && !overCellular) {
-            shouldPlay = NO;
-        } else {
-            shouldPlay = YES;
-        }
+        shouldPlay = YES;
     }
 
     if (outMode) *outMode = mode;


### PR DESCRIPTION
### Problem
With **Autoplay GIFs/Videos** set to **Always**, inline comment GIFs would sometimes show only a still cover frame instead of animating. The freeze was actually deterministic: it happened **on cellular (5G) and never on Wi-Fi**.

The cause was in `ApolloComputeShouldAutoplayInlineGIF` (`src/ApolloMediaAutoplay.m`). The `always` branch gated playback on a `AutoplayGifsOverCellular` preference:

```objc
if (ApolloNetworkIsOnCellular() && !overCellular) {
    shouldPlay = NO;
}
```

But Apollo has no such "autoplay over cellular" toggle — `AutoplayGifsOverCellular` is never written by Apollo or the tweak, so it was always `false`. The result: **"Always" mode never autoplayed on cellular**, leaving inline GIFs stuck on their thumbnail.

Apollo's only autoplay setting is the `AutoplayGIFs` key, with three valid values: `never`, `only-on-wifi`, `always`. There is no `automatic` value either.

### Fix
- **`always`** now means always — `shouldPlay = YES`, with no network gate. (Low Power Mode is still honored separately at the top of the function.)
- Removed the dead `AutoplayGifsOverCellular` key, its KVO observation, and the group-defaults lookup.
- Removed the dead `automatic` branch, which could never match.
- Updated the `ApolloAutoplayGIFModeString` doc comment to list the real values.

### Testing
- `make package` builds cleanly.
- Should be verified on cellular with **Autoplay GIFs = Always**: inline comment GIFs now animate instead of freezing on their cover frame.
