### PR TITLE
Improve deleted comments recovery performance and UI

### DIFF
--- a/src/ApolloDeletedCommentsData.h
+++ b/src/ApolloDeletedCommentsData.h
@@ -13,17 +13,23 @@ ApolloDeletedCommentsURLSessionCompletion ApolloDeletedCommentsMaybeWrapCompleti
 void ApolloDeletedCommentsInstallDelegateTransformerIfNeeded(NSURLSession *session, NSURLRequest *request);
 void ApolloDeletedCommentsRegisterRecoveredComment(NSString *fullName, NSString *reason);
 BOOL ApolloDeletedCommentsIsRecoveredComment(NSString *fullName);
+NSString *ApolloDeletedCommentsRecoveredReasonForComment(NSString *fullName);
 BOOL ApolloDeletedCommentsIsRecoveredCommentBody(NSString *author, NSString *body);
+NSString *ApolloDeletedCommentsRecoveredReasonForCommentBody(NSString *author, NSString *body);
+NSString *ApolloDeletedCommentsDisplayLabelForReason(NSString *reason);
 BOOL ApolloDeletedCommentsIsCommentRevealed(NSString *fullName);
 BOOL ApolloDeletedCommentsIsCommentBodyRevealed(NSString *author, NSString *body);
 void ApolloDeletedCommentsMarkCommentRevealed(NSString *fullName);
 void ApolloDeletedCommentsMarkCommentBodyRevealed(NSString *author, NSString *body);
+void ApolloDeletedCommentsUnmarkCommentRevealed(NSString *fullName);
+void ApolloDeletedCommentsUnmarkCommentBodyRevealed(NSString *author, NSString *body);
 
 #ifdef APOLLO_DELETED_COMMENTS_TESTING
 NSString *ApolloDeletedCommentsTestLinkFullNameFromRedditURL(NSURL *url);
 BOOL ApolloDeletedCommentsTestBodyLooksDeleted(NSString *body, NSString *bodyHTML);
 NSUInteger ApolloDeletedCommentsTestPatchRedditJSONRoot(id root, NSDictionary<NSString *, NSDictionary *> *archivedComments);
 BOOL ApolloDeletedCommentsTestArcticResponseShouldCooldown(NSInteger statusCode, NSInteger remaining);
+NSString *ApolloDeletedCommentsTestDisplayLabelForReason(NSString *reason);
 #endif
 
 #ifdef __cplusplus

--- a/src/ApolloDeletedCommentsData.h
+++ b/src/ApolloDeletedCommentsData.h
@@ -5,6 +5,7 @@ extern "C" {
 #endif
 
 extern NSString *const ApolloDeletedCommentsObservedThreadNotification;
+extern NSString *const ApolloDeletedCommentsArcticCacheUpdatedNotification;
 
 typedef void (^ApolloDeletedCommentsURLSessionCompletion)(NSData *data, NSURLResponse *response, NSError *error);
 
@@ -14,6 +15,11 @@ void ApolloDeletedCommentsInstallDelegateTransformerIfNeeded(NSURLSession *sessi
 void ApolloDeletedCommentsRegisterRecoveredComment(NSString *fullName, NSString *reason);
 BOOL ApolloDeletedCommentsIsRecoveredComment(NSString *fullName);
 NSString *ApolloDeletedCommentsRecoveredReasonForComment(NSString *fullName);
+void ApolloDeletedCommentsRegisterDeletedPlaceholder(NSString *fullName, NSString *reason);
+BOOL ApolloDeletedCommentsIsDeletedPlaceholder(NSString *fullName);
+NSString *ApolloDeletedCommentsDeletedPlaceholderReason(NSString *fullName);
+NSDictionary *ApolloDeletedCommentsCachedArchivedComment(NSString *fullName);
+BOOL ApolloDeletedCommentsApplyRecoveredArchivedCommentToObject(id comment, NSDictionary *archived, NSString *reason);
 BOOL ApolloDeletedCommentsIsRecoveredCommentBody(NSString *author, NSString *body);
 NSString *ApolloDeletedCommentsRecoveredReasonForCommentBody(NSString *author, NSString *body);
 NSString *ApolloDeletedCommentsDisplayLabelForReason(NSString *reason);
@@ -30,6 +36,8 @@ BOOL ApolloDeletedCommentsTestBodyLooksDeleted(NSString *body, NSString *bodyHTM
 NSUInteger ApolloDeletedCommentsTestPatchRedditJSONRoot(id root, NSDictionary<NSString *, NSDictionary *> *archivedComments);
 BOOL ApolloDeletedCommentsTestArcticResponseShouldCooldown(NSInteger statusCode, NSInteger remaining);
 NSString *ApolloDeletedCommentsTestDisplayLabelForReason(NSString *reason);
+NSUInteger ApolloDeletedCommentsTestMarkDeletedPlaceholdersInRoot(id root);
+NSData *ApolloDeletedCommentsTestPatchResponseImmediate(NSData *data, NSURLRequest *request);
 #endif
 
 #ifdef __cplusplus

--- a/src/ApolloDeletedCommentsData.h
+++ b/src/ApolloDeletedCommentsData.h
@@ -23,6 +23,7 @@ void ApolloDeletedCommentsMarkCommentBodyRevealed(NSString *author, NSString *bo
 NSString *ApolloDeletedCommentsTestLinkFullNameFromRedditURL(NSURL *url);
 BOOL ApolloDeletedCommentsTestBodyLooksDeleted(NSString *body, NSString *bodyHTML);
 NSUInteger ApolloDeletedCommentsTestPatchRedditJSONRoot(id root, NSDictionary<NSString *, NSDictionary *> *archivedComments);
+BOOL ApolloDeletedCommentsTestArcticResponseShouldCooldown(NSInteger statusCode, NSInteger remaining);
 #endif
 
 #ifdef __cplusplus

--- a/src/ApolloDeletedCommentsData.m
+++ b/src/ApolloDeletedCommentsData.m
@@ -455,7 +455,7 @@ static NSString *ApolloDeletedCommentsReasonForArchived(NSDictionary *archived) 
 
 NSString *ApolloDeletedCommentsDisplayLabelForReason(NSString *reason) {
     if ([reason isEqualToString:ApolloDeletedCommentsReasonUserDeleted]) return @"DELETED BY USER";
-    return @"DELETED BY MOD";
+    return @"REMOVED BY MOD";
 }
 
 static NSString *ApolloDeletedCommentsRedditBodyHTML(NSString *body) {

--- a/src/ApolloDeletedCommentsData.m
+++ b/src/ApolloDeletedCommentsData.m
@@ -510,6 +510,11 @@ static void ApolloDeletedCommentsSetRecoveredBody(NSMutableDictionary *data, NSS
     if (bodyHTML.length > 0) data[@"body_html"] = bodyHTML;
 }
 
+static void ApolloDeletedCommentsHideRecoveredBodyForTapToReveal(NSMutableDictionary *data, NSString *reason) {
+    if (!sTapToRevealDeletedComments) return;
+    ApolloDeletedCommentsSetRecoveredBody(data, ApolloDeletedCommentsDisplayLabelForReason(reason));
+}
+
 static void ApolloDeletedCommentsSetObjectValue(id object, SEL selector, id value) {
     if (!object || !selector || !value || ![object respondsToSelector:selector]) return;
     @try {
@@ -910,6 +915,7 @@ static NSMutableDictionary *ApolloDeletedCommentsThingFromArchived(NSDictionary 
     data[@"gilded"] = @0;
     ApolloDeletedCommentsApplyRecoveredMetadata(data, reason);
     ApolloDeletedCommentsClearRemovalMetadata(data);
+    ApolloDeletedCommentsHideRecoveredBodyForTapToReveal(data, reason);
     return [@{@"kind": @"t1", @"data": data} mutableCopy];
 }
 
@@ -950,6 +956,7 @@ static NSUInteger ApolloDeletedCommentsPatchRedditJSONNode(id node, NSDictionary
                 NSString *reason = ApolloDeletedCommentsReasonForCurrentBody(currentBody, currentBodyHTML);
                 ApolloDeletedCommentsApplyRecoveredMetadata(data, reason);
                 ApolloDeletedCommentsClearRemovalMetadata(data);
+                ApolloDeletedCommentsHideRecoveredBodyForTapToReveal(data, reason);
                 ApolloLog(@"[DeletedComments] Recovered visible deleted comment %@", fullName ?: @"unknown");
                 patched++;
             } else if (currentLooksDeleted && stats) {

--- a/src/ApolloDeletedCommentsData.m
+++ b/src/ApolloDeletedCommentsData.m
@@ -371,18 +371,49 @@ static BOOL ApolloDeletedCommentsBodyLooksDeleted(NSString *body) {
     return NO;
 }
 
+static BOOL ApolloDeletedCommentsAuthorLooksDeleted(NSString *author) {
+    NSString *trimmed = [[ApolloDeletedCommentsTrimmedString(author) ?: @"" lowercaseString] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    return [trimmed isEqualToString:@"[deleted]"] ||
+           [trimmed isEqualToString:@"[removed]"] ||
+           [trimmed isEqualToString:@"deleted"] ||
+           [trimmed isEqualToString:@"removed"];
+}
+
+static BOOL ApolloDeletedCommentsDataHasRemovalMetadata(NSDictionary *data) {
+    if (![data isKindOfClass:[NSDictionary class]]) return NO;
+    NSString *removedByCategory = [data[@"removed_by_category"] isKindOfClass:[NSString class]] ? data[@"removed_by_category"] : nil;
+    if (removedByCategory.length > 0) return YES;
+    if (data[@"banned_by"] && data[@"banned_by"] != (id)[NSNull null]) return YES;
+    NSString *collapsedReasonCode = [data[@"collapsed_reason_code"] isKindOfClass:[NSString class]] ? data[@"collapsed_reason_code"] : nil;
+    if (collapsedReasonCode.length > 0 &&
+        [collapsedReasonCode rangeOfString:@"removed" options:NSCaseInsensitiveSearch].location != NSNotFound) return YES;
+    if (collapsedReasonCode.length > 0 &&
+        [collapsedReasonCode rangeOfString:@"deleted" options:NSCaseInsensitiveSearch].location != NSNotFound) return YES;
+    return NO;
+}
+
 static BOOL ApolloDeletedCommentsCommentDataLooksDeleted(NSDictionary *data) {
     if (![data isKindOfClass:[NSDictionary class]]) return NO;
     NSString *body = [data[@"body"] isKindOfClass:[NSString class]] ? data[@"body"] : nil;
-    if (ApolloDeletedCommentsBodyLooksDeleted(body)) return YES;
+    NSString *trimmedBody = ApolloDeletedCommentsTrimmedString(body);
+    if (trimmedBody.length > 0 && ApolloDeletedCommentsBodyLooksDeleted(body)) return YES;
 
     NSString *bodyHTML = [data[@"body_html"] isKindOfClass:[NSString class]] ? data[@"body_html"] : nil;
-    if (bodyHTML.length == 0) return NO;
-    NSString *htmlText = ApolloDeletedCommentsUnescapedHTMLText(bodyHTML);
-    return [htmlText rangeOfString:@"[removed]" options:NSCaseInsensitiveSearch].location != NSNotFound ||
-           [htmlText rangeOfString:@"[deleted]" options:NSCaseInsensitiveSearch].location != NSNotFound ||
-           [htmlText rangeOfString:@"Removed by moderator" options:NSCaseInsensitiveSearch].location != NSNotFound ||
-           [htmlText rangeOfString:@"User deleted comment" options:NSCaseInsensitiveSearch].location != NSNotFound;
+    if (bodyHTML.length > 0) {
+        NSString *htmlText = ApolloDeletedCommentsUnescapedHTMLText(bodyHTML);
+        if ([htmlText rangeOfString:@"[removed]" options:NSCaseInsensitiveSearch].location != NSNotFound ||
+            [htmlText rangeOfString:@"[deleted]" options:NSCaseInsensitiveSearch].location != NSNotFound ||
+            [htmlText rangeOfString:@"Removed by moderator" options:NSCaseInsensitiveSearch].location != NSNotFound ||
+            [htmlText rangeOfString:@"User deleted comment" options:NSCaseInsensitiveSearch].location != NSNotFound) {
+            return YES;
+        }
+    }
+
+    if (trimmedBody.length == 0) {
+        NSString *author = [data[@"author"] isKindOfClass:[NSString class]] ? data[@"author"] : nil;
+        return ApolloDeletedCommentsAuthorLooksDeleted(author) || ApolloDeletedCommentsDataHasRemovalMetadata(data);
+    }
+    return NO;
 }
 
 static NSString *ApolloDeletedCommentsCommentFullName(NSDictionary *data) {

--- a/src/ApolloDeletedCommentsData.m
+++ b/src/ApolloDeletedCommentsData.m
@@ -20,6 +20,7 @@ static NSString *sApolloDeletedCommentsLastObservedLinkFullName = nil;
 static NSDate *sApolloDeletedCommentsLastObservedLinkDate = nil;
 static NSMutableDictionary<NSString *, NSString *> *sApolloDeletedCommentsRecoveredReasonsByFullName = nil;
 static NSMutableSet<NSString *> *sApolloDeletedCommentsRecoveredBodyKeys = nil;
+static NSMutableDictionary<NSString *, NSString *> *sApolloDeletedCommentsRecoveredReasonsByBodyKey = nil;
 static NSMutableSet<NSString *> *sApolloDeletedCommentsRevealedFullNames = nil;
 static NSMutableSet<NSString *> *sApolloDeletedCommentsRevealedBodyKeys = nil;
 static NSObject *sApolloDeletedCommentsRegistryLock = nil;
@@ -73,14 +74,18 @@ void ApolloDeletedCommentsRegisterRecoveredComment(NSString *fullName, NSString 
     }
 }
 
-static void ApolloDeletedCommentsRegisterRecoveredBody(NSString *author, NSString *body) {
+static void ApolloDeletedCommentsRegisterRecoveredBody(NSString *author, NSString *body, NSString *reason) {
     NSString *key = ApolloDeletedCommentsRegistryBodyKey(author, body);
     if (key.length == 0) return;
     @synchronized(ApolloDeletedCommentsRegistryLock()) {
         if (!sApolloDeletedCommentsRecoveredBodyKeys) {
             sApolloDeletedCommentsRecoveredBodyKeys = [NSMutableSet set];
         }
+        if (!sApolloDeletedCommentsRecoveredReasonsByBodyKey) {
+            sApolloDeletedCommentsRecoveredReasonsByBodyKey = [NSMutableDictionary dictionary];
+        }
         [sApolloDeletedCommentsRecoveredBodyKeys addObject:key];
+        sApolloDeletedCommentsRecoveredReasonsByBodyKey[key] = reason.length > 0 ? reason : ApolloDeletedCommentsReasonModeratorRemoved;
     }
 }
 
@@ -91,11 +96,27 @@ BOOL ApolloDeletedCommentsIsRecoveredComment(NSString *fullName) {
     }
 }
 
+NSString *ApolloDeletedCommentsRecoveredReasonForComment(NSString *fullName) {
+    if (![fullName isKindOfClass:[NSString class]] || fullName.length == 0) return nil;
+    @synchronized(ApolloDeletedCommentsRegistryLock()) {
+        return sApolloDeletedCommentsRecoveredReasonsByFullName[fullName];
+    }
+}
+
 BOOL ApolloDeletedCommentsIsRecoveredCommentBody(NSString *author, NSString *body) {
     NSString *key = ApolloDeletedCommentsRegistryBodyKey(author, body);
     if (key.length == 0) return NO;
     @synchronized(ApolloDeletedCommentsRegistryLock()) {
         return [sApolloDeletedCommentsRecoveredBodyKeys containsObject:key];
+    }
+}
+
+NSString *ApolloDeletedCommentsRecoveredReasonForCommentBody(NSString *author, NSString *body) {
+    NSString *key = ApolloDeletedCommentsRegistryBodyKey(author, body);
+    if (key.length == 0) return nil;
+    @synchronized(ApolloDeletedCommentsRegistryLock()) {
+        if (![sApolloDeletedCommentsRecoveredBodyKeys containsObject:key]) return nil;
+        return sApolloDeletedCommentsRecoveredReasonsByBodyKey[key] ?: ApolloDeletedCommentsReasonModeratorRemoved;
     }
 }
 
@@ -132,6 +153,21 @@ void ApolloDeletedCommentsMarkCommentBodyRevealed(NSString *author, NSString *bo
             sApolloDeletedCommentsRevealedBodyKeys = [NSMutableSet set];
         }
         [sApolloDeletedCommentsRevealedBodyKeys addObject:key];
+    }
+}
+
+void ApolloDeletedCommentsUnmarkCommentRevealed(NSString *fullName) {
+    if (![fullName isKindOfClass:[NSString class]] || fullName.length == 0) return;
+    @synchronized(ApolloDeletedCommentsRegistryLock()) {
+        [sApolloDeletedCommentsRevealedFullNames removeObject:fullName];
+    }
+}
+
+void ApolloDeletedCommentsUnmarkCommentBodyRevealed(NSString *author, NSString *body) {
+    NSString *key = ApolloDeletedCommentsRegistryBodyKey(author, body);
+    if (key.length == 0) return;
+    @synchronized(ApolloDeletedCommentsRegistryLock()) {
+        [sApolloDeletedCommentsRevealedBodyKeys removeObject:key];
     }
 }
 
@@ -417,9 +453,9 @@ static NSString *ApolloDeletedCommentsReasonForArchived(NSDictionary *archived) 
     return ApolloDeletedCommentsReasonModeratorRemoved;
 }
 
-static NSString *ApolloDeletedCommentsBadgeLabelForReason(NSString *reason) {
-    if ([reason isEqualToString:ApolloDeletedCommentsReasonUserDeleted]) return @"deleted by user";
-    return @"removed by mod";
+NSString *ApolloDeletedCommentsDisplayLabelForReason(NSString *reason) {
+    if ([reason isEqualToString:ApolloDeletedCommentsReasonUserDeleted]) return @"DELETED BY USER";
+    return @"DELETED BY MOD";
 }
 
 static NSString *ApolloDeletedCommentsRedditBodyHTML(NSString *body) {
@@ -474,19 +510,14 @@ static void ApolloDeletedCommentsApplyNeutralVoteMetadata(NSMutableDictionary *d
 }
 
 static void ApolloDeletedCommentsApplyRecoveredMetadata(NSMutableDictionary *data, NSString *reason) {
-    NSString *label = ApolloDeletedCommentsBadgeLabelForReason(reason);
     NSString *fullName = ApolloDeletedCommentsCommentFullName(data);
     NSString *author = [data[@"author"] isKindOfClass:[NSString class]] ? data[@"author"] : nil;
     NSString *body = [data[@"body"] isKindOfClass:[NSString class]] ? data[@"body"] : nil;
     data[ApolloDeletedCommentsMarkerKey] = @YES;
     data[ApolloDeletedCommentsReasonKey] = reason.length > 0 ? reason : ApolloDeletedCommentsReasonModeratorRemoved;
-    data[@"author_flair_text"] = label.length > 0 ? label : @"removed by mod";
-    data[@"author_flair_css_class"] = @"recovered-deleted";
-    data[@"author_flair_type"] = @"text";
-    data[@"author_flair_richtext"] = @[];
     ApolloDeletedCommentsApplyNeutralVoteMetadata(data);
     ApolloDeletedCommentsRegisterRecoveredComment(fullName, reason);
-    ApolloDeletedCommentsRegisterRecoveredBody(author, body);
+    ApolloDeletedCommentsRegisterRecoveredBody(author, body, reason);
 }
 
 static void ApolloDeletedCommentsClearRemovalMetadata(NSMutableDictionary *data) {
@@ -1465,5 +1496,9 @@ NSUInteger ApolloDeletedCommentsTestPatchRedditJSONRoot(id root, NSDictionary<NS
 
 BOOL ApolloDeletedCommentsTestArcticResponseShouldCooldown(NSInteger statusCode, NSInteger remaining) {
     return ApolloDeletedCommentsArcticResponseShouldCooldown(statusCode, remaining);
+}
+
+NSString *ApolloDeletedCommentsTestDisplayLabelForReason(NSString *reason) {
+    return ApolloDeletedCommentsDisplayLabelForReason(reason);
 }
 #endif

--- a/src/ApolloDeletedCommentsData.m
+++ b/src/ApolloDeletedCommentsData.m
@@ -13,12 +13,15 @@ BOOL sTapToRevealDeletedComments = NO;
 #endif
 
 NSString *const ApolloDeletedCommentsObservedThreadNotification = @"ApolloDeletedCommentsObservedThreadNotification";
+NSString *const ApolloDeletedCommentsArcticCacheUpdatedNotification = @"ApolloDeletedCommentsArcticCacheUpdatedNotification";
 
 static const void *kApolloDeletedCommentsResponseDataKey = &kApolloDeletedCommentsResponseDataKey;
 static NSMutableSet<NSString *> *sApolloDeletedCommentsDelegateTransformerInstalledClasses = nil;
 static NSString *sApolloDeletedCommentsLastObservedLinkFullName = nil;
 static NSDate *sApolloDeletedCommentsLastObservedLinkDate = nil;
 static NSMutableDictionary<NSString *, NSString *> *sApolloDeletedCommentsRecoveredReasonsByFullName = nil;
+static NSMutableDictionary<NSString *, NSString *> *sApolloDeletedCommentsPlaceholderReasonsByFullName = nil;
+static NSMutableDictionary<NSString *, NSDictionary *> *sApolloDeletedCommentsArchivedByFullName = nil;
 static NSMutableSet<NSString *> *sApolloDeletedCommentsRecoveredBodyKeys = nil;
 static NSMutableDictionary<NSString *, NSString *> *sApolloDeletedCommentsRecoveredReasonsByBodyKey = nil;
 static NSMutableSet<NSString *> *sApolloDeletedCommentsRevealedFullNames = nil;
@@ -31,21 +34,26 @@ static NSDate *sApolloDeletedCommentsArcticCooldownUntil = nil;
 
 static NSString *const ApolloDeletedCommentsMarkerKey = @"apollo_recovered_deleted_comment";
 static NSString *const ApolloDeletedCommentsReasonKey = @"apollo_recovered_deleted_reason";
+static NSString *const ApolloDeletedCommentsPlaceholderMarkerKey = @"apollo_deleted_comment_placeholder";
+static NSString *const ApolloDeletedCommentsPlaceholderReasonKey = @"apollo_deleted_comment_placeholder_reason";
 static NSString *const ApolloDeletedCommentsReasonUserDeleted = @"user_deleted";
 static NSString *const ApolloDeletedCommentsReasonModeratorRemoved = @"moderator_removed";
 static NSString *const ApolloDeletedCommentsArcticCacheCommentsKey = @"comments";
 static NSString *const ApolloDeletedCommentsArcticCacheExpiryKey = @"expires";
 
-static NSTimeInterval const ApolloDeletedCommentsArcticPatchTimeout = 1.5;
 static NSTimeInterval const ApolloDeletedCommentsArcticSuccessCacheTTL = 600.0;
 static NSTimeInterval const ApolloDeletedCommentsArcticEmptyCacheTTL = 60.0;
 static NSTimeInterval const ApolloDeletedCommentsArcticErrorCooldown = 30.0;
 static NSTimeInterval const ApolloDeletedCommentsArcticRateLimitCooldown = 60.0;
+static NSTimeInterval const ApolloDeletedCommentsInitialRecoveryWait = 2.0;
 static NSInteger const ApolloDeletedCommentsArcticLowRemainingThreshold = 3;
-static NSUInteger const ApolloDeletedCommentsArcticMaxExactBatches = 2;
 
 static NSString *ApolloDeletedCommentsTrimmedString(NSString *s);
 static NSString *ApolloDeletedCommentsUnescapedHTMLText(NSString *s);
+static NSString *ApolloDeletedCommentsCommentFullName(NSDictionary *data);
+static NSString *ApolloDeletedCommentsReasonForArchived(NSDictionary *archived);
+static BOOL ApolloDeletedCommentsBodyLooksDeleted(NSString *body);
+static void ApolloDeletedCommentsWarmArcticCacheForLink(NSString *linkFullName, NSString *source);
 
 #pragma mark - RecoveredCommentRegistry
 
@@ -71,6 +79,52 @@ void ApolloDeletedCommentsRegisterRecoveredComment(NSString *fullName, NSString 
             sApolloDeletedCommentsRecoveredReasonsByFullName = [NSMutableDictionary dictionary];
         }
         sApolloDeletedCommentsRecoveredReasonsByFullName[fullName] = reason.length > 0 ? reason : ApolloDeletedCommentsReasonModeratorRemoved;
+    }
+}
+
+void ApolloDeletedCommentsRegisterDeletedPlaceholder(NSString *fullName, NSString *reason) {
+    if (![fullName isKindOfClass:[NSString class]] || fullName.length == 0) return;
+    @synchronized(ApolloDeletedCommentsRegistryLock()) {
+        if (!sApolloDeletedCommentsPlaceholderReasonsByFullName) {
+            sApolloDeletedCommentsPlaceholderReasonsByFullName = [NSMutableDictionary dictionary];
+        }
+        sApolloDeletedCommentsPlaceholderReasonsByFullName[fullName] = reason.length > 0 ? reason : ApolloDeletedCommentsReasonModeratorRemoved;
+    }
+}
+
+BOOL ApolloDeletedCommentsIsDeletedPlaceholder(NSString *fullName) {
+    if (![fullName isKindOfClass:[NSString class]] || fullName.length == 0) return NO;
+    @synchronized(ApolloDeletedCommentsRegistryLock()) {
+        return sApolloDeletedCommentsPlaceholderReasonsByFullName[fullName] != nil;
+    }
+}
+
+NSString *ApolloDeletedCommentsDeletedPlaceholderReason(NSString *fullName) {
+    if (![fullName isKindOfClass:[NSString class]] || fullName.length == 0) return nil;
+    @synchronized(ApolloDeletedCommentsRegistryLock()) {
+        return sApolloDeletedCommentsPlaceholderReasonsByFullName[fullName];
+    }
+}
+
+static void ApolloDeletedCommentsStoreArchivedCommentsByFullName(NSDictionary<NSString *, NSDictionary *> *comments) {
+    if (comments.count == 0) return;
+    @synchronized(ApolloDeletedCommentsRegistryLock()) {
+        if (!sApolloDeletedCommentsArchivedByFullName) {
+            sApolloDeletedCommentsArchivedByFullName = [NSMutableDictionary dictionary];
+        }
+        for (NSString *fullName in comments) {
+            NSDictionary *archived = [comments[fullName] isKindOfClass:[NSDictionary class]] ? comments[fullName] : nil;
+            if ([fullName isKindOfClass:[NSString class]] && fullName.length > 0 && archived) {
+                sApolloDeletedCommentsArchivedByFullName[fullName] = archived;
+            }
+        }
+    }
+}
+
+NSDictionary *ApolloDeletedCommentsCachedArchivedComment(NSString *fullName) {
+    if (![fullName isKindOfClass:[NSString class]] || fullName.length == 0) return nil;
+    @synchronized(ApolloDeletedCommentsRegistryLock()) {
+        return [sApolloDeletedCommentsArchivedByFullName[fullName] copy];
     }
 }
 
@@ -280,6 +334,10 @@ void ApolloDeletedCommentsHandleRequestObservation(NSURLRequest *request, NSStri
         ApolloLog(@"[DeletedComments] Observed Reddit comments request %@ (%@)", fullName, source ?: @"unknown");
     }
 
+    if (!ApolloDeletedCommentsIsMoreChildrenRequest(request)) {
+        ApolloDeletedCommentsWarmArcticCacheForLink(fullName, source ?: @"request observation");
+    }
+
     dispatch_async(dispatch_get_main_queue(), ^{
         [[NSNotificationCenter defaultCenter] postNotificationName:ApolloDeletedCommentsObservedThreadNotification
                                                             object:nil
@@ -336,64 +394,6 @@ static NSString *ApolloDeletedCommentsCommentFullName(NSDictionary *data) {
     return [identifier hasPrefix:@"t1_"] ? identifier : [@"t1_" stringByAppendingString:identifier];
 }
 
-static NSArray<NSString *> *ApolloDeletedCommentsSplitIDs(NSString *value) {
-    if (![value isKindOfClass:[NSString class]] || value.length == 0) return @[];
-
-    NSMutableArray<NSString *> *fullNames = [NSMutableArray array];
-    NSArray<NSString *> *parts = [value componentsSeparatedByString:@","];
-    for (NSString *part in parts) {
-        NSString *identifier = [part stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-        if (identifier.length == 0) continue;
-        NSString *fullName = [identifier hasPrefix:@"t1_"] ? identifier : [@"t1_" stringByAppendingString:identifier];
-        [fullNames addObject:fullName];
-    }
-    return fullNames;
-}
-
-static void ApolloDeletedCommentsAddFormValue(NSMutableDictionary<NSString *, NSMutableArray<NSString *> *> *params, NSString *name, NSString *value) {
-    if (name.length == 0 || value.length == 0) return;
-    NSString *decodedName = [name stringByRemovingPercentEncoding] ?: name;
-    NSString *decodedValue = [value stringByRemovingPercentEncoding] ?: value;
-    if (!params[decodedName]) params[decodedName] = [NSMutableArray array];
-    [params[decodedName] addObject:decodedValue];
-}
-
-static NSDictionary<NSString *, NSArray<NSString *> *> *ApolloDeletedCommentsRequestParameters(NSURLRequest *request) {
-    NSMutableDictionary<NSString *, NSMutableArray<NSString *> *> *params = [NSMutableDictionary dictionary];
-
-    NSURLComponents *components = [NSURLComponents componentsWithURL:request.URL resolvingAgainstBaseURL:NO];
-    for (NSURLQueryItem *item in components.queryItems ?: @[]) {
-        ApolloDeletedCommentsAddFormValue(params, item.name, item.value);
-    }
-
-    NSData *body = request.HTTPBody;
-    if (body.length > 0) {
-        NSString *bodyString = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
-        for (NSString *pair in [bodyString componentsSeparatedByString:@"&"]) {
-            if (pair.length == 0) continue;
-            NSRange separator = [pair rangeOfString:@"="];
-            NSString *name = separator.location == NSNotFound ? pair : [pair substringToIndex:separator.location];
-            NSString *value = separator.location == NSNotFound ? @"" : [pair substringFromIndex:separator.location + 1];
-            ApolloDeletedCommentsAddFormValue(params, name, value);
-        }
-    }
-
-    NSMutableDictionary<NSString *, NSArray<NSString *> *> *immutableParams = [NSMutableDictionary dictionary];
-    for (NSString *key in params) immutableParams[key] = [params[key] copy];
-    return immutableParams;
-}
-
-static NSArray<NSString *> *ApolloDeletedCommentsRequestedMoreChildren(NSURLRequest *request) {
-    if (!ApolloDeletedCommentsIsMoreChildrenRequest(request)) return @[];
-
-    NSDictionary<NSString *, NSArray<NSString *> *> *params = ApolloDeletedCommentsRequestParameters(request);
-    NSMutableArray<NSString *> *fullNames = [NSMutableArray array];
-    for (NSString *value in params[@"children"] ?: @[]) {
-        [fullNames addObjectsFromArray:ApolloDeletedCommentsSplitIDs(value)];
-    }
-    return fullNames;
-}
-
 static NSString *ApolloDeletedCommentsEscapeHTML(NSString *s) {
     NSMutableString *escaped = [s ?: @"" mutableCopy];
     [escaped replaceOccurrencesOfString:@"&" withString:@"&amp;" options:0 range:NSMakeRange(0, escaped.length)];
@@ -434,12 +434,6 @@ static BOOL ApolloDeletedCommentsArchivedWasDeleted(NSDictionary *archived) {
     return NO;
 }
 
-static BOOL ApolloDeletedCommentsArchivedIsRecoverableDeleted(NSDictionary *archived) {
-    if (!ApolloDeletedCommentsArchivedWasDeleted(archived)) return NO;
-    NSString *body = ApolloDeletedCommentsTrimmedString([archived[@"body"] isKindOfClass:[NSString class]] ? archived[@"body"] : nil);
-    return body.length > 0 && !ApolloDeletedCommentsBodyLooksDeleted(body);
-}
-
 static NSString *ApolloDeletedCommentsReasonForCurrentBody(NSString *body, NSString *bodyHTML) {
     if (ApolloDeletedCommentsBodyLooksUserDeleted(body)) return ApolloDeletedCommentsReasonUserDeleted;
     if (ApolloDeletedCommentsBodyLooksUserDeleted(ApolloDeletedCommentsUnescapedHTMLText(bodyHTML))) return ApolloDeletedCommentsReasonUserDeleted;
@@ -476,30 +470,62 @@ static NSString *ApolloDeletedCommentsRedditBodyHTML(NSString *body) {
     return ApolloDeletedCommentsEscapeHTML(html);
 }
 
-static NSString *ApolloDeletedCommentsSpoilerMarkdownBody(NSString *body) {
-    NSString *trimmed = ApolloDeletedCommentsTrimmedString(body);
-    if (trimmed.length == 0) return nil;
-    return [NSString stringWithFormat:@">!%@!<", trimmed];
-}
-
-static NSString *ApolloDeletedCommentsRedditSpoilerBodyHTML(NSString *body) {
-    NSString *trimmed = ApolloDeletedCommentsTrimmedString(body);
-    if (trimmed.length == 0) return nil;
-
-    NSString *escaped = ApolloDeletedCommentsEscapeHTML(trimmed);
-    escaped = [escaped stringByReplacingOccurrencesOfString:@"\n" withString:@"<br/>"];
-    return [NSString stringWithFormat:@"<!-- SC_OFF --><div class=\"md\"><p><span class=\"md-spoiler-text\">%@</span></p>\n</div><!-- SC_ON -->", escaped];
-}
-
 static void ApolloDeletedCommentsSetRecoveredBody(NSMutableDictionary *data, NSString *body) {
     NSString *trimmed = ApolloDeletedCommentsTrimmedString(body);
     if (trimmed.length == 0) return;
 
-    NSString *displayBody = sTapToRevealDeletedComments ? ApolloDeletedCommentsSpoilerMarkdownBody(trimmed) : trimmed;
-    data[@"body"] = displayBody.length > 0 ? displayBody : trimmed;
-
-    NSString *bodyHTML = sTapToRevealDeletedComments ? ApolloDeletedCommentsRedditSpoilerBodyHTML(trimmed) : ApolloDeletedCommentsRedditBodyHTML(trimmed);
+    data[@"body"] = trimmed;
+    NSString *bodyHTML = ApolloDeletedCommentsRedditBodyHTML(trimmed);
     if (bodyHTML.length > 0) data[@"body_html"] = bodyHTML;
+}
+
+static void ApolloDeletedCommentsSetObjectValue(id object, SEL selector, id value) {
+    if (!object || !selector || !value || ![object respondsToSelector:selector]) return;
+    @try {
+        ((void (*)(id, SEL, id))objc_msgSend)(object, selector, value);
+    } @catch (__unused NSException *e) {}
+}
+
+static void ApolloDeletedCommentsSetObjectBoolValue(id object, SEL selector, BOOL value) {
+    if (!object || !selector || ![object respondsToSelector:selector]) return;
+    @try {
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(object, selector, value);
+    } @catch (__unused NSException *e) {}
+}
+
+static void ApolloDeletedCommentsSetObjectLongLongValue(id object, SEL selector, long long value) {
+    if (!object || !selector || ![object respondsToSelector:selector]) return;
+    @try {
+        ((void (*)(id, SEL, long long))objc_msgSend)(object, selector, value);
+    } @catch (__unused NSException *e) {}
+}
+
+BOOL ApolloDeletedCommentsApplyRecoveredArchivedCommentToObject(id comment, NSDictionary *archived, NSString *reason) {
+    if (!comment || ![archived isKindOfClass:[NSDictionary class]]) return NO;
+
+    NSString *fullName = ApolloDeletedCommentsCommentFullName(archived);
+    NSString *body = ApolloDeletedCommentsTrimmedString([archived[@"body"] isKindOfClass:[NSString class]] ? archived[@"body"] : nil);
+    if (fullName.length == 0 || body.length == 0 || ApolloDeletedCommentsBodyLooksDeleted(body)) return NO;
+
+    NSString *author = [archived[@"author"] isKindOfClass:[NSString class]] ? archived[@"author"] : nil;
+    NSString *bodyHTML = ApolloDeletedCommentsRedditBodyHTML(body);
+    NSString *resolvedReason = reason.length > 0 ? reason : ApolloDeletedCommentsReasonForArchived(archived);
+
+    ApolloDeletedCommentsSetObjectValue(comment, @selector(setBody:), body);
+    if (bodyHTML.length > 0) ApolloDeletedCommentsSetObjectValue(comment, @selector(setBodyHTML:), bodyHTML);
+    if (author.length > 0) ApolloDeletedCommentsSetObjectValue(comment, @selector(setAuthor:), author);
+    if ([archived[@"score"] respondsToSelector:@selector(longLongValue)]) {
+        ApolloDeletedCommentsSetObjectLongLongValue(comment, @selector(setScore:), [archived[@"score"] longLongValue]);
+    }
+
+    ApolloDeletedCommentsSetObjectBoolValue(comment, @selector(setRemoved:), NO);
+    ApolloDeletedCommentsSetObjectBoolValue(comment, @selector(setSpam:), NO);
+    ApolloDeletedCommentsSetObjectValue(comment, @selector(setBannedBy:), @"");
+    ApolloDeletedCommentsSetObjectValue(comment, @selector(setCollapsedReasonCode:), @"");
+
+    ApolloDeletedCommentsRegisterRecoveredComment(fullName, resolvedReason);
+    ApolloDeletedCommentsRegisterRecoveredBody(author, body, resolvedReason);
+    return YES;
 }
 
 static void ApolloDeletedCommentsApplyNeutralVoteMetadata(NSMutableDictionary *data) {
@@ -518,6 +544,37 @@ static void ApolloDeletedCommentsApplyRecoveredMetadata(NSMutableDictionary *dat
     ApolloDeletedCommentsApplyNeutralVoteMetadata(data);
     ApolloDeletedCommentsRegisterRecoveredComment(fullName, reason);
     ApolloDeletedCommentsRegisterRecoveredBody(author, body, reason);
+}
+
+static void ApolloDeletedCommentsApplyPlaceholderMetadata(NSMutableDictionary *data, NSString *reason) {
+    NSString *fullName = ApolloDeletedCommentsCommentFullName(data);
+    data[ApolloDeletedCommentsPlaceholderMarkerKey] = @YES;
+    data[ApolloDeletedCommentsPlaceholderReasonKey] = reason.length > 0 ? reason : ApolloDeletedCommentsReasonModeratorRemoved;
+    ApolloDeletedCommentsRegisterDeletedPlaceholder(fullName, reason);
+}
+
+static NSUInteger ApolloDeletedCommentsMarkDeletedPlaceholdersInJSONNode(id node) {
+    if (!node) return 0;
+    NSUInteger marked = 0;
+    if ([node isKindOfClass:[NSMutableDictionary class]]) {
+        NSMutableDictionary *dict = (NSMutableDictionary *)node;
+        NSString *kind = [dict[@"kind"] isKindOfClass:[NSString class]] ? dict[@"kind"] : nil;
+        NSMutableDictionary *data = [dict[@"data"] isKindOfClass:[NSMutableDictionary class]] ? dict[@"data"] : nil;
+        if ([kind isEqualToString:@"t1"] && data && ApolloDeletedCommentsCommentDataLooksDeleted(data)) {
+            NSString *body = [data[@"body"] isKindOfClass:[NSString class]] ? data[@"body"] : nil;
+            NSString *bodyHTML = [data[@"body_html"] isKindOfClass:[NSString class]] ? data[@"body_html"] : nil;
+            ApolloDeletedCommentsApplyPlaceholderMetadata(data, ApolloDeletedCommentsReasonForCurrentBody(body, bodyHTML));
+            marked++;
+        }
+        for (id value in [dict allValues]) {
+            marked += ApolloDeletedCommentsMarkDeletedPlaceholdersInJSONNode(value);
+        }
+    } else if ([node isKindOfClass:[NSArray class]]) {
+        for (id value in (NSArray *)node) {
+            marked += ApolloDeletedCommentsMarkDeletedPlaceholdersInJSONNode(value);
+        }
+    }
+    return marked;
 }
 
 static void ApolloDeletedCommentsClearRemovalMetadata(NSMutableDictionary *data) {
@@ -571,25 +628,6 @@ static NSDictionary<NSString *, NSDictionary *> *ApolloDeletedCommentsArcticComm
 
     NSMutableDictionary *comments = [NSMutableDictionary dictionary];
     ApolloDeletedCommentsFlattenArcticChildren(children, comments);
-    return comments.count > 0 ? comments : nil;
-}
-
-static NSDictionary<NSString *, NSDictionary *> *ApolloDeletedCommentsArcticCommentMapFromFlatData(id root) {
-    NSArray *commentsArray = nil;
-    if ([root isKindOfClass:[NSDictionary class]]) {
-        id data = ((NSDictionary *)root)[@"data"];
-        if ([data isKindOfClass:[NSArray class]]) commentsArray = data;
-    } else if ([root isKindOfClass:[NSArray class]]) {
-        commentsArray = root;
-    }
-    if (![commentsArray isKindOfClass:[NSArray class]]) return nil;
-
-    NSMutableDictionary *comments = [NSMutableDictionary dictionary];
-    for (id entry in commentsArray) {
-        if (![entry isKindOfClass:[NSDictionary class]]) continue;
-        NSString *fullName = ApolloDeletedCommentsCommentFullName(entry);
-        if (fullName.length > 0) comments[fullName] = entry;
-    }
     return comments.count > 0 ? comments : nil;
 }
 
@@ -680,12 +718,21 @@ static NSDictionary<NSString *, NSDictionary *> *ApolloDeletedCommentsCachedArct
 
 static void ApolloDeletedCommentsStoreArcticComments(NSString *linkFullName, NSDictionary<NSString *, NSDictionary *> *comments, NSTimeInterval ttl) {
     if (linkFullName.length == 0 || ttl <= 0.0) return;
+    NSDictionary *storedComments = comments ?: @{};
+    ApolloDeletedCommentsStoreArchivedCommentsByFullName(storedComments);
     @synchronized(ApolloDeletedCommentsArcticLock()) {
         if (!sApolloDeletedCommentsArcticCache) sApolloDeletedCommentsArcticCache = [NSMutableDictionary dictionary];
         sApolloDeletedCommentsArcticCache[linkFullName] = @{
-            ApolloDeletedCommentsArcticCacheCommentsKey: comments ?: @{},
+            ApolloDeletedCommentsArcticCacheCommentsKey: storedComments,
             ApolloDeletedCommentsArcticCacheExpiryKey: [NSDate dateWithTimeIntervalSinceNow:ttl],
         };
+    }
+    if (storedComments.count > 0) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:ApolloDeletedCommentsArcticCacheUpdatedNotification
+                                                                object:nil
+                                                              userInfo:@{@"linkFullName": linkFullName, @"comments": storedComments}];
+        });
     }
 }
 
@@ -761,79 +808,21 @@ static void ApolloDeletedCommentsFetchArcticComments(NSString *linkFullName, voi
     [task resume];
 }
 
-static NSArray<NSArray<NSString *> *> *ApolloDeletedCommentsBatches(NSArray<NSString *> *values, NSUInteger batchSize) {
-    if (values.count == 0 || batchSize == 0) return @[];
-    NSMutableArray *batches = [NSMutableArray array];
-    for (NSUInteger i = 0; i < values.count; i += batchSize) {
-        NSUInteger count = MIN(batchSize, values.count - i);
-        [batches addObject:[values subarrayWithRange:NSMakeRange(i, count)]];
-    }
-    return batches;
-}
+static void ApolloDeletedCommentsWarmArcticCacheForLink(NSString *linkFullName, NSString *source) {
+    if (linkFullName.length == 0) return;
+    if (ApolloDeletedCommentsCachedArcticComments(linkFullName) != nil) return;
+    if (ApolloDeletedCommentsArcticIsCoolingDown()) return;
 
-static void ApolloDeletedCommentsFetchArcticCommentsByFullNames(NSArray<NSString *> *fullNames,
-                                                                void (^completion)(NSDictionary<NSString *, NSDictionary *> *comments)) {
-    if (fullNames.count == 0) {
-        completion(@{});
-        return;
-    }
-    if (ApolloDeletedCommentsArcticIsCoolingDown()) {
-        completion(@{});
-        return;
-    }
-
-    NSMutableOrderedSet<NSString *> *baseIDs = [NSMutableOrderedSet orderedSet];
-    for (NSString *fullName in fullNames) {
-        if (![fullName isKindOfClass:[NSString class]] || ![fullName hasPrefix:@"t1_"] || fullName.length <= 3) continue;
-        [baseIDs addObject:[fullName substringFromIndex:3]];
-    }
-    if (baseIDs.count == 0) {
-        completion(@{});
-        return;
-    }
-
-    NSArray<NSArray<NSString *> *> *allBatches = ApolloDeletedCommentsBatches(baseIDs.array, 250);
-    NSArray<NSArray<NSString *> *> *batches = allBatches.count > ApolloDeletedCommentsArcticMaxExactBatches ? [allBatches subarrayWithRange:NSMakeRange(0, ApolloDeletedCommentsArcticMaxExactBatches)] : allBatches;
-    NSMutableDictionary<NSString *, NSDictionary *> *merged = [NSMutableDictionary dictionary];
-    __block NSUInteger nextIndex = 0;
-    __block void (^fetchNext)(void) = nil;
-    fetchNext = ^{
-        if (nextIndex >= batches.count) {
-            completion([merged copy]);
-            fetchNext = nil;
-            return;
-        }
-
-        NSArray<NSString *> *batch = batches[nextIndex++];
-        NSURLComponents *components = [NSURLComponents componentsWithString:@"https://arctic-shift.photon-reddit.com/api/comments/ids"];
-        components.queryItems = @[
-            [NSURLQueryItem queryItemWithName:@"ids" value:[batch componentsJoinedByString:@","]],
-            [NSURLQueryItem queryItemWithName:@"md2html" value:@"false"],
-        ];
-        NSURL *url = components.URL;
-        if (!url) {
-            fetchNext();
-            return;
-        }
-
-        NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:url];
-        urlRequest.timeoutInterval = 10.0;
-
-        NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-            NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
-            ApolloDeletedCommentsRecordArcticResponse(http, error);
-            if (!error && data.length > 0) {
-                if (!http || (http.statusCode >= 200 && http.statusCode < 300)) {
-                    id root = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
-                    NSDictionary *comments = ApolloDeletedCommentsArcticCommentMapFromFlatData(root);
-                    if (comments.count > 0) [merged addEntriesFromDictionary:comments];
-                }
-            }
-            fetchNext();
-        }];
-        [task resume];
-    };
-    fetchNext();
+#ifdef APOLLO_DELETED_COMMENTS_TESTING
+    (void)source;
+#else
+    NSString *capturedLinkFullName = [linkFullName copy];
+    NSString *capturedSource = [source copy] ?: @"unknown";
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        ApolloLog(@"[DeletedComments] Warming Arctic cache for %@ (%@)", capturedLinkFullName, capturedSource);
+        ApolloDeletedCommentsFetchArcticComments(capturedLinkFullName, ^(__unused NSDictionary<NSString *, NSDictionary *> *comments) {});
+    });
+#endif
 }
 
 static void ApolloDeletedCommentsCollectVisibleCommentNames(id node, NSMutableSet<NSString *> *names) {
@@ -849,48 +838,6 @@ static void ApolloDeletedCommentsCollectVisibleCommentNames(id node, NSMutableSe
         for (id value in [dict allValues]) ApolloDeletedCommentsCollectVisibleCommentNames(value, names);
     } else if ([node isKindOfClass:[NSArray class]]) {
         for (id value in (NSArray *)node) ApolloDeletedCommentsCollectVisibleCommentNames(value, names);
-    }
-}
-
-static void ApolloDeletedCommentsAddLookupTarget(NSMutableOrderedSet<NSString *> *targets, NSString *fullName) {
-    if (![targets isKindOfClass:[NSMutableOrderedSet class]]) return;
-    if (![fullName isKindOfClass:[NSString class]] || ![fullName hasPrefix:@"t1_"] || fullName.length <= 3) return;
-    [targets addObject:fullName];
-}
-
-static void ApolloDeletedCommentsCollectExactLookupTargets(id node,
-                                                           NSDictionary<NSString *, NSDictionary *> *arcticComments,
-                                                           NSMutableOrderedSet<NSString *> *targets) {
-    if (!node || !targets) return;
-    if ([node isKindOfClass:[NSDictionary class]]) {
-        NSDictionary *dict = (NSDictionary *)node;
-        NSString *kind = [dict[@"kind"] isKindOfClass:[NSString class]] ? dict[@"kind"] : nil;
-        NSDictionary *data = [dict[@"data"] isKindOfClass:[NSDictionary class]] ? dict[@"data"] : nil;
-        if ([kind isEqualToString:@"t1"] && data) {
-            NSString *fullName = ApolloDeletedCommentsCommentFullName(data);
-            NSDictionary *archived = fullName.length > 0 ? arcticComments[fullName] : nil;
-            NSString *archivedBody = ApolloDeletedCommentsTrimmedString([archived[@"body"] isKindOfClass:[NSString class]] ? archived[@"body"] : nil);
-            if (ApolloDeletedCommentsCommentDataLooksDeleted(data) &&
-                (archivedBody.length == 0 || ApolloDeletedCommentsBodyLooksDeleted(archivedBody))) {
-                ApolloDeletedCommentsAddLookupTarget(targets, fullName);
-            }
-        } else if ([kind isEqualToString:@"more"] && data) {
-            NSArray *children = [data[@"children"] isKindOfClass:[NSArray class]] ? data[@"children"] : nil;
-            for (id childID in children ?: @[]) {
-                NSString *identifier = nil;
-                if ([childID isKindOfClass:[NSString class]]) identifier = childID;
-                else if ([childID respondsToSelector:@selector(stringValue)]) identifier = [childID stringValue];
-                NSString *fullName = [identifier hasPrefix:@"t1_"] ? identifier : (identifier.length > 0 ? [@"t1_" stringByAppendingString:identifier] : nil);
-                NSDictionary *archived = fullName.length > 0 ? arcticComments[fullName] : nil;
-                if (!archived || ApolloDeletedCommentsArchivedWasDeleted(archived)) {
-                    ApolloDeletedCommentsAddLookupTarget(targets, fullName);
-                }
-            }
-        }
-
-        for (id value in [dict allValues]) ApolloDeletedCommentsCollectExactLookupTargets(value, arcticComments, targets);
-    } else if ([node isKindOfClass:[NSArray class]]) {
-        for (id value in (NSArray *)node) ApolloDeletedCommentsCollectExactLookupTargets(value, arcticComments, targets);
     }
 }
 
@@ -942,124 +889,7 @@ typedef struct {
     NSUInteger recoverableCount;
     NSUInteger unrecoverableCount;
     NSUInteger insertedFromMoreCount;
-    NSUInteger requestedMoreCount;
-    NSUInteger returnedRequestedMoreCount;
-    NSUInteger insertedMissingMoreCount;
-    NSUInteger skippedMissingWithoutDeletionEvidenceCount;
-    NSUInteger exactLookupCount;
-    NSUInteger exactMatchCount;
-    NSUInteger overlayInsertedCount;
-    NSUInteger overlayRecoverableCount;
 } ApolloDeletedCommentsPatchStats;
-
-static NSDictionary<NSString *, NSArray<NSDictionary *> *> *ApolloDeletedCommentsRecoverableChildrenByParent(NSDictionary<NSString *, NSDictionary *> *arcticComments,
-                                                                                                            ApolloDeletedCommentsPatchStats *stats) {
-    NSMutableDictionary<NSString *, NSMutableArray<NSDictionary *> *> *childrenByParent = [NSMutableDictionary dictionary];
-    for (NSString *fullName in arcticComments) {
-        NSDictionary *archived = arcticComments[fullName];
-        if (!ApolloDeletedCommentsArchivedIsRecoverableDeleted(archived)) continue;
-        NSString *parentID = [archived[@"parent_id"] isKindOfClass:[NSString class]] ? archived[@"parent_id"] : nil;
-        if (parentID.length == 0) continue;
-        if (!childrenByParent[parentID]) childrenByParent[parentID] = [NSMutableArray array];
-        [childrenByParent[parentID] addObject:archived];
-        if (stats) stats->overlayRecoverableCount++;
-    }
-
-    NSMutableDictionary<NSString *, NSArray<NSDictionary *> *> *sortedChildren = [NSMutableDictionary dictionary];
-    for (NSString *parentID in childrenByParent) {
-        NSArray<NSDictionary *> *children = [childrenByParent[parentID] sortedArrayUsingComparator:^NSComparisonResult(NSDictionary *a, NSDictionary *b) {
-            NSTimeInterval aTime = [a[@"created_utc"] respondsToSelector:@selector(doubleValue)] ? [a[@"created_utc"] doubleValue] : 0;
-            NSTimeInterval bTime = [b[@"created_utc"] respondsToSelector:@selector(doubleValue)] ? [b[@"created_utc"] doubleValue] : 0;
-            if (aTime < bTime) return NSOrderedAscending;
-            if (aTime > bTime) return NSOrderedDescending;
-            NSString *aName = ApolloDeletedCommentsCommentFullName(a) ?: @"";
-            NSString *bName = ApolloDeletedCommentsCommentFullName(b) ?: @"";
-            return [aName compare:bName];
-        }];
-        sortedChildren[parentID] = children;
-    }
-    return sortedChildren;
-}
-
-static NSUInteger ApolloDeletedCommentsOverlayArchivedChildrenForParent(NSMutableArray *children,
-                                                                        NSString *parentFullName,
-                                                                        NSDictionary<NSString *, NSArray<NSDictionary *> *> *childrenByParent,
-                                                                        NSMutableSet<NSString *> *visibleNames,
-                                                                        ApolloDeletedCommentsPatchStats *stats) {
-    if (![children isKindOfClass:[NSMutableArray class]] || parentFullName.length == 0) return 0;
-    NSArray<NSDictionary *> *archivedChildren = childrenByParent[parentFullName];
-    if (archivedChildren.count == 0) return 0;
-
-    NSMutableArray *inserted = [NSMutableArray array];
-    for (NSDictionary *archived in archivedChildren) {
-        NSString *fullName = ApolloDeletedCommentsCommentFullName(archived);
-        if (fullName.length == 0 || [visibleNames containsObject:fullName]) continue;
-        NSMutableDictionary *thing = ApolloDeletedCommentsThingFromArchived(archived, ApolloDeletedCommentsReasonForArchived(archived));
-        if (!thing) continue;
-        [inserted addObject:thing];
-        [visibleNames addObject:fullName];
-    }
-
-    if (inserted.count == 0) return 0;
-    [children addObjectsFromArray:inserted];
-    if (stats) stats->overlayInsertedCount += inserted.count;
-    return inserted.count;
-}
-
-static NSMutableArray *ApolloDeletedCommentsMutableRepliesChildrenForCommentData(NSMutableDictionary *data) {
-    if (![data isKindOfClass:[NSMutableDictionary class]]) return nil;
-    id replies = data[@"replies"];
-    if ([replies isKindOfClass:[NSMutableDictionary class]]) {
-        NSMutableDictionary *replyData = [((NSMutableDictionary *)replies)[@"data"] isKindOfClass:[NSMutableDictionary class]] ? ((NSMutableDictionary *)replies)[@"data"] : nil;
-        NSMutableArray *children = [replyData[@"children"] isKindOfClass:[NSMutableArray class]] ? replyData[@"children"] : nil;
-        if (children) return children;
-    }
-
-    NSMutableArray *children = [NSMutableArray array];
-    data[@"replies"] = [@{
-        @"kind": @"Listing",
-        @"data": [@{
-            @"after": [NSNull null],
-            @"before": [NSNull null],
-            @"children": children,
-            @"dist": @0,
-            @"modhash": @"",
-        } mutableCopy],
-    } mutableCopy];
-    return children;
-}
-
-static NSUInteger ApolloDeletedCommentsOverlayArchivedDeletedComments(id node,
-                                                                      NSString *linkFullName,
-                                                                      NSDictionary<NSString *, NSArray<NSDictionary *> *> *childrenByParent,
-                                                                      NSMutableSet<NSString *> *visibleNames,
-                                                                      ApolloDeletedCommentsPatchStats *stats) {
-    if (!node || childrenByParent.count == 0) return 0;
-    NSUInteger inserted = 0;
-
-    if ([node isKindOfClass:[NSMutableDictionary class]]) {
-        NSMutableDictionary *dict = (NSMutableDictionary *)node;
-        NSString *kind = [dict[@"kind"] isKindOfClass:[NSString class]] ? dict[@"kind"] : nil;
-        NSMutableDictionary *data = [dict[@"data"] isKindOfClass:[NSMutableDictionary class]] ? dict[@"data"] : nil;
-        if ([kind isEqualToString:@"t1"] && data) {
-            NSString *fullName = ApolloDeletedCommentsCommentFullName(data);
-            if (fullName.length > 0 && childrenByParent[fullName].count > 0) {
-                NSMutableArray *replyChildren = ApolloDeletedCommentsMutableRepliesChildrenForCommentData(data);
-                inserted += ApolloDeletedCommentsOverlayArchivedChildrenForParent(replyChildren, fullName, childrenByParent, visibleNames, stats);
-            }
-        }
-
-        for (id value in [dict allValues]) {
-            inserted += ApolloDeletedCommentsOverlayArchivedDeletedComments(value, linkFullName, childrenByParent, visibleNames, stats);
-        }
-    } else if ([node isKindOfClass:[NSArray class]]) {
-        NSArray *snapshot = [(NSArray *)node copy];
-        for (id value in snapshot) {
-            inserted += ApolloDeletedCommentsOverlayArchivedDeletedComments(value, linkFullName, childrenByParent, visibleNames, stats);
-        }
-    }
-    return inserted;
-}
 
 static NSUInteger ApolloDeletedCommentsPatchRedditJSONNode(id node, NSDictionary<NSString *, NSDictionary *> *arcticComments, NSMutableSet<NSString *> *visibleNames, ApolloDeletedCommentsPatchStats *stats) {
     if (!node || !arcticComments) return 0;
@@ -1163,79 +993,58 @@ static NSUInteger ApolloDeletedCommentsPatchRedditJSONNode(id node, NSDictionary
     return patched;
 }
 
-static NSMutableArray *ApolloDeletedCommentsPreferredInsertionArray(id node) {
-    if ([node isKindOfClass:[NSMutableDictionary class]]) {
-        NSMutableDictionary *dict = (NSMutableDictionary *)node;
-        NSString *kind = [dict[@"kind"] isKindOfClass:[NSString class]] ? dict[@"kind"] : nil;
-        NSMutableDictionary *data = [dict[@"data"] isKindOfClass:[NSMutableDictionary class]] ? dict[@"data"] : nil;
-        NSMutableArray *children = [data[@"children"] isKindOfClass:[NSMutableArray class]] ? data[@"children"] : nil;
-        if ([kind isEqualToString:@"Listing"] && children) return children;
+static NSUInteger ApolloDeletedCommentsPatchRootWithCachedComments(id root,
+                                                                   NSString *linkFullName,
+                                                                   NSDictionary<NSString *, NSDictionary *> *comments) {
+    if (!root || comments.count == 0) return 0;
 
-        NSMutableDictionary *json = [dict[@"json"] isKindOfClass:[NSMutableDictionary class]] ? dict[@"json"] : nil;
-        NSMutableDictionary *jsonData = [json[@"data"] isKindOfClass:[NSMutableDictionary class]] ? json[@"data"] : nil;
-        NSMutableArray *things = [jsonData[@"things"] isKindOfClass:[NSMutableArray class]] ? jsonData[@"things"] : nil;
-        if (things) return things;
-
-        for (id value in [dict allValues]) {
-            NSMutableArray *array = ApolloDeletedCommentsPreferredInsertionArray(value);
-            if (array) return array;
-        }
-    } else if ([node isKindOfClass:[NSMutableArray class]]) {
-        for (id value in (NSArray *)node) {
-            NSMutableArray *array = ApolloDeletedCommentsPreferredInsertionArray(value);
-            if (array) return array;
-        }
+    NSMutableSet<NSString *> *visibleNames = [NSMutableSet set];
+    ApolloDeletedCommentsCollectVisibleCommentNames(root, visibleNames);
+    ApolloDeletedCommentsPatchStats stats = {0};
+    NSUInteger patched = ApolloDeletedCommentsPatchRedditJSONNode(root, comments, visibleNames, &stats);
+    if (patched > 0) {
+        ApolloLog(@"[DeletedComments] Applied cached recovery for %@ (%lu comments, visible=%lu, unrecoverable=%lu, insertedMore=%lu)",
+                  linkFullName ?: @"unknown",
+                  (unsigned long)patched,
+                  (unsigned long)stats.recoverableCount,
+                  (unsigned long)stats.unrecoverableCount,
+                  (unsigned long)stats.insertedFromMoreCount);
     }
-    return nil;
+    return patched;
 }
 
-static NSUInteger ApolloDeletedCommentsInsertMissingMoreChildren(id root,
-                                                                 NSURLRequest *request,
-                                                                 NSDictionary<NSString *, NSDictionary *> *arcticComments,
-                                                                 NSMutableSet<NSString *> *visibleNames,
-                                                                 ApolloDeletedCommentsPatchStats *stats) {
-    NSArray<NSString *> *requested = ApolloDeletedCommentsRequestedMoreChildren(request);
-    if (requested.count == 0) return 0;
-    if (stats) stats->requestedMoreCount += requested.count;
-    if (requested.count > 100) {
-        ApolloLog(@"[DeletedComments] Skipping missing morechildren synthesis for bulk request (%lu requested)",
-                  (unsigned long)requested.count);
-        return 0;
+static NSData *ApolloDeletedCommentsSerializedResponseData(id root, NSData *fallbackData, NSUInteger changed) {
+    if (changed == 0) return fallbackData;
+    NSData *patchedData = [NSJSONSerialization dataWithJSONObject:root options:0 error:nil];
+    return patchedData.length > 0 ? patchedData : fallbackData;
+}
+
+static NSData *__attribute__((unused)) ApolloDeletedCommentsPatchResponseImmediate(NSData *data, NSURLRequest *request) {
+    NSString *linkFullName = sShowDeletedComments ? ApolloDeletedCommentsLinkFullNameForRequest(request) : nil;
+    if (linkFullName.length == 0 || data.length == 0) {
+        return data;
     }
 
-    NSMutableArray *insertionArray = ApolloDeletedCommentsPreferredInsertionArray(root);
-    if (!insertionArray) return 0;
-
-    NSMutableSet<NSString *> *seenRequested = [NSMutableSet set];
-    NSMutableArray *inserted = [NSMutableArray array];
-    for (NSString *fullName in requested) {
-        if (fullName.length == 0 || [seenRequested containsObject:fullName]) continue;
-        [seenRequested addObject:fullName];
-
-        if ([visibleNames containsObject:fullName]) {
-            if (stats) stats->returnedRequestedMoreCount++;
-            continue;
-        }
-
-        NSDictionary *archived = arcticComments[fullName];
-        NSString *body = ApolloDeletedCommentsTrimmedString([archived[@"body"] isKindOfClass:[NSString class]] ? archived[@"body"] : nil);
-        if (body.length == 0 || ApolloDeletedCommentsBodyLooksDeleted(body)) continue;
-        if (!ApolloDeletedCommentsArchivedWasDeleted(archived)) {
-            if (stats) stats->skippedMissingWithoutDeletionEvidenceCount++;
-            continue;
-        }
-
-        NSMutableDictionary *thing = ApolloDeletedCommentsThingFromArchived(archived, ApolloDeletedCommentsReasonForArchived(archived));
-        if (!thing) continue;
-
-        [inserted addObject:thing];
-        [visibleNames addObject:fullName];
+    id root = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:nil];
+    if (!root) {
+        return data;
     }
 
-    if (inserted.count == 0) return 0;
-    [insertionArray addObjectsFromArray:inserted];
-    if (stats) stats->insertedMissingMoreCount += inserted.count;
-    return inserted.count;
+    NSUInteger changed = ApolloDeletedCommentsMarkDeletedPlaceholdersInJSONNode(root);
+    NSDictionary<NSString *, NSDictionary *> *cached = ApolloDeletedCommentsCachedArcticComments(linkFullName);
+    if (cached.count > 0) {
+        changed += ApolloDeletedCommentsPatchRootWithCachedComments(root, linkFullName, cached);
+    }
+
+    if (cached == nil && changed > 0 && !ApolloDeletedCommentsIsMoreChildrenRequest(request)) {
+#ifndef APOLLO_DELETED_COMMENTS_TESTING
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+            ApolloDeletedCommentsFetchArcticComments(linkFullName, ^(__unused NSDictionary<NSString *, NSDictionary *> *comments) {});
+        });
+#endif
+    }
+
+    return ApolloDeletedCommentsSerializedResponseData(root, data, changed);
 }
 
 static void ApolloDeletedCommentsPatchResponseAsync(NSData *data, NSURLRequest *request, void (^completion)(NSData *patchedData)) {
@@ -1251,134 +1060,61 @@ static void ApolloDeletedCommentsPatchResponseAsync(NSData *data, NSURLRequest *
         return;
     }
 
-    NSObject *completionLock = [NSObject new];
-    __block BOOL didComplete = NO;
-    void (^completeOnce)(NSData *) = ^(NSData *patchedData) {
-        BOOL shouldComplete = NO;
-        @synchronized(completionLock) {
-            if (!didComplete) {
-                didComplete = YES;
-                shouldComplete = YES;
-            }
-        }
-        if (shouldComplete) completion(patchedData.length > 0 ? patchedData : data);
-    };
-
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(ApolloDeletedCommentsArcticPatchTimeout * NSEC_PER_SEC)), dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
-        BOOL timedOut = NO;
-        @synchronized(completionLock) {
-            timedOut = !didComplete;
-        }
-        if (timedOut) {
-            ApolloLog(@"[DeletedComments] Arctic patch timed out for %@; delivering original Reddit comments", linkFullName);
-            ApolloDeletedCommentsArcticBeginCooldown(ApolloDeletedCommentsArcticErrorCooldown, @"patch timeout");
-            completeOnce(data);
-        }
-    });
-
-    void (^applyPatchWithComments)(NSDictionary<NSString *, NSDictionary *> *, NSUInteger, NSUInteger) = ^(NSDictionary<NSString *, NSDictionary *> *mergedComments, NSUInteger exactLookupCount, NSUInteger exactMatchedCount) {
-        if (mergedComments.count == 0) {
-            completeOnce(data);
-            return;
-        }
-
-        NSMutableSet<NSString *> *visibleNames = [NSMutableSet set];
-        ApolloDeletedCommentsCollectVisibleCommentNames(root, visibleNames);
-        ApolloDeletedCommentsPatchStats stats = {0};
-        stats.exactLookupCount = exactLookupCount;
-        stats.exactMatchCount = exactMatchedCount;
-        NSDictionary<NSString *, NSArray<NSDictionary *> *> *childrenByParent = ApolloDeletedCommentsRecoverableChildrenByParent(mergedComments, &stats);
-        NSUInteger patched = ApolloDeletedCommentsOverlayArchivedDeletedComments(root, linkFullName, childrenByParent, visibleNames, &stats);
-        patched += ApolloDeletedCommentsPatchRedditJSONNode(root, mergedComments, visibleNames, &stats);
-        patched += ApolloDeletedCommentsInsertMissingMoreChildren(root, request, mergedComments, visibleNames, &stats);
-        if (patched == 0) {
-            ApolloLog(@"[DeletedComments] Response patch found no deleted comments to replace for %@ url=%@ (t1=%lu deletedLooking=%lu archivedMatches=%lu recoverable=%lu unrecoverable=%lu overlayInserted=%lu overlayRecoverable=%lu insertedMore=%lu requestedMore=%lu returnedRequested=%lu insertedMissing=%lu skippedMissingNoDelete=%lu exactLookup=%lu exactMatches=%lu archived=%lu)",
-                      linkFullName,
-                      request.URL.absoluteString ?: @"",
-                      (unsigned long)stats.t1Count,
-                      (unsigned long)stats.deletedLookingCount,
-                      (unsigned long)stats.archivedMatchCount,
-                      (unsigned long)stats.recoverableCount,
-                      (unsigned long)stats.unrecoverableCount,
-                      (unsigned long)stats.overlayInsertedCount,
-                      (unsigned long)stats.overlayRecoverableCount,
-                      (unsigned long)stats.insertedFromMoreCount,
-                      (unsigned long)stats.requestedMoreCount,
-                      (unsigned long)stats.returnedRequestedMoreCount,
-                      (unsigned long)stats.insertedMissingMoreCount,
-                      (unsigned long)stats.skippedMissingWithoutDeletionEvidenceCount,
-                      (unsigned long)stats.exactLookupCount,
-                      (unsigned long)stats.exactMatchCount,
-                      (unsigned long)mergedComments.count);
-            completeOnce(data);
-            return;
-        }
-
-        NSData *patchedData = [NSJSONSerialization dataWithJSONObject:root options:0 error:nil];
-        if (patchedData.length == 0) {
-            completeOnce(data);
-            return;
-        }
-        ApolloLog(@"[DeletedComments] Patched Reddit comments response for %@ (%lu comments, visible=%lu, unrecoverable=%lu, overlayInserted=%lu, overlayRecoverable=%lu, insertedMore=%lu, requestedMore=%lu, returnedRequested=%lu, insertedMissing=%lu, skippedMissingNoDelete=%lu, exactLookup=%lu, exactMatches=%lu)",
-                  linkFullName,
-                  (unsigned long)patched,
-                  (unsigned long)stats.recoverableCount,
-                  (unsigned long)stats.unrecoverableCount,
-                  (unsigned long)stats.overlayInsertedCount,
-                  (unsigned long)stats.overlayRecoverableCount,
-                  (unsigned long)stats.insertedFromMoreCount,
-                  (unsigned long)stats.requestedMoreCount,
-                  (unsigned long)stats.returnedRequestedMoreCount,
-                  (unsigned long)stats.insertedMissingMoreCount,
-                  (unsigned long)stats.skippedMissingWithoutDeletionEvidenceCount,
-                  (unsigned long)stats.exactLookupCount,
-                  (unsigned long)stats.exactMatchCount);
-        completeOnce(patchedData);
-    };
-
-    NSArray<NSString *> *requestedMoreChildren = ApolloDeletedCommentsRequestedMoreChildren(request);
-    if (ApolloDeletedCommentsIsMoreChildrenRequest(request) && requestedMoreChildren.count > 0) {
-        NSMutableOrderedSet<NSString *> *moreTargets = [NSMutableOrderedSet orderedSet];
-        for (NSString *fullName in requestedMoreChildren) {
-            ApolloDeletedCommentsAddLookupTarget(moreTargets, fullName);
-        }
-        ApolloDeletedCommentsFetchArcticCommentsByFullNames(moreTargets.array, ^(NSDictionary<NSString *, NSDictionary *> *exactComments) {
-            applyPatchWithComments(exactComments ?: @{}, moreTargets.count, exactComments.count);
-        });
+    NSUInteger changed = ApolloDeletedCommentsMarkDeletedPlaceholdersInJSONNode(root);
+    NSDictionary<NSString *, NSDictionary *> *cached = ApolloDeletedCommentsCachedArcticComments(linkFullName);
+    if (cached.count > 0) {
+        changed += ApolloDeletedCommentsPatchRootWithCachedComments(root, linkFullName, cached);
+        completion(ApolloDeletedCommentsSerializedResponseData(root, data, changed));
         return;
     }
 
+    BOOL shouldWaitForArctic = changed > 0 &&
+                               cached == nil &&
+                               !ApolloDeletedCommentsIsMoreChildrenRequest(request) &&
+                               !ApolloDeletedCommentsArcticIsCoolingDown();
+    if (!shouldWaitForArctic) {
+        completion(ApolloDeletedCommentsSerializedResponseData(root, data, changed));
+        return;
+    }
+
+#ifdef APOLLO_DELETED_COMMENTS_TESTING
+    completion(ApolloDeletedCommentsSerializedResponseData(root, data, changed));
+#else
+    __block BOOL finished = NO;
+    NSObject *finishLock = [NSObject new];
+
+    void (^finish)(NSDictionary<NSString *, NSDictionary *> *) = ^(NSDictionary<NSString *, NSDictionary *> *comments) {
+        @synchronized (finishLock) {
+            if (finished) return;
+            finished = YES;
+        }
+
+        NSUInteger finalChanged = changed;
+        if (comments.count > 0) {
+            finalChanged += ApolloDeletedCommentsPatchRootWithCachedComments(root, linkFullName, comments);
+        }
+        completion(ApolloDeletedCommentsSerializedResponseData(root, data, finalChanged));
+    };
+
     ApolloDeletedCommentsFetchArcticComments(linkFullName, ^(NSDictionary<NSString *, NSDictionary *> *comments) {
-        if (comments.count == 0) {
-            completeOnce(data);
-            return;
-        }
-
-        NSMutableDictionary<NSString *, NSDictionary *> *mergedComments = [comments mutableCopy];
-        NSMutableOrderedSet<NSString *> *exactTargets = [NSMutableOrderedSet orderedSet];
-        ApolloDeletedCommentsCollectExactLookupTargets(root, mergedComments, exactTargets);
-        for (NSString *fullName in requestedMoreChildren) {
-            ApolloDeletedCommentsAddLookupTarget(exactTargets, fullName);
-        }
-        __block NSUInteger exactMatchedCount = 0;
-
-        if (exactTargets.count == 0) {
-            applyPatchWithComments(mergedComments, exactTargets.count, exactMatchedCount);
-            return;
-        }
-
-        ApolloDeletedCommentsFetchArcticCommentsByFullNames(exactTargets.array, ^(NSDictionary<NSString *, NSDictionary *> *exactComments) {
-            exactMatchedCount = exactComments.count;
-            if (exactComments.count > 0) [mergedComments addEntriesFromDictionary:exactComments];
-            applyPatchWithComments(mergedComments, exactTargets.count, exactMatchedCount);
-        });
+        finish(comments);
     });
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(ApolloDeletedCommentsInitialRecoveryWait * NSEC_PER_SEC)),
+                   dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        finish(nil);
+    });
+#endif
 }
 
 #pragma mark - CompletionFacade
 
 ApolloDeletedCommentsURLSessionCompletion ApolloDeletedCommentsMaybeWrapCompletion(NSURLRequest *request, ApolloDeletedCommentsURLSessionCompletion completion) {
     if (!completion || !ApolloDeletedCommentsShouldTransformRequest(request)) return completion;
+
+    if (!ApolloDeletedCommentsIsMoreChildrenRequest(request)) {
+        ApolloDeletedCommentsWarmArcticCacheForLink(ApolloDeletedCommentsLinkFullNameForRequest(request), @"completion wrapper");
+    }
 
     ApolloDeletedCommentsURLSessionCompletion wrapped = ^(NSData *data, NSURLResponse *response, NSError *error) {
         if (error || data.length == 0) {
@@ -1472,6 +1208,9 @@ static void ApolloDeletedCommentsInstallResponseTransformerForDelegate(id delega
 
 void ApolloDeletedCommentsInstallDelegateTransformerIfNeeded(NSURLSession *session, NSURLRequest *request) {
     if (!ApolloDeletedCommentsShouldTransformRequest(request)) return;
+    if (!ApolloDeletedCommentsIsMoreChildrenRequest(request)) {
+        ApolloDeletedCommentsWarmArcticCacheForLink(ApolloDeletedCommentsLinkFullNameForRequest(request), @"delegate transformer");
+    }
     ApolloDeletedCommentsInstallResponseTransformerForDelegate(session.delegate);
 }
 
@@ -1500,5 +1239,13 @@ BOOL ApolloDeletedCommentsTestArcticResponseShouldCooldown(NSInteger statusCode,
 
 NSString *ApolloDeletedCommentsTestDisplayLabelForReason(NSString *reason) {
     return ApolloDeletedCommentsDisplayLabelForReason(reason);
+}
+
+NSUInteger ApolloDeletedCommentsTestMarkDeletedPlaceholdersInRoot(id root) {
+    return ApolloDeletedCommentsMarkDeletedPlaceholdersInJSONNode(root);
+}
+
+NSData *ApolloDeletedCommentsTestPatchResponseImmediate(NSData *data, NSURLRequest *request) {
+    return ApolloDeletedCommentsPatchResponseImmediate(data, request);
 }
 #endif

--- a/src/ApolloDeletedCommentsData.m
+++ b/src/ApolloDeletedCommentsData.m
@@ -23,11 +23,25 @@ static NSMutableSet<NSString *> *sApolloDeletedCommentsRecoveredBodyKeys = nil;
 static NSMutableSet<NSString *> *sApolloDeletedCommentsRevealedFullNames = nil;
 static NSMutableSet<NSString *> *sApolloDeletedCommentsRevealedBodyKeys = nil;
 static NSObject *sApolloDeletedCommentsRegistryLock = nil;
+static NSObject *sApolloDeletedCommentsArcticLock = nil;
+static NSMutableDictionary<NSString *, NSDictionary *> *sApolloDeletedCommentsArcticCache = nil;
+static NSMutableDictionary<NSString *, NSMutableArray *> *sApolloDeletedCommentsArcticInflight = nil;
+static NSDate *sApolloDeletedCommentsArcticCooldownUntil = nil;
 
 static NSString *const ApolloDeletedCommentsMarkerKey = @"apollo_recovered_deleted_comment";
 static NSString *const ApolloDeletedCommentsReasonKey = @"apollo_recovered_deleted_reason";
 static NSString *const ApolloDeletedCommentsReasonUserDeleted = @"user_deleted";
 static NSString *const ApolloDeletedCommentsReasonModeratorRemoved = @"moderator_removed";
+static NSString *const ApolloDeletedCommentsArcticCacheCommentsKey = @"comments";
+static NSString *const ApolloDeletedCommentsArcticCacheExpiryKey = @"expires";
+
+static NSTimeInterval const ApolloDeletedCommentsArcticPatchTimeout = 1.5;
+static NSTimeInterval const ApolloDeletedCommentsArcticSuccessCacheTTL = 600.0;
+static NSTimeInterval const ApolloDeletedCommentsArcticEmptyCacheTTL = 60.0;
+static NSTimeInterval const ApolloDeletedCommentsArcticErrorCooldown = 30.0;
+static NSTimeInterval const ApolloDeletedCommentsArcticRateLimitCooldown = 60.0;
+static NSInteger const ApolloDeletedCommentsArcticLowRemainingThreshold = 3;
+static NSUInteger const ApolloDeletedCommentsArcticMaxExactBatches = 2;
 
 static NSString *ApolloDeletedCommentsTrimmedString(NSString *s);
 static NSString *ApolloDeletedCommentsUnescapedHTMLText(NSString *s);
@@ -548,36 +562,170 @@ static NSDictionary<NSString *, NSDictionary *> *ApolloDeletedCommentsArcticComm
     return comments.count > 0 ? comments : nil;
 }
 
+static NSObject *ApolloDeletedCommentsArcticLock(void) {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sApolloDeletedCommentsArcticLock = [NSObject new];
+    });
+    return sApolloDeletedCommentsArcticLock;
+}
+
+static BOOL ApolloDeletedCommentsArcticIsCoolingDown(void) {
+    @synchronized(ApolloDeletedCommentsArcticLock()) {
+        if (!sApolloDeletedCommentsArcticCooldownUntil) return NO;
+        if ([sApolloDeletedCommentsArcticCooldownUntil timeIntervalSinceNow] <= 0.0) {
+            sApolloDeletedCommentsArcticCooldownUntil = nil;
+            return NO;
+        }
+        return YES;
+    }
+}
+
+static void ApolloDeletedCommentsArcticBeginCooldown(NSTimeInterval seconds, NSString *reason) {
+    if (seconds <= 0.0) return;
+    NSDate *until = [NSDate dateWithTimeIntervalSinceNow:seconds];
+    @synchronized(ApolloDeletedCommentsArcticLock()) {
+        if (!sApolloDeletedCommentsArcticCooldownUntil ||
+            [sApolloDeletedCommentsArcticCooldownUntil timeIntervalSinceDate:until] < 0.0) {
+            sApolloDeletedCommentsArcticCooldownUntil = until;
+        }
+    }
+    ApolloLog(@"[DeletedComments] Arctic cooldown for %.0fs (%@)", seconds, reason ?: @"unknown");
+}
+
+static NSInteger ApolloDeletedCommentsIntegerHeader(NSHTTPURLResponse *http, NSString *name, NSInteger fallback) {
+    id value = http.allHeaderFields[name];
+    if (!value) {
+        NSString *lowerName = [name lowercaseString];
+        for (id key in http.allHeaderFields) {
+            if ([[[key description] lowercaseString] isEqualToString:lowerName]) {
+                value = http.allHeaderFields[key];
+                break;
+            }
+        }
+    }
+    if ([value respondsToSelector:@selector(integerValue)]) return [value integerValue];
+    return fallback;
+}
+
+static BOOL ApolloDeletedCommentsArcticResponseShouldCooldown(NSInteger statusCode, NSInteger remaining) {
+    if (statusCode == 429) return YES;
+    return remaining != NSIntegerMax && remaining <= ApolloDeletedCommentsArcticLowRemainingThreshold;
+}
+
+static void ApolloDeletedCommentsRecordArcticResponse(NSHTTPURLResponse *http, NSError *error) {
+    if (error) {
+        ApolloDeletedCommentsArcticBeginCooldown(ApolloDeletedCommentsArcticErrorCooldown, error.localizedDescription ?: @"network error");
+        return;
+    }
+
+    NSInteger statusCode = http ? http.statusCode : 0;
+    if (statusCode == 429) {
+        NSInteger reset = ApolloDeletedCommentsIntegerHeader(http, @"X-RateLimit-Reset", ApolloDeletedCommentsArcticRateLimitCooldown);
+        ApolloDeletedCommentsArcticBeginCooldown(MAX((NSTimeInterval)reset, ApolloDeletedCommentsArcticRateLimitCooldown), @"rate limited");
+        return;
+    }
+
+    NSInteger remaining = ApolloDeletedCommentsIntegerHeader(http, @"X-RateLimit-Remaining", NSIntegerMax);
+    if (ApolloDeletedCommentsArcticResponseShouldCooldown(statusCode, remaining)) {
+        NSInteger reset = ApolloDeletedCommentsIntegerHeader(http, @"X-RateLimit-Reset", ApolloDeletedCommentsArcticRateLimitCooldown);
+        ApolloDeletedCommentsArcticBeginCooldown(MAX((NSTimeInterval)reset, ApolloDeletedCommentsArcticRateLimitCooldown), @"low remaining quota");
+    }
+}
+
+static NSDictionary<NSString *, NSDictionary *> *ApolloDeletedCommentsCachedArcticComments(NSString *linkFullName) {
+    if (linkFullName.length == 0) return nil;
+    @synchronized(ApolloDeletedCommentsArcticLock()) {
+        NSDictionary *entry = sApolloDeletedCommentsArcticCache[linkFullName];
+        NSDate *expires = [entry[ApolloDeletedCommentsArcticCacheExpiryKey] isKindOfClass:[NSDate class]] ? entry[ApolloDeletedCommentsArcticCacheExpiryKey] : nil;
+        if (!entry || !expires || [expires timeIntervalSinceNow] <= 0.0) {
+            if (entry) [sApolloDeletedCommentsArcticCache removeObjectForKey:linkFullName];
+            return nil;
+        }
+        id comments = entry[ApolloDeletedCommentsArcticCacheCommentsKey];
+        return [comments isKindOfClass:[NSDictionary class]] ? comments : @{};
+    }
+}
+
+static void ApolloDeletedCommentsStoreArcticComments(NSString *linkFullName, NSDictionary<NSString *, NSDictionary *> *comments, NSTimeInterval ttl) {
+    if (linkFullName.length == 0 || ttl <= 0.0) return;
+    @synchronized(ApolloDeletedCommentsArcticLock()) {
+        if (!sApolloDeletedCommentsArcticCache) sApolloDeletedCommentsArcticCache = [NSMutableDictionary dictionary];
+        sApolloDeletedCommentsArcticCache[linkFullName] = @{
+            ApolloDeletedCommentsArcticCacheCommentsKey: comments ?: @{},
+            ApolloDeletedCommentsArcticCacheExpiryKey: [NSDate dateWithTimeIntervalSinceNow:ttl],
+        };
+    }
+}
+
+static void ApolloDeletedCommentsFinishInflightArcticFetch(NSString *linkFullName, NSDictionary<NSString *, NSDictionary *> *comments) {
+    NSArray *completions = nil;
+    @synchronized(ApolloDeletedCommentsArcticLock()) {
+        completions = [sApolloDeletedCommentsArcticInflight[linkFullName] copy];
+        [sApolloDeletedCommentsArcticInflight removeObjectForKey:linkFullName];
+    }
+    for (id block in completions) {
+        void (^completion)(NSDictionary<NSString *, NSDictionary *> *) = block;
+        completion(comments ?: @{});
+    }
+}
+
 static void ApolloDeletedCommentsFetchArcticComments(NSString *linkFullName, void (^completion)(NSDictionary<NSString *, NSDictionary *> *comments)) {
     if (linkFullName.length == 0) {
         completion(nil);
         return;
     }
 
+    NSDictionary *cached = ApolloDeletedCommentsCachedArcticComments(linkFullName);
+    if (cached) {
+        completion(cached);
+        return;
+    }
+
+    if (ApolloDeletedCommentsArcticIsCoolingDown()) {
+        completion(@{});
+        return;
+    }
+
+    @synchronized(ApolloDeletedCommentsArcticLock()) {
+        if (!sApolloDeletedCommentsArcticInflight) sApolloDeletedCommentsArcticInflight = [NSMutableDictionary dictionary];
+        NSMutableArray *waiting = sApolloDeletedCommentsArcticInflight[linkFullName];
+        if (waiting) {
+            [waiting addObject:[completion copy]];
+            return;
+        }
+        sApolloDeletedCommentsArcticInflight[linkFullName] = [NSMutableArray arrayWithObject:[completion copy]];
+    }
+
     NSURLComponents *components = [NSURLComponents componentsWithString:@"https://arctic-shift.photon-reddit.com/api/comments/tree"];
     components.queryItems = @[
         [NSURLQueryItem queryItemWithName:@"link_id" value:linkFullName],
-        [NSURLQueryItem queryItemWithName:@"limit" value:@"25000"],
-        [NSURLQueryItem queryItemWithName:@"start_depth" value:@"99"],
-        [NSURLQueryItem queryItemWithName:@"start_breadth" value:@"99"],
+        [NSURLQueryItem queryItemWithName:@"limit" value:@"5000"],
+        [NSURLQueryItem queryItemWithName:@"start_depth" value:@"20"],
+        [NSURLQueryItem queryItemWithName:@"start_breadth" value:@"50"],
         [NSURLQueryItem queryItemWithName:@"md2html" value:@"false"],
     ];
     NSURL *url = components.URL;
     if (!url) {
-        completion(nil);
+        ApolloDeletedCommentsFinishInflightArcticFetch(linkFullName, @{});
         return;
     }
 
-    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+    NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:url];
+    urlRequest.timeoutInterval = 10.0;
+
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         NSDictionary *comments = nil;
+        NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
+        ApolloDeletedCommentsRecordArcticResponse(http, error);
         if (!error && data.length > 0) {
-            NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
             if (!http || (http.statusCode >= 200 && http.statusCode < 300)) {
                 id root = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
                 comments = ApolloDeletedCommentsArcticCommentMapFromRoot(root);
             }
         }
-        completion(comments);
+        ApolloDeletedCommentsStoreArcticComments(linkFullName, comments ?: @{}, comments.count > 0 ? ApolloDeletedCommentsArcticSuccessCacheTTL : ApolloDeletedCommentsArcticEmptyCacheTTL);
+        ApolloDeletedCommentsFinishInflightArcticFetch(linkFullName, comments ?: @{});
     }];
     [task resume];
 }
@@ -598,6 +746,10 @@ static void ApolloDeletedCommentsFetchArcticCommentsByFullNames(NSArray<NSString
         completion(@{});
         return;
     }
+    if (ApolloDeletedCommentsArcticIsCoolingDown()) {
+        completion(@{});
+        return;
+    }
 
     NSMutableOrderedSet<NSString *> *baseIDs = [NSMutableOrderedSet orderedSet];
     for (NSString *fullName in fullNames) {
@@ -609,7 +761,8 @@ static void ApolloDeletedCommentsFetchArcticCommentsByFullNames(NSArray<NSString
         return;
     }
 
-    NSArray<NSArray<NSString *> *> *batches = ApolloDeletedCommentsBatches(baseIDs.array, 250);
+    NSArray<NSArray<NSString *> *> *allBatches = ApolloDeletedCommentsBatches(baseIDs.array, 250);
+    NSArray<NSArray<NSString *> *> *batches = allBatches.count > ApolloDeletedCommentsArcticMaxExactBatches ? [allBatches subarrayWithRange:NSMakeRange(0, ApolloDeletedCommentsArcticMaxExactBatches)] : allBatches;
     NSMutableDictionary<NSString *, NSDictionary *> *merged = [NSMutableDictionary dictionary];
     __block NSUInteger nextIndex = 0;
     __block void (^fetchNext)(void) = nil;
@@ -632,9 +785,13 @@ static void ApolloDeletedCommentsFetchArcticCommentsByFullNames(NSArray<NSString
             return;
         }
 
-        NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:url];
+        urlRequest.timeoutInterval = 10.0;
+
+        NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
+            ApolloDeletedCommentsRecordArcticResponse(http, error);
             if (!error && data.length > 0) {
-                NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
                 if (!http || (http.statusCode >= 200 && http.statusCode < 300)) {
                     id root = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
                     NSDictionary *comments = ApolloDeletedCommentsArcticCommentMapFromFlatData(root);
@@ -1063,61 +1220,53 @@ static void ApolloDeletedCommentsPatchResponseAsync(NSData *data, NSURLRequest *
         return;
     }
 
-    ApolloDeletedCommentsFetchArcticComments(linkFullName, ^(NSDictionary<NSString *, NSDictionary *> *comments) {
-        if (comments.count == 0) {
-            completion(data);
+    NSObject *completionLock = [NSObject new];
+    __block BOOL didComplete = NO;
+    void (^completeOnce)(NSData *) = ^(NSData *patchedData) {
+        BOOL shouldComplete = NO;
+        @synchronized(completionLock) {
+            if (!didComplete) {
+                didComplete = YES;
+                shouldComplete = YES;
+            }
+        }
+        if (shouldComplete) completion(patchedData.length > 0 ? patchedData : data);
+    };
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(ApolloDeletedCommentsArcticPatchTimeout * NSEC_PER_SEC)), dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        BOOL timedOut = NO;
+        @synchronized(completionLock) {
+            timedOut = !didComplete;
+        }
+        if (timedOut) {
+            ApolloLog(@"[DeletedComments] Arctic patch timed out for %@; delivering original Reddit comments", linkFullName);
+            ApolloDeletedCommentsArcticBeginCooldown(ApolloDeletedCommentsArcticErrorCooldown, @"patch timeout");
+            completeOnce(data);
+        }
+    });
+
+    void (^applyPatchWithComments)(NSDictionary<NSString *, NSDictionary *> *, NSUInteger, NSUInteger) = ^(NSDictionary<NSString *, NSDictionary *> *mergedComments, NSUInteger exactLookupCount, NSUInteger exactMatchedCount) {
+        if (mergedComments.count == 0) {
+            completeOnce(data);
             return;
         }
 
-        NSMutableDictionary<NSString *, NSDictionary *> *mergedComments = [comments mutableCopy];
-        NSMutableOrderedSet<NSString *> *exactTargets = [NSMutableOrderedSet orderedSet];
-        ApolloDeletedCommentsCollectExactLookupTargets(root, mergedComments, exactTargets);
-        for (NSString *fullName in ApolloDeletedCommentsRequestedMoreChildren(request)) {
-            ApolloDeletedCommentsAddLookupTarget(exactTargets, fullName);
-        }
-        __block NSUInteger exactMatchedCount = 0;
-
-        void (^applyPatch)(void) = ^{
-            NSMutableSet<NSString *> *visibleNames = [NSMutableSet set];
-            ApolloDeletedCommentsCollectVisibleCommentNames(root, visibleNames);
-            ApolloDeletedCommentsPatchStats stats = {0};
-            stats.exactLookupCount = exactTargets.count;
-            stats.exactMatchCount = exactMatchedCount;
-            NSDictionary<NSString *, NSArray<NSDictionary *> *> *childrenByParent = ApolloDeletedCommentsRecoverableChildrenByParent(mergedComments, &stats);
-            NSUInteger patched = ApolloDeletedCommentsOverlayArchivedDeletedComments(root, linkFullName, childrenByParent, visibleNames, &stats);
-            patched += ApolloDeletedCommentsPatchRedditJSONNode(root, mergedComments, visibleNames, &stats);
-            patched += ApolloDeletedCommentsInsertMissingMoreChildren(root, request, mergedComments, visibleNames, &stats);
-            if (patched == 0) {
-                ApolloLog(@"[DeletedComments] Response patch found no deleted comments to replace for %@ url=%@ (t1=%lu deletedLooking=%lu archivedMatches=%lu recoverable=%lu unrecoverable=%lu overlayInserted=%lu overlayRecoverable=%lu insertedMore=%lu requestedMore=%lu returnedRequested=%lu insertedMissing=%lu skippedMissingNoDelete=%lu exactLookup=%lu exactMatches=%lu archived=%lu)",
-                          linkFullName,
-                          request.URL.absoluteString ?: @"",
-                          (unsigned long)stats.t1Count,
-                          (unsigned long)stats.deletedLookingCount,
-                          (unsigned long)stats.archivedMatchCount,
-                          (unsigned long)stats.recoverableCount,
-                          (unsigned long)stats.unrecoverableCount,
-                          (unsigned long)stats.overlayInsertedCount,
-                          (unsigned long)stats.overlayRecoverableCount,
-                          (unsigned long)stats.insertedFromMoreCount,
-                          (unsigned long)stats.requestedMoreCount,
-                          (unsigned long)stats.returnedRequestedMoreCount,
-                          (unsigned long)stats.insertedMissingMoreCount,
-                          (unsigned long)stats.skippedMissingWithoutDeletionEvidenceCount,
-                          (unsigned long)stats.exactLookupCount,
-                          (unsigned long)stats.exactMatchCount,
-                          (unsigned long)mergedComments.count);
-                completion(data);
-                return;
-            }
-
-            NSData *patchedData = [NSJSONSerialization dataWithJSONObject:root options:0 error:nil];
-            if (patchedData.length == 0) {
-                completion(data);
-                return;
-            }
-            ApolloLog(@"[DeletedComments] Patched Reddit comments response for %@ (%lu comments, visible=%lu, unrecoverable=%lu, overlayInserted=%lu, overlayRecoverable=%lu, insertedMore=%lu, requestedMore=%lu, returnedRequested=%lu, insertedMissing=%lu, skippedMissingNoDelete=%lu, exactLookup=%lu, exactMatches=%lu)",
+        NSMutableSet<NSString *> *visibleNames = [NSMutableSet set];
+        ApolloDeletedCommentsCollectVisibleCommentNames(root, visibleNames);
+        ApolloDeletedCommentsPatchStats stats = {0};
+        stats.exactLookupCount = exactLookupCount;
+        stats.exactMatchCount = exactMatchedCount;
+        NSDictionary<NSString *, NSArray<NSDictionary *> *> *childrenByParent = ApolloDeletedCommentsRecoverableChildrenByParent(mergedComments, &stats);
+        NSUInteger patched = ApolloDeletedCommentsOverlayArchivedDeletedComments(root, linkFullName, childrenByParent, visibleNames, &stats);
+        patched += ApolloDeletedCommentsPatchRedditJSONNode(root, mergedComments, visibleNames, &stats);
+        patched += ApolloDeletedCommentsInsertMissingMoreChildren(root, request, mergedComments, visibleNames, &stats);
+        if (patched == 0) {
+            ApolloLog(@"[DeletedComments] Response patch found no deleted comments to replace for %@ url=%@ (t1=%lu deletedLooking=%lu archivedMatches=%lu recoverable=%lu unrecoverable=%lu overlayInserted=%lu overlayRecoverable=%lu insertedMore=%lu requestedMore=%lu returnedRequested=%lu insertedMissing=%lu skippedMissingNoDelete=%lu exactLookup=%lu exactMatches=%lu archived=%lu)",
                       linkFullName,
-                      (unsigned long)patched,
+                      request.URL.absoluteString ?: @"",
+                      (unsigned long)stats.t1Count,
+                      (unsigned long)stats.deletedLookingCount,
+                      (unsigned long)stats.archivedMatchCount,
                       (unsigned long)stats.recoverableCount,
                       (unsigned long)stats.unrecoverableCount,
                       (unsigned long)stats.overlayInsertedCount,
@@ -1128,19 +1277,69 @@ static void ApolloDeletedCommentsPatchResponseAsync(NSData *data, NSURLRequest *
                       (unsigned long)stats.insertedMissingMoreCount,
                       (unsigned long)stats.skippedMissingWithoutDeletionEvidenceCount,
                       (unsigned long)stats.exactLookupCount,
-                      (unsigned long)stats.exactMatchCount);
-            completion(patchedData);
-        };
+                      (unsigned long)stats.exactMatchCount,
+                      (unsigned long)mergedComments.count);
+            completeOnce(data);
+            return;
+        }
+
+        NSData *patchedData = [NSJSONSerialization dataWithJSONObject:root options:0 error:nil];
+        if (patchedData.length == 0) {
+            completeOnce(data);
+            return;
+        }
+        ApolloLog(@"[DeletedComments] Patched Reddit comments response for %@ (%lu comments, visible=%lu, unrecoverable=%lu, overlayInserted=%lu, overlayRecoverable=%lu, insertedMore=%lu, requestedMore=%lu, returnedRequested=%lu, insertedMissing=%lu, skippedMissingNoDelete=%lu, exactLookup=%lu, exactMatches=%lu)",
+                  linkFullName,
+                  (unsigned long)patched,
+                  (unsigned long)stats.recoverableCount,
+                  (unsigned long)stats.unrecoverableCount,
+                  (unsigned long)stats.overlayInsertedCount,
+                  (unsigned long)stats.overlayRecoverableCount,
+                  (unsigned long)stats.insertedFromMoreCount,
+                  (unsigned long)stats.requestedMoreCount,
+                  (unsigned long)stats.returnedRequestedMoreCount,
+                  (unsigned long)stats.insertedMissingMoreCount,
+                  (unsigned long)stats.skippedMissingWithoutDeletionEvidenceCount,
+                  (unsigned long)stats.exactLookupCount,
+                  (unsigned long)stats.exactMatchCount);
+        completeOnce(patchedData);
+    };
+
+    NSArray<NSString *> *requestedMoreChildren = ApolloDeletedCommentsRequestedMoreChildren(request);
+    if (ApolloDeletedCommentsIsMoreChildrenRequest(request) && requestedMoreChildren.count > 0) {
+        NSMutableOrderedSet<NSString *> *moreTargets = [NSMutableOrderedSet orderedSet];
+        for (NSString *fullName in requestedMoreChildren) {
+            ApolloDeletedCommentsAddLookupTarget(moreTargets, fullName);
+        }
+        ApolloDeletedCommentsFetchArcticCommentsByFullNames(moreTargets.array, ^(NSDictionary<NSString *, NSDictionary *> *exactComments) {
+            applyPatchWithComments(exactComments ?: @{}, moreTargets.count, exactComments.count);
+        });
+        return;
+    }
+
+    ApolloDeletedCommentsFetchArcticComments(linkFullName, ^(NSDictionary<NSString *, NSDictionary *> *comments) {
+        if (comments.count == 0) {
+            completeOnce(data);
+            return;
+        }
+
+        NSMutableDictionary<NSString *, NSDictionary *> *mergedComments = [comments mutableCopy];
+        NSMutableOrderedSet<NSString *> *exactTargets = [NSMutableOrderedSet orderedSet];
+        ApolloDeletedCommentsCollectExactLookupTargets(root, mergedComments, exactTargets);
+        for (NSString *fullName in requestedMoreChildren) {
+            ApolloDeletedCommentsAddLookupTarget(exactTargets, fullName);
+        }
+        __block NSUInteger exactMatchedCount = 0;
 
         if (exactTargets.count == 0) {
-            applyPatch();
+            applyPatchWithComments(mergedComments, exactTargets.count, exactMatchedCount);
             return;
         }
 
         ApolloDeletedCommentsFetchArcticCommentsByFullNames(exactTargets.array, ^(NSDictionary<NSString *, NSDictionary *> *exactComments) {
             exactMatchedCount = exactComments.count;
             if (exactComments.count > 0) [mergedComments addEntriesFromDictionary:exactComments];
-            applyPatch();
+            applyPatchWithComments(mergedComments, exactTargets.count, exactMatchedCount);
         });
     });
 }
@@ -1262,5 +1461,9 @@ NSUInteger ApolloDeletedCommentsTestPatchRedditJSONRoot(id root, NSDictionary<NS
     ApolloDeletedCommentsCollectVisibleCommentNames(root, visibleNames);
     ApolloDeletedCommentsPatchStats stats = {0};
     return ApolloDeletedCommentsPatchRedditJSONNode(root, archivedComments, visibleNames, &stats);
+}
+
+BOOL ApolloDeletedCommentsTestArcticResponseShouldCooldown(NSInteger statusCode, NSInteger remaining) {
+    return ApolloDeletedCommentsArcticResponseShouldCooldown(statusCode, remaining);
 }
 #endif

--- a/src/ApolloDeletedCommentsData.m
+++ b/src/ApolloDeletedCommentsData.m
@@ -399,7 +399,7 @@ static BOOL ApolloDeletedCommentsCommentDataLooksDeleted(NSDictionary *data) {
     if (trimmedBody.length > 0 && ApolloDeletedCommentsBodyLooksDeleted(body)) return YES;
 
     NSString *bodyHTML = [data[@"body_html"] isKindOfClass:[NSString class]] ? data[@"body_html"] : nil;
-    if (bodyHTML.length > 0) {
+    if (trimmedBody.length == 0 && bodyHTML.length > 0) {
         NSString *htmlText = ApolloDeletedCommentsUnescapedHTMLText(bodyHTML);
         if ([htmlText rangeOfString:@"[removed]" options:NSCaseInsensitiveSearch].location != NSNotFound ||
             [htmlText rangeOfString:@"[deleted]" options:NSCaseInsensitiveSearch].location != NSNotFound ||

--- a/src/ApolloDeletedCommentsData.m
+++ b/src/ApolloDeletedCommentsData.m
@@ -511,8 +511,13 @@ static void ApolloDeletedCommentsSetRecoveredBody(NSMutableDictionary *data, NSS
 }
 
 static void ApolloDeletedCommentsHideRecoveredBodyForTapToReveal(NSMutableDictionary *data, NSString *reason) {
-    if (!sTapToRevealDeletedComments) return;
-    ApolloDeletedCommentsSetRecoveredBody(data, ApolloDeletedCommentsDisplayLabelForReason(reason));
+    if (!sTapToRevealDeletedComments || !data) return;
+    NSString *label = ApolloDeletedCommentsDisplayLabelForReason(reason);
+    if (label.length == 0) return;
+
+    data[@"body"] = label;
+    NSString *bodyHTML = ApolloDeletedCommentsRedditBodyHTML(label);
+    if (bodyHTML.length > 0) data[@"body_html"] = bodyHTML;
 }
 
 static void ApolloDeletedCommentsSetObjectValue(id object, SEL selector, id value) {
@@ -885,6 +890,9 @@ static NSMutableDictionary *ApolloDeletedCommentsThingFromArchived(NSDictionary 
 
     NSString *body = ApolloDeletedCommentsTrimmedString([archived[@"body"] isKindOfClass:[NSString class]] ? archived[@"body"] : nil);
     if (identifier.length == 0 || body.length == 0 || ApolloDeletedCommentsBodyLooksDeleted(body)) return nil;
+    if (fullName.length > 0) {
+        ApolloDeletedCommentsStoreArchivedCommentsByFullName(@{fullName: archived});
+    }
 
     NSString *author = [archived[@"author"] isKindOfClass:[NSString class]] ? archived[@"author"] : @"[deleted]";
     NSMutableDictionary *data = [NSMutableDictionary dictionary];
@@ -949,6 +957,9 @@ static NSUInteger ApolloDeletedCommentsPatchRedditJSONNode(id node, NSDictionary
             if (currentLooksDeleted && archivedBody.length > 0 && !ApolloDeletedCommentsBodyLooksDeleted(archivedBody)) {
                 if (stats) stats->recoverableCount++;
                 NSString *author = [archived[@"author"] isKindOfClass:[NSString class]] ? archived[@"author"] : nil;
+                if (fullName.length > 0) {
+                    ApolloDeletedCommentsStoreArchivedCommentsByFullName(@{fullName: archived});
+                }
                 ApolloDeletedCommentsSetRecoveredBody(data, archivedBody);
                 if (author.length > 0) data[@"author"] = author;
                 if ([archived[@"created_utc"] respondsToSelector:@selector(doubleValue)]) data[@"created_utc"] = archived[@"created_utc"];

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -41,6 +41,7 @@ static const void *kApolloDeletedCommentsBodyReplacementTextNodeKey = &kApolloDe
 static const void *kApolloDeletedCommentsOriginalBodyKey = &kApolloDeletedCommentsOriginalBodyKey;
 static const void *kApolloDeletedCommentsOriginalBodyHTMLKey = &kApolloDeletedCommentsOriginalBodyHTMLKey;
 static const void *kApolloDeletedCommentsHostLayoutRefreshScheduledKey = &kApolloDeletedCommentsHostLayoutRefreshScheduledKey;
+static const void *kApolloDeletedCommentsRevealToggleInFlightKey = &kApolloDeletedCommentsRevealToggleInFlightKey;
 
 static NSMutableDictionary<NSString *, NSHashTable *> *sApolloDeletedCommentsVisibleCellsByFullName = nil;
 static NSObject *sApolloDeletedCommentsVisibleCellsLock = nil;
@@ -602,6 +603,23 @@ static void ApolloDeletedCommentsRelayoutCellAndTextNode(id cellNode, id textNod
         }
     }
     ApolloDeletedCommentsScheduleHostLayoutRefresh(cellNode);
+}
+
+static void ApolloDeletedCommentsInvalidateCellAndTextNodeLocally(id cellNode, id textNode) {
+    SEL selectors[] = {
+        @selector(invalidateCalculatedLayout),
+        @selector(setNeedsLayout),
+        @selector(setNeedsDisplay),
+    };
+    for (size_t i = 0; i < sizeof(selectors) / sizeof(selectors[0]); i++) {
+        SEL sel = selectors[i];
+        if ([textNode respondsToSelector:sel]) {
+            @try { ((void (*)(id, SEL))objc_msgSend)(textNode, sel); } @catch (__unused NSException *e) {}
+        }
+        if ([cellNode respondsToSelector:sel]) {
+            @try { ((void (*)(id, SEL))objc_msgSend)(cellNode, sel); } @catch (__unused NSException *e) {}
+        }
+    }
 }
 
 static NSAttributedString *ApolloDeletedCommentsPlaceholderAttributedText(NSAttributedString *original, NSString *reasonLabel) {
@@ -1609,10 +1627,11 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyRevealedBodyTextTo
 
     ApolloDeletedCommentsSetTextNodeAttributedText(textNode, bodyText);
     ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
-    ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
+    ApolloDeletedCommentsInvalidateCellAndTextNodeLocally(cellNode, textNode);
 }
 
 static void __attribute__((unused)) ApolloDeletedCommentsRevealHiddenBodyForCell(id cellNode, id tappedTextNode) {
+    (void)tappedTextNode;
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     if (!comment || fullName.length == 0) return;
@@ -1643,7 +1662,6 @@ static void __attribute__((unused)) ApolloDeletedCommentsRevealHiddenBodyForCell
     ApolloDeletedCommentsRestoreOriginalModelBodyIfNeeded(comment);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    (void)tappedTextNode;
     ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyContainerNode(cellNode));
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyTextNode(cellNode));
@@ -1665,17 +1683,56 @@ static BOOL __attribute__((unused)) ApolloDeletedCommentsTouchHitsRecoveredBody(
 }
 
 static void __attribute__((unused)) ApolloDeletedCommentsHideRevealedBodyForCell(id cellNode, id tappedTextNode) {
+    (void)tappedTextNode;
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     if (!comment) return;
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     ApolloDeletedCommentsUnmarkCommentRevealed(fullName);
     objc_setAssociatedObject(comment, kApolloDeletedCommentsSuppressNextCollapseKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
-    (void)tappedTextNode;
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyContainerNode(cellNode));
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyTextNode(cellNode));
+}
+
+static void ApolloDeletedCommentsScheduleRevealToggleForTextNode(id cellNode, id textNode) {
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    if (!cellNode || !textNode || !comment || fullName.length == 0) return;
+    if ([objc_getAssociatedObject((id)comment, kApolloDeletedCommentsRevealToggleInFlightKey) boolValue]) return;
+
+    BOOL shouldHide = ApolloDeletedCommentsCommentIsRevealedByFullName(comment);
+    objc_setAssociatedObject((id)comment, kApolloDeletedCommentsRevealToggleInFlightKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    __weak id weakCellNode = cellNode;
+    __weak id weakTextNode = textNode;
+    __weak RDKComment *weakComment = comment;
+    NSString *capturedFullName = [fullName copy];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        id currentCellNode = weakCellNode;
+        id currentTextNode = weakTextNode;
+        RDKComment *currentComment = ApolloDeletedCommentsCommentFromCellNode(currentCellNode);
+        if (!currentComment) currentComment = weakComment;
+
+        @try {
+            NSString *currentFullName = ApolloDeletedCommentsFullNameForComment(currentComment);
+            if (currentCellNode && currentTextNode && [currentFullName isEqualToString:capturedFullName]) {
+                if (shouldHide) {
+                    ApolloDeletedCommentsHideRevealedBodyForCell(currentCellNode, currentTextNode);
+                } else {
+                    ApolloDeletedCommentsRevealHiddenBodyForCell(currentCellNode, currentTextNode);
+                }
+            }
+        } @catch (__unused NSException *e) {
+        } @finally {
+            RDKComment *clearComment = currentComment ?: weakComment;
+            if (clearComment) {
+                objc_setAssociatedObject((id)clearComment, kApolloDeletedCommentsRevealToggleInFlightKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            }
+        }
+    });
 }
 
 static id ApolloDeletedCommentsCommentCellNodeForTextNode(id textNode) {
@@ -1879,7 +1936,8 @@ static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpec
         objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
         displayText = ApolloDeletedCommentsBodyAttributedText(templateText, comment.body);
-        if (!sTapToRevealDeletedComments) {
+        BOOL shouldAppendReasonChip = !sTapToRevealDeletedComments || (recovered && revealed);
+        if (shouldAppendReasonChip) {
             NSDictionary *baseAttributes = displayText.length > 0 ? ([displayText attributesAtIndex:0 effectiveRange:NULL] ?: @{}) : @{};
             NSMutableDictionary *spacerAttributes = [baseAttributes mutableCopy];
             NSMutableParagraphStyle *spacerStyle = [NSMutableParagraphStyle new];
@@ -1888,7 +1946,9 @@ static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpec
             spacerAttributes[NSParagraphStyleAttributeName] = spacerStyle;
             NSMutableAttributedString *decorated = [displayText mutableCopy];
             [decorated appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n" attributes:spacerAttributes]];
-            [decorated appendAttributedString:ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment), baseAttributes, NO)];
+            [decorated appendAttributedString:ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment),
+                                                                                            baseAttributes,
+                                                                                            sTapToRevealDeletedComments && recovered && revealed)];
             displayText = decorated;
         }
     }
@@ -2256,12 +2316,7 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRe
 - (void)textNode:(id)textNode tappedLinkAttribute:(id)attribute value:(id)value atPoint:(CGPoint)point textRange:(NSRange)range {
     if (ApolloDeletedCommentsIsRevealLink(attribute, value)) {
         id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
-        RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
-        if (ApolloDeletedCommentsCommentIsRevealedByFullName(comment)) {
-            ApolloDeletedCommentsHideRevealedBodyForCell(cellNode, textNode);
-        } else {
-            ApolloDeletedCommentsRevealHiddenBodyForCell(cellNode, textNode);
-        }
+        ApolloDeletedCommentsScheduleRevealToggleForTextNode(cellNode, textNode);
         return;
     }
     %orig(textNode, attribute, value, point, range);

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -290,7 +290,7 @@ static NSString *ApolloDeletedCommentsBodyByAppendingReasonLabel(NSString *body,
     return [NSString stringWithFormat:@"%@\n\n%@", trimmedBody, normalizedLabel];
 }
 
-static NSString *ApolloDeletedCommentsBodyHTMLByAppendingReasonLabel(NSString *bodyHTML, NSString *body, NSString *label) {
+static NSString *__attribute__((unused)) ApolloDeletedCommentsBodyHTMLByAppendingReasonLabel(NSString *bodyHTML, NSString *body, NSString *label) {
     NSString *normalizedLabel = ApolloDeletedCommentsNormalizedReasonLabel(label);
     if (normalizedLabel.length == 0) return bodyHTML;
 
@@ -323,6 +323,41 @@ static BOOL ApolloDeletedCommentsStringIsReasonLabel(NSString *text) {
            [normalized isEqualToString:@"DELETED BY USER"] ||
            [normalized isEqualToString:@"LOADING..."] ||
            [normalized isEqualToString:@"NOT AVAILABLE"];
+}
+
+static NSString *ApolloDeletedCommentsRecoverableArchivedBody(NSDictionary *archived) {
+    NSString *body = ApolloDeletedCommentsTrimmedString([archived[@"body"] isKindOfClass:[NSString class]] ? archived[@"body"] : nil);
+    if (body.length == 0) return nil;
+    if (ApolloDeletedCommentsStringIsReasonLabel(body)) return nil;
+    if (ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(body)) return nil;
+    return body;
+}
+
+static BOOL ApolloDeletedCommentsAuthorLooksDeleted(NSString *author) {
+    NSString *trimmed = ApolloDeletedCommentsTrimmedString(author).lowercaseString;
+    return trimmed.length == 0 ||
+           [trimmed isEqualToString:@"[deleted]"] ||
+           [trimmed isEqualToString:@"[removed]"] ||
+           [trimmed isEqualToString:@"deleted"] ||
+           [trimmed isEqualToString:@"removed"];
+}
+
+static BOOL ApolloDeletedCommentsVisibleCommentNeedsRecoveredArchive(RDKComment *comment, NSString *archivedBody) {
+    if (!comment || archivedBody.length == 0) return NO;
+
+    NSString *savedBody = objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey);
+    BOOL savedBodyMatches = [savedBody isKindOfClass:[NSString class]] &&
+                            (ApolloDeletedCommentsTextQualifiesAsBodyCandidate(savedBody, archivedBody) ||
+                             ApolloDeletedCommentsTextQualifiesAsBodyFragment(savedBody, archivedBody));
+    BOOL authorLooksDeleted = ApolloDeletedCommentsAuthorLooksDeleted(comment.author);
+    if (savedBodyMatches && !authorLooksDeleted) return NO;
+
+    NSString *currentBody = comment.body;
+    BOOL currentLooksPlaceholder = ApolloDeletedCommentsStringIsReasonLabel(currentBody) ||
+                                   ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(currentBody);
+    BOOL currentBodyMatches = ApolloDeletedCommentsTextQualifiesAsBodyCandidate(currentBody, archivedBody) ||
+                              ApolloDeletedCommentsTextQualifiesAsBodyFragment(currentBody, archivedBody);
+    return authorLooksDeleted || currentLooksPlaceholder || !currentBodyMatches;
 }
 
 static void ApolloDeletedCommentsRememberOriginalModelBodyIfNeeded(RDKComment *comment) {
@@ -358,7 +393,7 @@ static BOOL ApolloDeletedCommentsRestoreOriginalModelBodyIfNeeded(RDKComment *co
     return YES;
 }
 
-static void ApolloDeletedCommentsSetModelBodyToReasonLabel(RDKComment *comment, NSString *label) {
+static void __attribute__((unused)) ApolloDeletedCommentsSetModelBodyToReasonLabel(RDKComment *comment, NSString *label) {
     if (!comment || label.length == 0) return;
     if (![comment.body isEqualToString:label]) {
         ApolloDeletedCommentsSetCommentStringValue(comment, @selector(setBody:), label);
@@ -381,24 +416,16 @@ static void ApolloDeletedCommentsSynchronizeCommentModelDisplayState(id cellNode
     if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return;
 
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
-    NSString *label = ApolloDeletedCommentsReasonLabelForComment(comment);
     BOOL placeholderOnly = ApolloDeletedCommentsIsDeletedPlaceholder(fullName) &&
                            !ApolloDeletedCommentsIsRecoveredComment(fullName);
     BOOL recovered = ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode);
-    BOOL revealed = ApolloDeletedCommentsCommentIsRevealedByFullName(comment);
 
     if (placeholderOnly) {
-        ApolloDeletedCommentsSetModelBodyToReasonLabel(comment, label);
-        return;
-    }
-
-    if (recovered && sTapToRevealDeletedComments && !revealed) {
-        ApolloDeletedCommentsRememberOriginalModelBodyIfNeeded(comment);
-        ApolloDeletedCommentsSetModelBodyToReasonLabel(comment, label);
         return;
     }
 
     if (recovered) {
+        ApolloDeletedCommentsRememberOriginalModelBodyIfNeeded(comment);
         ApolloDeletedCommentsRestoreOriginalModelBodyIfNeeded(comment);
     }
 }
@@ -412,7 +439,7 @@ static NSString *ApolloDeletedCommentsReasonLabelForCommentAndBody(RDKComment *c
     return ApolloDeletedCommentsNormalizedReasonLabel(label);
 }
 
-static NSString *ApolloDeletedCommentsHiddenReasonLabelForCommentBody(RDKComment *comment, NSString *body) {
+static NSString *__attribute__((unused)) ApolloDeletedCommentsHiddenReasonLabelForCommentBody(RDKComment *comment, NSString *body) {
     if (!sShowDeletedComments || !comment) return nil;
 
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
@@ -1571,7 +1598,7 @@ static BOOL __attribute__((unused)) ApolloDeletedCommentsTouchHitsHiddenBody(id 
     return NO;
 }
 
-static void ApolloDeletedCommentsApplyRevealedBodyTextToNode(id cellNode, id textNode) {
+static void __attribute__((unused)) ApolloDeletedCommentsApplyRevealedBodyTextToNode(id cellNode, id textNode) {
     if (!cellNode || !textNode) return;
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
@@ -1596,8 +1623,6 @@ static void __attribute__((unused)) ApolloDeletedCommentsRevealHiddenBodyForCell
     if (!comment || fullName.length == 0) return;
 
     if (ApolloDeletedCommentsIsDeletedPlaceholder(fullName) && !ApolloDeletedCommentsIsRecoveredComment(fullName)) {
-        ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
-        ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyContainerNode(cellNode));
         return;
     }
 
@@ -1606,8 +1631,14 @@ static void __attribute__((unused)) ApolloDeletedCommentsRevealHiddenBodyForCell
         NSDictionary *archived = ApolloDeletedCommentsCachedArchivedComment(fullName);
         if (archived.count > 0) {
             NSString *reason = ApolloDeletedCommentsDeletedPlaceholderReason(fullName) ?: ApolloDeletedCommentsRecoveredReasonForComment(fullName);
-            ApolloDeletedCommentsApplyRecoveredArchivedCommentToObject((id)comment, archived, reason);
-            restored = YES;
+            NSString *archivedBody = ApolloDeletedCommentsRecoverableArchivedBody(archived);
+            if (ApolloDeletedCommentsApplyRecoveredArchivedCommentToObject((id)comment, archived, reason)) {
+                if (archivedBody.length > 0) {
+                    objc_setAssociatedObject((id)comment, kApolloDeletedCommentsOriginalBodyKey, [archivedBody copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+                    objc_setAssociatedObject((id)comment, kApolloDeletedCommentsOriginalBodyHTMLKey, ApolloDeletedCommentsPlainBodyHTML(archivedBody), OBJC_ASSOCIATION_COPY_NONATOMIC);
+                }
+                restored = YES;
+            }
         }
     }
     if (!restored && ApolloDeletedCommentsStringIsReasonLabel(comment.body)) return;
@@ -1620,21 +1651,8 @@ static void __attribute__((unused)) ApolloDeletedCommentsRevealHiddenBodyForCell
     ApolloDeletedCommentsRestoreOriginalModelBodyIfNeeded(comment);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    if (tappedTextNode) {
-        ApolloDeletedCommentsApplyRevealedBodyTextToNode(cellNode, tappedTextNode);
-        NSString *capturedFullName = [fullName copy];
-        __weak id weakCellNode = cellNode;
-        __weak id weakTextNode = tappedTextNode;
-        for (NSNumber *delayNumber in @[@0.05, @0.16]) {
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayNumber.doubleValue * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                id strongCellNode = weakCellNode;
-                id strongTextNode = weakTextNode;
-                RDKComment *currentComment = ApolloDeletedCommentsCommentFromCellNode(strongCellNode);
-                if (![ApolloDeletedCommentsFullNameForComment(currentComment) isEqualToString:capturedFullName]) return;
-                ApolloDeletedCommentsApplyRevealedBodyTextToNode(strongCellNode, strongTextNode);
-            });
-        }
-    }
+    (void)tappedTextNode;
+    ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyContainerNode(cellNode));
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyTextNode(cellNode));
 }
@@ -1665,15 +1683,9 @@ static void __attribute__((unused)) ApolloDeletedCommentsHideRevealedBodyForCell
     ApolloDeletedCommentsUnmarkCommentBodyRevealed(comment.author, bodyForRevealKey);
     objc_setAssociatedObject(comment, kApolloDeletedCommentsSuppressNextCollapseKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
-    if (tappedTextNode) {
-        NSAttributedString *current = ApolloDeletedCommentsCurrentAttributedText(tappedTextNode);
-        NSAttributedString *chip = ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment),
-                                                                                 current.length > 0 ? ([current attributesAtIndex:0 effectiveRange:NULL] ?: @{}) : @{},
-                                                                                 YES);
-        ApolloDeletedCommentsSetTextNodeAttributedText(tappedTextNode, chip);
-        ApolloDeletedCommentsEnsureRevealAttributeIsTappable(tappedTextNode);
-        ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, tappedTextNode);
-    }
+    (void)tappedTextNode;
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyContainerNode(cellNode));
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyTextNode(cellNode));
 }
@@ -1913,14 +1925,23 @@ static void ApolloDeletedCommentsApplyRecoveredArchiveToVisibleCell(id cellNode,
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     if (fullName.length == 0) return;
-    if (!ApolloDeletedCommentsIsDeletedPlaceholder(fullName) || ApolloDeletedCommentsIsRecoveredComment(fullName)) return;
+    NSString *archivedBody = ApolloDeletedCommentsRecoverableArchivedBody(archived);
+    if (archivedBody.length == 0) return;
+    if (!ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode) &&
+        !ApolloDeletedCommentsVisibleCommentNeedsRecoveredArchive(comment, archivedBody)) {
+        return;
+    }
+    if (!ApolloDeletedCommentsVisibleCommentNeedsRecoveredArchive(comment, archivedBody)) return;
 
-    NSString *reason = ApolloDeletedCommentsDeletedPlaceholderReason(fullName);
+    NSString *reason = ApolloDeletedCommentsDeletedPlaceholderReason(fullName) ?: ApolloDeletedCommentsRecoveredReasonForComment(fullName);
     if (!ApolloDeletedCommentsApplyRecoveredArchivedCommentToObject((id)comment, archived, reason)) return;
+    objc_setAssociatedObject((id)comment, kApolloDeletedCommentsOriginalBodyKey, [archivedBody copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject((id)comment, kApolloDeletedCommentsOriginalBodyHTMLKey, ApolloDeletedCommentsPlainBodyHTML(archivedBody), OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
     ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
+    ApolloDeletedCommentsRepairVisibleReasonChipIfNeeded(cellNode);
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyContainerNode(cellNode));
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyTextNode(cellNode));
     ApolloDeletedCommentsApplyCellHighlight(cellNode);
@@ -1934,21 +1955,35 @@ static void ApolloDeletedCommentsHandleArcticCacheUpdated(NSNotification *notifi
     for (NSString *fullName in comments) {
         NSDictionary *archived = [comments[fullName] isKindOfClass:[NSDictionary class]] ? comments[fullName] : nil;
         if (![archived isKindOfClass:[NSDictionary class]]) continue;
-        for (id cellNode in ApolloDeletedCommentsTrackedCellsForFullName(fullName)) {
-            ApolloDeletedCommentsApplyRecoveredArchiveToVisibleCell(cellNode, archived);
+        NSDictionary *capturedArchive = [archived copy];
+        NSString *capturedFullName = [fullName copy];
+        for (NSNumber *delayNumber in @[@0.0, @0.05, @0.15, @0.35]) {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayNumber.doubleValue * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                for (id cellNode in ApolloDeletedCommentsTrackedCellsForFullName(capturedFullName)) {
+                    RDKComment *currentComment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+                    NSString *currentFullName = ApolloDeletedCommentsFullNameForComment(currentComment);
+                    if (![currentFullName isEqualToString:capturedFullName]) continue;
+                    ApolloDeletedCommentsApplyRecoveredArchiveToVisibleCell(cellNode, capturedArchive);
+                }
+            });
         }
     }
 }
 
-static void ApolloDeletedCommentsApplyCachedArchiveToVisiblePlaceholderCell(id cellNode) {
+static void ApolloDeletedCommentsApplyCachedArchiveToVisibleDeletedCell(id cellNode) {
     if (!cellNode) return;
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     if (fullName.length == 0) return;
-    if (!ApolloDeletedCommentsIsDeletedPlaceholder(fullName) || ApolloDeletedCommentsIsRecoveredComment(fullName)) return;
 
     NSDictionary *archived = ApolloDeletedCommentsCachedArchivedComment(fullName);
     if (archived.count == 0) return;
+    NSString *archivedBody = ApolloDeletedCommentsRecoverableArchivedBody(archived);
+    if (archivedBody.length == 0) return;
+    if (!ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode) &&
+        !ApolloDeletedCommentsVisibleCommentNeedsRecoveredArchive(comment, archivedBody)) {
+        return;
+    }
     ApolloDeletedCommentsApplyRecoveredArchiveToVisibleCell(cellNode, archived);
 }
 
@@ -1998,7 +2033,7 @@ static void __attribute__((unused)) ApolloDeletedCommentsRepairVisibleReasonChip
 
 static void ApolloDeletedCommentsUpdateCell(id cellNode) {
     ApolloDeletedCommentsTrackVisibleDeletedCommentCell(cellNode);
-    ApolloDeletedCommentsApplyCachedArchiveToVisiblePlaceholderCell(cellNode);
+    ApolloDeletedCommentsApplyCachedArchiveToVisibleDeletedCell(cellNode);
     ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
     ApolloDeletedCommentsRepairVisibleReasonChipIfNeeded(cellNode);
     ApolloDeletedCommentsApplyCellHighlight(cellNode);
@@ -2203,24 +2238,6 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
 - (NSString *)body {
     NSString *body = %orig;
     NSString *savedBody = objc_getAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyKey);
-    NSString *bodyForState = [savedBody isKindOfClass:[NSString class]] && savedBody.length > 0 ? savedBody : body;
-    NSString *hiddenLabel = ApolloDeletedCommentsHiddenReasonLabelForCommentBody((RDKComment *)self, bodyForState);
-    if (hiddenLabel.length > 0) {
-        if (!ApolloDeletedCommentsStringIsReasonLabel(bodyForState) &&
-            !ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(bodyForState) &&
-            !objc_getAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyKey)) {
-            objc_setAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyKey, [bodyForState copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
-        }
-        return hiddenLabel;
-    }
-    NSString *fullName = ApolloDeletedCommentsFullNameForComment((RDKComment *)self);
-    BOOL recovered = ApolloDeletedCommentsIsRecoveredComment(fullName) ||
-                     ApolloDeletedCommentsIsRecoveredCommentBody(((RDKComment *)self).author, bodyForState);
-    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
-                    ApolloDeletedCommentsIsCommentBodyRevealed(((RDKComment *)self).author, bodyForState);
-    if (sShowDeletedComments && recovered && (!sTapToRevealDeletedComments || revealed)) {
-        return ApolloDeletedCommentsBodyByAppendingReasonLabel(bodyForState, ApolloDeletedCommentsReasonLabelForComment((RDKComment *)self));
-    }
     if ([savedBody isKindOfClass:[NSString class]] && savedBody.length > 0 && ApolloDeletedCommentsStringIsReasonLabel(body)) {
         return savedBody;
     }
@@ -2229,31 +2246,10 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
 
 - (NSString *)bodyHTML {
     NSString *bodyHTML = %orig;
-    NSString *savedBody = objc_getAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyKey);
-    NSString *bodyForState = [savedBody isKindOfClass:[NSString class]] && savedBody.length > 0 ? savedBody : nil;
-    NSString *hiddenLabel = ApolloDeletedCommentsHiddenReasonLabelForCommentBody((RDKComment *)self, bodyForState);
-    if (hiddenLabel.length > 0) {
-        if (bodyHTML.length > 0 && !objc_getAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyHTMLKey)) {
-            objc_setAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyHTMLKey, [bodyHTML copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
-        }
-        return ApolloDeletedCommentsPlainBodyHTML(hiddenLabel);
-    }
-
     NSString *savedBodyHTML = objc_getAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyHTMLKey);
-    NSString *displayBody = ((NSString *(*)(id, SEL))objc_msgSend)((id)self, @selector(body));
-    NSString *fullName = ApolloDeletedCommentsFullNameForComment((RDKComment *)self);
-    NSString *displayBodyForState = [savedBody isKindOfClass:[NSString class]] && savedBody.length > 0 ? savedBody : displayBody;
-    BOOL recovered = ApolloDeletedCommentsIsRecoveredComment(fullName) ||
-                     ApolloDeletedCommentsIsRecoveredCommentBody(((RDKComment *)self).author, displayBodyForState);
-    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
-                    ApolloDeletedCommentsIsCommentBodyRevealed(((RDKComment *)self).author, displayBodyForState);
-    if (sShowDeletedComments && recovered && (!sTapToRevealDeletedComments || revealed)) {
-        NSString *baseHTML = [savedBodyHTML isKindOfClass:[NSString class]] && savedBodyHTML.length > 0 ? savedBodyHTML : bodyHTML;
-        return ApolloDeletedCommentsBodyHTMLByAppendingReasonLabel(baseHTML, displayBodyForState, ApolloDeletedCommentsReasonLabelForComment((RDKComment *)self));
-    }
     if ([savedBodyHTML isKindOfClass:[NSString class]] &&
         savedBodyHTML.length > 0 &&
-        (ApolloDeletedCommentsStringIsReasonLabel(ApolloDeletedCommentsTrimmedString(bodyHTML)) || !sTapToRevealDeletedComments)) {
+        ApolloDeletedCommentsStringIsReasonLabel(ApolloDeletedCommentsTrimmedString(bodyHTML))) {
         return savedBodyHTML;
     }
     return bodyHTML;
@@ -2275,6 +2271,8 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
 %hook _TtC6Apollo12MarkdownNode
 
 - (id)layoutSpecThatFits:(struct CDStruct_90e057aa)fits {
+    id deletedSpec = ApolloDeletedCommentsDeletedMarkdownLayoutSpecIfNeeded((id)self);
+    if (deletedSpec) return deletedSpec;
     return %orig;
 }
 

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -61,6 +61,8 @@ static NSAttributedString *ApolloDeletedCommentsCurrentAttributedText(id textNod
 static void ApolloDeletedCommentsSynchronizeCommentModelDisplayState(id cellNode);
 static void __attribute__((unused)) ApolloDeletedCommentsRepairVisibleReasonChipIfNeeded(id cellNode);
 static void ApolloDeletedCommentsScheduleHostLayoutRefresh(id cellNode);
+static BOOL ApolloDeletedCommentsStringIsReasonLabel(NSString *text);
+static BOOL ApolloDeletedCommentsAuthorLooksDeleted(NSString *author);
 static BOOL ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(NSString *candidate);
 static BOOL ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(NSAttributedString *attributedText);
 static BOOL ApolloDeletedCommentsAttributedTextHasReasonPrefix(NSAttributedString *attributedText);
@@ -204,9 +206,7 @@ static RDKComment *ApolloDeletedCommentsCommentFromCellNode(id commentCellNode) 
 static NSString *ApolloDeletedCommentsRecoveredReasonForCommentObject(RDKComment *comment) {
     if (!comment) return nil;
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
-    NSString *reason = ApolloDeletedCommentsRecoveredReasonForComment(fullName);
-    if (reason.length > 0) return reason;
-    return ApolloDeletedCommentsRecoveredReasonForCommentBody(comment.author, comment.body);
+    return ApolloDeletedCommentsRecoveredReasonForComment(fullName);
 }
 
 static BOOL ApolloDeletedCommentsCellNodeIsRecovered(id cellNode) {
@@ -218,7 +218,14 @@ static BOOL ApolloDeletedCommentsCellNodeIsRecovered(id cellNode) {
 static BOOL ApolloDeletedCommentsCellNodeIsDeletedPlaceholder(id cellNode) {
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
-    return ApolloDeletedCommentsIsDeletedPlaceholder(fullName);
+    if (!ApolloDeletedCommentsIsDeletedPlaceholder(fullName)) return NO;
+    NSString *body = comment.body;
+    if (ApolloDeletedCommentsStringIsReasonLabel(body) ||
+        ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(body)) {
+        return YES;
+    }
+    NSString *trimmedBody = ApolloDeletedCommentsTrimmedString(body);
+    return trimmedBody.length == 0 && ApolloDeletedCommentsAuthorLooksDeleted(comment.author);
 }
 
 static BOOL ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(id cellNode) {
@@ -230,8 +237,7 @@ static BOOL ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(id cellNode) {
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     if (!comment) return NO;
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
-    return ApolloDeletedCommentsIsRecoveredComment(fullName) ||
-           ApolloDeletedCommentsIsRecoveredCommentBody(comment.author, comment.body);
+    return ApolloDeletedCommentsIsRecoveredComment(fullName);
 }
 
 static NSString *ApolloDeletedCommentsReasonLabelForComment(RDKComment *comment) {
@@ -355,9 +361,7 @@ static BOOL ApolloDeletedCommentsVisibleCommentNeedsRecoveredArchive(RDKComment 
     NSString *currentBody = comment.body;
     BOOL currentLooksPlaceholder = ApolloDeletedCommentsStringIsReasonLabel(currentBody) ||
                                    ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(currentBody);
-    BOOL currentBodyMatches = ApolloDeletedCommentsTextQualifiesAsBodyCandidate(currentBody, archivedBody) ||
-                              ApolloDeletedCommentsTextQualifiesAsBodyFragment(currentBody, archivedBody);
-    return authorLooksDeleted || currentLooksPlaceholder || !currentBodyMatches;
+    return authorLooksDeleted || currentLooksPlaceholder;
 }
 
 static void ApolloDeletedCommentsRememberOriginalModelBodyIfNeeded(RDKComment *comment) {
@@ -404,10 +408,7 @@ static void __attribute__((unused)) ApolloDeletedCommentsSetModelBodyToReasonLab
 static BOOL ApolloDeletedCommentsCommentIsRevealedByFullName(RDKComment *comment) {
     if (!comment) return NO;
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
-    if (ApolloDeletedCommentsIsCommentRevealed(fullName)) return YES;
-    NSString *originalBody = objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey);
-    NSString *bodyForRevealKey = [originalBody isKindOfClass:[NSString class]] && originalBody.length > 0 ? originalBody : comment.body;
-    return ApolloDeletedCommentsIsCommentBodyRevealed(comment.author, bodyForRevealKey);
+    return ApolloDeletedCommentsIsCommentRevealed(fullName);
 }
 
 static void ApolloDeletedCommentsSynchronizeCommentModelDisplayState(id cellNode) {
@@ -434,7 +435,6 @@ static NSString *ApolloDeletedCommentsReasonLabelForCommentAndBody(RDKComment *c
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     NSString *reason = ApolloDeletedCommentsRecoveredReasonForComment(fullName);
     if (reason.length == 0) reason = ApolloDeletedCommentsDeletedPlaceholderReason(fullName);
-    if (reason.length == 0) reason = ApolloDeletedCommentsRecoveredReasonForCommentBody(comment.author, body);
     NSString *label = ApolloDeletedCommentsDisplayLabelForReason(reason);
     return ApolloDeletedCommentsNormalizedReasonLabel(label);
 }
@@ -446,11 +446,9 @@ static NSString *__attribute__((unused)) ApolloDeletedCommentsHiddenReasonLabelF
     NSString *savedBody = objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey);
     NSString *bodyForState = [savedBody isKindOfClass:[NSString class]] && savedBody.length > 0 ? savedBody : body;
     BOOL placeholder = ApolloDeletedCommentsIsDeletedPlaceholder(fullName);
-    BOOL recovered = ApolloDeletedCommentsIsRecoveredComment(fullName) ||
-                     ApolloDeletedCommentsIsRecoveredCommentBody(comment.author, bodyForState);
+    BOOL recovered = ApolloDeletedCommentsIsRecoveredComment(fullName);
     BOOL placeholderOnly = placeholder && !recovered;
-    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
-                    ApolloDeletedCommentsIsCommentBodyRevealed(comment.author, bodyForState);
+    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName);
 
     if (placeholderOnly) {
         return ApolloDeletedCommentsReasonLabelForCommentAndBody(comment, bodyForState);
@@ -1149,8 +1147,7 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsAttribut
     if (!comment || !ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode)) return attributedText;
 
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
-    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
-                    ApolloDeletedCommentsIsCommentBodyRevealed(comment.author, comment.body);
+    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName);
     if (revealed) return attributedText;
 
     BOOL bodyCandidate = ApolloDeletedCommentsTextQualifiesAsBodyCandidate(attributedText.string, comment.body) ||
@@ -1216,7 +1213,7 @@ static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(i
     return decorated;
 }
 
-static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonChipIfNeeded(id textNode, NSAttributedString *attributedText) {
+static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsAttributedTextWithReasonChipIfNeeded(id textNode, NSAttributedString *attributedText) {
     if (!sShowDeletedComments) return attributedText;
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
 
@@ -1433,7 +1430,6 @@ static void ApolloDeletedCommentsEnsureRevealAttributeIsTappable(id textNode) {
 static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeeded(id cellNode) {
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
-    NSString *author = comment.author;
     NSString *body = comment.body;
 
     BOOL placeholderOnly = ApolloDeletedCommentsCellNodeIsDeletedPlaceholder(cellNode) &&
@@ -1451,8 +1447,7 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeede
     }
 
     BOOL recovered = ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode);
-    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
-                    ApolloDeletedCommentsIsCommentBodyRevealed(author, body);
+    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName);
     BOOL shouldHide = sShowDeletedComments &&
                       sTapToRevealDeletedComments &&
                       recovered &&
@@ -1644,9 +1639,6 @@ static void __attribute__((unused)) ApolloDeletedCommentsRevealHiddenBodyForCell
     if (!restored && ApolloDeletedCommentsStringIsReasonLabel(comment.body)) return;
 
     ApolloDeletedCommentsMarkCommentRevealed(fullName);
-    NSString *originalBody = objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey);
-    NSString *bodyForRevealKey = [originalBody isKindOfClass:[NSString class]] && originalBody.length > 0 ? originalBody : comment.body;
-    ApolloDeletedCommentsMarkCommentBodyRevealed(comment.author, bodyForRevealKey);
     objc_setAssociatedObject(comment, kApolloDeletedCommentsSuppressNextCollapseKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloDeletedCommentsRestoreOriginalModelBodyIfNeeded(comment);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -1660,8 +1652,7 @@ static void __attribute__((unused)) ApolloDeletedCommentsRevealHiddenBodyForCell
 static BOOL __attribute__((unused)) ApolloDeletedCommentsCommentIsRevealed(RDKComment *comment) {
     if (!comment) return NO;
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
-    return ApolloDeletedCommentsIsCommentRevealed(fullName) ||
-           ApolloDeletedCommentsIsCommentBodyRevealed(comment.author, comment.body);
+    return ApolloDeletedCommentsIsCommentRevealed(fullName);
 }
 
 static BOOL __attribute__((unused)) ApolloDeletedCommentsTouchHitsRecoveredBody(id cellNode, UITouch *touch) {
@@ -1678,9 +1669,6 @@ static void __attribute__((unused)) ApolloDeletedCommentsHideRevealedBodyForCell
     if (!comment) return;
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     ApolloDeletedCommentsUnmarkCommentRevealed(fullName);
-    NSString *originalBody = objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey);
-    NSString *bodyForRevealKey = [originalBody isKindOfClass:[NSString class]] && originalBody.length > 0 ? originalBody : comment.body;
-    ApolloDeletedCommentsUnmarkCommentBodyRevealed(comment.author, bodyForRevealKey);
     objc_setAssociatedObject(comment, kApolloDeletedCommentsSuppressNextCollapseKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
     (void)tappedTextNode;
@@ -1693,11 +1681,12 @@ static void __attribute__((unused)) ApolloDeletedCommentsHideRevealedBodyForCell
 static id ApolloDeletedCommentsCommentCellNodeForTextNode(id textNode) {
     if (!textNode || ![textNode respondsToSelector:@selector(supernode)]) return nil;
     id current = textNode;
+    id fallbackOwnerCell = nil;
     for (NSUInteger i = 0; current && i < 10; i++) {
-        id ownerCell = objc_getAssociatedObject(current, kApolloDeletedCommentsBodyOwnerCellKey);
-        if (ownerCell) return ownerCell;
         const char *className = class_getName(object_getClass(current));
         if (className && strstr(className, "CommentCellNode")) return current;
+        id ownerCell = objc_getAssociatedObject(current, kApolloDeletedCommentsBodyOwnerCellKey);
+        if (ownerCell && !fallbackOwnerCell) fallbackOwnerCell = ownerCell;
         if (![current respondsToSelector:@selector(supernode)]) break;
         @try {
             current = ((id (*)(id, SEL))objc_msgSend)(current, @selector(supernode));
@@ -1705,7 +1694,7 @@ static id ApolloDeletedCommentsCommentCellNodeForTextNode(id textNode) {
             break;
         }
     }
-    return nil;
+    return fallbackOwnerCell;
 }
 
 static BOOL __attribute__((unused)) ApolloDeletedCommentsTextNodeBelongsToRecoveredComment(id textNode) {
@@ -1855,8 +1844,8 @@ static NSAttributedString *ApolloDeletedCommentsTemplateTextForMarkdownNode(id m
 }
 
 static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpecIfNeeded(id markdownNode) {
-    id cellNode = objc_getAssociatedObject(markdownNode, kApolloDeletedCommentsBodyOwnerCellKey);
-    if (!cellNode) cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(markdownNode);
+    id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(markdownNode);
+    if (!cellNode) cellNode = objc_getAssociatedObject(markdownNode, kApolloDeletedCommentsBodyOwnerCellKey);
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return nil;
 
@@ -1867,8 +1856,7 @@ static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpec
     BOOL placeholderOnly = ApolloDeletedCommentsCellNodeIsDeletedPlaceholder(cellNode) &&
                            !ApolloDeletedCommentsCellNodeIsRecovered(cellNode);
     BOOL recovered = ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode);
-    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
-                    ApolloDeletedCommentsIsCommentBodyRevealed(comment.author, comment.body);
+    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName);
     BOOL shouldHide = sShowDeletedComments &&
                       sTapToRevealDeletedComments &&
                       recovered &&
@@ -2080,7 +2068,7 @@ static BOOL ApolloDeletedCommentsIsRevealLink(id attribute, id value) {
     return [urlString isEqualToString:ApolloDeletedCommentsRevealURLString];
 }
 
-static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id textNode, NSAttributedString *attributedText) {
+static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id textNode, NSAttributedString *attributedText) {
     if (!sShowDeletedComments || !sTapToRevealDeletedComments) return attributedText;
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
     NSString *text = ApolloDeletedCommentsTrimmedString(attributedText.string);
@@ -2097,8 +2085,7 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
         return ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment), baseAttributes, NO);
     }
 
-    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
-                    ApolloDeletedCommentsIsCommentBodyRevealed(comment.author, comment.body);
+    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName);
     NSMutableAttributedString *renamed = [ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment), baseAttributes, !revealed) mutableCopy];
     NSRange targetRange = NSMakeRange(0, renamed.length);
     [attributedText enumerateAttributesInRange:NSMakeRange(0, attributedText.length)
@@ -2123,35 +2110,11 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
 %hook ASTextNode
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
-    NSAttributedString *renamedText = ApolloDeletedCommentsRenameRecoveredSpoilerLabel((id)self, attributedText);
-    NSAttributedString *chipText = ApolloDeletedCommentsAttributedTextWithReasonChipIfNeeded((id)self, renamedText);
-    NSAttributedString *rewrittenText = ApolloDeletedCommentsAttributedTextWithReasonPrefix((id)self, chipText);
-    %orig(rewrittenText);
+    %orig(attributedText);
 }
 
 - (void)didEnterDisplayState {
     %orig;
-    NSAttributedString *attributedText = nil;
-    @try {
-        attributedText = ((NSAttributedString *(*)(id, SEL))objc_msgSend)((id)self, @selector(attributedText));
-    } @catch (__unused NSException *e) {
-        attributedText = nil;
-    }
-    NSAttributedString *renamedAttributedText = ApolloDeletedCommentsAttributedTextWithReasonChipIfNeeded((id)self,
-        ApolloDeletedCommentsRenameRecoveredSpoilerLabel((id)self, attributedText)
-    );
-    if (renamedAttributedText != attributedText) {
-        @try {
-            ((void (*)(id, SEL, NSAttributedString *))objc_msgSend)((id)self, @selector(setAttributedText:), renamedAttributedText);
-            attributedText = renamedAttributedText;
-        } @catch (__unused NSException *e) {}
-    }
-    NSAttributedString *prefixedText = ApolloDeletedCommentsAttributedTextWithReasonPrefix((id)self, attributedText);
-    if (prefixedText != attributedText) {
-        @try {
-            ((void (*)(id, SEL, NSAttributedString *))objc_msgSend)((id)self, @selector(setAttributedText:), prefixedText);
-        } @catch (__unused NSException *e) {}
-    }
 }
 
 %end

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -128,7 +128,7 @@ static UIFont *ApolloDeletedCommentsReasonChipFont(void) {
 }
 
 static UIFont *ApolloDeletedCommentsRecoveredBodyFont(void) {
-    return [UIFont systemFontOfSize:15.0];
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
 }
 
 static NSString *ApolloDeletedCommentsNormalizeCommentFullName(NSString *value) {
@@ -683,9 +683,6 @@ static NSMutableDictionary *ApolloDeletedCommentsSanitizedBodyAttributes(NSDicti
     if (![font isKindOfClass:[UIFont class]]) return nil;
 
     NSMutableDictionary *attributes = [attrs mutableCopy];
-    if (font.pointSize > 15.5) {
-        attributes[NSFontAttributeName] = [font fontWithSize:15.0];
-    }
     [attributes removeObjectForKey:NSAttachmentAttributeName];
     [attributes removeObjectForKey:NSBackgroundColorAttributeName];
     [attributes removeObjectForKey:NSLinkAttributeName];
@@ -721,10 +718,6 @@ static NSAttributedString *ApolloDeletedCommentsBodyTextByNormalizingFont(NSAttr
                                    options:0
                                 usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attrs, NSRange range, __unused BOOL *stop) {
         if (attrs[NSAttachmentAttributeName]) return;
-        UIFont *font = attrs[NSFontAttributeName];
-        if ([font isKindOfClass:[UIFont class]] && font.pointSize > 15.5) {
-            [normalized addAttribute:NSFontAttributeName value:[font fontWithSize:15.0] range:range];
-        }
         [normalized removeAttribute:NSBackgroundColorAttributeName range:range];
         [normalized removeAttribute:NSLinkAttributeName range:range];
         [normalized removeAttribute:ApolloDeletedCommentsRevealAttributeName range:range];

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -11,6 +11,7 @@ static const void *kApolloDeletedCommentsHighlightViewKey = &kApolloDeletedComme
 static const void *kApolloDeletedCommentsHiddenOriginalTextKey = &kApolloDeletedCommentsHiddenOriginalTextKey;
 static const void *kApolloDeletedCommentsHiddenFullNameKey = &kApolloDeletedCommentsHiddenFullNameKey;
 static const void *kApolloDeletedCommentsHiddenTextNodeKey = &kApolloDeletedCommentsHiddenTextNodeKey;
+static const void *kApolloDeletedCommentsHiddenTextNodesKey = &kApolloDeletedCommentsHiddenTextNodesKey;
 static const void *kApolloDeletedCommentsSuppressNextCollapseKey = &kApolloDeletedCommentsSuppressNextCollapseKey;
 
 static NSString *const ApolloDeletedCommentsRevealURLString = @"apollo-deleted-comments://reveal";
@@ -354,6 +355,15 @@ static BOOL ApolloDeletedCommentsTextQualifiesAsBodyCandidate(NSString *candidat
     return [candidatePrefix isEqualToString:bodyPrefix];
 }
 
+static BOOL ApolloDeletedCommentsTextQualifiesAsBodyFragment(NSString *candidate, NSString *body) {
+    NSString *candidateNorm = ApolloDeletedCommentsNormalizeTextForCompare(candidate);
+    NSString *bodyNorm = ApolloDeletedCommentsNormalizeTextForCompare(ApolloDeletedCommentsUnwrappedSpoilerMarkdown(body));
+    if (candidateNorm.length < 12 || bodyNorm.length == 0) return NO;
+    if ([candidateNorm isEqualToString:@"spoiler"]) return NO;
+    if ([candidateNorm hasPrefix:@"deleted by "]) return NO;
+    return [bodyNorm rangeOfString:candidateNorm options:NSCaseInsensitiveSearch].location != NSNotFound;
+}
+
 static void ApolloDeletedCommentsCollectAttributedTextNodes(id object, NSInteger depth, NSHashTable *visited, NSMutableArray *nodes) {
     if (!object || depth < 0 || [visited containsObject:object]) return;
     [visited addObject:object];
@@ -408,6 +418,54 @@ static id ApolloDeletedCommentsBestBodyTextNode(id cellNode, RDKComment *comment
         }
     }
     return bestNode;
+}
+
+static BOOL ApolloDeletedCommentsAttributedTextHasReasonPrefix(NSAttributedString *attributedText);
+
+static NSArray *ApolloDeletedCommentsBodyTextNodes(id cellNode, RDKComment *comment) {
+    if (!cellNode || !comment) return @[];
+    NSString *body = comment.body;
+    NSMutableArray *bodyNodes = [NSMutableArray array];
+    NSHashTable *seen = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:16];
+
+    id known = ApolloDeletedCommentsKnownBodyTextNode(cellNode);
+    if (known) {
+        NSAttributedString *text = nil;
+        @try {
+            text = ((NSAttributedString *(*)(id, SEL))objc_msgSend)(known, @selector(attributedText));
+        } @catch (__unused NSException *e) {
+            text = nil;
+        }
+        if (ApolloDeletedCommentsTextQualifiesAsBodyCandidate(text.string, body) ||
+            ApolloDeletedCommentsTextQualifiesAsBodyFragment(text.string, body)) {
+            [bodyNodes addObject:known];
+            [seen addObject:known];
+        }
+    }
+
+    NSMutableArray *candidates = [NSMutableArray array];
+    NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:64];
+    ApolloDeletedCommentsCollectAttributedTextNodes(cellNode, 6, visited, candidates);
+    for (id candidate in candidates) {
+        if ([seen containsObject:candidate]) continue;
+        NSAttributedString *text = nil;
+        @try {
+            text = ((NSAttributedString *(*)(id, SEL))objc_msgSend)(candidate, @selector(attributedText));
+        } @catch (__unused NSException *e) {
+            text = nil;
+        }
+        if (ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(text) ||
+            ApolloDeletedCommentsAttributedTextHasReasonPrefix(text)) {
+            continue;
+        }
+        if (!ApolloDeletedCommentsTextQualifiesAsBodyCandidate(text.string, body) &&
+            !ApolloDeletedCommentsTextQualifiesAsBodyFragment(text.string, body)) {
+            continue;
+        }
+        [bodyNodes addObject:candidate];
+        [seen addObject:candidate];
+    }
+    return bodyNodes;
 }
 
 static BOOL ApolloDeletedCommentsAttributedTextHasReasonPrefix(NSAttributedString *attributedText) {
@@ -478,6 +536,36 @@ static void ApolloDeletedCommentsRestoreHiddenBodyIfNeeded(id cellNode, id textN
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
 }
 
+static NSArray *ApolloDeletedCommentsHiddenTextNodesForCell(id cellNode) {
+    id nodes = objc_getAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey);
+    if ([nodes isKindOfClass:[NSArray class]]) return nodes;
+
+    id textNode = objc_getAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey);
+    return textNode ? @[textNode] : @[];
+}
+
+static void ApolloDeletedCommentsRestoreHiddenBodiesIfNeeded(id cellNode, NSArray *textNodes) {
+    NSMutableArray *nodesToRestore = [NSMutableArray array];
+    NSHashTable *seen = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:16];
+
+    for (id node in ApolloDeletedCommentsHiddenTextNodesForCell(cellNode)) {
+        if (!node || [seen containsObject:node]) continue;
+        [nodesToRestore addObject:node];
+        [seen addObject:node];
+    }
+    for (id node in textNodes ?: @[]) {
+        if (!node || [seen containsObject:node]) continue;
+        [nodesToRestore addObject:node];
+        [seen addObject:node];
+    }
+
+    for (id node in nodesToRestore) {
+        ApolloDeletedCommentsRestoreHiddenBodyIfNeeded(cellNode, node);
+    }
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 static void ApolloDeletedCommentsEnsureRevealAttributeIsTappable(id textNode) {
     if (!textNode) return;
 
@@ -519,8 +607,8 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeede
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     NSString *author = comment.author;
     NSString *body = comment.body;
-    id textNode = ApolloDeletedCommentsBestBodyTextNode(cellNode, comment);
-    if (!textNode) return;
+    NSArray *textNodes = ApolloDeletedCommentsBodyTextNodes(cellNode, comment);
+    if (textNodes.count == 0) return;
 
     BOOL recovered = ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode);
     BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
@@ -530,50 +618,62 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeede
                       recovered &&
                       !revealed;
     if (!shouldHide) {
-        ApolloDeletedCommentsRestoreHiddenBodyIfNeeded(cellNode, textNode);
+        ApolloDeletedCommentsRestoreHiddenBodiesIfNeeded(cellNode, textNodes);
         return;
     }
 
-    NSAttributedString *existingOriginal = objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey);
-    NSAttributedString *existingCurrent = nil;
-    @try {
-        existingCurrent = ((NSAttributedString *(*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText));
-    } @catch (__unused NSException *e) {
-        existingCurrent = nil;
+    BOOL alreadyHiddenForComment = NO;
+    for (id textNode in ApolloDeletedCommentsHiddenTextNodesForCell(cellNode)) {
+        NSString *hiddenFullName = objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey);
+        NSAttributedString *existingOriginal = objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey);
+        if ([hiddenFullName isEqualToString:fullName] && [existingOriginal isKindOfClass:[NSAttributedString class]]) {
+            alreadyHiddenForComment = YES;
+            break;
+        }
     }
-    if ([existingOriginal isKindOfClass:[NSAttributedString class]] &&
-        ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(existingCurrent)) {
-        ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
+    if (alreadyHiddenForComment) {
+        id firstHiddenNode = ApolloDeletedCommentsHiddenTextNodesForCell(cellNode).firstObject;
+        ApolloDeletedCommentsEnsureRevealAttributeIsTappable(firstHiddenNode);
         return;
     }
 
-    NSString *hiddenFullName = objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey);
-    if ([hiddenFullName isEqualToString:fullName]) {
-        ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
-        return;
+    ApolloDeletedCommentsRestoreHiddenBodiesIfNeeded(cellNode, nil);
+
+    NSMutableArray *hiddenNodes = [NSMutableArray array];
+    BOOL placedPlaceholder = NO;
+    for (id textNode in textNodes) {
+        NSAttributedString *current = nil;
+        @try {
+            current = ((NSAttributedString *(*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText));
+        } @catch (__unused NSException *e) {
+            current = nil;
+        }
+        if (![current isKindOfClass:[NSAttributedString class]] || current.length == 0) continue;
+        if (ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(current)) continue;
+
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, [current copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
+        [hiddenNodes addObject:textNode];
+
+        NSAttributedString *replacement = nil;
+        if (!placedPlaceholder) {
+            replacement = ApolloDeletedCommentsPlaceholderAttributedText(current, ApolloDeletedCommentsReasonLabelForComment(comment));
+            placedPlaceholder = YES;
+        } else {
+            NSDictionary *attributes = [current attributesAtIndex:0 effectiveRange:NULL] ?: @{};
+            replacement = [[NSAttributedString alloc] initWithString:@"" attributes:attributes];
+        }
+
+        @try {
+            ((void (*)(id, SEL, NSAttributedString *))objc_msgSend)(textNode, @selector(setAttributedText:), replacement);
+        } @catch (__unused NSException *e) {}
+        ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
     }
 
-    ApolloDeletedCommentsRestoreHiddenBodyIfNeeded(cellNode, textNode);
-
-    NSAttributedString *current = nil;
-    @try {
-        current = ((NSAttributedString *(*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText));
-    } @catch (__unused NSException *e) {
-        current = nil;
-    }
-    if (![current isKindOfClass:[NSAttributedString class]] || current.length == 0) return;
-    if (ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(current)) return;
-
-    objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, [current copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
-    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-
-    NSAttributedString *placeholder = ApolloDeletedCommentsPlaceholderAttributedText(current, ApolloDeletedCommentsReasonLabelForComment(comment));
-    @try {
-        ((void (*)(id, SEL, NSAttributedString *))objc_msgSend)(textNode, @selector(setAttributedText:), placeholder);
-    } @catch (__unused NSException *e) {}
-    ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
-    ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
+    if (hiddenNodes.count == 0) return;
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, [hiddenNodes copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, hiddenNodes.firstObject, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloDeletedCommentsEnsureRevealAttributeIsTappable(hiddenNodes.firstObject);
 }
 
 static BOOL ApolloDeletedCommentsTouchHitsTextNode(id textNode, UITouch *touch) {
@@ -632,21 +732,29 @@ static void __attribute__((unused)) ApolloDeletedCommentsScheduleForceExpanded(R
 }
 
 static BOOL __attribute__((unused)) ApolloDeletedCommentsTouchHitsHiddenBody(id cellNode, UITouch *touch) {
-    id textNode = objc_getAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey);
-    if (!objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey)) return NO;
-    return ApolloDeletedCommentsTouchHitsTextNode(textNode, touch);
+    for (id textNode in ApolloDeletedCommentsHiddenTextNodesForCell(cellNode)) {
+        if (!objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey)) continue;
+        if (ApolloDeletedCommentsTouchHitsTextNode(textNode, touch)) return YES;
+    }
+    return NO;
 }
 
 static void __attribute__((unused)) ApolloDeletedCommentsRevealHiddenBodyForCell(id cellNode) {
-    id textNode = objc_getAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey);
-    if (!objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey)) return;
+    BOOL hasHiddenBody = NO;
+    for (id textNode in ApolloDeletedCommentsHiddenTextNodesForCell(cellNode)) {
+        if (objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey)) {
+            hasHiddenBody = YES;
+            break;
+        }
+    }
+    if (!hasHiddenBody) return;
 
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     ApolloDeletedCommentsMarkCommentRevealed(fullName);
     ApolloDeletedCommentsMarkCommentBodyRevealed(comment.author, comment.body);
     objc_setAssociatedObject(comment, kApolloDeletedCommentsSuppressNextCollapseKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    ApolloDeletedCommentsRestoreHiddenBodyIfNeeded(cellNode, textNode);
+    ApolloDeletedCommentsRestoreHiddenBodiesIfNeeded(cellNode, nil);
     ApolloDeletedCommentsScheduleForceExpanded(comment, cellNode);
 }
 
@@ -660,8 +768,10 @@ static BOOL __attribute__((unused)) ApolloDeletedCommentsCommentIsRevealed(RDKCo
 static BOOL __attribute__((unused)) ApolloDeletedCommentsTouchHitsRecoveredBody(id cellNode, UITouch *touch) {
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     if (!comment || !ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode)) return NO;
-    id textNode = ApolloDeletedCommentsBestBodyTextNode(cellNode, comment);
-    return ApolloDeletedCommentsTouchHitsTextNode(textNode, touch);
+    for (id textNode in ApolloDeletedCommentsBodyTextNodes(cellNode, comment)) {
+        if (ApolloDeletedCommentsTouchHitsTextNode(textNode, touch)) return YES;
+    }
+    return NO;
 }
 
 static void __attribute__((unused)) ApolloDeletedCommentsHideRevealedBodyForCell(id cellNode) {
@@ -743,6 +853,7 @@ static void ApolloDeletedCommentsApplyCellHighlight(id cellNode) {
 }
 
 static void ApolloDeletedCommentsUpdateCell(id cellNode) {
+    ApolloDeletedCommentsApplyTapToRevealIfNeeded(cellNode);
     ApolloDeletedCommentsApplyCellHighlight(cellNode);
 }
 

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -40,6 +40,7 @@ static const void *kApolloDeletedCommentsBodyOwnerCellKey = &kApolloDeletedComme
 static const void *kApolloDeletedCommentsBodyReplacementTextNodeKey = &kApolloDeletedCommentsBodyReplacementTextNodeKey;
 static const void *kApolloDeletedCommentsOriginalBodyKey = &kApolloDeletedCommentsOriginalBodyKey;
 static const void *kApolloDeletedCommentsOriginalBodyHTMLKey = &kApolloDeletedCommentsOriginalBodyHTMLKey;
+static const void *kApolloDeletedCommentsHostLayoutRefreshScheduledKey = &kApolloDeletedCommentsHostLayoutRefreshScheduledKey;
 
 static NSMutableDictionary<NSString *, NSHashTable *> *sApolloDeletedCommentsVisibleCellsByFullName = nil;
 static NSObject *sApolloDeletedCommentsVisibleCellsLock = nil;
@@ -58,9 +59,13 @@ static NSString *ApolloDeletedCommentsNormalizedReasonLabel(NSString *label);
 static void ApolloDeletedCommentsSetTextNodeAttributedText(id textNode, NSAttributedString *attributedText);
 static NSAttributedString *ApolloDeletedCommentsCurrentAttributedText(id textNode);
 static void ApolloDeletedCommentsSynchronizeCommentModelDisplayState(id cellNode);
+static void __attribute__((unused)) ApolloDeletedCommentsRepairVisibleReasonChipIfNeeded(id cellNode);
+static void ApolloDeletedCommentsScheduleHostLayoutRefresh(id cellNode);
 static BOOL ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(NSString *candidate);
 static BOOL ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(NSAttributedString *attributedText);
 static BOOL ApolloDeletedCommentsAttributedTextHasReasonPrefix(NSAttributedString *attributedText);
+static BOOL ApolloDeletedCommentsAttributedTextHasVisibleReasonChip(NSAttributedString *attributedText);
+static NSAttributedString *ApolloDeletedCommentsAttributedTextByRemovingReasonPrefix(NSAttributedString *attributedText);
 static BOOL ApolloDeletedCommentsTextQualifiesAsBodyCandidate(NSString *candidate, NSString *body);
 static BOOL ApolloDeletedCommentsTextQualifiesAsBodyFragment(NSString *candidate, NSString *body);
 
@@ -272,6 +277,46 @@ static NSString *ApolloDeletedCommentsPlainBodyHTML(NSString *text) {
     return [NSString stringWithFormat:@"&lt;div class=&quot;md&quot;&gt;&lt;p&gt;%@&lt;/p&gt;\n&lt;/div&gt;", escaped];
 }
 
+static NSString *ApolloDeletedCommentsBodyByAppendingReasonLabel(NSString *body, NSString *label) {
+    NSString *trimmedBody = ApolloDeletedCommentsTrimmedString(body);
+    NSString *normalizedLabel = ApolloDeletedCommentsNormalizedReasonLabel(label);
+    if (trimmedBody.length == 0 || normalizedLabel.length == 0) return body;
+
+    NSString *lowerBody = trimmedBody.lowercaseString;
+    NSString *lowerLabel = normalizedLabel.lowercaseString;
+    if ([lowerBody isEqualToString:lowerLabel] || [lowerBody hasSuffix:[@"\n\n" stringByAppendingString:lowerLabel]]) {
+        return trimmedBody;
+    }
+    return [NSString stringWithFormat:@"%@\n\n%@", trimmedBody, normalizedLabel];
+}
+
+static NSString *ApolloDeletedCommentsBodyHTMLByAppendingReasonLabel(NSString *bodyHTML, NSString *body, NSString *label) {
+    NSString *normalizedLabel = ApolloDeletedCommentsNormalizedReasonLabel(label);
+    if (normalizedLabel.length == 0) return bodyHTML;
+
+    NSString *trimmedHTML = ApolloDeletedCommentsTrimmedString(bodyHTML);
+    NSString *escapedParagraph = ApolloDeletedCommentsEscapedHTMLText([NSString stringWithFormat:@"<p>%@</p>", ApolloDeletedCommentsEscapedHTMLText(normalizedLabel)]);
+    if (trimmedHTML.length > 0 &&
+        [trimmedHTML rangeOfString:escapedParagraph options:NSCaseInsensitiveSearch].location == NSNotFound) {
+        NSRange escapedClosingDiv = [trimmedHTML rangeOfString:@"&lt;/div&gt;" options:NSBackwardsSearch | NSCaseInsensitiveSearch];
+        if (escapedClosingDiv.location != NSNotFound) {
+            NSMutableString *mutableHTML = [trimmedHTML mutableCopy];
+            [mutableHTML insertString:[@"\n" stringByAppendingString:escapedParagraph] atIndex:escapedClosingDiv.location];
+            return mutableHTML;
+        }
+
+        NSString *rawParagraph = [NSString stringWithFormat:@"<p>%@</p>", ApolloDeletedCommentsEscapedHTMLText(normalizedLabel)];
+        NSRange rawClosingDiv = [trimmedHTML rangeOfString:@"</div>" options:NSBackwardsSearch | NSCaseInsensitiveSearch];
+        if (rawClosingDiv.location != NSNotFound && [trimmedHTML rangeOfString:rawParagraph options:NSCaseInsensitiveSearch].location == NSNotFound) {
+            NSMutableString *mutableHTML = [trimmedHTML mutableCopy];
+            [mutableHTML insertString:[@"\n" stringByAppendingString:rawParagraph] atIndex:rawClosingDiv.location];
+            return mutableHTML;
+        }
+    }
+
+    return ApolloDeletedCommentsPlainBodyHTML(ApolloDeletedCommentsBodyByAppendingReasonLabel(body, normalizedLabel));
+}
+
 static BOOL ApolloDeletedCommentsStringIsReasonLabel(NSString *text) {
     NSString *normalized = ApolloDeletedCommentsNormalizedReasonLabel(ApolloDeletedCommentsTrimmedString(text));
     return [normalized isEqualToString:@"REMOVED BY MOD"] ||
@@ -465,7 +510,7 @@ static NSAttributedString *ApolloDeletedCommentsReasonChipAttributedText(NSStrin
     label = ApolloDeletedCommentsNormalizedReasonLabel(label);
     UIFont *font = ApolloDeletedCommentsReasonChipFont();
     UIImage *image = ApolloDeletedCommentsReasonChipImage(label, font);
-    CGFloat chipLineHeight = [image isKindOfClass:[UIImage class]] ? image.size.height + 2.0 : font.lineHeight + 2.0;
+    CGFloat chipLineHeight = [image isKindOfClass:[UIImage class]] ? image.size.height + 6.0 : font.lineHeight + 6.0;
     NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
     paragraphStyle.lineSpacing = 0.0;
     paragraphStyle.paragraphSpacing = 4.0;
@@ -476,7 +521,7 @@ static NSAttributedString *ApolloDeletedCommentsReasonChipAttributedText(NSStrin
     if ([image isKindOfClass:[UIImage class]]) {
         NSTextAttachment *attachment = [NSTextAttachment new];
         attachment.image = image;
-        attachment.bounds = CGRectMake(0.0, -2.0, image.size.width, image.size.height);
+        attachment.bounds = CGRectMake(0.0, -1.0, image.size.width, image.size.height);
         result = [[NSAttributedString attributedStringWithAttachment:attachment] mutableCopy];
         [result addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:NSMakeRange(0, result.length)];
     } else {
@@ -531,6 +576,7 @@ static void ApolloDeletedCommentsRelayoutCellAndTextNode(id cellNode, id textNod
             @try { ((void (*)(id, SEL))objc_msgSend)(cellNode, sel); } @catch (__unused NSException *e) {}
         }
     }
+    ApolloDeletedCommentsScheduleHostLayoutRefresh(cellNode);
 }
 
 static NSAttributedString *ApolloDeletedCommentsPlaceholderAttributedText(NSAttributedString *original, NSString *reasonLabel) {
@@ -649,6 +695,19 @@ static NSArray *ApolloDeletedCommentsTrackedCellsForFullName(NSString *fullName)
     }
 }
 
+static NSArray *ApolloDeletedCommentsAllTrackedVisibleCells(void) {
+    @synchronized (ApolloDeletedCommentsVisibleCellsLock()) {
+        if (sApolloDeletedCommentsVisibleCellsByFullName.count == 0) return @[];
+        NSMutableArray *allCells = [NSMutableArray array];
+        for (NSHashTable *cells in sApolloDeletedCommentsVisibleCellsByFullName.allValues) {
+            for (id cellNode in cells.allObjects) {
+                if (cellNode) [allCells addObject:cellNode];
+            }
+        }
+        return [allCells copy];
+    }
+}
+
 static BOOL ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(NSAttributedString *attributedText) {
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return NO;
 
@@ -711,6 +770,13 @@ static NSString *ApolloDeletedCommentsNormalizeTextForCompare(NSString *s) {
     for (NSString *prefix in reasonPrefixes) {
         if ([lowercase hasPrefix:prefix]) {
             trimmed = [[trimmed substringFromIndex:prefix.length] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+            break;
+        }
+    }
+    lowercase = trimmed.lowercaseString;
+    for (NSString *suffix in reasonPrefixes) {
+        if ([lowercase hasSuffix:suffix]) {
+            trimmed = [[trimmed substringToIndex:trimmed.length - suffix.length] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
             break;
         }
     }
@@ -915,6 +981,106 @@ static BOOL ApolloDeletedCommentsAttributedTextHasReasonPrefix(NSAttributedStrin
     return hasPrefix;
 }
 
+static BOOL ApolloDeletedCommentsAttributedTextHasVisibleReasonChip(NSAttributedString *attributedText) {
+    if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return NO;
+
+    __block BOOL hasAttachmentChip = NO;
+    [attributedText enumerateAttributesInRange:NSMakeRange(0, attributedText.length)
+                                       options:0
+                                    usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attrs, __unused NSRange range, BOOL *stop) {
+        id prefix = attrs[ApolloDeletedCommentsReasonPrefixAttributeName];
+        NSTextAttachment *attachment = [attrs[NSAttachmentAttributeName] isKindOfClass:[NSTextAttachment class]] ? attrs[NSAttachmentAttributeName] : nil;
+        if ([prefix respondsToSelector:@selector(boolValue)] && [prefix boolValue] && [attachment.image isKindOfClass:[UIImage class]]) {
+            hasAttachmentChip = YES;
+            *stop = YES;
+        }
+    }];
+    if (hasAttachmentChip) return YES;
+
+    NSString *upperText = ApolloDeletedCommentsTrimmedString(attributedText.string).uppercaseString;
+    return [upperText containsString:@"REMOVED BY MOD"] ||
+           [upperText containsString:@"DELETED BY USER"];
+}
+
+static NSAttributedString *ApolloDeletedCommentsAttributedTextByRemovingReasonPrefix(NSAttributedString *attributedText) {
+    if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
+    if (!ApolloDeletedCommentsAttributedTextHasReasonPrefix(attributedText)) return attributedText;
+
+    NSMutableArray<NSValue *> *ranges = [NSMutableArray array];
+    [attributedText enumerateAttribute:ApolloDeletedCommentsReasonPrefixAttributeName
+                               inRange:NSMakeRange(0, attributedText.length)
+                               options:0
+                            usingBlock:^(id value, NSRange range, __unused BOOL *stop) {
+        if ([value respondsToSelector:@selector(boolValue)] && [value boolValue] && range.length > 0) {
+            [ranges addObject:[NSValue valueWithRange:range]];
+        }
+    }];
+    if (ranges.count == 0) return attributedText;
+
+    NSMutableAttributedString *stripped = [attributedText mutableCopy];
+    for (NSValue *value in [ranges reverseObjectEnumerator]) {
+        NSRange range = value.rangeValue;
+        if (range.location >= stripped.length) continue;
+        range.length = MIN(range.length, stripped.length - range.location);
+
+        if (range.location > 0) {
+            unichar previous = [stripped.string characterAtIndex:range.location - 1];
+            if ([[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:previous]) {
+                range.location -= 1;
+                range.length += 1;
+            }
+        }
+        if (NSMaxRange(range) < stripped.length) {
+            unichar next = [stripped.string characterAtIndex:NSMaxRange(range)];
+            if ([[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:next]) {
+                range.length += 1;
+            }
+        }
+        [stripped deleteCharactersInRange:range];
+    }
+
+    NSCharacterSet *trimSet = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+    while (stripped.length > 0 && [trimSet characterIsMember:[stripped.string characterAtIndex:stripped.length - 1]]) {
+        [stripped deleteCharactersInRange:NSMakeRange(stripped.length - 1, 1)];
+    }
+    while (stripped.length > 0 && [trimSet characterIsMember:[stripped.string characterAtIndex:0]]) {
+        [stripped deleteCharactersInRange:NSMakeRange(0, 1)];
+    }
+    return stripped;
+}
+
+static NSAttributedString *ApolloDeletedCommentsAttributedTextByRemovingTrailingReasonLabel(NSAttributedString *attributedText, NSString *label) {
+    if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
+    NSString *normalizedLabel = ApolloDeletedCommentsNormalizedReasonLabel(label);
+    NSString *string = attributedText.string;
+    if (normalizedLabel.length == 0 || string.length == 0) return attributedText;
+
+    NSUInteger trimmedEnd = string.length;
+    NSCharacterSet *trimSet = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+    while (trimmedEnd > 0 && [trimSet characterIsMember:[string characterAtIndex:trimmedEnd - 1]]) {
+        trimmedEnd--;
+    }
+    if (trimmedEnd == 0) return attributedText;
+
+    NSRange searchRange = NSMakeRange(0, trimmedEnd);
+    NSRange labelRange = [string rangeOfString:normalizedLabel
+                                       options:NSBackwardsSearch | NSCaseInsensitiveSearch
+                                         range:searchRange];
+    if (labelRange.location == NSNotFound || NSMaxRange(labelRange) != trimmedEnd) return attributedText;
+
+    NSUInteger deleteStart = labelRange.location;
+    while (deleteStart > 0 && [trimSet characterIsMember:[string characterAtIndex:deleteStart - 1]]) {
+        deleteStart--;
+    }
+    NSMutableAttributedString *stripped = [attributedText mutableCopy];
+    [stripped deleteCharactersInRange:NSMakeRange(deleteStart, trimmedEnd - deleteStart)];
+
+    while (stripped.length > 0 && [trimSet characterIsMember:[stripped.string characterAtIndex:stripped.length - 1]]) {
+        [stripped deleteCharactersInRange:NSMakeRange(stripped.length - 1, 1)];
+    }
+    return stripped;
+}
+
 static void ApolloDeletedCommentsRememberHiddenTextNode(id cellNode, id textNode) {
     if (!cellNode || !textNode) return;
     NSMutableArray *nodes = nil;
@@ -985,9 +1151,13 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsAttribut
 static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(id textNode, NSAttributedString *attributedText) {
     if (!sShowDeletedComments) return attributedText;
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
-    if (ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(attributedText) ||
-        ApolloDeletedCommentsAttributedTextHasReasonPrefix(attributedText)) {
+    if (ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(attributedText)) {
         return attributedText;
+    }
+    if (ApolloDeletedCommentsAttributedTextHasReasonPrefix(attributedText)) {
+        if (ApolloDeletedCommentsAttributedTextHasVisibleReasonChip(attributedText)) return attributedText;
+        attributedText = ApolloDeletedCommentsAttributedTextByRemovingReasonPrefix(attributedText);
+        if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
     }
 
     id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
@@ -997,13 +1167,16 @@ static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(i
     if (sTapToRevealDeletedComments && !revealed) return attributedText;
     id bodyTextNode = ApolloDeletedCommentsBestBodyTextNode(cellNode, comment);
     if (bodyTextNode && bodyTextNode != textNode) return attributedText;
-    BOOL bodyCandidate = ApolloDeletedCommentsTextQualifiesAsBodyCandidate(attributedText.string, comment.body) ||
-                         ApolloDeletedCommentsTextQualifiesAsBodyFragment(attributedText.string, comment.body);
+    NSString *label = ApolloDeletedCommentsReasonLabelForComment(comment);
+    NSString *originalBody = objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey);
+    NSString *bodyForCompare = [originalBody isKindOfClass:[NSString class]] && originalBody.length > 0 ? originalBody : comment.body;
+    NSAttributedString *bodySourceText = ApolloDeletedCommentsAttributedTextByRemovingTrailingReasonLabel(attributedText, label);
+    BOOL bodyCandidate = ApolloDeletedCommentsTextQualifiesAsBodyCandidate(bodySourceText.string, bodyForCompare) ||
+                         ApolloDeletedCommentsTextQualifiesAsBodyFragment(bodySourceText.string, bodyForCompare);
     if (!bodyCandidate) return attributedText;
 
-    NSAttributedString *bodyText = ApolloDeletedCommentsRecoveredBodyTextForDisplay(attributedText, comment.body);
+    NSAttributedString *bodyText = ApolloDeletedCommentsRecoveredBodyTextForDisplay(bodySourceText, bodyForCompare);
     NSDictionary *baseAttributes = bodyText.length > 0 ? ([bodyText attributesAtIndex:0 effectiveRange:NULL] ?: @{}) : @{};
-    NSString *label = ApolloDeletedCommentsReasonLabelForComment(comment);
     NSMutableDictionary *spacerAttributes = [baseAttributes mutableCopy];
     NSMutableParagraphStyle *spacerStyle = [NSMutableParagraphStyle new];
     spacerStyle.minimumLineHeight = 20.0;
@@ -1539,6 +1712,55 @@ static UIView *ApolloDeletedCommentsCellView(id cellNode) {
     return [view isKindOfClass:[UIView class]] ? view : nil;
 }
 
+static UIView *ApolloDeletedCommentsHostListViewForCell(id cellNode) {
+    UIView *view = ApolloDeletedCommentsCellView(cellNode);
+    for (NSUInteger i = 0; view && i < 14; i++, view = view.superview) {
+        if ([view isKindOfClass:[UITableView class]] || [view isKindOfClass:[UICollectionView class]]) {
+            return view;
+        }
+    }
+    return nil;
+}
+
+static void ApolloDeletedCommentsScheduleHostLayoutRefresh(id cellNode) {
+    if (!cellNode || !sShowDeletedComments || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return;
+
+    UIView *hostView = ApolloDeletedCommentsHostListViewForCell(cellNode);
+    UIView *cellView = ApolloDeletedCommentsCellView(cellNode);
+    if (![hostView isKindOfClass:[UIView class]] || !hostView.window) return;
+    if (objc_getAssociatedObject(hostView, kApolloDeletedCommentsHostLayoutRefreshScheduledKey)) return;
+
+    objc_setAssociatedObject(hostView, kApolloDeletedCommentsHostLayoutRefreshScheduledKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    __weak UIView *weakHostView = hostView;
+    __weak UIView *weakCellView = cellView;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.03 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        UIView *strongHostView = weakHostView;
+        UIView *strongCellView = weakCellView;
+        if (![strongHostView isKindOfClass:[UIView class]]) return;
+
+        objc_setAssociatedObject(strongHostView, kApolloDeletedCommentsHostLayoutRefreshScheduledKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        for (UIView *view = strongCellView; view && view != strongHostView.superview; view = view.superview) {
+            [view setNeedsLayout];
+            [view setNeedsDisplay];
+        }
+
+        @try {
+            if ([strongHostView isKindOfClass:[UICollectionView class]]) {
+                [(UICollectionView *)strongHostView performBatchUpdates:nil completion:nil];
+            } else if ([strongHostView isKindOfClass:[UITableView class]]) {
+                UITableView *tableView = (UITableView *)strongHostView;
+                [tableView beginUpdates];
+                [tableView endUpdates];
+            } else {
+                [strongHostView setNeedsLayout];
+                [strongHostView layoutIfNeeded];
+            }
+        } @catch (__unused NSException *e) {
+            [strongHostView setNeedsLayout];
+        }
+    });
+}
+
 static void ApolloDeletedCommentsRemoveCellHighlight(id cellNode) {
     UIView *highlight = objc_getAssociatedObject(cellNode, kApolloDeletedCommentsHighlightViewKey);
     if ([highlight isKindOfClass:[UIView class]]) {
@@ -1731,9 +1953,10 @@ static void ApolloDeletedCommentsApplyCachedArchiveToVisiblePlaceholderCell(id c
 }
 
 static void __attribute__((unused)) ApolloDeletedCommentsRepairVisibleReasonChipIfNeeded(id cellNode) {
-    if (!sShowDeletedComments || sTapToRevealDeletedComments) return;
+    if (!sShowDeletedComments) return;
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return;
+    if (sTapToRevealDeletedComments && !ApolloDeletedCommentsCommentIsRevealedByFullName(comment)) return;
 
     NSArray *textNodes = ApolloDeletedCommentsBodyTextNodes(cellNode, comment);
     if (textNodes.count == 0) {
@@ -1755,9 +1978,16 @@ static void __attribute__((unused)) ApolloDeletedCommentsRepairVisibleReasonChip
             ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
             return;
         }
-        if (ApolloDeletedCommentsAttributedTextHasReasonPrefix(current)) return;
+        if (ApolloDeletedCommentsAttributedTextHasVisibleReasonChip(current)) return;
 
-        NSAttributedString *repaired = ApolloDeletedCommentsAttributedTextWithReasonPrefix(textNode, current);
+        NSAttributedString *bodySource = current;
+        if (ApolloDeletedCommentsAttributedTextHasReasonPrefix(current)) {
+            bodySource = ApolloDeletedCommentsAttributedTextByRemovingReasonPrefix(current);
+            if (![bodySource isKindOfClass:[NSAttributedString class]] || bodySource.length == 0) {
+                bodySource = ApolloDeletedCommentsBodyAttributedText(current, comment.body);
+            }
+        }
+        NSAttributedString *repaired = ApolloDeletedCommentsAttributedTextWithReasonPrefix(textNode, bodySource);
         if (repaired != current) {
             ApolloDeletedCommentsSetTextNodeAttributedText(textNode, repaired);
             ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
@@ -1770,7 +2000,17 @@ static void ApolloDeletedCommentsUpdateCell(id cellNode) {
     ApolloDeletedCommentsTrackVisibleDeletedCommentCell(cellNode);
     ApolloDeletedCommentsApplyCachedArchiveToVisiblePlaceholderCell(cellNode);
     ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
+    ApolloDeletedCommentsRepairVisibleReasonChipIfNeeded(cellNode);
     ApolloDeletedCommentsApplyCellHighlight(cellNode);
+}
+
+static void ApolloDeletedCommentsRefreshVisibleDeletedCells(void) {
+    if (!sShowDeletedComments) return;
+    for (id cellNode in ApolloDeletedCommentsAllTrackedVisibleCells()) {
+        ApolloDeletedCommentsUpdateCell(cellNode);
+        ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyContainerNode(cellNode));
+        ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyTextNode(cellNode));
+    }
 }
 
 static void ApolloDeletedCommentsScheduleVisibleCellRefreshForComment(RDKComment *comment) {
@@ -1888,6 +2128,17 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
                                                   usingBlock:^(NSNotification *notification) {
         ApolloDeletedCommentsHandleArcticCacheUpdated(notification);
     }];
+    [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidBecomeActiveNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(__unused NSNotification *notification) {
+        NSArray<NSNumber *> *delays = @[@0.0, @0.08, @0.25, @0.60];
+        for (NSNumber *delayNumber in delays) {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayNumber.doubleValue * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                ApolloDeletedCommentsRefreshVisibleDeletedCells();
+            });
+        }
+    }];
 }
 
 @interface _TtC6Apollo15CommentCellNode
@@ -1921,7 +2172,19 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
     if (bodyNode) {
         objc_setAssociatedObject(bodyNode, kApolloDeletedCommentsBodyOwnerCellKey, (id)self, OBJC_ASSOCIATION_ASSIGN);
     }
-    return %orig;
+    id spec = %orig;
+    if (sShowDeletedComments && ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment((id)self) && spec) {
+        Class insetClass = ApolloDeletedCommentsASInsetLayoutSpecClass();
+        if (insetClass) {
+            @try {
+                return ((id (*)(Class, SEL, UIEdgeInsets, id))objc_msgSend)(insetClass,
+                                                                             @selector(insetLayoutSpecWithInsets:child:),
+                                                                             UIEdgeInsetsMake(0.0, 0.0, 8.0, 0.0),
+                                                                             spec);
+            } @catch (__unused NSException *e) {}
+        }
+    }
+    return spec;
 }
 
 - (void)layout {
@@ -1950,9 +2213,15 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
         }
         return hiddenLabel;
     }
-    if ([savedBody isKindOfClass:[NSString class]] &&
-        savedBody.length > 0 &&
-        (ApolloDeletedCommentsStringIsReasonLabel(body) || !sTapToRevealDeletedComments)) {
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment((RDKComment *)self);
+    BOOL recovered = ApolloDeletedCommentsIsRecoveredComment(fullName) ||
+                     ApolloDeletedCommentsIsRecoveredCommentBody(((RDKComment *)self).author, bodyForState);
+    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
+                    ApolloDeletedCommentsIsCommentBodyRevealed(((RDKComment *)self).author, bodyForState);
+    if (sShowDeletedComments && recovered && (!sTapToRevealDeletedComments || revealed)) {
+        return ApolloDeletedCommentsBodyByAppendingReasonLabel(bodyForState, ApolloDeletedCommentsReasonLabelForComment((RDKComment *)self));
+    }
+    if ([savedBody isKindOfClass:[NSString class]] && savedBody.length > 0 && ApolloDeletedCommentsStringIsReasonLabel(body)) {
         return savedBody;
     }
     return body;
@@ -1971,6 +2240,17 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
     }
 
     NSString *savedBodyHTML = objc_getAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyHTMLKey);
+    NSString *displayBody = ((NSString *(*)(id, SEL))objc_msgSend)((id)self, @selector(body));
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment((RDKComment *)self);
+    NSString *displayBodyForState = [savedBody isKindOfClass:[NSString class]] && savedBody.length > 0 ? savedBody : displayBody;
+    BOOL recovered = ApolloDeletedCommentsIsRecoveredComment(fullName) ||
+                     ApolloDeletedCommentsIsRecoveredCommentBody(((RDKComment *)self).author, displayBodyForState);
+    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
+                    ApolloDeletedCommentsIsCommentBodyRevealed(((RDKComment *)self).author, displayBodyForState);
+    if (sShowDeletedComments && recovered && (!sTapToRevealDeletedComments || revealed)) {
+        NSString *baseHTML = [savedBodyHTML isKindOfClass:[NSString class]] && savedBodyHTML.length > 0 ? savedBodyHTML : bodyHTML;
+        return ApolloDeletedCommentsBodyHTMLByAppendingReasonLabel(baseHTML, displayBodyForState, ApolloDeletedCommentsReasonLabelForComment((RDKComment *)self));
+    }
     if ([savedBodyHTML isKindOfClass:[NSString class]] &&
         savedBodyHTML.length > 0 &&
         (ApolloDeletedCommentsStringIsReasonLabel(ApolloDeletedCommentsTrimmedString(bodyHTML)) || !sTapToRevealDeletedComments)) {

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -435,6 +435,13 @@ static BOOL ApolloDeletedCommentsCommentIsRevealedByFullName(RDKComment *comment
     return ApolloDeletedCommentsIsCommentRevealed(fullName);
 }
 
+static BOOL ApolloDeletedCommentsShouldKeepModelBodyHidden(RDKComment *comment) {
+    if (!sShowDeletedComments || !sTapToRevealDeletedComments || !comment) return NO;
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    return ApolloDeletedCommentsIsRecoveredComment(fullName) &&
+           !ApolloDeletedCommentsIsCommentRevealed(fullName);
+}
+
 static void ApolloDeletedCommentsSynchronizeCommentModelDisplayState(id cellNode) {
     if (!cellNode) return;
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
@@ -451,7 +458,11 @@ static void ApolloDeletedCommentsSynchronizeCommentModelDisplayState(id cellNode
 
     if (recovered) {
         ApolloDeletedCommentsRememberOriginalModelBodyIfNeeded(comment);
-        ApolloDeletedCommentsRestoreOriginalModelBodyIfNeeded(comment);
+        if (ApolloDeletedCommentsShouldKeepModelBodyHidden(comment)) {
+            ApolloDeletedCommentsSetModelBodyToReasonLabel(comment, ApolloDeletedCommentsReasonLabelForComment(comment));
+        } else {
+            ApolloDeletedCommentsRestoreOriginalModelBodyIfNeeded(comment);
+        }
     }
 }
 
@@ -2322,7 +2333,10 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRe
 - (NSString *)body {
     NSString *body = %orig;
     NSString *savedBody = objc_getAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyKey);
-    if ([savedBody isKindOfClass:[NSString class]] && savedBody.length > 0 && ApolloDeletedCommentsStringIsReasonLabel(body)) {
+    if ([savedBody isKindOfClass:[NSString class]] &&
+        savedBody.length > 0 &&
+        ApolloDeletedCommentsStringIsReasonLabel(body) &&
+        !ApolloDeletedCommentsShouldKeepModelBodyHidden((RDKComment *)self)) {
         return savedBody;
     }
     return body;
@@ -2333,7 +2347,8 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRe
     NSString *savedBodyHTML = objc_getAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyHTMLKey);
     if ([savedBodyHTML isKindOfClass:[NSString class]] &&
         savedBodyHTML.length > 0 &&
-        ApolloDeletedCommentsStringIsReasonLabel(ApolloDeletedCommentsTrimmedString(bodyHTML))) {
+        ApolloDeletedCommentsStringIsReasonLabel(ApolloDeletedCommentsTrimmedString(bodyHTML)) &&
+        !ApolloDeletedCommentsShouldKeepModelBodyHidden((RDKComment *)self)) {
         return savedBodyHTML;
     }
     return bodyHTML;

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -7,30 +7,21 @@
 #import "ApolloState.h"
 #import "Tweak.h"
 
-static const void *kApolloDeletedCommentsFlairContainerKey = &kApolloDeletedCommentsFlairContainerKey;
-static const void *kApolloDeletedCommentsFlairOriginalBackgroundKey = &kApolloDeletedCommentsFlairOriginalBackgroundKey;
+static const void *kApolloDeletedCommentsHighlightViewKey = &kApolloDeletedCommentsHighlightViewKey;
 static const void *kApolloDeletedCommentsHiddenOriginalTextKey = &kApolloDeletedCommentsHiddenOriginalTextKey;
 static const void *kApolloDeletedCommentsHiddenFullNameKey = &kApolloDeletedCommentsHiddenFullNameKey;
 static const void *kApolloDeletedCommentsHiddenTextNodeKey = &kApolloDeletedCommentsHiddenTextNodeKey;
 static const void *kApolloDeletedCommentsSuppressNextCollapseKey = &kApolloDeletedCommentsSuppressNextCollapseKey;
 
-static NSString *const ApolloDeletedCommentsTapPlaceholderText = @"SHOW";
 static NSString *const ApolloDeletedCommentsRevealURLString = @"apollo-deleted-comments://reveal";
 static NSString *const ApolloDeletedCommentsRevealAttributeName = @"ApolloDeletedCommentsRevealAttribute";
+static NSString *const ApolloDeletedCommentsReasonPrefixAttributeName = @"ApolloDeletedCommentsReasonPrefixAttribute";
+
+static id ApolloDeletedCommentsCommentCellNodeForTextNode(id textNode);
 
 static NSString *ApolloDeletedCommentsTrimmedString(NSString *s) {
     if (![s isKindOfClass:[NSString class]]) return nil;
     return [s stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-}
-
-static BOOL ApolloDeletedCommentsIsRecoveredFlairText(NSAttributedString *attributedText) {
-    if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return NO;
-    NSString *text = ApolloDeletedCommentsTrimmedString(attributedText.string);
-    NSString *lower = [text lowercaseString];
-    return [lower isEqualToString:@"deleted"] ||
-           [lower isEqualToString:@"user deleted"] ||
-           [lower isEqualToString:@"deleted by user"] ||
-           [lower isEqualToString:@"removed by mod"];
 }
 
 static UIColor *ApolloDeletedCommentsBadgeRed(void) {
@@ -40,83 +31,16 @@ static UIColor *ApolloDeletedCommentsBadgeRed(void) {
     return [UIColor redColor];
 }
 
-static NSAttributedString *ApolloDeletedCommentsStyledFlairText(NSAttributedString *attributedText) {
-    if (!ApolloDeletedCommentsIsRecoveredFlairText(attributedText)) return attributedText;
-
-    NSMutableAttributedString *styled = [attributedText mutableCopy];
-    NSRange fullRange = NSMakeRange(0, styled.length);
-    [styled addAttribute:NSForegroundColorAttributeName value:ApolloDeletedCommentsBadgeRed() range:fullRange];
-    [styled removeAttribute:NSBackgroundColorAttributeName range:fullRange];
-    return styled;
+static UIColor *ApolloDeletedCommentsHighlightColor(void) {
+    return [ApolloDeletedCommentsBadgeRed() colorWithAlphaComponent:0.22];
 }
 
-static id ApolloDeletedCommentsFlairContainerForTextNode(id textNode) {
-    if (!textNode || ![textNode respondsToSelector:@selector(supernode)]) return nil;
-
-    id current = nil;
-    @try {
-        current = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(supernode));
-    } @catch (__unused NSException *e) {
-        current = nil;
-    }
-
-    for (NSUInteger i = 0; current && i < 3; i++) {
-        const char *className = class_getName(object_getClass(current));
-        if (className && strstr(className, "CommentCellNode")) return nil;
-        if ([current respondsToSelector:@selector(setBackgroundColor:)]) return current;
-        if (![current respondsToSelector:@selector(supernode)]) break;
-        @try {
-            current = ((id (*)(id, SEL))objc_msgSend)(current, @selector(supernode));
-        } @catch (__unused NSException *e) {
-            break;
-        }
-    }
-    return nil;
+static UIColor *ApolloDeletedCommentsChipBackgroundColor(void) {
+    return [UIColor colorWithRed:1.0 green:0.78 blue:0.76 alpha:1.0];
 }
 
-static void ApolloDeletedCommentsRestoreFlairContainer(id textNode) {
-    id container = objc_getAssociatedObject(textNode, kApolloDeletedCommentsFlairContainerKey);
-    if (!container) return;
-
-    UIColor *original = objc_getAssociatedObject(textNode, kApolloDeletedCommentsFlairOriginalBackgroundKey);
-    if ([container respondsToSelector:@selector(setBackgroundColor:)]) {
-        @try {
-            ((void (*)(id, SEL, UIColor *))objc_msgSend)(container, @selector(setBackgroundColor:), original);
-        } @catch (__unused NSException *e) {}
-    }
-
-    objc_setAssociatedObject(textNode, kApolloDeletedCommentsFlairContainerKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    objc_setAssociatedObject(textNode, kApolloDeletedCommentsFlairOriginalBackgroundKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-static void ApolloDeletedCommentsApplyFlairContainerStyle(id textNode, NSAttributedString *attributedText) {
-    if (!sShowDeletedComments || !ApolloDeletedCommentsIsRecoveredFlairText(attributedText)) {
-        ApolloDeletedCommentsRestoreFlairContainer(textNode);
-        return;
-    }
-
-    id container = ApolloDeletedCommentsFlairContainerForTextNode(textNode);
-    if (!container) return;
-
-    id previous = objc_getAssociatedObject(textNode, kApolloDeletedCommentsFlairContainerKey);
-    if (previous && previous != container) ApolloDeletedCommentsRestoreFlairContainer(textNode);
-    if (!objc_getAssociatedObject(textNode, kApolloDeletedCommentsFlairContainerKey)) {
-        UIColor *original = nil;
-        if ([container respondsToSelector:@selector(backgroundColor)]) {
-            @try {
-                original = ((UIColor *(*)(id, SEL))objc_msgSend)(container, @selector(backgroundColor));
-            } @catch (__unused NSException *e) {
-                original = nil;
-            }
-        }
-        objc_setAssociatedObject(textNode, kApolloDeletedCommentsFlairContainerKey, container, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        if (original) objc_setAssociatedObject(textNode, kApolloDeletedCommentsFlairOriginalBackgroundKey, original, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    }
-
-    UIColor *background = [ApolloDeletedCommentsBadgeRed() colorWithAlphaComponent:0.24];
-    @try {
-        ((void (*)(id, SEL, UIColor *))objc_msgSend)(container, @selector(setBackgroundColor:), background);
-    } @catch (__unused NSException *e) {}
+static UIColor *ApolloDeletedCommentsChipTextColor(void) {
+    return [UIColor colorWithRed:0.30 green:0.04 blue:0.04 alpha:1.0];
 }
 
 static NSString *ApolloDeletedCommentsNormalizeCommentFullName(NSString *value) {
@@ -194,6 +118,103 @@ static RDKComment *ApolloDeletedCommentsCommentFromCellNode(id commentCellNode) 
     return (RDKComment *)comment;
 }
 
+static NSString *ApolloDeletedCommentsRecoveredReasonForCommentObject(RDKComment *comment) {
+    if (!comment) return nil;
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    NSString *reason = ApolloDeletedCommentsRecoveredReasonForComment(fullName);
+    if (reason.length > 0) return reason;
+    return ApolloDeletedCommentsRecoveredReasonForCommentBody(comment.author, comment.body);
+}
+
+static BOOL ApolloDeletedCommentsCellNodeIsRecovered(id cellNode) {
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    return ApolloDeletedCommentsRecoveredReasonForComment(fullName).length > 0;
+}
+
+static BOOL ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(id cellNode) {
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    if (!comment) return NO;
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    return ApolloDeletedCommentsIsRecoveredComment(fullName) ||
+           ApolloDeletedCommentsIsRecoveredCommentBody(comment.author, comment.body);
+}
+
+static NSString *ApolloDeletedCommentsReasonLabelForComment(RDKComment *comment) {
+    NSString *reason = ApolloDeletedCommentsRecoveredReasonForCommentObject(comment);
+    return ApolloDeletedCommentsDisplayLabelForReason(reason);
+}
+
+static UIImage *ApolloDeletedCommentsReasonChipImage(NSString *text, UIFont *font) {
+    if (![text isKindOfClass:[NSString class]] || text.length == 0) return nil;
+    if (![font isKindOfClass:[UIFont class]]) font = [UIFont boldSystemFontOfSize:15.0];
+
+    NSDictionary *attributes = @{
+        NSFontAttributeName: font,
+        NSForegroundColorAttributeName: ApolloDeletedCommentsChipTextColor(),
+    };
+    CGSize textSize = [text sizeWithAttributes:attributes];
+    CGFloat horizontalPadding = 8.0;
+    CGFloat verticalPadding = 2.0;
+    CGSize imageSize = CGSizeMake(ceil(textSize.width + horizontalPadding * 2.0),
+                                  ceil(textSize.height + verticalPadding * 2.0));
+
+    UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
+    format.opaque = NO;
+    format.scale = UIScreen.mainScreen.scale;
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:imageSize format:format];
+    return [renderer imageWithActions:^(__unused UIGraphicsImageRendererContext *context) {
+        CGRect bounds = CGRectMake(0.0, 0.0, imageSize.width, imageSize.height);
+        UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:bounds cornerRadius:7.0];
+        [ApolloDeletedCommentsChipBackgroundColor() setFill];
+        [path fill];
+
+        CGRect textRect = CGRectMake(horizontalPadding,
+                                     floor((imageSize.height - textSize.height) / 2.0),
+                                     textSize.width,
+                                     textSize.height);
+        [text drawInRect:textRect withAttributes:attributes];
+    }];
+}
+
+static NSAttributedString *ApolloDeletedCommentsReasonChipAttributedText(NSString *label, NSDictionary *baseAttributes, BOOL revealLink) {
+    UIFont *font = baseAttributes[NSFontAttributeName];
+    if (![font isKindOfClass:[UIFont class]]) {
+        font = [UIFont boldSystemFontOfSize:15.0];
+    } else {
+        font = [UIFont boldSystemFontOfSize:MAX(12.0, font.pointSize - 2.5)];
+    }
+
+    UIImage *image = ApolloDeletedCommentsReasonChipImage(label, font);
+    CGFloat chipLineHeight = [image isKindOfClass:[UIImage class]] ? image.size.height + 2.0 : font.lineHeight + 2.0;
+    NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
+    paragraphStyle.lineSpacing = 0.0;
+    paragraphStyle.paragraphSpacing = 4.0;
+    paragraphStyle.minimumLineHeight = ceil(chipLineHeight);
+    paragraphStyle.maximumLineHeight = ceil(chipLineHeight);
+
+    NSMutableAttributedString *result = nil;
+    if ([image isKindOfClass:[UIImage class]]) {
+        NSTextAttachment *attachment = [NSTextAttachment new];
+        attachment.image = image;
+        attachment.bounds = CGRectMake(0.0, -2.0, image.size.width, image.size.height);
+        result = [[NSAttributedString attributedStringWithAttachment:attachment] mutableCopy];
+        [result addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:NSMakeRange(0, result.length)];
+    } else {
+        result = [[NSMutableAttributedString alloc] initWithString:label attributes:@{
+            NSFontAttributeName: font,
+            NSForegroundColorAttributeName: ApolloDeletedCommentsChipTextColor(),
+            NSParagraphStyleAttributeName: paragraphStyle,
+        }];
+    }
+
+    if (revealLink) {
+        [result addAttribute:ApolloDeletedCommentsRevealAttributeName value:ApolloDeletedCommentsRevealURLString range:NSMakeRange(0, result.length)];
+    }
+    [result addAttribute:ApolloDeletedCommentsReasonPrefixAttributeName value:@YES range:NSMakeRange(0, result.length)];
+    return result;
+}
+
 static id ApolloDeletedCommentsKnownBodyTextNode(id commentCellNode) {
     if (!commentCellNode) return nil;
     static const char *candidateNames[] = {
@@ -245,78 +266,18 @@ static void ApolloDeletedCommentsRelayoutCellAndTextNode(id cellNode, id textNod
     }
 }
 
-static UIImage *ApolloDeletedCommentsSpoilerStyleImage(NSString *text, UIFont *font) {
-    if (![text isKindOfClass:[NSString class]] || text.length == 0) return nil;
-    if (![font isKindOfClass:[UIFont class]]) font = [UIFont boldSystemFontOfSize:15.0];
-
-    NSDictionary *attributes = @{
-        NSFontAttributeName: font,
-        NSForegroundColorAttributeName: [UIColor blackColor],
-    };
-    CGSize textSize = [text sizeWithAttributes:attributes];
-    CGFloat horizontalPadding = 4.0;
-    CGFloat verticalPadding = 0.5;
-    CGSize imageSize = CGSizeMake(ceil(textSize.width + horizontalPadding * 2.0),
-                                  ceil(textSize.height + verticalPadding * 2.0));
-
-    UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
-    format.opaque = NO;
-    format.scale = UIScreen.mainScreen.scale;
-    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:imageSize format:format];
-    return [renderer imageWithActions:^(UIGraphicsImageRendererContext *context) {
-        CGRect bounds = CGRectMake(0.0, 0.0, imageSize.width, imageSize.height);
-        UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:bounds cornerRadius:6.0];
-        [[UIColor colorWithWhite:0.84 alpha:1.0] setFill];
-        [path fill];
-
-        CGRect textRect = CGRectMake(horizontalPadding,
-                                     floor((imageSize.height - textSize.height) / 2.0),
-                                     textSize.width,
-                                     textSize.height);
-        [text drawInRect:textRect withAttributes:attributes];
-    }];
-}
-
-static NSAttributedString *ApolloDeletedCommentsPlaceholderAttributedText(NSAttributedString *original) {
+static NSAttributedString *ApolloDeletedCommentsPlaceholderAttributedText(NSAttributedString *original, NSString *reasonLabel) {
     NSDictionary *attributes = @{};
     if ([original isKindOfClass:[NSAttributedString class]] && original.length > 0) {
         attributes = [original attributesAtIndex:0 effectiveRange:NULL] ?: @{};
     }
-    UIFont *font = attributes[NSFontAttributeName];
-    if (![font isKindOfClass:[UIFont class]]) {
-        font = [UIFont boldSystemFontOfSize:15.0];
-    } else {
-        font = [UIFont boldSystemFontOfSize:MAX(12.0, font.pointSize - 2.5)];
-    }
 
-    NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
-    paragraphStyle.lineSpacing = 0.0;
-    paragraphStyle.paragraphSpacing = 0.0;
-    paragraphStyle.minimumLineHeight = ceil(font.lineHeight + 2.0);
-    paragraphStyle.maximumLineHeight = ceil(font.lineHeight + 2.0);
-
-    UIImage *image = ApolloDeletedCommentsSpoilerStyleImage(ApolloDeletedCommentsTapPlaceholderText, font);
-    if (![image isKindOfClass:[UIImage class]]) {
-        return [[NSAttributedString alloc] initWithString:ApolloDeletedCommentsTapPlaceholderText attributes:@{
-            NSFontAttributeName: font,
-            NSForegroundColorAttributeName: [UIColor blackColor],
-            NSParagraphStyleAttributeName: paragraphStyle,
-            ApolloDeletedCommentsRevealAttributeName: ApolloDeletedCommentsRevealURLString,
-        }];
-    }
-
-    NSTextAttachment *attachment = [NSTextAttachment new];
-    attachment.image = image;
-    attachment.bounds = CGRectMake(0.0, -1.0, image.size.width, image.size.height);
-    NSMutableAttributedString *result = [[NSAttributedString attributedStringWithAttachment:attachment] mutableCopy];
-    [result addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:NSMakeRange(0, result.length)];
-    [result addAttribute:ApolloDeletedCommentsRevealAttributeName value:ApolloDeletedCommentsRevealURLString range:NSMakeRange(0, result.length)];
-    return result;
+    NSAttributedString *chip = ApolloDeletedCommentsReasonChipAttributedText(reasonLabel, attributes, YES);
+    return chip;
 }
 
 static BOOL ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(NSAttributedString *attributedText) {
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return NO;
-    if ([attributedText.string isEqualToString:ApolloDeletedCommentsTapPlaceholderText]) return YES;
 
     __block BOOL hasRevealLink = NO;
     [attributedText enumerateAttribute:NSLinkAttributeName
@@ -351,13 +312,39 @@ static BOOL ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(NSAttributedS
 static NSString *ApolloDeletedCommentsNormalizeTextForCompare(NSString *s) {
     if (![s isKindOfClass:[NSString class]]) return @"";
     NSString *trimmed = [s stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if ([trimmed hasPrefix:@">!"] && [trimmed hasSuffix:@"!<"] && trimmed.length > 4) {
+        trimmed = [trimmed substringWithRange:NSMakeRange(2, trimmed.length - 4)];
+    }
+    NSMutableArray<NSString *> *lines = [NSMutableArray array];
+    for (NSString *line in [trimmed componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]]) {
+        NSString *normalizedLine = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        while ([normalizedLine hasPrefix:@">"]) {
+            normalizedLine = [[normalizedLine substringFromIndex:1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        }
+        if ([normalizedLine hasPrefix:@"!"] && ![normalizedLine hasPrefix:@"!!"]) {
+            normalizedLine = [normalizedLine substringFromIndex:1];
+        }
+        if ([normalizedLine hasSuffix:@"!<"] && normalizedLine.length > 2) {
+            normalizedLine = [normalizedLine substringToIndex:normalizedLine.length - 2];
+        }
+        [lines addObject:normalizedLine];
+    }
+    trimmed = [lines componentsJoinedByString:@" "];
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\s+" options:0 error:nil];
     return [regex stringByReplacingMatchesInString:trimmed options:0 range:NSMakeRange(0, trimmed.length) withTemplate:@" "];
 }
 
+static NSString *ApolloDeletedCommentsUnwrappedSpoilerMarkdown(NSString *s) {
+    NSString *trimmed = ApolloDeletedCommentsTrimmedString(s);
+    if ([trimmed hasPrefix:@">!"] && [trimmed hasSuffix:@"!<"] && trimmed.length > 4) {
+        return [trimmed substringWithRange:NSMakeRange(2, trimmed.length - 4)];
+    }
+    return trimmed;
+}
+
 static BOOL ApolloDeletedCommentsTextQualifiesAsBodyCandidate(NSString *candidate, NSString *body) {
     NSString *candidateNorm = ApolloDeletedCommentsNormalizeTextForCompare(candidate);
-    NSString *bodyNorm = ApolloDeletedCommentsNormalizeTextForCompare(body);
+    NSString *bodyNorm = ApolloDeletedCommentsNormalizeTextForCompare(ApolloDeletedCommentsUnwrappedSpoilerMarkdown(body));
     if (candidateNorm.length == 0 || bodyNorm.length == 0) return NO;
     if ([candidateNorm isEqualToString:bodyNorm]) return YES;
     NSUInteger minLen = MIN(candidateNorm.length, bodyNorm.length);
@@ -421,6 +408,50 @@ static id ApolloDeletedCommentsBestBodyTextNode(id cellNode, RDKComment *comment
         }
     }
     return bestNode;
+}
+
+static BOOL ApolloDeletedCommentsAttributedTextHasReasonPrefix(NSAttributedString *attributedText) {
+    if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return NO;
+    __block BOOL hasPrefix = NO;
+    [attributedText enumerateAttribute:ApolloDeletedCommentsReasonPrefixAttributeName
+                               inRange:NSMakeRange(0, attributedText.length)
+                               options:0
+                            usingBlock:^(id value, NSRange range, BOOL *stop) {
+        if ([value respondsToSelector:@selector(boolValue)] && [value boolValue]) {
+            hasPrefix = YES;
+            *stop = YES;
+        }
+    }];
+    return hasPrefix;
+}
+
+static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(id textNode, NSAttributedString *attributedText) {
+    if (!sShowDeletedComments) return attributedText;
+    if (sTapToRevealDeletedComments) return attributedText;
+    if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
+    if (ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(attributedText) ||
+        ApolloDeletedCommentsAttributedTextHasReasonPrefix(attributedText)) {
+        return attributedText;
+    }
+
+    id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    if (!comment || !ApolloDeletedCommentsCellNodeIsRecovered(cellNode)) return attributedText;
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
+                    ApolloDeletedCommentsIsCommentBodyRevealed(comment.author, comment.body);
+    if (sTapToRevealDeletedComments && !revealed) return attributedText;
+    id bodyTextNode = ApolloDeletedCommentsBestBodyTextNode(cellNode, comment);
+    if (bodyTextNode && bodyTextNode != textNode) return attributedText;
+    if (!ApolloDeletedCommentsTextQualifiesAsBodyCandidate(attributedText.string, comment.body)) return attributedText;
+
+    NSDictionary *baseAttributes = [attributedText attributesAtIndex:0 effectiveRange:NULL] ?: @{};
+    NSString *label = ApolloDeletedCommentsReasonLabelForComment(comment);
+    NSMutableAttributedString *prefixed = [[NSMutableAttributedString alloc] init];
+    [prefixed appendAttributedString:ApolloDeletedCommentsReasonChipAttributedText(label, baseAttributes, NO)];
+    [prefixed appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n" attributes:baseAttributes]];
+    [prefixed appendAttributedString:attributedText];
+    return prefixed;
 }
 
 static void ApolloDeletedCommentsRestoreHiddenBodyIfNeeded(id cellNode, id textNode) {
@@ -491,8 +522,7 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeede
     id textNode = ApolloDeletedCommentsBestBodyTextNode(cellNode, comment);
     if (!textNode) return;
 
-    BOOL recovered = ApolloDeletedCommentsIsRecoveredComment(fullName) ||
-                     ApolloDeletedCommentsIsRecoveredCommentBody(author, body);
+    BOOL recovered = ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode);
     BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
                     ApolloDeletedCommentsIsCommentBodyRevealed(author, body);
     BOOL shouldHide = sShowDeletedComments &&
@@ -538,7 +568,7 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeede
     objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-    NSAttributedString *placeholder = ApolloDeletedCommentsPlaceholderAttributedText(current);
+    NSAttributedString *placeholder = ApolloDeletedCommentsPlaceholderAttributedText(current, ApolloDeletedCommentsReasonLabelForComment(comment));
     @try {
         ((void (*)(id, SEL, NSAttributedString *))objc_msgSend)(textNode, @selector(setAttributedText:), placeholder);
     } @catch (__unused NSException *e) {}
@@ -559,7 +589,7 @@ static BOOL ApolloDeletedCommentsTouchHitsTextNode(id textNode, UITouch *touch) 
     return CGRectContainsPoint(CGRectInset(nodeView.bounds, -8.0, -8.0), point);
 }
 
-static void ApolloDeletedCommentsForceCommentExpanded(RDKComment *comment, id cellNode) {
+static void __attribute__((unused)) ApolloDeletedCommentsForceCommentExpanded(RDKComment *comment, id cellNode) {
     if (!comment) return;
 
     if ([(id)comment respondsToSelector:@selector(setCollapsed:)]) {
@@ -591,7 +621,7 @@ static void ApolloDeletedCommentsForceCommentExpanded(RDKComment *comment, id ce
     }
 }
 
-static void ApolloDeletedCommentsScheduleForceExpanded(RDKComment *comment, id cellNode) {
+static void __attribute__((unused)) ApolloDeletedCommentsScheduleForceExpanded(RDKComment *comment, id cellNode) {
     if (!comment) return;
     NSArray<NSNumber *> *delays = @[@0.0, @0.03, @0.12, @0.30];
     for (NSNumber *delayNumber in delays) {
@@ -607,7 +637,7 @@ static BOOL __attribute__((unused)) ApolloDeletedCommentsTouchHitsHiddenBody(id 
     return ApolloDeletedCommentsTouchHitsTextNode(textNode, touch);
 }
 
-static void ApolloDeletedCommentsRevealHiddenBodyForCell(id cellNode) {
+static void __attribute__((unused)) ApolloDeletedCommentsRevealHiddenBodyForCell(id cellNode) {
     id textNode = objc_getAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey);
     if (!objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey)) return;
 
@@ -617,6 +647,31 @@ static void ApolloDeletedCommentsRevealHiddenBodyForCell(id cellNode) {
     ApolloDeletedCommentsMarkCommentBodyRevealed(comment.author, comment.body);
     objc_setAssociatedObject(comment, kApolloDeletedCommentsSuppressNextCollapseKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloDeletedCommentsRestoreHiddenBodyIfNeeded(cellNode, textNode);
+    ApolloDeletedCommentsScheduleForceExpanded(comment, cellNode);
+}
+
+static BOOL __attribute__((unused)) ApolloDeletedCommentsCommentIsRevealed(RDKComment *comment) {
+    if (!comment) return NO;
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    return ApolloDeletedCommentsIsCommentRevealed(fullName) ||
+           ApolloDeletedCommentsIsCommentBodyRevealed(comment.author, comment.body);
+}
+
+static BOOL __attribute__((unused)) ApolloDeletedCommentsTouchHitsRecoveredBody(id cellNode, UITouch *touch) {
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    if (!comment || !ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode)) return NO;
+    id textNode = ApolloDeletedCommentsBestBodyTextNode(cellNode, comment);
+    return ApolloDeletedCommentsTouchHitsTextNode(textNode, touch);
+}
+
+static void __attribute__((unused)) ApolloDeletedCommentsHideRevealedBodyForCell(id cellNode) {
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    if (!comment) return;
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    ApolloDeletedCommentsUnmarkCommentRevealed(fullName);
+    ApolloDeletedCommentsUnmarkCommentBodyRevealed(comment.author, comment.body);
+    objc_setAssociatedObject(comment, kApolloDeletedCommentsSuppressNextCollapseKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloDeletedCommentsApplyTapToRevealIfNeeded(cellNode);
     ApolloDeletedCommentsScheduleForceExpanded(comment, cellNode);
 }
 
@@ -636,13 +691,59 @@ static id ApolloDeletedCommentsCommentCellNodeForTextNode(id textNode) {
     return nil;
 }
 
-static BOOL ApolloDeletedCommentsTextNodeBelongsToRecoveredComment(id textNode) {
+static BOOL __attribute__((unused)) ApolloDeletedCommentsTextNodeBelongsToRecoveredComment(id textNode) {
     id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
-    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
-    if (!comment) return NO;
-    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
-    return ApolloDeletedCommentsIsRecoveredComment(fullName) ||
-           ApolloDeletedCommentsIsRecoveredCommentBody(comment.author, comment.body);
+    return ApolloDeletedCommentsCellNodeIsRecovered(cellNode);
+}
+
+static UIView *ApolloDeletedCommentsCellView(id cellNode) {
+    if (!cellNode || ![cellNode respondsToSelector:@selector(view)]) return nil;
+    UIView *view = nil;
+    @try {
+        view = ((UIView *(*)(id, SEL))objc_msgSend)(cellNode, @selector(view));
+    } @catch (__unused NSException *e) {
+        view = nil;
+    }
+    return [view isKindOfClass:[UIView class]] ? view : nil;
+}
+
+static void ApolloDeletedCommentsRemoveCellHighlight(id cellNode) {
+    UIView *highlight = objc_getAssociatedObject(cellNode, kApolloDeletedCommentsHighlightViewKey);
+    if ([highlight isKindOfClass:[UIView class]]) {
+        [highlight removeFromSuperview];
+    }
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHighlightViewKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static void ApolloDeletedCommentsApplyCellHighlight(id cellNode) {
+    if (!sShowDeletedComments || !ApolloDeletedCommentsCellNodeIsRecovered(cellNode)) {
+        ApolloDeletedCommentsRemoveCellHighlight(cellNode);
+        return;
+    }
+
+    UIView *cellView = ApolloDeletedCommentsCellView(cellNode);
+    if (!cellView) return;
+
+    UIView *highlight = objc_getAssociatedObject(cellNode, kApolloDeletedCommentsHighlightViewKey);
+    if (![highlight isKindOfClass:[UIView class]]) {
+        highlight = [[UIView alloc] initWithFrame:cellView.bounds];
+        highlight.userInteractionEnabled = NO;
+        highlight.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        highlight.backgroundColor = ApolloDeletedCommentsHighlightColor();
+        objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHighlightViewKey, highlight, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    highlight.frame = cellView.bounds;
+    if (highlight.superview != cellView) {
+        [highlight removeFromSuperview];
+        [cellView addSubview:highlight];
+    } else {
+        [cellView bringSubviewToFront:highlight];
+    }
+}
+
+static void ApolloDeletedCommentsUpdateCell(id cellNode) {
+    ApolloDeletedCommentsApplyCellHighlight(cellNode);
 }
 
 static BOOL ApolloDeletedCommentsIsRevealLink(id attribute, id value) {
@@ -667,19 +768,34 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
     if (![text isEqualToString:@"SPOILER"]) return attributedText;
     if (!ApolloDeletedCommentsTextNodeBelongsToRecoveredComment(textNode)) return attributedText;
 
-    NSMutableAttributedString *renamed = [attributedText mutableCopy];
-    [renamed replaceCharactersInRange:NSMakeRange(0, renamed.length) withString:@" SHOW "];
+    id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    NSDictionary *baseAttributes = [attributedText attributesAtIndex:0 effectiveRange:NULL] ?: @{};
+    NSMutableAttributedString *renamed = [ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment), baseAttributes, NO) mutableCopy];
+    NSRange targetRange = NSMakeRange(0, renamed.length);
+    [attributedText enumerateAttributesInRange:NSMakeRange(0, attributedText.length)
+                                       options:0
+                                    usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attrs, __unused NSRange range, __unused BOOL *stop) {
+        for (NSAttributedStringKey key in attrs) {
+            if ([key isEqualToString:NSFontAttributeName] ||
+                [key isEqualToString:NSForegroundColorAttributeName] ||
+                [key isEqualToString:NSBackgroundColorAttributeName] ||
+                [key isEqualToString:NSParagraphStyleAttributeName]) {
+                continue;
+            }
+            [renamed addAttribute:key value:attrs[key] range:targetRange];
+        }
+    }];
     return renamed;
 }
 
 %hook ASTextNode
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
-    NSAttributedString *styledAttributedText = ApolloDeletedCommentsStyledFlairText(
+    NSAttributedString *rewrittenText = ApolloDeletedCommentsAttributedTextWithReasonPrefix((id)self,
         ApolloDeletedCommentsRenameRecoveredSpoilerLabel((id)self, attributedText)
     );
-    %orig(styledAttributedText);
-    ApolloDeletedCommentsApplyFlairContainerStyle((id)self, styledAttributedText);
+    %orig(rewrittenText);
 }
 
 - (void)didEnterDisplayState {
@@ -697,7 +813,12 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
             attributedText = renamedAttributedText;
         } @catch (__unused NSException *e) {}
     }
-    ApolloDeletedCommentsApplyFlairContainerStyle((id)self, attributedText);
+    NSAttributedString *prefixedText = ApolloDeletedCommentsAttributedTextWithReasonPrefix((id)self, attributedText);
+    if (prefixedText != attributedText) {
+        @try {
+            ((void (*)(id, SEL, NSAttributedString *))objc_msgSend)((id)self, @selector(setAttributedText:), prefixedText);
+        } @catch (__unused NSException *e) {}
+    }
 }
 
 %end
@@ -705,6 +826,7 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
 @interface _TtC6Apollo15CommentCellNode
 - (void)didLoad;
 - (void)didEnterDisplayState;
+- (void)calculatedLayoutDidChange;
 - (void)layout;
 @end
 
@@ -712,14 +834,22 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
 
 - (void)didLoad {
     %orig;
+    ApolloDeletedCommentsUpdateCell((id)self);
 }
 
 - (void)didEnterDisplayState {
     %orig;
+    ApolloDeletedCommentsUpdateCell((id)self);
+}
+
+- (void)calculatedLayoutDidChange {
+    %orig;
+    ApolloDeletedCommentsUpdateCell((id)self);
 }
 
 - (void)layout {
     %orig;
+    ApolloDeletedCommentsApplyCellHighlight((id)self);
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -14,11 +14,19 @@ static const void *kApolloDeletedCommentsHiddenTextNodeKey = &kApolloDeletedComm
 static const void *kApolloDeletedCommentsHiddenTextNodesKey = &kApolloDeletedCommentsHiddenTextNodesKey;
 static const void *kApolloDeletedCommentsSuppressNextCollapseKey = &kApolloDeletedCommentsSuppressNextCollapseKey;
 
+static NSMutableDictionary<NSString *, NSHashTable *> *sApolloDeletedCommentsVisibleCellsByFullName = nil;
+static NSObject *sApolloDeletedCommentsVisibleCellsLock = nil;
+
 static NSString *const ApolloDeletedCommentsRevealURLString = @"apollo-deleted-comments://reveal";
 static NSString *const ApolloDeletedCommentsRevealAttributeName = @"ApolloDeletedCommentsRevealAttribute";
 static NSString *const ApolloDeletedCommentsReasonPrefixAttributeName = @"ApolloDeletedCommentsReasonPrefixAttribute";
 
 static id ApolloDeletedCommentsCommentCellNodeForTextNode(id textNode);
+static void ApolloDeletedCommentsEnsureRevealAttributeIsTappable(id textNode);
+static void __attribute__((unused)) ApolloDeletedCommentsScheduleForceExpanded(RDKComment *comment, id cellNode);
+static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeeded(id cellNode);
+static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(id textNode, NSAttributedString *attributedText);
+static NSArray *ApolloDeletedCommentsHiddenTextNodesForCell(id cellNode);
 
 static NSString *ApolloDeletedCommentsTrimmedString(NSString *s) {
     if (![s isKindOfClass:[NSString class]]) return nil;
@@ -33,15 +41,15 @@ static UIColor *ApolloDeletedCommentsBadgeRed(void) {
 }
 
 static UIColor *ApolloDeletedCommentsHighlightColor(void) {
-    return [ApolloDeletedCommentsBadgeRed() colorWithAlphaComponent:0.22];
+    return [ApolloDeletedCommentsBadgeRed() colorWithAlphaComponent:0.24];
 }
 
 static UIColor *ApolloDeletedCommentsChipBackgroundColor(void) {
-    return [UIColor colorWithRed:1.0 green:0.78 blue:0.76 alpha:1.0];
+    return [UIColor colorWithRed:1.0 green:0.66 blue:0.64 alpha:1.0];
 }
 
 static UIColor *ApolloDeletedCommentsChipTextColor(void) {
-    return [UIColor colorWithRed:0.30 green:0.04 blue:0.04 alpha:1.0];
+    return [UIColor colorWithRed:0.42 green:0.06 blue:0.06 alpha:1.0];
 }
 
 static NSString *ApolloDeletedCommentsNormalizeCommentFullName(NSString *value) {
@@ -133,6 +141,17 @@ static BOOL ApolloDeletedCommentsCellNodeIsRecovered(id cellNode) {
     return ApolloDeletedCommentsRecoveredReasonForComment(fullName).length > 0;
 }
 
+static BOOL ApolloDeletedCommentsCellNodeIsDeletedPlaceholder(id cellNode) {
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    return ApolloDeletedCommentsIsDeletedPlaceholder(fullName);
+}
+
+static BOOL ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(id cellNode) {
+    return ApolloDeletedCommentsCellNodeIsRecovered(cellNode) ||
+           ApolloDeletedCommentsCellNodeIsDeletedPlaceholder(cellNode);
+}
+
 static BOOL ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(id cellNode) {
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     if (!comment) return NO;
@@ -142,11 +161,22 @@ static BOOL ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(id cellNode) {
 }
 
 static NSString *ApolloDeletedCommentsReasonLabelForComment(RDKComment *comment) {
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     NSString *reason = ApolloDeletedCommentsRecoveredReasonForCommentObject(comment);
-    return ApolloDeletedCommentsDisplayLabelForReason(reason);
+    if (reason.length == 0) reason = ApolloDeletedCommentsDeletedPlaceholderReason(fullName);
+    NSString *label = ApolloDeletedCommentsDisplayLabelForReason(reason);
+    if ([label isEqualToString:@"DELETED BY MOD"]) return @"REMOVED BY MOD";
+    return label;
+}
+
+static NSString *ApolloDeletedCommentsNormalizedReasonLabel(NSString *label) {
+    if (![label isKindOfClass:[NSString class]] || label.length == 0) return @"REMOVED BY MOD";
+    if ([label isEqualToString:@"DELETED BY MOD"]) return @"REMOVED BY MOD";
+    return label;
 }
 
 static UIImage *ApolloDeletedCommentsReasonChipImage(NSString *text, UIFont *font) {
+    text = ApolloDeletedCommentsNormalizedReasonLabel(text);
     if (![text isKindOfClass:[NSString class]] || text.length == 0) return nil;
     if (![font isKindOfClass:[UIFont class]]) font = [UIFont boldSystemFontOfSize:15.0];
 
@@ -155,8 +185,8 @@ static UIImage *ApolloDeletedCommentsReasonChipImage(NSString *text, UIFont *fon
         NSForegroundColorAttributeName: ApolloDeletedCommentsChipTextColor(),
     };
     CGSize textSize = [text sizeWithAttributes:attributes];
-    CGFloat horizontalPadding = 8.0;
-    CGFloat verticalPadding = 2.0;
+    CGFloat horizontalPadding = 9.0;
+    CGFloat verticalPadding = 2.5;
     CGSize imageSize = CGSizeMake(ceil(textSize.width + horizontalPadding * 2.0),
                                   ceil(textSize.height + verticalPadding * 2.0));
 
@@ -166,7 +196,7 @@ static UIImage *ApolloDeletedCommentsReasonChipImage(NSString *text, UIFont *fon
     UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:imageSize format:format];
     return [renderer imageWithActions:^(__unused UIGraphicsImageRendererContext *context) {
         CGRect bounds = CGRectMake(0.0, 0.0, imageSize.width, imageSize.height);
-        UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:bounds cornerRadius:7.0];
+        UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:bounds cornerRadius:floor(imageSize.height / 2.0)];
         [ApolloDeletedCommentsChipBackgroundColor() setFill];
         [path fill];
 
@@ -179,6 +209,7 @@ static UIImage *ApolloDeletedCommentsReasonChipImage(NSString *text, UIFont *fon
 }
 
 static NSAttributedString *ApolloDeletedCommentsReasonChipAttributedText(NSString *label, NSDictionary *baseAttributes, BOOL revealLink) {
+    label = ApolloDeletedCommentsNormalizedReasonLabel(label);
     UIFont *font = baseAttributes[NSFontAttributeName];
     if (![font isKindOfClass:[UIFont class]]) {
         font = [UIFont boldSystemFontOfSize:15.0];
@@ -277,6 +308,50 @@ static NSAttributedString *ApolloDeletedCommentsPlaceholderAttributedText(NSAttr
     return chip;
 }
 
+static NSAttributedString *ApolloDeletedCommentsBodyAttributedText(NSAttributedString *templateText, NSString *body) {
+    NSDictionary *attributes = @{};
+    if ([templateText isKindOfClass:[NSAttributedString class]] && templateText.length > 0) {
+        attributes = [templateText attributesAtIndex:0 effectiveRange:NULL] ?: @{};
+    }
+    return [[NSAttributedString alloc] initWithString:body ?: @"" attributes:attributes];
+}
+
+static NSObject *ApolloDeletedCommentsVisibleCellsLock(void) {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sApolloDeletedCommentsVisibleCellsLock = [NSObject new];
+    });
+    return sApolloDeletedCommentsVisibleCellsLock;
+}
+
+static void ApolloDeletedCommentsTrackVisiblePlaceholderCell(id cellNode) {
+    if (!cellNode) return;
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    if (fullName.length == 0) return;
+    if (!ApolloDeletedCommentsIsDeletedPlaceholder(fullName) || ApolloDeletedCommentsIsRecoveredComment(fullName)) return;
+
+    @synchronized (ApolloDeletedCommentsVisibleCellsLock()) {
+        if (!sApolloDeletedCommentsVisibleCellsByFullName) {
+            sApolloDeletedCommentsVisibleCellsByFullName = [NSMutableDictionary dictionary];
+        }
+        NSHashTable *cells = sApolloDeletedCommentsVisibleCellsByFullName[fullName];
+        if (!cells) {
+            cells = [NSHashTable weakObjectsHashTable];
+            sApolloDeletedCommentsVisibleCellsByFullName[fullName] = cells;
+        }
+        [cells addObject:cellNode];
+    }
+}
+
+static NSArray *ApolloDeletedCommentsTrackedCellsForFullName(NSString *fullName) {
+    if (fullName.length == 0) return @[];
+    @synchronized (ApolloDeletedCommentsVisibleCellsLock()) {
+        NSHashTable *cells = sApolloDeletedCommentsVisibleCellsByFullName[fullName];
+        return cells ? cells.allObjects : @[];
+    }
+}
+
 static BOOL ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(NSAttributedString *attributedText) {
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return NO;
 
@@ -332,7 +407,17 @@ static NSString *ApolloDeletedCommentsNormalizeTextForCompare(NSString *s) {
     }
     trimmed = [lines componentsJoinedByString:@" "];
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\s+" options:0 error:nil];
-    return [regex stringByReplacingMatchesInString:trimmed options:0 range:NSMakeRange(0, trimmed.length) withTemplate:@" "];
+    trimmed = [regex stringByReplacingMatchesInString:trimmed options:0 range:NSMakeRange(0, trimmed.length) withTemplate:@" "];
+
+    NSArray<NSString *> *reasonPrefixes = @[@"removed by mod", @"deleted by user", @"loading...", @"not available"];
+    NSString *lowercase = trimmed.lowercaseString;
+    for (NSString *prefix in reasonPrefixes) {
+        if ([lowercase hasPrefix:prefix]) {
+            trimmed = [[trimmed substringFromIndex:prefix.length] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+            break;
+        }
+    }
+    return trimmed;
 }
 
 static NSString *ApolloDeletedCommentsUnwrappedSpoilerMarkdown(NSString *s) {
@@ -362,6 +447,18 @@ static BOOL ApolloDeletedCommentsTextQualifiesAsBodyFragment(NSString *candidate
     if ([candidateNorm isEqualToString:@"spoiler"]) return NO;
     if ([candidateNorm hasPrefix:@"deleted by "]) return NO;
     return [bodyNorm rangeOfString:candidateNorm options:NSCaseInsensitiveSearch].location != NSNotFound;
+}
+
+static BOOL ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(NSString *candidate) {
+    NSString *candidateNorm = ApolloDeletedCommentsNormalizeTextForCompare(candidate).lowercaseString;
+    if (candidateNorm.length == 0) return NO;
+    return [candidateNorm isEqualToString:@"[deleted]"] ||
+           [candidateNorm isEqualToString:@"[removed]"] ||
+           [candidateNorm isEqualToString:@"deleted"] ||
+           [candidateNorm isEqualToString:@"removed"] ||
+           [candidateNorm isEqualToString:@"spoiler"] ||
+           [candidateNorm isEqualToString:@"..."] ||
+           [candidateNorm isEqualToString:@"…"];
 }
 
 static void ApolloDeletedCommentsCollectAttributedTextNodes(id object, NSInteger depth, NSHashTable *visited, NSMutableArray *nodes) {
@@ -425,6 +522,7 @@ static BOOL ApolloDeletedCommentsAttributedTextHasReasonPrefix(NSAttributedStrin
 static NSArray *ApolloDeletedCommentsBodyTextNodes(id cellNode, RDKComment *comment) {
     if (!cellNode || !comment) return @[];
     NSString *body = comment.body;
+    BOOL deletedPlaceholder = ApolloDeletedCommentsCellNodeIsDeletedPlaceholder(cellNode);
     NSMutableArray *bodyNodes = [NSMutableArray array];
     NSHashTable *seen = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:16];
 
@@ -436,7 +534,8 @@ static NSArray *ApolloDeletedCommentsBodyTextNodes(id cellNode, RDKComment *comm
         } @catch (__unused NSException *e) {
             text = nil;
         }
-        if (ApolloDeletedCommentsTextQualifiesAsBodyCandidate(text.string, body) ||
+        if ((deletedPlaceholder && ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(text.string)) ||
+            ApolloDeletedCommentsTextQualifiesAsBodyCandidate(text.string, body) ||
             ApolloDeletedCommentsTextQualifiesAsBodyFragment(text.string, body)) {
             [bodyNodes addObject:known];
             [seen addObject:known];
@@ -454,8 +553,12 @@ static NSArray *ApolloDeletedCommentsBodyTextNodes(id cellNode, RDKComment *comm
         } @catch (__unused NSException *e) {
             text = nil;
         }
-        if (ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(text) ||
-            ApolloDeletedCommentsAttributedTextHasReasonPrefix(text)) {
+        if (ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(text)) {
+            continue;
+        }
+        if (deletedPlaceholder && ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(text.string)) {
+            [bodyNodes addObject:candidate];
+            [seen addObject:candidate];
             continue;
         }
         if (!ApolloDeletedCommentsTextQualifiesAsBodyCandidate(text.string, body) &&
@@ -483,6 +586,73 @@ static BOOL ApolloDeletedCommentsAttributedTextHasReasonPrefix(NSAttributedStrin
     return hasPrefix;
 }
 
+static void ApolloDeletedCommentsRememberHiddenTextNode(id cellNode, id textNode) {
+    if (!cellNode || !textNode) return;
+    NSMutableArray *nodes = nil;
+    id existing = objc_getAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey);
+    if ([existing isKindOfClass:[NSArray class]]) {
+        nodes = [existing mutableCopy];
+    } else {
+        nodes = [NSMutableArray array];
+    }
+    for (id node in nodes) {
+        if (node == textNode) return;
+    }
+    [nodes addObject:textNode];
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, [nodes copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (!objc_getAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey)) {
+        objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+}
+
+static BOOL ApolloDeletedCommentsCellAlreadyHasHiddenPlaceholder(id cellNode, NSString *fullName) {
+    if (!cellNode || fullName.length == 0) return NO;
+    for (id textNode in ApolloDeletedCommentsHiddenTextNodesForCell(cellNode)) {
+        NSString *hiddenFullName = objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey);
+        NSAttributedString *original = objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey);
+        if ([hiddenFullName isEqualToString:fullName] && [original isKindOfClass:[NSAttributedString class]]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+static NSAttributedString *ApolloDeletedCommentsAttributedTextWithTapToRevealPlaceholder(id textNode, NSAttributedString *attributedText) {
+    if (!sShowDeletedComments || !sTapToRevealDeletedComments) return attributedText;
+    if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
+    if (ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(attributedText)) return attributedText;
+
+    id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    if (!comment || !ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode)) return attributedText;
+
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
+                    ApolloDeletedCommentsIsCommentBodyRevealed(comment.author, comment.body);
+    if (revealed) return attributedText;
+
+    BOOL bodyCandidate = ApolloDeletedCommentsTextQualifiesAsBodyCandidate(attributedText.string, comment.body) ||
+                         ApolloDeletedCommentsTextQualifiesAsBodyFragment(attributedText.string, comment.body);
+    if (!bodyCandidate) return attributedText;
+
+    if (!objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey)) {
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, [attributedText copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
+        ApolloDeletedCommentsRememberHiddenTextNode(cellNode, textNode);
+    }
+
+    NSDictionary *attributes = [attributedText attributesAtIndex:0 effectiveRange:NULL] ?: @{};
+    if (ApolloDeletedCommentsCellAlreadyHasHiddenPlaceholder(cellNode, fullName) &&
+        objc_getAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey) != textNode) {
+        return [[NSAttributedString alloc] initWithString:@"" attributes:attributes];
+    }
+
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    NSAttributedString *placeholder = ApolloDeletedCommentsPlaceholderAttributedText(attributedText, ApolloDeletedCommentsReasonLabelForComment(comment));
+    ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
+    return placeholder;
+}
+
 static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(id textNode, NSAttributedString *attributedText) {
     if (!sShowDeletedComments) return attributedText;
     if (sTapToRevealDeletedComments) return attributedText;
@@ -494,7 +664,7 @@ static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(i
 
     id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
-    if (!comment || !ApolloDeletedCommentsCellNodeIsRecovered(cellNode)) return attributedText;
+    if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return attributedText;
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
                     ApolloDeletedCommentsIsCommentBodyRevealed(comment.author, comment.body);
@@ -566,6 +736,71 @@ static void ApolloDeletedCommentsRestoreHiddenBodiesIfNeeded(id cellNode, NSArra
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+static void ApolloDeletedCommentsRefreshHiddenPlaceholderForCell(id cellNode) {
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    if (!comment) return;
+
+    BOOL placedPlaceholder = NO;
+    for (id textNode in ApolloDeletedCommentsHiddenTextNodesForCell(cellNode)) {
+        NSAttributedString *original = objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey);
+        if (![original isKindOfClass:[NSAttributedString class]]) continue;
+
+        NSAttributedString *replacement = nil;
+        if (!placedPlaceholder) {
+            replacement = ApolloDeletedCommentsPlaceholderAttributedText(original, ApolloDeletedCommentsReasonLabelForComment(comment));
+            placedPlaceholder = YES;
+        } else {
+            NSDictionary *attributes = original.length > 0 ? ([original attributesAtIndex:0 effectiveRange:NULL] ?: @{}) : @{};
+            replacement = [[NSAttributedString alloc] initWithString:@"" attributes:attributes];
+        }
+
+        @try {
+            ((void (*)(id, SEL, NSAttributedString *))objc_msgSend)(textNode, @selector(setAttributedText:), replacement);
+        } @catch (__unused NSException *e) {}
+        ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
+    }
+
+    id firstHiddenNode = ApolloDeletedCommentsHiddenTextNodesForCell(cellNode).firstObject;
+    ApolloDeletedCommentsEnsureRevealAttributeIsTappable(firstHiddenNode);
+}
+
+static void ApolloDeletedCommentsApplyStaticPlaceholderChip(id cellNode, NSArray *textNodes) {
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    if (!comment || textNodes.count == 0) return;
+
+    BOOL placedPlaceholder = NO;
+    for (id textNode in textNodes) {
+        NSAttributedString *current = nil;
+        @try {
+            current = ((NSAttributedString *(*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText));
+        } @catch (__unused NSException *e) {
+            current = nil;
+        }
+        if (![current isKindOfClass:[NSAttributedString class]] || current.length == 0) continue;
+
+        NSAttributedString *replacement = nil;
+        if (!placedPlaceholder) {
+            replacement = ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment),
+                                                                        [current attributesAtIndex:0 effectiveRange:NULL] ?: @{},
+                                                                        NO);
+            placedPlaceholder = YES;
+        } else {
+            replacement = [[NSAttributedString alloc] initWithString:@""
+                                                          attributes:[current attributesAtIndex:0 effectiveRange:NULL] ?: @{}];
+        }
+
+        @try {
+            ((void (*)(id, SEL, NSAttributedString *))objc_msgSend)(textNode, @selector(setAttributedText:), replacement);
+        } @catch (__unused NSException *e) {}
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+        ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
+    }
+
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 static void ApolloDeletedCommentsEnsureRevealAttributeIsTappable(id textNode) {
     if (!textNode) return;
 
@@ -610,6 +845,13 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeede
     NSArray *textNodes = ApolloDeletedCommentsBodyTextNodes(cellNode, comment);
     if (textNodes.count == 0) return;
 
+    BOOL placeholderOnly = ApolloDeletedCommentsCellNodeIsDeletedPlaceholder(cellNode) &&
+                           !ApolloDeletedCommentsCellNodeIsRecovered(cellNode);
+    if (placeholderOnly) {
+        ApolloDeletedCommentsApplyStaticPlaceholderChip(cellNode, textNodes);
+        return;
+    }
+
     BOOL recovered = ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode);
     BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
                     ApolloDeletedCommentsIsCommentBodyRevealed(author, body);
@@ -632,8 +874,7 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeede
         }
     }
     if (alreadyHiddenForComment) {
-        id firstHiddenNode = ApolloDeletedCommentsHiddenTextNodesForCell(cellNode).firstObject;
-        ApolloDeletedCommentsEnsureRevealAttributeIsTappable(firstHiddenNode);
+        ApolloDeletedCommentsRefreshHiddenPlaceholderForCell(cellNode);
         return;
     }
 
@@ -751,11 +992,16 @@ static void __attribute__((unused)) ApolloDeletedCommentsRevealHiddenBodyForCell
 
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+
+    if (ApolloDeletedCommentsIsDeletedPlaceholder(fullName) && !ApolloDeletedCommentsIsRecoveredComment(fullName)) {
+        ApolloDeletedCommentsRefreshHiddenPlaceholderForCell(cellNode);
+        return;
+    }
+
     ApolloDeletedCommentsMarkCommentRevealed(fullName);
     ApolloDeletedCommentsMarkCommentBodyRevealed(comment.author, comment.body);
     objc_setAssociatedObject(comment, kApolloDeletedCommentsSuppressNextCollapseKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloDeletedCommentsRestoreHiddenBodiesIfNeeded(cellNode, nil);
-    ApolloDeletedCommentsScheduleForceExpanded(comment, cellNode);
 }
 
 static BOOL __attribute__((unused)) ApolloDeletedCommentsCommentIsRevealed(RDKComment *comment) {
@@ -782,7 +1028,6 @@ static void __attribute__((unused)) ApolloDeletedCommentsHideRevealedBodyForCell
     ApolloDeletedCommentsUnmarkCommentBodyRevealed(comment.author, comment.body);
     objc_setAssociatedObject(comment, kApolloDeletedCommentsSuppressNextCollapseKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloDeletedCommentsApplyTapToRevealIfNeeded(cellNode);
-    ApolloDeletedCommentsScheduleForceExpanded(comment, cellNode);
 }
 
 static id ApolloDeletedCommentsCommentCellNodeForTextNode(id textNode) {
@@ -803,7 +1048,7 @@ static id ApolloDeletedCommentsCommentCellNodeForTextNode(id textNode) {
 
 static BOOL __attribute__((unused)) ApolloDeletedCommentsTextNodeBelongsToRecoveredComment(id textNode) {
     id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
-    return ApolloDeletedCommentsCellNodeIsRecovered(cellNode);
+    return ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode);
 }
 
 static UIView *ApolloDeletedCommentsCellView(id cellNode) {
@@ -826,7 +1071,7 @@ static void ApolloDeletedCommentsRemoveCellHighlight(id cellNode) {
 }
 
 static void ApolloDeletedCommentsApplyCellHighlight(id cellNode) {
-    if (!sShowDeletedComments || !ApolloDeletedCommentsCellNodeIsRecovered(cellNode)) {
+    if (!sShowDeletedComments || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) {
         ApolloDeletedCommentsRemoveCellHighlight(cellNode);
         return;
     }
@@ -852,7 +1097,95 @@ static void ApolloDeletedCommentsApplyCellHighlight(id cellNode) {
     }
 }
 
+static void ApolloDeletedCommentsSetTextNodeAttributedText(id textNode, NSAttributedString *attributedText) {
+    if (!textNode || ![attributedText isKindOfClass:[NSAttributedString class]]) return;
+    @try {
+        ((void (*)(id, SEL, NSAttributedString *))objc_msgSend)(textNode, @selector(setAttributedText:), attributedText);
+    } @catch (__unused NSException *e) {}
+}
+
+static NSAttributedString *ApolloDeletedCommentsCurrentAttributedText(id textNode) {
+    if (!textNode || ![textNode respondsToSelector:@selector(attributedText)]) return nil;
+    @try {
+        return ((NSAttributedString *(*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText));
+    } @catch (__unused NSException *e) {
+        return nil;
+    }
+}
+
+static void ApolloDeletedCommentsApplyRecoveredArchiveToVisibleCell(id cellNode, NSDictionary *archived) {
+    if (!cellNode || ![archived isKindOfClass:[NSDictionary class]]) return;
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    if (fullName.length == 0) return;
+    if (!ApolloDeletedCommentsIsDeletedPlaceholder(fullName) || ApolloDeletedCommentsIsRecoveredComment(fullName)) return;
+
+    NSArray *textNodes = ApolloDeletedCommentsBodyTextNodes(cellNode, comment);
+    if (textNodes.count == 0) {
+        id knownBodyNode = ApolloDeletedCommentsKnownBodyTextNode(cellNode);
+        if (knownBodyNode) textNodes = @[knownBodyNode];
+    }
+    if (textNodes.count == 0) return;
+    id firstTextNode = textNodes.firstObject;
+    NSAttributedString *templateText = ApolloDeletedCommentsCurrentAttributedText(firstTextNode);
+
+    NSString *reason = ApolloDeletedCommentsDeletedPlaceholderReason(fullName);
+    if (!ApolloDeletedCommentsApplyRecoveredArchivedCommentToObject((id)comment, archived, reason)) return;
+
+    for (id textNode in textNodes) {
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    }
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    NSAttributedString *bodyText = ApolloDeletedCommentsBodyAttributedText(templateText, comment.body);
+    if (!sTapToRevealDeletedComments) {
+        bodyText = ApolloDeletedCommentsAttributedTextWithReasonPrefix(firstTextNode, bodyText);
+    }
+    ApolloDeletedCommentsSetTextNodeAttributedText(firstTextNode, bodyText);
+    ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, firstTextNode);
+
+    NSDictionary *blankAttributes = bodyText.length > 0 ? ([bodyText attributesAtIndex:0 effectiveRange:NULL] ?: @{}) : @{};
+    for (NSUInteger i = 1; i < textNodes.count; i++) {
+        id textNode = textNodes[i];
+        ApolloDeletedCommentsSetTextNodeAttributedText(textNode, [[NSAttributedString alloc] initWithString:@"" attributes:blankAttributes]);
+        ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
+    }
+
+    ApolloDeletedCommentsApplyTapToRevealIfNeeded(cellNode);
+    ApolloDeletedCommentsApplyCellHighlight(cellNode);
+}
+
+static void ApolloDeletedCommentsHandleArcticCacheUpdated(NSNotification *notification) {
+    if (!sShowDeletedComments) return;
+    NSDictionary *comments = [notification.userInfo[@"comments"] isKindOfClass:[NSDictionary class]] ? notification.userInfo[@"comments"] : nil;
+    if (comments.count == 0) return;
+
+    for (NSString *fullName in comments) {
+        NSDictionary *archived = [comments[fullName] isKindOfClass:[NSDictionary class]] ? comments[fullName] : nil;
+        if (![archived isKindOfClass:[NSDictionary class]]) continue;
+        for (id cellNode in ApolloDeletedCommentsTrackedCellsForFullName(fullName)) {
+            ApolloDeletedCommentsApplyRecoveredArchiveToVisibleCell(cellNode, archived);
+        }
+    }
+}
+
+static void ApolloDeletedCommentsApplyCachedArchiveToVisiblePlaceholderCell(id cellNode) {
+    if (!cellNode) return;
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    if (fullName.length == 0) return;
+    if (!ApolloDeletedCommentsIsDeletedPlaceholder(fullName) || ApolloDeletedCommentsIsRecoveredComment(fullName)) return;
+
+    NSDictionary *archived = ApolloDeletedCommentsCachedArchivedComment(fullName);
+    if (archived.count == 0) return;
+    ApolloDeletedCommentsApplyRecoveredArchiveToVisibleCell(cellNode, archived);
+}
+
 static void ApolloDeletedCommentsUpdateCell(id cellNode) {
+    ApolloDeletedCommentsTrackVisiblePlaceholderCell(cellNode);
+    ApolloDeletedCommentsApplyCachedArchiveToVisiblePlaceholderCell(cellNode);
     ApolloDeletedCommentsApplyTapToRevealIfNeeded(cellNode);
     ApolloDeletedCommentsApplyCellHighlight(cellNode);
 }
@@ -882,7 +1215,16 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
     id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSDictionary *baseAttributes = [attributedText attributesAtIndex:0 effectiveRange:NULL] ?: @{};
-    NSMutableAttributedString *renamed = [ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment), baseAttributes, NO) mutableCopy];
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    BOOL placeholderOnly = ApolloDeletedCommentsIsDeletedPlaceholder(fullName) &&
+                           !ApolloDeletedCommentsIsRecoveredComment(fullName);
+    if (placeholderOnly) {
+        return ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment), baseAttributes, NO);
+    }
+
+    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
+                    ApolloDeletedCommentsIsCommentBodyRevealed(comment.author, comment.body);
+    NSMutableAttributedString *renamed = [ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment), baseAttributes, !revealed) mutableCopy];
     NSRange targetRange = NSMakeRange(0, renamed.length);
     [attributedText enumerateAttributesInRange:NSMakeRange(0, attributedText.length)
                                        options:0
@@ -897,6 +1239,15 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
             [renamed addAttribute:key value:attrs[key] range:targetRange];
         }
     }];
+    if (!revealed) {
+        NSString *body = ApolloDeletedCommentsUnwrappedSpoilerMarkdown(comment.body);
+        NSAttributedString *original = ApolloDeletedCommentsBodyAttributedText(attributedText, body);
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, original, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
+        objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, @[textNode], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
+    }
     return renamed;
 }
 
@@ -904,7 +1255,9 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
     NSAttributedString *rewrittenText = ApolloDeletedCommentsAttributedTextWithReasonPrefix((id)self,
-        ApolloDeletedCommentsRenameRecoveredSpoilerLabel((id)self, attributedText)
+        ApolloDeletedCommentsAttributedTextWithTapToRevealPlaceholder((id)self,
+            ApolloDeletedCommentsRenameRecoveredSpoilerLabel((id)self, attributedText)
+        )
     );
     %orig(rewrittenText);
 }
@@ -917,7 +1270,9 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
     } @catch (__unused NSException *e) {
         attributedText = nil;
     }
-    NSAttributedString *renamedAttributedText = ApolloDeletedCommentsRenameRecoveredSpoilerLabel((id)self, attributedText);
+    NSAttributedString *renamedAttributedText = ApolloDeletedCommentsAttributedTextWithTapToRevealPlaceholder((id)self,
+        ApolloDeletedCommentsRenameRecoveredSpoilerLabel((id)self, attributedText)
+    );
     if (renamedAttributedText != attributedText) {
         @try {
             ((void (*)(id, SEL, NSAttributedString *))objc_msgSend)((id)self, @selector(setAttributedText:), renamedAttributedText);
@@ -933,6 +1288,15 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
 }
 
 %end
+
+%ctor {
+    [[NSNotificationCenter defaultCenter] addObserverForName:ApolloDeletedCommentsArcticCacheUpdatedNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(NSNotification *notification) {
+        ApolloDeletedCommentsHandleArcticCacheUpdated(notification);
+    }];
+}
 
 @interface _TtC6Apollo15CommentCellNode
 - (void)didLoad;

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -42,6 +42,7 @@ static const void *kApolloDeletedCommentsOriginalBodyKey = &kApolloDeletedCommen
 static const void *kApolloDeletedCommentsOriginalBodyHTMLKey = &kApolloDeletedCommentsOriginalBodyHTMLKey;
 static const void *kApolloDeletedCommentsHostLayoutRefreshScheduledKey = &kApolloDeletedCommentsHostLayoutRefreshScheduledKey;
 static const void *kApolloDeletedCommentsRevealToggleInFlightKey = &kApolloDeletedCommentsRevealToggleInFlightKey;
+static const void *kApolloDeletedCommentsReasonChipRepairScheduledKey = &kApolloDeletedCommentsReasonChipRepairScheduledKey;
 
 static NSMutableDictionary<NSString *, NSHashTable *> *sApolloDeletedCommentsVisibleCellsByFullName = nil;
 static NSObject *sApolloDeletedCommentsVisibleCellsLock = nil;
@@ -348,7 +349,7 @@ static NSString *__attribute__((unused)) ApolloDeletedCommentsBodyHTMLByAppendin
 }
 
 static BOOL ApolloDeletedCommentsStringIsReasonLabel(NSString *text) {
-    NSString *normalized = ApolloDeletedCommentsNormalizedReasonLabel(ApolloDeletedCommentsTrimmedString(text));
+    NSString *normalized = ApolloDeletedCommentsNormalizedReasonLabel(ApolloDeletedCommentsTrimmedString(text)).uppercaseString;
     return [normalized isEqualToString:@"REMOVED BY MOD"] ||
            [normalized isEqualToString:@"DELETED BY USER"] ||
            [normalized isEqualToString:@"LOADING..."] ||
@@ -1063,22 +1064,18 @@ static BOOL ApolloDeletedCommentsAttributedTextHasReasonPrefix(NSAttributedStrin
 static BOOL ApolloDeletedCommentsAttributedTextHasVisibleReasonChip(NSAttributedString *attributedText) {
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return NO;
 
-    __block BOOL hasAttachmentChip = NO;
+    __block BOOL hasChip = NO;
     [attributedText enumerateAttributesInRange:NSMakeRange(0, attributedText.length)
                                        options:0
                                     usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attrs, __unused NSRange range, BOOL *stop) {
         id prefix = attrs[ApolloDeletedCommentsReasonPrefixAttributeName];
         NSTextAttachment *attachment = [attrs[NSAttachmentAttributeName] isKindOfClass:[NSTextAttachment class]] ? attrs[NSAttachmentAttributeName] : nil;
         if ([prefix respondsToSelector:@selector(boolValue)] && [prefix boolValue] && [attachment.image isKindOfClass:[UIImage class]]) {
-            hasAttachmentChip = YES;
+            hasChip = YES;
             *stop = YES;
         }
     }];
-    if (hasAttachmentChip) return YES;
-
-    NSString *upperText = ApolloDeletedCommentsTrimmedString(attributedText.string).uppercaseString;
-    return [upperText containsString:@"REMOVED BY MOD"] ||
-           [upperText containsString:@"DELETED BY USER"];
+    return hasChip;
 }
 
 static NSAttributedString *ApolloDeletedCommentsAttributedTextByRemovingReasonPrefix(NSAttributedString *attributedText) {
@@ -2124,6 +2121,17 @@ static void __attribute__((unused)) ApolloDeletedCommentsRepairVisibleReasonChip
         }
         if (ApolloDeletedCommentsAttributedTextHasVisibleReasonChip(current)) return;
 
+        NSString *label = ApolloDeletedCommentsReasonLabelForComment(comment);
+        NSString *currentLabel = ApolloDeletedCommentsNormalizedReasonLabel(ApolloDeletedCommentsTrimmedString(current.string)).uppercaseString;
+        if ([currentLabel isEqualToString:label.uppercaseString]) {
+            NSAttributedString *chip = ApolloDeletedCommentsReasonChipAttributedText(label,
+                                                                                     [current attributesAtIndex:0 effectiveRange:NULL] ?: @{},
+                                                                                     NO);
+            ApolloDeletedCommentsSetTextNodeAttributedText(textNode, chip);
+            ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
+            return;
+        }
+
         NSAttributedString *bodySource = current;
         if (ApolloDeletedCommentsAttributedTextHasReasonPrefix(current)) {
             bodySource = ApolloDeletedCommentsAttributedTextByRemovingReasonPrefix(current);
@@ -2140,11 +2148,39 @@ static void __attribute__((unused)) ApolloDeletedCommentsRepairVisibleReasonChip
     }
 }
 
+static void ApolloDeletedCommentsScheduleReasonChipRepair(id cellNode) {
+    if (!sShowDeletedComments || !cellNode) return;
+    if ([objc_getAssociatedObject(cellNode, kApolloDeletedCommentsReasonChipRepairScheduledKey) boolValue]) return;
+
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    if (fullName.length == 0 || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return;
+
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsReasonChipRepairScheduledKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    NSArray<NSNumber *> *delays = @[@0.05, @0.15, @0.35];
+    for (NSNumber *delayNumber in delays) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayNumber.doubleValue * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            RDKComment *currentComment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+            NSString *currentFullName = ApolloDeletedCommentsFullNameForComment(currentComment);
+            if (![currentFullName isEqualToString:fullName]) return;
+
+            ApolloDeletedCommentsRepairVisibleReasonChipIfNeeded(cellNode);
+            ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyContainerNode(cellNode));
+            ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyTextNode(cellNode));
+            ApolloDeletedCommentsApplyCellHighlight(cellNode);
+        });
+    }
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.40 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        objc_setAssociatedObject(cellNode, kApolloDeletedCommentsReasonChipRepairScheduledKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    });
+}
+
 static void ApolloDeletedCommentsUpdateCell(id cellNode) {
     ApolloDeletedCommentsTrackVisibleDeletedCommentCell(cellNode);
     ApolloDeletedCommentsApplyCachedArchiveToVisibleDeletedCell(cellNode);
     ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
     ApolloDeletedCommentsRepairVisibleReasonChipIfNeeded(cellNode);
+    ApolloDeletedCommentsScheduleReasonChipRepair(cellNode);
     ApolloDeletedCommentsApplyCellHighlight(cellNode);
 }
 
@@ -2231,7 +2267,12 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRe
 %hook ASTextNode
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
-    %orig(attributedText);
+    NSAttributedString *displayText = attributedText;
+    displayText = ApolloDeletedCommentsRenameRecoveredSpoilerLabel((id)self, displayText);
+    displayText = ApolloDeletedCommentsAttributedTextWithReasonChipIfNeeded((id)self, displayText);
+    displayText = ApolloDeletedCommentsAttributedTextWithTapToRevealPlaceholder((id)self, displayText);
+    displayText = ApolloDeletedCommentsAttributedTextWithReasonPrefix((id)self, displayText);
+    %orig(displayText);
 }
 
 - (void)didEnterDisplayState {

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -59,6 +59,7 @@ static NSArray *ApolloDeletedCommentsHiddenTextNodesForCell(id cellNode);
 static NSString *ApolloDeletedCommentsNormalizedReasonLabel(NSString *label);
 static void ApolloDeletedCommentsSetTextNodeAttributedText(id textNode, NSAttributedString *attributedText);
 static NSAttributedString *ApolloDeletedCommentsCurrentAttributedText(id textNode);
+static void ApolloDeletedCommentsDisableRevealTapInterception(id textNode);
 static void ApolloDeletedCommentsSynchronizeCommentModelDisplayState(id cellNode);
 static void __attribute__((unused)) ApolloDeletedCommentsRepairVisibleReasonChipIfNeeded(id cellNode);
 static void ApolloDeletedCommentsScheduleHostLayoutRefresh(id cellNode);
@@ -71,6 +72,7 @@ static BOOL ApolloDeletedCommentsAttributedTextHasVisibleReasonChip(NSAttributed
 static NSAttributedString *ApolloDeletedCommentsAttributedTextByRemovingReasonPrefix(NSAttributedString *attributedText);
 static BOOL ApolloDeletedCommentsTextQualifiesAsBodyCandidate(NSString *candidate, NSString *body);
 static BOOL ApolloDeletedCommentsTextQualifiesAsBodyFragment(NSString *candidate, NSString *body);
+static BOOL ApolloDeletedCommentsCommentIsCollapsed(RDKComment *comment);
 
 static Class ApolloDeletedCommentsASTextNodeClass(void) {
     static Class cls = Nil;
@@ -126,7 +128,7 @@ static UIFont *ApolloDeletedCommentsReasonChipFont(void) {
 }
 
 static UIFont *ApolloDeletedCommentsRecoveredBodyFont(void) {
-    return [UIFont systemFontOfSize:16.0];
+    return [UIFont systemFontOfSize:15.0];
 }
 
 static NSString *ApolloDeletedCommentsNormalizeCommentFullName(NSString *value) {
@@ -239,6 +241,27 @@ static BOOL ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(id cellNode) {
     if (!comment) return NO;
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     return ApolloDeletedCommentsIsRecoveredComment(fullName);
+}
+
+static BOOL ApolloDeletedCommentsCommentIsCollapsed(RDKComment *comment) {
+    if (!comment) return NO;
+    if ([(id)comment respondsToSelector:@selector(collapsed)]) {
+        @try {
+            return ((BOOL (*)(id, SEL))objc_msgSend)((id)comment, @selector(collapsed));
+        } @catch (__unused NSException *e) {}
+    }
+
+    Ivar collapsedIvar = class_getInstanceVariable([(id)comment class], "_collapsed");
+    if (collapsedIvar) {
+        @try {
+            ptrdiff_t offset = ivar_getOffset(collapsedIvar);
+            if (offset > 0) {
+                BOOL *slot = (BOOL *)((uint8_t *)(__bridge void *)comment + offset);
+                return *slot;
+            }
+        } @catch (__unused NSException *e) {}
+    }
+    return NO;
 }
 
 static NSString *ApolloDeletedCommentsReasonLabelForComment(RDKComment *comment) {
@@ -649,7 +672,9 @@ static NSMutableDictionary *ApolloDeletedCommentsSanitizedBodyAttributes(NSDicti
     if (![font isKindOfClass:[UIFont class]]) return nil;
 
     NSMutableDictionary *attributes = [attrs mutableCopy];
-    attributes[NSFontAttributeName] = ApolloDeletedCommentsRecoveredBodyFont();
+    if (font.pointSize > 15.5) {
+        attributes[NSFontAttributeName] = [font fontWithSize:15.0];
+    }
     [attributes removeObjectForKey:NSAttachmentAttributeName];
     [attributes removeObjectForKey:NSBackgroundColorAttributeName];
     [attributes removeObjectForKey:NSLinkAttributeName];
@@ -685,7 +710,14 @@ static NSAttributedString *ApolloDeletedCommentsBodyTextByNormalizingFont(NSAttr
                                    options:0
                                 usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attrs, NSRange range, __unused BOOL *stop) {
         if (attrs[NSAttachmentAttributeName]) return;
-        [normalized addAttribute:NSFontAttributeName value:ApolloDeletedCommentsRecoveredBodyFont() range:range];
+        UIFont *font = attrs[NSFontAttributeName];
+        if ([font isKindOfClass:[UIFont class]] && font.pointSize > 15.5) {
+            [normalized addAttribute:NSFontAttributeName value:[font fontWithSize:15.0] range:range];
+        }
+        [normalized removeAttribute:NSBackgroundColorAttributeName range:range];
+        [normalized removeAttribute:NSLinkAttributeName range:range];
+        [normalized removeAttribute:ApolloDeletedCommentsRevealAttributeName range:range];
+        [normalized removeAttribute:ApolloDeletedCommentsReasonPrefixAttributeName range:range];
     }];
     return normalized;
 }
@@ -1226,8 +1258,8 @@ static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(i
     spacerAttributes[NSParagraphStyleAttributeName] = spacerStyle;
     NSMutableAttributedString *decorated = [bodyText mutableCopy];
     [decorated appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n" attributes:spacerAttributes]];
-    [decorated appendAttributedString:ApolloDeletedCommentsReasonChipAttributedText(label, baseAttributes, sTapToRevealDeletedComments && revealed)];
-    if (sTapToRevealDeletedComments && revealed) ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
+    [decorated appendAttributedString:ApolloDeletedCommentsReasonChipAttributedText(label, baseAttributes, NO)];
+    ApolloDeletedCommentsDisableRevealTapInterception(textNode);
     return decorated;
 }
 
@@ -1280,6 +1312,7 @@ static void ApolloDeletedCommentsRestoreHiddenBodyIfNeeded(id cellNode, id textN
     if (objc_getAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey) == textNode) {
         objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
+    ApolloDeletedCommentsDisableRevealTapInterception(textNode);
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
 }
 
@@ -1445,6 +1478,23 @@ static void ApolloDeletedCommentsEnsureRevealAttributeIsTappable(id textNode) {
     } @catch (__unused NSException *e) {}
 }
 
+static void ApolloDeletedCommentsDisableRevealTapInterception(id textNode) {
+    if (!textNode) return;
+
+    if ([textNode respondsToSelector:@selector(setUserInteractionEnabled:)]) {
+        @try {
+            ((void (*)(id, SEL, BOOL))objc_msgSend)(textNode, @selector(setUserInteractionEnabled:), NO);
+        } @catch (__unused NSException *e) {}
+    }
+
+    if ([textNode respondsToSelector:@selector(view)]) {
+        @try {
+            UIView *view = ((UIView *(*)(id, SEL))objc_msgSend)(textNode, @selector(view));
+            if ([view isKindOfClass:[UIView class]]) view.userInteractionEnabled = NO;
+        } @catch (__unused NSException *e) {}
+    }
+}
+
 static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeeded(id cellNode) {
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
@@ -1483,6 +1533,9 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeede
             }
         }
         ApolloDeletedCommentsRestoreHiddenBodiesIfNeeded(cellNode, textNodes);
+        for (id textNode in textNodes) {
+            ApolloDeletedCommentsDisableRevealTapInterception(textNode);
+        }
         return;
     }
 
@@ -1626,7 +1679,7 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyRevealedBodyTextTo
     if (bodyText.length == 0) return;
 
     ApolloDeletedCommentsSetTextNodeAttributedText(textNode, bodyText);
-    ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
+    ApolloDeletedCommentsDisableRevealTapInterception(textNode);
     ApolloDeletedCommentsInvalidateCellAndTextNodeLocally(cellNode, textNode);
 }
 
@@ -1905,6 +1958,7 @@ static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpec
     if (!cellNode) cellNode = objc_getAssociatedObject(markdownNode, kApolloDeletedCommentsBodyOwnerCellKey);
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return nil;
+    if (ApolloDeletedCommentsCommentIsCollapsed(comment)) return nil;
 
     id textNode = ApolloDeletedCommentsBodyReplacementTextNode(markdownNode, cellNode);
     if (!textNode) return nil;
@@ -1948,12 +2002,15 @@ static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpec
             [decorated appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n" attributes:spacerAttributes]];
             [decorated appendAttributedString:ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment),
                                                                                             baseAttributes,
-                                                                                            sTapToRevealDeletedComments && recovered && revealed)];
+                                                                                            NO)];
             displayText = decorated;
         }
     }
 
     ApolloDeletedCommentsSetTextNodeAttributedText(textNode, displayText);
+    if (!(placeholderOnly || shouldHide)) {
+        ApolloDeletedCommentsDisableRevealTapInterception(textNode);
+    }
     Class insetClass = ApolloDeletedCommentsASInsetLayoutSpecClass();
     if (!insetClass) return nil;
     return [insetClass insetLayoutSpecWithInsets:UIEdgeInsetsZero child:textNode];
@@ -2226,12 +2283,16 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRe
 
 - (id)layoutSpecThatFits:(struct CDStruct_90e057aa)fits {
     ApolloDeletedCommentsSynchronizeCommentModelDisplayState((id)self);
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode((id)self);
     id bodyNode = ApolloDeletedCommentsKnownBodyContainerNode((id)self);
     if (bodyNode) {
         objc_setAssociatedObject(bodyNode, kApolloDeletedCommentsBodyOwnerCellKey, (id)self, OBJC_ASSOCIATION_ASSIGN);
     }
     id spec = %orig;
-    if (sShowDeletedComments && ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment((id)self) && spec) {
+    if (sShowDeletedComments &&
+        !ApolloDeletedCommentsCommentIsCollapsed(comment) &&
+        ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment((id)self) &&
+        spec) {
         Class insetClass = ApolloDeletedCommentsASInsetLayoutSpecClass();
         if (insetClass) {
             @try {

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -7,12 +7,39 @@
 #import "ApolloState.h"
 #import "Tweak.h"
 
+@class ASDisplayNode;
+@class ASTextNode;
+@class ASInsetLayoutSpec;
+
+@interface ASDisplayNode : NSObject
+- (void)addSubnode:(ASDisplayNode *)subnode;
+- (ASDisplayNode *)supernode;
+- (void)setNeedsLayout;
+@end
+
+@interface ASTextNode : ASDisplayNode
+@property (nonatomic, copy) NSAttributedString *attributedText;
+@property (nonatomic, weak) id delegate;
+@property (copy) NSArray<NSString *> *linkAttributeNames;
+@property (nonatomic) BOOL userInteractionEnabled;
+@end
+
+@interface ASInsetLayoutSpec : NSObject
++ (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id)child;
+@end
+
+struct CDStruct_90e057aa { CGSize min; CGSize max; };
+
 static const void *kApolloDeletedCommentsHighlightViewKey = &kApolloDeletedCommentsHighlightViewKey;
 static const void *kApolloDeletedCommentsHiddenOriginalTextKey = &kApolloDeletedCommentsHiddenOriginalTextKey;
 static const void *kApolloDeletedCommentsHiddenFullNameKey = &kApolloDeletedCommentsHiddenFullNameKey;
 static const void *kApolloDeletedCommentsHiddenTextNodeKey = &kApolloDeletedCommentsHiddenTextNodeKey;
 static const void *kApolloDeletedCommentsHiddenTextNodesKey = &kApolloDeletedCommentsHiddenTextNodesKey;
 static const void *kApolloDeletedCommentsSuppressNextCollapseKey = &kApolloDeletedCommentsSuppressNextCollapseKey;
+static const void *kApolloDeletedCommentsBodyOwnerCellKey = &kApolloDeletedCommentsBodyOwnerCellKey;
+static const void *kApolloDeletedCommentsBodyReplacementTextNodeKey = &kApolloDeletedCommentsBodyReplacementTextNodeKey;
+static const void *kApolloDeletedCommentsOriginalBodyKey = &kApolloDeletedCommentsOriginalBodyKey;
+static const void *kApolloDeletedCommentsOriginalBodyHTMLKey = &kApolloDeletedCommentsOriginalBodyHTMLKey;
 
 static NSMutableDictionary<NSString *, NSHashTable *> *sApolloDeletedCommentsVisibleCellsByFullName = nil;
 static NSObject *sApolloDeletedCommentsVisibleCellsLock = nil;
@@ -27,6 +54,33 @@ static void __attribute__((unused)) ApolloDeletedCommentsScheduleForceExpanded(R
 static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeeded(id cellNode);
 static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(id textNode, NSAttributedString *attributedText);
 static NSArray *ApolloDeletedCommentsHiddenTextNodesForCell(id cellNode);
+static NSString *ApolloDeletedCommentsNormalizedReasonLabel(NSString *label);
+static void ApolloDeletedCommentsSetTextNodeAttributedText(id textNode, NSAttributedString *attributedText);
+static NSAttributedString *ApolloDeletedCommentsCurrentAttributedText(id textNode);
+static void ApolloDeletedCommentsSynchronizeCommentModelDisplayState(id cellNode);
+static BOOL ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(NSString *candidate);
+static BOOL ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(NSAttributedString *attributedText);
+static BOOL ApolloDeletedCommentsAttributedTextHasReasonPrefix(NSAttributedString *attributedText);
+static BOOL ApolloDeletedCommentsTextQualifiesAsBodyCandidate(NSString *candidate, NSString *body);
+static BOOL ApolloDeletedCommentsTextQualifiesAsBodyFragment(NSString *candidate, NSString *body);
+
+static Class ApolloDeletedCommentsASTextNodeClass(void) {
+    static Class cls = Nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        cls = NSClassFromString(@"ASTextNode");
+    });
+    return cls;
+}
+
+static Class ApolloDeletedCommentsASInsetLayoutSpecClass(void) {
+    static Class cls = Nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        cls = NSClassFromString(@"ASInsetLayoutSpec");
+    });
+    return cls;
+}
 
 static NSString *ApolloDeletedCommentsTrimmedString(NSString *s) {
     if (![s isKindOfClass:[NSString class]]) return nil;
@@ -40,7 +94,14 @@ static UIColor *ApolloDeletedCommentsBadgeRed(void) {
     return [UIColor redColor];
 }
 
-static UIColor *ApolloDeletedCommentsHighlightColor(void) {
+static BOOL ApolloDeletedCommentsLabelIsUserDeleted(NSString *label) {
+    return [ApolloDeletedCommentsNormalizedReasonLabel(label) isEqualToString:@"DELETED BY USER"];
+}
+
+static UIColor *ApolloDeletedCommentsHighlightColorForLabel(NSString *label) {
+    if (ApolloDeletedCommentsLabelIsUserDeleted(label)) {
+        return [[UIColor colorWithRed:0.82 green:0.02 blue:0.08 alpha:1.0] colorWithAlphaComponent:0.20];
+    }
     return [ApolloDeletedCommentsBadgeRed() colorWithAlphaComponent:0.24];
 }
 
@@ -50,6 +111,14 @@ static UIColor *ApolloDeletedCommentsChipBackgroundColor(void) {
 
 static UIColor *ApolloDeletedCommentsChipTextColor(void) {
     return [UIColor colorWithRed:0.42 green:0.06 blue:0.06 alpha:1.0];
+}
+
+static UIFont *ApolloDeletedCommentsReasonChipFont(void) {
+    return [UIFont boldSystemFontOfSize:13.0];
+}
+
+static UIFont *ApolloDeletedCommentsRecoveredBodyFont(void) {
+    return [UIFont systemFontOfSize:16.0];
 }
 
 static NSString *ApolloDeletedCommentsNormalizeCommentFullName(NSString *value) {
@@ -169,6 +238,189 @@ static NSString *ApolloDeletedCommentsReasonLabelForComment(RDKComment *comment)
     return label;
 }
 
+static NSString *ApolloDeletedCommentsCommentStringValue(RDKComment *comment, SEL selector) {
+    if (!comment || !selector || ![(id)comment respondsToSelector:selector]) return nil;
+    id value = nil;
+    @try {
+        value = ((id (*)(id, SEL))objc_msgSend)((id)comment, selector);
+    } @catch (__unused NSException *e) {
+        value = nil;
+    }
+    return [value isKindOfClass:[NSString class]] ? value : nil;
+}
+
+static void ApolloDeletedCommentsSetCommentStringValue(RDKComment *comment, SEL selector, NSString *value) {
+    if (!comment || !selector || ![value isKindOfClass:[NSString class]] || ![(id)comment respondsToSelector:selector]) return;
+    @try {
+        ((void (*)(id, SEL, NSString *))objc_msgSend)((id)comment, selector, value);
+    } @catch (__unused NSException *e) {}
+}
+
+static NSString *ApolloDeletedCommentsEscapedHTMLText(NSString *text) {
+    NSMutableString *escaped = [text ?: @"" mutableCopy];
+    [escaped replaceOccurrencesOfString:@"&" withString:@"&amp;" options:0 range:NSMakeRange(0, escaped.length)];
+    [escaped replaceOccurrencesOfString:@"<" withString:@"&lt;" options:0 range:NSMakeRange(0, escaped.length)];
+    [escaped replaceOccurrencesOfString:@">" withString:@"&gt;" options:0 range:NSMakeRange(0, escaped.length)];
+    [escaped replaceOccurrencesOfString:@"\"" withString:@"&quot;" options:0 range:NSMakeRange(0, escaped.length)];
+    return escaped;
+}
+
+static NSString *ApolloDeletedCommentsPlainBodyHTML(NSString *text) {
+    NSString *trimmed = ApolloDeletedCommentsTrimmedString(text);
+    if (trimmed.length == 0) return @"";
+    NSString *escaped = ApolloDeletedCommentsEscapedHTMLText(trimmed);
+    return [NSString stringWithFormat:@"&lt;div class=&quot;md&quot;&gt;&lt;p&gt;%@&lt;/p&gt;\n&lt;/div&gt;", escaped];
+}
+
+static BOOL ApolloDeletedCommentsStringIsReasonLabel(NSString *text) {
+    NSString *normalized = ApolloDeletedCommentsNormalizedReasonLabel(ApolloDeletedCommentsTrimmedString(text));
+    return [normalized isEqualToString:@"REMOVED BY MOD"] ||
+           [normalized isEqualToString:@"DELETED BY USER"] ||
+           [normalized isEqualToString:@"LOADING..."] ||
+           [normalized isEqualToString:@"NOT AVAILABLE"];
+}
+
+static void ApolloDeletedCommentsRememberOriginalModelBodyIfNeeded(RDKComment *comment) {
+    if (!comment) return;
+    NSString *body = comment.body;
+    if (body.length == 0 || ApolloDeletedCommentsStringIsReasonLabel(body) || ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(body)) return;
+    if (!objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey)) {
+        objc_setAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey, [body copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+    }
+
+    NSString *bodyHTML = ApolloDeletedCommentsCommentStringValue(comment, @selector(bodyHTML));
+    if (bodyHTML.length > 0 && !objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyHTMLKey)) {
+        objc_setAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyHTMLKey, [bodyHTML copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+    }
+}
+
+static BOOL ApolloDeletedCommentsRestoreOriginalModelBodyIfNeeded(RDKComment *comment) {
+    if (!comment) return NO;
+    NSString *originalBody = objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey);
+    if (![originalBody isKindOfClass:[NSString class]] || originalBody.length == 0) return NO;
+
+    NSString *currentBody = comment.body;
+    if (![currentBody isEqualToString:originalBody]) {
+        ApolloDeletedCommentsSetCommentStringValue(comment, @selector(setBody:), originalBody);
+    }
+
+    NSString *originalBodyHTML = objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyHTMLKey);
+    if ([originalBodyHTML isKindOfClass:[NSString class]] && originalBodyHTML.length > 0) {
+        ApolloDeletedCommentsSetCommentStringValue(comment, @selector(setBodyHTML:), originalBodyHTML);
+    } else {
+        ApolloDeletedCommentsSetCommentStringValue(comment, @selector(setBodyHTML:), ApolloDeletedCommentsPlainBodyHTML(originalBody));
+    }
+    return YES;
+}
+
+static void ApolloDeletedCommentsSetModelBodyToReasonLabel(RDKComment *comment, NSString *label) {
+    if (!comment || label.length == 0) return;
+    if (![comment.body isEqualToString:label]) {
+        ApolloDeletedCommentsSetCommentStringValue(comment, @selector(setBody:), label);
+    }
+    ApolloDeletedCommentsSetCommentStringValue(comment, @selector(setBodyHTML:), ApolloDeletedCommentsPlainBodyHTML(label));
+}
+
+static BOOL ApolloDeletedCommentsCommentIsRevealedByFullName(RDKComment *comment) {
+    if (!comment) return NO;
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    if (ApolloDeletedCommentsIsCommentRevealed(fullName)) return YES;
+    NSString *originalBody = objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey);
+    NSString *bodyForRevealKey = [originalBody isKindOfClass:[NSString class]] && originalBody.length > 0 ? originalBody : comment.body;
+    return ApolloDeletedCommentsIsCommentBodyRevealed(comment.author, bodyForRevealKey);
+}
+
+static void ApolloDeletedCommentsSynchronizeCommentModelDisplayState(id cellNode) {
+    if (!cellNode) return;
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return;
+
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    NSString *label = ApolloDeletedCommentsReasonLabelForComment(comment);
+    BOOL placeholderOnly = ApolloDeletedCommentsIsDeletedPlaceholder(fullName) &&
+                           !ApolloDeletedCommentsIsRecoveredComment(fullName);
+    BOOL recovered = ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode);
+    BOOL revealed = ApolloDeletedCommentsCommentIsRevealedByFullName(comment);
+
+    if (placeholderOnly) {
+        ApolloDeletedCommentsSetModelBodyToReasonLabel(comment, label);
+        return;
+    }
+
+    if (recovered && sTapToRevealDeletedComments && !revealed) {
+        ApolloDeletedCommentsRememberOriginalModelBodyIfNeeded(comment);
+        ApolloDeletedCommentsSetModelBodyToReasonLabel(comment, label);
+        return;
+    }
+
+    if (recovered) {
+        ApolloDeletedCommentsRestoreOriginalModelBodyIfNeeded(comment);
+    }
+}
+
+static NSString *ApolloDeletedCommentsReasonLabelForCommentAndBody(RDKComment *comment, NSString *body) {
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    NSString *reason = ApolloDeletedCommentsRecoveredReasonForComment(fullName);
+    if (reason.length == 0) reason = ApolloDeletedCommentsDeletedPlaceholderReason(fullName);
+    if (reason.length == 0) reason = ApolloDeletedCommentsRecoveredReasonForCommentBody(comment.author, body);
+    NSString *label = ApolloDeletedCommentsDisplayLabelForReason(reason);
+    return ApolloDeletedCommentsNormalizedReasonLabel(label);
+}
+
+static NSString *ApolloDeletedCommentsHiddenReasonLabelForCommentBody(RDKComment *comment, NSString *body) {
+    if (!sShowDeletedComments || !comment) return nil;
+
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    NSString *savedBody = objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey);
+    NSString *bodyForState = [savedBody isKindOfClass:[NSString class]] && savedBody.length > 0 ? savedBody : body;
+    BOOL placeholder = ApolloDeletedCommentsIsDeletedPlaceholder(fullName);
+    BOOL recovered = ApolloDeletedCommentsIsRecoveredComment(fullName) ||
+                     ApolloDeletedCommentsIsRecoveredCommentBody(comment.author, bodyForState);
+    BOOL placeholderOnly = placeholder && !recovered;
+    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
+                    ApolloDeletedCommentsIsCommentBodyRevealed(comment.author, bodyForState);
+
+    if (placeholderOnly) {
+        return ApolloDeletedCommentsReasonLabelForCommentAndBody(comment, bodyForState);
+    }
+    if (sTapToRevealDeletedComments && recovered && !revealed) {
+        return ApolloDeletedCommentsReasonLabelForCommentAndBody(comment, bodyForState);
+    }
+    return nil;
+}
+
+static id ApolloDeletedCommentsObjectIvarByNames(id object, const char **candidateNames) {
+    if (!object || !candidateNames) return nil;
+    for (Class cls = [object class]; cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
+        for (size_t i = 0; candidateNames[i]; i++) {
+            Ivar ivar = class_getInstanceVariable(cls, candidateNames[i]);
+            if (!ivar) continue;
+            const char *type = ivar_getTypeEncoding(ivar);
+            if (!type || type[0] != '@') continue;
+            id value = nil;
+            @try {
+                value = object_getIvar(object, ivar);
+            } @catch (__unused NSException *e) {
+                value = nil;
+            }
+            if (value) return value;
+        }
+    }
+    return nil;
+}
+
+static id ApolloDeletedCommentsKnownBodyContainerNode(id commentCellNode) {
+    static const char *candidateNames[] = {
+        "bodyNode",
+        "markdownNode",
+        "commentMarkdownNode",
+        "commentBodyNode",
+        "bodyMarkdownNode",
+        NULL,
+    };
+    return ApolloDeletedCommentsObjectIvarByNames(commentCellNode, candidateNames);
+}
+
 static NSString *ApolloDeletedCommentsNormalizedReasonLabel(NSString *label) {
     if (![label isKindOfClass:[NSString class]] || label.length == 0) return @"REMOVED BY MOD";
     if ([label isEqualToString:@"DELETED BY MOD"]) return @"REMOVED BY MOD";
@@ -178,7 +430,7 @@ static NSString *ApolloDeletedCommentsNormalizedReasonLabel(NSString *label) {
 static UIImage *ApolloDeletedCommentsReasonChipImage(NSString *text, UIFont *font) {
     text = ApolloDeletedCommentsNormalizedReasonLabel(text);
     if (![text isKindOfClass:[NSString class]] || text.length == 0) return nil;
-    if (![font isKindOfClass:[UIFont class]]) font = [UIFont boldSystemFontOfSize:15.0];
+    if (![font isKindOfClass:[UIFont class]]) font = ApolloDeletedCommentsReasonChipFont();
 
     NSDictionary *attributes = @{
         NSFontAttributeName: font,
@@ -209,14 +461,9 @@ static UIImage *ApolloDeletedCommentsReasonChipImage(NSString *text, UIFont *fon
 }
 
 static NSAttributedString *ApolloDeletedCommentsReasonChipAttributedText(NSString *label, NSDictionary *baseAttributes, BOOL revealLink) {
+    (void)baseAttributes;
     label = ApolloDeletedCommentsNormalizedReasonLabel(label);
-    UIFont *font = baseAttributes[NSFontAttributeName];
-    if (![font isKindOfClass:[UIFont class]]) {
-        font = [UIFont boldSystemFontOfSize:15.0];
-    } else {
-        font = [UIFont boldSystemFontOfSize:MAX(12.0, font.pointSize - 2.5)];
-    }
-
+    UIFont *font = ApolloDeletedCommentsReasonChipFont();
     UIImage *image = ApolloDeletedCommentsReasonChipImage(label, font);
     CGFloat chipLineHeight = [image isKindOfClass:[UIImage class]] ? image.size.height + 2.0 : font.lineHeight + 2.0;
     NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
@@ -262,28 +509,16 @@ static id ApolloDeletedCommentsKnownBodyTextNode(id commentCellNode) {
         "bodyMarkdownNode",
         NULL,
     };
-    for (Class cls = [commentCellNode class]; cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
-        for (size_t i = 0; candidateNames[i]; i++) {
-            Ivar ivar = class_getInstanceVariable(cls, candidateNames[i]);
-            if (!ivar) continue;
-            const char *type = ivar_getTypeEncoding(ivar);
-            if (!type || type[0] != '@') continue;
-            id node = nil;
-            @try {
-                node = object_getIvar(commentCellNode, ivar);
-            } @catch (__unused NSException *e) {
-                node = nil;
-            }
-            if (node && [node respondsToSelector:@selector(attributedText)] && [node respondsToSelector:@selector(setAttributedText:)]) {
-                return node;
-            }
-        }
+    id node = ApolloDeletedCommentsObjectIvarByNames(commentCellNode, candidateNames);
+    if (node && [node respondsToSelector:@selector(attributedText)] && [node respondsToSelector:@selector(setAttributedText:)]) {
+        return node;
     }
     return nil;
 }
 
 static void ApolloDeletedCommentsRelayoutCellAndTextNode(id cellNode, id textNode) {
     SEL selectors[] = {
+        @selector(invalidateCalculatedLayout),
         @selector(setNeedsLayout),
         @selector(setNeedsDisplay),
     };
@@ -308,12 +543,74 @@ static NSAttributedString *ApolloDeletedCommentsPlaceholderAttributedText(NSAttr
     return chip;
 }
 
+static NSMutableDictionary *ApolloDeletedCommentsDefaultBodyAttributes(void) {
+    UIColor *textColor = nil;
+    if (@available(iOS 13.0, *)) {
+        textColor = [UIColor labelColor];
+    }
+    if (!textColor) textColor = [UIColor blackColor];
+    return [@{
+        NSFontAttributeName: ApolloDeletedCommentsRecoveredBodyFont(),
+        NSForegroundColorAttributeName: textColor,
+    } mutableCopy];
+}
+
+static NSMutableDictionary *ApolloDeletedCommentsSanitizedBodyAttributes(NSDictionary *attrs) {
+    UIFont *font = attrs[NSFontAttributeName];
+    if (![font isKindOfClass:[UIFont class]]) return nil;
+
+    NSMutableDictionary *attributes = [attrs mutableCopy];
+    attributes[NSFontAttributeName] = ApolloDeletedCommentsRecoveredBodyFont();
+    [attributes removeObjectForKey:NSAttachmentAttributeName];
+    [attributes removeObjectForKey:NSBackgroundColorAttributeName];
+    [attributes removeObjectForKey:NSLinkAttributeName];
+    [attributes removeObjectForKey:ApolloDeletedCommentsRevealAttributeName];
+    [attributes removeObjectForKey:ApolloDeletedCommentsReasonPrefixAttributeName];
+    return attributes;
+}
+
 static NSAttributedString *ApolloDeletedCommentsBodyAttributedText(NSAttributedString *templateText, NSString *body) {
-    NSDictionary *attributes = @{};
+    __block NSMutableDictionary *attributes = nil;
     if ([templateText isKindOfClass:[NSAttributedString class]] && templateText.length > 0) {
-        attributes = [templateText attributesAtIndex:0 effectiveRange:NULL] ?: @{};
+        [templateText enumerateAttributesInRange:NSMakeRange(0, templateText.length)
+                                         options:0
+                                      usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attrs, __unused NSRange range, BOOL *stop) {
+            if (attrs[NSAttachmentAttributeName]) return;
+            attributes = ApolloDeletedCommentsSanitizedBodyAttributes(attrs);
+            if (!attributes) return;
+            *stop = YES;
+        }];
+    }
+    if (!attributes) {
+        attributes = ApolloDeletedCommentsDefaultBodyAttributes();
     }
     return [[NSAttributedString alloc] initWithString:body ?: @"" attributes:attributes];
+}
+
+static NSAttributedString *ApolloDeletedCommentsBodyTextByNormalizingFont(NSAttributedString *attributedText) {
+    if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
+
+    NSMutableAttributedString *normalized = [attributedText mutableCopy];
+    NSRange fullRange = NSMakeRange(0, normalized.length);
+    [normalized enumerateAttributesInRange:fullRange
+                                   options:0
+                                usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attrs, NSRange range, __unused BOOL *stop) {
+        if (attrs[NSAttachmentAttributeName]) return;
+        [normalized addAttribute:NSFontAttributeName value:ApolloDeletedCommentsRecoveredBodyFont() range:range];
+    }];
+    return normalized;
+}
+
+static NSAttributedString *ApolloDeletedCommentsRecoveredBodyTextForDisplay(NSAttributedString *templateText, NSString *body) {
+    if ([templateText isKindOfClass:[NSAttributedString class]] &&
+        templateText.length > 0 &&
+        !ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(templateText) &&
+        !ApolloDeletedCommentsAttributedTextHasReasonPrefix(templateText) &&
+        (ApolloDeletedCommentsTextQualifiesAsBodyCandidate(templateText.string, body) ||
+         ApolloDeletedCommentsTextQualifiesAsBodyFragment(templateText.string, body))) {
+        return ApolloDeletedCommentsBodyTextByNormalizingFont(templateText);
+    }
+    return ApolloDeletedCommentsBodyAttributedText(templateText, body);
 }
 
 static NSObject *ApolloDeletedCommentsVisibleCellsLock(void) {
@@ -324,12 +621,12 @@ static NSObject *ApolloDeletedCommentsVisibleCellsLock(void) {
     return sApolloDeletedCommentsVisibleCellsLock;
 }
 
-static void ApolloDeletedCommentsTrackVisiblePlaceholderCell(id cellNode) {
+static void ApolloDeletedCommentsTrackVisibleDeletedCommentCell(id cellNode) {
     if (!cellNode) return;
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     if (fullName.length == 0) return;
-    if (!ApolloDeletedCommentsIsDeletedPlaceholder(fullName) || ApolloDeletedCommentsIsRecoveredComment(fullName)) return;
+    if (!ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return;
 
     @synchronized (ApolloDeletedCommentsVisibleCellsLock()) {
         if (!sApolloDeletedCommentsVisibleCellsByFullName) {
@@ -446,6 +743,7 @@ static BOOL ApolloDeletedCommentsTextQualifiesAsBodyFragment(NSString *candidate
     if (candidateNorm.length < 12 || bodyNorm.length == 0) return NO;
     if ([candidateNorm isEqualToString:@"spoiler"]) return NO;
     if ([candidateNorm hasPrefix:@"deleted by "]) return NO;
+    if ([candidateNorm hasPrefix:@"removed by "]) return NO;
     return [bodyNorm rangeOfString:candidateNorm options:NSCaseInsensitiveSearch].location != NSNotFound;
 }
 
@@ -480,6 +778,37 @@ static void ApolloDeletedCommentsCollectAttributedTextNodes(id object, NSInteger
             }
         }
     } @catch (__unused NSException *e) {}
+}
+
+static void ApolloDeletedCommentsCollectWritableTextNodes(id object, NSInteger depth, NSHashTable *visited, NSMutableArray *nodes) {
+    if (!object || depth < 0 || [visited containsObject:object]) return;
+    [visited addObject:object];
+
+    @try {
+        if ([object respondsToSelector:@selector(attributedText)] && [object respondsToSelector:@selector(setAttributedText:)]) {
+            [nodes addObject:object];
+        }
+
+        if ([object respondsToSelector:@selector(subnodes)]) {
+            NSArray *subnodes = ((NSArray *(*)(id, SEL))objc_msgSend)(object, @selector(subnodes));
+            if ([subnodes isKindOfClass:[NSArray class]]) {
+                for (id subnode in subnodes) ApolloDeletedCommentsCollectWritableTextNodes(subnode, depth - 1, visited, nodes);
+            }
+        }
+    } @catch (__unused NSException *e) {}
+}
+
+static id ApolloDeletedCommentsFallbackBodyTextNode(id cellNode) {
+    id known = ApolloDeletedCommentsKnownBodyTextNode(cellNode);
+    if (known) return known;
+
+    id bodyContainer = ApolloDeletedCommentsKnownBodyContainerNode(cellNode);
+    if (!bodyContainer) return nil;
+
+    NSMutableArray *candidates = [NSMutableArray array];
+    NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:32];
+    ApolloDeletedCommentsCollectWritableTextNodes(bodyContainer, 5, visited, candidates);
+    return candidates.firstObject;
 }
 
 static id ApolloDeletedCommentsBestBodyTextNode(id cellNode, RDKComment *comment) {
@@ -617,7 +946,7 @@ static BOOL ApolloDeletedCommentsCellAlreadyHasHiddenPlaceholder(id cellNode, NS
     return NO;
 }
 
-static NSAttributedString *ApolloDeletedCommentsAttributedTextWithTapToRevealPlaceholder(id textNode, NSAttributedString *attributedText) {
+static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsAttributedTextWithTapToRevealPlaceholder(id textNode, NSAttributedString *attributedText) {
     if (!sShowDeletedComments || !sTapToRevealDeletedComments) return attributedText;
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
     if (ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(attributedText)) return attributedText;
@@ -655,7 +984,6 @@ static NSAttributedString *ApolloDeletedCommentsAttributedTextWithTapToRevealPla
 
 static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(id textNode, NSAttributedString *attributedText) {
     if (!sShowDeletedComments) return attributedText;
-    if (sTapToRevealDeletedComments) return attributedText;
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
     if (ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(attributedText) ||
         ApolloDeletedCommentsAttributedTextHasReasonPrefix(attributedText)) {
@@ -665,21 +993,55 @@ static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(i
     id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return attributedText;
-    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
-    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
-                    ApolloDeletedCommentsIsCommentBodyRevealed(comment.author, comment.body);
+    BOOL revealed = ApolloDeletedCommentsCommentIsRevealedByFullName(comment);
     if (sTapToRevealDeletedComments && !revealed) return attributedText;
     id bodyTextNode = ApolloDeletedCommentsBestBodyTextNode(cellNode, comment);
     if (bodyTextNode && bodyTextNode != textNode) return attributedText;
-    if (!ApolloDeletedCommentsTextQualifiesAsBodyCandidate(attributedText.string, comment.body)) return attributedText;
+    BOOL bodyCandidate = ApolloDeletedCommentsTextQualifiesAsBodyCandidate(attributedText.string, comment.body) ||
+                         ApolloDeletedCommentsTextQualifiesAsBodyFragment(attributedText.string, comment.body);
+    if (!bodyCandidate) return attributedText;
 
-    NSDictionary *baseAttributes = [attributedText attributesAtIndex:0 effectiveRange:NULL] ?: @{};
+    NSAttributedString *bodyText = ApolloDeletedCommentsRecoveredBodyTextForDisplay(attributedText, comment.body);
+    NSDictionary *baseAttributes = bodyText.length > 0 ? ([bodyText attributesAtIndex:0 effectiveRange:NULL] ?: @{}) : @{};
     NSString *label = ApolloDeletedCommentsReasonLabelForComment(comment);
-    NSMutableAttributedString *prefixed = [[NSMutableAttributedString alloc] init];
-    [prefixed appendAttributedString:ApolloDeletedCommentsReasonChipAttributedText(label, baseAttributes, NO)];
-    [prefixed appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n" attributes:baseAttributes]];
-    [prefixed appendAttributedString:attributedText];
-    return prefixed;
+    NSMutableDictionary *spacerAttributes = [baseAttributes mutableCopy];
+    NSMutableParagraphStyle *spacerStyle = [NSMutableParagraphStyle new];
+    spacerStyle.minimumLineHeight = 20.0;
+    spacerStyle.maximumLineHeight = 20.0;
+    spacerAttributes[NSParagraphStyleAttributeName] = spacerStyle;
+    NSMutableAttributedString *decorated = [bodyText mutableCopy];
+    [decorated appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n" attributes:spacerAttributes]];
+    [decorated appendAttributedString:ApolloDeletedCommentsReasonChipAttributedText(label, baseAttributes, sTapToRevealDeletedComments && revealed)];
+    if (sTapToRevealDeletedComments && revealed) ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
+    return decorated;
+}
+
+static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonChipIfNeeded(id textNode, NSAttributedString *attributedText) {
+    if (!sShowDeletedComments) return attributedText;
+    if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
+
+    id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return attributedText;
+
+    NSString *label = ApolloDeletedCommentsReasonLabelForComment(comment);
+    NSString *text = ApolloDeletedCommentsNormalizedReasonLabel(ApolloDeletedCommentsTrimmedString(attributedText.string));
+    if (![text isEqualToString:label]) return attributedText;
+
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    BOOL placeholderOnly = ApolloDeletedCommentsIsDeletedPlaceholder(fullName) &&
+                           !ApolloDeletedCommentsIsRecoveredComment(fullName);
+    BOOL revealed = ApolloDeletedCommentsCommentIsRevealedByFullName(comment);
+    BOOL revealLink = sTapToRevealDeletedComments &&
+                      ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode) &&
+                      !placeholderOnly &&
+                      !revealed;
+
+    NSAttributedString *chip = ApolloDeletedCommentsReasonChipAttributedText(label,
+                                                                             [attributedText attributesAtIndex:0 effectiveRange:NULL] ?: @{},
+                                                                             revealLink);
+    if (revealLink) ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
+    return chip;
 }
 
 static void ApolloDeletedCommentsRestoreHiddenBodyIfNeeded(id cellNode, id textNode) {
@@ -736,9 +1098,9 @@ static void ApolloDeletedCommentsRestoreHiddenBodiesIfNeeded(id cellNode, NSArra
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-static void ApolloDeletedCommentsRefreshHiddenPlaceholderForCell(id cellNode) {
+static BOOL ApolloDeletedCommentsRefreshHiddenPlaceholderForCell(id cellNode) {
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
-    if (!comment) return;
+    if (!comment) return NO;
 
     BOOL placedPlaceholder = NO;
     for (id textNode in ApolloDeletedCommentsHiddenTextNodesForCell(cellNode)) {
@@ -762,6 +1124,37 @@ static void ApolloDeletedCommentsRefreshHiddenPlaceholderForCell(id cellNode) {
 
     id firstHiddenNode = ApolloDeletedCommentsHiddenTextNodesForCell(cellNode).firstObject;
     ApolloDeletedCommentsEnsureRevealAttributeIsTappable(firstHiddenNode);
+    return placedPlaceholder;
+}
+
+static BOOL ApolloDeletedCommentsInstallTapToRevealPlaceholderOnTextNode(id cellNode, id textNode, RDKComment *comment, NSString *fullName) {
+    if (!cellNode || !textNode || !comment || fullName.length == 0) return NO;
+    if (![textNode respondsToSelector:@selector(setAttributedText:)]) return NO;
+
+    NSAttributedString *current = ApolloDeletedCommentsCurrentAttributedText(textNode);
+    NSAttributedString *original = nil;
+    if ([current isKindOfClass:[NSAttributedString class]] &&
+        current.length > 0 &&
+        !ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(current) &&
+        !ApolloDeletedCommentsAttributedTextHasReasonPrefix(current) &&
+        (ApolloDeletedCommentsTextQualifiesAsBodyCandidate(current.string, comment.body) ||
+         ApolloDeletedCommentsTextQualifiesAsBodyFragment(current.string, comment.body))) {
+        original = [current copy];
+    } else {
+        original = ApolloDeletedCommentsBodyAttributedText(current, comment.body);
+    }
+    if (![original isKindOfClass:[NSAttributedString class]] || original.length == 0) return NO;
+
+    objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, original, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, @[textNode], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    NSAttributedString *placeholder = ApolloDeletedCommentsPlaceholderAttributedText(original, ApolloDeletedCommentsReasonLabelForComment(comment));
+    ApolloDeletedCommentsSetTextNodeAttributedText(textNode, placeholder);
+    ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
+    ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
+    return YES;
 }
 
 static void ApolloDeletedCommentsApplyStaticPlaceholderChip(id cellNode, NSArray *textNodes) {
@@ -842,11 +1235,16 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeede
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     NSString *author = comment.author;
     NSString *body = comment.body;
-    NSArray *textNodes = ApolloDeletedCommentsBodyTextNodes(cellNode, comment);
-    if (textNodes.count == 0) return;
 
     BOOL placeholderOnly = ApolloDeletedCommentsCellNodeIsDeletedPlaceholder(cellNode) &&
                            !ApolloDeletedCommentsCellNodeIsRecovered(cellNode);
+    NSArray *textNodes = ApolloDeletedCommentsBodyTextNodes(cellNode, comment);
+    if (textNodes.count == 0) {
+        id knownBodyNode = ApolloDeletedCommentsFallbackBodyTextNode(cellNode);
+        if (knownBodyNode) textNodes = @[knownBodyNode];
+    }
+    if (textNodes.count == 0) return;
+
     if (placeholderOnly) {
         ApolloDeletedCommentsApplyStaticPlaceholderChip(cellNode, textNodes);
         return;
@@ -860,6 +1258,17 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeede
                       recovered &&
                       !revealed;
     if (!shouldHide) {
+        if (recovered) {
+            for (id textNode in textNodes) {
+                NSAttributedString *current = ApolloDeletedCommentsCurrentAttributedText(textNode);
+                if ([current isKindOfClass:[NSAttributedString class]] && current.length > 0) continue;
+                NSAttributedString *bodyText = ApolloDeletedCommentsBodyAttributedText(current, body);
+                if (bodyText.length == 0) continue;
+                ApolloDeletedCommentsSetTextNodeAttributedText(textNode, bodyText);
+                ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
+                break;
+            }
+        }
         ApolloDeletedCommentsRestoreHiddenBodiesIfNeeded(cellNode, textNodes);
         return;
     }
@@ -874,8 +1283,13 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeede
         }
     }
     if (alreadyHiddenForComment) {
-        ApolloDeletedCommentsRefreshHiddenPlaceholderForCell(cellNode);
-        return;
+        BOOL refreshed = ApolloDeletedCommentsRefreshHiddenPlaceholderForCell(cellNode);
+        id knownBodyNode = ApolloDeletedCommentsFallbackBodyTextNode(cellNode);
+        id activeHiddenNode = ApolloDeletedCommentsHiddenTextNodesForCell(cellNode).firstObject;
+        if (refreshed && (!knownBodyNode || knownBodyNode == activeHiddenNode)) {
+            return;
+        }
+        ApolloDeletedCommentsRestoreHiddenBodiesIfNeeded(cellNode, nil);
     }
 
     ApolloDeletedCommentsRestoreHiddenBodiesIfNeeded(cellNode, nil);
@@ -911,7 +1325,11 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeede
         ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
     }
 
-    if (hiddenNodes.count == 0) return;
+    if (hiddenNodes.count == 0) {
+        id knownBodyNode = ApolloDeletedCommentsFallbackBodyTextNode(cellNode);
+        if (ApolloDeletedCommentsInstallTapToRevealPlaceholderOnTextNode(cellNode, knownBodyNode, comment, fullName)) return;
+        return;
+    }
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, [hiddenNodes copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, hiddenNodes.firstObject, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloDeletedCommentsEnsureRevealAttributeIsTappable(hiddenNodes.firstObject);
@@ -980,28 +1398,72 @@ static BOOL __attribute__((unused)) ApolloDeletedCommentsTouchHitsHiddenBody(id 
     return NO;
 }
 
-static void __attribute__((unused)) ApolloDeletedCommentsRevealHiddenBodyForCell(id cellNode) {
-    BOOL hasHiddenBody = NO;
-    for (id textNode in ApolloDeletedCommentsHiddenTextNodesForCell(cellNode)) {
-        if (objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey)) {
-            hasHiddenBody = YES;
-            break;
-        }
-    }
-    if (!hasHiddenBody) return;
-
+static void ApolloDeletedCommentsApplyRevealedBodyTextToNode(id cellNode, id textNode) {
+    if (!cellNode || !textNode) return;
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    if (!comment || fullName.length == 0 || !ApolloDeletedCommentsIsCommentRevealed(fullName)) return;
+
+    NSAttributedString *templateText = objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey);
+    if (![templateText isKindOfClass:[NSAttributedString class]] || templateText.length == 0) {
+        templateText = ApolloDeletedCommentsCurrentAttributedText(textNode);
+    }
+    NSAttributedString *bodyText = ApolloDeletedCommentsRecoveredBodyTextForDisplay(templateText, comment.body);
+    bodyText = ApolloDeletedCommentsAttributedTextWithReasonPrefix(textNode, bodyText);
+    if (bodyText.length == 0) return;
+
+    ApolloDeletedCommentsSetTextNodeAttributedText(textNode, bodyText);
+    ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
+    ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
+}
+
+static void __attribute__((unused)) ApolloDeletedCommentsRevealHiddenBodyForCell(id cellNode, id tappedTextNode) {
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    if (!comment || fullName.length == 0) return;
 
     if (ApolloDeletedCommentsIsDeletedPlaceholder(fullName) && !ApolloDeletedCommentsIsRecoveredComment(fullName)) {
-        ApolloDeletedCommentsRefreshHiddenPlaceholderForCell(cellNode);
+        ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
+        ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyContainerNode(cellNode));
         return;
     }
 
+    BOOL restored = ApolloDeletedCommentsRestoreOriginalModelBodyIfNeeded(comment);
+    if (!restored) {
+        NSDictionary *archived = ApolloDeletedCommentsCachedArchivedComment(fullName);
+        if (archived.count > 0) {
+            NSString *reason = ApolloDeletedCommentsDeletedPlaceholderReason(fullName) ?: ApolloDeletedCommentsRecoveredReasonForComment(fullName);
+            ApolloDeletedCommentsApplyRecoveredArchivedCommentToObject((id)comment, archived, reason);
+            restored = YES;
+        }
+    }
+    if (!restored && ApolloDeletedCommentsStringIsReasonLabel(comment.body)) return;
+
     ApolloDeletedCommentsMarkCommentRevealed(fullName);
-    ApolloDeletedCommentsMarkCommentBodyRevealed(comment.author, comment.body);
+    NSString *originalBody = objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey);
+    NSString *bodyForRevealKey = [originalBody isKindOfClass:[NSString class]] && originalBody.length > 0 ? originalBody : comment.body;
+    ApolloDeletedCommentsMarkCommentBodyRevealed(comment.author, bodyForRevealKey);
     objc_setAssociatedObject(comment, kApolloDeletedCommentsSuppressNextCollapseKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    ApolloDeletedCommentsRestoreHiddenBodiesIfNeeded(cellNode, nil);
+    ApolloDeletedCommentsRestoreOriginalModelBodyIfNeeded(comment);
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (tappedTextNode) {
+        ApolloDeletedCommentsApplyRevealedBodyTextToNode(cellNode, tappedTextNode);
+        NSString *capturedFullName = [fullName copy];
+        __weak id weakCellNode = cellNode;
+        __weak id weakTextNode = tappedTextNode;
+        for (NSNumber *delayNumber in @[@0.05, @0.16]) {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayNumber.doubleValue * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                id strongCellNode = weakCellNode;
+                id strongTextNode = weakTextNode;
+                RDKComment *currentComment = ApolloDeletedCommentsCommentFromCellNode(strongCellNode);
+                if (![ApolloDeletedCommentsFullNameForComment(currentComment) isEqualToString:capturedFullName]) return;
+                ApolloDeletedCommentsApplyRevealedBodyTextToNode(strongCellNode, strongTextNode);
+            });
+        }
+    }
+    ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyContainerNode(cellNode));
+    ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyTextNode(cellNode));
 }
 
 static BOOL __attribute__((unused)) ApolloDeletedCommentsCommentIsRevealed(RDKComment *comment) {
@@ -1020,20 +1482,35 @@ static BOOL __attribute__((unused)) ApolloDeletedCommentsTouchHitsRecoveredBody(
     return NO;
 }
 
-static void __attribute__((unused)) ApolloDeletedCommentsHideRevealedBodyForCell(id cellNode) {
+static void __attribute__((unused)) ApolloDeletedCommentsHideRevealedBodyForCell(id cellNode, id tappedTextNode) {
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     if (!comment) return;
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     ApolloDeletedCommentsUnmarkCommentRevealed(fullName);
-    ApolloDeletedCommentsUnmarkCommentBodyRevealed(comment.author, comment.body);
+    NSString *originalBody = objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey);
+    NSString *bodyForRevealKey = [originalBody isKindOfClass:[NSString class]] && originalBody.length > 0 ? originalBody : comment.body;
+    ApolloDeletedCommentsUnmarkCommentBodyRevealed(comment.author, bodyForRevealKey);
     objc_setAssociatedObject(comment, kApolloDeletedCommentsSuppressNextCollapseKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    ApolloDeletedCommentsApplyTapToRevealIfNeeded(cellNode);
+    ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
+    if (tappedTextNode) {
+        NSAttributedString *current = ApolloDeletedCommentsCurrentAttributedText(tappedTextNode);
+        NSAttributedString *chip = ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment),
+                                                                                 current.length > 0 ? ([current attributesAtIndex:0 effectiveRange:NULL] ?: @{}) : @{},
+                                                                                 YES);
+        ApolloDeletedCommentsSetTextNodeAttributedText(tappedTextNode, chip);
+        ApolloDeletedCommentsEnsureRevealAttributeIsTappable(tappedTextNode);
+        ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, tappedTextNode);
+    }
+    ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyContainerNode(cellNode));
+    ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyTextNode(cellNode));
 }
 
 static id ApolloDeletedCommentsCommentCellNodeForTextNode(id textNode) {
     if (!textNode || ![textNode respondsToSelector:@selector(supernode)]) return nil;
     id current = textNode;
     for (NSUInteger i = 0; current && i < 10; i++) {
+        id ownerCell = objc_getAssociatedObject(current, kApolloDeletedCommentsBodyOwnerCellKey);
+        if (ownerCell) return ownerCell;
         const char *className = class_getName(object_getClass(current));
         if (className && strstr(className, "CommentCellNode")) return current;
         if (![current respondsToSelector:@selector(supernode)]) break;
@@ -1084,9 +1561,10 @@ static void ApolloDeletedCommentsApplyCellHighlight(id cellNode) {
         highlight = [[UIView alloc] initWithFrame:cellView.bounds];
         highlight.userInteractionEnabled = NO;
         highlight.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-        highlight.backgroundColor = ApolloDeletedCommentsHighlightColor();
         objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHighlightViewKey, highlight, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    highlight.backgroundColor = ApolloDeletedCommentsHighlightColorForLabel(ApolloDeletedCommentsReasonLabelForComment(comment));
 
     highlight.frame = cellView.bounds;
     if (highlight.superview != cellView) {
@@ -1102,6 +1580,101 @@ static void ApolloDeletedCommentsSetTextNodeAttributedText(id textNode, NSAttrib
     @try {
         ((void (*)(id, SEL, NSAttributedString *))objc_msgSend)(textNode, @selector(setAttributedText:), attributedText);
     } @catch (__unused NSException *e) {}
+}
+
+static id ApolloDeletedCommentsBodyReplacementTextNode(id markdownNode, id cellNode) {
+    if (!markdownNode || !cellNode) return nil;
+    id textNode = objc_getAssociatedObject(markdownNode, kApolloDeletedCommentsBodyReplacementTextNodeKey);
+    Class textNodeClass = ApolloDeletedCommentsASTextNodeClass();
+    if (!textNode || !textNodeClass || ![textNode isKindOfClass:textNodeClass]) {
+        textNode = [[textNodeClass alloc] init];
+        if (!textNode) return nil;
+        objc_setAssociatedObject(markdownNode, kApolloDeletedCommentsBodyReplacementTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        @try {
+            ((void (*)(id, SEL, id))objc_msgSend)(markdownNode, @selector(addSubnode:), textNode);
+        } @catch (__unused NSException *e) {}
+    }
+    @try {
+        ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setDelegate:), markdownNode);
+    } @catch (__unused NSException *e) {}
+    ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
+    return textNode;
+}
+
+static NSAttributedString *ApolloDeletedCommentsTemplateTextForMarkdownNode(id markdownNode) {
+    NSMutableArray *textNodes = [NSMutableArray array];
+    NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:16];
+    ApolloDeletedCommentsCollectAttributedTextNodes(markdownNode, 4, visited, textNodes);
+    for (id textNode in textNodes) {
+        NSAttributedString *current = ApolloDeletedCommentsCurrentAttributedText(textNode);
+        if ([current isKindOfClass:[NSAttributedString class]] && current.length > 0) return current;
+    }
+    UIColor *fallbackTextColor = nil;
+    if (@available(iOS 13.0, *)) {
+        fallbackTextColor = [UIColor labelColor];
+    }
+    if (!fallbackTextColor) fallbackTextColor = [UIColor blackColor];
+    return [[NSAttributedString alloc] initWithString:@" " attributes:@{
+        NSFontAttributeName: [UIFont systemFontOfSize:16.0],
+        NSForegroundColorAttributeName: fallbackTextColor,
+    }];
+}
+
+static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpecIfNeeded(id markdownNode) {
+    id cellNode = objc_getAssociatedObject(markdownNode, kApolloDeletedCommentsBodyOwnerCellKey);
+    if (!cellNode) cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(markdownNode);
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return nil;
+
+    id textNode = ApolloDeletedCommentsBodyReplacementTextNode(markdownNode, cellNode);
+    if (!textNode) return nil;
+
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    BOOL placeholderOnly = ApolloDeletedCommentsCellNodeIsDeletedPlaceholder(cellNode) &&
+                           !ApolloDeletedCommentsCellNodeIsRecovered(cellNode);
+    BOOL recovered = ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode);
+    BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName) ||
+                    ApolloDeletedCommentsIsCommentBodyRevealed(comment.author, comment.body);
+    BOOL shouldHide = sShowDeletedComments &&
+                      sTapToRevealDeletedComments &&
+                      recovered &&
+                      !revealed;
+
+    NSAttributedString *templateText = ApolloDeletedCommentsTemplateTextForMarkdownNode(markdownNode);
+    NSAttributedString *displayText = nil;
+    if (placeholderOnly || shouldHide) {
+        NSAttributedString *original = ApolloDeletedCommentsBodyAttributedText(templateText, comment.body);
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, original, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
+        objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, @[textNode], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        displayText = placeholderOnly
+            ? ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment),
+                                                            [templateText attributesAtIndex:0 effectiveRange:NULL] ?: @{},
+                                                            NO)
+            : ApolloDeletedCommentsPlaceholderAttributedText(templateText, ApolloDeletedCommentsReasonLabelForComment(comment));
+    } else {
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+        displayText = ApolloDeletedCommentsBodyAttributedText(templateText, comment.body);
+        if (!sTapToRevealDeletedComments) {
+            NSDictionary *baseAttributes = displayText.length > 0 ? ([displayText attributesAtIndex:0 effectiveRange:NULL] ?: @{}) : @{};
+            NSMutableDictionary *spacerAttributes = [baseAttributes mutableCopy];
+            NSMutableParagraphStyle *spacerStyle = [NSMutableParagraphStyle new];
+            spacerStyle.minimumLineHeight = 20.0;
+            spacerStyle.maximumLineHeight = 20.0;
+            spacerAttributes[NSParagraphStyleAttributeName] = spacerStyle;
+            NSMutableAttributedString *decorated = [displayText mutableCopy];
+            [decorated appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n" attributes:spacerAttributes]];
+            [decorated appendAttributedString:ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment), baseAttributes, NO)];
+            displayText = decorated;
+        }
+    }
+
+    ApolloDeletedCommentsSetTextNodeAttributedText(textNode, displayText);
+    Class insetClass = ApolloDeletedCommentsASInsetLayoutSpecClass();
+    if (!insetClass) return nil;
+    return [insetClass insetLayoutSpecWithInsets:UIEdgeInsetsZero child:textNode];
 }
 
 static NSAttributedString *ApolloDeletedCommentsCurrentAttributedText(id textNode) {
@@ -1120,40 +1693,14 @@ static void ApolloDeletedCommentsApplyRecoveredArchiveToVisibleCell(id cellNode,
     if (fullName.length == 0) return;
     if (!ApolloDeletedCommentsIsDeletedPlaceholder(fullName) || ApolloDeletedCommentsIsRecoveredComment(fullName)) return;
 
-    NSArray *textNodes = ApolloDeletedCommentsBodyTextNodes(cellNode, comment);
-    if (textNodes.count == 0) {
-        id knownBodyNode = ApolloDeletedCommentsKnownBodyTextNode(cellNode);
-        if (knownBodyNode) textNodes = @[knownBodyNode];
-    }
-    if (textNodes.count == 0) return;
-    id firstTextNode = textNodes.firstObject;
-    NSAttributedString *templateText = ApolloDeletedCommentsCurrentAttributedText(firstTextNode);
-
     NSString *reason = ApolloDeletedCommentsDeletedPlaceholderReason(fullName);
     if (!ApolloDeletedCommentsApplyRecoveredArchivedCommentToObject((id)comment, archived, reason)) return;
-
-    for (id textNode in textNodes) {
-        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
-    }
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-    NSAttributedString *bodyText = ApolloDeletedCommentsBodyAttributedText(templateText, comment.body);
-    if (!sTapToRevealDeletedComments) {
-        bodyText = ApolloDeletedCommentsAttributedTextWithReasonPrefix(firstTextNode, bodyText);
-    }
-    ApolloDeletedCommentsSetTextNodeAttributedText(firstTextNode, bodyText);
-    ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, firstTextNode);
-
-    NSDictionary *blankAttributes = bodyText.length > 0 ? ([bodyText attributesAtIndex:0 effectiveRange:NULL] ?: @{}) : @{};
-    for (NSUInteger i = 1; i < textNodes.count; i++) {
-        id textNode = textNodes[i];
-        ApolloDeletedCommentsSetTextNodeAttributedText(textNode, [[NSAttributedString alloc] initWithString:@"" attributes:blankAttributes]);
-        ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
-    }
-
-    ApolloDeletedCommentsApplyTapToRevealIfNeeded(cellNode);
+    ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
+    ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyContainerNode(cellNode));
+    ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyTextNode(cellNode));
     ApolloDeletedCommentsApplyCellHighlight(cellNode);
 }
 
@@ -1183,11 +1730,64 @@ static void ApolloDeletedCommentsApplyCachedArchiveToVisiblePlaceholderCell(id c
     ApolloDeletedCommentsApplyRecoveredArchiveToVisibleCell(cellNode, archived);
 }
 
+static void __attribute__((unused)) ApolloDeletedCommentsRepairVisibleReasonChipIfNeeded(id cellNode) {
+    if (!sShowDeletedComments || sTapToRevealDeletedComments) return;
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return;
+
+    NSArray *textNodes = ApolloDeletedCommentsBodyTextNodes(cellNode, comment);
+    if (textNodes.count == 0) {
+        id knownBodyNode = ApolloDeletedCommentsFallbackBodyTextNode(cellNode);
+        if (knownBodyNode) textNodes = @[knownBodyNode];
+    }
+    for (id textNode in textNodes) {
+        NSAttributedString *current = nil;
+        @try {
+            current = ((NSAttributedString *(*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText));
+        } @catch (__unused NSException *e) {
+            current = nil;
+        }
+        if (![current isKindOfClass:[NSAttributedString class]] || current.length == 0) {
+            NSAttributedString *bodyText = ApolloDeletedCommentsBodyAttributedText(current, comment.body);
+            if (bodyText.length == 0) continue;
+            NSAttributedString *repaired = ApolloDeletedCommentsAttributedTextWithReasonPrefix(textNode, bodyText);
+            ApolloDeletedCommentsSetTextNodeAttributedText(textNode, repaired);
+            ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
+            return;
+        }
+        if (ApolloDeletedCommentsAttributedTextHasReasonPrefix(current)) return;
+
+        NSAttributedString *repaired = ApolloDeletedCommentsAttributedTextWithReasonPrefix(textNode, current);
+        if (repaired != current) {
+            ApolloDeletedCommentsSetTextNodeAttributedText(textNode, repaired);
+            ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
+            return;
+        }
+    }
+}
+
 static void ApolloDeletedCommentsUpdateCell(id cellNode) {
-    ApolloDeletedCommentsTrackVisiblePlaceholderCell(cellNode);
+    ApolloDeletedCommentsTrackVisibleDeletedCommentCell(cellNode);
     ApolloDeletedCommentsApplyCachedArchiveToVisiblePlaceholderCell(cellNode);
-    ApolloDeletedCommentsApplyTapToRevealIfNeeded(cellNode);
+    ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
     ApolloDeletedCommentsApplyCellHighlight(cellNode);
+}
+
+static void ApolloDeletedCommentsScheduleVisibleCellRefreshForComment(RDKComment *comment) {
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    if (fullName.length == 0) return;
+
+    NSArray<NSNumber *> *delays = @[@0.0, @0.05, @0.15, @0.35];
+    for (NSNumber *delayNumber in delays) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayNumber.doubleValue * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            for (id cellNode in ApolloDeletedCommentsTrackedCellsForFullName(fullName)) {
+                RDKComment *currentComment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+                NSString *currentFullName = ApolloDeletedCommentsFullNameForComment(currentComment);
+                if (![currentFullName isEqualToString:fullName]) continue;
+                ApolloDeletedCommentsUpdateCell(cellNode);
+            }
+        });
+    }
 }
 
 static BOOL ApolloDeletedCommentsIsRevealLink(id attribute, id value) {
@@ -1240,12 +1840,6 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
         }
     }];
     if (!revealed) {
-        NSString *body = ApolloDeletedCommentsUnwrappedSpoilerMarkdown(comment.body);
-        NSAttributedString *original = ApolloDeletedCommentsBodyAttributedText(attributedText, body);
-        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, original, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
-        objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, @[textNode], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
     }
     return renamed;
@@ -1254,11 +1848,9 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
 %hook ASTextNode
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
-    NSAttributedString *rewrittenText = ApolloDeletedCommentsAttributedTextWithReasonPrefix((id)self,
-        ApolloDeletedCommentsAttributedTextWithTapToRevealPlaceholder((id)self,
-            ApolloDeletedCommentsRenameRecoveredSpoilerLabel((id)self, attributedText)
-        )
-    );
+    NSAttributedString *renamedText = ApolloDeletedCommentsRenameRecoveredSpoilerLabel((id)self, attributedText);
+    NSAttributedString *chipText = ApolloDeletedCommentsAttributedTextWithReasonChipIfNeeded((id)self, renamedText);
+    NSAttributedString *rewrittenText = ApolloDeletedCommentsAttributedTextWithReasonPrefix((id)self, chipText);
     %orig(rewrittenText);
 }
 
@@ -1270,7 +1862,7 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
     } @catch (__unused NSException *e) {
         attributedText = nil;
     }
-    NSAttributedString *renamedAttributedText = ApolloDeletedCommentsAttributedTextWithTapToRevealPlaceholder((id)self,
+    NSAttributedString *renamedAttributedText = ApolloDeletedCommentsAttributedTextWithReasonChipIfNeeded((id)self,
         ApolloDeletedCommentsRenameRecoveredSpoilerLabel((id)self, attributedText)
     );
     if (renamedAttributedText != attributedText) {
@@ -1302,6 +1894,7 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
 - (void)didLoad;
 - (void)didEnterDisplayState;
 - (void)calculatedLayoutDidChange;
+- (id)layoutSpecThatFits:(struct CDStruct_90e057aa)fits;
 - (void)layout;
 @end
 
@@ -1322,6 +1915,15 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
     ApolloDeletedCommentsUpdateCell((id)self);
 }
 
+- (id)layoutSpecThatFits:(struct CDStruct_90e057aa)fits {
+    ApolloDeletedCommentsSynchronizeCommentModelDisplayState((id)self);
+    id bodyNode = ApolloDeletedCommentsKnownBodyContainerNode((id)self);
+    if (bodyNode) {
+        objc_setAssociatedObject(bodyNode, kApolloDeletedCommentsBodyOwnerCellKey, (id)self, OBJC_ASSOCIATION_ASSIGN);
+    }
+    return %orig;
+}
+
 - (void)layout {
     %orig;
     ApolloDeletedCommentsApplyCellHighlight((id)self);
@@ -1335,21 +1937,69 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
 
 %hook RDKComment
 
+- (NSString *)body {
+    NSString *body = %orig;
+    NSString *savedBody = objc_getAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyKey);
+    NSString *bodyForState = [savedBody isKindOfClass:[NSString class]] && savedBody.length > 0 ? savedBody : body;
+    NSString *hiddenLabel = ApolloDeletedCommentsHiddenReasonLabelForCommentBody((RDKComment *)self, bodyForState);
+    if (hiddenLabel.length > 0) {
+        if (!ApolloDeletedCommentsStringIsReasonLabel(bodyForState) &&
+            !ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(bodyForState) &&
+            !objc_getAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyKey)) {
+            objc_setAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyKey, [bodyForState copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+        }
+        return hiddenLabel;
+    }
+    if ([savedBody isKindOfClass:[NSString class]] &&
+        savedBody.length > 0 &&
+        (ApolloDeletedCommentsStringIsReasonLabel(body) || !sTapToRevealDeletedComments)) {
+        return savedBody;
+    }
+    return body;
+}
+
+- (NSString *)bodyHTML {
+    NSString *bodyHTML = %orig;
+    NSString *savedBody = objc_getAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyKey);
+    NSString *bodyForState = [savedBody isKindOfClass:[NSString class]] && savedBody.length > 0 ? savedBody : nil;
+    NSString *hiddenLabel = ApolloDeletedCommentsHiddenReasonLabelForCommentBody((RDKComment *)self, bodyForState);
+    if (hiddenLabel.length > 0) {
+        if (bodyHTML.length > 0 && !objc_getAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyHTMLKey)) {
+            objc_setAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyHTMLKey, [bodyHTML copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+        }
+        return ApolloDeletedCommentsPlainBodyHTML(hiddenLabel);
+    }
+
+    NSString *savedBodyHTML = objc_getAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyHTMLKey);
+    if ([savedBodyHTML isKindOfClass:[NSString class]] &&
+        savedBodyHTML.length > 0 &&
+        (ApolloDeletedCommentsStringIsReasonLabel(ApolloDeletedCommentsTrimmedString(bodyHTML)) || !sTapToRevealDeletedComments)) {
+        return savedBodyHTML;
+    }
+    return bodyHTML;
+}
+
 - (void)setCollapsed:(BOOL)collapsed {
     if (collapsed && [objc_getAssociatedObject((id)self, kApolloDeletedCommentsSuppressNextCollapseKey) boolValue]) {
         objc_setAssociatedObject((id)self, kApolloDeletedCommentsSuppressNextCollapseKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         return;
     }
     %orig;
+    if (!collapsed) {
+        ApolloDeletedCommentsScheduleVisibleCellRefreshForComment((RDKComment *)self);
+    }
 }
 
 %end
 
 %hook _TtC6Apollo12MarkdownNode
 
+- (id)layoutSpecThatFits:(struct CDStruct_90e057aa)fits {
+    return %orig;
+}
+
 - (BOOL)textNode:(id)textNode shouldHighlightLinkAttribute:(id)attribute value:(id)value atPoint:(CGPoint)point {
-    if (ApolloDeletedCommentsIsRevealLink(attribute, value) &&
-        objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey)) {
+    if (ApolloDeletedCommentsIsRevealLink(attribute, value)) {
         return YES;
     }
     return %orig(textNode, attribute, value, point);
@@ -1363,10 +2013,14 @@ static NSAttributedString *ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id t
 }
 
 - (void)textNode:(id)textNode tappedLinkAttribute:(id)attribute value:(id)value atPoint:(CGPoint)point textRange:(NSRange)range {
-    if (ApolloDeletedCommentsIsRevealLink(attribute, value) &&
-        objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey)) {
+    if (ApolloDeletedCommentsIsRevealLink(attribute, value)) {
         id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
-        ApolloDeletedCommentsRevealHiddenBodyForCell(cellNode);
+        RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+        if (ApolloDeletedCommentsCommentIsRevealedByFullName(comment)) {
+            ApolloDeletedCommentsHideRevealedBodyForCell(cellNode, textNode);
+        } else {
+            ApolloDeletedCommentsRevealHiddenBodyForCell(cellNode, textNode);
+        }
         return;
     }
     %orig(textNode, attribute, value, point, range);

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -1,8 +1,11 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import <math.h>
+#import <string.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
 
+#import "ApolloCommon.h"
 #import "ApolloDeletedCommentsData.h"
 #import "ApolloState.h"
 #import "Tweak.h"
@@ -37,22 +40,30 @@ static const void *kApolloDeletedCommentsHiddenTextNodeKey = &kApolloDeletedComm
 static const void *kApolloDeletedCommentsHiddenTextNodesKey = &kApolloDeletedCommentsHiddenTextNodesKey;
 static const void *kApolloDeletedCommentsSuppressNextCollapseKey = &kApolloDeletedCommentsSuppressNextCollapseKey;
 static const void *kApolloDeletedCommentsBodyOwnerCellKey = &kApolloDeletedCommentsBodyOwnerCellKey;
+// Reverse of BodyOwnerCellKey: the cell -> its MarkdownNode (captured when the
+// MarkdownNode's layoutSpecThatFits hook runs, which is the only place we have a
+// guaranteed-correct reference to that node, independent of ivar-name lookup).
+static const void *kApolloDeletedCommentsCellMarkdownNodeKey = &kApolloDeletedCommentsCellMarkdownNodeKey;
 static const void *kApolloDeletedCommentsBodyReplacementTextNodeKey = &kApolloDeletedCommentsBodyReplacementTextNodeKey;
 static const void *kApolloDeletedCommentsOriginalBodyKey = &kApolloDeletedCommentsOriginalBodyKey;
 static const void *kApolloDeletedCommentsOriginalBodyHTMLKey = &kApolloDeletedCommentsOriginalBodyHTMLKey;
 static const void *kApolloDeletedCommentsHostLayoutRefreshScheduledKey = &kApolloDeletedCommentsHostLayoutRefreshScheduledKey;
 static const void *kApolloDeletedCommentsRevealToggleInFlightKey = &kApolloDeletedCommentsRevealToggleInFlightKey;
 static const void *kApolloDeletedCommentsReasonChipRepairScheduledKey = &kApolloDeletedCommentsReasonChipRepairScheduledKey;
+static const void *kApolloDeletedCommentsRevealTapGestureKey = &kApolloDeletedCommentsRevealTapGestureKey;
 
 static NSMutableDictionary<NSString *, NSHashTable *> *sApolloDeletedCommentsVisibleCellsByFullName = nil;
 static NSObject *sApolloDeletedCommentsVisibleCellsLock = nil;
-
+static NSDictionary<NSAttributedStringKey, id> *sApolloDeletedCommentsBodyAttributesTemplate = nil;
+static BOOL sApolloDeletedCommentsBodyAttributesRefreshScheduled = NO;
 static NSString *const ApolloDeletedCommentsRevealURLString = @"apollo-deleted-comments://reveal";
 static NSString *const ApolloDeletedCommentsRevealAttributeName = @"ApolloDeletedCommentsRevealAttribute";
 static NSString *const ApolloDeletedCommentsReasonPrefixAttributeName = @"ApolloDeletedCommentsReasonPrefixAttribute";
 
 static id ApolloDeletedCommentsCommentCellNodeForTextNode(id textNode);
+static void ApolloDeletedCommentsScheduleRevealToggleForTextNode(id cellNode, id textNode);
 static void ApolloDeletedCommentsEnsureRevealAttributeIsTappable(id textNode);
+static void ApolloDeletedCommentsRevealCommentInsteadOfCollapsing(RDKComment *comment);
 static void __attribute__((unused)) ApolloDeletedCommentsScheduleForceExpanded(RDKComment *comment, id cellNode);
 static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeeded(id cellNode);
 static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(id textNode, NSAttributedString *attributedText);
@@ -60,8 +71,12 @@ static NSArray *ApolloDeletedCommentsHiddenTextNodesForCell(id cellNode);
 static NSString *ApolloDeletedCommentsNormalizedReasonLabel(NSString *label);
 static void ApolloDeletedCommentsSetTextNodeAttributedText(id textNode, NSAttributedString *attributedText);
 static NSAttributedString *ApolloDeletedCommentsCurrentAttributedText(id textNode);
+static NSMutableDictionary *ApolloDeletedCommentsDefaultBodyAttributes(void);
+static NSMutableDictionary *ApolloDeletedCommentsBodyAttributesFromAttributedText(NSAttributedString *templateText);
+static NSMutableDictionary *ApolloDeletedCommentsReasonChipBaseAttributes(NSAttributedString *templateText, id cellNode);
 static void ApolloDeletedCommentsDisableRevealTapInterception(id textNode);
 static void ApolloDeletedCommentsSynchronizeCommentModelDisplayState(id cellNode);
+static NSString *ApolloDeletedCommentsReasonLabelForCommentAndBody(RDKComment *comment, NSString *body);
 static void __attribute__((unused)) ApolloDeletedCommentsRepairVisibleReasonChipIfNeeded(id cellNode);
 static void ApolloDeletedCommentsScheduleHostLayoutRefresh(id cellNode);
 static BOOL ApolloDeletedCommentsStringIsReasonLabel(NSString *text);
@@ -73,7 +88,13 @@ static BOOL ApolloDeletedCommentsAttributedTextHasVisibleReasonChip(NSAttributed
 static NSAttributedString *ApolloDeletedCommentsAttributedTextByRemovingReasonPrefix(NSAttributedString *attributedText);
 static BOOL ApolloDeletedCommentsTextQualifiesAsBodyCandidate(NSString *candidate, NSString *body);
 static BOOL ApolloDeletedCommentsTextQualifiesAsBodyFragment(NSString *candidate, NSString *body);
+static BOOL ApolloDeletedCommentsTextLooksLikeRecoveredBodyDisplay(NSString *candidate, NSString *body);
 static BOOL ApolloDeletedCommentsCommentIsCollapsed(RDKComment *comment);
+static void ApolloDeletedCommentsRefreshVisibleDeletedCells(void);
+static BOOL ApolloDeletedCommentsBodyAttributesAreUsable(NSDictionary *attributes);
+static NSDictionary *ApolloDeletedCommentsRegularizedBodyAttributes(NSDictionary *attributes);
+static void ApolloDeletedCommentsScheduleBodyAttributesRefresh(void);
+static BOOL ApolloDeletedCommentsBodyAttributeFontsDiffer(NSDictionary *left, NSDictionary *right);
 
 static Class ApolloDeletedCommentsASTextNodeClass(void) {
     static Class cls = Nil;
@@ -126,6 +147,25 @@ static UIColor *ApolloDeletedCommentsChipTextColor(void) {
 
 static UIFont *ApolloDeletedCommentsReasonChipFont(void) {
     return [UIFont boldSystemFontOfSize:13.0];
+}
+
+static UIFont *ApolloDeletedCommentsReasonChipFontForBaseAttributes(NSDictionary *baseAttributes) {
+    UIFont *bodyFont = [baseAttributes isKindOfClass:[NSDictionary class]] ? baseAttributes[NSFontAttributeName] : nil;
+    if (![bodyFont isKindOfClass:[UIFont class]]) {
+        bodyFont = [sApolloDeletedCommentsBodyAttributesTemplate isKindOfClass:[NSDictionary class]] ? sApolloDeletedCommentsBodyAttributesTemplate[NSFontAttributeName] : nil;
+    }
+    if (![bodyFont isKindOfClass:[UIFont class]]) {
+        bodyFont = ApolloDeletedCommentsDefaultBodyAttributes()[NSFontAttributeName];
+    }
+    if (![bodyFont isKindOfClass:[UIFont class]]) return ApolloDeletedCommentsReasonChipFont();
+
+    CGFloat pointSize = bodyFont.pointSize;
+    if (pointSize <= 0.0) return ApolloDeletedCommentsReasonChipFont();
+
+    CGFloat chipPointSize = MAX(11.0, MIN(20.0, pointSize * 0.82));
+    UIFontDescriptor *descriptor = [bodyFont.fontDescriptor fontDescriptorWithSymbolicTraits:(bodyFont.fontDescriptor.symbolicTraits | UIFontDescriptorTraitBold)];
+    UIFont *font = descriptor ? [UIFont fontWithDescriptor:descriptor size:chipPointSize] : nil;
+    return font ?: [UIFont boldSystemFontOfSize:chipPointSize];
 }
 
 static UIFont *ApolloDeletedCommentsRecoveredBodyFont(void) {
@@ -364,6 +404,44 @@ static NSString *ApolloDeletedCommentsRecoverableArchivedBody(NSDictionary *arch
     return body;
 }
 
+static BOOL ApolloDeletedCommentsBodyIsDisplayableRecoveredText(NSString *body) {
+    NSString *trimmed = ApolloDeletedCommentsTrimmedString(body);
+    if (trimmed.length == 0) return NO;
+    if (ApolloDeletedCommentsStringIsReasonLabel(trimmed)) return NO;
+    if (ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(trimmed)) return NO;
+    return YES;
+}
+
+static NSString *ApolloDeletedCommentsResolvedRecoveredBodyForComment(RDKComment *comment) {
+    if (!comment) return nil;
+
+    NSString *savedBody = objc_getAssociatedObject((id)comment, kApolloDeletedCommentsOriginalBodyKey);
+    if (ApolloDeletedCommentsBodyIsDisplayableRecoveredText(savedBody)) {
+        return savedBody;
+    }
+
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    NSDictionary *archived = ApolloDeletedCommentsCachedArchivedComment(fullName);
+    NSString *archivedBody = ApolloDeletedCommentsRecoverableArchivedBody(archived);
+    if (archivedBody.length > 0) {
+        objc_setAssociatedObject((id)comment, kApolloDeletedCommentsOriginalBodyKey, [archivedBody copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+        objc_setAssociatedObject((id)comment, kApolloDeletedCommentsOriginalBodyHTMLKey, ApolloDeletedCommentsPlainBodyHTML(archivedBody), OBJC_ASSOCIATION_COPY_NONATOMIC);
+        return archivedBody;
+    }
+
+    NSString *currentBody = comment.body;
+    if (ApolloDeletedCommentsBodyIsDisplayableRecoveredText(currentBody)) {
+        objc_setAssociatedObject((id)comment, kApolloDeletedCommentsOriginalBodyKey, [currentBody copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+        NSString *bodyHTML = ApolloDeletedCommentsCommentStringValue(comment, @selector(bodyHTML));
+        if (bodyHTML.length > 0) {
+            objc_setAssociatedObject((id)comment, kApolloDeletedCommentsOriginalBodyHTMLKey, [bodyHTML copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+        }
+        return currentBody;
+    }
+
+    return nil;
+}
+
 static BOOL ApolloDeletedCommentsAuthorLooksDeleted(NSString *author) {
     NSString *trimmed = ApolloDeletedCommentsTrimmedString(author).lowercaseString;
     return trimmed.length == 0 ||
@@ -436,9 +514,10 @@ static BOOL ApolloDeletedCommentsCommentIsRevealedByFullName(RDKComment *comment
     return ApolloDeletedCommentsIsCommentRevealed(fullName);
 }
 
-static BOOL ApolloDeletedCommentsShouldKeepModelBodyHidden(RDKComment *comment) {
+static BOOL __attribute__((unused)) ApolloDeletedCommentsShouldKeepModelBodyHidden(RDKComment *comment) {
     if (!sShowDeletedComments || !sTapToRevealDeletedComments || !comment) return NO;
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    if (fullName.length == 0) return NO;
     return ApolloDeletedCommentsIsRecoveredComment(fullName) &&
            !ApolloDeletedCommentsIsCommentRevealed(fullName);
 }
@@ -458,12 +537,18 @@ static void ApolloDeletedCommentsSynchronizeCommentModelDisplayState(id cellNode
     }
 
     if (recovered) {
-        ApolloDeletedCommentsRememberOriginalModelBodyIfNeeded(comment);
-        if (ApolloDeletedCommentsShouldKeepModelBodyHidden(comment)) {
-            ApolloDeletedCommentsSetModelBodyToReasonLabel(comment, ApolloDeletedCommentsReasonLabelForComment(comment));
-        } else {
-            ApolloDeletedCommentsRestoreOriginalModelBodyIfNeeded(comment);
+        NSString *resolvedBody = ApolloDeletedCommentsResolvedRecoveredBodyForComment(comment);
+        if (ApolloDeletedCommentsBodyIsDisplayableRecoveredText(resolvedBody) &&
+            !objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey)) {
+            objc_setAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey, [resolvedBody copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
         }
+        if (ApolloDeletedCommentsShouldKeepModelBodyHidden(comment)) {
+            NSString *label = ApolloDeletedCommentsReasonLabelForCommentAndBody(comment, resolvedBody ?: comment.body);
+            ApolloDeletedCommentsSetModelBodyToReasonLabel(comment, label);
+            return;
+        }
+        ApolloDeletedCommentsRememberOriginalModelBodyIfNeeded(comment);
+        ApolloDeletedCommentsRestoreOriginalModelBodyIfNeeded(comment);
     }
 }
 
@@ -502,7 +587,14 @@ static id ApolloDeletedCommentsObjectIvarByNames(id object, const char **candida
             Ivar ivar = class_getInstanceVariable(cls, candidateNames[i]);
             if (!ivar) continue;
             const char *type = ivar_getTypeEncoding(ivar);
-            if (!type || type[0] != '@') continue;
+            if (!type) continue;
+            // Skip leading type-encoding qualifier chars before the object marker.
+            // Swift class-type ivars on CommentCellNode (e.g. `bodyNode`) are
+            // declared `_Atomic`, which clang encodes as `A@"..."` — without
+            // skipping the 'A' we'd reject the MarkdownNode and never find it.
+            const char *cursor = type;
+            while (*cursor && strchr("rnNoORVAj", *cursor)) cursor++;
+            if (*cursor != '@') continue;
             id value = nil;
             @try {
                 value = object_getIvar(object, ivar);
@@ -567,9 +659,8 @@ static UIImage *ApolloDeletedCommentsReasonChipImage(NSString *text, UIFont *fon
 }
 
 static NSAttributedString *ApolloDeletedCommentsReasonChipAttributedText(NSString *label, NSDictionary *baseAttributes, BOOL revealLink) {
-    (void)baseAttributes;
     label = ApolloDeletedCommentsNormalizedReasonLabel(label);
-    UIFont *font = ApolloDeletedCommentsReasonChipFont();
+    UIFont *font = ApolloDeletedCommentsReasonChipFontForBaseAttributes(baseAttributes);
     UIImage *image = ApolloDeletedCommentsReasonChipImage(label, font);
     CGFloat chipLineHeight = [image isKindOfClass:[UIImage class]] ? image.size.height + 6.0 : font.lineHeight + 6.0;
     NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
@@ -657,17 +748,18 @@ static void ApolloDeletedCommentsInvalidateCellAndTextNodeLocally(id cellNode, i
     }
 }
 
-static NSAttributedString *ApolloDeletedCommentsPlaceholderAttributedText(NSAttributedString *original, NSString *reasonLabel) {
-    NSDictionary *attributes = @{};
-    if ([original isKindOfClass:[NSAttributedString class]] && original.length > 0) {
-        attributes = [original attributesAtIndex:0 effectiveRange:NULL] ?: @{};
-    }
-
+static NSAttributedString *ApolloDeletedCommentsPlaceholderAttributedText(NSAttributedString *original, NSString *reasonLabel, id cellNode) {
+    NSDictionary *attributes = ApolloDeletedCommentsReasonChipBaseAttributes(original, cellNode);
     NSAttributedString *chip = ApolloDeletedCommentsReasonChipAttributedText(reasonLabel, attributes, YES);
     return chip;
 }
 
 static NSMutableDictionary *ApolloDeletedCommentsDefaultBodyAttributes(void) {
+    if ([sApolloDeletedCommentsBodyAttributesTemplate isKindOfClass:[NSDictionary class]] &&
+        sApolloDeletedCommentsBodyAttributesTemplate.count > 0) {
+        return [sApolloDeletedCommentsBodyAttributesTemplate mutableCopy];
+    }
+
     UIColor *textColor = nil;
     if (@available(iOS 13.0, *)) {
         textColor = [UIColor labelColor];
@@ -677,6 +769,121 @@ static NSMutableDictionary *ApolloDeletedCommentsDefaultBodyAttributes(void) {
         NSFontAttributeName: ApolloDeletedCommentsRecoveredBodyFont(),
         NSForegroundColorAttributeName: textColor,
     } mutableCopy];
+}
+
+// Apollo's in-app text size lives in standardUserDefaults (same domain as its
+// other appearance settings):
+//   UseSystemTextSize (Bool)   — YES: comment fonts follow the SYSTEM Dynamic Type
+//                                size; NO: Apollo uses its own in-app slider.
+//   ApolloCustomTextSize (Int) — the slider value: an Apollo.ApplicationTextSize
+//                                raw value. Its 12 cases map 1:1, in declaration
+//                                order, to the UIContentSizeCategory constants.
+// Reading these is what lets us match Apollo's comment size exactly in BOTH modes
+// without learning, guessing, or hardcoding any point size.
+static NSString *const kApolloDeletedCommentsUseSystemTextSizeKey = @"UseSystemTextSize";
+static NSString *const kApolloDeletedCommentsCustomTextSizeKey = @"ApolloCustomTextSize";
+
+static NSString *ApolloDeletedCommentsCategoryForApplicationTextSize(NSInteger raw) {
+    static NSArray<NSString *> *categories = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        categories = @[
+            UIContentSizeCategoryExtraSmall,                        // xSmall
+            UIContentSizeCategorySmall,                             // small
+            UIContentSizeCategoryMedium,                            // medium
+            UIContentSizeCategoryLarge,                             // large
+            UIContentSizeCategoryExtraLarge,                        // xLarge
+            UIContentSizeCategoryExtraExtraLarge,                   // xxLarge
+            UIContentSizeCategoryExtraExtraExtraLarge,              // xxxLarge
+            UIContentSizeCategoryAccessibilityMedium,              // accessibilityMedium
+            UIContentSizeCategoryAccessibilityLarge,               // accessibilityLarge
+            UIContentSizeCategoryAccessibilityExtraLarge,          // accessibilityXLarge
+            UIContentSizeCategoryAccessibilityExtraExtraLarge,     // accessibilityXXLarge
+            UIContentSizeCategoryAccessibilityExtraExtraExtraLarge,// accessibilityXXXLarge
+        ];
+    });
+    if (raw < 0 || raw >= (NSInteger)categories.count) return nil;
+    return categories[(NSUInteger)raw];
+}
+
+// The live SYSTEM content size category (used when "Use System Text Size" is on).
+static NSString *ApolloDeletedCommentsSystemContentSizeCategory(id node) {
+    NSString *category = nil;
+    if (node) {
+        @try {
+            if ([node respondsToSelector:@selector(asyncTraitCollection)]) {
+                id traitCollection = ((id (*)(id, SEL))objc_msgSend)(node, @selector(asyncTraitCollection));
+                if (traitCollection && [traitCollection respondsToSelector:@selector(preferredContentSizeCategory)]) {
+                    id value = ((id (*)(id, SEL))objc_msgSend)(traitCollection, @selector(preferredContentSizeCategory));
+                    if ([value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0) category = value;
+                }
+            }
+        } @catch (__unused NSException *e) {}
+    }
+    if (![category isKindOfClass:[NSString class]] || category.length == 0) {
+        category = UIApplication.sharedApplication.preferredContentSizeCategory;
+    }
+    if (![category isKindOfClass:[NSString class]] || category.length == 0) {
+        category = UIContentSizeCategoryLarge;
+    }
+    return category;
+}
+
+// The EFFECTIVE comment-body content size category, resolved exactly like Apollo:
+// follow the system size when "Use System Text Size" is on (or unset), otherwise
+// use Apollo's own slider value. outUsedAppSize (optional) reports which branch
+// was taken, for logging.
+static NSString *ApolloDeletedCommentsEffectiveContentSizeCategory(id node, BOOL *outUsedAppSize) {
+    if (outUsedAppSize) *outUsedAppSize = NO;
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    id useSystemObj = [defaults objectForKey:kApolloDeletedCommentsUseSystemTextSizeKey];
+    BOOL useSystem = (useSystemObj == nil) ? YES : [defaults boolForKey:kApolloDeletedCommentsUseSystemTextSizeKey];
+    if (!useSystem) {
+        if ([defaults objectForKey:kApolloDeletedCommentsCustomTextSizeKey] != nil) {
+            NSString *category = ApolloDeletedCommentsCategoryForApplicationTextSize(
+                [defaults integerForKey:kApolloDeletedCommentsCustomTextSizeKey]);
+            if ([category isKindOfClass:[NSString class]] && category.length > 0) {
+                if (outUsedAppSize) *outUsedAppSize = YES;
+                return category;
+            }
+        }
+    }
+    return ApolloDeletedCommentsSystemContentSizeCategory(node);
+}
+
+// THE app's comment-body font, resolved deterministically from the effective
+// content size category above. Apollo's comment body is UIFontTextStyleSubheadline
+// scaled by that category (verified: .large=15pt, .xxxLarge=21pt), regular weight.
+static UIFont *ApolloDeletedCommentsAppCommentBodyFontForNode(id node) {
+    NSString *category = ApolloDeletedCommentsEffectiveContentSizeCategory(node, NULL);
+    if (![category isKindOfClass:[NSString class]] || category.length == 0) {
+        category = UIContentSizeCategoryLarge;
+    }
+    UITraitCollection *traits = [UITraitCollection traitCollectionWithPreferredContentSizeCategory:category];
+    UIFont *font = [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline compatibleWithTraitCollection:traits];
+    return [font isKindOfClass:[UIFont class]] ? font : nil;
+}
+
+// Body attributes using the deterministic app font (above) for size/weight, while
+// keeping Apollo's body text color/paragraph from whatever we last saw (or sane
+// defaults). This is the primary source for revealed comment bodies.
+static NSDictionary *ApolloDeletedCommentsAppBodyAttributesForNode(id node) {
+    UIFont *font = ApolloDeletedCommentsAppCommentBodyFontForNode(node);
+    if (![font isKindOfClass:[UIFont class]]) return nil;
+
+    NSDictionary *base = [sApolloDeletedCommentsBodyAttributesTemplate isKindOfClass:[NSDictionary class]] &&
+                         sApolloDeletedCommentsBodyAttributesTemplate.count > 0
+                             ? sApolloDeletedCommentsBodyAttributesTemplate
+                             : nil;
+    NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
+    UIColor *color = base[NSForegroundColorAttributeName];
+    if (![color isKindOfClass:[UIColor class]]) {
+        if (@available(iOS 13.0, *)) color = [UIColor labelColor];
+        if (![color isKindOfClass:[UIColor class]]) color = [UIColor blackColor];
+    }
+    attributes[NSForegroundColorAttributeName] = color;
+    attributes[NSFontAttributeName] = font;
+    return attributes;
 }
 
 static NSMutableDictionary *ApolloDeletedCommentsSanitizedBodyAttributes(NSDictionary *attrs) {
@@ -692,9 +899,17 @@ static NSMutableDictionary *ApolloDeletedCommentsSanitizedBodyAttributes(NSDicti
     return attributes;
 }
 
-static NSAttributedString *ApolloDeletedCommentsBodyAttributedText(NSAttributedString *templateText, NSString *body) {
+static NSMutableDictionary *ApolloDeletedCommentsBodyAttributesFromAttributedText(NSAttributedString *templateText) {
     __block NSMutableDictionary *attributes = nil;
     if ([templateText isKindOfClass:[NSAttributedString class]] && templateText.length > 0) {
+        NSString *trimmed = ApolloDeletedCommentsTrimmedString(templateText.string);
+        NSString *normalized = ApolloDeletedCommentsNormalizedReasonLabel(trimmed);
+        NSString *lowercase = trimmed.lowercaseString;
+        if (ApolloDeletedCommentsStringIsReasonLabel(normalized) ||
+            [lowercase isEqualToString:@"spoiler"] ||
+            ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(trimmed)) {
+            return nil;
+        }
         [templateText enumerateAttributesInRange:NSMakeRange(0, templateText.length)
                                          options:0
                                       usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attrs, __unused NSRange range, BOOL *stop) {
@@ -703,6 +918,30 @@ static NSAttributedString *ApolloDeletedCommentsBodyAttributedText(NSAttributedS
             if (!attributes) return;
             *stop = YES;
         }];
+    }
+    return attributes;
+}
+
+static BOOL ApolloDeletedCommentsBodyAttributesNeedRefresh(NSDictionary *attributes) {
+    if (![attributes isKindOfClass:[NSDictionary class]]) return NO;
+    if (![sApolloDeletedCommentsBodyAttributesTemplate isKindOfClass:[NSDictionary class]] ||
+        sApolloDeletedCommentsBodyAttributesTemplate.count == 0) {
+        return NO;
+    }
+
+    UIFont *currentFont = attributes[NSFontAttributeName];
+    UIFont *targetFont = sApolloDeletedCommentsBodyAttributesTemplate[NSFontAttributeName];
+    if (![currentFont isKindOfClass:[UIFont class]] || ![targetFont isKindOfClass:[UIFont class]]) return NO;
+
+    if (fabs(currentFont.pointSize - targetFont.pointSize) > 0.1) return YES;
+    if (![currentFont.fontName isEqualToString:targetFont.fontName]) return YES;
+    return NO;
+}
+
+static NSAttributedString *ApolloDeletedCommentsBodyAttributedText(NSAttributedString *templateText, NSString *body) {
+    NSMutableDictionary *attributes = ApolloDeletedCommentsBodyAttributesFromAttributedText(templateText);
+    if (ApolloDeletedCommentsBodyAttributesNeedRefresh(attributes)) {
+        attributes = nil;
     }
     if (!attributes) {
         attributes = ApolloDeletedCommentsDefaultBodyAttributes();
@@ -715,6 +954,7 @@ static NSAttributedString *ApolloDeletedCommentsBodyTextByNormalizingFont(NSAttr
 
     NSMutableAttributedString *normalized = [attributedText mutableCopy];
     NSRange fullRange = NSMakeRange(0, normalized.length);
+    NSDictionary *targetAttributes = [sApolloDeletedCommentsBodyAttributesTemplate isKindOfClass:[NSDictionary class]] ? sApolloDeletedCommentsBodyAttributesTemplate : nil;
     [normalized enumerateAttributesInRange:fullRange
                                    options:0
                                 usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attrs, NSRange range, __unused BOOL *stop) {
@@ -723,6 +963,11 @@ static NSAttributedString *ApolloDeletedCommentsBodyTextByNormalizingFont(NSAttr
         [normalized removeAttribute:NSLinkAttributeName range:range];
         [normalized removeAttribute:ApolloDeletedCommentsRevealAttributeName range:range];
         [normalized removeAttribute:ApolloDeletedCommentsReasonPrefixAttributeName range:range];
+        if (targetAttributes.count > 0 && ApolloDeletedCommentsBodyAttributesNeedRefresh(attrs)) {
+            for (NSAttributedStringKey key in targetAttributes) {
+                [normalized addAttribute:key value:targetAttributes[key] range:range];
+            }
+        }
     }];
     return normalized;
 }
@@ -732,8 +977,7 @@ static NSAttributedString *ApolloDeletedCommentsRecoveredBodyTextForDisplay(NSAt
         templateText.length > 0 &&
         !ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(templateText) &&
         !ApolloDeletedCommentsAttributedTextHasReasonPrefix(templateText) &&
-        (ApolloDeletedCommentsTextQualifiesAsBodyCandidate(templateText.string, body) ||
-         ApolloDeletedCommentsTextQualifiesAsBodyFragment(templateText.string, body))) {
+        ApolloDeletedCommentsTextLooksLikeRecoveredBodyDisplay(templateText.string, body)) {
         return ApolloDeletedCommentsBodyTextByNormalizingFont(templateText);
     }
     return ApolloDeletedCommentsBodyAttributedText(templateText, body);
@@ -893,6 +1137,66 @@ static BOOL ApolloDeletedCommentsTextQualifiesAsBodyFragment(NSString *candidate
     return [bodyNorm rangeOfString:candidateNorm options:NSCaseInsensitiveSearch].location != NSNotFound;
 }
 
+static NSArray<NSString *> *ApolloDeletedCommentsBodyMatchTokens(NSString *text) {
+    NSString *normalized = ApolloDeletedCommentsNormalizeTextForCompare(ApolloDeletedCommentsUnwrappedSpoilerMarkdown(text)).lowercaseString;
+    if (normalized.length == 0) return @[];
+
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"[^a-z0-9]+"
+                                                                           options:0
+                                                                             error:nil];
+    NSString *tokenText = [regex stringByReplacingMatchesInString:normalized
+                                                          options:0
+                                                            range:NSMakeRange(0, normalized.length)
+                                                     withTemplate:@" "];
+    NSMutableArray<NSString *> *tokens = [NSMutableArray array];
+    for (NSString *part in [tokenText componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]) {
+        if (part.length < 4) continue;
+        [tokens addObject:part];
+    }
+    return tokens;
+}
+
+static BOOL ApolloDeletedCommentsTextLooksLikeRecoveredBodyDisplay(NSString *candidate, NSString *body) {
+    NSString *candidateNorm = ApolloDeletedCommentsNormalizeTextForCompare(candidate);
+    NSString *bodyNorm = ApolloDeletedCommentsNormalizeTextForCompare(ApolloDeletedCommentsUnwrappedSpoilerMarkdown(body));
+    if (candidateNorm.length == 0 || bodyNorm.length == 0) return NO;
+
+    NSString *candidateLower = candidateNorm.lowercaseString;
+    if ([candidateLower isEqualToString:@"spoiler"] ||
+        [candidateLower hasPrefix:@"deleted by "] ||
+        [candidateLower hasPrefix:@"removed by "] ||
+        ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(candidateNorm)) {
+        return NO;
+    }
+
+    if (ApolloDeletedCommentsTextQualifiesAsBodyCandidate(candidateNorm, bodyNorm) ||
+        ApolloDeletedCommentsTextQualifiesAsBodyFragment(candidateNorm, bodyNorm)) {
+        return YES;
+    }
+
+    if (candidateNorm.length >= 16 &&
+        [bodyNorm rangeOfString:candidateNorm options:NSCaseInsensitiveSearch].location != NSNotFound) {
+        return YES;
+    }
+    if (bodyNorm.length >= 16 &&
+        [candidateNorm rangeOfString:bodyNorm options:NSCaseInsensitiveSearch].location != NSNotFound) {
+        return YES;
+    }
+
+    NSArray<NSString *> *candidateTokens = ApolloDeletedCommentsBodyMatchTokens(candidateNorm);
+    NSArray<NSString *> *bodyTokens = ApolloDeletedCommentsBodyMatchTokens(bodyNorm);
+    if (candidateTokens.count < 3 || bodyTokens.count == 0) return NO;
+
+    NSSet<NSString *> *bodyTokenSet = [NSSet setWithArray:bodyTokens];
+    NSUInteger matches = 0;
+    for (NSString *token in candidateTokens) {
+        if ([bodyTokenSet containsObject:token]) matches++;
+    }
+
+    NSUInteger requiredMatches = MAX((NSUInteger)3, (candidateTokens.count + 1) / 2);
+    return matches >= requiredMatches;
+}
+
 static BOOL ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(NSString *candidate) {
     NSString *candidateNorm = ApolloDeletedCommentsNormalizeTextForCompare(candidate).lowercaseString;
     if (candidateNorm.length == 0) return NO;
@@ -967,7 +1271,7 @@ static id ApolloDeletedCommentsBestBodyTextNode(id cellNode, RDKComment *comment
         } @catch (__unused NSException *e) {
             text = nil;
         }
-        if (ApolloDeletedCommentsTextQualifiesAsBodyCandidate(text.string, body)) return known;
+        if (ApolloDeletedCommentsTextLooksLikeRecoveredBodyDisplay(text.string, body)) return known;
     }
 
     NSMutableArray *candidates = [NSMutableArray array];
@@ -983,7 +1287,7 @@ static id ApolloDeletedCommentsBestBodyTextNode(id cellNode, RDKComment *comment
         } @catch (__unused NSException *e) {
             text = nil;
         }
-        if (!ApolloDeletedCommentsTextQualifiesAsBodyCandidate(text.string, body)) continue;
+        if (!ApolloDeletedCommentsTextLooksLikeRecoveredBodyDisplay(text.string, body)) continue;
         if (text.length > bestLength) {
             bestLength = text.length;
             bestNode = candidate;
@@ -1010,8 +1314,7 @@ static NSArray *ApolloDeletedCommentsBodyTextNodes(id cellNode, RDKComment *comm
             text = nil;
         }
         if ((deletedPlaceholder && ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(text.string)) ||
-            ApolloDeletedCommentsTextQualifiesAsBodyCandidate(text.string, body) ||
-            ApolloDeletedCommentsTextQualifiesAsBodyFragment(text.string, body)) {
+            ApolloDeletedCommentsTextLooksLikeRecoveredBodyDisplay(text.string, body)) {
             [bodyNodes addObject:known];
             [seen addObject:known];
         }
@@ -1036,14 +1339,24 @@ static NSArray *ApolloDeletedCommentsBodyTextNodes(id cellNode, RDKComment *comm
             [seen addObject:candidate];
             continue;
         }
-        if (!ApolloDeletedCommentsTextQualifiesAsBodyCandidate(text.string, body) &&
-            !ApolloDeletedCommentsTextQualifiesAsBodyFragment(text.string, body)) {
+        if (!ApolloDeletedCommentsTextLooksLikeRecoveredBodyDisplay(text.string, body)) {
             continue;
         }
         [bodyNodes addObject:candidate];
         [seen addObject:candidate];
     }
     return bodyNodes;
+}
+
+static NSMutableDictionary *ApolloDeletedCommentsReasonChipBaseAttributes(NSAttributedString *templateText, id cellNode) {
+    (void)cellNode;
+
+    NSMutableDictionary *attributes = ApolloDeletedCommentsBodyAttributesFromAttributedText(templateText);
+    if (ApolloDeletedCommentsBodyAttributesAreUsable(attributes)) {
+        return attributes;
+    }
+
+    return ApolloDeletedCommentsDefaultBodyAttributes();
 }
 
 static BOOL ApolloDeletedCommentsAttributedTextHasReasonPrefix(NSAttributedString *attributedText) {
@@ -1176,6 +1489,30 @@ static void ApolloDeletedCommentsRememberHiddenTextNode(id cellNode, id textNode
     }
 }
 
+static BOOL __attribute__((unused)) ApolloDeletedCommentsPrepareTextNodeForRevealChip(id cellNode, id textNode, RDKComment *comment, NSAttributedString *templateText) {
+    if (!cellNode || !textNode || !comment) return NO;
+    NSAttributedString *existingOriginal = objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey);
+    if ([existingOriginal isKindOfClass:[NSAttributedString class]] && existingOriginal.length > 0) {
+        ApolloDeletedCommentsRememberHiddenTextNode(cellNode, textNode);
+        return YES;
+    }
+
+    NSString *resolvedBody = ApolloDeletedCommentsResolvedRecoveredBodyForComment(comment);
+    if (!ApolloDeletedCommentsBodyIsDisplayableRecoveredText(resolvedBody)) return NO;
+
+    NSAttributedString *sourceText = [templateText isKindOfClass:[NSAttributedString class]] && templateText.length > 0
+        ? templateText
+        : ApolloDeletedCommentsCurrentAttributedText(textNode);
+    NSAttributedString *original = ApolloDeletedCommentsBodyAttributedText(sourceText, resolvedBody);
+    if (![original isKindOfClass:[NSAttributedString class]] || original.length == 0) return NO;
+
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, original, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    ApolloDeletedCommentsRememberHiddenTextNode(cellNode, textNode);
+    return YES;
+}
+
 static BOOL ApolloDeletedCommentsCellAlreadyHasHiddenPlaceholder(id cellNode, NSString *fullName) {
     if (!cellNode || fullName.length == 0) return NO;
     for (id textNode in ApolloDeletedCommentsHiddenTextNodesForCell(cellNode)) {
@@ -1196,17 +1533,23 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsAttribut
     id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     if (!comment || !ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode)) return attributedText;
+    NSString *resolvedBody = ApolloDeletedCommentsResolvedRecoveredBodyForComment(comment);
+    if (!ApolloDeletedCommentsBodyIsDisplayableRecoveredText(resolvedBody)) return attributedText;
 
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName);
     if (revealed) return attributedText;
 
-    BOOL bodyCandidate = ApolloDeletedCommentsTextQualifiesAsBodyCandidate(attributedText.string, comment.body) ||
-                         ApolloDeletedCommentsTextQualifiesAsBodyFragment(attributedText.string, comment.body);
+    BOOL bodyCandidate = ApolloDeletedCommentsTextLooksLikeRecoveredBodyDisplay(attributedText.string, resolvedBody);
     if (!bodyCandidate) return attributedText;
 
     if (!objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey)) {
-        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, [attributedText copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        NSAttributedString *original = [attributedText copy];
+        if (ApolloDeletedCommentsStringIsReasonLabel(ApolloDeletedCommentsTrimmedString(attributedText.string)) ||
+            ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(attributedText.string)) {
+            original = ApolloDeletedCommentsBodyAttributedText(attributedText, resolvedBody);
+        }
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, original, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
         ApolloDeletedCommentsRememberHiddenTextNode(cellNode, textNode);
     }
@@ -1218,7 +1561,11 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsAttribut
     }
 
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    NSAttributedString *placeholder = ApolloDeletedCommentsPlaceholderAttributedText(attributedText, ApolloDeletedCommentsReasonLabelForComment(comment));
+    NSAttributedString *chipSourceText = objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey);
+    if (![chipSourceText isKindOfClass:[NSAttributedString class]] || chipSourceText.length == 0) {
+        chipSourceText = attributedText;
+    }
+    NSAttributedString *placeholder = ApolloDeletedCommentsPlaceholderAttributedText(chipSourceText, ApolloDeletedCommentsReasonLabelForComment(comment), cellNode);
     ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
     return placeholder;
 }
@@ -1244,14 +1591,14 @@ static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(i
     if (bodyTextNode && bodyTextNode != textNode) return attributedText;
     NSString *label = ApolloDeletedCommentsReasonLabelForComment(comment);
     NSString *originalBody = objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey);
-    NSString *bodyForCompare = [originalBody isKindOfClass:[NSString class]] && originalBody.length > 0 ? originalBody : comment.body;
+    NSString *resolvedBody = ApolloDeletedCommentsResolvedRecoveredBodyForComment(comment);
+    NSString *bodyForCompare = [originalBody isKindOfClass:[NSString class]] && originalBody.length > 0 ? originalBody : (resolvedBody ?: comment.body);
     NSAttributedString *bodySourceText = ApolloDeletedCommentsAttributedTextByRemovingTrailingReasonLabel(attributedText, label);
-    BOOL bodyCandidate = ApolloDeletedCommentsTextQualifiesAsBodyCandidate(bodySourceText.string, bodyForCompare) ||
-                         ApolloDeletedCommentsTextQualifiesAsBodyFragment(bodySourceText.string, bodyForCompare);
+    BOOL bodyCandidate = ApolloDeletedCommentsTextLooksLikeRecoveredBodyDisplay(bodySourceText.string, bodyForCompare);
     if (!bodyCandidate) return attributedText;
 
-    NSAttributedString *bodyText = ApolloDeletedCommentsRecoveredBodyTextForDisplay(bodySourceText, bodyForCompare);
-    NSDictionary *baseAttributes = bodyText.length > 0 ? ([bodyText attributesAtIndex:0 effectiveRange:NULL] ?: @{}) : @{};
+    NSAttributedString *bodyText = bodySourceText;
+    NSDictionary *baseAttributes = ApolloDeletedCommentsReasonChipBaseAttributes(bodyText, cellNode);
     NSMutableDictionary *spacerAttributes = [baseAttributes mutableCopy];
     NSMutableParagraphStyle *spacerStyle = [NSMutableParagraphStyle new];
     spacerStyle.minimumLineHeight = 20.0;
@@ -1267,26 +1614,30 @@ static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(i
 static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsAttributedTextWithReasonChipIfNeeded(id textNode, NSAttributedString *attributedText) {
     if (!sShowDeletedComments) return attributedText;
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
+    if (ApolloDeletedCommentsAttributedTextHasVisibleReasonChip(attributedText)) return attributedText;
+
+    NSString *text = ApolloDeletedCommentsNormalizedReasonLabel(ApolloDeletedCommentsTrimmedString(attributedText.string));
+    BOOL exactReasonLabel = ApolloDeletedCommentsStringIsReasonLabel(text);
+    if (!exactReasonLabel) return attributedText;
 
     id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
-    if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return attributedText;
+    if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) {
+        NSDictionary *baseAttributes = ApolloDeletedCommentsReasonChipBaseAttributes(attributedText, cellNode);
+        NSAttributedString *chip = ApolloDeletedCommentsReasonChipAttributedText(text,
+                                                                                 baseAttributes,
+                                                                                 sTapToRevealDeletedComments);
+        if (sTapToRevealDeletedComments) ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
+        return chip;
+    }
 
     NSString *label = ApolloDeletedCommentsReasonLabelForComment(comment);
-    NSString *text = ApolloDeletedCommentsNormalizedReasonLabel(ApolloDeletedCommentsTrimmedString(attributedText.string));
     if (![text isEqualToString:label]) return attributedText;
 
-    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
-    BOOL placeholderOnly = ApolloDeletedCommentsIsDeletedPlaceholder(fullName) &&
-                           !ApolloDeletedCommentsIsRecoveredComment(fullName);
-    BOOL revealed = ApolloDeletedCommentsCommentIsRevealedByFullName(comment);
-    BOOL revealLink = sTapToRevealDeletedComments &&
-                      ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode) &&
-                      !placeholderOnly &&
-                      !revealed;
-
+    NSDictionary *baseAttributes = ApolloDeletedCommentsReasonChipBaseAttributes(attributedText, cellNode);
+    BOOL revealLink = sTapToRevealDeletedComments && ApolloDeletedCommentsShouldKeepModelBodyHidden(comment);
     NSAttributedString *chip = ApolloDeletedCommentsReasonChipAttributedText(label,
-                                                                             [attributedText attributesAtIndex:0 effectiveRange:NULL] ?: @{},
+                                                                             baseAttributes,
                                                                              revealLink);
     if (revealLink) ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
     return chip;
@@ -1358,7 +1709,7 @@ static BOOL ApolloDeletedCommentsRefreshHiddenPlaceholderForCell(id cellNode) {
 
         NSAttributedString *replacement = nil;
         if (!placedPlaceholder) {
-            replacement = ApolloDeletedCommentsPlaceholderAttributedText(original, ApolloDeletedCommentsReasonLabelForComment(comment));
+            replacement = ApolloDeletedCommentsPlaceholderAttributedText(original, ApolloDeletedCommentsReasonLabelForComment(comment), cellNode);
             placedPlaceholder = YES;
         } else {
             NSDictionary *attributes = original.length > 0 ? ([original attributesAtIndex:0 effectiveRange:NULL] ?: @{}) : @{};
@@ -1379,6 +1730,8 @@ static BOOL ApolloDeletedCommentsRefreshHiddenPlaceholderForCell(id cellNode) {
 static BOOL ApolloDeletedCommentsInstallTapToRevealPlaceholderOnTextNode(id cellNode, id textNode, RDKComment *comment, NSString *fullName) {
     if (!cellNode || !textNode || !comment || fullName.length == 0) return NO;
     if (![textNode respondsToSelector:@selector(setAttributedText:)]) return NO;
+    NSString *resolvedBody = ApolloDeletedCommentsResolvedRecoveredBodyForComment(comment);
+    if (!ApolloDeletedCommentsBodyIsDisplayableRecoveredText(resolvedBody)) return NO;
 
     NSAttributedString *current = ApolloDeletedCommentsCurrentAttributedText(textNode);
     NSAttributedString *original = nil;
@@ -1386,11 +1739,10 @@ static BOOL ApolloDeletedCommentsInstallTapToRevealPlaceholderOnTextNode(id cell
         current.length > 0 &&
         !ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(current) &&
         !ApolloDeletedCommentsAttributedTextHasReasonPrefix(current) &&
-        (ApolloDeletedCommentsTextQualifiesAsBodyCandidate(current.string, comment.body) ||
-         ApolloDeletedCommentsTextQualifiesAsBodyFragment(current.string, comment.body))) {
+        ApolloDeletedCommentsTextLooksLikeRecoveredBodyDisplay(current.string, resolvedBody)) {
         original = [current copy];
     } else {
-        original = ApolloDeletedCommentsBodyAttributedText(current, comment.body);
+        original = ApolloDeletedCommentsBodyAttributedText(current, resolvedBody);
     }
     if (![original isKindOfClass:[NSAttributedString class]] || original.length == 0) return NO;
 
@@ -1399,7 +1751,7 @@ static BOOL ApolloDeletedCommentsInstallTapToRevealPlaceholderOnTextNode(id cell
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, @[textNode], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-    NSAttributedString *placeholder = ApolloDeletedCommentsPlaceholderAttributedText(original, ApolloDeletedCommentsReasonLabelForComment(comment));
+    NSAttributedString *placeholder = ApolloDeletedCommentsPlaceholderAttributedText(original, ApolloDeletedCommentsReasonLabelForComment(comment), cellNode);
     ApolloDeletedCommentsSetTextNodeAttributedText(textNode, placeholder);
     ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
@@ -1423,7 +1775,7 @@ static void ApolloDeletedCommentsApplyStaticPlaceholderChip(id cellNode, NSArray
         NSAttributedString *replacement = nil;
         if (!placedPlaceholder) {
             replacement = ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment),
-                                                                        [current attributesAtIndex:0 effectiveRange:NULL] ?: @{},
+                                                                        ApolloDeletedCommentsReasonChipBaseAttributes(current, cellNode),
                                                                         NO);
             placedPlaceholder = YES;
         } else {
@@ -1443,40 +1795,55 @@ static void ApolloDeletedCommentsApplyStaticPlaceholderChip(id cellNode, NSArray
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+// "Tap to show" is a single tap on a recovered-but-hidden comment that's
+// currently expanded (its chip is on screen), kept completely separate from
+// Apollo's collapse/expand:
+//
+//   * Tap an expanded hidden comment -> reveal the body.
+//   * A collapsed comment expands natively (so uncollapsing never reveals), and a
+//     revealed/non-deleted comment collapses/expands natively. Apollo's own
+//     programmatic/auto collapses never reveal because they aren't taps.
+//
+// We attach one tap recognizer to the comment cell's view (the only reliably
+// hit-testable view — the chip's own node is frequently rasterized with no usable
+// backing view, which is why earlier per-node-gesture and body-rectangle attempts
+// silently swallowed taps). Its delegate only lets it fire when a tap should
+// reveal (see ApolloDeletedCommentsTapShouldReveal); when it fires it reveals
+// synchronously and, via cancelsTouchesInView, swallows that tap so it can't also
+// collapse the row.
+//
+// The chip itself is made non-interactive (the reveal attribute stays only as a
+// marker for AttributedTextIsRevealPlaceholder, never added to linkAttributeNames)
+// so it can't swallow the touch as an ASTextNode link before the cell sees it.
+
+// True when a tap on this comment should reveal its recovered body instead of
+// collapsing: tap-to-reveal is on, the body is recoverable, and it isn't revealed
+// yet. (Whether it is currently collapsed is handled by the caller.)
+static BOOL ApolloDeletedCommentsCommentArmedForReveal(RDKComment *comment) {
+    if (!sShowDeletedComments || !sTapToRevealDeletedComments || !comment) return NO;
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    if (fullName.length == 0) return NO;
+    return ApolloDeletedCommentsIsRecoveredComment(fullName) &&
+           !ApolloDeletedCommentsIsCommentRevealed(fullName);
+}
+
+// Make a reveal-chip node non-interactive so taps fall through to the cell and
+// drive Apollo's normal collapse handler (which we redirect into a reveal).
 static void ApolloDeletedCommentsEnsureRevealAttributeIsTappable(id textNode) {
     if (!textNode) return;
 
     if ([textNode respondsToSelector:@selector(setUserInteractionEnabled:)]) {
         @try {
-            ((void (*)(id, SEL, BOOL))objc_msgSend)(textNode, @selector(setUserInteractionEnabled:), YES);
+            ((void (*)(id, SEL, BOOL))objc_msgSend)(textNode, @selector(setUserInteractionEnabled:), NO);
         } @catch (__unused NSException *e) {}
     }
 
     if ([textNode respondsToSelector:@selector(view)]) {
         @try {
             UIView *view = ((UIView *(*)(id, SEL))objc_msgSend)(textNode, @selector(view));
-            if ([view isKindOfClass:[UIView class]]) view.userInteractionEnabled = YES;
+            if ([view isKindOfClass:[UIView class]]) view.userInteractionEnabled = NO;
         } @catch (__unused NSException *e) {}
     }
-
-    if (![textNode respondsToSelector:@selector(setLinkAttributeNames:)]) return;
-
-    NSMutableSet *names = [NSMutableSet setWithObjects:NSLinkAttributeName, ApolloDeletedCommentsRevealAttributeName, nil];
-    if ([textNode respondsToSelector:@selector(linkAttributeNames)]) {
-        @try {
-            id existing = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(linkAttributeNames));
-            if ([existing isKindOfClass:[NSArray class]]) {
-                [names addObjectsFromArray:(NSArray *)existing];
-            } else if ([existing isKindOfClass:[NSSet class]]) {
-                [names unionSet:(NSSet *)existing];
-            }
-        } @catch (__unused NSException *e) {}
-    }
-
-    NSArray *orderedNames = names.allObjects;
-    @try {
-        ((void (*)(id, SEL, NSArray *))objc_msgSend)(textNode, @selector(setLinkAttributeNames:), orderedNames);
-    } @catch (__unused NSException *e) {}
 }
 
 static void ApolloDeletedCommentsDisableRevealTapInterception(id textNode) {
@@ -1496,10 +1863,97 @@ static void ApolloDeletedCommentsDisableRevealTapInterception(id textNode) {
     }
 }
 
+// A tap should reveal only when the comment is armed (recovered + hidden) AND
+// currently expanded — i.e. its chip is on screen. A collapsed comment must be
+// left to expand natively, so uncollapsing never reveals. We deliberately do NOT
+// gate on a body-rectangle: the chip node is frequently rasterized with no usable
+// frame, and that geometry test was unreliable enough to swallow real taps. The
+// only taps we'd "over-claim" are header taps on an expanded hidden comment
+// (whose author is usually "[deleted]" anyway), which is an acceptable trade for
+// a chip tap that reliably reveals.
+static BOOL ApolloDeletedCommentsTapShouldReveal(id cellNode) {
+    RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    if (!ApolloDeletedCommentsCommentArmedForReveal(comment)) return NO;
+    return !ApolloDeletedCommentsCommentIsCollapsed(comment);
+}
+
+@interface ApolloDeletedCommentsRevealTapHandler : NSObject <UIGestureRecognizerDelegate>
+@property (nonatomic, weak) id cellNode;
+@end
+
+@implementation ApolloDeletedCommentsRevealTapHandler
+- (void)apolloRevealTap:(UITapGestureRecognizer *)recognizer {
+    if (recognizer.state != UIGestureRecognizerStateEnded) return;
+    id cellNode = self.cellNode;
+    if (!ApolloDeletedCommentsTapShouldReveal(cellNode)) return;
+    ApolloDeletedCommentsRevealCommentInsteadOfCollapsing(ApolloDeletedCommentsCommentFromCellNode(cellNode));
+}
+
+// Only claim (and swallow) the tap when it should reveal. For a collapsed comment,
+// a revealed comment, or a non-deleted comment this returns NO, so collapse,
+// expand, links and buttons all behave exactly as Apollo intends.
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
+    return ApolloDeletedCommentsTapShouldReveal(self.cellNode);
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return YES;
+}
+
+// Apollo's tap-to-collapse is a Swift single-tap gesture that does NOT go through
+// -[RDKComment setCollapsed:] (it drives CollapsedCommentsTracker directly), so
+// suppressing setCollapsed: never stopped the visible collapse. Instead, force
+// that collapse gesture to wait for — and be cancelled by — our reveal: when the
+// comment is armed, our reveal recognizes and Apollo's single-tap collapse is
+// required to fail, so a chip tap reveals without ever collapsing.
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    if (![otherGestureRecognizer isKindOfClass:[UITapGestureRecognizer class]]) return NO;
+    if (((UITapGestureRecognizer *)otherGestureRecognizer).numberOfTapsRequired > 1) return NO;
+    return ApolloDeletedCommentsTapShouldReveal(self.cellNode);
+}
+@end
+
+// One persistent recognizer per cell view. The delegate gates it per-tap, so it
+// is safe across cell reuse (the comment is resolved live from the cell node).
+static void ApolloDeletedCommentsInstallRevealTapGestureOnCell(id cellNode) {
+    if (!cellNode || ![cellNode respondsToSelector:@selector(view)]) return;
+    UIView *view = nil;
+    @try {
+        view = ((UIView *(*)(id, SEL))objc_msgSend)(cellNode, @selector(view));
+    } @catch (__unused NSException *e) {
+        return;
+    }
+    if (![view isKindOfClass:[UIView class]]) return;
+
+    UITapGestureRecognizer *existing = objc_getAssociatedObject(cellNode, kApolloDeletedCommentsRevealTapGestureKey);
+    if ([existing isKindOfClass:[UITapGestureRecognizer class]]) {
+        if (existing.view == view) return;
+        @try { [existing.view removeGestureRecognizer:existing]; } @catch (__unused NSException *e) {}
+        objc_setAssociatedObject(cellNode, kApolloDeletedCommentsRevealTapGestureKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    ApolloDeletedCommentsRevealTapHandler *handler = [ApolloDeletedCommentsRevealTapHandler new];
+    handler.cellNode = cellNode;
+
+    UITapGestureRecognizer *gesture = [[UITapGestureRecognizer alloc] initWithTarget:handler
+                                                                              action:@selector(apolloRevealTap:)];
+    gesture.delegate = handler;
+    gesture.cancelsTouchesInView = YES;   // a reveal tap must not also collapse the row
+    gesture.delaysTouchesBegan = NO;
+    gesture.delaysTouchesEnded = NO;
+    // UIGestureRecognizer doesn't retain its target; keep the handler alive.
+    objc_setAssociatedObject(gesture, kApolloDeletedCommentsRevealTapGestureKey, handler, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    @try { [view addGestureRecognizer:gesture]; } @catch (__unused NSException *e) { return; }
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsRevealTapGestureKey, gesture, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeeded(id cellNode) {
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
-    NSString *body = comment.body;
+    NSString *body = ApolloDeletedCommentsResolvedRecoveredBodyForComment(comment) ?: comment.body;
 
     BOOL placeholderOnly = ApolloDeletedCommentsCellNodeIsDeletedPlaceholder(cellNode) &&
                            !ApolloDeletedCommentsCellNodeIsRecovered(cellNode);
@@ -1544,7 +1998,9 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeede
     for (id textNode in ApolloDeletedCommentsHiddenTextNodesForCell(cellNode)) {
         NSString *hiddenFullName = objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey);
         NSAttributedString *existingOriginal = objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey);
-        if ([hiddenFullName isEqualToString:fullName] && [existingOriginal isKindOfClass:[NSAttributedString class]]) {
+        if ([hiddenFullName isEqualToString:fullName] &&
+            [existingOriginal isKindOfClass:[NSAttributedString class]] &&
+            ApolloDeletedCommentsBodyIsDisplayableRecoveredText(existingOriginal.string)) {
             alreadyHiddenForComment = YES;
             break;
         }
@@ -1573,13 +2029,18 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeede
         if (![current isKindOfClass:[NSAttributedString class]] || current.length == 0) continue;
         if (ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(current)) continue;
 
-        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, [current copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        NSAttributedString *hiddenOriginal = current;
+        if (ApolloDeletedCommentsStringIsReasonLabel(ApolloDeletedCommentsTrimmedString(current.string)) ||
+            ApolloDeletedCommentsTextLooksLikeDeletedPlaceholderNode(current.string)) {
+            hiddenOriginal = ApolloDeletedCommentsBodyAttributedText(current, body);
+        }
+        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, [hiddenOriginal copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
         [hiddenNodes addObject:textNode];
 
         NSAttributedString *replacement = nil;
         if (!placedPlaceholder) {
-            replacement = ApolloDeletedCommentsPlaceholderAttributedText(current, ApolloDeletedCommentsReasonLabelForComment(comment));
+            replacement = ApolloDeletedCommentsPlaceholderAttributedText(hiddenOriginal, ApolloDeletedCommentsReasonLabelForComment(comment), cellNode);
             placedPlaceholder = YES;
         } else {
             NSDictionary *attributes = [current attributesAtIndex:0 effectiveRange:NULL] ?: @{};
@@ -1670,12 +2131,14 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyRevealedBodyTextTo
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     if (!comment || fullName.length == 0 || !ApolloDeletedCommentsIsCommentRevealed(fullName)) return;
+    NSString *resolvedBody = ApolloDeletedCommentsResolvedRecoveredBodyForComment(comment);
+    if (!ApolloDeletedCommentsBodyIsDisplayableRecoveredText(resolvedBody)) return;
 
     NSAttributedString *templateText = objc_getAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey);
     if (![templateText isKindOfClass:[NSAttributedString class]] || templateText.length == 0) {
         templateText = ApolloDeletedCommentsCurrentAttributedText(textNode);
     }
-    NSAttributedString *bodyText = ApolloDeletedCommentsRecoveredBodyTextForDisplay(templateText, comment.body);
+    NSAttributedString *bodyText = ApolloDeletedCommentsRecoveredBodyTextForDisplay(templateText, resolvedBody);
     bodyText = ApolloDeletedCommentsAttributedTextWithReasonPrefix(textNode, bodyText);
     if (bodyText.length == 0) return;
 
@@ -1685,7 +2148,6 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyRevealedBodyTextTo
 }
 
 static void __attribute__((unused)) ApolloDeletedCommentsRevealHiddenBodyForCell(id cellNode, id tappedTextNode) {
-    (void)tappedTextNode;
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     if (!comment || fullName.length == 0) return;
@@ -1709,16 +2171,28 @@ static void __attribute__((unused)) ApolloDeletedCommentsRevealHiddenBodyForCell
             }
         }
     }
-    if (!restored && ApolloDeletedCommentsStringIsReasonLabel(comment.body)) return;
+    NSString *resolvedBody = ApolloDeletedCommentsResolvedRecoveredBodyForComment(comment);
+    if (!ApolloDeletedCommentsBodyIsDisplayableRecoveredText(resolvedBody)) return;
 
     ApolloDeletedCommentsMarkCommentRevealed(fullName);
     objc_setAssociatedObject(comment, kApolloDeletedCommentsSuppressNextCollapseKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    ApolloDeletedCommentsRestoreOriginalModelBodyIfNeeded(comment);
+    ApolloDeletedCommentsSetCommentStringValue(comment, @selector(setBody:), resolvedBody);
+    ApolloDeletedCommentsSetCommentStringValue(comment, @selector(setBodyHTML:), ApolloDeletedCommentsPlainBodyHTML(resolvedBody));
+    ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
+
+    id revealTextNode = tappedTextNode;
+    if (!revealTextNode) {
+        revealTextNode = ApolloDeletedCommentsHiddenTextNodesForCell(cellNode).firstObject;
+    }
+    if (!revealTextNode) {
+        revealTextNode = ApolloDeletedCommentsKnownBodyTextNode(cellNode);
+    }
+    ApolloDeletedCommentsApplyRevealedBodyTextToNode(cellNode, revealTextNode);
+
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyContainerNode(cellNode));
-    ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyTextNode(cellNode));
+    ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, revealTextNode ?: ApolloDeletedCommentsKnownBodyTextNode(cellNode));
 }
 
 static BOOL __attribute__((unused)) ApolloDeletedCommentsCommentIsRevealed(RDKComment *comment) {
@@ -1746,14 +2220,17 @@ static void __attribute__((unused)) ApolloDeletedCommentsHideRevealedBodyForCell
     ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloDeletedCommentsApplyTapToRevealIfNeeded(cellNode);
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyContainerNode(cellNode));
     ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyTextNode(cellNode));
 }
 
+// textNode is an optional hint of which body node was tapped. When nil (the cell
+// level tap path) the reveal/hide helpers resolve the right body node themselves.
 static void ApolloDeletedCommentsScheduleRevealToggleForTextNode(id cellNode, id textNode) {
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
-    if (!cellNode || !textNode || !comment || fullName.length == 0) return;
+    if (!cellNode || !comment || fullName.length == 0) return;
     if ([objc_getAssociatedObject((id)comment, kApolloDeletedCommentsRevealToggleInFlightKey) boolValue]) return;
 
     BOOL shouldHide = ApolloDeletedCommentsCommentIsRevealedByFullName(comment);
@@ -1772,7 +2249,7 @@ static void ApolloDeletedCommentsScheduleRevealToggleForTextNode(id cellNode, id
 
         @try {
             NSString *currentFullName = ApolloDeletedCommentsFullNameForComment(currentComment);
-            if (currentCellNode && currentTextNode && [currentFullName isEqualToString:capturedFullName]) {
+            if (currentCellNode && [currentFullName isEqualToString:capturedFullName]) {
                 if (shouldHide) {
                     ApolloDeletedCommentsHideRevealedBodyForCell(currentCellNode, currentTextNode);
                 } else {
@@ -1811,6 +2288,47 @@ static id ApolloDeletedCommentsCommentCellNodeForTextNode(id textNode) {
 static BOOL __attribute__((unused)) ApolloDeletedCommentsTextNodeBelongsToRecoveredComment(id textNode) {
     id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
     return ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode);
+}
+
+static BOOL ApolloDeletedCommentsBodyAttributeFontsDiffer(NSDictionary *left, NSDictionary *right) {
+    UIFont *leftFont = [left isKindOfClass:[NSDictionary class]] ? left[NSFontAttributeName] : nil;
+    UIFont *rightFont = [right isKindOfClass:[NSDictionary class]] ? right[NSFontAttributeName] : nil;
+    if (![leftFont isKindOfClass:[UIFont class]] || ![rightFont isKindOfClass:[UIFont class]]) {
+        return leftFont != rightFont;
+    }
+    if (fabs(leftFont.pointSize - rightFont.pointSize) > 0.1) return YES;
+    return ![leftFont.fontName isEqualToString:rightFont.fontName];
+}
+
+static BOOL ApolloDeletedCommentsBodyAttributesAreUsable(NSDictionary *attributes) {
+    if (![attributes isKindOfClass:[NSDictionary class]]) return NO;
+    UIFont *font = attributes[NSFontAttributeName];
+    return [font isKindOfClass:[UIFont class]] && font.pointSize >= 8.0 && font.pointSize <= 40.0;
+}
+
+static void ApolloDeletedCommentsScheduleBodyAttributesRefresh(void) {
+    if (sApolloDeletedCommentsBodyAttributesRefreshScheduled) return;
+    sApolloDeletedCommentsBodyAttributesRefreshScheduled = YES;
+
+    NSArray<NSNumber *> *delays = @[@0.0, @0.05, @0.15];
+    for (NSNumber *delayNumber in delays) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayNumber.doubleValue * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            ApolloDeletedCommentsRefreshVisibleDeletedCells();
+        });
+    }
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.20 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        sApolloDeletedCommentsBodyAttributesRefreshScheduled = NO;
+    });
+}
+
+// On a SYSTEM Dynamic Type change, drop the cached body template and refresh the
+// visible deleted cells so they re-resolve at the new size (relevant when "Use
+// System Text Size" is on).
+static void ApolloDeletedCommentsHandleContentSizeChanged(__unused NSNotification *note) {
+    sApolloDeletedCommentsBodyAttributesTemplate = nil;
+    if (sShowDeletedComments) {
+        ApolloDeletedCommentsScheduleBodyAttributesRefresh();
+    }
 }
 
 static UIView *ApolloDeletedCommentsCellView(id cellNode) {
@@ -1909,8 +2427,55 @@ static void ApolloDeletedCommentsApplyCellHighlight(id cellNode) {
     }
 }
 
+// Single unification chokepoint: force the body text to the one body template font
+// regardless of which path built it. Multiple paths construct the revealed body
+// (layout spec, tap reveal, redecoration, defaults) and historically disagreed on
+// size, which is why some comments rendered small and others large. Here we rewrite
+// every long, non-attachment (body) run to the template font, leaving short runs
+// (reason-chip labels) and image attachments (the chip itself) untouched.
+static NSAttributedString *ApolloDeletedCommentsBodyFontUnifiedText(NSAttributedString *text) {
+    if (![text isKindOfClass:[NSAttributedString class]] || text.length == 0) return text;
+    UIFont *templateFont = [sApolloDeletedCommentsBodyAttributesTemplate isKindOfClass:[NSDictionary class]]
+                               ? sApolloDeletedCommentsBodyAttributesTemplate[NSFontAttributeName]
+                               : nil;
+    if (![templateFont isKindOfClass:[UIFont class]]) return text;
+
+    __block NSUInteger longestPlainRun = 0;
+    [text enumerateAttributesInRange:NSMakeRange(0, text.length) options:0
+                          usingBlock:^(NSDictionary<NSAttributedStringKey, id> *a, NSRange r, __unused BOOL *stop) {
+        if (a[NSAttachmentAttributeName]) return;
+        if (r.length > longestPlainRun) longestPlainRun = r.length;
+    }];
+    if (longestPlainRun < 20) return text;
+
+    NSMutableAttributedString *result = [text mutableCopy];
+    [result enumerateAttributesInRange:NSMakeRange(0, result.length) options:0
+                            usingBlock:^(NSDictionary<NSAttributedStringKey, id> *a, NSRange r, __unused BOOL *stop) {
+        if (a[NSAttachmentAttributeName]) return;
+        UIFont *runFont = a[NSFontAttributeName];
+        UIFont *target = templateFont;
+        if ([runFont isKindOfClass:[UIFont class]]) {
+            // Preserve inline bold/italic by applying the template size to the run's traits.
+            UIFontDescriptorSymbolicTraits emphasis = runFont.fontDescriptor.symbolicTraits &
+                                                      (UIFontDescriptorTraitBold | UIFontDescriptorTraitItalic);
+            if (emphasis) {
+                UIFontDescriptor *d = [templateFont.fontDescriptor fontDescriptorWithSymbolicTraits:
+                                       templateFont.fontDescriptor.symbolicTraits | emphasis];
+                if (d) target = [UIFont fontWithDescriptor:d size:templateFont.pointSize] ?: templateFont;
+            }
+            if (fabs(runFont.pointSize - target.pointSize) <= 0.5 &&
+                [runFont.fontName isEqualToString:target.fontName]) {
+                return;
+            }
+        }
+        [result addAttribute:NSFontAttributeName value:target range:r];
+    }];
+    return result;
+}
+
 static void ApolloDeletedCommentsSetTextNodeAttributedText(id textNode, NSAttributedString *attributedText) {
     if (!textNode || ![attributedText isKindOfClass:[NSAttributedString class]]) return;
+    attributedText = ApolloDeletedCommentsBodyFontUnifiedText(attributedText);
     @try {
         ((void (*)(id, SEL, NSAttributedString *))objc_msgSend)(textNode, @selector(setAttributedText:), attributedText);
     } @catch (__unused NSException *e) {}
@@ -1943,15 +2508,65 @@ static NSAttributedString *ApolloDeletedCommentsTemplateTextForMarkdownNode(id m
         NSAttributedString *current = ApolloDeletedCommentsCurrentAttributedText(textNode);
         if ([current isKindOfClass:[NSAttributedString class]] && current.length > 0) return current;
     }
-    UIColor *fallbackTextColor = nil;
-    if (@available(iOS 13.0, *)) {
-        fallbackTextColor = [UIColor labelColor];
+    return [[NSAttributedString alloc] initWithString:@" "
+                                           attributes:ApolloDeletedCommentsDefaultBodyAttributes()];
+}
+
+// Reads the font Apollo actually uses for THIS MarkdownNode's body, straight from
+// its native display nodes. This is the deterministic, per-comment source of the
+// user's configured comment font — no global capture, no guessing. We deliberately
+// ignore the node's STRING (it may be a "[removed]"/reason-label placeholder while
+// hidden); we only want the font/paragraph attributes, which Apollo renders at the
+// real body size regardless of the placeholder text. The replacement text node we
+// inject is skipped so we never read back our own (chip-sized) attributes.
+static NSDictionary *ApolloDeletedCommentsNativeBodyAttributesForMarkdownNode(id markdownNode) {
+    if (!markdownNode) return nil;
+    id replacement = objc_getAssociatedObject(markdownNode, kApolloDeletedCommentsBodyReplacementTextNodeKey);
+
+    NSMutableArray *nodes = [NSMutableArray array];
+    NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:16];
+    ApolloDeletedCommentsCollectAttributedTextNodes(markdownNode, 4, visited, nodes);
+
+    for (id node in nodes) {
+        if (node == replacement) continue;
+        NSAttributedString *text = ApolloDeletedCommentsCurrentAttributedText(node);
+        if (![text isKindOfClass:[NSAttributedString class]] || text.length == 0) continue;
+
+        __block NSMutableDictionary *attrs = nil;
+        [text enumerateAttributesInRange:NSMakeRange(0, text.length)
+                                 options:0
+                              usingBlock:^(NSDictionary<NSAttributedStringKey, id> *a, __unused NSRange r, BOOL *stop) {
+            if (a[NSAttachmentAttributeName]) return;
+            UIFont *font = a[NSFontAttributeName];
+            if (![font isKindOfClass:[UIFont class]] || font.pointSize < 8.0 || font.pointSize > 40.0) return;
+            if ((font.fontDescriptor.symbolicTraits & (UIFontDescriptorTraitBold | UIFontDescriptorTraitItalic)) != 0) return;
+            attrs = ApolloDeletedCommentsSanitizedBodyAttributes(a);
+            *stop = YES;
+        }];
+        if (attrs) return ApolloDeletedCommentsRegularizedBodyAttributes(attrs);
     }
-    if (!fallbackTextColor) fallbackTextColor = [UIColor blackColor];
-    return [[NSAttributedString alloc] initWithString:@" " attributes:@{
-        NSFontAttributeName: [UIFont systemFontOfSize:16.0],
-        NSForegroundColorAttributeName: fallbackTextColor,
-    }];
+    return nil;
+}
+
+// Force a body-attributes dictionary's font to the REGULAR (non-bold, non-italic)
+// weight at the same family/size. Guards against ever storing a bold/semibold body
+// template, which would render revealed comments heavier than normal comments.
+static NSDictionary *ApolloDeletedCommentsRegularizedBodyAttributes(NSDictionary *attributes) {
+    if (![attributes isKindOfClass:[NSDictionary class]]) return attributes;
+    UIFont *font = attributes[NSFontAttributeName];
+    if (![font isKindOfClass:[UIFont class]]) return attributes;
+    UIFontDescriptorSymbolicTraits traits = font.fontDescriptor.symbolicTraits;
+    if ((traits & (UIFontDescriptorTraitBold | UIFontDescriptorTraitItalic)) == 0) return attributes;
+
+    UIFont *regular = nil;
+    UIFontDescriptor *desc = [font.fontDescriptor fontDescriptorWithSymbolicTraits:
+                              traits & ~(UIFontDescriptorTraitBold | UIFontDescriptorTraitItalic)];
+    if (desc) regular = [UIFont fontWithDescriptor:desc size:font.pointSize];
+    if (!regular) regular = [UIFont systemFontOfSize:font.pointSize weight:UIFontWeightRegular];
+
+    NSMutableDictionary *copy = [attributes mutableCopy];
+    copy[NSFontAttributeName] = regular;
+    return copy;
 }
 
 static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpecIfNeeded(id markdownNode) {
@@ -1960,9 +2575,6 @@ static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpec
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return nil;
     if (ApolloDeletedCommentsCommentIsCollapsed(comment)) return nil;
-
-    id textNode = ApolloDeletedCommentsBodyReplacementTextNode(markdownNode, cellNode);
-    if (!textNode) return nil;
 
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     BOOL placeholderOnly = ApolloDeletedCommentsCellNodeIsDeletedPlaceholder(cellNode) &&
@@ -1973,45 +2585,79 @@ static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpec
                       sTapToRevealDeletedComments &&
                       recovered &&
                       !revealed;
+    // Once revealed, KEEP owning this MarkdownNode's layout (don't fall back to
+    // %orig). %orig re-lays-out the node's stale displayNodes, which were built
+    // from the hidden "[removed]" body, so it never shows the recovered text. By
+    // staying on our replacement text node and just swapping its content from the
+    // chip to the body, a single tap renders the body in place.
+    BOOL revealedRecovered = sShowDeletedComments &&
+                             sTapToRevealDeletedComments &&
+                             recovered &&
+                             revealed;
+
+    if (!(placeholderOnly || shouldHide || revealedRecovered)) {
+        return nil;
+    }
+
+    id textNode = ApolloDeletedCommentsBodyReplacementTextNode(markdownNode, cellNode);
+    if (!textNode) return nil;
 
     NSAttributedString *templateText = ApolloDeletedCommentsTemplateTextForMarkdownNode(markdownNode);
     NSAttributedString *displayText = nil;
-    if (placeholderOnly || shouldHide) {
-        NSAttributedString *original = ApolloDeletedCommentsBodyAttributedText(templateText, comment.body);
-        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, original, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
-        objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, @[textNode], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        displayText = placeholderOnly
-            ? ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment),
-                                                            [templateText attributesAtIndex:0 effectiveRange:NULL] ?: @{},
-                                                            NO)
-            : ApolloDeletedCommentsPlaceholderAttributedText(templateText, ApolloDeletedCommentsReasonLabelForComment(comment));
-    } else {
-        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
-        displayText = ApolloDeletedCommentsBodyAttributedText(templateText, comment.body);
-        BOOL shouldAppendReasonChip = !sTapToRevealDeletedComments || (recovered && revealed);
-        if (shouldAppendReasonChip) {
-            NSDictionary *baseAttributes = displayText.length > 0 ? ([displayText attributesAtIndex:0 effectiveRange:NULL] ?: @{}) : @{};
-            NSMutableDictionary *spacerAttributes = [baseAttributes mutableCopy];
-            NSMutableParagraphStyle *spacerStyle = [NSMutableParagraphStyle new];
-            spacerStyle.minimumLineHeight = 20.0;
-            spacerStyle.maximumLineHeight = 20.0;
-            spacerAttributes[NSParagraphStyleAttributeName] = spacerStyle;
-            NSMutableAttributedString *decorated = [displayText mutableCopy];
-            [decorated appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n" attributes:spacerAttributes]];
-            [decorated appendAttributedString:ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment),
-                                                                                            baseAttributes,
-                                                                                            NO)];
-            displayText = decorated;
+    NSString *resolvedBody = ApolloDeletedCommentsResolvedRecoveredBodyForComment(comment) ?: comment.body;
+    // Font resolution — deterministic, matching Apollo exactly with NO learning,
+    // guessing, or hardcoded point sizes:
+    //   "Use System Text Size" ON  -> the live system Dynamic Type size
+    //   "Use System Text Size" OFF -> Apollo's in-app slider (ApolloCustomTextSize)
+    // SIZE/WEIGHT come from that resolver; body COLOR comes from the comment's own
+    // native attributes when available (so it matches the active theme).
+    NSDictionary *nativeAttributes = ApolloDeletedCommentsNativeBodyAttributesForMarkdownNode(markdownNode);
+    NSDictionary *appAttributes = ApolloDeletedCommentsAppBodyAttributesForNode(markdownNode);
+    if (appAttributes && [nativeAttributes[NSForegroundColorAttributeName] isKindOfClass:[UIColor class]]) {
+        NSMutableDictionary *merged = [appAttributes mutableCopy];
+        merged[NSForegroundColorAttributeName] = nativeAttributes[NSForegroundColorAttributeName];
+        appAttributes = merged;
+    }
+
+    // Promote the resolved app font to the single authoritative body template so
+    // EVERY body path (this layout, tap reveal, redecoration) and the unify
+    // chokepoint render at the exact same size. When it changes (e.g. the user
+    // moves the in-app text-size slider), refresh the visible deleted cells.
+    if (ApolloDeletedCommentsBodyAttributesAreUsable(appAttributes)) {
+        NSDictionary *cap = ApolloDeletedCommentsRegularizedBodyAttributes([appAttributes copy]);
+        if (![sApolloDeletedCommentsBodyAttributesTemplate isKindOfClass:[NSDictionary class]] ||
+            ApolloDeletedCommentsBodyAttributeFontsDiffer(sApolloDeletedCommentsBodyAttributesTemplate, cap)) {
+            sApolloDeletedCommentsBodyAttributesTemplate = cap;
+            if (sShowDeletedComments) ApolloDeletedCommentsScheduleBodyAttributesRefresh();
         }
+        appAttributes = cap;
+    }
+
+    NSAttributedString *original = nil;
+    if (appAttributes && resolvedBody.length > 0) {
+        original = [[NSAttributedString alloc] initWithString:resolvedBody attributes:appAttributes];
+    } else if (nativeAttributes && resolvedBody.length > 0) {
+        original = [[NSAttributedString alloc] initWithString:resolvedBody attributes:nativeAttributes];
+    } else {
+        original = ApolloDeletedCommentsBodyAttributedText(templateText, resolvedBody);
+    }
+    objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenOriginalTextKey, original, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloDeletedCommentsHiddenFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, @[textNode], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    NSDictionary *chipAttributes = ApolloDeletedCommentsReasonChipBaseAttributes(original, cellNode);
+    if (revealedRecovered) {
+        // Show the recovered body itself.
+        displayText = ApolloDeletedCommentsAttributedTextWithReasonPrefix(textNode, original);
+    } else if (placeholderOnly) {
+        displayText = ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment),
+                                                                    chipAttributes,
+                                                                    NO);
+    } else {
+        displayText = ApolloDeletedCommentsPlaceholderAttributedText(original, ApolloDeletedCommentsReasonLabelForComment(comment), cellNode);
     }
 
     ApolloDeletedCommentsSetTextNodeAttributedText(textNode, displayText);
-    if (!(placeholderOnly || shouldHide)) {
-        ApolloDeletedCommentsDisableRevealTapInterception(textNode);
-    }
     Class insetClass = ApolloDeletedCommentsASInsetLayoutSpecClass();
     if (!insetClass) return nil;
     return [insetClass insetLayoutSpecWithInsets:UIEdgeInsetsZero child:textNode];
@@ -2097,7 +2743,7 @@ static void __attribute__((unused)) ApolloDeletedCommentsRepairVisibleReasonChip
     if (!sShowDeletedComments) return;
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return;
-    if (sTapToRevealDeletedComments && !ApolloDeletedCommentsCommentIsRevealedByFullName(comment)) return;
+    BOOL hiddenTapToReveal = sTapToRevealDeletedComments && !ApolloDeletedCommentsCommentIsRevealedByFullName(comment);
 
     NSArray *textNodes = ApolloDeletedCommentsBodyTextNodes(cellNode, comment);
     if (textNodes.count == 0) {
@@ -2111,32 +2757,28 @@ static void __attribute__((unused)) ApolloDeletedCommentsRepairVisibleReasonChip
         } @catch (__unused NSException *e) {
             current = nil;
         }
-        if (![current isKindOfClass:[NSAttributedString class]] || current.length == 0) {
-            NSAttributedString *bodyText = ApolloDeletedCommentsBodyAttributedText(current, comment.body);
-            if (bodyText.length == 0) continue;
-            NSAttributedString *repaired = ApolloDeletedCommentsAttributedTextWithReasonPrefix(textNode, bodyText);
-            ApolloDeletedCommentsSetTextNodeAttributedText(textNode, repaired);
-            ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
+        if (![current isKindOfClass:[NSAttributedString class]] || current.length == 0) continue;
+        if (ApolloDeletedCommentsAttributedTextHasVisibleReasonChip(current)) {
             return;
         }
-        if (ApolloDeletedCommentsAttributedTextHasVisibleReasonChip(current)) return;
 
         NSString *label = ApolloDeletedCommentsReasonLabelForComment(comment);
         NSString *currentLabel = ApolloDeletedCommentsNormalizedReasonLabel(ApolloDeletedCommentsTrimmedString(current.string)).uppercaseString;
         if ([currentLabel isEqualToString:label.uppercaseString]) {
             NSAttributedString *chip = ApolloDeletedCommentsReasonChipAttributedText(label,
-                                                                                     [current attributesAtIndex:0 effectiveRange:NULL] ?: @{},
+                                                                                     ApolloDeletedCommentsReasonChipBaseAttributes(current, cellNode),
                                                                                      NO);
             ApolloDeletedCommentsSetTextNodeAttributedText(textNode, chip);
             ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, textNode);
             return;
         }
+        if (hiddenTapToReveal) continue;
 
         NSAttributedString *bodySource = current;
         if (ApolloDeletedCommentsAttributedTextHasReasonPrefix(current)) {
             bodySource = ApolloDeletedCommentsAttributedTextByRemovingReasonPrefix(current);
             if (![bodySource isKindOfClass:[NSAttributedString class]] || bodySource.length == 0) {
-                bodySource = ApolloDeletedCommentsBodyAttributedText(current, comment.body);
+                continue;
             }
         }
         NSAttributedString *repaired = ApolloDeletedCommentsAttributedTextWithReasonPrefix(textNode, bodySource);
@@ -2182,6 +2824,9 @@ static void ApolloDeletedCommentsUpdateCell(id cellNode) {
     ApolloDeletedCommentsRepairVisibleReasonChipIfNeeded(cellNode);
     ApolloDeletedCommentsScheduleReasonChipRepair(cellNode);
     ApolloDeletedCommentsApplyCellHighlight(cellNode);
+    if (sShowDeletedComments && sTapToRevealDeletedComments) {
+        ApolloDeletedCommentsInstallRevealTapGestureOnCell(cellNode);
+    }
 }
 
 static void ApolloDeletedCommentsRefreshVisibleDeletedCells(void) {
@@ -2234,7 +2879,7 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRe
 
     id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
-    NSDictionary *baseAttributes = [attributedText attributesAtIndex:0 effectiveRange:NULL] ?: @{};
+    NSDictionary *baseAttributes = ApolloDeletedCommentsReasonChipBaseAttributes(attributedText, cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     BOOL placeholderOnly = ApolloDeletedCommentsIsDeletedPlaceholder(fullName) &&
                            !ApolloDeletedCommentsIsRecoveredComment(fullName);
@@ -2268,9 +2913,9 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRe
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
     NSAttributedString *displayText = attributedText;
+    displayText = ApolloDeletedCommentsAttributedTextWithTapToRevealPlaceholder((id)self, displayText);
     displayText = ApolloDeletedCommentsRenameRecoveredSpoilerLabel((id)self, displayText);
     displayText = ApolloDeletedCommentsAttributedTextWithReasonChipIfNeeded((id)self, displayText);
-    displayText = ApolloDeletedCommentsAttributedTextWithTapToRevealPlaceholder((id)self, displayText);
     displayText = ApolloDeletedCommentsAttributedTextWithReasonPrefix((id)self, displayText);
     %orig(displayText);
 }
@@ -2287,6 +2932,12 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRe
                                                        queue:[NSOperationQueue mainQueue]
                                                   usingBlock:^(NSNotification *notification) {
         ApolloDeletedCommentsHandleArcticCacheUpdated(notification);
+    }];
+    [[NSNotificationCenter defaultCenter] addObserverForName:UIContentSizeCategoryDidChangeNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(NSNotification *notification) {
+        ApolloDeletedCommentsHandleContentSizeChanged(notification);
     }];
     [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidBecomeActiveNotification
                                                       object:nil
@@ -2356,11 +3007,96 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRe
     ApolloDeletedCommentsApplyCellHighlight((id)self);
 }
 
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
-    return %orig;
-}
-
 %end
+
+// Reveal a recovered-but-hidden comment. This is the whole "show the text" path:
+//
+//   1. Put the recovered body into the model and flip the comment to "revealed",
+//      so the body getters and the MarkdownNode layout spec both return the real
+//      body instead of the chip.
+//   2. Keep the row expanded and swallow the collapse that the same tap triggers
+//      (the tap that reveals would otherwise also collapse the row — that's why
+//      the body used to appear only after a manual collapse/expand). We both undo
+//      a collapse that landed first (forceExpanded) and suppress one that lands
+//      after (suppress flag).
+//   3. Invalidate the MarkdownNode's cached layout and re-measure the row, which
+//      is exactly what makes collapse/expand re-render — so the body shows now.
+static void ApolloDeletedCommentsRevealCommentInsteadOfCollapsing(RDKComment *comment) {
+    NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
+    if (fullName.length == 0) return;
+
+    // 1. Make the recovered body available on the model.
+    if (!ApolloDeletedCommentsRestoreOriginalModelBodyIfNeeded(comment)) {
+        NSDictionary *archived = ApolloDeletedCommentsCachedArchivedComment(fullName);
+        if (archived.count > 0) {
+            NSString *reason = ApolloDeletedCommentsDeletedPlaceholderReason(fullName) ?: ApolloDeletedCommentsRecoveredReasonForComment(fullName);
+            NSString *archivedBody = ApolloDeletedCommentsRecoverableArchivedBody(archived);
+            if (ApolloDeletedCommentsApplyRecoveredArchivedCommentToObject((id)comment, archived, reason) && archivedBody.length > 0) {
+                objc_setAssociatedObject((id)comment, kApolloDeletedCommentsOriginalBodyKey, [archivedBody copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+                objc_setAssociatedObject((id)comment, kApolloDeletedCommentsOriginalBodyHTMLKey, ApolloDeletedCommentsPlainBodyHTML(archivedBody), OBJC_ASSOCIATION_COPY_NONATOMIC);
+            }
+        }
+    }
+    NSString *resolvedBody = ApolloDeletedCommentsResolvedRecoveredBodyForComment(comment);
+    if (!ApolloDeletedCommentsBodyIsDisplayableRecoveredText(resolvedBody)) return;
+
+    ApolloDeletedCommentsMarkCommentRevealed(fullName);
+    ApolloDeletedCommentsSetCommentStringValue(comment, @selector(setBody:), resolvedBody);
+    ApolloDeletedCommentsSetCommentStringValue(comment, @selector(setBodyHTML:), ApolloDeletedCommentsPlainBodyHTML(resolvedBody));
+
+    // 2. Eat the collapse this tap also fires.
+    objc_setAssociatedObject(comment, kApolloDeletedCommentsSuppressNextCollapseKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    // 3. Re-render every on-screen cell for this comment.
+    NSArray *trackedCells = ApolloDeletedCommentsTrackedCellsForFullName(fullName);
+    for (id cellNode in trackedCells) {
+        RDKComment *cellComment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+        if (![ApolloDeletedCommentsFullNameForComment(cellComment) isEqualToString:fullName]) continue;
+
+        ApolloDeletedCommentsForceCommentExpanded(comment, cellNode);
+        ApolloDeletedCommentsSynchronizeCommentModelDisplayState(cellNode);
+
+        // Prefer the MarkdownNode captured live from its own layout hook; fall
+        // back to the ivar lookup. We keep owning its layout (the layout spec now
+        // emits the body when revealed), and we also push the body text straight
+        // onto our replacement text node so it changes immediately, then
+        // invalidate to re-measure the row height.
+        id bodyNode = objc_getAssociatedObject(cellNode, kApolloDeletedCommentsCellMarkdownNodeKey);
+        if (!bodyNode) bodyNode = ApolloDeletedCommentsKnownBodyContainerNode(cellNode);
+
+        id replacementNode = bodyNode ? objc_getAssociatedObject(bodyNode, kApolloDeletedCommentsBodyReplacementTextNodeKey) : nil;
+        if (!replacementNode) replacementNode = ApolloDeletedCommentsHiddenTextNodesForCell(cellNode).firstObject;
+        if (replacementNode) {
+            NSAttributedString *templateText = objc_getAssociatedObject(replacementNode, kApolloDeletedCommentsHiddenOriginalTextKey);
+            if (![templateText isKindOfClass:[NSAttributedString class]] || templateText.length == 0) {
+                templateText = ApolloDeletedCommentsCurrentAttributedText(replacementNode);
+            }
+            NSAttributedString *bodyText = ApolloDeletedCommentsBodyAttributedText(templateText, resolvedBody);
+            bodyText = ApolloDeletedCommentsAttributedTextWithReasonPrefix(replacementNode, bodyText);
+            if (bodyText.length > 0) {
+                ApolloDeletedCommentsSetTextNodeAttributedText(replacementNode, bodyText);
+            }
+        }
+
+        objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+        // Invalidate the MarkdownNode (body) + replacement node so the layout
+        // spec re-runs and the table re-measures the row to the body's height.
+        ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, bodyNode);
+        ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, replacementNode);
+    }
+
+    // Clear the suppress flag shortly after in case no stray collapse arrived, so
+    // the user's next genuine collapse of the now-revealed comment still works.
+    __weak RDKComment *weakComment = comment;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.30 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        RDKComment *strongComment = weakComment;
+        if (strongComment) {
+            objc_setAssociatedObject(strongComment, kApolloDeletedCommentsSuppressNextCollapseKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+    });
+}
 
 %hook RDKComment
 
@@ -2369,8 +3105,10 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRe
     NSString *savedBody = objc_getAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyKey);
     if ([savedBody isKindOfClass:[NSString class]] &&
         savedBody.length > 0 &&
-        ApolloDeletedCommentsStringIsReasonLabel(body) &&
-        !ApolloDeletedCommentsShouldKeepModelBodyHidden((RDKComment *)self)) {
+        ApolloDeletedCommentsStringIsReasonLabel(body)) {
+        if (ApolloDeletedCommentsShouldKeepModelBodyHidden((RDKComment *)self)) {
+            return body;
+        }
         return savedBody;
     }
     return body;
@@ -2381,8 +3119,10 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRe
     NSString *savedBodyHTML = objc_getAssociatedObject((id)self, kApolloDeletedCommentsOriginalBodyHTMLKey);
     if ([savedBodyHTML isKindOfClass:[NSString class]] &&
         savedBodyHTML.length > 0 &&
-        ApolloDeletedCommentsStringIsReasonLabel(ApolloDeletedCommentsTrimmedString(bodyHTML)) &&
-        !ApolloDeletedCommentsShouldKeepModelBodyHidden((RDKComment *)self)) {
+        ApolloDeletedCommentsStringIsReasonLabel(ApolloDeletedCommentsTrimmedString(bodyHTML))) {
+        if (ApolloDeletedCommentsShouldKeepModelBodyHidden((RDKComment *)self)) {
+            return bodyHTML;
+        }
         return savedBodyHTML;
     }
     return bodyHTML;
@@ -2393,6 +3133,12 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRe
         objc_setAssociatedObject((id)self, kApolloDeletedCommentsSuppressNextCollapseKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         return;
     }
+
+    // Collapse/expand stays fully native here and never reveals: revealing is a
+    // separate chip-region tap handled by the cell's reveal recognizer. (Earlier
+    // this redirected collapses into reveals, but that also fired on Apollo's
+    // programmatic/auto collapses, so a comment would appear revealed only after
+    // an expand and ordinary collapse/expand would reveal it.)
     %orig;
     if (!collapsed) {
         ApolloDeletedCommentsScheduleVisibleCellRefreshForComment((RDKComment *)self);
@@ -2404,8 +3150,16 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRe
 %hook _TtC6Apollo12MarkdownNode
 
 - (id)layoutSpecThatFits:(struct CDStruct_90e057aa)fits {
+    // Record cell -> this MarkdownNode so the reveal path can invalidate the
+    // exact node that renders the body, without relying on ivar-name lookup
+    // (CommentCellNode.bodyNode is _Atomic and was not being found reliably).
+    id ownerCell = ApolloDeletedCommentsCommentCellNodeForTextNode((id)self);
+    if (ownerCell) {
+        objc_setAssociatedObject(ownerCell, kApolloDeletedCommentsCellMarkdownNodeKey, (id)self, OBJC_ASSOCIATION_ASSIGN);
+    }
     id deletedSpec = ApolloDeletedCommentsDeletedMarkdownLayoutSpecIfNeeded((id)self);
     if (deletedSpec) return deletedSpec;
+
     return %orig;
 }
 

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -2148,6 +2148,8 @@ typedef NS_ENUM(NSInteger, Tag) {
     NSArray<NSIndexPath *> *paths = @[[NSIndexPath indexPathForRow:4 inSection:SectionGeneral]];
     if (sShowDeletedComments) {
         [self.tableView insertRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
+        [self showAlertWithTitle:@"Show Deleted Comments"
+                          message:@"This feature uses Arctic Shift to recover deleted comments. When Arctic Shift is slow or rate-limited, comments may load more slowly or recovered comments may not appear."];
     } else {
         [self.tableView deleteRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
     }

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1306,13 +1306,8 @@ static void initializeRandomSources() {
                                     UDKeyRedditClientSecret: @""};
     NSUserDefaults *standardDefaults = [NSUserDefaults standardUserDefaults];
     [standardDefaults registerDefaults:defaultValues];
-
     NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
     NSDictionary *persistentDomain = bundleID.length > 0 ? [standardDefaults persistentDomainForName:bundleID] : nil;
-    if (!persistentDomain[UDKeyShowDeletedComments] && persistentDomain[UDKeyLegacyRevealDeletedComments]) {
-        [standardDefaults setBool:[standardDefaults boolForKey:UDKeyLegacyRevealDeletedComments] forKey:UDKeyShowDeletedComments];
-        persistentDomain = bundleID.length > 0 ? [standardDefaults persistentDomainForName:bundleID] : nil;
-    }
 
     sRedditClientId = (NSString *)[[[NSUserDefaults standardUserDefaults] objectForKey:UDKeyRedditClientId] ?: @"" copy];
     sRedditClientSecret = (NSString *)[[[NSUserDefaults standardUserDefaults] objectForKey:UDKeyRedditClientSecret] ?: @"" copy];

--- a/tests/deleted_comments_manual_checklist.md
+++ b/tests/deleted_comments_manual_checklist.md
@@ -1,12 +1,20 @@
 # Deleted Comments Manual Validation
 
-- Open a comments thread with visible `[deleted]` or `[removed]` comments and confirm recovered bodies render with a translucent red cell highlight and a `REMOVED BY MOD` or `DELETED BY USER` chip.
+- Open a comments thread with visible `[deleted]` or `[removed]` comments and confirm the normal comments render immediately.
+- On a thread where Arctic responds quickly, confirm recovered deleted comments appear on the first render without leaving and reopening the thread.
+- Confirm Arctic recovery starts in parallel with the Reddit comments request and first render waits no more than about 2 seconds for matching recovery data.
+- Confirm visible deleted placeholders render with the translucent red cell highlight and a `REMOVED BY MOD` or `DELETED BY USER` chip before Arctic recovery finishes.
+- If Arctic finishes shortly after the first render, confirm visible deleted placeholders upgrade in place to recovered comments without duplicating rows.
 - Confirm long usernames do not crowd the recovered-comment reason chip.
-- With "Tap to Show Deleted Comments" on, confirm recovered bodies start hidden behind the reason chip and reveal after tapping the chip.
+- With "Tap to Show Deleted Comments" on, confirm unrecovered placeholders stay as stable reason chips and do not show `LOADING...`, `NOT AVAILABLE`, or native `SPOILER`.
+- With "Tap to Show Deleted Comments" on, tap a recovered/cached deleted comment and confirm it toggles between the reason chip and recovered body without collapsing the whole comment.
 - With "Tap to Show Deleted Comments" off, confirm recovered bodies are visible by default and still show the reason chip before the body.
-- Open a comments thread where removed replies are hidden behind "more replies" and confirm recoverable deleted children appear inline.
-- With Arctic Shift slow or blocked, confirm the thread still shows Apollo's normal comments after the short timeout instead of waiting 10-20 seconds.
-- Reload the same recovered thread and confirm cached archive data is reused without another visible loading penalty.
+- Open a comments thread where removed replies are hidden behind "more replies" and confirm recoverable deleted children appear only as part of Apollo's normal response or "more replies" response, not as a live list shift.
+- With Arctic Shift slow or blocked, confirm the thread still shows Apollo's normal comments immediately instead of waiting 10-20 seconds.
+- Reopen the same recovered thread and confirm cached archive data is reused without another visible loading penalty.
 - Trigger "load more comments" on a thread with deleted replies and confirm recovery still works without delaying the full thread.
+- Confirm background Arctic completion does not automatically expand or shift visible deleted placeholders.
+- Confirm revealing recovered comments does not duplicate comments after scrolling, collapsing, or opening more replies.
+- Confirm quote-block recovered comments hide and reveal correctly.
 - Toggle "Show Deleted Comments" off, reload the same thread, and confirm Apollo returns to its native deleted/removed output.
 - Confirm normal user flair and moderator flair remain unchanged.

--- a/tests/deleted_comments_manual_checklist.md
+++ b/tests/deleted_comments_manual_checklist.md
@@ -1,9 +1,12 @@
 # Deleted Comments Manual Validation
 
-- Open a comments thread with visible `[deleted]` or `[removed]` comments and confirm recovered bodies render with a red recovery badge.
+- Open a comments thread with visible `[deleted]` or `[removed]` comments and confirm recovered bodies render with a translucent red cell highlight and a `DELETED BY MOD` or `DELETED BY USER` chip.
+- Confirm long usernames do not crowd the recovered-comment reason chip.
+- With "Tap to Show Deleted Comments" on, confirm recovered bodies start hidden behind the reason chip and reveal after tapping the chip.
+- With "Tap to Show Deleted Comments" off, confirm recovered bodies are visible by default and still show the reason chip before the body.
 - Open a comments thread where removed replies are hidden behind "more replies" and confirm recoverable deleted children appear inline.
 - With Arctic Shift slow or blocked, confirm the thread still shows Apollo's normal comments after the short timeout instead of waiting 10-20 seconds.
 - Reload the same recovered thread and confirm cached archive data is reused without another visible loading penalty.
 - Trigger "load more comments" on a thread with deleted replies and confirm recovery still works without delaying the full thread.
 - Toggle "Show Deleted Comments" off, reload the same thread, and confirm Apollo returns to its native deleted/removed output.
-- Confirm normal user flair and moderator flair do not receive the recovered-comment red badge styling.
+- Confirm normal user flair and moderator flair remain unchanged.

--- a/tests/deleted_comments_manual_checklist.md
+++ b/tests/deleted_comments_manual_checklist.md
@@ -8,7 +8,8 @@
 - Confirm long usernames do not crowd the recovered-comment reason chip.
 - With "Tap to Show Deleted Comments" on, confirm unrecovered placeholders stay as stable reason chips and do not show `LOADING...`, `NOT AVAILABLE`, or native `SPOILER`.
 - With "Tap to Show Deleted Comments" on, tap a recovered/cached deleted comment and confirm it toggles between the reason chip and recovered body without collapsing the whole comment.
-- With "Tap to Show Deleted Comments" off, confirm recovered bodies are visible by default and still show the reason chip before the body.
+- With "Tap to Show Deleted Comments" off, confirm recovered bodies are visible by default and show the reason chip below the body.
+- Confirm `REMOVED BY MOD` and `DELETED BY USER` use the same chip style but slightly different red highlight shades in light and dark mode.
 - Open a comments thread where removed replies are hidden behind "more replies" and confirm recoverable deleted children appear only as part of Apollo's normal response or "more replies" response, not as a live list shift.
 - With Arctic Shift slow or blocked, confirm the thread still shows Apollo's normal comments immediately instead of waiting 10-20 seconds.
 - Reopen the same recovered thread and confirm cached archive data is reused without another visible loading penalty.

--- a/tests/deleted_comments_manual_checklist.md
+++ b/tests/deleted_comments_manual_checklist.md
@@ -1,6 +1,6 @@
 # Deleted Comments Manual Validation
 
-- Open a comments thread with visible `[deleted]` or `[removed]` comments and confirm recovered bodies render with a translucent red cell highlight and a `DELETED BY MOD` or `DELETED BY USER` chip.
+- Open a comments thread with visible `[deleted]` or `[removed]` comments and confirm recovered bodies render with a translucent red cell highlight and a `REMOVED BY MOD` or `DELETED BY USER` chip.
 - Confirm long usernames do not crowd the recovered-comment reason chip.
 - With "Tap to Show Deleted Comments" on, confirm recovered bodies start hidden behind the reason chip and reveal after tapping the chip.
 - With "Tap to Show Deleted Comments" off, confirm recovered bodies are visible by default and still show the reason chip before the body.

--- a/tests/deleted_comments_manual_checklist.md
+++ b/tests/deleted_comments_manual_checklist.md
@@ -2,5 +2,8 @@
 
 - Open a comments thread with visible `[deleted]` or `[removed]` comments and confirm recovered bodies render with a red recovery badge.
 - Open a comments thread where removed replies are hidden behind "more replies" and confirm recoverable deleted children appear inline.
+- With Arctic Shift slow or blocked, confirm the thread still shows Apollo's normal comments after the short timeout instead of waiting 10-20 seconds.
+- Reload the same recovered thread and confirm cached archive data is reused without another visible loading penalty.
+- Trigger "load more comments" on a thread with deleted replies and confirm recovery still works without delaying the full thread.
 - Toggle "Show Deleted Comments" off, reload the same thread, and confirm Apollo returns to its native deleted/removed output.
 - Confirm normal user flair and moderator flair do not receive the recovered-comment red badge styling.

--- a/tests/deleted_comments_tests.m
+++ b/tests/deleted_comments_tests.m
@@ -136,9 +136,10 @@ static void TestTapToRevealPatchDoesNotEmitNativeSpoiler(void) {
     sTapToRevealDeletedComments = previousTapSetting;
 
     Require(patched == 1, @"tap-to-reveal patches one visible comment");
-    Require([body isEqualToString:@"Recovered body"], @"tap-to-reveal recovered body remains plain markdown");
+    Require([body isEqualToString:@"DELETED BY USER"], @"tap-to-reveal starts hidden behind the reason label");
     Require([body rangeOfString:@">!"].location == NSNotFound, @"tap-to-reveal body does not use native spoiler markdown");
     Require([bodyHTML rangeOfString:@"md-spoiler-text"].location == NSNotFound, @"tap-to-reveal body_html does not use native spoiler HTML");
+    Require([bodyHTML rangeOfString:@"DELETED BY USER"].location != NSNotFound, @"tap-to-reveal body_html renders the reason label");
 }
 
 static void TestMoreExpansion(void) {

--- a/tests/deleted_comments_tests.m
+++ b/tests/deleted_comments_tests.m
@@ -133,6 +133,13 @@ static void TestNoOp(void) {
     Require([root[@"data"][@"children"][0][@"data"][@"body"] isEqualToString:@"[deleted]"], @"body remains unchanged");
 }
 
+static void TestArcticCooldownPolicy(void) {
+    Require(ApolloDeletedCommentsTestArcticResponseShouldCooldown(429, NSIntegerMax), @"429 triggers cooldown");
+    Require(ApolloDeletedCommentsTestArcticResponseShouldCooldown(200, 3), @"low remaining quota triggers cooldown");
+    Require(!ApolloDeletedCommentsTestArcticResponseShouldCooldown(200, 4), @"remaining quota above threshold does not trigger cooldown");
+    Require(!ApolloDeletedCommentsTestArcticResponseShouldCooldown(200, NSIntegerMax), @"missing quota header does not trigger cooldown");
+}
+
 int main(void) {
     @autoreleasepool {
         TestURLExtraction();
@@ -141,6 +148,7 @@ int main(void) {
         TestMoreExpansion();
         TestMixedMoreKeepsRemainingChildren();
         TestNoOp();
+        TestArcticCooldownPolicy();
         NSLog(@"deleted_comments_tests passed");
     }
     return 0;

--- a/tests/deleted_comments_tests.m
+++ b/tests/deleted_comments_tests.m
@@ -143,8 +143,8 @@ static void TestArcticCooldownPolicy(void) {
 
 static void TestReasonLabels(void) {
     Require([ApolloDeletedCommentsTestDisplayLabelForReason(@"user_deleted") isEqualToString:@"DELETED BY USER"], @"user-deleted reason label");
-    Require([ApolloDeletedCommentsTestDisplayLabelForReason(@"moderator_removed") isEqualToString:@"DELETED BY MOD"], @"mod-deleted reason label");
-    Require([ApolloDeletedCommentsTestDisplayLabelForReason(nil) isEqualToString:@"DELETED BY MOD"], @"default reason label");
+    Require([ApolloDeletedCommentsTestDisplayLabelForReason(@"moderator_removed") isEqualToString:@"REMOVED BY MOD"], @"mod-deleted reason label");
+    Require([ApolloDeletedCommentsTestDisplayLabelForReason(nil) isEqualToString:@"REMOVED BY MOD"], @"default reason label");
 }
 
 int main(void) {

--- a/tests/deleted_comments_tests.m
+++ b/tests/deleted_comments_tests.m
@@ -2,6 +2,8 @@
 
 #import "ApolloDeletedCommentsData.h"
 
+extern BOOL sTapToRevealDeletedComments;
+
 static id MutableJSON(id object) {
     NSData *data = [NSJSONSerialization dataWithJSONObject:object options:0 error:nil];
     return [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:nil];
@@ -39,6 +41,28 @@ static NSMutableDictionary *VisibleDeletedRoot(void) {
                         @"name": @"t1_c1",
                         @"body": @"[deleted]",
                         @"body_html": @"&lt;div class=\"md\"&gt;&lt;p&gt;[deleted]&lt;/p&gt;&lt;/div&gt;",
+                        @"author": @"[deleted]",
+                        @"score": @0,
+                        @"replies": @"",
+                    },
+                },
+            ],
+        },
+    });
+}
+
+static NSMutableDictionary *VisibleRemovedRoot(void) {
+    return MutableJSON(@{
+        @"kind": @"Listing",
+        @"data": @{
+            @"children": @[
+                @{
+                    @"kind": @"t1",
+                    @"data": @{
+                        @"id": @"c2",
+                        @"name": @"t1_c2",
+                        @"body": @"[removed]",
+                        @"body_html": @"&lt;div class=\"md\"&gt;&lt;p&gt;[removed]&lt;/p&gt;&lt;/div&gt;",
                         @"author": @"[deleted]",
                         @"score": @0,
                         @"replies": @"",
@@ -98,6 +122,24 @@ static void TestVisibleReplacement(void) {
     Require([data[@"user_vote"] isEqual:@0] && [data[@"likes"] isKindOfClass:[NSNull class]], @"neutralizes vote metadata");
 }
 
+static void TestTapToRevealPatchDoesNotEmitNativeSpoiler(void) {
+    BOOL previousTapSetting = sTapToRevealDeletedComments;
+    sTapToRevealDeletedComments = YES;
+
+    NSMutableDictionary *root = VisibleDeletedRoot();
+    NSUInteger patched = ApolloDeletedCommentsTestPatchRedditJSONRoot(root, @{@"t1_c1": Archived(@"c1", @"Recovered body", @{@"removal_type": @"deleted"})});
+    NSDictionary *data = root[@"data"][@"children"][0][@"data"];
+    NSString *body = data[@"body"];
+    NSString *bodyHTML = data[@"body_html"];
+
+    sTapToRevealDeletedComments = previousTapSetting;
+
+    Require(patched == 1, @"tap-to-reveal patches one visible comment");
+    Require([body isEqualToString:@"Recovered body"], @"tap-to-reveal recovered body remains plain markdown");
+    Require([body rangeOfString:@">!"].location == NSNotFound, @"tap-to-reveal body does not use native spoiler markdown");
+    Require([bodyHTML rangeOfString:@"md-spoiler-text"].location == NSNotFound, @"tap-to-reveal body_html does not use native spoiler HTML");
+}
+
 static void TestMoreExpansion(void) {
     NSMutableDictionary *root = MoreRoot(@[@"c1", @"c2"], @2);
     NSDictionary *archive = @{
@@ -134,6 +176,34 @@ static void TestNoOp(void) {
     Require([root[@"data"][@"children"][0][@"data"][@"body"] isEqualToString:@"[deleted]"], @"body remains unchanged");
 }
 
+static void TestPlaceholderMetadata(void) {
+    NSMutableDictionary *deletedRoot = VisibleDeletedRoot();
+    NSUInteger deletedMarked = ApolloDeletedCommentsTestMarkDeletedPlaceholdersInRoot(deletedRoot);
+    NSDictionary *deletedData = deletedRoot[@"data"][@"children"][0][@"data"];
+    Require(deletedMarked == 1, @"marks deleted placeholder");
+    Require([deletedData[@"apollo_deleted_comment_placeholder"] boolValue], @"sets deleted placeholder marker");
+    Require([deletedData[@"apollo_deleted_comment_placeholder_reason"] isEqualToString:@"user_deleted"], @"deleted placeholder reason");
+
+    NSMutableDictionary *removedRoot = VisibleRemovedRoot();
+    NSUInteger removedMarked = ApolloDeletedCommentsTestMarkDeletedPlaceholdersInRoot(removedRoot);
+    NSDictionary *removedData = removedRoot[@"data"][@"children"][0][@"data"];
+    Require(removedMarked == 1, @"marks removed placeholder");
+    Require([removedData[@"apollo_deleted_comment_placeholder"] boolValue], @"sets removed placeholder marker");
+    Require([removedData[@"apollo_deleted_comment_placeholder_reason"] isEqualToString:@"moderator_removed"], @"removed placeholder reason");
+}
+
+static void TestImmediatePatchReturnsPlaceholderWithoutArchive(void) {
+    NSMutableDictionary *root = VisibleRemovedRoot();
+    NSData *data = [NSJSONSerialization dataWithJSONObject:root options:0 error:nil];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://oauth.reddit.com/comments/thread.json?raw_json=1"]];
+    NSData *patchedData = ApolloDeletedCommentsTestPatchResponseImmediate(data, request);
+    NSDictionary *patched = [NSJSONSerialization JSONObjectWithData:patchedData options:0 error:nil];
+    NSDictionary *commentData = patched[@"data"][@"children"][0][@"data"];
+    Require([commentData[@"body"] isEqualToString:@"[removed]"], @"immediate patch leaves body as placeholder");
+    Require([commentData[@"apollo_deleted_comment_placeholder"] boolValue], @"immediate patch marks placeholder");
+    Require(commentData[@"apollo_recovered_deleted_comment"] == nil, @"immediate patch does not pretend placeholder is recovered");
+}
+
 static void TestArcticCooldownPolicy(void) {
     Require(ApolloDeletedCommentsTestArcticResponseShouldCooldown(429, NSIntegerMax), @"429 triggers cooldown");
     Require(ApolloDeletedCommentsTestArcticResponseShouldCooldown(200, 3), @"low remaining quota triggers cooldown");
@@ -152,9 +222,12 @@ int main(void) {
         TestURLExtraction();
         TestDeletedBodyPolicy();
         TestVisibleReplacement();
+        TestTapToRevealPatchDoesNotEmitNativeSpoiler();
         TestMoreExpansion();
         TestMixedMoreKeepsRemainingChildren();
         TestNoOp();
+        TestPlaceholderMetadata();
+        TestImmediatePatchReturnsPlaceholderWithoutArchive();
         TestArcticCooldownPolicy();
         TestReasonLabels();
         NSLog(@"deleted_comments_tests passed");

--- a/tests/deleted_comments_tests.m
+++ b/tests/deleted_comments_tests.m
@@ -94,6 +94,7 @@ static void TestVisibleReplacement(void) {
     Require([data[@"score"] isEqual:@42], @"replaces score");
     Require([data[@"apollo_recovered_deleted_comment"] boolValue], @"sets marker");
     Require([data[@"apollo_recovered_deleted_reason"] isEqualToString:@"user_deleted"], @"sets reason");
+    Require(data[@"author_flair_text"] == nil, @"does not replace author flair with recovered reason");
     Require([data[@"user_vote"] isEqual:@0] && [data[@"likes"] isKindOfClass:[NSNull class]], @"neutralizes vote metadata");
 }
 
@@ -140,6 +141,12 @@ static void TestArcticCooldownPolicy(void) {
     Require(!ApolloDeletedCommentsTestArcticResponseShouldCooldown(200, NSIntegerMax), @"missing quota header does not trigger cooldown");
 }
 
+static void TestReasonLabels(void) {
+    Require([ApolloDeletedCommentsTestDisplayLabelForReason(@"user_deleted") isEqualToString:@"DELETED BY USER"], @"user-deleted reason label");
+    Require([ApolloDeletedCommentsTestDisplayLabelForReason(@"moderator_removed") isEqualToString:@"DELETED BY MOD"], @"mod-deleted reason label");
+    Require([ApolloDeletedCommentsTestDisplayLabelForReason(nil) isEqualToString:@"DELETED BY MOD"], @"default reason label");
+}
+
 int main(void) {
     @autoreleasepool {
         TestURLExtraction();
@@ -149,6 +156,7 @@ int main(void) {
         TestMixedMoreKeepsRemainingChildren();
         TestNoOp();
         TestArcticCooldownPolicy();
+        TestReasonLabels();
         NSLog(@"deleted_comments_tests passed");
     }
     return 0;

--- a/tests/deleted_comments_tests.m
+++ b/tests/deleted_comments_tests.m
@@ -103,7 +103,7 @@ static void TestURLExtraction(void) {
 static void TestDeletedBodyPolicy(void) {
     Require(ApolloDeletedCommentsTestBodyLooksDeleted(@"[deleted]", nil), @"detects [deleted]");
     Require(ApolloDeletedCommentsTestBodyLooksDeleted(@"[removed]", nil), @"detects [removed]");
-    Require(ApolloDeletedCommentsTestBodyLooksDeleted(@"", nil), @"detects empty body");
+    Require(!ApolloDeletedCommentsTestBodyLooksDeleted(@"", nil), @"empty body alone is not deleted");
     Require(ApolloDeletedCommentsTestBodyLooksDeleted(@"hello", @"&lt;p&gt;Removed by moderator&lt;/p&gt;"), @"detects removed HTML");
     Require(!ApolloDeletedCommentsTestBodyLooksDeleted(@"normal comment", nil), @"normal body is not deleted");
 }

--- a/tests/deleted_comments_tests.m
+++ b/tests/deleted_comments_tests.m
@@ -104,7 +104,8 @@ static void TestDeletedBodyPolicy(void) {
     Require(ApolloDeletedCommentsTestBodyLooksDeleted(@"[deleted]", nil), @"detects [deleted]");
     Require(ApolloDeletedCommentsTestBodyLooksDeleted(@"[removed]", nil), @"detects [removed]");
     Require(!ApolloDeletedCommentsTestBodyLooksDeleted(@"", nil), @"empty body alone is not deleted");
-    Require(ApolloDeletedCommentsTestBodyLooksDeleted(@"hello", @"&lt;p&gt;Removed by moderator&lt;/p&gt;"), @"detects removed HTML");
+    Require(ApolloDeletedCommentsTestBodyLooksDeleted(@"", @"&lt;p&gt;Removed by moderator&lt;/p&gt;"), @"detects removed HTML without body");
+    Require(!ApolloDeletedCommentsTestBodyLooksDeleted(@"hello", @"&lt;p&gt;Removed by moderator&lt;/p&gt;"), @"stale removed HTML does not override visible body");
     Require(!ApolloDeletedCommentsTestBodyLooksDeleted(@"normal comment", nil), @"normal body is not deleted");
 }
 

--- a/tests/deleted_comments_tests.m
+++ b/tests/deleted_comments_tests.m
@@ -136,10 +136,11 @@ static void TestTapToRevealPatchDoesNotEmitNativeSpoiler(void) {
     sTapToRevealDeletedComments = previousTapSetting;
 
     Require(patched == 1, @"tap-to-reveal patches one visible comment");
-    Require([body isEqualToString:@"DELETED BY USER"], @"tap-to-reveal starts hidden behind the reason label");
+    Require([body isEqualToString:@"DELETED BY USER"], @"tap-to-reveal hides the recovered body before first render");
     Require([body rangeOfString:@">!"].location == NSNotFound, @"tap-to-reveal body does not use native spoiler markdown");
     Require([bodyHTML rangeOfString:@"md-spoiler-text"].location == NSNotFound, @"tap-to-reveal body_html does not use native spoiler HTML");
-    Require([bodyHTML rangeOfString:@"DELETED BY USER"].location != NSNotFound, @"tap-to-reveal body_html renders the reason label");
+    Require([bodyHTML rangeOfString:@"DELETED BY USER"].location != NSNotFound, @"tap-to-reveal body_html uses the reason label before first render");
+    Require([bodyHTML rangeOfString:@"Recovered body"].location == NSNotFound, @"tap-to-reveal body_html does not expose recovered text before reveal");
 }
 
 static void TestMoreExpansion(void) {


### PR DESCRIPTION
 # Improve deleted comments recovery performance and UI

Addresses deleted-comment recovery slowdowns from Arctic Shift and cleans up the recovered comment presentation after the feature rollout.

## Changes

- Adds Arctic Shift safeguards for deleted comment recovery:
  - in-memory thread recovery cache
  - request de-duping for in-flight Arctic lookups
  - cooldown handling after errors, rate limits, or low remaining quota
  - bounded initial recovery wait so slow Arctic responses do not block threads for 10-20 seconds
- Marks visible Reddit `[deleted]` / `[removed]` placeholders locally before Arctic recovery finishes
- Applies cached Arctic recovery data before render when available
- Warms Arctic recovery data in the background and upgrades visible deleted placeholders in place when safe
- Keeps background recovery from automatically expanding hidden "more replies" groups or shifting the visible thread unexpectedly
- Reworks deleted-comment metadata so recovery labels do not replace `author_flair_text`
- Updates deleted-comment UI:
  - translucent red deleted-comment cell highlights
  - `REMOVED BY MOD` / `DELETED BY USER` reason chips
  - reason chip shown below recovered text when bodies are visible
  - tap-to-show uses the same deleted-comment presentation path instead of native spoiler markup
- Adds an enable-warning modal explaining that deleted comment recovery depends on Arctic Shift and may affect loading
- Removes the legacy `RevealDeletedComments` to `ShowDeletedComments` auto-migration

## Screenshots

| Tap to show | Revealed |
| --- | --- |
| <img width="330" alt="IMG_6368" src="https://github.com/user-attachments/assets/79129416-4f9a-471b-991e-eefa783ad2e4" /> | <img width="330" alt="IMG_6369" src="https://github.com/user-attachments/assets/fc234723-8e05-44a5-8c38-262f57a5d0d5" /> |
| <img width="330" alt="IMG_6370" src="https://github.com/user-attachments/assets/50f70af0-1999-44b1-b912-2a36eec4c2d1" /> | <img width="330" alt="IMG_6371" src="https://github.com/user-attachments/assets/d06f779f-4503-4560-973c-aeb3c3c965c7" /> |

## Validation

- `xcrun clang -fobjc-arc -framework Foundation -DAPOLLO_DELETED_COMMENTS_TESTING -Isrc tests/deleted_comments_tests.m src/ApolloDeletedCommentsData.m -o /tmp/deleted_comments_tests && /tmp/deleted_comments_tests`
- `make package`
- Test IPA build

## Manual Testing

- Normal comments render immediately with Show Deleted Comments enabled
- Deleted placeholders show a red highlight and `REMOVED BY MOD` or `DELETED BY USER`
- Recovered comments appear without needing to leave and reopen the thread
- Cached recovered comments render without another visible loading penalty
- Tap-to-show toggles recovered bodies without native `SPOILER` labels
- With tap-to-show off, recovered bodies are visible by default and show the reason chip below the body
- Background Arctic completion does not duplicate comments or shift visible comment lists
- Quote-block recovered comments hide and reveal correctly
- Normal user flairs and moderator flairs are unchanged

Closes #384