### PR TITLE
Overlay fixes and consolidate cache options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloTranslation.xm \
     $(SRC_DIR)/ApolloVideoUnmute.xm \
     $(SRC_DIR)/ApolloVideoSwipeFix.xm \
+    $(SRC_DIR)/ApolloMediaPreviewErrorFix.xm \
     $(SRC_DIR)/ApolloSubredditIndexPolish.xm \
     $(SRC_DIR)/ApolloTagFilters.xm \
     $(SRC_DIR)/ApolloImageChestResolver.m \

--- a/src/ApolloBannedProfile.h
+++ b/src/ApolloBannedProfile.h
@@ -6,6 +6,8 @@ FOUNDATION_EXPORT NSString *ApolloBannedProfileBannedDescriptionText(void);
 FOUNDATION_EXPORT UIImage *ApolloBannedProfileIconImage(void);
 FOUNDATION_EXPORT BOOL ApolloBannedProfileCachedIsSuspended(NSString *username);
 FOUNDATION_EXPORT void ApolloBannedProfileNoteListEndpoint403ForURL(NSURL *url);
+FOUNDATION_EXPORT void ApolloBannedProfileClearListEndpoint403ForUsername(NSString *username);
+FOUNDATION_EXPORT void ApolloBannedProfileClearDismissedOverlays(void);
 FOUNDATION_EXPORT void ApolloBannedProfileRefreshViewController(UIViewController *viewController);
 FOUNDATION_EXPORT void ApolloBannedProfileRefreshProfilesForUsername(NSString *username);
 FOUNDATION_EXPORT void ApolloBannedProfileDecorateCommentCellIfNeeded(id cell);

--- a/src/ApolloBannedProfile.xm
+++ b/src/ApolloBannedProfile.xm
@@ -15,6 +15,22 @@ static Class sProfileViewControllerClass = Nil;
 static NSMutableSet<NSString *> *sListEndpoint403Usernames = nil;
 static NSSet<NSString *> *sBlockedNavTitles = nil;
 
+// Usernames whose banned overlay the user has manually dismissed. Persisted so
+// the overlay never reappears for that account — the escape hatch for false
+// positives (e.g. your own temporarily-suspended account flashing the overlay
+// for a split second right after login, before RDKClient.currentUser resolves).
+static NSString *const kApolloBannedProfileDismissedUsernamesDefaultsKey = @"ApolloBannedProfileDismissedUsernames";
+static NSMutableSet<NSString *> *sDismissedUsernames = nil;
+
+static void ApolloBannedProfileLoadDismissedUsernames(void) {
+    if (sDismissedUsernames) return;
+    sDismissedUsernames = [NSMutableSet set];
+    NSArray *stored = [[NSUserDefaults standardUserDefaults] arrayForKey:kApolloBannedProfileDismissedUsernamesDefaultsKey];
+    for (id entry in stored) {
+        if ([entry isKindOfClass:[NSString class]]) [sDismissedUsernames addObject:entry];
+    }
+}
+
 static NSString *ApolloBannedProfileNormalizedUsername(NSString *username) {
     if (![username isKindOfClass:[NSString class]]) return nil;
     NSString *clean = [username stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
@@ -29,6 +45,33 @@ static BOOL ApolloBannedProfileUsernamesMatch(NSString *left, NSString *right) {
     NSString *normalizedRight = ApolloBannedProfileNormalizedUsername(right);
     if (normalizedLeft.length == 0 || normalizedRight.length == 0) return NO;
     return [normalizedLeft caseInsensitiveCompare:normalizedRight] == NSOrderedSame;
+}
+
+static BOOL ApolloBannedProfileOverlayDismissedForUsername(NSString *username) {
+    NSString *key = ApolloBannedProfileNormalizedUsername(username);
+    if (key.length == 0) return NO;
+    ApolloBannedProfileLoadDismissedUsernames();
+    return [sDismissedUsernames containsObject:key.lowercaseString];
+}
+
+static void ApolloBannedProfileMarkOverlayDismissedForUsername(NSString *username) {
+    NSString *key = ApolloBannedProfileNormalizedUsername(username);
+    if (key.length == 0) return;
+    ApolloBannedProfileLoadDismissedUsernames();
+    NSString *lower = key.lowercaseString;
+    if ([sDismissedUsernames containsObject:lower]) return;
+    [sDismissedUsernames addObject:lower];
+    [[NSUserDefaults standardUserDefaults] setObject:sDismissedUsernames.allObjects
+                                              forKey:kApolloBannedProfileDismissedUsernamesDefaultsKey];
+    ApolloLog(@"[BannedProfile] user dismissed banned overlay for u/%@", key);
+}
+
+void ApolloBannedProfileClearDismissedOverlays(void) {
+    ApolloBannedProfileLoadDismissedUsernames();
+    [sDismissedUsernames removeAllObjects];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kApolloBannedProfileDismissedUsernamesDefaultsKey];
+    [sListEndpoint403Usernames removeAllObjects];
+    ApolloLog(@"[BannedProfile] cleared all dismissed banned overlays and 403 markers");
 }
 
 // A Swift class instance is a real heap pointer that is safe to read with
@@ -130,6 +173,29 @@ static NSString *ApolloBannedProfileUsernameFromModelObject(id object) {
         }
     }
     return nil;
