### PR TITLE
Publish release dSYMs for crash symbolication (resolving raw crash addresses to source code lines)

### DIFF
--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -119,6 +119,19 @@ jobs:
           echo "deb_path=$DEB_PATH" >> "$GITHUB_OUTPUT"
           echo "Built tweak: $DEB_PATH"
 
+      - name: Collect debug symbols
+        if: inputs.inject_tweak
+        run: bash ./scripts/collect-debug-symbols.sh --label rootful --output-dir ./dist/symbols
+
+      - name: Archive debug symbols
+        if: inputs.inject_tweak
+        id: symbols
+        run: |
+          SYMBOLS_ZIP="Apollo-Reborn-dSYMs-${{ github.run_number }}.zip"
+          (cd dist && zip -qry "../${SYMBOLS_ZIP}" symbols)
+          echo "symbols_zip=${SYMBOLS_ZIP}" >> "$GITHUB_OUTPUT"
+          echo "Debug symbols: ${SYMBOLS_ZIP} ($(wc -c < "${SYMBOLS_ZIP}") bytes)"
+
       - name: Install cyan injector
         if: inputs.inject_tweak
         run: |
@@ -229,8 +242,28 @@ jobs:
           path: ${{ steps.patch.outputs.output_ipa }}
           retention-days: 30
 
+      - name: Upload debug symbols artifact
+        if: inputs.inject_tweak
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ steps.symbols.outputs.symbols_zip }}
+          path: ${{ steps.symbols.outputs.symbols_zip }}
+          retention-days: 30
+
       - name: Create release
-        if: inputs.create_release
+        if: inputs.create_release && inputs.inject_tweak
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
+        with:
+          draft: true
+          tag_name: build-ipa-${{ github.run_number }}
+          name: Apollo build ${{ github.run_number }}
+          files: |
+            ${{ steps.patch.outputs.output_ipa }}
+            ${{ steps.symbols.outputs.symbols_zip }}
+          prerelease: false
+
+      - name: Create release without tweak symbols
+        if: inputs.create_release && !inputs.inject_tweak
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         with:
           draft: true

--- a/.github/workflows/release-ipa-variants.yml
+++ b/.github/workflows/release-ipa-variants.yml
@@ -78,6 +78,9 @@ jobs:
           echo "deb_path=$DEB_PATH" >> "$GITHUB_OUTPUT"
           echo "Rootful tweak: $DEB_PATH"
 
+      - name: Collect rootful debug symbols
+        run: bash ./scripts/collect-debug-symbols.sh --label rootful --output-dir ./dist/symbols
+
       - name: Clean before rootless build
         run: make clean
         env:
@@ -98,6 +101,9 @@ jobs:
           ROOTLESS_RENAMED="${ROOTLESS_DEB%-arm64.deb}-arm64_rootless.deb"
           mv "$ROOTLESS_DEB" "$ROOTLESS_RENAMED"
           echo "Rootless tweak: $ROOTLESS_RENAMED"
+
+      - name: Collect rootless debug symbols
+        run: bash ./scripts/collect-debug-symbols.sh --label rootless --output-dir ./dist/symbols
 
       - name: Install cyan
         run: |
@@ -153,6 +159,14 @@ jobs:
             --deb "${{ steps.rootful_deb.outputs.deb_path }}" \
             --output-dir ./dist/out
 
+      - name: Archive debug symbols
+        id: symbols
+        run: |
+          SYMBOLS_ZIP="dist/Apollo-Reborn-${{ steps.meta.outputs.tweak_version }}-dSYMs.zip"
+          (cd dist && zip -qry "$(basename "${SYMBOLS_ZIP}")" symbols)
+          echo "symbols_zip=${SYMBOLS_ZIP}" >> "$GITHUB_OUTPUT"
+          echo "Debug symbols: ${SYMBOLS_ZIP} ($(wc -c < "${SYMBOLS_ZIP}") bytes)"
+
       - name: Generate release notes
         run: python3 ./scripts/generate_release_notes.py > RELEASE_NOTES.md
         env:
