### PR TITLE
Fix crash reading dangling host pointer in inline image dealloc

### DIFF
--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -156,6 +156,18 @@ static char kApolloInlineGIFGenerationKey;     // NSNumber — bumped on clear/r
 static char kApolloStackedCardSyncerKey;       // ApolloStackedCardSyncer — keeps the multi-image card peeking behind imageNode
 static char kApolloImageChestItemsKey;         // NSArray<NSDictionary *> direct ImageChest CDN image entries for album pager
 
+// kApolloHostMarkdownNodeKey is an OBJC_ASSOCIATION_ASSIGN (unsafe unretained)
+// reference to the host MarkdownNode. The host can be deallocated before the
+// image node (e.g. during comments table teardown), leaving the association
+// slot pointing at freed memory. Reading it as an `id` lets ARC retain the
+// result, which crashes in objc_retain on the dangling pointer. Bridge-cast to
+// a raw void* so ARC performs no retain/release; we only ever need to know
+// whether the node is an inline-hosted image node, not to message the host.
+static inline BOOL ApolloImageNodeHasInlineHost(id node) {
+    if (!node) return NO;
+    return ((__bridge void *)objc_getAssociatedObject(node, &kApolloHostMarkdownNodeKey)) != NULL;
+}
+
 static void ApolloApplyInlineGIFPlaybackPolicyWithCover(ASNetworkImageNode *imageNode, UIImage *cover, NSUInteger retryIndex);
 static void ApolloStartInlineGIFPlayback(ASNetworkImageNode *imageNode);
 static BOOL ApolloResumeInlineGIFPlaybackIfPossible(ASNetworkImageNode *imageNode);
