### PR TITLE
Publish IPAs with custom URL schemes and add toggle to restore original sign-in behaviour

### DIFF
--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -36,9 +36,10 @@ on:
         type: boolean
         default: false
       url_schemes:
-        description: 'Comma-separated URL schemes to add (e.g. "custom, test, myapp")'
+        description: 'Comma-separated URL schemes to add'
         required: false
         type: string
+        default: 'dystopia,redreader'
       remove_code_signature:
         description: 'Remove code signature'
         required: false
@@ -207,7 +208,7 @@ jobs:
           if [ "${{ github.event.inputs.liquid_glass_icons }}" == "true" ]; then
             SUFFIX="${SUFFIX}-LiquidGlassIcons"
           fi
-          if [ -n "${{ github.event.inputs.url_schemes }}" ]; then
+          if [ -n "${{ github.event.inputs.url_schemes }}" ] && [ "${{ github.event.inputs.url_schemes }}" != "dystopia,redreader" ]; then
             SUFFIX="${SUFFIX}-URLSchemes"
           fi
           OUTPUT_IPA="${BASE}${SUFFIX}.ipa"

--- a/scripts/build_release_variants.sh
+++ b/scripts/build_release_variants.sh
@@ -54,6 +54,25 @@ print(config["app"]["buildVersion"])
 PY
 }
 
+# Default URL schemes baked into every released IPA so the native
+# ASWebAuthenticationSession sign-in works out-of-the-box for the most common
+# shared-key workarounds (Dystopia / RedReader) without manual Info.plist edits.
+DEFAULT_URL_SCHEMES="dystopia,redreader"
+
+# Run patch.sh over a finished IPA to inject DEFAULT_URL_SCHEMES and write the
+# result back in place. Only the standard/no-extensions variants need this: the
+# four Liquid Glass variants below are derived from those two via patch.sh and
+# therefore inherit the already-injected schemes.
+inject_default_url_schemes_in_place() {
+    local ipa="$1"
+    local work output
+    work="$(mktemp -d)"
+    output="$work/$(basename "$ipa")"
+    bash "${REPO_DIR}/patch.sh" "$ipa" --url-schemes "$DEFAULT_URL_SCHEMES" -o "$output"
+    mv -f "$output" "$ipa"
+    rm -rf "$work"
+}
+
 set_main_app_bundle_versions_in_ipa() {
     local ipa="$1"
     local short_version="$2"
@@ -253,6 +272,7 @@ bash "${REPO_DIR}/scripts/fix-safari-extension.sh" "$STANDARD_IPA"
 # too, and the no-extensions variants have no appex (the script no-ops).
 bash "${REPO_DIR}/scripts/fix-openin-extension.sh" "$STANDARD_IPA"
 set_main_app_bundle_versions_in_ipa "$STANDARD_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
+inject_default_url_schemes_in_place "$STANDARD_IPA"
 
 # Inject the Reborn widget extension into the STANDARD IPA so the GLASS and
 # GLASSICONS variants (both derived from it via patch.sh below) inherit it. The
@@ -272,6 +292,7 @@ echo "[2/6] Building no-extensions injected IPA..."
 cyan -i "$IPA_PATH" -f "$DEB_PATH" -o "$NOEXT_IPA" -e
 strip_arm64e_from_substrate_in_ipa "$NOEXT_IPA"
 set_main_app_bundle_versions_in_ipa "$NOEXT_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
+inject_default_url_schemes_in_place "$NOEXT_IPA"
 
 echo ""
 echo "[3/6] Applying Liquid Glass patch to standard IPA..."

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -139,6 +139,26 @@ typedef NS_ENUM(NSInteger, Tag) {
     return NO;
 }
 
+- (BOOL)apollo_usesCustomOAuthSignIn {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseCustomOAuthSignIn];
+}
+
+- (NSString *)apollo_redirectURIDetailText {
+    if ([self apollo_usesCustomOAuthSignIn]) {
+        return @"Must match the redirect URI registered with your Reddit API app. Any URI scheme is supported.";
+    }
+
+    NSString *registered = [[self registeredURLSchemes] componentsJoinedByString:@", "];
+    if (registered.length == 0) registered = @"none";
+    return [NSString stringWithFormat:@"Must match the app whose API key you're using. URI scheme (part before ://) must be registered in Info.plist under CFBundleURLTypes. Registered: %@", registered];
+}
+
+- (void)apollo_applyRedirectURITextColorToCell:(UITableViewCell *)cell {
+    UITextField *textField = [self apollo_textFieldInCell:cell];
+    if (!textField) return;
+    textField.textColor = ([self apollo_usesCustomOAuthSignIn] || [self isRedirectURISchemeValid:textField.text]) ? [UIColor labelColor] : [UIColor systemRedColor];
+}
+
 - (UIImage *)decodeBase64ToImage:(NSString *)strEncodeData {
     NSData *data = [[NSData alloc]initWithBase64EncodedString:strEncodeData options:NSDataBase64DecodingIgnoreUnknownCharacters];
     return [UIImage imageWithData:data];
@@ -660,7 +680,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     switch (section) {
         case SectionBackupRestore: return 4;
-        case SectionAPIKeys: return 10; // 7 text fields + Can't sign in? + API key setup guide + Copy Widget Setup Code
+        case SectionAPIKeys: return 11; // 7 text fields + OAuth switch + Can't sign in? + API key setup guide + Copy Widget Setup Code
         case SectionGeneral: return sShowDeletedComments ? 11 : 10;
         case SectionMedia: return 12 + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows);
         case SectionSubreddits: return sSubredditListEnhancements ? 8 : 7;
@@ -939,16 +959,23 @@ typedef NS_ENUM(NSInteger, Tag) {
                                                                 placeholder:defaultRedirectURI
                                                                        text:sRedirectURI
                                                                         tag:TagRedirectURI
-                                                                     detail:@"Must match the redirect URI registered with your Reddit API app. Any URI scheme is supported."];
+                                                                      detail:[self apollo_redirectURIDetailText]];
+            [self apollo_applyRedirectURITextColorToCell:cell];
             return cell;
         }
         case 6:
