### PR TITLE
Add manual sign in fallback using an external browser and userscript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloTweetBuddy.xm \
 	$(SRC_DIR)/ApolloVisionOSFix.xm \
     $(SRC_DIR)/ApolloWebAuthViewController.m \
+    $(SRC_DIR)/ApolloManualSignInViewController.m \
     $(SRC_DIR)/CustomAPIViewController.m \
     $(SRC_DIR)/TranslationSettingsViewController.m \
     $(SRC_DIR)/SavedCategoriesViewController.m \

--- a/src/ApolloManualSignInViewController.h
+++ b/src/ApolloManualSignInViewController.h
@@ -1,0 +1,14 @@
+#import <UIKit/UIKit.h>
+
+// Manual sign-in fallback for devices where the in-app WKWebView can't render
+// Reddit's login/consent page (notably iOS 15.3.1 and below). The user signs in
+// using an external Gecko browser (e.g. Reynard) with the companion Tampermonkey
+// userscript, which surfaces the OAuth authorization code; they paste it back
+// here and we synthesize the redirect callback to complete the existing sign-in.
+@interface ApolloManualSignInViewController : UIViewController
+
+- (instancetype)initWithAuthURL:(NSURL *)authURL
+                 callbackScheme:(NSString *)scheme
+                     onComplete:(void (^)(NSURL *callbackURL))onComplete;
+
+@end