@@ -1495,7 +1507,7 @@ static BOOL ApolloPresentOrResolveImageChestAlbumURL(NSURL *url, UIView *sourceV
 %hook ASImageNode
 
 - (void)_locked_setAnimatedImage:(id)animatedImage {
-    BOOL hosted = objc_getAssociatedObject(self, &kApolloHostMarkdownNodeKey) != nil;
+    BOOL hosted = ApolloImageNodeHasInlineHost(self);
     if (hosted && animatedImage && !ApolloInlineGIFAnimatedImageArgumentIsUsable(animatedImage)) {
         ApolloLog(@"[InlineImages] _locked_setAnimatedImage rejecting unusable animatedImage node=%p", self);
         ApolloClearInlineGIFNodeState((ASNetworkImageNode *)self);
@@ -1587,7 +1599,7 @@ static BOOL ApolloPresentOrResolveImageChestAlbumURL(NSURL *url, UIView *sourceV
 }
 
 - (void)dealloc {
-    if (objc_getAssociatedObject(self, &kApolloHostMarkdownNodeKey)) {
+    if (ApolloImageNodeHasInlineHost(self)) {
         ApolloCancelInlineGIFPendingPolicyBlocks(self);
         ApolloInlineGIFBumpGeneration(self);
         id anim = objc_getAssociatedObject(self, &kApolloInlineGIFAnimatedImageKey);
@@ -1601,7 +1613,7 @@ static BOOL ApolloPresentOrResolveImageChestAlbumURL(NSURL *url, UIView *sourceV
 %hook ASNetworkImageNode
 
 - (void)setURL:(NSURL *)URL {
-    if (objc_getAssociatedObject(self, &kApolloHostMarkdownNodeKey)) {
+    if (ApolloImageNodeHasInlineHost(self)) {
         NSURL *previous = [self respondsToSelector:@selector(URL)] ? [self URL] : nil;
         if ((previous && URL && ![previous isEqual:URL]) || (previous && !URL)) {
             ApolloLog(@"[AutoplayGIF] clearing GIF state on URL change node=%p", self);
@@ -1612,7 +1624,7 @@ static BOOL ApolloPresentOrResolveImageChestAlbumURL(NSURL *url, UIView *sourceV
 }
 
 - (void)clearImage {
-    if (objc_getAssociatedObject(self, &kApolloHostMarkdownNodeKey)) {
+    if (ApolloImageNodeHasInlineHost(self)) {
         ApolloClearInlineGIFNodeState(self);
     }
     %orig;


### PR DESCRIPTION
Fixes crash when navigating into comments:

```

Thread 0 name:   Dispatch queue: com.apple.main-thread
Thread 0 Crashed:
0   libobjc.A.dylib               	       0x185d4d44c objc_retain + 16
1   ApolloReborn.dylib            	       0x105ffac7c _logos_method$_ungrouped$ASImageNode$dealloc(ASImageNode*, objc_selector*) + 44
2   AsyncDisplayKit               	       0x105213944 -[ASNetworkImageNode dealloc] + 56
3   UIKitCore                     	       0x18ed798f0 __45-[UIView(Hierarchy) _postMovedFromSuperview:]_block_invoke + 900
4   UIKitCore                     	       0x18ed794f8 -[UIView _postMovedFromSuperview:] + 508
5   UIKitCore                     	       0x18ed87f84 __UIViewWasRemovedFromSuperview + 136
6   UIKitCore                     	       0x18ed88eb4 -[UIView(Hierarchy) removeFromSuperview] + 256
7   UIKitCore                     	       0x18ee34d5c -[UIView dealloc] + 348
8   libobjc.A.dylib               	       0x185d517f8 AutoreleasePoolPage::releaseUntil(objc_object**) + 204
9   libobjc.A.dylib               	       0x185d51684 objc_autoreleasePoolPop + 244
10  UIKitCore                     	       0x18ee35008 -[UIView dealloc] + 1032
11  AsyncDisplayKit               	       0x1051e3d98 -[ASDisplayNode .cxx_destruct] + 504
12  libobjc.A.dylib               	       0x185d56660 object_cxxDestructFromClass(objc_object*, objc_class*) + 116
13  libobjc.A.dylib               	       0x185d52358 objc_destructInstance_nonnull_realized(objc_object*) + 76
14  libobjc.A.dylib               	       0x185d518a4 _objc_rootDealloc + 72
15  AsyncDisplayKit               	       0x1051db09c -[ASDisplayNode dealloc] + 316
16  AsyncDisplayKit               	       0x1051bad64 -[ASCollectionElement .cxx_destruct] + 72
17  libobjc.A.dylib               	       0x185d56660 object_cxxDestructFromClass(objc_object*, objc_class*) + 116
18  libobjc.A.dylib               	       0x185d52358 objc_destructInstance_nonnull_realized(objc_object*) + 76
19  libobjc.A.dylib               	       0x185d518a4 _objc_rootDealloc + 72
20  Foundation                    	       0x186436e9c empty + 96
21  Foundation                    	       0x186436c78 dealloc + 60
22  Foundation                    	       0x186436ce8 -[NSConcreteMapTable dealloc] + 52
23  AsyncDisplayKit               	       0x1051fa34c -[ASElementMap .cxx_destruct] + 52
24  libobjc.A.dylib               	       0x185d56660 object_cxxDestructFromClass(objc_object*, objc_class*) + 116
25  libobjc.A.dylib               	       0x185d52358 objc_destructInstance_nonnull_realized(objc_object*) + 76
26  libobjc.A.dylib               	       0x185d518a4 _objc_rootDealloc + 72
27  AsyncDisplayKit               	       0x1051d80fc -[ASDataController clearData] + 72
28  AsyncDisplayKit               	       0x10522bc68 -[ASTableView setAsyncDelegate:] + 2516
29  AsyncDisplayKit               	       0x10522ac7c -[ASTableView dealloc] + 76
30  libobjc.A.dylib               	       0x185d517f8 AutoreleasePoolPage::releaseUntil(objc_object**) + 204
31  libobjc.A.dylib               	       0x185d51684 objc_autoreleasePoolPop + 244
32  UIKitCore                     	       0x18ee35008 -[UIView dealloc] + 1032
33  AsyncDisplayKit               	       0x1051e3d98 -[ASDisplayNode .cxx_destruct] + 504
34  libobjc.A.dylib               	       0x185d56660 object_cxxDestructFromClass(objc_object*, objc_class*) + 116
35  libobjc.A.dylib               	       0x185d52358 objc_destructInstance_nonnull_realized(objc_object*) + 76
36  libobjc.A.dylib               	       0x185d518a4 _objc_rootDealloc + 72
37  AsyncDisplayKit               	       0x1051db09c -[ASDisplayNode dealloc] + 316
38  libobjc.A.dylib               	       0x185d56660 object_cxxDestructFromClass(objc_object*, objc_class*) + 116
39  libobjc.A.dylib               	       0x185d52358 objc_destructInstance_nonnull_realized(objc_object*) + 76
40  libobjc.A.dylib               	       0x185d518a4 _objc_rootDealloc + 72
41  UIKitCore                     	       0x18ee35d28 -[UIResponder dealloc] + 128
42  UIKitCore                     	       0x18effe648 -[UIViewController dealloc] + 1628
43  Apollo                        	       0x10484e500 0x10414c000 + 7349504
44  libswiftCore.dylib            	       0x185e98ed8 swift_arrayDestroy + 192
45  libswiftCore.dylib            	       0x185e99934 _ContiguousArrayStorage.__deallocating_deinit + 96
46  libswiftCore.dylib            	       0x185e980f0 _swift_release_dealloc + 64
47  libswiftCore.dylib            	       0x185e9944c bool swift::RefCounts<swift::RefCountBitsT<(swift::RefCountInlinedness)1>>::doDecrementSlow<(swift::PerformDeinit)1>(swift::RefCountBitsT<(swift::RefCountInlinedness)1>, unsigned int) + 168
48  Apollo                        	       0x1042abf98 0x10414c000 + 1441688
49  Apollo                        	       0x1042a935c 0x10414c000 + 1430364
50  UIKitCore                     	       0x18f01839c -[UINavigationController _didEndTransitionFromView:toView:wasCustom:] + 1532
51  UIKitCore                     	       0x18f517e08 -[UINavigationController transitionConductor:didEndCustomTransitionWithContext:didComplete:] + 612
52  UIKit                         	       0x2ac4e7f7c -[UINavigationControllerAccessibility transitionConductor:didEndCustomTransitionWithContext:didComplete:] + 144
53  UIKitCore                     	       0x18f517b78 __63-[_UIViewControllerTransitionConductor _startCustomTransition:]_block_invoke + 72
54  UIKitCore                     	       0x18eeb64ec -[_UIViewControllerTransitionContext completeTransition:] + 200
55  Apollo                        	       0x1047cf71c 0x10414c000 + 6829852
56  Apollo                        	       0x1044c9cc8 0x10414c000 + 3661000
57  UIKitCore                     	       0x18ee6fd60 __UIVIEW_IS_EXECUTING_ANIMATION_COMPLETION_BLOCK__ + 36
58  UIKitCore                     	       0x18ed90630 -[UIViewAnimationBlockDelegate _didEndBlockAnimation:finished:context:] + 632
59  UIKitCore                     	       0x18ed900e4 -[UIViewAnimationState sendDelegateAnimationDidStop:finished:] + 260
60  UIKitCore                     	       0x18ee77374 -[UIViewAnimationState animationDidStop:finished:] + 192
61  UIKit                         	       0x2ac595190 -[UIViewAnimationStateAccessibility animationDidStop:finished:] + 252
62  QuartzCore                    	       0x189c694a4 run_animation_callbacks(void*) + 132
63  libdispatch.dylib             	       0x1c33f61e4 _dispatch_client_callout + 16
64  libdispatch.dylib             	       0x1c3413e10 _dispatch_main_queue_drain.cold.6 + 832
65  libdispatch.dylib             	       0x1c33eb964 _dispatch_main_queue_drain + 176
66  libdispatch.dylib             	       0x1c33eb8a4 _dispatch_main_queue_callback_4CF + 44
67  CoreFoundation                	       0x189234a64 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 16
68  CoreFoundation                	       0x1891c2288 __CFRunLoopRun + 1944
69  CoreFoundation                	       0x1891c11d0 _CFRunLoopRunSpecificWithOptions + 532
70  GraphicsServices              	       0x22e6ff498 GSEventRunModal + 120
71  UIKitCore                     	       0x18ee852c4 -[UIApplication _run] + 796
72  UIKitCore                     	       0x18edf0158 UIApplicationMain + 332
73  Apollo                        	       0x10419162c 0x10414c000 + 284204
74  dyld                          	       0x185dd5c1c start + 6928
```