### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -118,6 +118,18 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: was-existing-apollo-bug
+    attributes:
+      label: Was this a previously existing Apollo bug?
+      description: Do you know if this bug existed in the original Apollo app, or is it new to the Apollo Reborn tweak? You can also check the [original Apollo bug tracker](https://github.com/christianselig/apollo-bugs/issues) to see if it's been reported there.
+      options:
+        - "No"
+        - "Yes"
+        - "Not sure"
+    validations:
+      required: false
+
   - type: textarea
     id: additional
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,125 @@
+name: 🐞 Bug Report
+description: Report a bug, crash, or broken feature in Apollo Reborn
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill out the sections below so we can reproduce and fix the issue quickly.
+
+        Before submitting, please [search existing issues](https://github.com/Apollo-Reborn/Apollo-Reborn/issues?q=is%3Aissue) to avoid duplicates.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I searched existing issues and this hasn't been reported yet.
+          required: true
+        - label: I'm running the latest version of Apollo Reborn.
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: When I scroll past an unmuted video in comments, the audio stops...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this behavior?
+      placeholder: |
+        1. Go to '...'
+        2. Tap on '...'
+        3. Scroll to '...'
+        4. See the bug
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Crash log / console output / screenshots
+      description: |
+        Paste any crash backtraces, `ApolloLog` console output, or `.ips` crash reports. Drag and drop screenshots or screen recordings here.
+        Crash reports help enormously — see the README for how to grab them.
+      render: text
+    validations:
+      required: false
+
+  - type: input
+    id: tweak-version
+    attributes:
+      label: Apollo Reborn version
+      description: Found in Settings → Apollo Reborn → scroll to bottom, or the IPA filename (e.g. `Apollo-Reborn-3.1.1.ipa`).
+      placeholder: "3.1.1"
+    validations:
+      required: true
+
+  - type: input
+    id: ios-version
+    attributes:
+      label: iOS version
+      placeholder: "iOS 26.5.1"
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device
+      placeholder: "iPhone 16 Pro"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Installation method
+      description: How did you install the IPA?
+      options:
+        - AltStore Classic/SideStore
+        - Feather
+        - LiveContainer
+        - TrollStore
+        - Jailbreak (.deb tweak)
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: variant
+    attributes:
+      label: IPA variant
+      description: Which build are you running?
+      options:
+        - Standard
+        - No Extensions
+        - Liquid Glass
+        - Liquid Glass + No Extensions
+        - Glass Icons
+        - Glass Icons + No Extensions
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else that might help — custom API keys in use, recently changed settings, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -95,6 +95,8 @@ body:
         - AltStore Classic/SideStore
         - Feather
         - LiveContainer
+        - Sideloadly
+        - Impactor
         - TrollStore
         - Jailbreak (.deb tweak)
         - Other

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,9 @@ contact_links:
   - name: 📦 IPA Sources
     url: https://apolloreborn.app/#download
     about: Pre-built IPAs and AltStore/SideStore/Feather sources.
+  - name: 🐞 Original Apollo Bug Tracker
+    url: https://github.com/christianselig/apollo-bugs/issues
+    about: Bug tracker for the original Apollo app. Search issues here to see if a bug existed in the original app or is new to Apollo Reborn.
   - name: 🤝 Contributing Guide
     url: https://github.com/Apollo-Reborn/Apollo-Reborn/blob/main/CONTRIBUTING.md
     about: Want to build or contribute? Start here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 r/ApolloReborn Community
+    url: https://www.reddit.com/r/ApolloReborn/
+    about: Ask questions, get help, and discuss with the community. (Do not directly discuss API key workarounds using alternative apps in this subreddit.)
+  - name: 📦 IPA Sources
+    url: https://apolloreborn.app/#download
+    about: Pre-built IPAs and AltStore/SideStore/Feather sources.
+  - name: 🤝 Contributing Guide
+    url: https://github.com/Apollo-Reborn/Apollo-Reborn/blob/main/CONTRIBUTING.md
+    about: Want to build or contribute? Start here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -46,7 +46,7 @@ body:
       required: false
 
   - type: dropdown
-    id: was-ultra
+    id: was-existing-apollo-feature
     attributes:
       label: Was this a previously existing Apollo feature?
       description: Knowing whether the data/UI already exists in the binary helps gauge feasibility.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: ✨ Feature Request
+description: Suggest a new feature or enhancement for Apollo Reborn
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an idea! Apollo Reborn works by patching Apollo's runtime, so features are subject to what's technically feasible against the existing binary.
+
+        Before submitting, please [search existing issues](https://github.com/Apollo-Reborn/Apollo-Reborn/issues?q=is%3Aissue) to avoid duplicates.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I searched existing issues and this hasn't already been requested.
+          required: true
+        - label: I'm running the latest version of Apollo Reborn, and this feature doesn't already exist.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the behavior you want from the user's perspective, and the problem it addresses.
+      placeholder: I want to be able to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Describe the feature you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions, workarounds, or existing settings you've tried.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: was-ultra
+    attributes:
+      label: Was this a previously existing Apollo feature?
+      description: Knowing whether the data/UI already exists in the binary helps gauge feasibility.
+      options:
+        - "No"
+        - "Yes"
+        - "Not sure"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other context or information about the feature request. Links to related discussions, mockups, or screenshots are welcome!
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/login_api_help.yml
+++ b/.github/ISSUE_TEMPLATE/login_api_help.yml
@@ -1,0 +1,101 @@
+name: 🔑 Login & API Key Help
+description: Trouble signing in or setting up API keys
+title: "[Login]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Most sign-in problems come from the API key / redirect setup. Please fill this out completely so we (and other users) can help.
+
+        **Please check these first:**
+        - The [Don't have an API key?](https://github.com/Apollo-Reborn/Apollo-Reborn#dont-have-an-api-key) section of the README for setup instructions and troubleshooting.
+        - Existing [login issues](https://github.com/Apollo-Reborn/Apollo-Reborn/issues?q=is%3Aissue+label%3Aquestion+login) — note that Reddit has been revoking API keys, which is **not** something the tweak can fix.
+        - Make sure you are running at least version 3.1.0 of Apollo Reborn if you are using a custom redirect URI.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I searched existing issues and the subreddit guides first.
+          required: true
+        - label: I'm running the latest version of Apollo Reborn.
+          required: true
+
+  - type: dropdown
+    id: method
+    attributes:
+      label: Which sign-in method are you using?
+      options:
+        - My own Reddit API key (own app on reddit.com/prefs/apps)
+        - Dystopia
+        - RedReader
+        - Custom redirect URI
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happens
+    attributes:
+      label: What happens?
+      description: Describe exactly where it fails. Include the error text shown (e.g. "{}", "can't open the page"), and what the in-app browser does at the final "Accept"/"Open in Apollo" step.
+      placeholder: I enter my username and password, tap Accept, and the in-app browser says...
+    validations:
+      required: true
+
+  - type: input
+    id: redirect-uri
+    attributes:
+      label: Redirect URI
+      description: The redirect URI you entered in settings (do NOT include any client secret).
+      placeholder: "redreader://rr_oauth_redir"
+    validations:
+      required: false
+
+  - type: input
+    id: user-agent
+    attributes:
+      label: User agent
+      placeholder: "org.quantumbadger.redreader/1.25.1"
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / screen recording
+      description: A recording of the full login flow is the most helpful thing you can attach. Drag and drop here.
+    validations:
+      required: false
+
+  - type: input
+    id: tweak-version
+    attributes:
+      label: Apollo Reborn version
+      placeholder: "3.1.1"
+    validations:
+      required: true
+
+  - type: input
+    id: ios-version
+    attributes:
+      label: iOS version
+      placeholder: "iOS 26.5.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Installation method
+      options:
+        - AltStore Classic/SideStore
+        - Feather
+        - LiveContainer
+        - TrollStore
+        - Jailbreak (.deb tweak)
+        - Other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/login_api_help.yml
+++ b/.github/ISSUE_TEMPLATE/login_api_help.yml
@@ -18,7 +18,7 @@ body:
     attributes:
       label: Pre-submission checklist
       options:
-        - label: I searched existing issues and the subreddit guides first.
+        - label: I searched existing issues and read the README section first.
           required: true
         - label: I'm running the latest version of Apollo Reborn.
           required: true
@@ -31,7 +31,7 @@ body:
         - My own Reddit API key (own app on reddit.com/prefs/apps)
         - Dystopia
         - RedReader
-        - Custom redirect URI
+        - Other custom redirect URI
         - Not sure
     validations:
       required: true
@@ -49,8 +49,8 @@ body:
     id: redirect-uri
     attributes:
       label: Redirect URI
-      description: The redirect URI you entered in settings (do NOT include any client secret).
-      placeholder: "redreader://rr_oauth_redir"
+      description: The redirect URI you entered in Apollo Reborn settings (do NOT send any client ID or secret here).
+      placeholder: "apollo://reddit-oauth"
     validations:
       required: false
 
@@ -58,7 +58,8 @@ body:
     id: user-agent
     attributes:
       label: User agent
-      placeholder: "org.quantumbadger.redreader/1.25.1"
+      description: The user agent you entered in Apollo Reborn settings.
+      placeholder: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
     validations:
       required: false
 
@@ -94,6 +95,8 @@ body:
         - AltStore Classic/SideStore
         - Feather
         - LiveContainer
+        - Sideloadly
+        - Impactor
         - TrollStore
         - Jailbreak (.deb tweak)
         - Other

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -41,3 +41,11 @@ body:
       placeholder: "3.1.1"
     validations:
       required: false
+
+  - type: input
+    id: ios-version
+    attributes:
+      label: iOS version (if applicable)
+      placeholder: "iOS 26.5.1"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,43 @@
+name: ❓ Question / Support
+description: Ask a question or get help with something that isn't a bug or feature request
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question about using Apollo Reborn, building it, or whether some behavior is expected? Ask away.
+
+        For faster help with general usage, the [r/ApolloReborn](https://www.reddit.com/r/ApolloReborn/) community is often the quickest place. For **login/API key** problems, please use the dedicated "Login & API Key Help" template instead.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I searched existing issues and the README/subreddit, and didn't find an answer.
+          required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: Ask your question clearly. If it's about a specific behavior, describe what you see vs. what you expected.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Screenshots, links, console output, or any other detail that helps. If this is a build/development question, include the full command and error output.
+    validations:
+      required: false
+
+  - type: input
+    id: tweak-version
+    attributes:
+      label: Apollo Reborn version (if applicable)
+      placeholder: "3.1.1"
+    validations:
+      required: false


### PR DESCRIPTION
- Adds structured issue templates (bug report, feature request, login/API key help, question) under `.github/ISSUE_TEMPLATE/`, plus a `config.yml` that disables blank issues and links to the subreddit, IPA download page, and contributing guide.
- The login/API key template targets the most common report type we get right now: sign-in failures after Reddit's API key revocations, by collecting sign-in method, redirect URI, user agent, and a screen recording of the login flow.
- Bug reports now capture IPA variant (including Liquid Glass) and installation method, plus a dedicated field for crash logs/`.ips` reports.
- Question template now requires iOS version for better triage.

## Screenshots
**Modal Window:**
<img width="998" height="617" alt="image" src="https://github.com/user-attachments/assets/ca613f0b-79de-48e1-911b-bd7a35071634" />

---

**Bug Report:**
<img width="1681" height="2841" alt="image" src="https://github.com/user-attachments/assets/1aadf029-bd97-4783-9adc-9b64eef5518b" />

---

**Feature Request:**
<img width="1690" height="2076" alt="image" src="https://github.com/user-attachments/assets/05e575c5-91f5-45f5-a6e5-f3fb376dbb8c" />

---

**Login & API Key Help:**
<img width="1686" height="1926" alt="image" src="https://github.com/user-attachments/assets/83b3b2f5-f144-4a5c-b575-0ab94f41c6de" />

---

**Question:**
<img width="1678" height="1381" alt="image" src="https://github.com/user-attachments/assets/bba7ef13-1e52-4266-9be6-361c7356d336" />