### PR TITLE
Fix modern subreddit-list header tint when Home is selected (#450)

### DIFF
--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -502,15 +502,19 @@ static void ApolloSubredditIndexClearHeaderChrome(UIView *header, UILabel *label
 }
 
 static void ApolloSubredditIndexApplyModernTableSurfaceBackground(UITableView *tableView) {
-    if (!sModernSubredditDividers || !tableView) return;
-
-    // Transparent section headers reveal UITableView gaps; match the row surface instead.
-    UIColor *surfaceColor = ApolloSubredditIndexThemeListBackgroundColor(tableView, tableView);
-    tableView.backgroundColor = surfaceColor;
-    if (tableView.backgroundView) {
-        tableView.backgroundView.backgroundColor = surfaceColor;
-        tableView.backgroundView.opaque = ApolloSubredditIndexColorIsVisible(surfaceColor);
-    }
+    // Intentionally does NOT give the table a coloured background (#450).
+    //
+    // This used to colour the scroll view's backgroundColor (and backgroundView) to the row
+    // surface so transparent modern section headers wouldn't reveal a mismatched gap. But on
+    // iOS 26, ANY coloured background on a UIScrollView (backgroundColor OR a coloured
+    // backgroundView, opaque flag irrelevant) makes the navigation bar switch from its
+    // transparent scroll-edge appearance to its glass / content-reflecting appearance. The bar
+    // then mirrors the selected first row (Home, which sits right at the bar's edge) across the
+    // whole header — the reported tint. Classic mode never coloured the table, which is exactly
+    // why classic never bled. The section-header gaps are instead filled by each header's own
+    // opaque backgroundColor (see ApolloSubredditIndexStyleHeaderView), so the scroll view stays
+    // transparent and the nav bar never reflects the selection.
+    (void)tableView;
 }
 
 static UITableView *ApolloSubredditIndexTableForView(UIView *view) {
@@ -1564,6 +1568,14 @@ static void ApolloSubredditIndexStyleHeaderView(UIView *header, UITableView *tab
         objc_setAssociatedObject(tableView, &kApolloSubredditHeaderLoggedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         ApolloLog(@"[SubredditIndex] styled-header class=%@ title=%@", NSStringFromClass([header class]), text);
     }
+
+    // Fill the gap a transparent modern header would otherwise leave by giving the header its
+    // own opaque surface colour (matching the rows). This replaces the old approach of colouring
+    // the whole scroll view, which tripped the iOS 26 nav-bar glass reflection (#450) — see
+    // ApolloSubredditIndexApplyModernTableSurfaceBackground. The header is a subview below the
+    // first row, so it never reaches the nav bar's reflected band.
+    UIColor *surfaceColor = ApolloSubredditIndexThemeListBackgroundColor(tableView, header);
+    header.backgroundColor = ApolloSubredditIndexColorIsVisible(surfaceColor) ? surfaceColor : tableView.backgroundColor;
 }
 
 static void ApolloSubredditIndexHeaderLayoutSubviewsHook(id self, SEL _cmd) {

--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -501,22 +501,6 @@ static void ApolloSubredditIndexClearHeaderChrome(UIView *header, UILabel *label
     header.opaque = NO;
 }
 
-static void ApolloSubredditIndexApplyModernTableSurfaceBackground(UITableView *tableView) {
-    // Intentionally does NOT give the table a coloured background (#450).
-    //
-    // This used to colour the scroll view's backgroundColor (and backgroundView) to the row
-    // surface so transparent modern section headers wouldn't reveal a mismatched gap. But on
-    // iOS 26, ANY coloured background on a UIScrollView (backgroundColor OR a coloured
-    // backgroundView, opaque flag irrelevant) makes the navigation bar switch from its
-    // transparent scroll-edge appearance to its glass / content-reflecting appearance. The bar
-    // then mirrors the selected first row (Home, which sits right at the bar's edge) across the
-    // whole header — the reported tint. Classic mode never coloured the table, which is exactly
-    // why classic never bled. The section-header gaps are instead filled by each header's own
-    // opaque backgroundColor (see ApolloSubredditIndexStyleHeaderView), so the scroll view stays
-    // transparent and the nav bar never reflects the selection.
-    (void)tableView;
-}
-
 static UITableView *ApolloSubredditIndexTableForView(UIView *view) {
     while (view) {
         if ([view isKindOfClass:[UITableView class]]) return (UITableView *)view;
@@ -1135,7 +1119,11 @@ static void ApolloSubredditIndexInstallOrUpdate(UITableView *tableView) {
 
     objc_setAssociatedObject(tableView, &kApolloSubredditIndexTableKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloSubredditIndexApplySeparatorInsets(tableView);
-    ApolloSubredditIndexApplyModernTableSurfaceBackground(tableView);
+    // NB: deliberately do NOT colour the table's scroll-view background here. On iOS 26 any opaque
+    // UIScrollView background flips the nav bar to its glass / content-reflecting appearance, which
+    // mirrors the selected Home row across the whole header (#450). The gaps that transparent modern
+    // section headers would leave are instead filled by each header's own opaque backgroundColor in
+    // ApolloSubredditIndexStyleHeaderView, so the scroll view stays transparent.
     ApolloSubredditIndexHideNativeIndex(tableView);
 
     UIView *container = tableView.superview ?: tableView;
@@ -1571,9 +1559,8 @@ static void ApolloSubredditIndexStyleHeaderView(UIView *header, UITableView *tab
 
     // Fill the gap a transparent modern header would otherwise leave by giving the header its
     // own opaque surface colour (matching the rows). This replaces the old approach of colouring
-    // the whole scroll view, which tripped the iOS 26 nav-bar glass reflection (#450) — see
-    // ApolloSubredditIndexApplyModernTableSurfaceBackground. The header is a subview below the
-    // first row, so it never reaches the nav bar's reflected band.
+    // the whole scroll view, which tripped the iOS 26 nav-bar glass reflection (#450). The header
+    // is a subview below the first row, so it never reaches the nav bar's reflected band.
     UIColor *surfaceColor = ApolloSubredditIndexThemeListBackgroundColor(tableView, header);
     header.backgroundColor = ApolloSubredditIndexColorIsVisible(surfaceColor) ? surfaceColor : tableView.backgroundColor;
 }


### PR DESCRIPTION
Fixes #450.

## The bug
In **modern** subreddit-list mode, selecting the **Home** row tints the whole navigation-bar / header area instead of just the row. Only Home, and only in modern mode — **classic never does this**.

## Root cause
It's iOS 26's navigation bar, not the row selection itself.

`ApolloSubredditIndexApplyModernTableSurfaceBackground` coloured the subreddit table's **scroll-view `backgroundColor`** (to stop transparent modern section headers revealing a mismatched gap). On iOS 26, giving a `UIScrollView` *any* opaque background flips the navigation bar from its transparent scroll-edge appearance to its **glass / content-reflecting** appearance. The bar then mirrors the content at its edge — the first row, Home — across the whole header whenever Home is selected.

Classic mode never colours the table, so its bar stays transparent and never reflects the selection. That's the entire modern-vs-classic difference.

## The fix
- Stop colouring the scroll view's background (the trigger).
- Fill the transparent-modern-header gaps via each **section header's own opaque `backgroundColor`** instead. The header is a subview below the first row, so it never enters the nav bar's reflected band, and the scroll view stays transparent — so the bar no longer reflects the selection.

## Video

<table>
  <tr>
    <td align="center"><b>Before</b></td>
    <td align="center"><b>After</b></td>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/80c9b790-960d-4874-8d5f-d3d7e9f16e25" width="320" controls></video></td>
    <td><video src="https://github.com/user-attachments/assets/509acabb-daaf-4791-a9ee-0421b6fc2b8d" width="320" controls></video></td>
  </tr>
</table>

## Testing
Verified in the iOS Simulator (iOS 26, Liquid Glass build). With the Home row forced into a held selected state, the nav-bar band reads pure black after the change (it read the selection tint before), while the Home row itself still highlights normally. No section-header gaps, list looks unchanged at rest.

