### PR TITLE
Fix colored flairs reverting to grey after returning from background

### DIFF
--- a/src/ApolloFlairColors.xm
+++ b/src/ApolloFlairColors.xm
@@ -41,10 +41,21 @@
 // Attached to each RDKFlair instance that we recovered colors for.
 static char kApolloFlairBackgroundColorKey;
 static char kApolloFlairTextColorKey;
-// Attached to a FlairNode once we've recolored its text (so reapply passes only
-// touch the cheap, layout-safe background color and don't re-edit attributed
-// text repeatedly).
-static char kApolloFlairNodeTextAppliedKey;
+// Attached to each flair content TEXT node we've recolored, holding the target
+// UIColor foreground. The global ASTextNode/ASTextNode2 setAttributedText: hook
+// reads this so it can re-impose our color any time Apollo overwrites the text
+// (app foreground re-theme, vote/score refresh, edit, etc.) regardless of
+// Texture interface-state timing. nil for every non-flair text node, so the
+// hook is a strict no-op for the rest of the app.
+static char kApolloFlairTextNodeForegroundKey;
+// Attached to a FlairNode the first time we successfully resolve its colors,
+// memoizing the exact background + text color. Every later reapply (app
+// foreground, re-display) reuses these instead of re-resolving — otherwise the
+// post-foreground path, where the RDKFlair associated colors are gone and
+// richtext flairs have a nil text cache key, falls through to the generated
+// hash color and the flair drifts to a wrong shade (e.g. purple -> teal).
+static char kApolloFlairNodeResolvedBackgroundKey;
+static char kApolloFlairNodeResolvedTextKey;
 
 #pragma mark - Fallback cache (text -> colors)
 
