### PR TITLE
Separate inline GIF autoplay into own setting

### DIFF
--- a/src/ApolloMediaAutoplay.h
+++ b/src/ApolloMediaAutoplay.h
@@ -7,14 +7,15 @@ NS_ASSUME_NONNULL_BEGIN
 extern "C" {
 #endif
 
-/// Reads Apollo's native General > Autoplay GIFs/Videos setting.
+/// Reads the tweak's "Autoplay Inline GIFs" setting. In Default mode this follows
+/// Apollo's native Autoplay GIFs/Videos setting; otherwise it is independent.
 BOOL ApolloShouldAutoplayInlineGIF(void);
 
 /// Cached autoplay decision for the current settings/reachability epoch.
 /// Invalidated when settings, reachability, or Low Power Mode changes.
 BOOL ApolloShouldAutoplayInlineGIFCached(void);
 
-/// Current AutoplayGIFs raw string (never / only-on-wifi / always).
+/// Current inline-GIF autoplay mode as a normalized string (never / only-on-wifi / always).
 NSString *ApolloAutoplayGIFModeString(void);
 
 /// YES for URLs that are typically animated GIFs (not static JPEG/PNG/WebP).
@@ -61,7 +62,7 @@ BOOL ApolloPauseInlineGIFNodeForAutoplay(id imageNode);
 /// Returns YES when a paused node was reloaded; NO when skipped or resume-only.
 BOOL ApolloReloadInlineGIFImageNodeForAutoplay(id imageNode);
 
-/// Install observers for AutoplayGIFs preference / reachability / Low Power Mode.
+/// Install observers for the Autoplay Inline GIFs preference / reachability / Low Power Mode.
 void ApolloMediaAutoplayInstall(void);
 
 #ifdef __cplusplus

--- a/src/ApolloMediaAutoplay.m
+++ b/src/ApolloMediaAutoplay.m
@@ -2,11 +2,14 @@
 #import "ApolloCommon.h"
 #import "ApolloMediaMetadata.h"
 #import "ApolloState.h"
+#import "UserDefaultConstants.h"
 
 #import <SystemConfiguration/SystemConfiguration.h>
 #import <objc/runtime.h>
 
-static NSString *const kApolloAutoplayGIFsKey = @"AutoplayGIFs";
+// Apollo's native General > Autoplay GIFs/Videos preference. Followed only when the
+// tweak's Autoplay Inline GIFs setting is in Default mode.
+static NSString *const kApolloNativeAutoplayGIFsKey = @"AutoplayGIFs";
 static NSString *const kApolloGroupSuiteName = @"group.com.christianselig.apollo";
 
 static const void *kApolloInlineAnimatedGIFViewKey = &kApolloInlineAnimatedGIFViewKey;
@@ -30,6 +33,7 @@ static void ApolloStartReachabilityMonitor(void);
 static BOOL ApolloNetworkIsOnWiFi(void);
 static BOOL ApolloNetworkIsOnCellular(void);
 static void ApolloLogAutoplayDecision(NSString *mode, BOOL shouldPlay);
+static void ApolloReloadAutoplayInlineGIFModeFromDefaults(void);
 
 static Class ApolloASNetworkImageNodeClass(void) {
     static Class cls = Nil;
@@ -53,6 +57,7 @@ BOOL ApolloInlineGIFNodeIsRegistryEligible(id imageNode) {
 }
 
 static void ApolloAutoplaySettingsDidChange(void) {
+    ApolloReloadAutoplayInlineGIFModeFromDefaults();
     ApolloRefreshVisibleInlineGIFAutoplay();
 }
 
@@ -68,7 +73,8 @@ static void ApolloAutoplaySettingsDidChange(void) {
     (void)object;
     (void)change;
     (void)context;
-    if ([keyPath isEqualToString:kApolloAutoplayGIFsKey]) {
+    if ([keyPath isEqualToString:UDKeyAutoplayInlineGIFs] ||
+        [keyPath isEqualToString:kApolloNativeAutoplayGIFsKey]) {
         ApolloAutoplaySettingsDidChange();
     }
 }
@@ -77,15 +83,15 @@ static void ApolloAutoplaySettingsDidChange(void) {
 
 static ApolloAutoplayDefaultsObserver *sAutoplayDefaultsObserver = nil;
 
-static void ApolloInstallAutoplayDefaultsKVO(NSUserDefaults *defaults) {
+static void ApolloInstallAutoplayDefaultsKVO(NSUserDefaults *defaults, NSString *keyPath) {
     if (!defaults || !sAutoplayDefaultsObserver) return;
     @try {
         [defaults addObserver:sAutoplayDefaultsObserver
-                   forKeyPath:kApolloAutoplayGIFsKey
+                   forKeyPath:keyPath
                       options:NSKeyValueObservingOptionNew
                       context:NULL];
     } @catch (__unused NSException *exception) {
-        ApolloLog(@"[AutoplayGIF] KVO unavailable for defaults key=%@", kApolloAutoplayGIFsKey);
+        ApolloLog(@"[AutoplayGIF] KVO unavailable for defaults key=%@", keyPath);
     }
 }
 
@@ -149,25 +155,38 @@ static void ApolloStartReachabilityMonitor(void) {
     });
 }
 
-static NSString *ApolloAutoplayGIFModeFromDefaults(NSUserDefaults *defaults) {
-    if (!defaults) return nil;
-    id value = [defaults objectForKey:kApolloAutoplayGIFsKey];
-    if ([value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0) {
-        return [(NSString *)value lowercaseString];
+// Reloads and validates the inline-GIF autoplay mode from user defaults into the
+// shared sAutoplayInlineGIFMode global. Called on KVO changes so external/defaults-
+// driven edits are reflected even when the settings UI isn't the writer.
+static void ApolloReloadAutoplayInlineGIFModeFromDefaults(void) {
+    NSInteger mode = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyAutoplayInlineGIFs];
+    if (mode < ApolloAutoplayInlineGIFModeDefault || mode > ApolloAutoplayInlineGIFModeAlways) {
+        mode = ApolloAutoplayInlineGIFModeDefault;
     }
-    return nil;
+    sAutoplayInlineGIFMode = mode;
+}
+
+// Reads Apollo's native Autoplay GIFs/Videos preference (standard, then group defaults),
+// normalized to never / only-on-wifi / always. Falls back to "never" when unset.
+static NSString *ApolloNativeAutoplayGIFModeString(void) {
+    for (NSUserDefaults *defaults in @[[NSUserDefaults standardUserDefaults],
+                                       [[NSUserDefaults alloc] initWithSuiteName:kApolloGroupSuiteName]]) {
+        id value = [defaults objectForKey:kApolloNativeAutoplayGIFsKey];
+        if ([value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0) {
+            return [(NSString *)value lowercaseString];
+        }
+    }
+    return @"never";
 }
 
 NSString *ApolloAutoplayGIFModeString(void) {
-    NSString *mode = ApolloAutoplayGIFModeFromDefaults([NSUserDefaults standardUserDefaults]);
-    if (mode.length == 0) {
-        NSUserDefaults *groupDefaults = [[NSUserDefaults alloc] initWithSuiteName:kApolloGroupSuiteName];
-        mode = ApolloAutoplayGIFModeFromDefaults(groupDefaults);
+    switch (sAutoplayInlineGIFMode) {
+        case ApolloAutoplayInlineGIFModeNever:    return @"never";
+        case ApolloAutoplayInlineGIFModeWiFiOnly: return @"only-on-wifi";
+        case ApolloAutoplayInlineGIFModeAlways:   return @"always";
+        case ApolloAutoplayInlineGIFModeDefault:
+        default:                                  return ApolloNativeAutoplayGIFModeString();
     }
-    if (mode.length == 0) {
-        mode = @"never";
-    }
-    return mode;
 }
 
 static void ApolloLogAutoplayDecision(NSString *mode, BOOL shouldPlay) {
@@ -475,9 +494,13 @@ void ApolloMediaAutoplayInstall(void) {
     static dispatch_once_t once;
     dispatch_once(&once, ^{
         ApolloStartReachabilityMonitor();
+        ApolloReloadAutoplayInlineGIFModeFromDefaults();
         sAutoplayDefaultsObserver = [ApolloAutoplayDefaultsObserver new];
-        ApolloInstallAutoplayDefaultsKVO([NSUserDefaults standardUserDefaults]);
-        ApolloInstallAutoplayDefaultsKVO([[NSUserDefaults alloc] initWithSuiteName:kApolloGroupSuiteName]);
+        // Tweak setting (standard defaults) + Apollo's native setting (standard + group,
+        // followed in Default mode).
+        ApolloInstallAutoplayDefaultsKVO([NSUserDefaults standardUserDefaults], UDKeyAutoplayInlineGIFs);
+        ApolloInstallAutoplayDefaultsKVO([NSUserDefaults standardUserDefaults], kApolloNativeAutoplayGIFsKey);
+        ApolloInstallAutoplayDefaultsKVO([[NSUserDefaults alloc] initWithSuiteName:kApolloGroupSuiteName], kApolloNativeAutoplayGIFsKey);
         if (@available(iOS 9.0, *)) {
             [[NSNotificationCenter defaultCenter] addObserverForName:NSProcessInfoPowerStateDidChangeNotification
                                                               object:nil

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -44,6 +44,19 @@ typedef NS_ENUM(NSInteger, ApolloInlineImageAlignment) {
     ApolloInlineImageAlignmentRight  = 2,
 };
 extern NSInteger sInlineImageAlignment;
+
+// Autoplay policy for inline GIF/animated media previews. Decoupled from Apollo's
+// native "Autoplay GIFs/Videos" setting, except for the Default mode which follows it.
+// Defaults to Default. Only takes effect when Inline Media Previews
+// (sEnableInlineImages) is on. See ApolloMediaAutoplay.m.
+typedef NS_ENUM(NSInteger, ApolloAutoplayInlineGIFMode) {
+    ApolloAutoplayInlineGIFModeDefault  = 0, // follow Apollo's Autoplay GIFs/Videos
+    ApolloAutoplayInlineGIFModeNever    = 1,
+    ApolloAutoplayInlineGIFModeWiFiOnly = 2,
+    ApolloAutoplayInlineGIFModeAlways   = 3,
+};
+extern NSInteger sAutoplayInlineGIFMode;
+
 typedef NS_ENUM(NSInteger, ApolloLinkPreviewMode) {
     ApolloLinkPreviewModeOff = 0,
     ApolloLinkPreviewModeCompact = 1,

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -30,6 +30,7 @@ BOOL sModernSubredditDividers = YES;
 BOOL sSubredditListEnhancements = YES;
 BOOL sEnableInlineImages = NO;
 NSInteger sInlineImageAlignment = ApolloInlineImageAlignmentCenter;
+NSInteger sAutoplayInlineGIFMode = ApolloAutoplayInlineGIFModeDefault;
 NSInteger sLinkPreviewBodyMode = ApolloLinkPreviewModeOff;
 NSInteger sLinkPreviewCommentsMode = ApolloLinkPreviewModeOff;
 NSInteger sLinkPreviewCardColor = ApolloLinkPreviewCardColorNeutral;

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -27,6 +27,28 @@ typedef NS_ENUM(NSInteger, SectionIndex) {
     SectionCount
 };
 
+// The Media section hides two adjacent inline-media-dependent rows (Inline Media
+// Alignment + Autoplay Inline GIFs) when Inline Media Previews is off. These helpers
+// centralize the physical<->logical row mapping so the index math stays consistent.
+static const NSInteger kApolloMediaInlineDependentRows = 2;
+static const NSInteger kApolloMediaFirstInlineDependentRow = 5;
+
+// Map a physical (visible) Media row to its logical row.
+static NSInteger ApolloMediaLogicalRow(NSInteger physicalRow) {
+    if (!sEnableInlineImages && physicalRow >= kApolloMediaFirstInlineDependentRow) {
+        return physicalRow + kApolloMediaInlineDependentRows;
+    }
+    return physicalRow;
+}
+
+// Map a logical Media row to its physical (visible) row.
+static NSInteger ApolloMediaPhysicalRow(NSInteger logicalRow) {
+    if (!sEnableInlineImages && logicalRow >= kApolloMediaFirstInlineDependentRow + kApolloMediaInlineDependentRows) {
+        return logicalRow - kApolloMediaInlineDependentRows;
+    }
+    return logicalRow;
+}
+
 static BOOL sLinkPreviewModeRefreshPending = NO;
 static NSString *sPendingLinkPreviewModeRefreshArea = nil;
 static NSInteger sPendingLinkPreviewModeRefreshMode = ApolloLinkPreviewModeFull;
@@ -442,7 +464,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 }
 
 - (void)setLinkPreviewMode:(NSInteger)mode body:(BOOL)body {
-    NSInteger row = (body ? 6 : 7) - (sEnableInlineImages ? 0 : 1);
+    NSInteger row = ApolloMediaPhysicalRow(body ? 7 : 8);
     NSString *key = body ? UDKeyLinkPreviewBodyMode : UDKeyLinkPreviewCommentsMode;
     if (body) {
         sLinkPreviewBodyMode = mode;
@@ -483,7 +505,7 @@ typedef NS_ENUM(NSInteger, Tag) {
                                                           @"cardColor": @(color),
                                                       }];
 
-    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:8 - (sEnableInlineImages ? 0 : 1) inSection:SectionMedia];
+    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(9) inSection:SectionMedia];
     if ([[self.tableView indexPathsForVisibleRows] containsObject:indexPath]) {
         [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
     }
@@ -637,8 +659,8 @@ typedef NS_ENUM(NSInteger, Tag) {
     switch (section) {
         case SectionBackupRestore: return 2;
         case SectionAPIKeys: return 9; // 7 text fields + Can't sign in? + API key setup guide
-        case SectionGeneral: return sShowDeletedComments ? 10 : 9;
-        case SectionMedia: return (sShowUserAvatars ? 13 : 12) + (sEnableInlineImages ? 0 : -1);
+    case SectionGeneral: return sShowDeletedComments ? 10 : 9;
+    case SectionMedia: return (sShowUserAvatars ? 14 : 13) + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows);
         case SectionSubreddits: return sSubredditListEnhancements ? 9 : 8;
         case SectionNotificationBackend: return 3; // URL + Registration Token + Test Connection
         case SectionAbout: return 5; // GitHub + Reddit + Thanks To + Export Logs + Version
@@ -1030,8 +1052,8 @@ typedef NS_ENUM(NSInteger, Tag) {
 }
 
 - (UITableViewCell *)mediaCellForRow:(NSInteger)row tableView:(UITableView *)tableView {
-    // When the alignment row is hidden, physical rows ≥ 5 map to the next logical row
-    if (row >= 5 && !sEnableInlineImages) row += 1;
+    // When the inline-dependent rows are hidden, physical rows map to later logical rows.
+    row = ApolloMediaLogicalRow(row);
     switch (row) {
         case 0: {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_GIFFallbackFormat"];
@@ -1092,6 +1114,18 @@ typedef NS_ENUM(NSInteger, Tag) {
             return cell;
         }
         case 6: {
+            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_AutoplayInlineGIFs"];
+            if (!cell) {
+                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_AutoplayInlineGIFs"];
+                cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+            }
+            cell.textLabel.text = @"Autoplay Inline GIFs";
+            cell.detailTextLabel.text = [self autoplayInlineGIFModeText];
+            cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+            return cell;
+        }
+        case 7: {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_LinkPreviewBodyMode"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_LinkPreviewBodyMode"];
@@ -1103,7 +1137,7 @@ typedef NS_ENUM(NSInteger, Tag) {
             cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
             return cell;
         }
-        case 7: {
+        case 8: {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_LinkPreviewCommentsMode"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_LinkPreviewCommentsMode"];
@@ -1115,7 +1149,7 @@ typedef NS_ENUM(NSInteger, Tag) {
             cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
             return cell;
         }
-        case 8: {
+        case 9: {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_LinkPreviewCardColor"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_LinkPreviewCardColor"];
@@ -1127,17 +1161,17 @@ typedef NS_ENUM(NSInteger, Tag) {
             cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
             return cell;
         }
-        case 9:
+        case 10:
             return [self switchCellWithIdentifier:@"Cell_Media_UserAvatars"
                                             label:@"Show User Profile Pictures"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars]
                                            action:@selector(userAvatarsSwitchToggled:)];
-        case 10:
+        case 11:
             return [self switchCellWithIdentifier:@"Cell_Media_ProfileTabAvatar"
                                             label:@"Profile Picture Tab Icon"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon]
                                            action:@selector(profileTabAvatarSwitchToggled:)];
-        case 11: {
+        case 12: {
             BOOL avatarsOn = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars];
             if (avatarsOn) {
                 UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_ClearAvatarCache"];
@@ -1158,7 +1192,7 @@ typedef NS_ENUM(NSInteger, Tag) {
             cell.selectionStyle = UITableViewCellSelectionStyleDefault;
             return cell;
         }
-        case 12: {
+        case 13: {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_ClearLinkPreviewCache"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell_Media_ClearLinkPreviewCache"];
@@ -1558,7 +1592,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         }
     } else if (indexPath.section == SectionMedia) {
         UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
-        NSInteger row = (indexPath.row >= 5 && !sEnableInlineImages) ? indexPath.row + 1 : indexPath.row;
+        NSInteger row = ApolloMediaLogicalRow(indexPath.row);
         if (row == 0) {
             [self presentPreferredGIFFallbackFormatSheetFromSourceView:cell];
         } else if (row == 1) {
@@ -1568,14 +1602,16 @@ typedef NS_ENUM(NSInteger, Tag) {
         } else if (row == 5) {
             [self presentInlineImageAlignmentSheetFromSourceView:cell];
         } else if (row == 6) {
-            [self presentLinkPreviewModeSheetFromSourceView:cell body:YES];
+            [self presentAutoplayInlineGIFModeSheetFromSourceView:cell];
         } else if (row == 7) {
-            [self presentLinkPreviewModeSheetFromSourceView:cell body:NO];
+            [self presentLinkPreviewModeSheetFromSourceView:cell body:YES];
         } else if (row == 8) {
+            [self presentLinkPreviewModeSheetFromSourceView:cell body:NO];
+        } else if (row == 9) {
             [self presentLinkPreviewCardColorSheetFromSourceView:cell];
-        } else if (row == 11 && sShowUserAvatars) {
+        } else if (row == 12 && sShowUserAvatars) {
             [self promptClearProfilePictureCacheFromSourceView:cell];
-        } else if ((row == 11 && !sShowUserAvatars) || (row == 12 && sShowUserAvatars)) {
+        } else if ((row == 12 && !sShowUserAvatars) || (row == 13 && sShowUserAvatars)) {
             [self promptClearLinkPreviewCacheFromSourceView:cell];
         }
     } else if (indexPath.section == SectionNotificationBackend && indexPath.row == 2) {
@@ -1618,8 +1654,8 @@ typedef NS_ENUM(NSInteger, Tag) {
         return logicalRow == 8;
     }
     if (indexPath.section == SectionMedia) {
-        NSInteger row = (indexPath.row >= 5 && !sEnableInlineImages) ? indexPath.row + 1 : indexPath.row;
-        return (row == 0 || row == 1 || row == 2 || row == 5 || row == 6 || row == 7 || row == 8 || row == 11 || row == 12);
+        NSInteger row = ApolloMediaLogicalRow(indexPath.row);
+        return (row == 0 || row == 1 || row == 2 || row == 5 || row == 6 || row == 7 || row == 8 || row == 9 || row == 12 || row == 13);
     }
     if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 || indexPath.row == 3)) return YES;
     if (indexPath.section == SectionNotificationBackend && indexPath.row == 2) return YES;
@@ -2002,14 +2038,13 @@ typedef NS_ENUM(NSInteger, Tag) {
     [[NSUserDefaults standardUserDefaults] setBool:sShowUserAvatars forKey:UDKeyShowUserAvatars];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloUserAvatarsToggleChangedNotification" object:nil];
     if (sShowUserAvatars == wasOn) return;
-    NSInteger offset = sEnableInlineImages ? 0 : 1;
-    NSArray<NSIndexPath *> *paths = @[[NSIndexPath indexPathForRow:11 - offset inSection:SectionMedia]];
+    NSArray<NSIndexPath *> *paths = @[[NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(12) inSection:SectionMedia]];
     if (sShowUserAvatars) {
         [self.tableView insertRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
     } else {
         [self.tableView deleteRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
     }
-    [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:(sShowUserAvatars ? 12 : 11) - offset inSection:SectionMedia]]
+    [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(sShowUserAvatars ? 13 : 12) inSection:SectionMedia]]
                           withRowAnimation:UITableViewRowAnimationNone];
 }
 
@@ -2037,7 +2072,12 @@ typedef NS_ENUM(NSInteger, Tag) {
     sEnableInlineImages = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sEnableInlineImages forKey:UDKeyEnableInlineImages];
     if (sEnableInlineImages == wasOn) return;
-    NSArray<NSIndexPath *> *paths = @[[NSIndexPath indexPathForRow:5 inSection:SectionMedia]];
+    // Two adjacent rows are gated on this toggle: Inline Media Alignment (logical 5)
+    // and Autoplay Inline GIFs (logical 6). Insert/delete both to keep row counts consistent.
+    NSArray<NSIndexPath *> *paths = @[
+        [NSIndexPath indexPathForRow:5 inSection:SectionMedia],
+        [NSIndexPath indexPathForRow:6 inSection:SectionMedia],
+    ];
     if (sEnableInlineImages) {
         [self.tableView insertRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
     } else {
@@ -2087,6 +2127,57 @@ typedef NS_ENUM(NSInteger, Tag) {
     [[NSUserDefaults standardUserDefaults] setInteger:sInlineImageAlignment forKey:UDKeyInlineImageAlignment];
     NSIndexPath *alignmentRow = [NSIndexPath indexPathForRow:5 inSection:SectionMedia];
     [self.tableView reloadRowsAtIndexPaths:@[alignmentRow] withRowAnimation:UITableViewRowAnimationNone];
+}
+
+- (NSString *)autoplayInlineGIFModeText {
+    switch (sAutoplayInlineGIFMode) {
+        case ApolloAutoplayInlineGIFModeNever:    return @"Never";
+        case ApolloAutoplayInlineGIFModeWiFiOnly: return @"WiFi Only";
+        case ApolloAutoplayInlineGIFModeAlways:   return @"Always";
+        case ApolloAutoplayInlineGIFModeDefault:
+        default:                                  return @"Default";
+    }
+}
+
+- (void)presentAutoplayInlineGIFModeSheetFromSourceView:(UIView *)sourceView {
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Autoplay Inline GIFs"
+                                                                   message:@"Default follows Apollo's Autoplay GIFs/Videos setting in General."
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+
+    NSString *defaultTitle = (sAutoplayInlineGIFMode == ApolloAutoplayInlineGIFModeDefault)  ? @"Default (Current)"   : @"Default";
+    NSString *alwaysTitle  = (sAutoplayInlineGIFMode == ApolloAutoplayInlineGIFModeAlways)   ? @"Always (Current)"    : @"Always";
+    NSString *wifiTitle    = (sAutoplayInlineGIFMode == ApolloAutoplayInlineGIFModeWiFiOnly) ? @"WiFi Only (Current)" : @"WiFi Only";
+    NSString *neverTitle   = (sAutoplayInlineGIFMode == ApolloAutoplayInlineGIFModeNever)    ? @"Never (Current)"     : @"Never";
+
+    [sheet addAction:[UIAlertAction actionWithTitle:defaultTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self setAutoplayInlineGIFMode:ApolloAutoplayInlineGIFModeDefault];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:alwaysTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self setAutoplayInlineGIFMode:ApolloAutoplayInlineGIFModeAlways];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:wifiTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self setAutoplayInlineGIFMode:ApolloAutoplayInlineGIFModeWiFiOnly];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:neverTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self setAutoplayInlineGIFMode:ApolloAutoplayInlineGIFModeNever];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    if (popover && sourceView) {
+        popover.sourceView = sourceView;
+        popover.sourceRect = sourceView.bounds;
+    }
+
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+- (void)setAutoplayInlineGIFMode:(ApolloAutoplayInlineGIFMode)mode {
+    sAutoplayInlineGIFMode = mode;
+    // The autoplay module observes this key via KVO and re-evaluates visible inline GIFs.
+    [[NSUserDefaults standardUserDefaults] setInteger:sAutoplayInlineGIFMode forKey:UDKeyAutoplayInlineGIFs];
+    NSIndexPath *autoplayRow = [NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(6) inSection:SectionMedia];
+    [self.tableView reloadRowsAtIndexPaths:@[autoplayRow] withRowAnimation:UITableViewRowAnimationNone];
 }
 
 - (void)promptClearCustomSubredditBannersFromSourceView:(__unused UIView *)sourceView {

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -982,6 +982,7 @@ static void initializeRandomSources() {
                                     UDKeyGiphyAPIKey: @"",
                                     UDKeyEnableInlineImages: @YES,
                                     UDKeyInlineImageAlignment: @(ApolloInlineImageAlignmentCenter),
+                                    UDKeyAutoplayInlineGIFs: @(ApolloAutoplayInlineGIFModeDefault),
                                     UDKeyLinkPreviewBodyMode: @(ApolloLinkPreviewModeFull),
                                     UDKeyLinkPreviewCommentsMode: @(ApolloLinkPreviewModeFull),
                                     UDKeyLinkPreviewCardColor: @(ApolloLinkPreviewCardColorNeutral),
@@ -1035,6 +1036,11 @@ static void initializeRandomSources() {
     if (sInlineImageAlignment < ApolloInlineImageAlignmentCenter || sInlineImageAlignment > ApolloInlineImageAlignmentRight) {
         sInlineImageAlignment = ApolloInlineImageAlignmentCenter;
         [standardDefaults setInteger:sInlineImageAlignment forKey:UDKeyInlineImageAlignment];
+    }
+    sAutoplayInlineGIFMode = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyAutoplayInlineGIFs];
+    if (sAutoplayInlineGIFMode < ApolloAutoplayInlineGIFModeDefault || sAutoplayInlineGIFMode > ApolloAutoplayInlineGIFModeAlways) {
+        sAutoplayInlineGIFMode = ApolloAutoplayInlineGIFModeDefault;
+        [standardDefaults setInteger:sAutoplayInlineGIFMode forKey:UDKeyAutoplayInlineGIFs];
     }
     sLinkPreviewBodyMode = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyLinkPreviewBodyMode];
     if (sLinkPreviewBodyMode < ApolloLinkPreviewModeOff || sLinkPreviewBodyMode > ApolloLinkPreviewModeFull) {

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -43,6 +43,10 @@ static NSString *const UDKeyEnableInlineImages = @"EnableInlineImages";
 // Horizontal alignment for inline media that is narrower than the row (e.g. tall portrait images).
 // 0 = Center (default), 1 = Left, 2 = Right.
 static NSString *const UDKeyInlineImageAlignment = @"InlineImageAlignment";
+// Autoplay for inline GIF/animated media previews. 0 = Default (follow Apollo's
+// native "Autoplay GIFs/Videos"), 1 = Never, 2 = WiFi Only, 3 = Always. Only
+// meaningful when Inline Media Previews (UDKeyEnableInlineImages) is on.
+static NSString *const UDKeyAutoplayInlineGIFs = @"AutoplayInlineGIFs";
 
 // Bulk translation feature
 static NSString *const UDKeyEnableBulkTranslation = @"EnableBulkTranslation";


### PR DESCRIPTION
Add a separate **Autoplay Inline GIFs** setting (Default / Never / WiFi Only / Always) in **Settings > Apollo Reborn Options > Media**, shown when **Inline Media Previews** is on, to control inline GIF autoplay independently of Apollo's native Autoplay GIFs/Videos setting. The default **Default** option follows Apollo's native setting (#313)

<img width="1206" height="1276" alt="IMG_3657" src="https://github.com/user-attachments/assets/510e884a-4469-4699-b90b-c4cbdbc36100" />
