### PR TITLE
Add API key workaround guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,27 @@ Then, in any browser, on a Reddit page tap **Share → Open in Apollo**.
 
 > [!IMPORTANT]
 > Reddit and Imgur no longer allow new API key creation so you'll need to share or use existing keys.
+>
+> Reddit has also recently started revoking API keys that are specifically used for Apollo or any other third party client.
 
-See [this guide](https://github.com/wchill/patcheddit?tab=readme-ov-file#what-if-i-dont-have-a-client-id) for workarounds (proceed at your own risk).
+Reddit has a special deal with [Dystopia](https://apps.apple.com/us/app/dystopia-for-reddit/id1430599061) and [RedReader](https://play.google.com/store/apps/details?id=org.quantumbadger.redreader) to use the API for free for accessibility reasons. It is possible to use the client ID from one of those apps on either iOS or Android:
 
-When using credentials from another app, set the **Reddit API Key** (OAuth client ID), **Redirect URI**, and **User Agent** in the tweak settings to match the app's values. You'll also need to register the redirect URI scheme in the IPA (see [below](#custom-redirect-uri)).
+1. Install [Dystopia](https://apps.apple.com/us/app/dystopia-for-reddit/id1430599061) from the App Store (if running iOS) or [RedReader](https://play.google.com/store/apps/details?id=org.quantumbadger.redreader) from the Play Store (if running Android).
+2. Log in with your Reddit account in Dystopia/RedReader and allow it access to your account.
+3. After logging in, you should receive an email from Reddit with the subject "You’ve authorized a new app in your Reddit account". Open the email and look for the text after "App ID". Copy that value.
+4. In Apollo Reborn's settings, go to **Custom API** and enter the following values:
+    - **Reddit API Key**: Paste the App ID you copied from the email
+    - **Redirect URI**:
+        - If using Dystopia: `dystopia://response`
+        - If using RedReader: `redreader://rr_oauth_redir`
+    - **User Agent**:
+        - If using Dystopia: `ios:com.CarbonDev.Dystopia:v1.0.1(by /u/DystopiaForReddit)`
+        - If using RedReader: `RedReader/1.25.1`
+5. Log in to Reddit in Apollo normally. Reddit should ask to connect your Reddit account with Dystopia/RedReader instead of your own Reddit app. Accept the connection and you should be good to go!
 
-More discussion in [#82](https://github.com/Apollo-Reborn/Apollo-Reborn/issues/82).
+Credits to [this guide](https://github.com/wchill/patcheddit?tab=readme-ov-file#what-if-i-dont-have-a-client-id) for the original workaround with RedReader.
+
+More discussion in [#82](https://github.com/Apollo-Reborn/Apollo-Reborn/issues/82) and [#367](https://github.com/Apollo-Reborn/Apollo-Reborn/issues/367).
 
 ## Custom Redirect URI
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ More discussion in [#82](https://github.com/Apollo-Reborn/Apollo-Reborn/issues/8
 
 ## Custom Redirect URI
 
+> [!NOTE]
+> Starting with Apollo Reborn v3.1.0, patching the `Info.plist` is no longer required to use a custom redirect URI. This section will remain for older versions, but if you're on v3.1.0 or later you can just enter your custom redirect URI in the tweak settings and it will work without any additional patching.
+
 The redirect URI scheme (the part before `://`) must be registered in the Apollo IPA's `Info.plist` under `CFBundleURLTypes`, otherwise the OAuth callback won't return to Apollo. Add your scheme with [`patch.sh`](#patching-ipa) or the **Build IPA** GitHub Action:
 
 ```bash
@@ -174,7 +177,7 @@ Available patches:
 
 - **`--liquid-glass`** - enables the iOS 26 Liquid Glass UI and installs a pack of Liquid Glass icons that can be switched between in the tweak's in-app icon picker. Requires the Git LFS asset to be pulled first (`git lfs install && git lfs pull`); see the [Build](#build) note. `patch.sh` will refuse to run with an un-pulled pointer.
 - **`--liquid-glass-icons`** - installs the Liquid Glass icon catalog **only**, without the iOS 26 UI chrome (skips the `vtool` build-version bump that opts the app into the iOS 26 runtime, so legacy UIKit behaviors like the bottom-tab swipe gesture are preserved). Mutually exclusive with `--liquid-glass`. Same Git LFS requirement applies.
-- **`--url-schemes <list>`** - adds comma-separated URL schemes to `CFBundleURLTypes` (see [Custom Redirect URI](#custom-redirect-uri)).
+- **`--url-schemes <list>`** - adds comma-separated URL schemes to `CFBundleURLTypes` (see [Custom Redirect URI](#custom-redirect-uri), obsolete on v3.1.0+).
 - **`--remove-code-signature`** - strips the existing code signature.
 
 To run via GitHub Actions, fork this repo and trigger **Actions** > **Build IPA**. It can inject the tweak (`inject_tweak`), strip extensions (`no_extensions`), apply Liquid Glass (`liquid_glass`) or Liquid Glass icons only (`liquid_glass_icons`), add URL schemes, and remove the code signature in one run, from an Apollo IPA URL.


### PR DESCRIPTION
- Update the README.md with a guide to use external API keys as a workaround to the revoked API keys in #367
- Mark the "Custom Redirect URI" section in the README.md with a note that states that Info.plist patching is no longer needed for using custom URI schemes