@@ -307,8 +318,20 @@ static void ApolloFlairRecolorTextNodes(NSArray *contentNodes, UIColor *textColo
         // Recolor text runs (leave emoji/image attachments alone).
         if ([contentNode respondsToSelector:@selector(attributedText)] &&
             [contentNode respondsToSelector:@selector(setAttributedText:)]) {
+            // Tag the node with our target foreground so the global
+            // setAttributedText: chokepoint can re-impose it whenever Apollo
+            // rewrites the text later (e.g. on app foreground).
+            objc_setAssociatedObject(contentNode, &kApolloFlairTextNodeForegroundKey, foreground, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
             id attributed = ApolloFlairPerformObject(contentNode, @selector(attributedText));
             if ([attributed isKindOfClass:[NSAttributedString class]] && [(NSAttributedString *)attributed length] > 0) {
+                // Idempotency guard: if the first character already carries our
+                // target foreground color, the text is already recolored. This
+                // lets us safely re-run on every display-state re-entry (e.g.
+                // returning from background) without churning setAttributedText:.
+                UIColor *existing = [(NSAttributedString *)attributed attribute:NSForegroundColorAttributeName
+                                                                       atIndex:0
+                                                                effectiveRange:NULL];
+                if ([existing isEqual:foreground]) continue;
                 NSMutableAttributedString *recolored = [(NSAttributedString *)attributed mutableCopy];
                 [recolored addAttribute:NSForegroundColorAttributeName value:foreground range:NSMakeRange(0, recolored.length)];
                 ((void (*)(id, SEL, id))objc_msgSend)(contentNode, @selector(setAttributedText:), recolored);
@@ -325,24 +348,53 @@ static void ApolloFlairRecolorTextNodes(NSArray *contentNodes, UIColor *textColo
     }
 }
 
+// Re-impose our recovered flair foreground color onto an attributed string that
+// Apollo is about to set on a tagged flair text node. Returns the input
+// untouched for any node we don't own, or when the color is already present.
+static NSAttributedString *ApolloFlairRecolorAttributedForNode(id node, NSAttributedString *input) {
+    UIColor *foreground = objc_getAssociatedObject(node, &kApolloFlairTextNodeForegroundKey);
+    if (!foreground) return input;
+    if (![input isKindOfClass:[NSAttributedString class]] || input.length == 0) return input;
+    UIColor *existing = [input attribute:NSForegroundColorAttributeName atIndex:0 effectiveRange:NULL];
+    if ([existing isEqual:foreground]) return input;
+    NSMutableAttributedString *recolored = [input mutableCopy];
+    [recolored addAttribute:NSForegroundColorAttributeName value:foreground range:NSMakeRange(0, recolored.length)];
+    return recolored;
+}
+
 static void ApolloFlairApply(id node, BOOL allowTextRecolor) {
     if (!sEnableFlairColors || !node) return;
 
     NSArray *flairs = ApolloFlairSwiftArrayIvar(node, "flairs");
     if (flairs.count == 0) return;
 
-    UIColor *background = nil, *textColor = nil;
-    // Prefer Reddit's assigned color; otherwise generate a stable color from the
-    // flair text so flairs still stand out in subreddits that set no color.
-    if (!ApolloFlairResolveColors(flairs, &background, &textColor) || !background) {
-        NSString *text = ApolloFlairText(flairs.firstObject);
-        if (!ApolloFlairGeneratedColors(text, &background, &textColor) || !background) return;
+    // Reuse the colors we resolved the first time for this node. This is what
+    // keeps the color stable across app foreground / re-display: on those paths
+    // the precise RDKFlair associations are gone and richtext flairs have a nil
+    // text cache key, so a fresh resolve would miss and fall to the generated
+    // hash color (wrong shade). Memoizing avoids that drift entirely.
+    UIColor *background = objc_getAssociatedObject(node, &kApolloFlairNodeResolvedBackgroundKey);
+    UIColor *textColor = objc_getAssociatedObject(node, &kApolloFlairNodeResolvedTextKey);
+
+    if (!background) {
+        // Prefer Reddit's assigned color; otherwise generate a stable color from
+        // the flair text so flairs still stand out in subreddits that set none.
+        if (!ApolloFlairResolveColors(flairs, &background, &textColor) || !background) {
+            NSString *text = ApolloFlairText(flairs.firstObject);
+            if (!ApolloFlairGeneratedColors(text, &background, &textColor) || !background) return;
+        }
+        objc_setAssociatedObject(node, &kApolloFlairNodeResolvedBackgroundKey, background, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(node, &kApolloFlairNodeResolvedTextKey, textColor, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
 
     ApolloFlairSetBackground(node, background);
 
-    if (allowTextRecolor && !objc_getAssociatedObject(node, &kApolloFlairNodeTextAppliedKey)) {
-        objc_setAssociatedObject(node, &kApolloFlairNodeTextAppliedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    // Recolor is now idempotent (ApolloFlairRecolorTextNodes skips text nodes
+    // already carrying our color), so it's safe to re-run on every render pass.
+    // We no longer set a permanent guard — that one-shot guard caused flairs to
+    // revert to Apollo's default grey after the app returned from background,
+    // because the content text nodes get rebuilt and our recolor was blocked.
+    if (allowTextRecolor) {
         NSArray *contentNodes = ApolloFlairSwiftArrayIvar(node, "contentNodes");
         ApolloFlairRecolorTextNodes(contentNodes, textColor);
     }
@@ -435,9 +487,60 @@ static void ApolloFlairRecoverForModel(id model, NSDictionary *json) {
 
 - (void)didEnterPreloadState {
     %orig;
-    // Reapply only the (layout-safe) background in case Apollo re-set it after
-    // didLoad; text was already handled and is guarded against repeats.
-    ApolloFlairApply(self, NO);
+    // Reapply background + (idempotent) text in case Apollo re-set them after
+    // didLoad.
+    ApolloFlairApply(self, YES);
+}
+
+- (void)didEnterDisplayState {
+    %orig;
+    // Fires on scroll / re-display (cell reuse). Idempotent reapply.
+    ApolloFlairApply(self, YES);
+}
+
+- (void)didEnterVisibleState {
+    %orig;
+    // THIS is the callback that fires when the app returns from the background.
+    // On app background, Texture clears the node's Visible interface state while
+    // typically RETAINING the Display state, so didEnterDisplayState does NOT
+    // re-fire on foreground — only didEnterVisibleState does. Apollo re-themes the
+    // flair to its default grey during its own %orig here, so we reapply our
+    // colors AFTER %orig to win the race. Idempotent (no-op if already colored).
+    static NSUInteger sVisibleLogCount = 0;
+    if (sVisibleLogCount < 20) {
+        sVisibleLogCount++;
+        ApolloLog(@"[FlairColors] FlairNode.didEnterVisibleState enabled=%d reapplying", (int)sEnableFlairColors);
+    }
+    ApolloFlairApply(self, YES);
+}
+
+%end
+
+#pragma mark - Text-node re-theme chokepoint
+
+// Apollo overwrites a flair's content text node back to its default grey on a
+// number of pathways that don't reliably re-fire Texture's interface-state
+// callbacks — most importantly when the app returns from the background. To
+// guarantee our color survives all of them, we intercept setAttributedText: on
+// the text node classes and re-impose our recovered foreground for any node we
+// previously tagged in ApolloFlairRecolorTextNodes. This is the same proven
+// pattern ApolloTranslation uses for translated comment bodies. Strict no-op
+// for every untagged node, so the rest of the app is unaffected.
+
+%hook ASTextNode
+
+- (void)setAttributedText:(NSAttributedString *)attributedText {
+    if (!sEnableFlairColors) { %orig; return; }
+    %orig(ApolloFlairRecolorAttributedForNode(self, attributedText));
+}
+
+%end
+
+%hook ASTextNode2
+
+- (void)setAttributedText:(NSAttributedString *)attributedText {
+    if (!sEnableFlairColors) { %orig; return; }
+    %orig(ApolloFlairRecolorAttributedForNode(self, attributedText));
 }
 
 %end


### PR DESCRIPTION
## Problem

With the **Color Flairs** option enabled, post/user flairs lost their Reddit-assigned color and snapped back to Apollo's default grey whenever the app was sent to the background and reopened. A follow-up issue: once the color *did* persist, the reapplied shade was sometimes wrong (e.g. a purple flair came back teal).

## Root causes

1. **Wrong Texture lifecycle hook.** On background, Texture clears a node's **Visible** interface state but typically retains its **Display** state, so `didEnterDisplayState` does **not** re-fire on foreground — only `didEnterVisibleState` does. The original reapply was driven from the display-state path, so it never ran on a pure background→foreground cycle.

2. **Permanent one-shot recolor guard.** A `kApolloFlairNodeTextAppliedKey` association blocked the text recolor *forever* after the first pass. When Apollo rebuilt the flair's content text nodes (which it does on foreground), the color could never be restored.

3. **Re-resolving against missing data.** On the foreground path the per-instance `RDKFlair` color associations are gone and richtext flairs have a `nil` text cache key, so a fresh resolve missed and fell through to the generated hash color — producing an arbitrary, wrong shade.

## Fix

- Hook **`didEnterVisibleState`** (and `didEnterDisplayState`) and reapply **after `%orig`** so we win the race against Apollo re-theming the flair to grey on foreground.
- Remove the permanent one-shot guard and make `ApolloFlairRecolorTextNodes` **idempotent** — it skips any text node whose first character already carries our foreground color, so it's safe to re-run on every render pass.
- Add a global **`setAttributedText:` chokepoint** on `ASTextNode`/`ASTextNode2` that re-imposes our recovered foreground for any flair text node we previously tagged. This guarantees the color survives every re-theme path, not just the lifecycle callbacks. It's the same proven pattern `ApolloTranslation` uses, and a strict **no-op for every untagged node** (and when the feature flag is off).
- **Memoize** the resolved background + text color per `FlairNode` on first successful resolve, and reuse it on every later reapply. This keeps the exact original shade stable across foreground/redisplay instead of drifting to the hash fallback.

All new work is gated behind the existing `Color Flairs` setting (`sEnableFlairColors`); when the feature is disabled, the hooks pass straight through to `%orig`.

## Testing

Built a debug IPA and validated on device: enabled Color Flairs, backgrounded the app and returned multiple times across feed and subreddit views — flairs keep their exact Reddit-assigned color (purple stays purple), and device logs confirm `didEnterVisibleState` fires and reapplies the memoized color on each foreground.

Scope: a single file, `src/ApolloFlairColors.xm` (+118/−15).