@@ -170,6 +184,7 @@ jobs:
           files: |
             dist/out/*.ipa
             packages/*.deb
+            ${{ steps.symbols.outputs.symbols_zip }}
 
       - name: Summarize release outputs
         run: |
@@ -188,6 +203,10 @@ jobs:
             for ipa in dist/out/*.ipa; do
               echo "- \`$(basename "$ipa")\` ($(du -h "$ipa" | cut -f1))"
             done
+            echo ""
+            echo "## Debug symbols"
+            echo ""
+            echo "- \`$(basename "${{ steps.symbols.outputs.symbols_zip }}")\` ($(du -h "${{ steps.symbols.outputs.symbols_zip }}" | cut -f1))"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Summarize source URLs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,58 @@ Once you have `hopperAddr`:
 
 - `Hopper/goto_address` -> `Hopper/current_procedure` -> decompile around the trap/crash site.
 
+### Symbolicating User Crash Reports With Release dSYMs
+
+Release IPAs are built with `FINALPACKAGE=1`, so the shipped tweak dylib is optimized and stripped. Public release IPAs always come from the `Apollo-Reborn/Apollo-Reborn` release workflow:
+
+```text
+https://github.com/Apollo-Reborn/Apollo-Reborn/actions/workflows/release-ipa-variants.yml
+```
+
+That workflow publishes a matching `*-dSYMs.zip` release asset alongside the IPA/deb assets; use that dSYM for `.ips` reports instead of asking users to reproduce on debug builds.
+
+First identify the release that produced the user's IPA from the IPA filename, release tag, or app/tweak version shown in the `.ips`. Then download and unpack symbols with `gh`:
+
+```bash
+mkdir -p /tmp/apollo-reborn-symbols
+gh release download <release-tag> \
+  --repo Apollo-Reborn/Apollo-Reborn \
+  --pattern '*-dSYMs.zip' \
+  --dir /tmp/apollo-reborn-symbols
+unzip -q /tmp/apollo-reborn-symbols/*-dSYMs.zip -d /tmp/apollo-reborn-symbols/unpacked
+find /tmp/apollo-reborn-symbols/unpacked -name 'ApolloReborn.dylib.dSYM' -type d
+```
+
+If the tag is unknown, inspect recent releases and asset names:
+
+```bash
+gh release list --repo Apollo-Reborn/Apollo-Reborn --limit 20
+gh release view <release-tag> --repo Apollo-Reborn/Apollo-Reborn --json assets --jq '.assets[].name'
+```
+
+For tweak frames like:
+
+```text
+ApolloReborn.dylib  0x103bbca90 0x103ad4000 + 952976
+```
+
+1. Match the `ApolloReborn.dylib` UUID in the `.ips` `usedImages` / `binaryImages` section against:
+
+```bash
+dwarfdump --uuid /tmp/apollo-reborn-symbols/unpacked/symbols/rootful/ApolloReborn.dylib.dSYM
+```
+
+2. Symbolicate every `ApolloReborn.dylib` frame from the crashed thread:
+
+```bash
+atos -arch arm64 \
+  -o /tmp/apollo-reborn-symbols/unpacked/symbols/rootful/ApolloReborn.dylib.dSYM/Contents/Resources/DWARF/ApolloReborn.dylib \
+  -l 0x103ad4000 \
+  0x103bbca90
+```
+
+Use the image load address as `-l` and the frame PC/address as the final argument. If the crash only provides an offset, compute `address = imageLoadAddress + offset`. Once frames resolve to source files/lines, investigate the Logos hook/block at that location and use the rest of the crashed thread plus exception type to infer runtime state.
+
 ### Swift Struct Ivars and iOS Version Pitfalls
 
 Swift value types (structs like `Foundation.URL`) stored as ivars in a class are laid out inline — they are NOT object pointers. `MSHookIvar<NSURL *>` on a `URL` ivar works by accident on older iOS (where `URL`'s first field happened to be an `NSURL *`) but breaks when Apple changes the struct layout (e.g. iOS 26 swift-foundation changes). When you need data from a Swift struct ivar:

--- a/scripts/collect-debug-symbols.sh
+++ b/scripts/collect-debug-symbols.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+LABEL=""
+OUTPUT_DIR="${REPO_DIR}/dist/symbols"
+
+usage() {
+    echo "Usage: $0 --label <name> [--output-dir <dir>]"
+    echo ""
+    echo "Copies Theos-generated .dSYM bundles into a labeled symbol staging folder."
+}
+
+absolute_path() {
+    case "$1" in
+        /*) printf '%s\n' "$1" ;;
+        *) printf '%s/%s\n' "$PWD" "${1#./}" ;;
+    esac
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --label)
+            LABEL="$2"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$LABEL" ]]; then
+    echo "Error: --label is required."
+    usage
+    exit 1
+fi
+
+OUTPUT_DIR="$(absolute_path "$OUTPUT_DIR")"
+DEST_DIR="${OUTPUT_DIR}/${LABEL}"
+rm -rf "$DEST_DIR"
+mkdir -p "$DEST_DIR"
+
+found=0
+for search_dir in "${REPO_DIR}/.theos/obj" "${REPO_DIR}/openin-extension/.theos/obj"; do
+    [[ -d "$search_dir" ]] || continue
+    while IFS= read -r -d '' dsym; do
+        found=1
+        dest_name="$(basename "$dsym")"
+        if [[ -e "${DEST_DIR}/${dest_name}" ]]; then
+            parent_name="$(basename "$(dirname "$dsym")")"
+            dest_name="${parent_name}-${dest_name}"
+        fi
+        cp -R "$dsym" "${DEST_DIR}/${dest_name}"
+        echo "Collected ${LABEL}/${dest_name}"
+    done < <(find "$search_dir" -path '*/debug/*' -prune -o -name '*.dSYM' -type d -prune -print0)
+done
+
+if [[ "$found" -eq 0 ]]; then
+    echo "Error: no .dSYM bundles found under Theos build directories."
+    exit 1
+fi


### PR DESCRIPTION
This publishes matching dSYM zips alongside release IPA/deb builds, so crash reports from stripped `ApolloReborn.dylib` binaries can be symbolicated without asking users to install debug builds.

Today, a user crash report might only show raw tweak addresses like:

```text
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libobjc.A.dylib                          0x186ad791c objc_retain + 16
1   ApolloReborn.dylib                       0x103bbca90 0x103ad4000 + 952976
2   ApolloReborn.dylib                       0x103bbc9d8 0x103ad4000 + 952792
3   libdispatch.dylib                        0x186d7aa28 _dispatch_call_block_and_release + 32
```

With the matching dSYM, those `ApolloReborn.dylib` frames can be resolved back to the tweak method/block and source line that crashed (for example, `__43-[ApolloThanksToViewController loadContributors]_block_invoke (CustomAPIViewController.m:2663)`).

The release workflows now collect Theos-generated dSYM bundles with a shared `scripts/collect-debug-symbols.sh` helper. Both the manual IPA workflow and the six-variant release workflow upload the resulting symbol archive with their build outputs.

This also documents in AGENTS.md the agent workflow for downloading the matching dSYM asset from `Apollo-Reborn/Apollo-Reborn`, unpacking it, checking UUIDs, and using `atos` to resolve tweak frames from user-provided `.ips` files.

### Testing

Built a release package with `make package FINALPACKAGE=1` and confirmed the `.deb` `ApolloReborn.dylib` UUID matches the generated `ApolloReborn.dylib.dSYM`. Also parsed the updated workflow YAML and ran `git diff --check`.
