### PR TITLE
Update changelog for v3.1.1 and fix version entry merging in source JSON generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Fixes
+## [v3.1.1] - 2026-06-07
 
 - Fix a **crash when sharing a post to Messages or Mail** from the share sheet — the system compose controller was misidentified as an Apollo composer, leaving GIF-toolbar injection timers that dereferenced the dismissed share UI and crashed (#378: @nickclyde)
+- Fix **Reddit login on iOS 15** by automatically falling back to Old Reddit, and add an Old Reddit button to the auth view for users who need to switch manually (#377: @DeltAndy123)
+- Fix **video controls** overlay rendering, including the AirPlay button getting clipped or misaligned (#383: @JeffreyCA)
+- Fix **flair alignment** so post and user flairs no longer sit too low or clip their text (#389: @JeffreyCA)
+- Fix **Color Flairs** reverting to grey or the wrong shade after returning to Apollo from the background (#391: @icpryde)
 
 ## [v3.1.0] - 2026-06-05
 
@@ -505,6 +509,7 @@ There are currently a few limitations:
 ## [v1.0.0] - 2023-10-13
 - Initial release
 
+[v3.1.1]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v1.15.11_3.1.0...v1.15.11_3.1.1
 [v3.1.0]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v1.15.11_3.0.0...v1.15.11_3.1.0
 [v3.0.0]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v2.14.0...v1.15.11_3.0.0
 [v2.14.0]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v2.13.0...v2.14.0

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: com.apollo.reborn
 Name: Apollo-Reborn
-Version: 3.1.0
+Version: 3.1.1
 Architecture: iphoneos-arm
 Description: Apollo for Reddit tweak with in-app configurable API keys
 Maintainer: Apollo Reborn team

--- a/distribution/config.json
+++ b/distribution/config.json
@@ -12,7 +12,7 @@
   },
   "app": {
     "bundleIdentifier": "com.christianselig.Apollo",
-    "buildVersion": "287",
+    "buildVersion": "288",
     "developerName": "Christian Selig (& Apollo-Reborn contributors)",
     "iconURL": "https://apolloreborn.app/assets/icon.png",
     "tintColor": "#F0542D",

--- a/scripts/update_source_json.py
+++ b/scripts/update_source_json.py
@@ -310,6 +310,34 @@ def build_news_entry(
     }
 
 
+def version_entry_key(entry: dict[str, Any]) -> tuple[Any, ...]:
+    download_url = entry.get("downloadURL")
+    if download_url:
+        return ("downloadURL", download_url)
+    return (
+        "version",
+        entry.get("version"),
+        entry.get("buildVersion"),
+        entry.get("date"),
+    )
+
+
+def merge_version_entries(
+    new_entries: list[dict[str, Any]],
+    existing_entries: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    merged: dict[tuple[Any, ...], dict[str, Any]] = {}
+    for entry in existing_entries:
+        merged[version_entry_key(entry)] = entry
+    for entry in new_entries:
+        merged[version_entry_key(entry)] = entry
+    return sorted(
+        merged.values(),
+        key=lambda item: item.get("date") or "",
+        reverse=True,
+    )
+
+
 def update_source_json(
     output_path: Path,
     releases: list[dict[str, Any]],
@@ -333,6 +361,9 @@ def update_source_json(
     build_version = config["app"].get("buildVersion")
     versions: list[dict[str, Any]] = []
     news: list[dict[str, Any]] = []
+    existing_versions = app.get("versions") or []
+    if not isinstance(existing_versions, list):
+        existing_versions = []
 
     sorted_releases = sorted(
         releases,
@@ -345,17 +376,17 @@ def update_source_json(
         )
         if not entry:
             continue
-        # Historical IPAs were published before the bundle-version rewrite and
-        # still carry Apollo's original 1.15.11/285 plist values. The source
-        # config only knows the current build number, so advertise the newest
-        # installable asset while keeping the full release history in news.
+        # The source config only knows the current IPA build number. Generate the
+        # newest release entry, then preserve older entries already in the source
+        # so their historical buildVersion values remain installable.
         if not versions:
             versions.append(entry)
         news.append(build_news_entry(release, config, variant.get("newsLabel")))
 
-    app["versions"] = versions
-    if versions:
-        latest = versions[0]
+    merged_versions = merge_version_entries(versions, existing_versions)
+    app["versions"] = merged_versions
+    if merged_versions:
+        latest = merged_versions[0]
         app["version"] = latest["version"]
         app["buildVersion"] = latest["buildVersion"]
         app["marketingVersion"] = latest["marketingVersion"]
@@ -364,7 +395,7 @@ def update_source_json(
         app["downloadURL"] = latest["downloadURL"]
         app["size"] = latest["size"]
 
-    data["news"] = sorted(news, key=lambda item: item.get("date") or "", reverse=True)
+    data["news"] = sorted(news, key=lambda item: item.get("date") or "")
 
     output_path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 


### PR DESCRIPTION
Fixes https://github.com/Apollo-Reborn/Apollo-Reborn/issues/372

### Changes
- **Preserve previous versions** — `update_source_json.py` now merges newly generated entries with the existing `versions` array instead of replacing it. Older releases (with their original `buildVersion`) stay installable, so Feather can offer previous versions, not just the latest. Merge dedups by `downloadURL` and is idempotent.
- **Reverse news ordering** — the `news` array is now sorted oldest-first. Feather (which displays the array in reverse) now shows newest first; AltStore is unaffected since it sorts by `date` itself.

### Notes
- Forward-looking: history rebuilds from the current release onward, since the script can't recover build numbers for versions already dropped from the committed source files.
- Generated `apps*.json` files are produced by the release automation and aren't included here.
- The issue's third suggestion (curated/manual news items) is out of scope.
