### PR TITLE
Fix comment scroll lockup on failed link previews

### DIFF
--- a/src/ApolloLinkPreviewFetcher.m
+++ b/src/ApolloLinkPreviewFetcher.m
@@ -810,7 +810,12 @@ static NSString *ApolloLinkPreviewBrowserUserAgent(void) {
 
 + (void)finishURL:(NSURL *)url preview:(ApolloLinkPreview *)preview {
     if (!preview) {
-        ApolloLog(@"[LinkPreviews] no cache for empty preview host=%@", ApolloLinkPreviewHost(url));
+        // Negatively cache the failure so the next layout resolves from cache
+        // instead of refetching. Without this, a URL that always 404s (e.g. a
+        // removed v.redd.it video surfaced as a redd.it/<id> short link) loops
+        // forever: fetch fails -> node relayouts -> refetches, freezing scroll.
+        ApolloLog(@"[LinkPreviews] caching negative result for empty preview host=%@", ApolloLinkPreviewHost(url));
+        [[ApolloLinkPreviewCache sharedCache] markNoMetadataForURL:url];
         NSString *key = url.absoluteString ?: @"";
         dispatch_async(ApolloLinkPreviewFetcherQueue(), ^{
             NSMutableArray *completions = ApolloLinkPreviewPendingFetches()[key];


### PR DESCRIPTION
### Problem
Opening a thread with a comment linking to removed media (e.g. a deleted `v.redd.it` video, which Apollo surfaces as a `redd.it/<id>` short link) freezes scrolling at the bottom of the comments. Nav buttons still work, but the list can't scroll. Logs show the same preview fetch 404ing and retrying ~150 ms apart, indefinitely.

### Cause
`redd.it/<id>` is fetched as a post (`/comments/<id>/.json`), which 404s for a video ID. On a `nil` result, `finishURL:preview:` logged `no cache for empty preview` and cached nothing. The inline `LinkButtonNode` then cleared its in-flight flag and triggered a relayout, which re-fetched, which failed again — an unbounded fetch/relayout loop that thrashed the comment table.

### Fix
Negatively cache `nil` fetch results via `markNoMetadataForURL:` (24h negative TTL, the same mechanism already used for empty-metadata previews). After one failed attempt the next layout resolves from cache and renders the native link instead of refetching, breaking the loop. Generalizes to any link whose preview fetch fails (404s, removed content, network errors).
