### PR TITLE
Fix crash sharing a post to Messages/Mail (#366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixes
+
+- Fix a **crash when sharing a post to Messages or Mail** from the share sheet — the system compose controller was misidentified as an Apollo composer, leaving GIF-toolbar injection timers that dereferenced the dismissed share UI and crashed (#378: @nickclyde)
+
 ## [v3.1.0] - 2026-06-05
 
 ### Features

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -31,4 +31,12 @@ NSString *ApolloBundledResourcePath(NSString *baseName, NSString *extension);
 // nil if neither path yields a usable string.
 NSString *ApolloGetLinkButtonNodeURLString(id linkButtonNode);
 void ApolloPresentWebURLFromViewController(UIViewController *presenter, NSURL *url);
+
+// Returns YES for Apple's out-of-process share/compose controllers that the
+// tweak must never traverse or mutate. Their class names end in
+// "ComposeViewController" (e.g. MFMessageComposeViewController), so loose
+// suffix matchers misidentify them as Apollo composers and crash when the
+// GIF/composer machinery pokes at the remote view hierarchy (issue #366).
+// Resolved via objc_getClass so we don't link MessageUI/Social.
+BOOL ApolloIsSystemShareComposeController(UIViewController *controller);
 __END_DECLS

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -474,3 +474,20 @@ void ApolloPresentWebURLFromViewController(UIViewController *presenter, NSURL *u
     ApolloRecordBrowserPresent(normalizedURL);
     [[UIApplication sharedApplication] openURL:normalizedURL options:@{} completionHandler:nil];
 }
+
+BOOL ApolloIsSystemShareComposeController(UIViewController *controller) {
+    if (![controller isKindOfClass:[UIViewController class]]) return NO;
+    // Apple's out-of-process compose controllers whose class names collide with
+    // Apollo's "...ComposeViewController" suffix matchers. Treating them as
+    // Apollo composers crashes the GIF/composer machinery (issue #366).
+    static const char *kSystemComposeClassNames[] = {
+        "MFMessageComposeViewController",
+        "MFMailComposeViewController",
+        "SLComposeViewController",
+    };
+    for (size_t i = 0; i < sizeof(kSystemComposeClassNames) / sizeof(kSystemComposeClassNames[0]); i++) {
+        Class cls = objc_getClass(kSystemComposeClassNames[i]);
+        if (cls && [controller isKindOfClass:cls]) return YES;
+    }
+    return NO;
+}

--- a/src/ApolloMarkdownToolbarGif.xm
+++ b/src/ApolloMarkdownToolbarGif.xm
@@ -78,6 +78,12 @@ static void ApolloMarkdownGifShowGatingToast(UIViewController *host, NSString *m
 static BOOL ApolloMarkdownGifClassLooksLikeCompose(UIViewController *controller) {
     if (!controller) return NO;
     NSString *className = NSStringFromClass(controller.class);
+    // Only Apollo's own Swift composers (mangled to _TtC6Apollo…). Apple's
+    // MFMessageComposeViewController / MFMailComposeViewController also end in
+    // "ComposeViewController"; running the GIF-injection machinery against those
+    // out-of-process controllers crashes when sharing a post to Messages/Mail
+    // (issue #366).
+    if (![className hasPrefix:@"_TtC6Apollo"]) return NO;
     return [className hasSuffix:@"ComposeViewController"] ||
            [className hasSuffix:@"ComposePostViewController"] ||
            [className hasSuffix:@"WatcherComposerViewController"];
@@ -1534,6 +1540,7 @@ void ApolloMarkdownGifInstall(void) {
 
 - (void)viewDidAppear:(BOOL)animated {
     %orig;
+    if (ApolloIsSystemShareComposeController((UIViewController *)self)) return;
     if (ApolloMarkdownGifClassLooksLikeCompose((UIViewController *)self)) {
         ApolloMarkdownGifScheduleInjection((UIViewController *)self, @"viewController-viewDidAppear");
     }
@@ -1541,6 +1548,7 @@ void ApolloMarkdownGifInstall(void) {
 
 - (void)presentViewController:(UIViewController *)viewControllerToPresent animated:(BOOL)flag completion:(void (^)(void))completion {
     %orig;
+    if (ApolloIsSystemShareComposeController(viewControllerToPresent)) return;
     if (ApolloMarkdownGifClassLooksLikeCompose(viewControllerToPresent)) {
         dispatch_async(dispatch_get_main_queue(), ^{
             ApolloMarkdownGifScheduleInjection(viewControllerToPresent, @"presentViewController");

--- a/src/ApolloPhotoPostComposerScrollFix.xm
+++ b/src/ApolloPhotoPostComposerScrollFix.xm
@@ -2590,7 +2590,8 @@ static UIViewController *ApolloMediaComposerActiveComposeControllerForToken(void
     UIViewController *tracked = ApolloMediaComposerCanonicalBodyController(sApolloMediaComposerActiveBodyController) ?: sApolloMediaComposerActiveBodyController;
     if (tracked) {
         NSString *cls = NSStringFromClass(tracked.class) ?: @"";
-        if ([cls hasSuffix:@"ComposePostViewController"] || [cls hasSuffix:@"ComposeViewController"]) {
+        if ([cls hasPrefix:@"_TtC6Apollo"] &&
+            ([cls hasSuffix:@"ComposePostViewController"] || [cls hasSuffix:@"ComposeViewController"])) {
             return tracked;
         }
     }
@@ -2604,7 +2605,8 @@ static UIViewController *ApolloMediaComposerActiveComposeControllerForToken(void
             NSUInteger guard = 0;
             while (vc && guard++ < 32) {
                 NSString *cls = NSStringFromClass(vc.class) ?: @"";
-                if ([cls hasSuffix:@"ComposePostViewController"] || [cls hasSuffix:@"ComposeViewController"]) {
+                if ([cls hasPrefix:@"_TtC6Apollo"] &&
+                    ([cls hasSuffix:@"ComposePostViewController"] || [cls hasSuffix:@"ComposeViewController"])) {
                     return vc;
                 }
                 vc = vc.presentedViewController;
@@ -3281,12 +3283,16 @@ static void ApolloMediaComposerInstallComposeTableHooks(void) {
 
 - (void)viewDidLoad {
     %orig;
+    // Never treat Apple's out-of-process share/compose controllers as Apollo
+    // composers — traversing their remote view hierarchy crashes (issue #366).
+    if (ApolloIsSystemShareComposeController(self)) return;
     ApolloMediaComposerMarkContextActive(self, @"viewDidLoad");
     ApolloPhotoComposerRepairControllerSoon(self, @"viewDidLoad");
 }
 
 - (void)viewWillAppear:(BOOL)animated {
     %orig;
+    if (ApolloIsSystemShareComposeController(self)) return;
     ApolloMediaComposerMarkContextActive(self, @"viewWillAppear");
     if (ApolloMediaComposerControllerLooksLikeNativeTextEditor(self)) {
         ApolloMediaComposerMarkVisibleNativeBodyTextViews(self, @"viewWillAppear-native-editor");
@@ -3298,6 +3304,7 @@ static void ApolloMediaComposerInstallComposeTableHooks(void) {
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
+    if (ApolloIsSystemShareComposeController(self)) { %orig; return; }
     ApolloMediaComposerMarkVisibleNativeBodyTextViews(self, @"viewWillDisappear");
     UIViewController *bodyController = ApolloMediaComposerCanonicalBodyController(self);
     if (bodyController) ApolloMediaComposerRestoreOriginalPostType(bodyController, NO, @"viewWillDisappear");
@@ -3306,6 +3313,7 @@ static void ApolloMediaComposerInstallComposeTableHooks(void) {
 
 - (void)viewDidAppear:(BOOL)animated {
     %orig;
+    if (ApolloIsSystemShareComposeController(self)) return;
     ApolloMediaComposerMarkContextActive(self, @"viewDidAppear");
     NSString *className = NSStringFromClass(self.class);
     if (ApolloMediaComposerShouldBridgeVideoPicker() && ApolloPhotoComposerClassLooksLikeMediaPicker(className)) {
@@ -3325,6 +3333,7 @@ static void ApolloMediaComposerInstallComposeTableHooks(void) {
 
 - (void)viewDidLayoutSubviews {
     %orig;
+    if (ApolloIsSystemShareComposeController(self)) return;
     ApolloMediaComposerMarkContextActive(self, @"viewDidLayoutSubviews");
     if (ApolloMediaComposerControllerLooksLikeNativeTextEditor(self)) {
         ApolloMediaComposerMarkVisibleNativeBodyTextViews(self, @"viewDidLayoutSubviews-native-editor");
@@ -3333,7 +3342,9 @@ static void ApolloMediaComposerInstallComposeTableHooks(void) {
 }
 
 - (void)presentViewController:(UIViewController *)viewControllerToPresent animated:(BOOL)flag completion:(void (^)(void))completion {
-    ApolloPhotoComposerMaybeEnableMoviePicking(self, viewControllerToPresent);
+    if (!ApolloIsSystemShareComposeController(viewControllerToPresent)) {
+        ApolloPhotoComposerMaybeEnableMoviePicking(self, viewControllerToPresent);
+    }
     UIViewController *bodyController = ApolloMediaComposerCanonicalBodyController(self);
     %orig;
     (void)bodyController;
@@ -3360,6 +3371,7 @@ static void ApolloMediaComposerInstallComposeTableHooks(void) {
 
 - (void)viewDidDisappear:(BOOL)animated {
     %orig;
+    if (ApolloIsSystemShareComposeController(self)) return;
     NSString *className = NSStringFromClass(self.class);
     if (!ApolloPhotoComposerClassLooksLikeComposer(className)) return;
 


### PR DESCRIPTION
## Summary

Fixes #366 — Apollo crashes when sharing a post via the share sheet and choosing **Messages** + a recipient (or tapping an individual contact suggestion). **Copy link** was unaffected.

## Root cause

The GIF-toolbar module identifies Apollo's compose controllers with a suffix match (`ApolloMarkdownGifClassLooksLikeCompose`):

```objc
[className hasSuffix:@"ComposeViewController"] || …
```

Apple's `MFMessageComposeViewController` and `MFMailComposeViewController` also end in `"ComposeViewController"`. Sharing a post to Messages presents that out-of-process controller, and the module's **global `UIViewController` hooks** then treated it as an Apollo composer: set it as the active composer and re-armed its 7 deferred GIF-injection timers (0–2.5 s) on **every keyboard event** while the sheet was up. A timer firing during the share sheet's teardown dereferenced the dying remote controller and crashed.

The on-device syslog confirmed it — the message actually sent successfully, then the crash hit ~1 s later during dismiss, squarely inside the deferred-timer window:

```
[MarkdownGif] compose appeared class=MFMessageComposeViewController reason=presentViewController
[MarkdownGif] compose appeared class=MFMessageComposeViewController reason=keyboard   (×N)
… message sent … scene invalidated (mobilesms.compose) … Corpse / fatal report
```

(The shared items were `OptionalTextActivityItemSource` + `NSURL` only — no image source — ruling out the native item-source path.)

## Fix

- **`ApolloCommon`**: new shared guard `ApolloIsSystemShareComposeController()` flagging `MFMessageComposeViewController` / `MFMailComposeViewController` / `SLComposeViewController` (resolved via `objc_getClass`, no MessageUI/Social link).
- **`ApolloMarkdownToolbarGif`**: require the `_TtC6Apollo` Swift-module prefix in the matcher (covers all call sites), plus the shared guard in both global `UIViewController` hooks.
- **`ApolloPhotoPostComposerScrollFix`**: same guard in its second global `UIViewController` lifecycle/present hook, and tighten the bearer-token resolver's loose suffix matchers to require the `_TtC6Apollo` prefix.

`ApolloNativeActionMenus.xm`'s global `presentViewController:` was already safe (bails unless the VC is `_TtC6Apollo16ActionController`).

## Testing

Confirmed fixed on device (iOS 26): post → Share → Messages → recipient → Send no longer crashes; Mail likewise; Copy link unaffected; the GIF button still injects in genuine Apollo composers. After the fix, the `compose appeared class=MFMessageComposeViewController` log lines are gone.

Might address #366.

## Relationship to #335

#335 ("Fix Share as Image on iOS 26 native action menu") also claimed to fix the share-to-Messages crash, but it only patched a **symptom**, not the cause:

- #335's only Messages-related change (incorporating #337) replaced an `OBJC_ASSOCIATION_ASSIGN` active-controller pointer with a `__weak` static — fixing the *dangling-pointer* variant where deferred timers ARC-retained a freed `id` and crashed in `objc_retain`. It did **not** touch the matcher (`git show 7eaf8fd` leaves `ApolloMarkdownGifClassLooksLikeCompose` unchanged).
- The **root cause** — the matcher matching Apple's `MFMessageComposeViewController` so the GIF machinery runs against it at all — remained. The crash log here is from a build that already has #335's `__weak` fix, yet still crashes: with `__weak` the timer no longer derefs a dead pointer, but it still fires against the *being-torn-down* Messages controller and traverses its invalidated remote view hierarchy (scene invalidated at `12:55:06.476`, timer fires ~`12:55:06.9`) — same root cause, different faulting frame.

So #335 fixed the `objc_retain` variant it tested (intermittent — only fires if a timer lands in the narrow teardown window); this PR removes the root cause so no timers are ever armed against the Messages controller.
