### PR TITLE
Make text post thumbnails consistent: toggle, badge, and tap-to-open

### DIFF
--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -39,4 +39,10 @@ void ApolloPresentWebURLFromViewController(UIViewController *presenter, NSURL *u
 // GIF/composer machinery pokes at the remote view hierarchy (issue #366).
 // Resolved via objc_getClass so we don't link MessageUI/Social.
 BOOL ApolloIsSystemShareComposeController(UIViewController *controller);
+
+// Present the tweak's fullscreen zoomable image-album viewer (implemented in
+// ApolloInlineImages). Items are dictionaries with an @"url" NSURL; despite
+// the name it is a generic viewer, not ImageChest-specific. Returns NO when
+// items is empty or no presenter could be found from sourceView.
+BOOL ApolloPresentImageChestItems(NSArray<NSDictionary *> *items, UIView *sourceView, NSInteger initialIndex);
 __END_DECLS

--- a/src/ApolloFeedTextPostThumbnails.xm
+++ b/src/ApolloFeedTextPostThumbnails.xm
@@ -789,17 +789,40 @@ static void ApolloFeedReapplyCleanup(id node, BOOL triggerLayout) {
             // Apollo wires the thumbnail's tap action only for posts with
             // media, so the squares we fill are inert — taps fell through to
             // the cell and opened the thread (review feedback on the PR).
-            // Wire our own target once per node; the handler re-checks
+            // Wire our own target once per wrapper; the handler re-checks
             // eligibility, so node reuse on media posts stays Apollo's.
-            if (![objc_getAssociatedObject(thumb, &kApolloFeedCompactTapWiredKey) boolValue] &&
-                [thumb respondsToSelector:@selector(addTarget:action:forControlEvents:)]) {
-                objc_setAssociatedObject(thumb, &kApolloFeedCompactTapWiredKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            //
+            // The wiring must run on the main queue, and `thumbnailNode` must
+            // be RE-READ there: layoutSpecThatFits runs on Texture's
+            // background layout threads, and a raw ivar pointer captured
+            // across the async hop can dangle if the cell is torn down first
+            // (crashed as doesNotRecognizeSelector on a reincarnated pointer).
+            // Only the wrapper crosses the boundary, weakly.
+            if (![objc_getAssociatedObject(self, &kApolloFeedCompactTapWiredKey) boolValue]) {
+                objc_setAssociatedObject(self, &kApolloFeedCompactTapWiredKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                __weak ASDisplayNode *weakWrapper = (ASDisplayNode *)self;
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    ASNetworkImageNode *thumbNode = (ASNetworkImageNode *)thumb;
-                    thumbNode.userInteractionEnabled = YES;
-                    [thumbNode addTarget:[ApolloFeedHeroTapHandler shared]
-                                  action:@selector(compactThumbTapped:)
-                        forControlEvents:ApolloFeedControlEventTouchUpInside];
+                    @try {
+                        ASDisplayNode *wrapper = weakWrapper;
+                        if (!wrapper) return;
+                        id thumbNode = ApolloFeedIvar(wrapper, "thumbnailNode");
+                        if (![thumbNode respondsToSelector:@selector(addTarget:action:forControlEvents:)] ||
+                            ![thumbNode respondsToSelector:@selector(setUserInteractionEnabled:)]) {
+                            ApolloLog(@"[FeedThumb] compact wiring skipped: thumb=%@ lacks control surface",
+                                      NSStringFromClass([thumbNode class]));
+                            return;
+                        }
+                        // Apollo leaves the whole thumbnail chain inert for
+                        // media-less posts; touches need every ancestor enabled.
+                        wrapper.userInteractionEnabled = YES;
+                        [(ASNetworkImageNode *)thumbNode setUserInteractionEnabled:YES];
+                        [(ASNetworkImageNode *)thumbNode addTarget:[ApolloFeedHeroTapHandler shared]
+                                                            action:@selector(compactThumbTapped:)
+                                                  forControlEvents:ApolloFeedControlEventTouchUpInside];
+                        ApolloLog(@"[FeedThumb] compact tap target wired (thumb=%@)", NSStringFromClass([thumbNode class]));
+                    } @catch (NSException *e) {
+                        ApolloLog(@"[FeedThumb] compact wiring failed: %@", e.reason);
+                    }
                 });
             }
         }

--- a/src/ApolloFeedTextPostThumbnails.xm
+++ b/src/ApolloFeedTextPostThumbnails.xm
@@ -7,8 +7,18 @@
 // in compact mode.
 //
 // Strategy A (non-invasive): we only set the existing thumbnail node's URL on
-// the affected cells. We do NOT change tap routing, post type, or the layout
-// model — eligible posts stay self posts and tapping still opens the post.
+// the affected cells (compact) or inject a hero node above Apollo's content
+// (large). Eligible posts stay self posts; tapping the title/body still opens
+// the post.
+//
+// Consistency additions (issue #419):
+//   * Settings toggle (Media > Text Post Thumbnails, default ON; off restores
+//     Apollo's native no-thumbnail behavior for text posts).
+//   * A "Text Post" pill on the large-mode hero so these thumbnails are
+//     distinguishable from image posts in the feed.
+//   * Tapping the thumbnail opens the embedded image(s) in a fullscreen
+//     zoomable viewer — same expectation as tapping an image post — instead
+//     of opening the thread.
 //
 // Eligibility (strict): act ONLY when
 //   * link.selfPost == YES, AND
@@ -25,6 +35,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloMediaMetadata.h"
+#import "ApolloState.h"
 #import "Tweak.h"
 
 // Tweak.h's RDKLink declares selfPost/selfText/mediaMetadata/previewMedia. The
@@ -88,6 +99,19 @@ typedef NS_ENUM(unsigned char, ApolloFeedStackAlign) {
 @property (nullable, nonatomic, copy) UIColor *placeholderColor;
 @property (nonatomic) BOOL placeholderEnabled;@property (nonatomic) NSTimeInterval placeholderFadeDuration;
 @property (nonatomic, weak) id delegate;
+// ASImageNode is an ASControlNode subclass, so target-action is available.
+- (void)addTarget:(id)target action:(SEL)action forControlEvents:(NSUInteger)controlEvents;
+@end
+
+// ASControlNodeEventTouchUpInside from Texture's ASControlNode.h.
+static const NSUInteger ApolloFeedControlEventTouchUpInside = 1 << 4;
+
+// Tweak.h already declares a bare ASImageNode; extend it with the display-node
+// surface the badge needs (the runtime class is a real ASDisplayNode subclass).
+@interface ASImageNode (ApolloFeedThumb)
+@property (nullable, nonatomic, strong) UIImage *image;
+@property (nonatomic, getter=isHidden) BOOL hidden;
+- (id)style;
 @end
 
 @interface ASLayoutSpec : NSObject
@@ -109,6 +133,22 @@ typedef NS_ENUM(unsigned char, ApolloFeedStackAlign) {
 
 @interface ASRatioLayoutSpec : ASLayoutSpec
 + (instancetype)ratioLayoutSpecWithRatio:(CGFloat)ratio child:(id)child;
+@end
+
+@interface ASOverlayLayoutSpec : ASLayoutSpec
++ (instancetype)overlayLayoutSpecWithChild:(id)child overlay:(id)overlay;
+@end
+
+@interface ASInsetLayoutSpec : ASLayoutSpec
++ (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id)child;
+@end
+
+// ASRelativeLayoutSpecPosition: None=0, Start=1, Center=2, End=3.
+@interface ASRelativeLayoutSpec : ASLayoutSpec
++ (instancetype)relativePositionLayoutSpecWithHorizontalPosition:(NSUInteger)horizontalPosition
+                                                verticalPosition:(NSUInteger)verticalPosition
+                                                    sizingOption:(NSUInteger)sizingOption
+                                                           child:(id)child;
 @end
 
 // ASLayoutElementStyle subset for fixing the hero height.
@@ -137,6 +177,17 @@ static char kApolloFeedThumbRatioKey;
 // Associated-object: the ASNetworkImageNode we inject into a RichMediaNode's
 // layout for large-mode text/link posts (created once per node, reused).
 static char kApolloFeedHeroNodeKey;
+
+// Associated-object: the "Text Post" badge node overlaid on the hero.
+static char kApolloFeedBadgeNodeKey;
+
+// Associated-object on the hero node: the RDKLink it currently displays
+// (updated every layout pass — cells get reused for different links).
+static char kApolloFeedHeroLinkKey;
+
+// Associated-object on an RDKLink: cached full-resolution viewer items
+// (NSArray<NSDictionary *> with @"url"), used when the hero is tapped.
+static char kApolloFeedViewerItemsKey;
 
 // Shared ASNetworkImageNode delegate that fades the hero image in once it
 // finishes loading. ASNetworkImageNode's placeholderFadeDuration only fades the
@@ -183,8 +234,9 @@ static char kApolloFeedHeroNodeKey;
 }
 @end
 
-// Master switch (always on for now; eligibility gate keeps it scoped).
-static BOOL sEnableFeedTextThumbnails = YES;
+// Master switch lives in ApolloState (sFeedTextPostThumbnails), hydrated from
+// UDKeyFeedTextPostThumbnails and toggled from the Media settings section.
+// Off restores Apollo's native behavior (no thumbnails on text posts).
 
 #pragma mark - URL helpers
 
@@ -369,8 +421,9 @@ static NSURL *ApolloFeedThumbURLFromSelfText(NSString *selfText) {
 
 // Resolve (and cache) the thumbnail URL for an eligible self/text post.
 // Returns nil for ineligible posts or when no embedded image was found.
+// Deliberately NOT gated on sFeedTextPostThumbnails — the toggle-off path
+// still needs eligibility to strip raw image URLs from preview text.
 static NSURL *ApolloFeedThumbnailURLForLink(RDKLink *link) {
-    if (!sEnableFeedTextThumbnails) return nil;
     if (!link) return nil;
 
     id cached = objc_getAssociatedObject(link, &kApolloFeedThumbURLKey);
@@ -419,6 +472,143 @@ static NSURL *ApolloFeedThumbnailURLForLink(RDKLink *link) {
                              result ?: (id)[NSNull null],
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     return result;
+}
+
+#pragma mark - Fullscreen viewer plumbing
+
+// Full-resolution viewer items for an eligible text post: every embedded
+// media_metadata image, ordered by first occurrence in the selftext (same
+// ordering rule as the thumbnail choice), as @{ @"url": NSURL } dictionaries
+// for ApolloPresentImageChestItems. Falls back to the single thumbnail URL
+// for selftext-link images. Cached per link.
+static NSArray<NSDictionary *> *ApolloFeedViewerItemsForLink(RDKLink *link) {
+    if (!link) return @[];
+    NSArray *cached = objc_getAssociatedObject(link, &kApolloFeedViewerItemsKey);
+    if ([cached isKindOfClass:[NSArray class]]) return cached;
+
+    NSMutableArray<NSDictionary *> *items = [NSMutableArray array];
+    @try {
+        NSDictionary *mediaMetadata = link.mediaMetadata;
+        NSString *body = [link.selfText isKindOfClass:[NSString class]] ? link.selfText : @"";
+        if ([mediaMetadata isKindOfClass:[NSDictionary class]] && mediaMetadata.count > 0) {
+            NSMutableArray<NSString *> *keys = [NSMutableArray array];
+            for (NSString *assetID in mediaMetadata) {
+                if (ApolloFeedEntryIsImage(mediaMetadata[assetID])) [keys addObject:assetID];
+            }
+            // Body order; images never referenced in the body sort last
+            // (NSNotFound compares greater than any real index).
+            [keys sortUsingComparator:^NSComparisonResult(NSString *a, NSString *b) {
+                NSUInteger ia = [body rangeOfString:a].location;
+                NSUInteger ib = [body rangeOfString:b].location;
+                if (ia == ib) return NSOrderedSame;
+                return ia < ib ? NSOrderedAscending : NSOrderedDescending;
+            }];
+            for (NSString *assetID in keys) {
+                NSString *urlString = ApolloMediaDisplayURLFromMetadataEntry(assetID, mediaMetadata[assetID], NO);
+                NSURL *url = urlString.length > 0 ? [NSURL URLWithString:urlString] : nil;
+                if (url) [items addObject:@{ @"url": url }];
+            }
+        }
+        if (items.count == 0) {
+            NSURL *thumb = ApolloFeedThumbnailURLForLink(link);
+            if (thumb) [items addObject:@{ @"url": thumb }];
+        }
+    } @catch (__unused NSException *e) {}
+
+    objc_setAssociatedObject(link, &kApolloFeedViewerItemsKey, items, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return items;
+}
+
+// Route an image URL into Apollo's native link-tap machinery by walking the
+// supernode chain for textNode:tappedLinkAttribute:value:atPoint:textRange:
+// (RichMediaNode and LargePostCellNode implement it). With the "ApolloLink"
+// attribute, Apollo routes direct image URLs into its native MediaViewer —
+// identical to tapping an image link anywhere else in the app. Returns NO
+// when no handler exists in the chain (e.g. compact cells).
+static BOOL ApolloFeedRouteURLToNativeHandler(id startNode, NSURL *url) {
+    if (![url isKindOfClass:[NSURL class]]) return NO;
+    SEL sel = @selector(textNode:tappedLinkAttribute:value:atPoint:textRange:);
+    id target = startNode;
+    for (int hops = 0; target && hops < 24; hops++) {
+        if ([target respondsToSelector:sel]) break;
+        target = [target respondsToSelector:@selector(supernode)] ? [target supernode] : nil;
+    }
+    if (!target) return NO;
+
+    ApolloLog(@"[FeedThumb] routing %@ to native viewer via %@", url.host, NSStringFromClass([target class]));
+    void (*msgSend)(id, SEL, id, id, id, CGPoint, NSRange) =
+        (void (*)(id, SEL, id, id, id, CGPoint, NSRange))objc_msgSend;
+    msgSend(target, sel, target, @"ApolloLink", url, CGPointZero, NSMakeRange(NSNotFound, 0));
+    return YES;
+}
+
+// Shared tap handler: opens the tapped text post's embedded image the same
+// way a normal image post opens its media, instead of confusingly opening
+// the thread.
+@interface ApolloFeedHeroTapHandler : NSObject
+@end
+
+@implementation ApolloFeedHeroTapHandler
++ (instancetype)shared {
+    static ApolloFeedHeroTapHandler *sShared = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ sShared = [[ApolloFeedHeroTapHandler alloc] init]; });
+    return sShared;
+}
+
+- (void)heroTapped:(id)sender {
+    @try {
+        RDKLink *link = objc_getAssociatedObject(sender, &kApolloFeedHeroLinkKey);
+        NSArray<NSDictionary *> *items = ApolloFeedViewerItemsForLink(link);
+        ASDisplayNode *node = (ASDisplayNode *)sender;
+        UIView *sourceView = [node isNodeLoaded] ? [node view] : nil;
+
+        // Multi-image posts use the tweak's album viewer so every embedded
+        // image is swipeable — Apollo's native viewer can only take a single
+        // ad-hoc URL through the link-tap route.
+        if (items.count > 1) {
+            ApolloLog(@"[FeedThumb] hero tapped: presenting %lu-image album", (unsigned long)items.count);
+            if (ApolloPresentImageChestItems(items, sourceView, 0)) return;
+        }
+
+        // Single image: Apollo's native MediaViewer via the link-tap handler
+        // on the hero's supernode chain.
+        NSURL *url = [items.firstObject[@"url"] isKindOfClass:[NSURL class]] ? items.firstObject[@"url"] : nil;
+        if (ApolloFeedRouteURLToNativeHandler(sender, url)) return;
+
+        // Fallback: the tweak's own zoomable viewer.
+        ApolloLog(@"[FeedThumb] hero tapped: no native handler, presenting %lu image(s) in fallback viewer",
+                  (unsigned long)items.count);
+        if (items.count > 0) {
+            ApolloPresentImageChestItems(items, sourceView, 0);
+        }
+    } @catch (__unused NSException *e) {}
+}
+@end
+
+// "Text Post" pill rendered once — overlaid bottom-right on the hero so the
+// feed makes clear this thumbnail belongs to a text post (issue #419).
+static UIImage *ApolloFeedTextPostBadgeImage(void) {
+    static UIImage *sBadge = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        NSString *text = @"Text Post";
+        NSDictionary *attrs = @{
+            NSFontAttributeName: [UIFont systemFontOfSize:10.0 weight:UIFontWeightSemibold],
+            NSForegroundColorAttributeName: [UIColor whiteColor],
+        };
+        CGSize textSize = [text sizeWithAttributes:attrs];
+        CGFloat hPad = 7.0, vPad = 3.0;
+        CGSize size = CGSizeMake(ceil(textSize.width) + hPad * 2.0, ceil(textSize.height) + vPad * 2.0);
+        UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size];
+        sBadge = [renderer imageWithActions:^(UIGraphicsImageRendererContext *context) {
+            [[UIColor colorWithWhite:0.0 alpha:0.6] setFill];
+            [[UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, 0, size.width, size.height)
+                                        cornerRadius:size.height / 2.0] fill];
+            [text drawAtPoint:CGPointMake(hPad, vPad) withAttributes:attrs];
+        }];
+    });
+    return sBadge;
 }
 
 // Apply the URL to a thumbnail image node (idempotent — skips if already set).