+            return [self switchCellWithIdentifier:@"Cell_API_CustomOAuth"
+                                            label:@"Universal OAuth Sign-In"
+                                           detail:@"Signs in with an in-app web view so any Redirect URI works. Turn off for Apollo's native sign-in."
+                                               on:[self apollo_usesCustomOAuthSignIn]
+                                           action:@selector(customOAuthSignInSwitchToggled:)];
+        case 7:
             return [self stackedTextFieldCellWithIdentifier:@"Cell_API_UserAgent"
                                                       label:@"User Agent"
                                                 placeholder:defaultUserAgent
-                                                       text:sUserAgent
+                                                        text:sUserAgent
                                                         tag:TagUserAgent];
-        case 7: {
+        case 8: {
             UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"Cell_Troubleshooting"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell_Troubleshooting"];
@@ -957,7 +984,7 @@ typedef NS_ENUM(NSInteger, Tag) {
             cell.textLabel.text = @"Can't sign in?";
             return cell;
         }
-        case 8: {
+        case 9: {
             UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"Cell_Instructions"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell_Instructions"];
@@ -967,7 +994,7 @@ typedef NS_ENUM(NSInteger, Tag) {
             cell.textLabel.text = @"Giphy & ImgChest API Key Setup";
             return cell;
         }
-        case 9: {
+        case 10: {
             UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"Cell_WidgetSetupCode"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell_WidgetSetupCode"];
@@ -1546,11 +1573,11 @@ typedef NS_ENUM(NSInteger, Tag) {
             [self promptClearCustomSubredditBannersFromSourceView:cell];
         }
     } else if (indexPath.section == SectionAPIKeys) {
-        if (indexPath.row == 7) {
+        if (indexPath.row == 8) {
             [self pushTroubleshootingViewController];
-        } else if (indexPath.row == 8) {
-            [self pushInstructionsViewController];
         } else if (indexPath.row == 9) {
+            [self pushInstructionsViewController];
+        } else if (indexPath.row == 10) {
             [self copyWidgetSetupCode];
         }
     } else if (indexPath.section == SectionAbout) {
@@ -1651,7 +1678,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 
 - (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.section == SectionBackupRestore) return YES;
-    if (indexPath.section == SectionAPIKeys && (indexPath.row == 7 || indexPath.row == 8 || indexPath.row == 9)) return YES;
+    if (indexPath.section == SectionAPIKeys && (indexPath.row == 8 || indexPath.row == 9 || indexPath.row == 10)) return YES;
     if (indexPath.section == SectionMedia) {
         NSInteger row = ApolloMediaLogicalRow(indexPath.row);
         return (row == 0 || row == 1 || row == 2 || row == 5 || row == 6 || row == 7 || row == 8 || row == 9);
@@ -1882,7 +1909,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         textField.text = [textField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
         sRedirectURI = textField.text;
         [[NSUserDefaults standardUserDefaults] setValue:sRedirectURI forKey:UDKeyRedirectURI];
-        textField.textColor = [UIColor labelColor];
+        textField.textColor = ([self apollo_usesCustomOAuthSignIn] || [self isRedirectURISchemeValid:textField.text]) ? [UIColor labelColor] : [UIColor systemRedColor];
     } else if (textField.tag == TagUserAgent) {
         textField.text = [textField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
         sUserAgent = textField.text;
@@ -1952,6 +1979,12 @@ typedef NS_ENUM(NSInteger, Tag) {
 
 - (void)randNsfwSwitchToggled:(UISwitch *)sender {
     [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:UDKeyShowRandNsfw];
+}
+
+- (void)customOAuthSignInSwitchToggled:(UISwitch *)sender {
+    [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:UDKeyUseCustomOAuthSignIn];
+    [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:5 inSection:SectionAPIKeys]]
+                          withRowAnimation:UITableViewRowAnimationNone];
 }
 
 - (void)subredditListEnhancementsSwitchToggled:(UISwitch *)sender {

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -346,6 +346,10 @@ static const char kARCompletion = '\0';
 }
 
 - (BOOL)start {
+    if (![[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseCustomOAuthSignIn]) {
+        return %orig;
+    }
+
     NSString *callbackScheme = objc_getAssociatedObject(self, &kARScheme);
     NSURL *authURL            = objc_getAssociatedObject(self, &kARAuthURL);
     void (^completion)(NSURL *, NSError *) = objc_getAssociatedObject(self, &kARCompletion);
@@ -1195,6 +1199,7 @@ static void initializeRandomSources() {
                                     UDKeyProxyImgurDDG: @NO,
                                     UDKeyImageChestAPIToken: @"",
                                     UDKeyGiphyAPIKey: @"",
+                                    UDKeyUseCustomOAuthSignIn: @YES,
                                     UDKeyEnableInlineImages: @YES,
                                     UDKeyInlineImageAlignment: @(ApolloInlineImageAlignmentCenter),
                                     UDKeyAutoplayInlineGIFs: @(ApolloAutoplayInlineGIFModeDefault),

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -8,6 +8,7 @@ static NSString *const UDKeyImgurClientId = @"ImgurApiClientId";
 static NSString *const UDKeyGiphyAPIKey = @"GiphyAPIKey";
 static NSString *const UDKeyImageChestAPIToken = @"ImageChestAPIToken";
 static NSString *const UDKeyRedirectURI = @"RedirectURI";
+static NSString *const UDKeyUseCustomOAuthSignIn = @"UseCustomOAuthSignIn";
 static NSString *const UDKeyUserAgent = @"UserAgent";
 static NSString *const UDKeyBlockAnnouncements = @"DisableApollonouncements";
 static NSString *const UDKeyEnableFLEX = @"EnableFlexDebugging";


### PR DESCRIPTION
Two related sign-in changes:

1. **New "Universal OAuth Sign-In" toggle** (Settings → Custom API, default **on**) that lets users fall back to Apollo's original native sign-in if the custom in-app web view flow  causes trouble.
  <img width="400" alt="IMG_3689" src="https://github.com/user-attachments/assets/872f98c2-52c4-41c2-a1c5-9f3611032b86" />

2. **Released IPAs now register the `dystopia` and `redreader` URL schemes by default**, so the shared-API-key workarounds work out-of-the-box with Apollo's native sign-in — no manual `Info.plist` patching.

This should reduce user-reported issues like #425 and #421

## Build / release pipeline

- `scripts/build_release_variants.sh`: a new `inject_default_url_schemes_in_place` helper runs `patch.sh --url-schemes dystopia,redreader` over the standard and no-extensions IPAs. The four Liquid Glass variants are derived from those via `patch.sh`, so they inherit the schemes.
- `.github/workflows/build-ipa.yml`: the `url_schemes` input now defaults to `dystopia,redreader`. The `-URLSchemes` filename suffix is suppressed for that default so standard builds keep their normal names.
- `patch.sh` is unchanged — the scheme list is passed by the callers, keeping the script generic.

## Toggle

- New `UDKeyUseCustomOAuthSignIn` default (`@YES`).
- `Tweak.xm`: the `ASWebAuthenticationSession start` hook returns `%orig` when the toggle is off, restoring Apple's native auth session. PR #377's iOS 15 Old Reddit fallback lives entirely inside `ApolloWebAuthViewController`, which is only reached from the custom path, so it's disabled automatically too.
- `CustomAPIViewController.m`: adds the switch cell, and restores the Redirect URI validity coloring + the `Info.plist`-scheme hint in the field's description **only when the toggle is off** (native sign-in requires the scheme to be registered).
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 