### PR TITLE
Fix Liquid Glass nav-bar translation globe spacing (#393)

### DIFF
--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -48,6 +48,26 @@ static const void *kApolloTitleOwnedTextNodeKey = &kApolloTitleOwnedTextNodeKey;
 // The globe-installation code uses this to gate visibility on
 // sTranslatePostTitles in addition to sEnableBulkTranslation.
 static const void *kApolloFeedTranslationVCKey = &kApolloFeedTranslationVCKey;
+// Liquid Glass globe-merge: instead of adding the translation globe as a SEPARATE
+// trailing bar button item (which iOS 26 spaces apart from Apollo's mod/sort/more
+// container with a visible inter-group gap), we inject the globe button directly
+// into Apollo's existing trailing container so all icons form one evenly-spaced
+// group. kApolloGlobeMergeButtonKey holds the globe UIButton on the navigationItem;
+// sApplyingGlobeMerge guards the setRightBarButtonItem(s) re-injection hook.
+static const void *kApolloGlobeMergeButtonKey = &kApolloGlobeMergeButtonKey;
+// Fallback for screens with no multi-button container to merge into: the globe
+// is shown as its own trailing bar button item (the pre-26 behavior).
+static const void *kApolloGlobeStandaloneItemKey = &kApolloGlobeStandaloneItemKey;
+// The right-shift the merge applied to Apollo's buttons, stored on the container
+// so removal can undo it exactly.
+static const void *kApolloGlobeMergeShiftKey = &kApolloGlobeMergeShiftKey;
+static BOOL sApplyingGlobeMerge = NO;
+// Globe slot width inside Apollo's container. ~34pt centers the ~26pt glyph with
+// the same modest padding Apollo's own icons use, so spacing reads even.
+static const CGFloat kApolloGlobeMergeSlotWidth = 34.0;
+// Points to nudge the globe glyph toward the next icon (compensates for the wide
+// 44pt mod-badge slot's leading padding so the globe→badge gap looks even).
+static const CGFloat kApolloGlobeMergeGlyphNudge = 3.0;
 static const void *kApolloFeedSettledTitleRefreshScheduledKey = &kApolloFeedSettledTitleRefreshScheduledKey;
 static const void *kApolloReapplyScheduledKey = &kApolloReapplyScheduledKey;
 // Phase B — status banner above comments.
@@ -3247,6 +3267,193 @@ static UIColor *ApolloThemeTintColorFromNavigationItems(NSArray<UIBarButtonItem 
     return nil;
 }
 
+// MARK: - Liquid Glass globe-merge helpers
+//
+// On iOS 26, each custom-view UIBarButtonItem is hosted in its own
+// NavigationButtonBar item wrapper, and the bar inserts ~16pt of inter-item
+// spacing between separate items — far more than the ~2-3pt Apollo gets by
+// hand-packing its mod/sort/more buttons into ONE combined custom-view
+// container (CGRectGetMaxX layout). Added as a separate item, the globe sits
+// visibly isolated with a big gap before Apollo's cluster (issue #393). The
+// fix: inject the globe button straight into Apollo's container so every icon
+// is one evenly-spaced group. Apollo rebuilds that container on various events,
+// so the setRightBarButtonItem(s) hook re-applies this after each rebuild.
+
+// Find Apollo's combined trailing button container for this nav item: a
+// custom-view UIView that holds at least one UIButton OTHER than our globe.
+static UIView *ApolloFindTrailingButtonContainer(UINavigationItem *navItem, UIButton *globe) {
+    for (UIBarButtonItem *item in navItem.rightBarButtonItems) {
+        UIView *cv = item.customView;
+        if (![cv isKindOfClass:[UIView class]]) continue;
+        BOOL hasOtherButton = NO;
+        for (UIView *sub in cv.subviews) {
+            if ([sub isKindOfClass:[UIButton class]] && sub != globe) { hasOtherButton = YES; break; }
+        }
+        if (hasOtherButton) return cv;
+    }
+    return nil;
+}
+
+// Detach the globe from any container it was merged into, restoring that
+// container's original button layout (shift back, shrink).
+static void ApolloDetachGlobeFromContainer(UIButton *globe) {
+    if (!globe || ![globe.superview isKindOfClass:[UIView class]]) return;
+    UIView *container = globe.superview;
+    // Undo exactly the right-shift we applied when merging (stored on the
+    // container), falling back to the slot width if unknown.
+    CGFloat shift = [objc_getAssociatedObject(container, kApolloGlobeMergeShiftKey) doubleValue];
+    if (shift <= 0.0) shift = globe.frame.size.width > 1.0 ? globe.frame.size.width : kApolloGlobeMergeSlotWidth;
+    [globe removeFromSuperview];
+    for (UIView *sub in container.subviews) {
+        if (![sub isKindOfClass:[UIButton class]]) continue;
+        CGRect f = sub.frame;
+        f.origin.x -= shift;
+        sub.frame = f;
+    }
+    CGRect cf = container.frame;
+    cf.size.width = MAX(0.0, cf.size.width - shift);
+    container.frame = cf;
+    container.bounds = CGRectMake(0.0, 0.0, cf.size.width, cf.size.height);
+    objc_setAssociatedObject(container, kApolloGlobeMergeShiftKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [container setNeedsLayout];
+}
+
+// Place the globe correctly for this nav item (idempotent). If Apollo has a
+// multi-button trailing container, inject the globe as its leading button so
+// every icon is one evenly-spaced group (issue #393). Otherwise fall back to a
+// standalone trailing bar button item (pre-26 behavior) so the globe still
+// appears on single-button screens. Re-runs after each Apollo rebuild via the
+// setRightBarButtonItem(s) hook.
+static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
+    if (!navItem) return;
+    UIButton *globe = objc_getAssociatedObject(navItem, kApolloGlobeMergeButtonKey);
+    if (!globe) return;
+
+    UIView *container = ApolloFindTrailingButtonContainer(navItem, globe);
+    UIBarButtonItem *standalone = objc_getAssociatedObject(navItem, kApolloGlobeStandaloneItemKey);
+
+    if (container) {
+        // Prefer the merged layout — drop any standalone fallback we added.
+        if (standalone) {
+            NSMutableArray<UIBarButtonItem *> *its = [navItem.rightBarButtonItems mutableCopy];
+            if ([its containsObject:standalone]) {
+                [its removeObject:standalone];
+                sApplyingGlobeMerge = YES;
+                navItem.rightBarButtonItems = its;
+                sApplyingGlobeMerge = NO;
+            }
+            objc_setAssociatedObject(navItem, kApolloGlobeStandaloneItemKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+
+        if (globe.superview == container) return;  // already merged — don't double-shift
+
+        CGFloat gw = kApolloGlobeMergeSlotWidth;
+        CGFloat h = container.bounds.size.height > 1.0 ? container.bounds.size.height : 44.0;
+        [globe removeFromSuperview];  // out of any previous (stale) container
+
+        // Measure Apollo's button cluster and the container's trailing inset so
+        // we can insert the globe and keep the whole group SYMMETRIC inside the
+        // glass capsule (equal leading/trailing padding). Apollo's container can
+        // carry an asymmetric leading inset (the subreddit nav bar starts its
+        // first button ~10pt in) — inheriting it would leave a gap before the
+        // globe, so we re-place the leading edge to match the trailing inset.
+        CGFloat leadingX = CGFLOAT_MAX, rightEdge = 0.0, firstBtnWidth = 0.0;
+        for (UIView *sub in container.subviews) {
+            if (![sub isKindOfClass:[UIButton class]]) continue;
+            if (CGRectGetMinX(sub.frame) < leadingX) {
+                leadingX = CGRectGetMinX(sub.frame);
+                firstBtnWidth = CGRectGetWidth(sub.frame);  // the button the globe sits before
+            }
+            rightEdge = MAX(rightEdge, CGRectGetMaxX(sub.frame));
+        }
+        if (leadingX == CGFLOAT_MAX) leadingX = 0.0;
+        CGFloat contW = container.frame.size.width;
+        CGFloat trailInset = (contW > rightEdge) ? (contW - rightEdge) : 0.0;
+        trailInset = MAX(0.0, MIN(trailInset, 20.0));
+        CGFloat globeX = trailInset;                    // symmetric leading inset
+        CGFloat shift  = globeX + gw - leadingX;        // first Apollo button lands flush after the globe
+
+        // Center the glyph, then nudge it toward the next icon by HALF that
+        // icon's extra slot width beyond a normal ~38pt slot. The mod badge sits
+        // in a wide 44pt slot, so its centered glyph carries extra leading
+        // padding that makes the globe→badge gap read large; a narrow first icon
+        // (e.g. the 34pt trophy on Home) gets no nudge. Keeps spacing even on
+        // every screen without a one-size-fits-all shift.
+        CGFloat nudge = (firstBtnWidth - 38.0) * 0.5;
+        nudge = MAX(0.0, MIN(nudge, kApolloGlobeMergeGlyphNudge));
+        globe.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
+        globe.imageEdgeInsets = UIEdgeInsetsMake(0.0, nudge, 0.0, -nudge);
+        for (UIView *sub in container.subviews) {
+            if (![sub isKindOfClass:[UIButton class]]) continue;
+            CGRect f = sub.frame;
+            f.origin.x += shift;
+            sub.frame = f;
+        }
+        globe.frame = CGRectMake(globeX, 0.0, gw, h);
+        [container insertSubview:globe atIndex:0];
+
+        // Resize so the bar item re-measures: content spans [globeX, rightEdge+
+        // shift] with a matching trailing inset. Remember the shift for removal.
+        CGFloat newW = rightEdge + shift + trailInset;
+        CGRect cf = container.frame;
+        cf.size.width = newW;
+        container.frame = cf;
+        container.bounds = CGRectMake(0.0, 0.0, newW, cf.size.height > 1.0 ? cf.size.height : h);
+        objc_setAssociatedObject(container, kApolloGlobeMergeShiftKey, @(shift), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        [container setNeedsLayout];
+        return;
+    }
+
+    // No multi-button container to merge into yet. Don't eagerly add a
+    // standalone item — Apollo often builds its trailing container slightly
+    // AFTER the first merge attempt (e.g. async mod-status load), and a
+    // standalone globe added now would conflict with the container injection
+    // that follows (the same button can't live in both), leaving the globe
+    // stranded in its own item with a gap. Instead wait: the
+    // setRightBarButtonItem(s) hook re-runs this as soon as Apollo sets its
+    // container. Only fall back to standalone if the globe truly has nowhere to
+    // go (already detached and no container appeared).
+    if (globe.superview && ![globe.superview isKindOfClass:[UIView class]]) {
+        // shouldn't happen, but normalize
+    }
+    ApolloDetachGlobeFromContainer(globe);
+    globe.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
+    globe.frame = CGRectMake(0.0, 0.0, kApolloGlobeMergeSlotWidth, 32.0);
+    if (!standalone) {
+        standalone = [[UIBarButtonItem alloc] initWithCustomView:globe];
+        objc_setAssociatedObject(navItem, kApolloGlobeStandaloneItemKey, standalone, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    } else if (standalone.customView != globe) {
+        standalone.customView = globe;
+    }
+    NSMutableArray<UIBarButtonItem *> *its = [navItem.rightBarButtonItems mutableCopy] ?: [NSMutableArray array];
+    if (![its containsObject:standalone]) {
+        [its addObject:standalone];
+        sApplyingGlobeMerge = YES;
+        navItem.rightBarButtonItems = its;
+        sApplyingGlobeMerge = NO;
+    }
+}
+
+// Remove the globe entirely (translation gated off): detach from any container,
+// drop any standalone item, and clear tracking.
+static void ApolloRemoveGlobeMergeForNavItem(UINavigationItem *navItem) {
+    if (!navItem) return;
+    UIButton *globe = objc_getAssociatedObject(navItem, kApolloGlobeMergeButtonKey);
+    ApolloDetachGlobeFromContainer(globe);
+    UIBarButtonItem *standalone = objc_getAssociatedObject(navItem, kApolloGlobeStandaloneItemKey);
+    if (standalone) {
+        NSMutableArray<UIBarButtonItem *> *its = [navItem.rightBarButtonItems mutableCopy];
+        if ([its containsObject:standalone]) {
+            [its removeObject:standalone];
+            sApplyingGlobeMerge = YES;
+            navItem.rightBarButtonItems = its;
+            sApplyingGlobeMerge = NO;
+        }
+    }
+    objc_setAssociatedObject(navItem, kApolloGlobeStandaloneItemKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(navItem, kApolloGlobeMergeButtonKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 static void ApolloUpdateTranslationUIForController(id controller) {
     UIViewController *vc = (UIViewController *)controller;
     if (!sEnableBulkTranslation) return;
@@ -3275,6 +3482,8 @@ static void ApolloUpdateTranslationUIForController(id controller) {
             vc.navigationItem.rightBarButtonItems = items;
             objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         }
+        // Liquid Glass: also pull the globe back out of Apollo's merged container.
+        ApolloRemoveGlobeMergeForNavItem(vc.navigationItem);
         if (!isFeedVC) ApolloUpdateBannerForController(vc);
         return;
     }
@@ -3283,31 +3492,31 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     BOOL visibleTranslationApplied = [objc_getAssociatedObject(vc, kApolloVisibleTranslationAppliedKey) boolValue];
     NSString *targetName = ApolloLocalizedTargetLanguageName();
 
-    // Compact globe icon — backed by a UIButton in a custom view so we can
-    // shrink its slot below UIKit's default ~44pt and keep it grouped in the
-    // same bubble as Apollo's sort/3-dots items (any fixed-space item would
-    // split that bubble).
+    // Globe icon — a UIButton hosted either inside Apollo's trailing container
+    // (Liquid Glass, so it groups evenly with mod/sort/more — issue #393) or as
+    // our own separate bar button item (pre-26, where that's the tuned layout).
+    BOOL liquidGlass = IsLiquidGlass();
+
     UIImage *globeImage = [[UIImage systemImageNamed:@"globe"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+
     UIButton *globeButton = nil;
-    if (translationItem && [translationItem.customView isKindOfClass:[UIButton class]]) {
+    if (liquidGlass) {
+        globeButton = objc_getAssociatedObject(vc.navigationItem, kApolloGlobeMergeButtonKey);
+    }
+    if (!globeButton && translationItem && [translationItem.customView isKindOfClass:[UIButton class]]) {
         globeButton = (UIButton *)translationItem.customView;
     }
     if (!globeButton) {
         globeButton = [UIButton buttonWithType:UIButtonTypeSystem];
         globeButton.frame = CGRectMake(0.0, 0.0, 36.0, 32.0);
+        // Pre-26: right-align so the glyph tucks against Apollo's adjacent pill.
+        // Liquid Glass: ApolloApplyGlobeMergeForNavItem re-centers it in the slot.
         globeButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
         globeButton.imageEdgeInsets = UIEdgeInsetsZero;
         [globeButton addTarget:controller action:@selector(apollo_translationGlobeTapped) forControlEvents:UIControlEventTouchUpInside];
     }
     [globeButton setImage:globeImage forState:UIControlStateNormal];
 
-    if (!translationItem) {
-        translationItem = [[UIBarButtonItem alloc] initWithCustomView:globeButton];
-        objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, translationItem, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    } else if (translationItem.customView != globeButton) {
-        translationItem.customView = globeButton;
-    }
-    translationItem.menu = nil;
     UIColor *themeTintColor = ApolloThemeTintColorFromNavigationItems(items, translationItem, vc.traitCollection);
     if (!themeTintColor) {
         themeTintColor = ApolloThemeTintCandidate(vc.view.tintColor, vc.traitCollection);
@@ -3322,20 +3531,41 @@ static void ApolloUpdateTranslationUIForController(id controller) {
         themeTintColor = [UIColor systemBlueColor];
     }
     UIColor *resolvedTint = visibleTranslationApplied ? [UIColor systemGreenColor] : themeTintColor;
-    translationItem.tintColor = resolvedTint;
     globeButton.tintColor = resolvedTint;
     globeButton.accessibilityLabel = translatedMode
         ? @"Translation: showing translated. Tap to show original."
         : [NSString stringWithFormat:@"Translation: showing original. Tap to translate to %@.", targetName];
-    translationItem.accessibilityLabel = globeButton.accessibilityLabel;
 
-    if (![items containsObject:translationItem]) {
-        // Apollo's rightBarButtonItems are laid out right-to-left. Adding to
-        // the end places the globe just to the left of Apollo's sort/3-dots
-        // pill — same bubble, tighter spacing thanks to the narrower frame.
-        [items addObject:translationItem];
+    if (liquidGlass) {
+        // Merge the globe into Apollo's combined trailing container so all icons
+        // share one evenly-spaced group. Track the button on the nav item so the
+        // setRightBarButtonItem(s) hook re-injects it after Apollo rebuilds.
+        objc_setAssociatedObject(vc.navigationItem, kApolloGlobeMergeButtonKey, globeButton, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        // Drop any separate bar item from a prior pre-26 run (migration safety).
+        if (translationItem && [items containsObject:translationItem]) {
+            [items removeObject:translationItem];
+            vc.navigationItem.rightBarButtonItems = items;
+            objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+        ApolloApplyGlobeMergeForNavItem(vc.navigationItem);
+    } else {
+        if (!translationItem) {
+            translationItem = [[UIBarButtonItem alloc] initWithCustomView:globeButton];
+            objc_setAssociatedObject(controller, kApolloTranslateBarButtonKey, translationItem, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        } else if (translationItem.customView != globeButton) {
+            translationItem.customView = globeButton;
+        }
+        translationItem.menu = nil;
+        translationItem.tintColor = resolvedTint;
+        translationItem.accessibilityLabel = globeButton.accessibilityLabel;
+        if (![items containsObject:translationItem]) {
+            // Apollo's rightBarButtonItems are laid out right-to-left. Adding to
+            // the end places the globe just to the left of Apollo's sort/3-dots
+            // pill — same bubble, tighter spacing thanks to the narrower frame.
+            [items addObject:translationItem];
+        }
+        vc.navigationItem.rightBarButtonItems = items;
     }
-    vc.navigationItem.rightBarButtonItems = items;
 
     if (!isFeedVC) ApolloUpdateBannerForController(vc);
 }
@@ -5059,6 +5289,31 @@ static void ApolloReapplyTranslationOnAppResume(void) {
         });
     }
 }
+
+// Liquid Glass globe-merge re-injection. Apollo rebuilds its combined trailing
+// button container on various events (mod-status load, trait changes, etc.) and
+// re-sets it via setRightBarButtonItem(s):. When a nav item is flagged for the
+// globe merge, re-inject the globe into the freshly-built container after each
+// set. sApplyingGlobeMerge guards against our own re-set recursing.
+%hook UINavigationItem
+
+- (void)setRightBarButtonItems:(NSArray<UIBarButtonItem *> *)items animated:(BOOL)animated {
+    %orig(items, animated);
+    if (sApplyingGlobeMerge) return;
+    if (IsLiquidGlass() && objc_getAssociatedObject(self, kApolloGlobeMergeButtonKey)) {
+        ApolloApplyGlobeMergeForNavItem(self);
+    }
+}
+
+- (void)setRightBarButtonItem:(UIBarButtonItem *)item animated:(BOOL)animated {
+    %orig(item, animated);
+    if (sApplyingGlobeMerge) return;
+    if (IsLiquidGlass() && objc_getAssociatedObject(self, kApolloGlobeMergeButtonKey)) {
+        ApolloApplyGlobeMergeForNavItem(self);
+    }
+}
+
+%end
 
 %ctor {
     sTranslationCache = [NSCache new];


### PR DESCRIPTION
## Summary

Fixes the uneven trailing nav-bar icon spacing under iOS 26 Liquid Glass, where the translation globe sat isolated with a large gap before Apollo's moderation / trophy / sort / more cluster. Addresses #393.

## Root cause

On iOS 26, UIKit hosts each custom-view `UIBarButtonItem` in its own `NavigationButtonBar` item wrapper and inserts noticeable inter-group spacing between *separate* items. Apollo hand-packs its own trailing buttons (moderation badge, sort, more, trophy) into a **single** combined custom-view container, so they're tightly grouped — but the tweak added the translation globe as a **separate** bar item, so it rendered with the larger inter-group gap.

On a moderated subreddit this reads exactly as #393 describes: the moderation icon appears to have "too much padding to the left" — that space is really the gap between the globe and the badge. (The moderation/sort/more cluster on its own is already symmetric; the gap only appears once the globe is present.)

## Fix

Inject the globe directly into Apollo's combined trailing container (Liquid Glass only) so every trailing icon forms one evenly-spaced group:

- Find Apollo's container and insert the globe as the leading button, shifting Apollo's buttons right and widening the container so the bar item re-measures.
- Re-apply via a `setRightBarButtonItem(s):` hook so it survives Apollo rebuilding the container (async moderator-status load, trait changes, etc.).
- Keep the group symmetric inside the glass capsule (leading inset matched to the trailing inset) and nudge the globe glyph toward a wide leading icon (the 44pt moderation badge) so spacing reads even on every screen.
- Standalone fallback when there is no container to merge into; the pre-26 layout (separate right-aligned item) is unchanged.

## Screenshots

Trailing nav-bar icons under Liquid Glass — **before vs after**. The translation globe now groups evenly with Apollo's icons instead of sitting isolated with a gap (most visible on a moderated subreddit):

<img width="1210" height="506" alt="lg-globe-spacing-before-after" src="https://github.com/user-attachments/assets/d9aac9c2-69ac-4af5-80d8-216a7f2bd9fa" />

## Testing

Verified in the iOS 26 simulator (Liquid Glass) with a signed-in moderator account, reading the live bar-item geometry:

- Moderated subreddit (globe · badge · sort/trophy · more) — globe now grouped and evenly spaced.
- Home / non-moderated feeds (globe · trophy · more) — unchanged, even spacing.
- Translation toggled on and off — globe added/removed cleanly, container restored.
- Non–Liquid-Glass build — separate-item behavior unchanged.
