### PR TITLE
Support any redirect URI without Info.plist patching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloInlineLinkPreviews.xm \
     $(SRC_DIR)/ApolloTweetBuddy.xm \
 	$(SRC_DIR)/ApolloVisionOSFix.xm \
+    $(SRC_DIR)/ApolloWebAuthViewController.m \
     $(SRC_DIR)/CustomAPIViewController.m \
     $(SRC_DIR)/TranslationSettingsViewController.m \
     $(SRC_DIR)/SavedCategoriesViewController.m \
@@ -76,7 +77,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/UIWindow+Apollo.m \
     $(SRC_DIR)/fishhook.c \
     $(SSZIPARCHIVE_FILES)
-ApolloReborn_FRAMEWORKS = UIKit Security AVFoundation OSLog NaturalLanguage ImageIO StoreKit PhotosUI SafariServices SystemConfiguration
+ApolloReborn_FRAMEWORKS = UIKit Security AVFoundation OSLog NaturalLanguage ImageIO StoreKit PhotosUI SafariServices SystemConfiguration WebKit AuthenticationServices
 ApolloReborn_LIBRARIES = z iconv
 ApolloReborn_CFLAGS = -fobjc-arc -Wno-unguarded-availability-new -Wno-module-import-in-extern-c -I$(THEOS_PROJECT_DIR)/$(SRC_DIR) -I$(THEOS_PROJECT_DIR)/liquid-glass/generated -I$(THEOS_PROJECT_DIR)/$(MODULES_DIR) -I$(THEOS_PROJECT_DIR)/$(SSZIPARCHIVE_DIR) -I$(THEOS_PROJECT_DIR)/$(SSZIPARCHIVE_DIR)/minizip -DHAVE_ARC4RANDOM_BUF -DHAVE_ICONV -DHAVE_INTTYPES_H -DHAVE_PKCRYPT -DHAVE_STDINT_H -DHAVE_WZAES -DHAVE_ZLIB -DZLIB_COMPAT
 

--- a/src/ApolloWebAuthViewController.h
+++ b/src/ApolloWebAuthViewController.h
@@ -1,0 +1,18 @@
+#import <UIKit/UIKit.h>
+#import <AuthenticationServices/AuthenticationServices.h>
+
+// WKWebView-based OAuth sign-in flow used when the configured redirect URI
+// scheme isn't registered in CFBundleURLTypes and therefore can't be used
+// as ASWebAuthenticationSession's callbackURLScheme.
+//
+// WKNavigationDelegate fires decidePolicyForNavigationAction for ALL URLs —
+// including unregistered custom schemes — before iOS URL routing, so we can
+// intercept the redirect and call the completion handler directly without
+// the scheme ever touching the system URL dispatcher.
+@interface ApolloWebAuthViewController : UIViewController
+
+- (instancetype)initWithURL:(NSURL *)url
+             callbackScheme:(NSString *)scheme
+          completionHandler:(ASWebAuthenticationSessionCompletionHandler)completion;
+
+@end