--- a/src/ApolloManualSignInViewController.m
+++ b/src/ApolloManualSignInViewController.m
@@ -1,0 +1,275 @@
+#import "ApolloManualSignInViewController.h"
+#import "ApolloCommon.h"
+
+// Raw userscript URL. Opening a *.user.js link in a Gecko browser triggers
+// Tampermonkey/Violentmonkey's one-tap install prompt — far better UX than
+// pasting raw script text into the editor — so we always hand over the link.
+static NSString *const kApolloUserscriptURL =
+    @"https://raw.githubusercontent.com/Apollo-Reborn/Apollo-Reborn/refs/heads/main/userscript/apollo-oauth-helper.user.js";
+
+// Extracts a query OR fragment parameter from a URL string (defined below).
+static NSString *ARExtractParam(NSString *urlString, NSString *name);
+
+@interface ApolloManualSignInViewController ()
+@property (nonatomic, copy) NSURL *authURL;
+@property (nonatomic, copy) NSString *callbackScheme;
+@property (nonatomic, copy) void (^onComplete)(NSURL *callbackURL);
+@property (nonatomic, strong) UITextView *codeTextView;
+@end
+
+@implementation ApolloManualSignInViewController
+
+- (instancetype)initWithAuthURL:(NSURL *)authURL
+                 callbackScheme:(NSString *)scheme
+                     onComplete:(void (^)(NSURL *callbackURL))onComplete {
+    self = [super init];
+    if (self) {
+        _authURL = [authURL copy];
+        _callbackScheme = [scheme copy];
+        _onComplete = [onComplete copy];
+    }
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Manual Sign-In";
+    self.view.backgroundColor = [UIColor systemBackgroundColor];
+
+    UIScrollView *scroll = [UIScrollView new];
+    scroll.translatesAutoresizingMaskIntoConstraints = NO;
+    scroll.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
+    [self.view addSubview:scroll];
+
+    UIStackView *stack = [UIStackView new];
+    stack.axis = UILayoutConstraintAxisVertical;
+    stack.spacing = 14;
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    [scroll addSubview:stack];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [scroll.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor],
+        [scroll.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [scroll.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [scroll.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+
+        [stack.topAnchor constraintEqualToAnchor:scroll.contentLayoutGuide.topAnchor constant:20],
+        [stack.bottomAnchor constraintEqualToAnchor:scroll.contentLayoutGuide.bottomAnchor constant:-32],
+        [stack.leadingAnchor constraintEqualToAnchor:scroll.frameLayoutGuide.leadingAnchor constant:20],
+        [stack.trailingAnchor constraintEqualToAnchor:scroll.frameLayoutGuide.trailingAnchor constant:-20],
+    ]];
+
+    [stack addArrangedSubview:[self _headingLabel:@"Sign in with an external browser"]];
+    [stack addArrangedSubview:[self _bodyLabel:
+        @"Use this if the Reddit login page won't load in the in-app browser "
+        @"(common on iOS 15.3.1 and earlier). You'll sign in using a Gecko-based "
+        @"browser such as Reynard (v0.3.0 or later) with the helper userscript, "
+        @"then paste the authorization code back here."]];
+
+    [stack addArrangedSubview:[self _bodyLabel:
+        @"1.  In Reynard, install the Tampermonkey add-on.\n"
+        @"2.  Tap “Copy Userscript Link”, paste it into Reynard's address bar, "
+        @"and tap Install when Tampermonkey prompts you.\n"
+        @"3.  Tap “Copy Sign-In URL”, open it in Reynard, and sign in to Reddit.\n"
+        @"4.  When Reddit asks to connect your account, tap “Accept.“\n"
+        @"5.  A popup will appear with your authorization code. Copy it, return here, "
+        @"paste it below, and tap “Complete Sign-In”."]];
+
+    [stack addArrangedSubview:[self _button:@"Copy Userscript Link" filled:NO action:@selector(_copyUserscriptLink:)]];
+    [stack addArrangedSubview:[self _button:@"Copy Sign-In URL" filled:NO action:@selector(_copyAuthURL:)]];
+
+    [stack addArrangedSubview:[self _spacer:6]];
+    [stack addArrangedSubview:[self _headingLabel:@"Authorization code"]];
+
+    UITextView *tv = [UITextView new];
+    tv.font = [UIFont monospacedSystemFontOfSize:14 weight:UIFontWeightRegular];
+    tv.backgroundColor = [UIColor secondarySystemBackgroundColor];
+    tv.textColor = [UIColor labelColor];
+    tv.layer.cornerRadius = 10;
+    tv.textContainerInset = UIEdgeInsetsMake(12, 10, 12, 10);
+    tv.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    tv.autocorrectionType = UITextAutocorrectionTypeNo;
+    tv.spellCheckingType = UITextSpellCheckingTypeNo;
+    tv.scrollEnabled = NO;
+    tv.translatesAutoresizingMaskIntoConstraints = NO;
+    [tv.heightAnchor constraintGreaterThanOrEqualToConstant:80].active = YES;
+    self.codeTextView = tv;
+    [stack addArrangedSubview:tv];
+
+    [stack addArrangedSubview:[self _button:@"Paste from Clipboard" filled:NO action:@selector(_pasteFromClipboard:)]];
+    [stack addArrangedSubview:[self _spacer:6]];
+    [stack addArrangedSubview:[self _button:@"Complete Sign-In" filled:YES action:@selector(_completeTapped:)]];
+}
+
+#pragma mark - Actions
+
+- (void)_copyUserscriptLink:(UIButton *)sender {
+    [UIPasteboard generalPasteboard].string = kApolloUserscriptURL;
+    [self _flashButton:sender title:@"Copied!"];
+}
+
+- (void)_copyAuthURL:(UIButton *)sender {
+    NSString *urlString = self.authURL.absoluteString;
+    if (urlString.length) {
+        [UIPasteboard generalPasteboard].string = urlString;
+        [self _flashButton:sender title:@"Copied!"];
+    }
+}
+
+- (void)_pasteFromClipboard:(UIButton *)sender {
+    NSString *clip = [UIPasteboard generalPasteboard].string;
+    if (clip.length) {
+        self.codeTextView.text = clip;
+    } else {
+        [self _flashButton:sender title:@"Clipboard empty"];
+    }
+}
+
+- (void)_completeTapped:(UIButton *)sender {
+    NSURL *callback = [self _buildCallbackURLFromText:self.codeTextView.text];
+    if (!callback) {
+        [self _alert:@"No code entered"
+             message:@"Paste the authorization code (or the full callback URL) "
+                     @"shown by the helper, then try again."];
+        return;
+    }
+    ApolloLog(@"[ManualSignIn] completing with callback: %@", callback);
+    if (self.onComplete) self.onComplete(callback);
+}
+
+#pragma mark - Callback synthesis
+
+// Accepts either the raw authorization code or a full callback URL, and rebuilds
+// the redirect Reddit would have produced: <redirect_uri>?state=<state>&code=<code>.
+- (NSURL *)_buildCallbackURLFromText:(NSString *)text {
+    NSString *trimmed = [text stringByTrimmingCharactersInSet:
+        [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (trimmed.length == 0) return nil;
+
+    NSString *code = nil;
+    NSString *state = nil;
+
+    if ([trimmed containsString:@"code="]) {
+        code  = ARExtractParam(trimmed, @"code");
+        state = ARExtractParam(trimmed, @"state");
+    }
+    if (code.length == 0) {
+        code = trimmed; // treat the whole paste as the bare code
+    }
+
+    // Pull redirect_uri (and state, if not already found) from the auth URL.
+    NSString *redirectURI = nil;
+    NSURLComponents *authComponents =
+        [NSURLComponents componentsWithURL:self.authURL resolvingAgainstBaseURL:NO];
+    for (NSURLQueryItem *item in authComponents.queryItems) {
+        if ([item.name isEqualToString:@"redirect_uri"]) {
+            redirectURI = item.value;
+        } else if ([item.name isEqualToString:@"state"] && state.length == 0) {
+            state = item.value;
+        }
+    }
+    if (redirectURI.length == 0) {
+        redirectURI = [NSString stringWithFormat:@"%@://", self.callbackScheme ?: @"apollo"];
+    }
+
+    NSURLComponents *cb = [NSURLComponents componentsWithString:redirectURI];
+    if (cb) {
+        NSMutableArray<NSURLQueryItem *> *items = [NSMutableArray array];
+        if (state.length) [items addObject:[NSURLQueryItem queryItemWithName:@"state" value:state]];
+        [items addObject:[NSURLQueryItem queryItemWithName:@"code" value:code]];
+        cb.queryItems = items;
+        if (cb.URL) return cb.URL;
+    }
+
+    // Fallback: assemble the string by hand (redirect_uri may be just "scheme://").
+    NSCharacterSet *allowed = [NSCharacterSet URLQueryAllowedCharacterSet];
+    NSMutableString *str = [NSMutableString stringWithString:redirectURI];
+    [str appendString:[redirectURI containsString:@"?"] ? @"&" : @"?"];
+    if (state.length) {
+        [str appendFormat:@"state=%@&",
+            [state stringByAddingPercentEncodingWithAllowedCharacters:allowed]];
+    }
+    [str appendFormat:@"code=%@",
+        [code stringByAddingPercentEncodingWithAllowedCharacters:allowed]];
+    return [NSURL URLWithString:str];
+}
+
+// Extracts a query OR fragment parameter from a URL string.
+static NSString *ARExtractParam(NSString *urlString, NSString *name) {
+    NSURLComponents *c = [NSURLComponents componentsWithString:urlString];
+    if (!c) return nil;
+    for (NSURLQueryItem *item in c.queryItems) {
+        if ([item.name isEqualToString:name]) return item.value;
+    }
+    if (c.fragment.length) {
+        NSURLComponents *fc = [NSURLComponents new];
+        fc.query = c.fragment; // reuse query parser on the fragment
+        for (NSURLQueryItem *item in fc.queryItems) {
+            if ([item.name isEqualToString:name]) return item.value;
+        }
+    }
+    return nil;
+}
+
+#pragma mark - UI helpers
+
+- (UILabel *)_headingLabel:(NSString *)text {
+    UILabel *l = [UILabel new];
+    l.text = text;
+    l.numberOfLines = 0;
+    l.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
+    l.textColor = [UIColor labelColor];
+    return l;
+}
+
+- (UILabel *)_bodyLabel:(NSString *)text {
+    UILabel *l = [UILabel new];
+    l.text = text;
+    l.numberOfLines = 0;
+    l.font = [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline];
+    l.textColor = [UIColor secondaryLabelColor];
+    return l;
+}
+
+- (UIView *)_spacer:(CGFloat)height {
+    UIView *v = [UIView new];
+    [v.heightAnchor constraintEqualToConstant:height].active = YES;
+    return v;
+}
+
+- (UIButton *)_button:(NSString *)title filled:(BOOL)filled action:(SEL)action {
+    UIButtonConfiguration *cfg = filled
+        ? [UIButtonConfiguration filledButtonConfiguration]
+        : [UIButtonConfiguration tintedButtonConfiguration];
+    cfg.title = title;
+    cfg.cornerStyle = UIButtonConfigurationCornerStyleLarge;
+    cfg.contentInsets = NSDirectionalEdgeInsetsMake(12, 16, 12, 16);
+
+    UIButton *b = [UIButton buttonWithType:UIButtonTypeSystem];
+    b.configuration = cfg;
+    [b addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
+    return b;
+}
+
+- (void)_flashButton:(UIButton *)button title:(NSString *)title {
+    UIButtonConfiguration *cfg = button.configuration;
+    NSString *original = cfg.title;
+    cfg.title = title;
+    button.configuration = cfg;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.3 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        UIButtonConfiguration *c = button.configuration;
+        c.title = original;
+        button.configuration = c;
+    });
+}
+
+- (void)_alert:(NSString *)title message:(NSString *)message {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title
+                                                                  message:message
+                                                           preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+@end

--- a/src/ApolloManualSignInViewController.m
+++ b/src/ApolloManualSignInViewController.m
@@ -15,6 +15,7 @@ static NSString *ARExtractParam(NSString *urlString, NSString *name);
 @property (nonatomic, copy) NSString *callbackScheme;
 @property (nonatomic, copy) void (^onComplete)(NSURL *callbackURL);
 @property (nonatomic, strong) UITextView *codeTextView;
+@property (nonatomic, strong) UIScrollView *scrollView;
 @end
 
 @implementation ApolloManualSignInViewController
@@ -40,6 +41,7 @@ static NSString *ARExtractParam(NSString *urlString, NSString *name);
     scroll.translatesAutoresizingMaskIntoConstraints = NO;
     scroll.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
     [self.view addSubview:scroll];
+    self.scrollView = scroll;
 
     UIStackView *stack = [UIStackView new];
     stack.axis = UILayoutConstraintAxisVertical;
@@ -99,9 +101,48 @@ static NSString *ARExtractParam(NSString *urlString, NSString *name);
     [stack addArrangedSubview:[self _button:@"Paste from Clipboard" filled:NO action:@selector(_pasteFromClipboard:)]];
     [stack addArrangedSubview:[self _spacer:6]];
     [stack addArrangedSubview:[self _button:@"Complete Sign-In" filled:YES action:@selector(_completeTapped:)]];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(_keyboardWillChangeFrame:)
+                                                 name:UIKeyboardWillChangeFrameNotification
+                                               object:nil];
 }
 
 #pragma mark - Actions
+
+#pragma mark - Keyboard avoidance
+
+- (void)_keyboardWillChangeFrame:(NSNotification *)note {
+    NSDictionary *info = note.userInfo;
+    CGRect endFrame = [info[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+    // Convert from screen to view coordinates; on hide the end frame sits
+    // below the screen, so the overlap naturally computes to 0.
+    CGRect endInView = [self.view convertRect:endFrame fromView:nil];
+    CGFloat overlap = MAX(0, CGRectGetMaxY(self.view.bounds) - CGRectGetMinY(endInView));
+    // The scroll view already absorbs the bottom safe area through its
+    // adjusted content inset; only add the keyboard height above it.
+    CGFloat bottomInset = MAX(0, overlap - self.view.safeAreaInsets.bottom);
+
+    NSTimeInterval duration = [info[UIKeyboardAnimationDurationUserInfoKey] doubleValue];
+    UIViewAnimationOptions curve =
+        (UIViewAnimationOptions)([info[UIKeyboardAnimationCurveUserInfoKey] unsignedIntegerValue] << 16);
+
+    [UIView animateWithDuration:duration
+                          delay:0
+                        options:curve | UIViewAnimationOptionBeginFromCurrentState
+                     animations:^{
+        UIEdgeInsets inset = self.scrollView.contentInset;
+        inset.bottom = bottomInset;
+        self.scrollView.contentInset = inset;
+        self.scrollView.verticalScrollIndicatorInsets = inset;
+    } completion:^(BOOL finished) {
+        if (bottomInset > 0 && self.codeTextView.isFirstResponder) {
+            CGRect target = [self.scrollView convertRect:self.codeTextView.bounds
+                                                fromView:self.codeTextView];
+            [self.scrollView scrollRectToVisible:CGRectInset(target, 0, -12) animated:YES];
+        }
+    }];
+}
 
 - (void)_copyUserscriptLink:(UIButton *)sender {
     [UIPasteboard generalPasteboard].string = kApolloUserscriptURL;
@@ -303,6 +344,10 @@ static NSString *ARExtractParam(NSString *urlString, NSString *name) {
                                                            preferredStyle:UIAlertControllerStyleAlert];
     [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
     [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 @end

--- a/src/ApolloManualSignInViewController.m
+++ b/src/ApolloManualSignInViewController.m
@@ -238,30 +238,63 @@ static NSString *ARExtractParam(NSString *urlString, NSString *name) {
 }
 
 - (UIButton *)_button:(NSString *)title filled:(BOOL)filled action:(SEL)action {
-    UIButtonConfiguration *cfg = filled
-        ? [UIButtonConfiguration filledButtonConfiguration]
-        : [UIButtonConfiguration tintedButtonConfiguration];
-    cfg.title = title;
-    cfg.cornerStyle = UIButtonConfigurationCornerStyleLarge;
-    cfg.contentInsets = NSDirectionalEdgeInsetsMake(12, 16, 12, 16);
-
     UIButton *b = [UIButton buttonWithType:UIButtonTypeSystem];
-    b.configuration = cfg;
+    
+    // UIButtonConfiguration is iOS 15+. Apollo Reborn still loads on iOS 14
+    // (jailbreak), so fall back to manual styling there.
+    if (@available(iOS 15.0, *)) {
+        UIButtonConfiguration *cfg = filled
+            ? [UIButtonConfiguration filledButtonConfiguration]
+            : [UIButtonConfiguration tintedButtonConfiguration];
+        cfg.title = title;
+        cfg.cornerStyle = UIButtonConfigurationCornerStyleLarge;
+        cfg.contentInsets = NSDirectionalEdgeInsetsMake(12, 16, 12, 16);
+        b.configuration = cfg;
+    } else {
+        [b setTitle:title forState:UIControlStateNormal];
+        b.titleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        b.contentEdgeInsets = UIEdgeInsetsMake(12, 16, 12, 16); // iOS 14 fallback; ignored under UIButtonConfiguration
+#pragma clang diagnostic pop
+        b.layer.cornerRadius = 12;
+        b.clipsToBounds = YES;
+        UIColor *tint = self.view.tintColor ?: [UIColor systemBlueColor];
+        if (filled) {
+            b.backgroundColor = tint;
+            [b setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+        } else {
+            b.backgroundColor = [tint colorWithAlphaComponent:0.15];
+            [b setTitleColor:tint forState:UIControlStateNormal];
+        }
+    }
+
     [b addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
     return b;
 }
 
 - (void)_flashButton:(UIButton *)button title:(NSString *)title {
-    UIButtonConfiguration *cfg = button.configuration;
-    NSString *original = cfg.title;
-    cfg.title = title;
-    button.configuration = cfg;
+    NSString *original;
+    if (@available(iOS 15.0, *)) {
+        original = button.configuration.title;
+    } else {
+        original = [button titleForState:UIControlStateNormal];
+    }
+    [self _setButton:button title:title];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.3 * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{
-        UIButtonConfiguration *c = button.configuration;
-        c.title = original;
-        button.configuration = c;
+        [self _setButton:button title:original];
     });
+}
+
+- (void)_setButton:(UIButton *)button title:(NSString *)title {
+    if (@available(iOS 15.0, *)) {
+        UIButtonConfiguration *cfg = button.configuration;
+        cfg.title = title;
+        button.configuration = cfg;
+    } else {
+        [button setTitle:title forState:UIControlStateNormal];
+    }
 }
 
 - (void)_alert:(NSString *)title message:(NSString *)message {

--- a/src/ApolloManualSignInViewController.m
+++ b/src/ApolloManualSignInViewController.m
@@ -106,11 +106,26 @@ static NSString *ARExtractParam(NSString *urlString, NSString *name);
                                              selector:@selector(_keyboardWillChangeFrame:)
                                                  name:UIKeyboardWillChangeFrameNotification
                                                object:nil];
+
+    // Tap anywhere outside the text view to dismiss the keyboard. UIKit has no
+    // built-in tap-away resign, so wire it explicitly. cancelsTouchesInView=NO
+    // lets the tap fall through to whatever was hit — so tapping a button while
+    // the keyboard is up both dismisses it AND fires the button in one tap,
+    // instead of the stock "first tap eats, second tap acts" annoyance.
+    UITapGestureRecognizer *tapAway =
+        [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                action:@selector(_dismissKeyboard)];
+    tapAway.cancelsTouchesInView = NO;
+    [self.view addGestureRecognizer:tapAway];
 }
 
 #pragma mark - Actions
 
 #pragma mark - Keyboard avoidance
+
+- (void)_dismissKeyboard {
+    [self.view endEditing:NO];
+}
 
 - (void)_keyboardWillChangeFrame:(NSNotification *)note {
     NSDictionary *info = note.userInfo;

--- a/src/ApolloWebAuthViewController.m
+++ b/src/ApolloWebAuthViewController.m
@@ -1,4 +1,5 @@
 #import "ApolloWebAuthViewController.h"
+#import "ApolloManualSignInViewController.h"
 #import "ApolloCommon.h"
 
 #import <WebKit/WebKit.h>
@@ -36,14 +37,14 @@
                              target:self
                              action:@selector(_cancelTapped)];
 
-    // "Old Reddit" button — lets users on any iOS switch to old.reddit.com mid-flow.
-    // On iOS 15 and earlier the modern Reddit login page fails to render, so we auto-rewrite
-    // below; the button is still shown so users can see why the URL changed.
+    // Options menu — "Switch to Old Reddit" (rewrite mid-flow to old.reddit.com,
+    // useful on any iOS) and "Manual Sign-In (Reynard)" (external-browser fallback
+    // for devices where neither the modern nor old login page renders, e.g. iOS
+    // 15.3.1). On iOS 15 and earlier we also auto-rewrite to old.reddit below.
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc]
-        initWithTitle:@"Old Reddit"
-                style:UIBarButtonItemStylePlain
-               target:self
-               action:@selector(_switchToOldReddit)];
+        initWithImage:[UIImage systemImageNamed:@"ellipsis.circle"]
+                 menu:nil];
+    [self _rebuildOptionsMenu];
 
     // iOS 15 and earlier can't render the modern Reddit login page.
     // Rewrite www.reddit.com → old.reddit.com before the first load.
@@ -89,7 +90,45 @@
     NSURL *rewritten = [self _rewriteToOldReddit:self.webView.URL ?: self.authURL];
     ApolloLog(@"[WebAuth] Switching to old Reddit: %@", rewritten);
     [self.webView loadRequest:[NSURLRequest requestWithURL:rewritten]];
-    self.navigationItem.rightBarButtonItem.enabled = NO;
+    // didFinishNavigation rebuilds the menu, disabling this action once loaded.
+}
+
+// Rebuilds the right-bar options menu, disabling "Switch to Old Reddit" when the
+// web view is already on old.reddit.com. Keeping it a menu (rather than toggling
+// the bar button's enabled state) means the manual fallback stays reachable.
+- (void)_rebuildOptionsMenu {
+    BOOL onOldReddit = [self.webView.URL.host isEqualToString:@"old.reddit.com"];
+    __weak typeof(self) weakSelf = self;
+
+    UIAction *oldReddit = [UIAction actionWithTitle:@"Switch to Old Reddit"
+                                              image:[UIImage systemImageNamed:@"arrow.triangle.2.circlepath"]
+                                         identifier:nil
+                                            handler:^(__kindof UIAction *action) {
+        [weakSelf _switchToOldReddit];
+    }];
+    if (onOldReddit) oldReddit.attributes = UIMenuElementAttributesDisabled;
+
+    UIAction *manual = [UIAction actionWithTitle:@"Manual Sign-In (Reynard)…"
+                                           image:[UIImage systemImageNamed:@"doc.on.clipboard"]
+                                      identifier:nil
+                                         handler:^(__kindof UIAction *action) {
+        [weakSelf _showManualSignIn];
+    }];
+
+    UIMenu *menu = [UIMenu menuWithTitle:@"Sign-In Options" children:@[oldReddit, manual]];
+    self.navigationItem.rightBarButtonItem.menu = menu;
+}
+
+- (void)_showManualSignIn {
+    __weak typeof(self) weakSelf = self;
+    ApolloManualSignInViewController *vc = [[ApolloManualSignInViewController alloc]
+        initWithAuthURL:self.authURL
+         callbackScheme:self.callbackScheme
+             onComplete:^(NSURL *callbackURL) {
+        ApolloLog(@"[WebAuth] manual sign-in produced callback: %@", callbackURL);
+        [weakSelf _finishWithURL:callbackURL error:nil];
+    }];
+    [self.navigationController pushViewController:vc animated:YES];
 }
 
 - (void)_cancelTapped {
@@ -149,8 +188,7 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
     [self.spinner stopAnimating];
-    BOOL onOldReddit = [webView.URL.host isEqualToString:@"old.reddit.com"];
-    self.navigationItem.rightBarButtonItem.enabled = !onOldReddit;
+    [self _rebuildOptionsMenu];
 }
 
 - (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error {

--- a/src/ApolloWebAuthViewController.m
+++ b/src/ApolloWebAuthViewController.m
@@ -108,7 +108,7 @@
     }];
     if (onOldReddit) oldReddit.attributes = UIMenuElementAttributesDisabled;
 
-    UIAction *manual = [UIAction actionWithTitle:@"Manual Sign-In (Reynard)…"
+    UIAction *manual = [UIAction actionWithTitle:@"Manual Sign-In (Reynard)"
                                            image:[UIImage systemImageNamed:@"doc.on.clipboard"]
                                       identifier:nil
                                          handler:^(__kindof UIAction *action) {

--- a/userscript/apollo-oauth-helper.user.js
+++ b/userscript/apollo-oauth-helper.user.js
@@ -1,0 +1,329 @@
+// ==UserScript==
+// @name         Apollo Reddit OAuth Code Helper
+// @namespace    apollo-reborn
+// @version      1.2.0
+// @description  On the Reddit "would like to connect to your account" page, captures the OAuth authorization code so you can paste it into Apollo. Works with both the legacy (/api/v1/authorize) and modern shreddit (/svc/shreddit/oauth-grant) consent flows. For iOS browsers (e.g. Reynard) where the apollo:// (or any custom URL scheme) app callback can't be handed off.
+// @author       Apollo-Reborn
+// @match        *://old.reddit.com/api/v1/authorize*
+// @match        *://www.reddit.com/api/v1/authorize*
+// @match        *://reddit.com/api/v1/authorize*
+// @run-at       document-idle
+// @grant        GM_xmlhttpRequest
+// @grant        GM_setClipboard
+// @connect      old.reddit.com
+// @connect      www.reddit.com
+// @connect      reddit.com
+// ==/UserScript==
+
+/*
+ * How it works
+ * ------------
+ * Tapping "Allow" does a full-page form POST. Reddit replies with a 302 whose
+ * Location is the app callback, e.g.
+ *     Location: apollo://reddit-oauth?state=RedditKit&code=rd-XXXX#_
+ * On iOS the browser can't open that custom scheme, so the code is lost.
+ *
+ * Two consent flows exist:
+ *   - legacy old.reddit:  POST /api/v1/authorize       (authorize=Allow, uh=...)
+ *   - modern shreddit:    POST /svc/shreddit/oauth-grant (authorize=ALLOW, csrf_token=...)
+ * We don't hardcode either — we serialize whatever the real consent form is and
+ * POST to its own action.
+ *
+ * Reading the 302 callback from script is the hard part: page fetch() with
+ * redirect:"manual" returns an opaque response (no headers/body). We use the
+ * privileged GM_xmlhttpRequest and look for the callback in EVERY place it can
+ * appear — the Location header, the response body ("Redirecting to ..."), and
+ * finalUrl — first with redirect:"manual", then falling back to redirect:"follow"
+ * (where the engine often exposes the custom-scheme target as finalUrl). If all
+ * of that still fails, we dump diagnostics into the overlay so it can be
+ * reported back.
+ */
+
+(function () {
+    "use strict";
+
+    const LOG = (...a) => console.log("[Apollo OAuth Helper]", ...a);
+
+    // ---- callback detection ----------------------------------------------
+
+    function isCustomCallback(u) {
+        return !!u &&
+            /^[a-z][\w+.-]*:\/\//i.test(u) &&
+            !/^https?:/i.test(u) &&
+            /[?&#]code=/.test(u);
+    }
+
+    function findLocationHeader(headers) {
+        if (!headers) return null;
+        const m = /^location:\s*(.+)$/im.exec(headers);
+        if (!m) return null;
+        const val = m[1].trim();
+        return isCustomCallback(val) ? val : (/[?&#]code=/.test(val) ? val : null);
+    }
+
+    // Scan arbitrary text (headers blob, or the "Redirecting to ..." body) for a
+    // custom-scheme URL carrying ?code=. HTML-escapes &amp; back to & first.
+    function findCallbackInText(text) {
+        if (!text) return null;
+        const decoded = text.replace(/&amp;/g, "&");
+        const m = /([a-z][\w+.-]*:\/\/[^\s"'<>]*[?&#]code=[^\s"'<>]+)/i.exec(decoded);
+        if (!m) return null;
+        let url = m[1].replace(/[.\s]+$/, ""); // trim trailing period/space from prose
+        return /^https?:/i.test(url) ? null : url;
+    }
+
+    function extractCallback(res) {
+        const headers = (res && res.responseHeaders) || "";
+        const text = (res && res.responseText) || "";
+        const finalUrl = res && res.finalUrl;
+        return (
+            findLocationHeader(headers) ||
+            (isCustomCallback(finalUrl) ? finalUrl : null) ||
+            findCallbackInText(headers) ||
+            findCallbackInText(text) ||
+            null
+        );
+    }
+
+    function parseCallback(raw) {
+        const out = { code: null, state: null, error: null };
+        const grab = (re) => { const x = re.exec(raw); return x ? decodeURIComponent(x[1]) : null; };
+        out.code = grab(/[?&#]code=([^&#]+)/);
+        out.state = grab(/[?&#]state=([^&#]+)/);
+        out.error = grab(/[?&#]error=([^&#]+)/);
+        return out;
+    }
+
+    // ---- form location + replay ------------------------------------------
+
+    function findConsentForm() {
+        const forms = Array.from(document.querySelectorAll("form"));
+        return forms.find(f =>
+            f.querySelector('[name="client_id"]') ||
+            f.querySelector('[name="redirect_uri"]') ||
+            f.querySelector('[name="authorize"]') ||
+            f.querySelector('[name="csrf_token"]')
+        ) || null;
+    }
+
+    function looksLikeAllow(submitter) {
+        if (!submitter) return true; // no info -> assume Allow
+        const text = (submitter.value || submitter.textContent || "").trim();
+        if (/decline|deny|cancel/i.test(text)) return false;
+        return /allow|accept|authorize/i.test(text) || true;
+    }
+
+    function getCookie(name) {
+        const m = document.cookie.match(new RegExp("(?:^|;\\s*)" + name + "=([^;]*)"));
+        return m ? decodeURIComponent(m[1]) : null;
+    }
+
+    function captureCode(form, submitter) {
+        const action = form.getAttribute("action") || location.href;
+        const url = new URL(action, location.href).href;
+
+        const params = new URLSearchParams();
+        new FormData(form).forEach((v, k) => params.append(k, v));
+        if (submitter && submitter.name) {
+            if (!params.has(submitter.name)) params.append(submitter.name, submitter.value || "");
+        } else if (!params.has("authorize")) {
+            params.append("authorize", "Allow");
+        }
+
+        // CSRF: the modern /svc/shreddit/oauth-grant endpoint uses a double-submit
+        // token — the body csrf_token must match the csrf_token cookie, and it
+        // checks Origin/Referer. From the extension context the SameSite=Strict
+        // csrf cookie isn't attached and Origin/Referer differ, so the grant 400s
+        // before issuing the redirect. The csrf cookie is NOT HttpOnly, so read it
+        // and force both sides to agree (and set Origin/Referer in doGrant).
+        const csrf = getCookie("csrf_token");
+        if (csrf) {
+            params.set("csrf_token", csrf);
+            LOG("using csrf_token cookie:", csrf.slice(0, 8) + "…");
+        } else {
+            LOG("no csrf_token cookie found in document.cookie");
+        }
+
+        LOG("captured consent form -> action:", url);
+        showOverlay({ loading: true });
+        doGrant(url, params.toString(), csrf, "manual", /*allowFallback*/ true);
+    }
+
+    function doGrant(url, body, csrf, mode, allowFallback) {
+        LOG("POST", url, "redirect:", mode);
+        const req = {
+            method: "POST",
+            url: url,
+            redirect: mode,
+            anonymous: false, // include the browser's cookies (session, etc.)
+            headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Origin": location.origin,
+                "Referer": location.href
+            },
+            data: body,
+            onload: (r) => handleResponse(r, url, body, csrf, mode, allowFallback),
+            onerror: (r) => handleResponse(r, url, body, csrf, mode, allowFallback),
+            ontimeout: (r) => handleResponse(r, url, body, csrf, mode, allowFallback)
+        };
+        // Patch the csrf cookie into the request in case SameSite=Strict stops the
+        // engine attaching it from the jar.
+        if (csrf) req.cookie = "csrf_token=" + csrf;
+        GM_xmlhttpRequest(req);
+    }
+
+    function handleResponse(res, url, body, csrf, mode, allowFallback) {
+        const status = res && res.status;
+        const finalUrl = res && res.finalUrl;
+        const headers = (res && res.responseHeaders) || "";
+        const text = (res && res.responseText) || "";
+        LOG("response [" + mode + "]", { status, finalUrl, headersLen: headers.length, bodyLen: text.length });
+        LOG("headers:\n" + headers);
+        LOG("body (first 500):\n" + text.slice(0, 500));
+
+        const callback = extractCallback(res);
+
+        if (!callback && allowFallback && mode === "manual") {
+            LOG("manual mode found nothing — retrying with redirect:follow");
+            doGrant(url, body, csrf, "follow", /*allowFallback*/ false);
+            return;
+        }
+
+        if (!callback) {
+            showOverlay({ diag: { status, finalUrl, headers, text } });
+            return;
+        }
+
+        LOG("callback:", callback);
+        const parsed = parseCallback(callback);
+        if (parsed.error) {
+            showOverlay({ error: "Reddit returned an error: " + parsed.error });
+        } else if (parsed.code) {
+            showOverlay({ code: parsed.code, state: parsed.state, callback });
+        } else {
+            showOverlay({ error: "Callback had no authorization code:\n" + callback });
+        }
+    }
+
+    // ---- overlay UI -------------------------------------------------------
+
+    function button(label, bg, fg) {
+        const b = document.createElement("button");
+        b.textContent = label;
+        b.setAttribute("style", [
+            "appearance:none", "border:none", "border-radius:10px",
+            "background:" + bg, "color:" + fg, "font:600 16px -apple-system,system-ui,sans-serif",
+            "padding:13px 16px", "width:100%", "margin-top:8px", "cursor:pointer"
+        ].join(";"));
+        return b;
+    }
+
+    function copyButton(label, getText, statusEl, bg, fg) {
+        const b = button(label, bg, fg);
+        b.addEventListener("click", () => {
+            try { GM_setClipboard(getText()); statusEl.textContent = "Copied!"; }
+            catch (e) { statusEl.textContent = "Long-press the box above to copy."; }
+        });
+        return b;
+    }
+
+    function showOverlay(opts) {
+        const { loading, error, code, state, callback, diag } = opts;
+        let host = document.getElementById("apollo-oauth-overlay");
+        if (host) host.remove();
+        host = document.createElement("div");
+        host.id = "apollo-oauth-overlay";
+
+        const box = document.createElement("div");
+        box.setAttribute("style", [
+            "position:fixed", "inset:0", "z-index:2147483647",
+            "background:rgba(0,0,0,0.6)", "display:flex",
+            "align-items:center", "justify-content:center", "padding:18px"
+        ].join(";"));
+
+        const card = document.createElement("div");
+        card.setAttribute("style", [
+            "background:#fff", "color:#111", "max-width:480px", "width:100%",
+            "max-height:88vh", "overflow:auto", "border-radius:16px", "padding:22px",
+            "box-sizing:border-box", "font:16px/1.45 -apple-system,system-ui,sans-serif",
+            "box-shadow:0 10px 40px rgba(0,0,0,0.35)"
+        ].join(";"));
+
+        const status = document.createElement("div");
+        status.setAttribute("style", "min-height:1.2em;color:#1a8a1a;font-size:.85rem;margin:8px 0 0");
+
+        if (loading) {
+            card.innerHTML = "<h2 style='margin:0 0 8px;font-size:1.15rem'>Getting your code…</h2>" +
+                "<p style='margin:0;opacity:.7'>Confirming authorization with Reddit.</p>";
+        } else if (error) {
+            card.innerHTML = "<h2 style='margin:0 0 10px;font-size:1.15rem;color:#c0392b'>Something went wrong</h2>" +
+                "<pre style='white-space:pre-wrap;word-break:break-word;margin:0 0 14px;font:13px ui-monospace,monospace'></pre>";
+            card.querySelector("pre").textContent = error;
+            card.appendChild(closeButton(host));
+        } else if (diag) {
+            const dump =
+                "status: " + diag.status + "\n" +
+                "finalUrl: " + diag.finalUrl + "\n\n" +
+                "--- responseHeaders ---\n" + (diag.headers || "(empty)") + "\n\n" +
+                "--- body (first 1000) ---\n" + ((diag.text || "(empty)").slice(0, 1000));
+            card.innerHTML =
+                "<h2 style='margin:0 0 6px;font-size:1.15rem;color:#c0392b'>Couldn't read the callback</h2>" +
+                "<p style='margin:0 0 12px;opacity:.7;font-size:.9rem'>The Allow request went through, but the code wasn't in the header, body, or final URL. Copy this diagnostic and send it to the developer.</p>" +
+                "<pre style='white-space:pre-wrap;word-break:break-all;margin:0 0 8px;font:11px ui-monospace,monospace;background:#f1f1f1;border-radius:10px;padding:10px;max-height:40vh;overflow:auto'></pre>";
+            card.querySelector("pre").textContent = dump;
+            card.appendChild(copyButton("Copy diagnostics", () => dump, status, "#d93900", "#fff"));
+            card.appendChild(status);
+            card.appendChild(closeButton(host));
+        } else {
+            card.innerHTML =
+                "<h2 style='margin:0 0 4px;font-size:1.2rem'>Authorization code</h2>" +
+                "<p style='margin:0 0 16px;opacity:.7;font-size:.92rem'>Copy this and paste it into Apollo to finish signing in.</p>" +
+                "<div style='font:600 12px/1 ui-monospace,monospace;text-transform:uppercase;letter-spacing:.04em;opacity:.55;margin-bottom:6px'>CODE</div>" +
+                "<div id='apollo-code' style='font:15px ui-monospace,monospace;word-break:break-all;background:#f1f1f1;border-radius:10px;padding:12px 14px;user-select:all;-webkit-user-select:all'></div>";
+            card.querySelector("#apollo-code").textContent = code;
+            card.appendChild(copyButton("Copy code", () => code, status, "#d93900", "#fff"));
+            if (callback) {
+                card.appendChild(copyButton("Copy full callback URL", () => callback, status, "#e8e8e8", "#111"));
+            }
+            card.appendChild(status);
+            card.appendChild(closeButton(host));
+        }
+
+        box.appendChild(card);
+        host.appendChild(box);
+        document.documentElement.appendChild(host);
+    }
+
+    function closeButton(host) {
+        const b = button("Close", "transparent", "#888");
+        b.addEventListener("click", () => host.remove());
+        return b;
+    }
+
+    // ---- wire up the form -------------------------------------------------
+
+    function attach() {
+        const form = findConsentForm();
+        if (!form || form.dataset.apolloHooked) return false;
+        form.dataset.apolloHooked = "1";
+        LOG("hooked consent form, action =", form.getAttribute("action"));
+
+        form.addEventListener("submit", (e) => {
+            const submitter = e.submitter;
+            if (!looksLikeAllow(submitter)) {
+                LOG("non-Allow submit, ignoring");
+                return; // let Decline behave normally
+            }
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            captureCode(form, submitter);
+        }, true);
+        return true;
+    }
+
+    if (!attach()) {
+        const obs = new MutationObserver(() => { if (attach()) obs.disconnect(); });
+        obs.observe(document.documentElement, { childList: true, subtree: true });
+        setTimeout(() => obs.disconnect(), 10000);
+    }
+})();


### PR DESCRIPTION
- Fixes #416
- Credits to @Alstruit for keyboard improvements in sign in page

---

PR #377 solves the issue where the app consent page does not render on iOS 15 by forcing it to load the old.reddit.com consent page instead. However, the login page does not have any old.reddit.com fallback page for it, and that PR would likely only work on iOS 15.4 or above, as WebKit on iOS 15.4 is able to render the new sign in page.

iOS 15.3.1 is unable to render the sign in page entirely, even in native Safari, meaning that it is impossible to sign in to Reddit to display the consent form at all. The only known alternative is to use [Reynard Browser](https://github.com/minh-ton/reynard-browser), which uses Gecko, separate from the system WebKit.

However, Reynard Browser does not support URL scheme redirects at all, so a userscript is provided that intercepts the "Accept" button in the app consent page, and displays a code to be pasted into Apollo to log in.

**Note:** The app provides a link to https://raw.githubusercontent.com/Apollo-Reborn/Apollo-Reborn/refs/heads/main/userscript/apollo-oauth-helper.user.js in the instructions. Currently, this link will return a 404 error, as this PR has not been merged into `main` yet. If needed for testing, you can use https://raw.githubusercontent.com/DeltAndy123/Apollo-Reborn/refs/heads/manual-auth-code/userscript/apollo-oauth-helper.user.js for the userscript link instead.

## Screenshots
| New sign in page in Apollo | Authorization code popup |
|---|---|
| <img width="603" height="1311" alt="IMG_3231" src="https://github.com/user-attachments/assets/d8306429-d961-49d9-a2b3-9717382a7f3d" /> | <img width="603" height="1311" alt="IMG_3233" src="https://github.com/user-attachments/assets/25a8e596-e300-47e1-8869-3da2716c8264" /> |