### PR TITLE
Support fork PRs via workflow_run with code-owner comment gate

### DIFF
--- a/.github/workflows/pr-build-ipa-comment.yml
+++ b/.github/workflows/pr-build-ipa-comment.yml
@@ -1,0 +1,120 @@
+name: PR build IPA comment
+
+# Posts the sticky "test IPAs" comment for the PR build, on behalf of
+# pr-build-ipa.yml. That workflow runs on the `pull_request` event, whose token
+# is read-only for fork PRs and so cannot comment. This companion runs on
+# `workflow_run`, which executes from the base repo's default branch with a
+# write-scoped token even for fork-originated runs, and only ever handles DATA
+# (the prebuilt comment body) — it never checks out or runs the PR's code. The
+# target PR and its author are resolved from trusted inputs (event data + the
+# API), and the authoritative code-owner gate is enforced HERE, in this
+# fork-uneditable workflow, before any comment is posted.
+#
+# Note: workflow_run only fires once this file exists on the default branch.
+
+on:
+  workflow_run:
+    workflows: ["PR build IPA variants"]
+    types: [completed]
+
+concurrency:
+  # Serialize comment updates per source branch so a newer build's comment wins.
+  group: pr-build-ipa-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read          # download artifacts from the triggering run
+  pull-requests: write   # post/update the comment
+
+jobs:
+  comment:
+    name: Post or update sticky PR comment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download comment payload
+        id: download
+        # Fork-PR builds upload `pr-comment`; non-code-owner or cancelled runs do
+        # not, so a missing artifact is normal — don't fail the job over it.
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: pr-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Post or update comment
+        if: steps.download.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MARKER: '<!-- apollo-pr-ipa-build -->'
+          # Attacker-controllable fields (a fork controls the build workflow and
+          # its branch name) MUST go through env, never inline ${{ }} in the
+          # script, to avoid shell injection in this privileged context.
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          [ -f comment.md ] || { echo "No comment body; nothing to post."; exit 0; }
+
+          # Resolve the target PR from TRUSTED workflow_run event data, not from
+          # the artifact: a build runs the PR head's workflow file and could
+          # otherwise spoof an arbitrary PR number. head_sha is a hex commit id;
+          # branch/owner are only ever passed as data (env / API query field).
+          PR_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
+                --jq 'map(select(.state == "open")) | .[0] // empty' 2>/dev/null || true)
+          if [ -z "$PR_JSON" ]; then
+            # Fallback: match open PRs by head label, then by exact head SHA.
+            PR_JSON=$(gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
+                  -f state=open -f head="${HEAD_OWNER}:${HEAD_BRANCH}" \
+                  --jq "([.[] | select(.head.sha == \"${HEAD_SHA}\")] + .) | .[0] // empty" 2>/dev/null || true)
+          fi
+          if [ -z "$PR_JSON" ]; then
+            echo "No open PR found for ${HEAD_OWNER}:${HEAD_BRANCH} @ ${HEAD_SHA}; skipping."
+            exit 0
+          fi
+          PR=$(echo "$PR_JSON" | jq -r '.number')
+          PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.user.login')
+          echo "Target PR: #${PR} by ${PR_AUTHOR}"
+
+          # Authoritative code-owner gate, enforced HERE (trusted, fork can't edit
+          # this workflow) rather than in the build workflow (whose file the PR
+          # head controls). Read CODEOWNERS from the default branch via the API,
+          # and the author from the resolved PR object — both trusted inputs.
+          OWNERS=$(gh api "repos/${GITHUB_REPOSITORY}/contents/.github/CODEOWNERS" \
+                    -H "Accept: application/vnd.github.raw" 2>/dev/null \
+                    | grep -E '^\*[[:space:]]' | sed 's/#.*//' \
+                    | grep -oE '@[A-Za-z0-9_-]+' | sed 's/@//')
+          is_owner=false
+          while IFS= read -r owner; do
+            [ -z "$owner" ] && continue
+            if [ "$(echo "$owner" | tr '[:upper:]' '[:lower:]')" = "$(echo "$PR_AUTHOR" | tr '[:upper:]' '[:lower:]')" ]; then
+              is_owner=true
+              break
+            fi
+          done <<< "$OWNERS"
+          if [ "$is_owner" != "true" ]; then
+            echo "PR author ${PR_AUTHOR} is not a code owner; not commenting."
+            exit 0
+          fi
+
+          # Build the request body as proper JSON so quotes/backticks/newlines in
+          # the comment are escaped correctly (safer than gh's -F type magic).
+          jq -Rs '{body: .}' comment.md > payload.json
+
+          # Upsert one marker-keyed comment so we never clobber an unrelated
+          # github-actions[bot] comment.
+          COMMENT_ID=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | tail -1)
+          if [ -n "$COMMENT_ID" ]; then
+            gh api --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
+              --input payload.json >/dev/null
+            echo "Updated existing comment ${COMMENT_ID} on PR #${PR}"
+          else
+            gh api --method POST \
+              "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
+              --input payload.json >/dev/null
+            echo "Created new comment on PR #${PR}"
+          fi

--- a/.github/workflows/pr-build-ipa.yml
+++ b/.github/workflows/pr-build-ipa.yml
@@ -1,17 +1,13 @@
 name: PR build IPA variants
 
-# Builds the distributable IPA variants for a PR and posts a sticky comment with
-# per-variant download links, so reviewers can sideload a test build without
-# building locally.
+# Builds the distributable IPA variants for a PR and hands a comment body off to
+# pr-build-ipa-comment.yml, which posts a sticky comment with per-variant
+# download links so reviewers can sideload a test build without building locally.
 #