@@ -566,7 +756,7 @@ static void ApolloFeedReapplyCleanup(id node, BOOL triggerLayout) {
 
 - (id)layoutSpecThatFits:(struct ApolloFeedThumbSizeRange)constrainedSize {
     id spec = %orig;
-    if (!sEnableFeedTextThumbnails) return spec;
+    if (!sFeedTextPostThumbnails) return spec;
     @try {
         RDKLink *link = MSHookIvar<RDKLink *>(self, "link");
         NSURL *url = ApolloFeedThumbnailURLForLink(link);
@@ -576,6 +766,45 @@ static void ApolloFeedReapplyCleanup(id node, BOOL triggerLayout) {
         }
     } @catch (__unused NSException *e) {}
     return spec;
+}
+
+%end
+
+// Compact cells route thumbnail taps through the cell node. For text posts we
+// filled the thumbnail ourselves, so route the tap to the fullscreen image
+// viewer (matching image posts) instead of whatever Apollo would do with a
+// medialess self post. Everything else falls through to the native handler.
+%hook _TtC6Apollo19CompactPostCellNode
+
+- (void)thumbnailTappedWithSender:(id)sender {
+    if (sFeedTextPostThumbnails) {
+        @try {
+            RDKLink *link = MSHookIvar<RDKLink *>(self, "link");
+            if (link && link.selfPost && ApolloFeedThumbnailURLForLink(link)) {
+                NSArray<NSDictionary *> *items = ApolloFeedViewerItemsForLink(link);
+                ASDisplayNode *node = (ASDisplayNode *)self;
+                UIView *sourceView = [node isNodeLoaded] ? [node view] : nil;
+
+                // Multi-image posts: swipeable album viewer (see heroTapped).
+                if (items.count > 1) {
+                    ApolloLog(@"[FeedThumb] compact thumbnail tapped: presenting %lu-image album",
+                              (unsigned long)items.count);
+                    if (ApolloPresentImageChestItems(items, sourceView, 0)) return;
+                }
+
+                // Single image: native MediaViewer when a handler is reachable.
+                NSURL *url = [items.firstObject[@"url"] isKindOfClass:[NSURL class]] ? items.firstObject[@"url"] : nil;
+                if (ApolloFeedRouteURLToNativeHandler(self, url)) return;
+
+                ApolloLog(@"[FeedThumb] compact thumbnail tapped on text post: presenting %lu image(s)",
+                          (unsigned long)items.count);
+                if (items.count > 0 && ApolloPresentImageChestItems(items, sourceView, 0)) {
+                    return;
+                }
+            }
+        } @catch (__unused NSException *e) {}
+    }
+    %orig;
 }
 
 %end
@@ -590,7 +819,25 @@ static void ApolloFeedReapplyCleanup(id node, BOOL triggerLayout) {
 
 - (id)layoutSpecThatFits:(struct ApolloFeedThumbSizeRange)constrainedSize {
     id origSpec = %orig;
-    if (!sEnableFeedTextThumbnails) return origSpec;
+    if (!sFeedTextPostThumbnails) {
+        // Toggled off mid-session: a previously injected hero/badge would
+        // otherwise keep its last frame even though it left the layout spec.
+        ASDisplayNode *staleHero = objc_getAssociatedObject(self, &kApolloFeedHeroNodeKey);
+        if (staleHero) staleHero.hidden = YES;
+        ASDisplayNode *staleBadge = objc_getAssociatedObject(self, &kApolloFeedBadgeNodeKey);
+        if (staleBadge) staleBadge.hidden = YES;
+        // Even without a thumbnail, a naked image URL leading the preview
+        // text is noise — show the post's actual text, like a normal text
+        // post. (Link card stays native.)
+        @try {
+            RDKLink *link = MSHookIvar<RDKLink *>(self, "link");
+            if (link && link.selfPost && ApolloFeedThumbnailURLForLink(link)) {
+                ApolloFeedStripImageURLsFromTextNode(ApolloFeedIvar(self, "selfPostPreviewNode"));
+                [ApolloFeedInjectedNodes() addObject:self];
+            }
+        } @catch (__unused NSException *e) {}
+        return origSpec;
+    }
 
     @try {
         RDKLink *link = MSHookIvar<RDKLink *>(self, "link");
@@ -659,12 +906,26 @@ static void ApolloFeedReapplyCleanup(id node, BOOL triggerLayout) {
                 if ([hero respondsToSelector:@selector(setDelegate:)]) {
                     hero.delegate = [ApolloFeedHeroFadeDelegate shared];
                 }
+                // Tapping the hero opens the embedded image(s) fullscreen,
+                // matching what a thumbnail tap does on a real image post
+                // (issue #419). Taps elsewhere still open the thread.
+                if ([hero respondsToSelector:@selector(addTarget:action:forControlEvents:)]) {
+                    hero.userInteractionEnabled = YES;
+                    [hero addTarget:[ApolloFeedHeroTapHandler shared]
+                             action:@selector(heroTapped:)
+                   forControlEvents:ApolloFeedControlEventTouchUpInside];
+                } else {
+                    ApolloLog(@"[FeedThumb] hero node does not support target-action; tap-to-open disabled");
+                }
             } @catch (__unused NSException *e) {}
             [(ASDisplayNode *)self addSubnode:hero];
             objc_setAssociatedObject(self, &kApolloFeedHeroNodeKey, hero,
                                      OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         }
         if (![hero.URL isEqual:url]) hero.URL = url;
+        hero.hidden = NO;
+        // Cells are reused across links — keep the tap handler's link current.
+        objc_setAssociatedObject(hero, &kApolloFeedHeroLinkKey, link, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
         // Size the hero via an aspect ratio (height/width) layout spec.
         CGFloat ratio = 0.56;
@@ -678,6 +939,40 @@ static void ApolloFeedReapplyCleanup(id node, BOOL triggerLayout) {
         }
 
         id heroSpec = [ratioCls ratioLayoutSpecWithRatio:ratio child:hero];
+
+        // "Text Post" pill pinned to the hero's bottom-right corner, so it's
+        // obvious in the feed that this thumbnail belongs to a text post.
+        Class overlayCls = objc_getClass("ASOverlayLayoutSpec");
+        Class relativeCls = objc_getClass("ASRelativeLayoutSpec");
+        Class insetCls = objc_getClass("ASInsetLayoutSpec");
+        if (overlayCls && relativeCls && insetCls) {
+            ASImageNode *badge = (ASImageNode *)objc_getAssociatedObject(self, &kApolloFeedBadgeNodeKey);
+            if (!badge) {
+                Class imgNodeCls = objc_getClass("ASImageNode");
+                badge = imgNodeCls ? [[imgNodeCls alloc] init] : nil;
+                if (badge) {
+                    UIImage *pill = ApolloFeedTextPostBadgeImage();
+                    badge.image = pill;
+                    id badgeStyle = [badge style];
+                    if ([badgeStyle respondsToSelector:@selector(setPreferredSize:)]) {
+                        ((ApolloFeedLayoutStyle *)badgeStyle).preferredSize = pill.size;
+                    }
+                    [(ASDisplayNode *)self addSubnode:(ASDisplayNode *)badge];
+                    objc_setAssociatedObject(self, &kApolloFeedBadgeNodeKey, badge,
+                                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                }
+            }
+            if (badge) {
+                badge.hidden = NO;
+                id positioned = [relativeCls relativePositionLayoutSpecWithHorizontalPosition:3 /* End */
+                                                                             verticalPosition:3 /* End */
+                                                                                 sizingOption:0
+                                                                                        child:badge];
+                id inset = [insetCls insetLayoutSpecWithInsets:UIEdgeInsetsMake(0, 0, 8, 8) child:positioned];
+                heroSpec = [overlayCls overlayLayoutSpecWithChild:heroSpec overlay:inset] ?: heroSpec;
+            }
+        }
+
         id stacked = [stackCls stackLayoutSpecWithDirection:ApolloFeedStackDirectionVertical
                                                     spacing:8.0
                                              justifyContent:ApolloFeedStackJustifyStart
@@ -693,7 +988,7 @@ static void ApolloFeedReapplyCleanup(id node, BOOL triggerLayout) {
 #pragma mark - ctor
 
 %ctor {
-    ApolloLog(@"[FeedThumb] ApolloFeedTextPostThumbnails loaded");
+    ApolloLog(@"[FeedThumb] ApolloFeedTextPostThumbnails loaded enabled=%d", (int)sFeedTextPostThumbnails);
 
     // When the app returns to the foreground, Apollo rebuilds the self-post
     // preview text (re-adding the naked image URL) without re-running our
@@ -704,14 +999,19 @@ static void ApolloFeedReapplyCleanup(id node, BOOL triggerLayout) {
                     object:nil
                      queue:[NSOperationQueue mainQueue]
                 usingBlock:^(NSNotification *note) {
-        if (!sEnableFeedTextThumbnails) return;
         for (NSNumber *delay in @[ @0.0, @0.2, @0.6 ]) {
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
                                          (int64_t)(delay.doubleValue * NSEC_PER_SEC)),
                            dispatch_get_main_queue(), ^{
                 @try {
                     for (id node in ApolloFeedInjectedNodes().allObjects) {
-                        ApolloFeedReapplyCleanup(node, YES);
+                        if (sFeedTextPostThumbnails) {
+                            // Full cleanup: hidden link card + stripped URL.
+                            ApolloFeedReapplyCleanup(node, YES);
+                        } else {
+                            // Toggle off: only keep the preview text clean.
+                            ApolloFeedStripImageURLsFromTextNode(ApolloFeedIvar(node, "selfPostPreviewNode"));
+                        }
                     }
                 } @catch (__unused NSException *e) {}
             });

--- a/src/ApolloFeedTextPostThumbnails.xm
+++ b/src/ApolloFeedTextPostThumbnails.xm
@@ -189,6 +189,9 @@ static char kApolloFeedHeroLinkKey;
 // (NSArray<NSDictionary *> with @"url"), used when the hero is tapped.
 static char kApolloFeedViewerItemsKey;
 
+// NSNumber(BOOL) on a compact thumbnail node: our tap target is attached.
+static char kApolloFeedCompactTapWiredKey;
+
 // Shared ASNetworkImageNode delegate that fades the hero image in once it
 // finishes loading. ASNetworkImageNode's placeholderFadeDuration only fades the
 // (near-transparent) placeholder layer out, so the downloaded image still
@@ -545,6 +548,8 @@ static BOOL ApolloFeedRouteURLToNativeHandler(id startNode, NSURL *url) {
 // Shared tap handler: opens the tapped text post's embedded image the same
 // way a normal image post opens its media, instead of confusingly opening
 // the thread.
+static id ApolloFeedIvar(id obj, const char *name);
+
 @interface ApolloFeedHeroTapHandler : NSObject
 @end
 
@@ -563,16 +568,11 @@ static BOOL ApolloFeedRouteURLToNativeHandler(id startNode, NSURL *url) {
         ASDisplayNode *node = (ASDisplayNode *)sender;
         UIView *sourceView = [node isNodeLoaded] ? [node view] : nil;
 
-        // Multi-image posts use the tweak's album viewer so every embedded
-        // image is swipeable — Apollo's native viewer can only take a single
-        // ad-hoc URL through the link-tap route.
-        if (items.count > 1) {
-            ApolloLog(@"[FeedThumb] hero tapped: presenting %lu-image album", (unsigned long)items.count);
-            if (ApolloPresentImageChestItems(items, sourceView, 0)) return;
-        }
-
-        // Single image: Apollo's native MediaViewer via the link-tap handler
-        // on the hero's supernode chain.
+        // Open the hero's image in Apollo's NATIVE media viewer via the
+        // link-tap handler on the supernode chain (review feedback on the
+        // PR: native viewer with its bottom toolbar and flick-to-dismiss
+        // beats a custom gallery; the hero shows the first image, so that's
+        // the one that opens).
         NSURL *url = [items.firstObject[@"url"] isKindOfClass:[NSURL class]] ? items.firstObject[@"url"] : nil;
         if (ApolloFeedRouteURLToNativeHandler(sender, url)) return;
 
@@ -582,6 +582,29 @@ static BOOL ApolloFeedRouteURLToNativeHandler(id startNode, NSURL *url) {
         if (items.count > 0) {
             ApolloPresentImageChestItems(items, sourceView, 0);
         }
+    } @catch (__unused NSException *e) {}
+}
+
+// Compact thumbnails we filled have no Apollo-wired tap action (Apollo only
+// wires one for posts with media), so we attach this. Walks to the cell and
+// replays its thumbnailTappedWithSender: — intercepted by the hook below,
+// which points the link at the image so Apollo presents its native viewer.
+// No-ops unless the post is still an eligible self post, so a reused
+// thumbnail node on a media post can't double-fire Apollo's own action.
+- (void)compactThumbTapped:(id)sender {
+    @try {
+        id target = sender;
+        for (int hops = 0; target && hops < 24; hops++) {
+            if ([target respondsToSelector:@selector(thumbnailTappedWithSender:)]) break;
+            target = [target respondsToSelector:@selector(supernode)] ? [target supernode] : nil;
+        }
+        if (!target) {
+            ApolloLog(@"[FeedThumb] compact thumb tap: no cell handler in chain");
+            return;
+        }
+        RDKLink *link = ApolloFeedIvar(target, "link");
+        if (!(link.selfPost && ApolloFeedThumbnailURLForLink(link))) return;
+        ((void (*)(id, SEL, id))objc_msgSend)(target, @selector(thumbnailTappedWithSender:), sender);
     } @catch (__unused NSException *e) {}
 }
 @end
@@ -763,6 +786,22 @@ static void ApolloFeedReapplyCleanup(id node, BOOL triggerLayout) {
         if (url) {
             id thumb = MSHookIvar<id>(self, "thumbnailNode");
             ApolloFeedApplyThumbnailURL(thumb, url);
+            // Apollo wires the thumbnail's tap action only for posts with
+            // media, so the squares we fill are inert — taps fell through to
+            // the cell and opened the thread (review feedback on the PR).
+            // Wire our own target once per node; the handler re-checks
+            // eligibility, so node reuse on media posts stays Apollo's.
+            if (![objc_getAssociatedObject(thumb, &kApolloFeedCompactTapWiredKey) boolValue] &&
+                [thumb respondsToSelector:@selector(addTarget:action:forControlEvents:)]) {
+                objc_setAssociatedObject(thumb, &kApolloFeedCompactTapWiredKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    ASNetworkImageNode *thumbNode = (ASNetworkImageNode *)thumb;
+                    thumbNode.userInteractionEnabled = YES;
+                    [thumbNode addTarget:[ApolloFeedHeroTapHandler shared]
+                                  action:@selector(compactThumbTapped:)
+                        forControlEvents:ApolloFeedControlEventTouchUpInside];
+                });
+            }
         }
     } @catch (__unused NSException *e) {}
     return spec;
@@ -770,10 +809,14 @@ static void ApolloFeedReapplyCleanup(id node, BOOL triggerLayout) {
 
 %end
 
-// Compact cells route thumbnail taps through the cell node. For text posts we
-// filled the thumbnail ourselves, so route the tap to the fullscreen image
-// viewer (matching image posts) instead of whatever Apollo would do with a
-// medialess self post. Everything else falls through to the native handler.
+// Compact cells: Apollo only wires a thumbnail tap action when the post has
+// media, so for our filled-in text post thumbnails the tap fell through to
+// the cell and opened the thread (review feedback on the PR). Intercept the
+// tap and replay Apollo's own handler with the link temporarily pointed at
+// the embedded image: Apollo then presents its native media viewer — bottom
+// toolbar wired to the post's votes/comments, flick-to-dismiss — exactly as
+// if this were an image post. URL and selfPost are restored immediately
+// after the synchronous presentation.
 %hook _TtC6Apollo19CompactPostCellNode
 
 - (void)thumbnailTappedWithSender:(id)sender {
@@ -782,23 +825,19 @@ static void ApolloFeedReapplyCleanup(id node, BOOL triggerLayout) {
             RDKLink *link = MSHookIvar<RDKLink *>(self, "link");
             if (link && link.selfPost && ApolloFeedThumbnailURLForLink(link)) {
                 NSArray<NSDictionary *> *items = ApolloFeedViewerItemsForLink(link);
-                ASDisplayNode *node = (ASDisplayNode *)self;
-                UIView *sourceView = [node isNodeLoaded] ? [node view] : nil;
-
-                // Multi-image posts: swipeable album viewer (see heroTapped).
-                if (items.count > 1) {
-                    ApolloLog(@"[FeedThumb] compact thumbnail tapped: presenting %lu-image album",
-                              (unsigned long)items.count);
-                    if (ApolloPresentImageChestItems(items, sourceView, 0)) return;
-                }
-
-                // Single image: native MediaViewer when a handler is reachable.
-                NSURL *url = [items.firstObject[@"url"] isKindOfClass:[NSURL class]] ? items.firstObject[@"url"] : nil;
-                if (ApolloFeedRouteURLToNativeHandler(self, url)) return;
-
-                ApolloLog(@"[FeedThumb] compact thumbnail tapped on text post: presenting %lu image(s)",
-                          (unsigned long)items.count);
-                if (items.count > 0 && ApolloPresentImageChestItems(items, sourceView, 0)) {
+                NSURL *imageURL = [items.firstObject[@"url"] isKindOfClass:[NSURL class]] ? items.firstObject[@"url"] : nil;
+                if (imageURL) {
+                    ApolloLog(@"[FeedThumb] compact thumbnail tapped: replaying native handler with %@", imageURL.host);
+                    NSURL *originalURL = link.URL;
+                    BOOL originalSelfPost = link.selfPost;
+                    link.URL = imageURL;
+                    link.selfPost = NO;
+                    @try {
+                        %orig;
+                    } @finally {
+                        link.URL = originalURL;
+                        link.selfPost = originalSelfPost;
+                    }
                     return;
                 }
             }

--- a/src/ApolloFeedTextPostThumbnails.xm
+++ b/src/ApolloFeedTextPostThumbnails.xm
@@ -106,14 +106,6 @@ typedef NS_ENUM(unsigned char, ApolloFeedStackAlign) {
 // ASControlNodeEventTouchUpInside from Texture's ASControlNode.h.
 static const NSUInteger ApolloFeedControlEventTouchUpInside = 1 << 4;
 
-// Tweak.h already declares a bare ASImageNode; extend it with the display-node
-// surface the badge needs (the runtime class is a real ASDisplayNode subclass).
-@interface ASImageNode (ApolloFeedThumb)
-@property (nullable, nonatomic, strong) UIImage *image;
-@property (nonatomic, getter=isHidden) BOOL hidden;
-- (id)style;
-@end
-
 @interface ASLayoutSpec : NSObject
 @property (nullable, nonatomic) NSArray *children;
 - (id)style;
@@ -135,20 +127,8 @@ static const NSUInteger ApolloFeedControlEventTouchUpInside = 1 << 4;
 + (instancetype)ratioLayoutSpecWithRatio:(CGFloat)ratio child:(id)child;
 @end
 
-@interface ASOverlayLayoutSpec : ASLayoutSpec
-+ (instancetype)overlayLayoutSpecWithChild:(id)child overlay:(id)overlay;
-@end
-
 @interface ASInsetLayoutSpec : ASLayoutSpec
 + (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id)child;
-@end
-
-// ASRelativeLayoutSpecPosition: None=0, Start=1, Center=2, End=3.
-@interface ASRelativeLayoutSpec : ASLayoutSpec
-+ (instancetype)relativePositionLayoutSpecWithHorizontalPosition:(NSUInteger)horizontalPosition
-                                                verticalPosition:(NSUInteger)verticalPosition
-                                                    sizingOption:(NSUInteger)sizingOption
-                                                           child:(id)child;
 @end
 
 // ASLayoutElementStyle subset for fixing the hero height.
@@ -178,8 +158,10 @@ static char kApolloFeedThumbRatioKey;
 // layout for large-mode text/link posts (created once per node, reused).
 static char kApolloFeedHeroNodeKey;
 
-// Associated-object: the "Text Post" badge node overlaid on the hero.
-static char kApolloFeedBadgeNodeKey;
+// Apollo's standard large-cell horizontal content margin (matches the feed
+// search bar and the title/body text), so the rounded hero lines up with the
+// rest of the cell instead of bleeding to the screen edge.
+static const CGFloat kApolloFeedHeroSideInset = 16.0;
 
 // Associated-object on the hero node: the RDKLink it currently displays
 // (updated every layout pass — cells get reused for different links).
@@ -609,31 +591,6 @@ static id ApolloFeedIvar(id obj, const char *name);
 }
 @end
 
-// "Text Post" pill rendered once — overlaid bottom-right on the hero so the
-// feed makes clear this thumbnail belongs to a text post (issue #419).
-static UIImage *ApolloFeedTextPostBadgeImage(void) {
-    static UIImage *sBadge = nil;
-    static dispatch_once_t once;
-    dispatch_once(&once, ^{
-        NSString *text = @"Text Post";
-        NSDictionary *attrs = @{
-            NSFontAttributeName: [UIFont systemFontOfSize:10.0 weight:UIFontWeightSemibold],
-            NSForegroundColorAttributeName: [UIColor whiteColor],
-        };
-        CGSize textSize = [text sizeWithAttributes:attrs];
-        CGFloat hPad = 7.0, vPad = 3.0;
-        CGSize size = CGSizeMake(ceil(textSize.width) + hPad * 2.0, ceil(textSize.height) + vPad * 2.0);
-        UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size];
-        sBadge = [renderer imageWithActions:^(UIGraphicsImageRendererContext *context) {
-            [[UIColor colorWithWhite:0.0 alpha:0.6] setFill];
-            [[UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, 0, size.width, size.height)
-                                        cornerRadius:size.height / 2.0] fill];
-            [text drawAtPoint:CGPointMake(hPad, vPad) withAttributes:attrs];
-        }];
-    });
-    return sBadge;
-}
-
 // Apply the URL to a thumbnail image node (idempotent — skips if already set).
 static void ApolloFeedApplyThumbnailURL(id thumbNode, NSURL *url) {
     if (!thumbNode || !url) return;
@@ -882,12 +839,10 @@ static void ApolloFeedReapplyCleanup(id node, BOOL triggerLayout) {
 - (id)layoutSpecThatFits:(struct ApolloFeedThumbSizeRange)constrainedSize {
     id origSpec = %orig;
     if (!sFeedTextPostThumbnails) {
-        // Toggled off mid-session: a previously injected hero/badge would
-        // otherwise keep its last frame even though it left the layout spec.
+        // Toggled off mid-session: a previously injected hero would otherwise
+        // keep its last frame even though it left the layout spec.
         ASDisplayNode *staleHero = objc_getAssociatedObject(self, &kApolloFeedHeroNodeKey);
         if (staleHero) staleHero.hidden = YES;
-        ASDisplayNode *staleBadge = objc_getAssociatedObject(self, &kApolloFeedBadgeNodeKey);
-        if (staleBadge) staleBadge.hidden = YES;
         // Even without a thumbnail, a naked image URL leading the preview
         // text is noise — show the post's actual text, like a normal text
         // post. (Link card stays native.)
@@ -1002,37 +957,16 @@ static void ApolloFeedReapplyCleanup(id node, BOOL triggerLayout) {
 
         id heroSpec = [ratioCls ratioLayoutSpecWithRatio:ratio child:hero];
 
-        // "Text Post" pill pinned to the hero's bottom-right corner, so it's
-        // obvious in the feed that this thumbnail belongs to a text post.
-        Class overlayCls = objc_getClass("ASOverlayLayoutSpec");
-        Class relativeCls = objc_getClass("ASRelativeLayoutSpec");
+        // RichMediaNode spans the cell edge-to-edge (Apollo's image posts are
+        // intentionally full-bleed), but a rounded-corner thumbnail looks
+        // clipped flush against the screen edge. Inset it to Apollo's standard
+        // content margin so it lines up with the title/body text (review
+        // feedback on #426).
         Class insetCls = objc_getClass("ASInsetLayoutSpec");
-        if (overlayCls && relativeCls && insetCls) {
-            ASImageNode *badge = (ASImageNode *)objc_getAssociatedObject(self, &kApolloFeedBadgeNodeKey);
-            if (!badge) {
-                Class imgNodeCls = objc_getClass("ASImageNode");
-                badge = imgNodeCls ? [[imgNodeCls alloc] init] : nil;
-                if (badge) {
-                    UIImage *pill = ApolloFeedTextPostBadgeImage();
-                    badge.image = pill;
-                    id badgeStyle = [badge style];
-                    if ([badgeStyle respondsToSelector:@selector(setPreferredSize:)]) {
-                        ((ApolloFeedLayoutStyle *)badgeStyle).preferredSize = pill.size;
-                    }
-                    [(ASDisplayNode *)self addSubnode:(ASDisplayNode *)badge];
-                    objc_setAssociatedObject(self, &kApolloFeedBadgeNodeKey, badge,
-                                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-                }
-            }
-            if (badge) {
-                badge.hidden = NO;
-                id positioned = [relativeCls relativePositionLayoutSpecWithHorizontalPosition:3 /* End */
-                                                                             verticalPosition:3 /* End */
-                                                                                 sizingOption:0
-                                                                                        child:badge];
-                id inset = [insetCls insetLayoutSpecWithInsets:UIEdgeInsetsMake(0, 0, 8, 8) child:positioned];
-                heroSpec = [overlayCls overlayLayoutSpecWithChild:heroSpec overlay:inset] ?: heroSpec;
-            }
+        if (insetCls) {
+            id padded = [insetCls insetLayoutSpecWithInsets:UIEdgeInsetsMake(0, kApolloFeedHeroSideInset, 0, kApolloFeedHeroSideInset)
+                                                      child:heroSpec];
+            if (padded) heroSpec = padded;
         }
 
         id stacked = [stackCls stackLayoutSpecWithDirection:ApolloFeedStackDirectionVertical

--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -1294,7 +1294,6 @@ static CGFloat ApolloAspectRatioFromURL(NSURL *url) {
 @end
 
 static UIViewController *ApolloTopVCFromView(UIView *v);
-static BOOL ApolloPresentImageChestItems(NSArray<NSDictionary *> *items, UIView *sourceView, NSInteger initialIndex);
 static void ApolloOpenImageChestURLNormally(NSURL *url);
 static BOOL ApolloPresentOrResolveImageChestAlbumURL(NSURL *url, UIView *sourceView, void (^fallback)(void));
 
@@ -1385,7 +1384,11 @@ static UIViewController *ApolloTopVCFromView(UIView *v) {
     return vc;
 }
 
-static BOOL ApolloPresentImageChestItems(NSArray<NSDictionary *> *items, UIView *sourceView, NSInteger initialIndex) {
+// Non-static: also used by ApolloFeedTextPostThumbnails to open a text post's
+// embedded images fullscreen (declared in ApolloCommon.h). Despite the name,
+// the viewer is a generic zoomable image-album viewer; items are dictionaries
+// with an @"url" NSURL.
+BOOL ApolloPresentImageChestItems(NSArray<NSDictionary *> *items, UIView *sourceView, NSInteger initialIndex) {
     if (items.count == 0) return NO;
     UIViewController *top = ApolloTopVCFromView(sourceView);
     if (!top) return NO;

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -15,6 +15,7 @@ extern BOOL sBlockAnnouncements;
 extern BOOL sShowDeletedComments;
 extern BOOL sTapToRevealDeletedComments;
 extern BOOL sShowRecentlyReadThumbnails;
+extern BOOL sFeedTextPostThumbnails;
 extern NSInteger sPreferredGIFFallbackFormat;
 
 extern NSInteger sReadPostMaxCount;

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -15,6 +15,7 @@ BOOL sBlockAnnouncements = NO;
 BOOL sShowDeletedComments = NO;
 BOOL sTapToRevealDeletedComments = NO;
 BOOL sShowRecentlyReadThumbnails = YES;
+BOOL sFeedTextPostThumbnails = YES;
 NSInteger sPreferredGIFFallbackFormat = 1; // 0=GIF, 1=MP4
 
 NSInteger sReadPostMaxCount = 0;

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -660,7 +660,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionBackupRestore: return 2;
         case SectionAPIKeys: return 9; // 7 text fields + Can't sign in? + API key setup guide
         case SectionGeneral: return sShowDeletedComments ? 11 : 10;
-        case SectionMedia: return (sShowUserAvatars ? 14 : 13) + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows);
+        case SectionMedia: return (sShowUserAvatars ? 15 : 14) + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows);
         case SectionSubreddits: return sSubredditListEnhancements ? 9 : 8;
         case SectionNotificationBackend: return 3; // URL + Registration Token + Test Connection
         case SectionAbout: return 5; // GitHub + Reddit + Thanks To + Export Logs + Version
@@ -1158,16 +1158,21 @@ typedef NS_ENUM(NSInteger, Tag) {
             return cell;
         }
         case 10:
+            return [self switchCellWithIdentifier:@"Cell_Media_TextPostThumbnails"
+                                            label:@"Text Post Thumbnails"
+                                               on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyFeedTextPostThumbnails]
+                                           action:@selector(textPostThumbnailsSwitchToggled:)];
+        case 11:
             return [self switchCellWithIdentifier:@"Cell_Media_UserAvatars"
                                             label:@"Show User Profile Pictures"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars]
                                            action:@selector(userAvatarsSwitchToggled:)];
-        case 11:
+        case 12:
             return [self switchCellWithIdentifier:@"Cell_Media_ProfileTabAvatar"
                                             label:@"Profile Picture Tab Icon"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon]
                                            action:@selector(profileTabAvatarSwitchToggled:)];
-        case 12: {
+        case 13: {
             BOOL avatarsOn = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars];
             if (avatarsOn) {
                 UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_ClearAvatarCache"];
@@ -1188,7 +1193,7 @@ typedef NS_ENUM(NSInteger, Tag) {
             cell.selectionStyle = UITableViewCellSelectionStyleDefault;
             return cell;
         }
-        case 13: {
+        case 14: {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_ClearLinkPreviewCache"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell_Media_ClearLinkPreviewCache"];
@@ -1605,9 +1610,9 @@ typedef NS_ENUM(NSInteger, Tag) {
             [self presentLinkPreviewModeSheetFromSourceView:cell body:NO];
         } else if (row == 9) {
             [self presentLinkPreviewCardColorSheetFromSourceView:cell];
-        } else if (row == 12 && sShowUserAvatars) {
+        } else if (row == 13 && sShowUserAvatars) {
             [self promptClearProfilePictureCacheFromSourceView:cell];
-        } else if ((row == 12 && !sShowUserAvatars) || (row == 13 && sShowUserAvatars)) {
+        } else if ((row == 13 && !sShowUserAvatars) || (row == 14 && sShowUserAvatars)) {
             [self promptClearLinkPreviewCacheFromSourceView:cell];
         }
     } else if (indexPath.section == SectionNotificationBackend && indexPath.row == 2) {
@@ -1651,7 +1656,7 @@ typedef NS_ENUM(NSInteger, Tag) {
     }
     if (indexPath.section == SectionMedia) {
         NSInteger row = ApolloMediaLogicalRow(indexPath.row);
-        return (row == 0 || row == 1 || row == 2 || row == 5 || row == 6 || row == 7 || row == 8 || row == 9 || row == 12 || row == 13);
+        return (row == 0 || row == 1 || row == 2 || row == 5 || row == 6 || row == 7 || row == 8 || row == 9 || row == 13 || row == 14);
     }
     if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 || indexPath.row == 3)) return YES;
     if (indexPath.section == SectionNotificationBackend && indexPath.row == 2) return YES;
@@ -2035,19 +2040,24 @@ typedef NS_ENUM(NSInteger, Tag) {
     [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloSubredditHeaderToggleChangedNotification" object:nil];
 }
 
+- (void)textPostThumbnailsSwitchToggled:(UISwitch *)sender {
+    sFeedTextPostThumbnails = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sFeedTextPostThumbnails forKey:UDKeyFeedTextPostThumbnails];
+}
+
 - (void)userAvatarsSwitchToggled:(UISwitch *)sender {
     BOOL wasOn = sShowUserAvatars;
     sShowUserAvatars = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sShowUserAvatars forKey:UDKeyShowUserAvatars];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloUserAvatarsToggleChangedNotification" object:nil];
     if (sShowUserAvatars == wasOn) return;
-    NSArray<NSIndexPath *> *paths = @[[NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(12) inSection:SectionMedia]];
+    NSArray<NSIndexPath *> *paths = @[[NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(13) inSection:SectionMedia]];
     if (sShowUserAvatars) {
         [self.tableView insertRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
     } else {
         [self.tableView deleteRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
     }
-    [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(sShowUserAvatars ? 13 : 12) inSection:SectionMedia]]
+    [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(sShowUserAvatars ? 14 : 13) inSection:SectionMedia]]
                           withRowAnimation:UITableViewRowAnimationNone];
 }
 

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1053,6 +1053,7 @@ static void initializeRandomSources() {
                                     UDKeyTapToRevealDeletedComments: @NO,
                                     UDKeyEnableFlairColors: @NO,
                                     UDKeyShowRecentlyReadThumbnails: @YES,
+                                    UDKeyFeedTextPostThumbnails: @YES,
                                     UDKeyPreferredGIFFallbackFormat: @1,
                                     UDKeyUnmuteCommentsVideos: @0,
                                     UDKeyProxyImgurDDG: @NO,
@@ -1105,6 +1106,7 @@ static void initializeRandomSources() {
     sShowDeletedComments = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowDeletedComments];
     sTapToRevealDeletedComments = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyTapToRevealDeletedComments];
     sShowRecentlyReadThumbnails = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowRecentlyReadThumbnails];
+    sFeedTextPostThumbnails = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyFeedTextPostThumbnails];
     sPreferredGIFFallbackFormat = ([[NSUserDefaults standardUserDefaults] integerForKey:UDKeyPreferredGIFFallbackFormat] == 0) ? 0 : 1;
     sReadPostMaxCount = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyReadPostMaxCount];
     sUnmuteCommentsVideos = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyUnmuteCommentsVideos];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -86,6 +86,9 @@ static NSString *const UDKeyNotificationBackendURL = @"NotificationBackendURL";
 // endpoints (/v1/device, /v1/device/{apns}/account[s]).
 static NSString *const UDKeyNotificationBackendRegistrationToken = @"NotificationBackendRegistrationToken";
 
+// Feed thumbnails for text posts with embedded images (off = native behavior).
+static NSString *const UDKeyFeedTextPostThumbnails = @"FeedTextPostThumbnails";
+
 // Rich link preview cards: 0 = Off, 1 = Compact, 2 = Full.
 static NSString *const UDKeyLinkPreviewBodyMode = @"LinkPreviewBodyMode";
 static NSString *const UDKeyLinkPreviewCommentsMode = @"LinkPreviewCommentsMode";


### PR DESCRIPTION
Fixes #419.

## What

Text post thumbnails (introduced in #351) looked identical to image posts in the feed, but tapping one opened the thread instead of the image — there was no way to know what a tap would do before tapping. This addresses the inconsistency three ways, covering both options proposed in the issue plus the badge suggestion from the comments:

- **Settings toggle** — Settings > Media > **Text Post Thumbnails** (default on, preserving current behavior). Off restores Apollo's native look: no thumbnails on text posts. Naked embedded-image URLs are still stripped from the body preview either way, so the preview shows the post's actual text rather than leading with a `preview.redd.it/...` wall.
- **"Text Post" badge** — large-mode heroes carry a small pill in the bottom-right corner of the image, so text posts are distinguishable from image posts at a glance (same idea as link previews labeling their domain).
- **Predictable taps** — tapping the thumbnail now opens the embedded image, matching image posts. It routes through Apollo's own link-tap handler on `RichMediaNode` (`ApolloLink` attribute) into the **native MediaViewer** — bottom toolbar wired to the post's votes/comments, flick-to-dismiss — exactly like tapping an image post. Tapping the title or anywhere else still opens the thread, as before.

## How

- New `UDKeyFeedTextPostThumbnails` / `sFeedTextPostThumbnails` wired through ApolloState + registerDefaults, with a switch row in the Media section (avatar/cache row indices shifted accordingly). Toggling off mid-session hides already-injected heroes; the feed is fully native after a refresh.
- The badge is a pre-rendered pill image on an `ASImageNode`, overlaid bottom-right on the hero via `ASOverlayLayoutSpec`/`ASRelativeLayoutSpec`/`ASInsetLayoutSpec` (all guarded by `objc_getClass`, falling back to no badge).
- The hero is an `ASControlNode` subclass, so the tap is plain target-action; compact mode intercepts `CompactPostCellNode thumbnailTappedWithSender:` for eligible text posts and falls through to `%orig` otherwise.
- Tapping replays Apollo's own `thumbnailTappedWithSender:` with the link's URL momentarily pointed at the embedded image (restored immediately after the synchronous presentation), so the presentation path is 100% Apollo's own — single image, native viewer, no custom gallery.

## Thumbnails

| 1. Toggle off: native text post, no thumbnail — and the body preview shows the post text, not the raw image URL | 2. Toggle on: thumbnail with the "Text Post" badge in the bottom-right corner | 3. Tapping the thumbnail opens the image in Apollo's native media viewer instead of the thread |
| :--: | :--: | :--: |
| <img width="320" alt="toggle off - native text post" src="https://github.com/user-attachments/assets/f53ad680-574b-4b14-92fc-f3eb9e61518d" /> | <img width="320" alt="toggle on - thumbnail with Text Post badge" src="https://github.com/user-attachments/assets/75894477-6c4e-4c47-9cb7-da43ad6aadf6" /> | <img width="320" alt="tap opens image in native viewer" src="https://github.com/user-attachments/assets/4ade9e3e-ef18-4208-9891-588d8a5b50e6" /> |

## Testing

Validated manually on-device (iOS 26, sideloaded): tapping a text post thumbnail opens the native MediaViewer; title/body taps still open the thread; badge renders correctly across aspect ratios; toggle off shows native no-thumbnail text posts with clean preview text, on/off applies live. Diagnostics under the `[FeedThumb]` log prefix.
