### PR TITLE
Fix gallery GIFs getting stuck while loading

### DIFF
--- a/src/ApolloMediaMetadata.m
+++ b/src/ApolloMediaMetadata.m
@@ -54,6 +54,23 @@ NSString *ApolloRedditHostedGIFDisplayURL(NSString *assetID) {
     return [NSString stringWithFormat:@"https://i.redd.it/%@.gif", assetID];
 }
 
+// A Reddit-hosted GIF entry only needs our normalization when Reddit's own
+// metadata is incomplete (e.g. a freshly uploaded GIF that came back not-yet
+// "valid", missing the AnimatedImage type, or lacking a usable source URL).
+// Healthy entries — which already carry an efficient signed
+// `preview.redd.it/<id>.gif?format=mp4` in `s.mp4` that the gallery/album
+// viewer streams — must be left untouched so we don't downgrade playback to
+// the full `i.redd.it/<id>.gif`.
+static BOOL ApolloRedditHostedGifEntryNeedsNormalization(NSDictionary *entry) {
+    if (![[entry objectForKey:@"status"] isEqualToString:@"valid"]) return YES;
+    if (![[entry objectForKey:@"e"] isEqualToString:@"AnimatedImage"]) return YES;
+    if (![[entry objectForKey:@"m"] isEqualToString:@"image/gif"]) return YES;
+    NSDictionary *source = [entry[@"s"] isKindOfClass:[NSDictionary class]] ? entry[@"s"] : nil;
+    if (!ApolloStringIsNonEmpty(source[@"gif"])) return YES;
+    if (!ApolloStringIsNonEmpty(source[@"mp4"])) return YES;
+    return NO;
+}
+
 NSDictionary *ApolloFixRedditHostedGifMetadata(NSDictionary *orig, NSUInteger *outFixedCount) {
     if (outFixedCount) *outFixedCount = 0;
     if (![orig isKindOfClass:[NSDictionary class]] || orig.count == 0) return orig;
@@ -66,6 +83,11 @@ NSDictionary *ApolloFixRedditHostedGifMetadata(NSDictionary *orig, NSUInteger *o
 
         NSDictionary *entry = orig[key];
         if (!ApolloMetadataEntryIsRedditHostedGIF(key, entry)) continue;
+        // Only repair entries Reddit returned incomplete. Skipping healthy
+        // entries preserves their efficient signed `preview.redd.it ...
+        // format=mp4` source, fixing the regression where the gallery viewer
+        // started streaming full `i.redd.it/<id>.gif` files (stuck spinner).
+        if (!ApolloRedditHostedGifEntryNeedsNormalization(entry)) continue;
 
         NSString *gifURL = ApolloRedditHostedGIFDisplayURL(key);
         if (!gifURL) continue;
@@ -74,9 +96,13 @@ NSDictionary *ApolloFixRedditHostedGifMetadata(NSDictionary *orig, NSUInteger *o
 
         NSDictionary *existingSource = [entry[@"s"] isKindOfClass:[NSDictionary class]] ? entry[@"s"] : nil;
         NSMutableDictionary *source = existingSource ? [existingSource mutableCopy] : [NSMutableDictionary dictionary];
-        source[@"gif"] = gifURL;
-        // MP4 preference must still resolve to an animatable GIF for Reddit uploads.
-        source[@"mp4"] = gifURL;
+        // Synthesize only the source URLs Reddit left missing. Never overwrite
+        // an existing value: a present `mp4` is Reddit's efficient signed
+        // preview that the gallery streams, and a present `gif` already points
+        // at the animatable i.redd.it asset. A missing `mp4` must still resolve
+        // to an animatable GIF (otherwise Apollo opens it in a webview).
+        if (!ApolloStringIsNonEmpty(source[@"gif"])) source[@"gif"] = gifURL;
+        if (!ApolloStringIsNonEmpty(source[@"mp4"])) source[@"mp4"] = gifURL;
 
         NSMutableDictionary *normalized = [entry mutableCopy];
         normalized[@"status"] = @"valid";


### PR DESCRIPTION
Fixes #399
Fixes #402

https://github.com/user-attachments/assets/c244ab18-bcd9-49d4-bc22-a53cb175ba9e

### Problem

In gallery/album posts with multiple GIFs, navigating between items left the GIFs stuck on a loading spinner. Network traces showed each item being fetched as a full `https://i.redd.it/<id>.gif` instead of the efficient signed `https://preview.redd.it/<id>.gif?format=mp4` stream. Regression introduced in PR #276 (between v2.14.0 and v3.0.0).

### Cause

`ApolloFixRedditHostedGifMetadata` (`setMediaMetadata:` hook) overwrote `s.mp4` with the full `i.redd.it/<id>.gif` for **every** reddit-hosted GIF entry. Healthy gallery entries already carry a valid signed `preview.redd.it ...?format=mp4` in `s.mp4`, which the gallery viewer streams — clobbering it forced full-GIF downloads that stalled.

### Fix

- Skip entries Reddit already returned as healthy (`status=valid`, `AnimatedImage`, `image/gif`, with usable `s.gif` + `s.mp4`), preserving the efficient signed MP4 source.
- When normalizing incomplete/uploaded entries, only synthesize **missing** source URLs instead of overwriting existing ones.

This keeps the original intent (freshly uploaded GIFs without a usable source still animate instead of opening in a webview) while no longer downgrading healthy gallery playback. Also benefits inline rendering, which matches posters against the original signed `s.mp4`.

### Testing

- `make package` builds cleanly.
- Manual: verified affected threads load GIFs via `preview.redd.it ...format=mp4` again instead of full `i.redd.it` GIFs.