+}
+
+// Currently logged-in account username, or nil. Used to avoid blocking the
+// user's own profile when their account is temporarily banned.
+static NSString *ApolloBannedProfileCurrentLoggedInUsername(void) {
+    Class clientClass = objc_getClass("RDKClient");
+    SEL sharedClientSEL = @selector(sharedClient);
+    if (!clientClass || ![clientClass respondsToSelector:sharedClientSEL]) return nil;
+
+    id client = ((id (*)(id, SEL))objc_msgSend)(clientClass, sharedClientSEL);
+    if (!client) return nil;
+
+    SEL currentUserSEL = @selector(currentUser);
+    if (![client respondsToSelector:currentUserSEL]) return nil;
+
+    id currentUser = ((id (*)(id, SEL))objc_msgSend)(client, currentUserSEL);
+    return ApolloBannedProfileUsernameFromModelObject(currentUser);
+}
+
+static BOOL ApolloBannedProfileIsCurrentLoggedInUser(NSString *username) {
+    NSString *current = ApolloBannedProfileCurrentLoggedInUsername();
+    if (current.length == 0) return NO;
+    return ApolloBannedProfileUsernamesMatch(current, username);
 }
 
 static NSString *ApolloBannedProfileUsernameFromViewControllerDirect(UIViewController *viewController) {
@@ -537,6 +603,9 @@ NSString *ApolloBannedProfileBannedDescriptionText(void) {
 @interface ApolloBannedProfileOverlayView : UIView
 @property(nonatomic, strong) UIImageView *iconView;
 @property(nonatomic, strong) UILabel *messageLabel;
+@property(nonatomic, strong) UIButton *dismissButton;
+@property(nonatomic, copy) void (^dismissHandler)(void);
+- (void)applyThemeAccentColor:(UIColor *)accent;
 @end
 
 @implementation ApolloBannedProfileOverlayView
@@ -554,17 +623,25 @@ NSString *ApolloBannedProfileBannedDescriptionText(void) {
         _messageLabel = [[UILabel alloc] init];
         _messageLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _messageLabel.text = message;
-        _messageLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleTitle3];
+        _messageLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
         _messageLabel.textColor = [UIColor labelColor];
         _messageLabel.textAlignment = NSTextAlignmentCenter;
         _messageLabel.numberOfLines = 0;
         _messageLabel.adjustsFontForContentSizeCategory = YES;
 
-        UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[_iconView, _messageLabel]];
+        _dismissButton = [UIButton buttonWithType:UIButtonTypeSystem];
+        _dismissButton.translatesAutoresizingMaskIntoConstraints = NO;
+        [_dismissButton setTitle:@"Dismiss Overlay" forState:UIControlStateNormal];
+        _dismissButton.titleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline];
+        _dismissButton.titleLabel.adjustsFontForContentSizeCategory = YES;
+        [_dismissButton addTarget:self action:@selector(handleDismissTapped) forControlEvents:UIControlEventTouchUpInside];
+
+        UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[_iconView, _messageLabel, _dismissButton]];
         stack.translatesAutoresizingMaskIntoConstraints = NO;
         stack.axis = UILayoutConstraintAxisVertical;
         stack.spacing = 16.0;
         stack.alignment = UIStackViewAlignmentCenter;
