### PR TITLE
Send registration token on /v1/live_activities

### DIFF
--- a/src/ApolloNotificationBackend.m
+++ b/src/ApolloNotificationBackend.m
@@ -114,11 +114,18 @@ static BOOL ApolloPathIsAccountUpsertBulk(NSString *path) {
         && [parts[4] isEqualToString:@"accounts"];
 }
 
+// Match `/v1/live_activities` (Live Activity registration — the backend polls
+// the thread and pushes ActivityKit updates).
+static BOOL ApolloPathIsLiveActivityRegistration(NSString *path) {
+    return [path isEqualToString:@"/v1/live_activities"];
+}
+
 // Endpoints behind REGISTRATION_SECRET on the new backend.
 static BOOL ApolloPathRequiresRegistrationToken(NSString *path) {
     return ApolloPathIsDeviceRegistration(path)
         || ApolloPathIsAccountUpsertSingular(path)
-        || ApolloPathIsAccountUpsertBulk(path);
+        || ApolloPathIsAccountUpsertBulk(path)
+        || ApolloPathIsLiveActivityRegistration(path);
 }
 
 // MARK: - JSON body augmentation


### PR DESCRIPTION
## Summary

The backend's restored Live Activities endpoint (Apollo-Reborn/apollo-backend#4) sits behind `REGISTRATION_SECRET`, so the notification-backend rewrite hook must attach `X-Registration-Token` to `POST /v1/live_activities` the same way it already does for device and account registration. Without this, secret-protected backends return 401 and the activity silently never updates.

One-line behavior change: `ApolloPathRequiresRegistrationToken` now also matches `/v1/live_activities`.

Here it is working:

<img width="332" height="720" alt="ScreenRecording_06-09-2026 15-31-54_1" src="https://github.com/user-attachments/assets/a306c0a9-df71-45f4-966e-d92dd7faba24" />


## Testing

Verified on a real device against a self-hosted backend running the companion branch: Live Activity registration returns 200 with the token attached, and the activity receives comment/score updates.
