### PR TITLE
Move libflex into bundle for rootless deb builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,5 +132,13 @@ lg-previews:
 	@echo "Regenerating $(notdir $(LG_PREVIEW_HEADER)) from liquid-glass/icons.json"
 	@python3 $(LG_DIR)/scripts/generate_previews_header.py $(LG_PREVIEW_HEADER)
 
+# Move libflex into bundle for rootless deb builds
+#   Remove libflex.plist for all packages since it's not needed
+before-package::
+ifeq ($(THEOS_PACKAGE_SCHEME),rootless)
+	@mv $(THEOS_STAGING_DIR)/Library/MobileSubstrate/DynamicLibraries/libflex.dylib $(THEOS_STAGING_DIR)/Library/Application\ Support/ApolloReborn/ApolloReborn.bundle/libflex.dylib
+endif
+	@rm $(THEOS_STAGING_DIR)/Library/MobileSubstrate/DynamicLibraries/libflex.plist
+
 include $(THEOS_MAKE_PATH)/aggregate.mk
 include $(THEOS_MAKE_PATH)/tweak.mk

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <dlfcn.h>
 #import <objc/runtime.h>
 #import <objc/message.h>
 #import <sys/utsname.h>
@@ -1293,6 +1294,11 @@ static void initializeRandomSources() {
     }, 4);
 
     if ([[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableFLEX]) {
+        if (!%c(FLEXManager)) {
+            // try to load from our ApolloReborn.bundle/libFLEX.dylib
+            NSString *flexFromBundle = ApolloBundledResourcePath(@"libflex", @"dylib");
+            if (flexFromBundle) dlopen(flexFromBundle.UTF8String, RTLD_LAZY);
+        }
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             [[%c(FLEXManager) performSelector:@selector(sharedManager)] performSelector:@selector(showExplorer)];
         });


### PR DESCRIPTION
- Move libflex into bundle for rootless deb builds
- Remove libflex.plist for all packages since it's not needed

This simply allows rootless jailbreak users to have the standalone libFLEX package installed system-wide, without conflicting with Apollo Reborn

Rootful builds are not impacted since that deb is injected into the IPA