--- a/src/ApolloWebAuthViewController.m
+++ b/src/ApolloWebAuthViewController.m
@@ -1,0 +1,121 @@
+#import "ApolloWebAuthViewController.h"
+#import "ApolloCommon.h"
+
+#import <WebKit/WebKit.h>
+
+@interface ApolloWebAuthViewController () <WKNavigationDelegate>
+@property (nonatomic, strong) WKWebView *webView;
+@property (nonatomic, strong) UIActivityIndicatorView *spinner;
+@property (nonatomic, copy) NSURL *authURL;
+@property (nonatomic, copy) NSString *callbackScheme;
+@property (nonatomic, copy) ASWebAuthenticationSessionCompletionHandler completion;
+@property (nonatomic) BOOL finished;
+@end
+
+@implementation ApolloWebAuthViewController
+
+- (instancetype)initWithURL:(NSURL *)url
+             callbackScheme:(NSString *)scheme
+          completionHandler:(ASWebAuthenticationSessionCompletionHandler)completion {
+    self = [super init];
+    if (self) {
+        _authURL = [url copy];
+        _callbackScheme = [scheme copy];
+        _completion = [completion copy];
+    }
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Sign In to Reddit";
+    self.view.backgroundColor = [UIColor systemBackgroundColor];
+
+    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc]
+        initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
+                             target:self
+                             action:@selector(_cancelTapped)];
+
+    // Non-persistent data store mirrors Apollo's prefersEphemeralWebBrowserSession = YES
+    WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+    config.websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
+
+    self.webView = [[WKWebView alloc] initWithFrame:self.view.bounds configuration:config];
+    self.webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.webView.navigationDelegate = self;
+    [self.view addSubview:self.webView];
+
+    self.spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+    self.spinner.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin |
+                                    UIViewAutoresizingFlexibleLeftMargin  | UIViewAutoresizingFlexibleRightMargin;
+    self.spinner.center = self.view.center;
+    [self.view addSubview:self.spinner];
+    [self.spinner startAnimating];
+
+    ApolloLog(@"[WebAuth] Loading auth URL: %@", self.authURL);
+    [self.webView loadRequest:[NSURLRequest requestWithURL:self.authURL]];
+}
+
+- (void)_cancelTapped {
+    ApolloLog(@"[WebAuth] User cancelled sign-in");
+    [self _finishWithURL:nil
+                   error:[NSError errorWithDomain:ASWebAuthenticationSessionErrorDomain
+                                            code:ASWebAuthenticationSessionErrorCodeCanceledLogin
+                                        userInfo:nil]];
+}
+
+- (void)_finishWithURL:(NSURL *)url error:(NSError *)error {
+    if (self.finished) return;
+    self.finished = YES;
+    ASWebAuthenticationSessionCompletionHandler completion = self.completion;
+    [self.navigationController dismissViewControllerAnimated:YES completion:^{
+        if (completion) completion(url, error);
+    }];
+}
+
+#pragma mark - WKNavigationDelegate
+
+- (void)webView:(WKWebView *)webView
+decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction
+decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
+    NSURL *url = navigationAction.request.URL;
+
+    if ([url.scheme caseInsensitiveCompare:self.callbackScheme] == NSOrderedSame) {
+        // Reddit redirected to our callback scheme — intercept before the OS tries
+        // to dispatch it (which would fail for unregistered schemes).
+        decisionHandler(WKNavigationActionPolicyCancel);
+        ApolloLog(@"[WebAuth] Intercepted callback for scheme: %@", url.scheme);
+        [self _finishWithURL:url error:nil];
+        return;
+    }
+
+    decisionHandler(WKNavigationActionPolicyAllow);
+}
+
+- (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation {
+    [self.spinner startAnimating];
+}
+
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
+    [self.spinner stopAnimating];
+}
+
+- (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error {
+    [self.spinner stopAnimating];
+    // NSURLErrorCancelled (-999): fired by our own decisionHandler cancel.
+    // WebKitErrorDomain 102 (WebKitErrorFrameLoadInterruptedByPolicyChange): also
+    // fired when decidePolicyForNavigationAction cancels a navigation — expected.
+    if (error.code == NSURLErrorCancelled) return;
+    if ([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102) return;
+    ApolloLog(@"[WebAuth] Provisional navigation failed: %@", error);
+    [self _finishWithURL:nil error:error];
+}
+
+- (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error {
+    [self.spinner stopAnimating];
+    if (error.code == NSURLErrorCancelled) return;
+    ApolloLog(@"[WebAuth] Navigation failed: %@", error);
+    [self _finishWithURL:nil error:error];
+}
+
+@end

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -910,21 +910,12 @@ typedef NS_ENUM(NSInteger, Tag) {
                                                      detail:@"Required for GIF picker. Get one at developers.giphy.com"];
             break;
         case 5: {
-            NSString *schemesDetail = [NSString stringWithFormat:@"Must match the app whose API key you're using. URI scheme (part before ://) must be registered in Info.plist under CFBundleURLTypes. Registered: %@", [[self registeredURLSchemes] componentsJoinedByString:@", "]];
             UITableViewCell *cell = [self stackedTextFieldCellWithIdentifier:@"Cell_API_Redirect"
                                                                       label:@"Redirect URI"
                                                                 placeholder:defaultRedirectURI
                                                                        text:sRedirectURI
                                                                         tag:TagRedirectURI
-                                                                     detail:schemesDetail];
-            // Color the text field based on validity
-            for (UIView *subview in cell.contentView.subviews) {
-                if ([subview isKindOfClass:[UITextField class]]) {
-                    UITextField *tf = (UITextField *)subview;
-                    tf.textColor = [self isRedirectURISchemeValid:sRedirectURI] ? [UIColor labelColor] : [UIColor systemRedColor];
-                    break;
-                }
-            }
+                                                                     detail:@"Must match the redirect URI registered with your Reddit API app. Any URI scheme is supported."];
             return cell;
         }
         case 6:
@@ -1847,7 +1838,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         textField.text = [textField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
         sRedirectURI = textField.text;
         [[NSUserDefaults standardUserDefaults] setValue:sRedirectURI forKey:UDKeyRedirectURI];
-        textField.textColor = [self isRedirectURISchemeValid:textField.text] ? [UIColor labelColor] : [UIColor systemRedColor];
+        textField.textColor = [UIColor labelColor];
     } else if (textField.tag == TagUserAgent) {
         textField.text = [textField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
         sUserAgent = textField.text;

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -4,6 +4,7 @@
 #import <sys/utsname.h>
 #import <Security/Security.h>
 #import <StoreKit/StoreKit.h>
+#import <AuthenticationServices/AuthenticationServices.h>
 
 #import "fishhook.h"
 #import "ApolloCommon.h"
@@ -17,6 +18,7 @@
 #import "UserDefaultConstants.h"
 #import "Defaults.h"
 #import "ApolloMarkdownToolbarGif.h"
+#import "ApolloWebAuthViewController.h"
 
 // MARK: - Sideload Fixes
 
@@ -181,6 +183,81 @@ static NSCache<NSString *, NSString *> *subredditListCache;
 - (NSURL *)redirectURI {
     NSString *customURI = [sRedirectURI length] > 0 ? sRedirectURI : defaultRedirectURI;
     return [NSURL URLWithString:customURI];
+}
+
+%end
+
+static const char kARScheme     = '\0';
+static const char kARAuthURL    = '\0';
+static const char kARCompletion = '\0';
+
+// Replace ASWebAuthenticationSession with a WKWebView-based flow for all
+// Reddit OAuth sign-ins. WKNavigationDelegate fires decidePolicyForNavigationAction
+// for every URL before iOS URL routing, so the callback can be intercepted
+// regardless of whether the redirect URI scheme is registered in CFBundleURLTypes.
+%hook ASWebAuthenticationSession
+
+- (instancetype)initWithURL:(NSURL *)URL
+        callbackURLScheme:(NSString *)callbackURLScheme
+        completionHandler:(void (^)(NSURL *, NSError *))completionHandler {
+    id result = %orig;
+    id target = result ?: self;
+    objc_setAssociatedObject(target, &kARScheme,     callbackURLScheme, OBJC_ASSOCIATION_COPY);
+    objc_setAssociatedObject(target, &kARAuthURL,    URL,               OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(target, &kARCompletion, completionHandler, OBJC_ASSOCIATION_COPY);
+    return result;
+}
+
+- (BOOL)start {
+    NSString *callbackScheme = objc_getAssociatedObject(self, &kARScheme);
+    NSURL *authURL            = objc_getAssociatedObject(self, &kARAuthURL);
+    void (^completion)(NSURL *, NSError *) = objc_getAssociatedObject(self, &kARCompletion);
+
+    if (!authURL || !completion) {
+        ApolloLog(@"[WebAuth] missing authURL or completion — falling back to %%orig");
+        return %orig;
+    }
+
+    // Prefer the scheme from redirect_uri in the auth URL (set by our
+    // RDKOAuthCredential hook); fall back to callbackURLScheme if not found.
+    NSString *interceptScheme = callbackScheme;
+    for (NSURLQueryItem *item in [NSURLComponents componentsWithURL:authURL resolvingAgainstBaseURL:NO].queryItems) {
+        if ([item.name isEqualToString:@"redirect_uri"]) {
+            NSString *s = [NSURL URLWithString:item.value].scheme;
+            if (s.length) interceptScheme = s;
+            break;
+        }
+    }
+
+    ApolloLog(@"[WebAuth] using WKWebView, intercepting scheme=%@", interceptScheme);
+
+    // Use Apollo's own presentationContextProvider — it's set before start is called
+    // and returns the correct window. start is already on the main queue.
+    id<ASWebAuthenticationPresentationContextProviding> provider = [self presentationContextProvider];
+    UIWindow *window = [provider presentationAnchorForWebAuthenticationSession:self];
+
+    if (!window) {
+        for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+            if (scene.activationState == UISceneActivationStateForegroundActive
+                    && [scene isKindOfClass:[UIWindowScene class]]) {
+                window = ((UIWindowScene *)scene).keyWindow ?: ((UIWindowScene *)scene).windows.firstObject;
+                break;
+            }
+        }
+    }
+
+    ApolloLog(@"[WebAuth] presenting from window=%@", window);
+
+    ApolloWebAuthViewController *authVC = [[ApolloWebAuthViewController alloc]
+        initWithURL:authURL callbackScheme:interceptScheme completionHandler:completion];
+    UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:authVC];
+    nav.modalPresentationStyle = UIModalPresentationFormSheet;
+
+    UIViewController *top = window.rootViewController;
+    while (top.presentedViewController) top = top.presentedViewController;
+    [top presentViewController:nav animated:YES completion:nil];
+
+    return YES;
 }
 
 %end


### PR DESCRIPTION
When using a custom redirect URI for the Reddit API, you currently need to register the URI schemes in the Info.plist of the Apollo IPA, otherwise you would get a "Safari cannot open the page because the address is invalid" error when trying to authenticate.

This PR modifies the authentication flow, making it use `WKWebView` instead of the original `ASWebAuthenticationSession`, and intercept the redirect URI, allowing the use of URI schemes that are not registered in the app's Info.plist.

As a side effect, LiveContainer users will also no longer have to manually patch the Info.plist for LiveContainer itself to add the URI scheme.

This PR also removes the URI scheme check in the "Apollo Reborn" settings page, removing the red tint for unsupported URI schemes and updating the section description to reflect these changes.