### PR TITLE
Fix inline video play button + clipped AirPlay icon

### DIFF
--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -1972,6 +1972,54 @@ static void ApolloInstallPlayOverlayOnView(UIView *v, ASDisplayNode *node) {
     objc_setAssociatedObject(node, &kApolloPlayOverlayViewKey, container, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+// The play overlay is first added in onDidLoad while the node still has
+// zero bounds, then relies on KVO to recenter once Texture assigns the
+// real frame. Two things break that for inline video thumbnails:
+//   1. When the async DASH/poster resolve triggers a relayout-from-above,
+//      Texture can recycle the node's backing view and silently drop our
+//      manually-added overlay subview (the association still points at the
+//      now-detached container).
+//   2. If the very first layout pass already gave the node real bounds,
+//      the KVO "new bounds" notification may have fired before the overlay
+//      was attached.
+// Re-assert the overlay a few times after load so it survives view
+// recycling and late sizing. Idempotent when the overlay is already
+// correctly attached.
+static void ApolloScheduleVideoPlayOverlayReassert(ASNetworkImageNode *imageNode, NSUInteger attempt) {
+    static const NSTimeInterval delays[] = {0.10, 0.25, 0.50, 1.0, 1.75, 2.5};
+    static const NSUInteger maxAttempts = sizeof(delays) / sizeof(delays[0]);
+    if (!imageNode || attempt >= maxAttempts) return;
+
+    __weak ASNetworkImageNode *weak = imageNode;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delays[attempt] * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        ASNetworkImageNode *node = weak;
+        if (!node) return;
+        BOOL loaded = [node respondsToSelector:@selector(isNodeLoaded)] && [node isNodeLoaded];
+        UIView *view = loaded ? [node view] : nil;
+        if (view) {
+            UIView *overlay = objc_getAssociatedObject(node, &kApolloPlayOverlayViewKey);
+            BOOL stale = overlay && overlay.superview != view;
+            if (stale) {
+                // Association points at a recycled/detached view — drop it
+                // and reinstall onto the live view.
+                [overlay removeFromSuperview];
+                objc_setAssociatedObject(node, &kApolloPlayOverlayViewKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                overlay = nil;
+            }
+            if (!overlay) {
+                ApolloInstallPlayOverlayOnView(view, node);
+            } else {
+                [view bringSubviewToFront:overlay];
+                if ([overlay isKindOfClass:[ApolloPlayOverlayContainer class]]) {
+                    [(ApolloPlayOverlayContainer *)overlay recenter];
+                }
+            }
+        }
+        ApolloScheduleVideoPlayOverlayReassert(node, attempt + 1);
+    });
+}
+
 // Pause inline GIF playback without clearing animatedImage via KVC — that path
 // races with Texture teardown during AutoplayGIFs preference changes and caused
 // SIGSEGV in _locked_setAnimatedImage on stale nodes.
@@ -2357,6 +2405,23 @@ static ASNetworkImageNode *ApolloMakeInlineVideoThumbnailNode(NSURL *videoURL,
             } else {
                 NSURL *dashURL = mm ? ApolloDashURLFromMediaMetadata(mm, videoURL) : nil;
                 NSString *assetID = ApolloMediaMetadataIDFromVideoURL(videoURL);
+                // Fallback when mediaMetadata isn't reachable up the supernode
+                // chain (a timing race on first layout that leaves hostMD=nil):
+                // Reddit hosted-video permalinks expose a stable DASH manifest
+                // at v.redd.it/<assetID>/DASHPlaylist.mpd. Deriving it directly
+                // from the asset id lets the poster — and the play-button
+                // overlay, which only becomes visible once the node has real
+                // bounds — resolve without metadata.
+                if (!dashURL && assetID.length) {
+                    NSString *host = [[videoURL host] lowercaseString] ?: @"";
+                    NSString *path = [[videoURL path] lowercaseString] ?: @"";
+                    BOOL isRedditPlayer = ([host isEqualToString:@"reddit.com"] || [host hasSuffix:@".reddit.com"])
+                        && [path hasPrefix:@"/link/"] && [path containsString:@"/video/"] && [path hasSuffix:@"/player"];
+                    if (isRedditPlayer) {
+                        dashURL = [NSURL URLWithString:[NSString stringWithFormat:
+                            @"https://v.redd.it/%@/DASHPlaylist.mpd", assetID]];
+                    }
+                }
                 if (dashURL && assetID.length) {
                     ApolloFetchDashPoster(assetID, dashURL, ^(UIImage *poster) {
                         ASNetworkImageNode *strong = weakImage;
@@ -2379,6 +2444,7 @@ static ASNetworkImageNode *ApolloMakeInlineVideoThumbnailNode(NSURL *videoURL,
         }
 
         if (v) ApolloInstallPlayOverlayOnView(v, img);
+        ApolloScheduleVideoPlayOverlayReassert(img, 0);
         if (v && ![objc_getAssociatedObject(img, &kApolloLongPressInstalledKey) boolValue]) {
             NSURL *u = objc_getAssociatedObject(img, &kApolloImageURLKey);
             objc_setAssociatedObject(v, &kApolloImageURLKey, u, OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/src/ApolloMedia.xm
+++ b/src/ApolloMedia.xm
@@ -45,8 +45,22 @@ static BOOL ApolloMediaRouteControlIsInMediaViewer(UIView *view) {
     return NO;
 }
 
-static void ApolloMediaRepairRouteControlLayout(UIView *routeView, NSString *reason) {
-    if (![routeView isKindOfClass:[UIView class]] || !ApolloMediaRouteControlIsInMediaViewer(routeView)) return;
+// Reads a UIView-typed Swift/ObjC ivar by name. Swift stored properties on
+// classes don't expose @objc getters, so go through the runtime ivar list.
+static UIView *ApolloMediaReadViewIvar(id obj, const char *name) {
+    if (!obj || !name) return nil;
+    Ivar ivar = class_getInstanceVariable([obj class], name);
+    if (!ivar) return nil;
+    id value = nil;
+    @try { value = object_getIvar(obj, ivar); } @catch (__unused NSException *e) {}
+    return [value isKindOfClass:[UIView class]] ? value : nil;
+}
+
+// The actual clip/aspect-fit/min-size fixes, applied without any container
+// gate. Callers that need the MediaViewer gate go through
+// ApolloMediaRepairRouteControlLayout below.
+static void ApolloMediaApplyRouteControlLayoutFixes(UIView *routeView, NSString *reason) {
+    if (![routeView isKindOfClass:[UIView class]]) return;
     routeView.clipsToBounds = NO;
     routeView.contentMode = UIViewContentModeScaleAspectFit;
     routeView.layer.masksToBounds = NO;
@@ -82,6 +96,11 @@ static void ApolloMediaRepairRouteControlLayout(UIView *routeView, NSString *rea
     }
 }
 
+static void ApolloMediaRepairRouteControlLayout(UIView *routeView, NSString *reason) {
+    if (![routeView isKindOfClass:[UIView class]] || !ApolloMediaRouteControlIsInMediaViewer(routeView)) return;
+    ApolloMediaApplyRouteControlLayoutFixes(routeView, reason);
+}
+
 %hook AVRoutePickerView
 
 - (void)layoutSubviews {
@@ -96,6 +115,35 @@ static void ApolloMediaRepairRouteControlLayout(UIView *routeView, NSString *rea
 - (void)layoutSubviews {
     %orig;
     ApolloMediaRepairRouteControlLayout((UIView *)self, @"MPVolumeView layoutSubviews");
+}
+
+%end
+
+// Apollo's in-app player controls bar (a rounded UIVisualEffectView) clips
+// the AirPlay icon at the bottom-left corner. Stop the bar (and its
+// contentView) from clipping, and repair the airPlayButton's own layout so
+// the glyph renders at full size. fauxVolumeView is an MPVolumeView already
+// covered by the hook above; we re-apply here to be safe since this view is
+// unambiguously the in-app player.
+%hook _TtC6Apollo17VideoControlsView
+
+- (void)layoutSubviews {
+    %orig;
+    UIVisualEffectView *bar = (UIVisualEffectView *)self;
+    bar.clipsToBounds = NO;
+    bar.layer.masksToBounds = NO;
+    UIView *contentView = [bar respondsToSelector:@selector(contentView)] ? bar.contentView : nil;
+    contentView.clipsToBounds = NO;
+    contentView.layer.masksToBounds = NO;
+
+    UIView *airPlayButton = ApolloMediaReadViewIvar(self, "airPlayButton");
+    if (airPlayButton) {
+        ApolloMediaApplyRouteControlLayoutFixes(airPlayButton, @"VideoControlsView airPlayButton");
+    }
+    UIView *fauxVolumeView = ApolloMediaReadViewIvar(self, "fauxVolumeView");
+    if (fauxVolumeView) {
+        ApolloMediaApplyRouteControlLayoutFixes(fauxVolumeView, @"VideoControlsView fauxVolumeView");
+    }
 }
 
 %end


### PR DESCRIPTION
## Fix inline video play button + clipped AirPlay icon

Two unrelated media bugs in one branch.

### 1. Inline Reddit-hosted videos showed only a thumbnail, no play button

Reddit-hosted videos embedded in a **post body** rendered as a static thumbnail with no play-button overlay, so they didn't look tappable. (We fixed this a while back, but it regressed.)

<img src="https://github.com/user-attachments/assets/f9449a2f-c5c2-4357-820e-14aabf7ac457" width="320" alt="Inline Reddit video showing the play-button overlay" />

**Root cause:** the play-button overlay is added to the inline `ASNetworkImageNode`'s view in `onDidLoad`, while the node still has zero bounds, then relies on a single KVO `bounds` notification to recenter once Texture assigns the real frame. That's fragile for body videos: when the async DASH/poster resolve triggers a relayout-from-above, Texture recycles the node's backing view and silently drops our manually-added overlay subview — the association still points at the now-detached container, so nothing ever re-attaches it.

**Fix (scoped to `src/ApolloInlineImages.xm`):**
- Self-heal the overlay after load — re-assert it at a few short delays so it survives Texture view recycling and late sizing. Each pass detects a stale/detached overlay (`overlay.superview != view`), removes it, and reinstalls onto the live view; otherwise it just re-centers and brings to front. Idempotent when already correctly attached.
- Add a DASH poster fallback for Reddit player URLs so the thumbnail still resolves when the comment's `mediaMetadata` isn't reachable at layout time, by constructing the stable `v.redd.it/<assetID>/DASHPlaylist.mpd`.

### 2. Clipped AirPlay icon in Apollo's in-app video player

The AirPlay / route-picker icon in Apollo's video controls was cut off — only part of the icon was visible.

**Root cause:** the existing route-icon repair only covered `AVRoutePickerView` / `MPVolumeView`, not Apollo's own `_TtC6Apollo17VideoControlsView` container. That container is a rounded `UIVisualEffectView` whose clipping was cropping the `airPlayButton`.

**Fix (scoped to `src/ApolloMedia.xm`):**
- Hook `-[_TtC6Apollo17VideoControlsView layoutSubviews]`, disable clipping on the visual-effect container and its `contentView`, and run the route-control layout repair (min 36pt, aspect-fit, clip-free) on both the `airPlayButton` and `fauxVolumeView` ivars.
- Split the repair into a gate-free apply helper so it can be reused from the new hook.



### Testing

Built and tested on device:
- Inline Reddit video in a post body now shows the centered play-button overlay on first load (verified the overlay is *our* inline node via its long-press menu).
- AirPlay icon renders fully in the in-app player.