+        [stack setCustomSpacing:24.0 afterView:_messageLabel];
         [self addSubview:stack];
 
         [NSLayoutConstraint activateConstraints:@[
@@ -579,7 +656,39 @@ NSString *ApolloBannedProfileBannedDescriptionText(void) {
     return self;
 }
 
+// Apollo applies its accent color directly to views rather than via an
+// inheritable window tint, so adopt the accent resolved from the host profile's
+// chrome instead of the UIKit-default tint. Background stays the solid default.
+- (void)applyThemeAccentColor:(UIColor *)accent {
+    if (accent) {
+        self.tintColor = accent;
+        self.dismissButton.tintColor = accent;
+        [self.dismissButton setTitleColor:accent forState:UIControlStateNormal];
+    }
+}
+
+- (void)handleDismissTapped {
+    if (self.dismissHandler) self.dismissHandler();
+}
+
 @end
+
+// Resolves the active Apollo theme's accent color from the host profile's chrome.
+// Apollo themes its nav/tab bars with the accent color, so prefer those over the
+// UIKit-default view tint (which stays system blue when untouched).
+static UIColor *ApolloBannedProfileResolveAccentColor(UIViewController *viewController) {
+    NSMutableArray<UIColor *> *candidates = [NSMutableArray array];
+    UITabBar *tabBar = viewController.tabBarController.tabBar;
+    if (tabBar.tintColor) [candidates addObject:tabBar.tintColor];
+    UINavigationBar *navBar = viewController.navigationController.navigationBar;
+    if (navBar.tintColor) [candidates addObject:navBar.tintColor];
+    if (viewController.view.window.tintColor) [candidates addObject:viewController.view.window.tintColor];
+    if (viewController.view.tintColor) [candidates addObject:viewController.view.tintColor];
+    for (UIColor *color in candidates) {
+        if ([color isKindOfClass:[UIColor class]]) return color;
+    }
+    return viewController.view.tintColor ?: [UIColor systemBlueColor];
+}
 
 NSString *ApolloBannedProfileMessageForUsername(NSString *username) {
     NSString *clean = ApolloBannedProfileNormalizedUsername(username) ?: @"username";
@@ -589,6 +698,9 @@ NSString *ApolloBannedProfileMessageForUsername(NSString *username) {
 BOOL ApolloBannedProfileCachedIsSuspended(NSString *username) {
     NSString *key = ApolloBannedProfileNormalizedUsername(username);
     if (key.length == 0) return NO;
+    // Never treat the logged-in user's own account as banned; a temporary
+    // suspension must not lock them out of their own profile.
+    if (ApolloBannedProfileIsCurrentLoggedInUser(key)) return NO;
     if ([sListEndpoint403Usernames containsObject:key.lowercaseString]) return YES;
     return [[ApolloUserProfileCache sharedCache] cachedIsSuspendedForUsername:key];
 }
@@ -611,11 +723,26 @@ void ApolloBannedProfileNoteListEndpoint403ForURL(NSURL *url) {
         if (![parts[i] isEqualToString:@"user"]) continue;
         NSString *username = ApolloBannedProfileNormalizedUsername(parts[i + 1]);
         if (username.length == 0) return;
+        // A 403 on the own account's listing is transient (auth/temp ban),
+        // not a permanent suspension; don't poison the cache.
+        if (ApolloBannedProfileIsCurrentLoggedInUser(username)) {
+            ApolloLog(@"[BannedProfile] ignoring list endpoint 403 for own account u/%@", username);
+            return;
+        }
         if (!sListEndpoint403Usernames) sListEndpoint403Usernames = [NSMutableSet set];
         [sListEndpoint403Usernames addObject:username.lowercaseString];
         ApolloLog(@"[BannedProfile] list endpoint 403 for u/%@", username);
         return;
     }
+}
+
+void ApolloBannedProfileClearListEndpoint403ForUsername(NSString *username) {
+    NSString *key = ApolloBannedProfileNormalizedUsername(username);
+    if (key.length == 0 || !sListEndpoint403Usernames) return;
+    NSString *lower = key.lowercaseString;
+    if (![sListEndpoint403Usernames containsObject:lower]) return;
+    [sListEndpoint403Usernames removeObject:lower];
+    ApolloLog(@"[BannedProfile] cleared list endpoint 403 for u/%@ (no longer suspended)", key);
 }
 
 static void ApolloBannedProfileRemoveOverlay(UIViewController *viewController) {
@@ -631,6 +758,14 @@ static void ApolloBannedProfileRemoveOverlay(UIViewController *viewController) {
 static void ApolloBannedProfileInstallOverlay(UIViewController *viewController, NSString *username) {
     UIView *hostView = viewController.view;
     if (!hostView) return;
+
+    // If the user previously dismissed the overlay for this account, never show
+    // it again — reveal the underlying profile instead. This is the escape hatch
+    // for false positives (own temp-banned account flashing on login, etc.).
+    if (ApolloBannedProfileOverlayDismissedForUsername(username)) {
+        ApolloBannedProfileRemoveOverlay(viewController);
+        return;
+    }
 
     NSString *message = ApolloBannedProfileMessageForUsername(username);
     ApolloBannedProfileOverlayView *overlay = objc_getAssociatedObject(viewController, kApolloBannedProfileOverlayKey);
@@ -654,7 +789,18 @@ static void ApolloBannedProfileInstallOverlay(UIViewController *viewController, 
         }
     }
 
+    NSString *dismissUsername = [ApolloBannedProfileNormalizedUsername(username) copy];
+    __weak UIViewController *weakViewController = viewController;
+    overlay.dismissHandler = ^{
+        ApolloBannedProfileMarkOverlayDismissedForUsername(dismissUsername);
+        ApolloBannedProfileRemoveOverlay(weakViewController);
+    };
+
     [hostView bringSubviewToFront:overlay];
+    // Re-resolve each install so the accent tracks the theme once Apollo has
+    // finished tinting the profile's chrome (may not be ready on first pass).
+    UIColor *accent = ApolloBannedProfileResolveAccentColor(viewController);
+    [overlay applyThemeAccentColor:accent];
     ApolloBannedProfileApplyHeaderSuspendedAppearance(viewController, YES);
     ApolloBannedProfileStopVisibleSpinnersInView(viewController.view);
 }
@@ -677,12 +823,18 @@ static void ApolloBannedProfileEvaluateViewController(UIViewController *viewCont
         return;
     }
 
-    if (ApolloBannedProfileCachedIsSuspended(username)) {
-        ApolloBannedProfileApplySuspendedState(viewController, YES, username);
+    // Never block the logged-in user's own profile, even if suspended; clear
+    // any stale overlay installed before the account resolved.
+    if (ApolloBannedProfileIsCurrentLoggedInUser(username)) {
+        ApolloLog(@"[BannedProfile] skipping overlay for own account u/%@", username);
+        ApolloBannedProfileApplySuspendedState(viewController, NO, username);
         return;
     }
 
-    ApolloBannedProfileApplySuspendedState(viewController, NO, username);
+    // Show the cached overlay immediately if suspended, but still revalidate so
+    // a lifted ban clears the overlay instead of persisting for the cache TTL.
+    BOOL cachedSuspended = ApolloBannedProfileCachedIsSuspended(username);
+    ApolloBannedProfileApplySuspendedState(viewController, cachedSuspended, username);
 
     __weak UIViewController *weakViewController = viewController;
     [[ApolloUserProfileCache sharedCache] requestInfoForUsername:username completion:^(ApolloUserProfileInfo *info) {
@@ -690,6 +842,7 @@ static void ApolloBannedProfileEvaluateViewController(UIViewController *viewCont
         if (!strongViewController) return;
         NSString *currentUsername = ApolloBannedProfileUsernameFromViewController(strongViewController);
         if (!ApolloBannedProfileUsernamesMatch(currentUsername, username)) return;
+        if (ApolloBannedProfileIsCurrentLoggedInUser(username)) return;
         BOOL suspended = info.isSuspended || ApolloBannedProfileCachedIsSuspended(username);
         ApolloBannedProfileApplySuspendedState(strongViewController, suspended, username);
     }];
@@ -836,8 +989,14 @@ static BOOL ApolloBannedProfileURLMatchesUserListEndpoint(NSURL *url) {
 
     NSString *username = ApolloBannedProfileUsernameFromViewController(self);
     if (username.length == 0) return;
+    // Respect a manual dismissal: don't re-pin (or churn header layout) for an
+    // account the user chose to reveal.
+    if (ApolloBannedProfileOverlayDismissedForUsername(username)) return;
     if (ApolloBannedProfileCachedIsSuspended(username)) {
+        // Keep the overlay pinned during layout, but also schedule a revalidation
+        // so a lifted ban clears it instead of re-pinning the stale cached state.
         ApolloBannedProfileInstallOverlay(self, username);
+        ApolloBannedProfileScheduleRefresh(self);
     }
 }
 

--- a/src/ApolloMediaPreviewErrorFix.xm
+++ b/src/ApolloMediaPreviewErrorFix.xm
@@ -1,0 +1,70 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+#import "ApolloCommon.h"
+
+// =============================================================================
+// MARK: - Overview
+// =============================================================================
+//
+// Suppresses the spurious "<Domain> error :( / Tap to open in browser" overlay
+// shown over inline video posts in the feed when the post's static preview
+// image fails to load (e.g. a RedGIFs post whose external-preview.redd.it
+// poster 404s while the v.redd.it video still plays fine).
+//
+// -[RichMediaNode imageNode:didFailWithError:] builds a RichMediaErrorLoadingNode
+// on any image-load failure without checking for a video, and layoutSpecThatFits:
+// overlays it even in the video branch — so it covers the playing video. The
+// comments view presents the video without that poster, so it never fires there.
+//
+// Fix: if the node has a video, swallow the failure (skip %orig) so no overlay
+// is built. Posts with no video keep the original behavior, so genuinely broken
+// image/album/link posts still surface the error.
+//
+// =============================================================================
+
+// Read an ObjC object ivar by name (walks the superclass chain).
+static id PreviewErrorGetIvarObject(id obj, const char *ivarName) {
+    if (!obj) return nil;
+    Ivar ivar = class_getInstanceVariable([obj class], ivarName);
+    return ivar ? object_getIvar(obj, ivar) : nil;
+}
+
+%hook RichMediaNode
+
+- (void)imageNode:(id)imageNode didFailWithError:(NSError *)error {
+    // Node has a video: the failed image is just the poster, so suppress the
+    // overlay and let the video play.
+    id videoNode = PreviewErrorGetIvarObject(self, "videoNode");
+    if (videoNode) {
+        ApolloLog(@"[PreviewErrorFix] Suppressing media preview error overlay — node has a "
+                  @"playable video (failed image: %@, error: %@)",
+                  [imageNode class], error.localizedDescription ?: @"(none)");
+        return;
+    }
+
+    %orig;
+}
+
+%end
+
+// =============================================================================
+// MARK: - Constructor
+// =============================================================================
+
+%ctor {
+    Class richMediaNodeClass = objc_getClass("_TtC6Apollo13RichMediaNode");
+
+    ApolloLog(@"[PreviewErrorFix] ctor: RichMediaNode=%p", (void *)richMediaNodeClass);
+
+    if (!richMediaNodeClass) {
+        ApolloLog(@"[PreviewErrorFix] ctor: RichMediaNode class not found — skipping hook");
+        return;
+    }
+
+    %init(RichMediaNode = richMediaNodeClass);
+
+    ApolloLog(@"[PreviewErrorFix] ctor: hook initialized");
+}

--- a/src/ApolloUserProfileCache.m
+++ b/src/ApolloUserProfileCache.m
@@ -393,6 +393,10 @@ static UIImage *ApolloDecodedAvatarImage(UIImage *image) {
             if (info) {
                 if (info.isSuspended) {
                     [[ApolloLinkPreviewCache sharedCache] removePreviewsForRedditUsername:key];
+                } else {
+                    // Ban lifted: drop the transient 403 marker so the overlay
+                    // and inline banned hints clear on the next evaluation.
+                    ApolloBannedProfileClearListEndpoint403ForUsername(key);
                 }
                 [[NSNotificationCenter defaultCenter] postNotificationName:ApolloUserProfileInfoUpdatedNotification
                                                                     object:self
@@ -464,7 +468,18 @@ static UIImage *ApolloDecodedAvatarImage(UIImage *image) {
         if (info && completion) {
             dispatch_async(dispatch_get_main_queue(), ^{ completion(info); });
         }
-        if (info && [self isFreshInfo:info] && info.suspensionChecked) return;
+        // Always revalidate a cached suspension: a lifted temp ban must clear
+        // promptly instead of persisting for the full cache TTL. Non-suspended
+        // fresh entries still short-circuit and skip the network.
+        if (info && [self isFreshInfo:info] && info.suspensionChecked && !info.isSuspended) return;
+
+        // A cached suspension must be revalidated against the network, not the
+        // HTTP cache. about.json for a suspended user is cacheable, so a normal
+        // fetch can be served the stale suspended response from NSURLCache and
+        // the overlay would never clear after the ban is lifted. Use the local
+        // `info` (not ApolloBannedProfileCachedIsSuspended) to avoid a
+        // dispatch_sync re-entry onto self.queue.
+        BOOL bypassHTTPCache = (info != nil && info.isSuspended);
 
         NSMutableArray<void (^)(ApolloUserProfileInfo *)> *callbacks = self.infoCompletions[key];
         if (callbacks) {
@@ -475,7 +490,7 @@ static UIImage *ApolloDecodedAvatarImage(UIImage *image) {
         callbacks = [NSMutableArray array];
         if (completion) [callbacks addObject:[completion copy]];
         self.infoCompletions[key] = callbacks;
-        [self startInfoFetchForKey:key];
+        [self startInfoFetchForKey:key bypassingCache:bypassHTTPCache];
     });
 }
 

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -7,6 +7,7 @@
 #import "ApolloSubredditCustomBannerCache.h"
 #import "ApolloSubredditCustomIconCache.h"
 #import "ApolloSubredditInfoCache.h"
+#import "ApolloBannedProfile.h"
 #import "UserDefaultConstants.h"
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <objc/runtime.h>
@@ -657,11 +658,11 @@ typedef NS_ENUM(NSInteger, Tag) {
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     switch (section) {
-        case SectionBackupRestore: return 2;
+        case SectionBackupRestore: return 4;
         case SectionAPIKeys: return 9; // 7 text fields + Can't sign in? + API key setup guide
         case SectionGeneral: return sShowDeletedComments ? 11 : 10;
-        case SectionMedia: return (sShowUserAvatars ? 14 : 13) + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows);
-        case SectionSubreddits: return sSubredditListEnhancements ? 9 : 8;
+        case SectionMedia: return 12 + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows);
+        case SectionSubreddits: return sSubredditListEnhancements ? 8 : 7;
         case SectionNotificationBackend: return 3; // URL + Registration Token + Test Connection
         case SectionAbout: return 5; // GitHub + Reddit + Thanks To + Export Logs + Version
         default: return 0;
@@ -670,7 +671,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
     switch (section) {
-        case SectionBackupRestore: return @"Backup / Restore";
+        case SectionBackupRestore: return @"Data";
         case SectionAPIKeys: return @"API Keys";
         case SectionGeneral: return @"General";
         case SectionMedia: return @"Media";
@@ -1167,37 +1168,6 @@ typedef NS_ENUM(NSInteger, Tag) {
                                             label:@"Profile Picture Tab Icon"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon]
                                            action:@selector(profileTabAvatarSwitchToggled:)];
-        case 12: {
-            BOOL avatarsOn = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars];
-            if (avatarsOn) {
-                UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_ClearAvatarCache"];
-                if (!cell) {
-                    cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell_Media_ClearAvatarCache"];
-                }
-                cell.textLabel.text = @"Clear Profile Picture Cache";
-                cell.textLabel.textColor = self.view.tintColor;
-                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-                return cell;
-            }
-            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_ClearLinkPreviewCache"];
-            if (!cell) {
-                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell_Media_ClearLinkPreviewCache"];
-            }
-            cell.textLabel.text = @"Clear Link Preview Cache";
-            cell.textLabel.textColor = self.view.tintColor;
-            cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-            return cell;
-        }
-        case 13: {
-            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_ClearLinkPreviewCache"];
-            if (!cell) {
-                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell_Media_ClearLinkPreviewCache"];
-            }
-            cell.textLabel.text = @"Clear Link Preview Cache";
-            cell.textLabel.textColor = self.view.tintColor;
-            cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-            return cell;
-        }
         default: return [[UITableViewCell alloc] init];
     }
 }
@@ -1251,16 +1221,6 @@ typedef NS_ENUM(NSInteger, Tag) {
                                                 placeholder:@"(empty)"
                                                        text:sRandNsfwSubredditsSource
                                                         tag:TagRandNsfwSubredditsSource];
-        case 8: {
-            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Sub_ClearCustomBanners"];
-            if (!cell) {
-                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell_Sub_ClearCustomBanners"];
-            }
-            cell.textLabel.text = @"Clear Custom Banners & Icons";
-            cell.textLabel.textColor = self.view.tintColor;
-            cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-            return cell;
-        }
         default: return [[UITableViewCell alloc] init];
     }
 }
@@ -1316,15 +1276,23 @@ typedef NS_ENUM(NSInteger, Tag) {
 }
 
 - (UITableViewCell *)backupRestoreCellForRow:(NSInteger)row tableView:(UITableView *)tableView {
-    UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"Cell_Backup"];
+    if (row == 0 || row == 1) {
+        UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Backup"];
+        if (!cell) {
+            cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell_Backup"];
+        }
+        cell.textLabel.text = (row == 0) ? @"Backup Settings" : @"Restore Settings";
+        cell.textLabel.textColor = self.view.tintColor;
+        cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+        return cell;
+    }
+
+    NSString *identifier = (row == 2) ? @"Cell_Data_ClearCaches" : @"Cell_Data_ClearCustomBanners";
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:identifier];
     if (!cell) {
-        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell_Backup"];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:identifier];
     }
-    if (row == 0) {
-        cell.textLabel.text = @"Backup Settings";
-    } else {
-        cell.textLabel.text = @"Restore Settings";
-    }
+    cell.textLabel.text = (row == 2) ? @"Clear Tweak Caches" : @"Clear Custom Banners & Icons";
     cell.textLabel.textColor = self.view.tintColor;
     cell.selectionStyle = UITableViewCellSelectionStyleDefault;
     return cell;
@@ -1556,10 +1524,15 @@ typedef NS_ENUM(NSInteger, Tag) {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 
     if (indexPath.section == SectionBackupRestore) {
+        UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
         if (indexPath.row == 0) {
             [self backupSettings];
-        } else {
+        } else if (indexPath.row == 1) {
             [self restoreSettings];
+        } else if (indexPath.row == 2) {
+            [self promptClearAllCachesFromSourceView:cell];
+        } else if (indexPath.row == 3) {
+            [self promptClearCustomSubredditBannersFromSourceView:cell];
         }
     } else if (indexPath.section == SectionAPIKeys) {
         if (indexPath.row == 7) {
@@ -1580,12 +1553,6 @@ typedef NS_ENUM(NSInteger, Tag) {
         } else if (indexPath.row == 3) {
             [self exportLogs];
         }
-    } else if (indexPath.section == SectionSubreddits) {
-        NSInteger logicalRow = (indexPath.row >= 1 && !sSubredditListEnhancements) ? indexPath.row + 1 : indexPath.row;
-        if (logicalRow == 8) {
-            UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
-            [self promptClearCustomSubredditBannersFromSourceView:cell];
-        }
     } else if (indexPath.section == SectionMedia) {
         UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
         NSInteger row = ApolloMediaLogicalRow(indexPath.row);
@@ -1605,10 +1572,6 @@ typedef NS_ENUM(NSInteger, Tag) {
             [self presentLinkPreviewModeSheetFromSourceView:cell body:NO];
         } else if (row == 9) {
             [self presentLinkPreviewCardColorSheetFromSourceView:cell];
-        } else if (row == 12 && sShowUserAvatars) {
-            [self promptClearProfilePictureCacheFromSourceView:cell];
-        } else if ((row == 12 && !sShowUserAvatars) || (row == 13 && sShowUserAvatars)) {
-            [self promptClearLinkPreviewCacheFromSourceView:cell];
         }
     } else if (indexPath.section == SectionNotificationBackend && indexPath.row == 2) {
         [self testNotificationBackendConnection];
@@ -1645,13 +1608,9 @@ typedef NS_ENUM(NSInteger, Tag) {
 - (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.section == SectionBackupRestore) return YES;
     if (indexPath.section == SectionAPIKeys && (indexPath.row == 7 || indexPath.row == 8)) return YES;
-    if (indexPath.section == SectionSubreddits) {
-        NSInteger logicalRow = (indexPath.row >= 1 && !sSubredditListEnhancements) ? indexPath.row + 1 : indexPath.row;
-        return logicalRow == 8;
-    }
     if (indexPath.section == SectionMedia) {
         NSInteger row = ApolloMediaLogicalRow(indexPath.row);
-        return (row == 0 || row == 1 || row == 2 || row == 5 || row == 6 || row == 7 || row == 8 || row == 9 || row == 12 || row == 13);
+        return (row == 0 || row == 1 || row == 2 || row == 5 || row == 6 || row == 7 || row == 8 || row == 9);
     }
     if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 || indexPath.row == 3)) return YES;
     if (indexPath.section == SectionNotificationBackend && indexPath.row == 2) return YES;
@@ -2036,19 +1995,9 @@ typedef NS_ENUM(NSInteger, Tag) {
 }
 
 - (void)userAvatarsSwitchToggled:(UISwitch *)sender {
-    BOOL wasOn = sShowUserAvatars;
     sShowUserAvatars = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sShowUserAvatars forKey:UDKeyShowUserAvatars];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloUserAvatarsToggleChangedNotification" object:nil];
-    if (sShowUserAvatars == wasOn) return;
-    NSArray<NSIndexPath *> *paths = @[[NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(12) inSection:SectionMedia]];
-    if (sShowUserAvatars) {
-        [self.tableView insertRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
-    } else {
-        [self.tableView deleteRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
-    }
-    [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(sShowUserAvatars ? 13 : 12) inSection:SectionMedia]]
-                          withRowAnimation:UITableViewRowAnimationNone];
 }
 
 - (void)profileTabAvatarSwitchToggled:(UISwitch *)sender {
@@ -2057,16 +2006,26 @@ typedef NS_ENUM(NSInteger, Tag) {
     [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloProfileTabAvatarIconChangedNotification" object:nil];
 }
 
-- (void)promptClearProfilePictureCacheFromSourceView:(UIView *)sourceView {
-    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Clear Profile Picture Cache?"
-                                                                   message:@"Cached user avatars, banners, and profile metadata will be removed. They'll be re-downloaded the next time they're shown."
+- (void)promptClearAllCachesFromSourceView:(UIView *)sourceView {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Clear Tweak Caches?"
+                                                                   message:@"This removes cached profile pictures, banners, link previews, and remembered banned-profile dismissals."
                                                             preferredStyle:UIAlertControllerStyleAlert];
     [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
     [alert addAction:[UIAlertAction actionWithTitle:@"Clear" style:UIAlertActionStyleDestructive handler:^(__unused UIAlertAction *action) {
         [[ApolloUserProfileCache sharedCache] clearAllCaches];
+        [[ApolloLinkPreviewCache sharedCache] flushCache];
+        [[ApolloSubredditInfoCache sharedCache] clearAllCaches];
+        ApolloBannedProfileClearDismissedOverlays();
         // Re-broadcast the avatars-toggle notification so visible profile headers reload immediately.
         [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloUserAvatarsToggleChangedNotification" object:nil];
     }]];
+
+    UIPopoverPresentationController *popover = alert.popoverPresentationController;
+    if (popover && sourceView) {
+        popover.sourceView = sourceView;
+        popover.sourceRect = sourceView.bounds;
+    }
+
     [self presentViewController:alert animated:YES completion:nil];
 }
 
@@ -2191,17 +2150,6 @@ typedef NS_ENUM(NSInteger, Tag) {
     [alert addAction:[UIAlertAction actionWithTitle:@"Clear" style:UIAlertActionStyleDestructive handler:^(__unused UIAlertAction *action) {
         [[ApolloSubredditCustomBannerCache sharedCache] clearAllCustomBanners];
         [[ApolloSubredditCustomIconCache sharedCache] clearAllCustomIcons];
-    }]];
-    [self presentViewController:alert animated:YES completion:nil];
-}
-
-- (void)promptClearLinkPreviewCacheFromSourceView:(__unused UIView *)sourceView {
-    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Clear Link Preview Cache?"
-                                                                   message:@"Cached link preview titles, descriptions, and thumbnails will be removed."
-                                                            preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
-    [alert addAction:[UIAlertAction actionWithTitle:@"Clear" style:UIAlertActionStyleDestructive handler:^(__unused UIAlertAction *action) {
-        [[ApolloLinkPreviewCache sharedCache] flushCache];
     }]];
     [self presentViewController:alert animated:YES completion:nil];
 }


### PR DESCRIPTION
Fixes #345

### Banned-profile overlay (`ApolloBannedProfile.*`, `ApolloUserProfileCache.m`)
- Overlay is now dismissable via a centered "Dismiss Overlay" button; dismissals persist in `NSUserDefaults` (escape hatch for the login flash and false positives). Button text adopts the active theme accent.
- Cached suspensions are always revalidated and bypass the HTTP cache, so a lifted ban clears promptly instead of persisting for the 7-day TTL.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/3195344a-690c-41dc-917d-4bf9ce32f76f" />

### Consolidated "Clear Tweak Caches" (`CustomAPIViewController.m`)
- Renamed the **Backup / Restore** section to **Data**.
- Replaced the separate Media/Subreddits clear cells with one **Clear Tweak Caches** cell that flushes the profile, link-preview, subreddit-info, and banned-overlay caches. "Clear Custom Banners & Icons" also moves under Data.

<img width="500" alt="IMG_3678" src="https://github.com/user-attachments/assets/57b7cf33-3330-4622-b690-ec3f63e3dc2b" />

### Media preview error suppression (`ApolloMediaPreviewErrorFix.xm`)
- New `RichMediaNode imageNode:didFailWithError:` hook: when the node has a `videoNode`, the failed image is just the poster (e.g. a 404'd `external-preview.redd.it` poster over a playing `v.redd.it` video), so the spurious "error :( / Tap to open in browser" overlay is suppressed. Video-less posts keep the original error behavior.
