### PR TITLE
Add toggle to disable subreddit list enhancements

### DIFF
--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -26,6 +26,8 @@ extern BOOL sUseProfileAvatarTabIcon;
 extern BOOL sShowSubredditHeaders;
 extern BOOL sAutoHideTabBarShowOnIdle;
 extern BOOL sModernSubredditDividers;
+// Master toggle for subreddit list enhancements (see UDKeySubredditListEnhancements).
+extern BOOL sSubredditListEnhancements;
 
 // Render image URLs inline in post selftext and comments. Defaults to YES on
 // fresh installs (registerDefaults). When NO, Apollo's native behavior (text

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -25,6 +25,7 @@ BOOL sUseProfileAvatarTabIcon = NO;
 BOOL sShowSubredditHeaders = NO;
 BOOL sAutoHideTabBarShowOnIdle = NO;
 BOOL sModernSubredditDividers = YES;
+BOOL sSubredditListEnhancements = YES;
 BOOL sEnableInlineImages = NO;
 NSInteger sInlineImageAlignment = ApolloInlineImageAlignmentCenter;
 NSInteger sLinkPreviewBodyMode = ApolloLinkPreviewModeOff;

--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -1062,6 +1062,7 @@ static void ApolloSubredditIndexRefreshFavorites(UITableView *tableView, NSStrin
 }
 
 static void ApolloSubredditIndexScheduleFavoritesRefresh(UITableView *tableView, UITableViewCell *cell, NSString *subredditName, UIControl *nativeControl) {
+    if (!sSubredditListEnhancements) return;
     __weak UITableView *weakTable = tableView;
     __weak UIControl *weakControl = nativeControl;
     NSString *name = [subredditName copy];
@@ -1122,6 +1123,7 @@ static void ApolloSubredditIndexInstallStarProxyForCell(UITableViewCell *cell, U
 }
 
 static void ApolloSubredditIndexInstallOrUpdate(UITableView *tableView) {
+    if (!sSubredditListEnhancements) return;
     if (!ApolloSubredditIndexShouldInspectTable(tableView)) return;
 
     NSArray<NSString *> *titles = ApolloSubredditIndexTitlesForTable(tableView);
@@ -1174,6 +1176,7 @@ static void ApolloSubredditIndexInstallOrUpdate(UITableView *tableView) {
 }
 
 static void ApolloSubredditIndexRefreshTablesInView(UIView *view) {
+    if (!sSubredditListEnhancements) return;
     if (!view) return;
 
     if ([view isKindOfClass:[UITableView class]]) {
@@ -1207,6 +1210,7 @@ static void ApolloSubredditIndexRefreshAllVisibleTables(void) {
 }
 
 static BOOL ApolloSubredditIndexEnsureSubredditTable(UITableView *tableView) {
+    if (!sSubredditListEnhancements) return NO;
     if (!tableView) return NO;
     if ([objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue]) return YES;
     if (!ApolloSubredditIndexShouldInspectTable(tableView)) return NO;
@@ -1353,6 +1357,7 @@ static NSInteger ApolloSubredditIndexMultiredditsSection(UITableView *tableView)
 }
 
 static void ApolloSubredditIndexTrackMultiredditsSection(UITableView *tableView, UIView *headerView, NSInteger section) {
+    if (!sSubredditListEnhancements) return;
     if (!tableView || !headerView) return;
 
     UILabel *label = ApolloSubredditIndexHeaderLabelInView(headerView);
@@ -1486,6 +1491,7 @@ static void ApolloSubredditIndexPrepareCellForDisplay(UITableView *tableView, UI
 }
 
 static void ApolloSubredditIndexStyleHeaderView(UIView *header, UITableView *tableView) {
+    if (!sSubredditListEnhancements) return;
     if (!header || !tableView) return;
     if (![objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue]) {
         if (!ApolloSubredditIndexShouldInspectTable(tableView)) return;

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -639,7 +639,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionAPIKeys: return 9; // 7 text fields + Can't sign in? + API key setup guide
         case SectionGeneral: return 8;
         case SectionMedia: return (sShowUserAvatars ? 13 : 12) + (sEnableInlineImages ? 0 : -1);
-        case SectionSubreddits: return 8;
+        case SectionSubreddits: return sSubredditListEnhancements ? 9 : 8;
         case SectionNotificationBackend: return 3; // URL + Registration Token + Test Connection
         case SectionAbout: return 5; // GitHub + Reddit + Thanks To + Export Logs + Version
         default: return 0;
@@ -1162,48 +1162,55 @@ typedef NS_ENUM(NSInteger, Tag) {
 }
 
 - (UITableViewCell *)subredditCellForRow:(NSInteger)row tableView:(UITableView *)tableView {
-    switch (row) {
+    // Modern Dividers row (logical 1) is hidden when the master toggle is off.
+    NSInteger logicalRow = (row >= 1 && !sSubredditListEnhancements) ? row + 1 : row;
+    switch (logicalRow) {
         case 0:
+            return [self switchCellWithIdentifier:@"Cell_Sub_Enhancements"
+                                            label:@"Subreddit List Enhancements"
+                                               on:sSubredditListEnhancements
+                                           action:@selector(subredditListEnhancementsSwitchToggled:)];
+        case 1:
             return [self switchCellWithIdentifier:@"Cell_Sub_ModernDividers"
                                             label:@"Modern Subreddit Dividers"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyModernSubredditDividers]
                                            action:@selector(modernSubredditDividersSwitchToggled:)];
-        case 1:
+        case 2:
             return [self switchCellWithIdentifier:@"Cell_Sub_Headers"
                                             label:@"Show Subreddit Headers"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowSubredditHeaders]
                                            action:@selector(subredditHeadersSwitchToggled:)];
-        case 2:
+        case 3:
             return [self textFieldCellWithIdentifier:@"Cell_Sub_TrendLimit"
                                                label:@"Trending Subreddits Limit"
                                          placeholder:@"(unlimited)"
                                                 text:sTrendingSubredditsLimit
                                                  tag:TagTrendingLimit
                                            numerical:YES];
-        case 3:
+        case 4:
             return [self stackedTextFieldCellWithIdentifier:@"Cell_Sub_Trending"
                                                       label:@"Trending Source"
                                                 placeholder:defaultTrendingSubredditsSource
                                                        text:sTrendingSubredditsSource
                                                         tag:TagTrendingSubredditsSource];
-        case 4:
+        case 5:
             return [self stackedTextFieldCellWithIdentifier:@"Cell_Sub_Random"
                                                       label:@"Random Source"
                                                 placeholder:defaultRandomSubredditsSource
                                                        text:sRandomSubredditsSource
                                                         tag:TagRandomSubredditsSource];
-        case 5:
+        case 6:
             return [self switchCellWithIdentifier:@"Cell_Sub_RandNSFW"
                                             label:@"Show RandNSFW in Search"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowRandNsfw]
                                            action:@selector(randNsfwSwitchToggled:)];
-        case 6:
+        case 7:
             return [self stackedTextFieldCellWithIdentifier:@"Cell_Sub_RandNSFW_Source"
                                                       label:@"RandNSFW Source"
                                                 placeholder:@"(empty)"
                                                        text:sRandNsfwSubredditsSource
                                                         tag:TagRandNsfwSubredditsSource];
-        case 7: {
+        case 8: {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Sub_ClearCustomBanners"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell_Sub_ClearCustomBanners"];
@@ -1533,7 +1540,8 @@ typedef NS_ENUM(NSInteger, Tag) {
             [self exportLogs];
         }
     } else if (indexPath.section == SectionSubreddits) {
-        if (indexPath.row == 7) {
+        NSInteger logicalRow = (indexPath.row >= 1 && !sSubredditListEnhancements) ? indexPath.row + 1 : indexPath.row;
+        if (logicalRow == 8) {
             UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
             [self promptClearCustomSubredditBannersFromSourceView:cell];
         }
@@ -1594,7 +1602,10 @@ typedef NS_ENUM(NSInteger, Tag) {
 - (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.section == SectionBackupRestore) return YES;
     if (indexPath.section == SectionAPIKeys && (indexPath.row == 7 || indexPath.row == 8)) return YES;
-    if (indexPath.section == SectionSubreddits && indexPath.row == 7) return YES;
+    if (indexPath.section == SectionSubreddits) {
+        NSInteger logicalRow = (indexPath.row >= 1 && !sSubredditListEnhancements) ? indexPath.row + 1 : indexPath.row;
+        return logicalRow == 8;
+    }
     if (indexPath.section == SectionMedia) {
         NSInteger row = (indexPath.row >= 5 && !sEnableInlineImages) ? indexPath.row + 1 : indexPath.row;
         return (row == 0 || row == 1 || row == 2 || row == 5 || row == 6 || row == 7 || row == 8 || row == 11 || row == 12);
@@ -1888,6 +1899,23 @@ typedef NS_ENUM(NSInteger, Tag) {
 
 - (void)randNsfwSwitchToggled:(UISwitch *)sender {
     [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:UDKeyShowRandNsfw];
+}
+
+- (void)subredditListEnhancementsSwitchToggled:(UISwitch *)sender {
+    BOOL wasOn = sSubredditListEnhancements;
+    sSubredditListEnhancements = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sSubredditListEnhancements forKey:UDKeySubredditListEnhancements];
+    if (sSubredditListEnhancements == wasOn) return;
+
+    // Modern Dividers row (logical 1) only exists while the master toggle is on.
+    NSArray<NSIndexPath *> *dividerPaths = @[[NSIndexPath indexPathForRow:1 inSection:SectionSubreddits]];
+    if (sSubredditListEnhancements) {
+        [self.tableView insertRowsAtIndexPaths:dividerPaths withRowAnimation:UITableViewRowAnimationFade];
+    } else {
+        [self.tableView deleteRowsAtIndexPaths:dividerPaths withRowAnimation:UITableViewRowAnimationFade];
+    }
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloModernSubredditDividersChangedNotification object:nil];
 }
 
 - (void)modernSubredditDividersSwitchToggled:(UISwitch *)sender {

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -963,6 +963,7 @@ static void initializeRandomSources() {
                                     UDKeyRandNsfwSubredditsSource: @"",
                                     UDKeyTrendingSubredditsSource: defaultTrendingSubredditsSource,
                                     UDKeyReadPostMaxCount: @0,
+                                    UDKeySubredditListEnhancements: @YES,
                                     UDKeyModernSubredditDividers: @YES,
                                     UDKeyShowRecentlyReadThumbnails: @YES,
                                     UDKeyPreferredGIFFallbackFormat: @1,
@@ -1042,6 +1043,7 @@ static void initializeRandomSources() {
     sShowSubredditHeaders = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowSubredditHeaders];
     sAutoHideTabBarShowOnIdle = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyAutoHideTabBarShowOnIdle];
     sModernSubredditDividers = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyModernSubredditDividers];
+    sSubredditListEnhancements = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeySubredditListEnhancements];
     sEnableBulkTranslation = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableBulkTranslation];
     sAutoTranslateOnAppear = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyAutoTranslateOnAppear];
     sTranslatePostTitles = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyTranslatePostTitles];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -16,6 +16,9 @@ static NSString *const UDKeyRandomSubredditsSource = @"RandomSubredditsSource";
 static NSString *const UDKeyRandNsfwSubredditsSource = @"RandNsfwSubredditsSource";
 static NSString *const UDKeyTrendingSubredditsSource = @"TrendingSubredditsSource";
 static NSString *const UDKeyTrendingSubredditsLimit = @"TrendingSubredditsLimit";
+// Master toggle (short-term fix) for all subreddit list polish/enhancements. Default
+// YES. Modern Subreddit Dividers depends on it — that row hides when this is off.
+static NSString *const UDKeySubredditListEnhancements = @"SubredditListEnhancements";
 static NSString *const UDKeyModernSubredditDividers = @"ModernSubredditDividers";
 static NSString *const ApolloModernSubredditDividersChangedNotification = @"ApolloModernSubredditDividersChangedNotification";
 static NSString *const UDKeyReadPostMaxCount = @"ReadPostMaxCount";


### PR DESCRIPTION
Closes #288
Closes #334

Adds a **Subreddit List Enhancements** switch under Settings > Custom API > Subreddits as a short-term bandaid fix for the issues reported in #288 and #334 (misaligned rows / transparent multireddit arrows on older devices, and the index scrubber not working in non-Liquid Glass mode).

The toggle is on by default. When turned off, the subreddit list polish hooks (custom index scrubber, modern dividers, row/header styling, multireddit styling) stop running and Apollo falls back to its native list behavior. The off-by-one favorite delete fix stays active regardless, since it's unrelated to the reported bugs.

**Modern Subreddit Dividers** now depends on this toggle — its row is hidden when enhancements are off, since it's a no-op in that state.

<img width="500" alt="IMG_3656" src="https://github.com/user-attachments/assets/537b1761-fde3-4104-9f37-dfae930ae50b" />