-# Gated to CODEOWNERS authors: they push branches to this repo directly, so the
-# PR is same-repo and GITHUB_TOKEN is write-scoped (enough to comment). Fork PRs
-# get a read-only token and are not built. No dedicated GitHub App needed.
-#
-# Known limitation: if a code owner opens the PR from a fork, GITHUB_TOKEN is
-# read-only regardless of the requested permissions. The build still runs, but
-# the comment step cannot post (it 403s). Code owners normally push branches to
-# this repo directly, so this is rare in practice.
+# Gated to CODEOWNERS authors (read from the trusted base ref). The build runs on
+# both same-repo and fork PRs, but fork PRs get a read-only token here, so this
+# workflow never comments directly: it uploads the comment body as an artifact
+# and a separate workflow_run workflow (write-scoped) posts it. No GitHub App.
 
 on:
   pull_request:
@@ -32,13 +28,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# No write scopes: this workflow only builds and uploads artifacts. The comment
+# is posted by pr-build-ipa-comment.yml. (Fork PRs get a read-only token anyway.)
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   authorize:
     name: Check PR author is a code owner
+    # Cheap pre-filter to skip the expensive build for non-code-owner PRs. This
+    # is NOT the security boundary for forks (a fork controls this workflow file
+    # and could bypass it) — the authoritative code-owner gate runs in the
+    # fork-uneditable pr-build-ipa-comment.yml before any comment is posted.
     runs-on: ubuntu-latest
     outputs:
       is_owner: ${{ steps.check.outputs.is_owner }}
@@ -46,6 +47,9 @@ jobs:
       - name: Checkout CODEOWNERS
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          # Read CODEOWNERS from the trusted BASE ref, never the PR head: a fork
+          # could otherwise add itself to CODEOWNERS to self-authorize the build.
+          ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout: .github/CODEOWNERS
           sparse-checkout-cone-mode: false
 
@@ -287,28 +291,14 @@ jobs:
             echo "The IPA build for \`${{ steps.meta.outputs.short_sha || github.event.pull_request.head.sha }}\` failed. See the [workflow run](${RUN_URL}) for logs."
           } > comment.md
 
-      - name: Post or update sticky PR comment
-        # Run on success or failure, but not when the run was cancelled.
+      - name: Upload comment payload
+        # The PR-event token is read-only for fork PRs, so it cannot comment.
+        # Hand the comment body to pr-build-ipa-comment.yml, which runs in the
+        # base-repo context with a write token and posts it. The target PR is
+        # resolved there from trusted event data, so no PR number is passed here.
         if: ${{ !cancelled() }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
-          MARKER: '<!-- apollo-pr-ipa-build -->'
-        run: |
-          # Upsert one marker-keyed comment: find our previous comment by its
-          # hidden marker and PATCH it in place, otherwise create a new one. This
-          # keys on the marker (not gh's --edit-last) so it never clobbers an
-          # unrelated github-actions[bot] comment.
-          [ -f comment.md ] || { echo "No comment body to post."; exit 0; }
-          COMMENT_ID=$(gh api --paginate \
-            "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
-            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | tail -1)
-          if [ -n "$COMMENT_ID" ]; then
-            gh api --method PATCH \
-              "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
-              -f body="$(cat comment.md)" >/dev/null
-            echo "Updated existing comment ${COMMENT_ID}"
-          else
-            gh pr comment "${PR}" --body-file comment.md
-            echo "Created new comment"
-          fi
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pr-comment
+          path: comment.md
+          retention-days: 1


### PR DESCRIPTION
The PR build automation (#433) builds on the `pull_request` event, whose `GITHUB_TOKEN` is read-only for fork PRs. So a fork PR — even one opened by a code owner — built all the IPAs successfully but failed at the final comment step with a 403, leaving reviewers no download links (e.g. #427).

### Changes

This splits commenting out of the build so fork PRs work end to end, and moves the code-owner gate somewhere a fork cannot bypass.

- **`pr-build-ipa.yml`** no longer comments. It builds as before and uploads the prebuilt comment body as a short-lived `pr-comment` artifact. Permissions are dropped to `contents: read`, and its `authorize` job is now just a cheap pre-filter (skips the build for non-code-owners), not a security boundary.
- **`pr-build-ipa-comment.yml`** (new) runs on `workflow_run`, which executes from the base repo's default branch with a write-scoped token even for fork-originated runs. It downloads the comment body and posts/updates the sticky comment.

### Security

A fork controls the build workflow file (it runs from the PR head), so authorization and the target PR cannot be trusted from anything the build produces. The `workflow_run` workflow — which a fork cannot edit — is therefore the authoritative gate:

- Resolves the target PR and its author from trusted inputs only (the `workflow_run` event's head SHA, via the API), never from the artifact, so the build can't spoof which PR gets commented on.
- Reads CODEOWNERS from the default branch and posts only if the PR author is a code owner; otherwise it exits without commenting.
- Never checks out or runs the PR's code, passes the attacker-controlled branch name via env (never inline `${{ }}`), and builds the request body as JSON with `jq`.

### Result

A code owner's fork PR now builds and comments automatically, with no command needed. Non-code-owner PRs get no comment, and the gate can't be spoofed.

### Notes

- Takes effect once `pr-build-ipa-comment.yml` is on the default branch (`workflow_run` requirement); existing fork PRs need a rebase onto `main` to pick up the build-side change.
- The build job still runs for non-code-owners before the comment gate rejects them — GitHub's "require approval for fork PR workflows" setting remains the backstop for build minutes.
