### PR TITLE
Decode HTML entities in link-preview card text

### DIFF
--- a/src/ApolloInlineLinkPreviews.xm
+++ b/src/ApolloInlineLinkPreviews.xm
@@ -1275,7 +1275,11 @@ static BOOL ApolloLPSetTextNodeAttributedTextIfChanged(ASTextNode *textNode, NSA
 
 static NSString *ApolloLPCleanDisplayText(NSString *text) {
     if (![text isKindOfClass:[NSString class]] || text.length == 0) return text;
-    NSString *clean = [text stringByReplacingOccurrencesOfString:@"&nbsp;" withString:@" "];
+    // Decode HTML entities FIRST (named + numeric, incl. « » ° €) — the fetcher
+    // decodes freshly-stored metadata, but cached and *translated* card text reach
+    // this render choke point raw and would otherwise show literal "&laquo;".
+    // Decoding before tag-stripping also lets an encoded "&lt;b&gt;" collapse out.
+    NSString *clean = ApolloLinkPreviewDecodeEntities(text) ?: text;
     NSRegularExpression *tagRegex = [NSRegularExpression regularExpressionWithPattern:@"<[^>]+>" options:0 error:nil];
     clean = [tagRegex stringByReplacingMatchesInString:clean options:0 range:NSMakeRange(0, clean.length) withTemplate:@" "];
     NSRegularExpression *whitespace = [NSRegularExpression regularExpressionWithPattern:@"\\s+" options:0 error:nil];
@@ -1290,7 +1294,9 @@ static NSString *ApolloLPCleanDisplayText(NSString *text) {
 // a multi-paragraph post into one run-on blob.
 static NSString *ApolloLPCleanMultilineDisplayText(NSString *text) {
     if (![text isKindOfClass:[NSString class]] || text.length == 0) return text;
-    NSString *clean = [text stringByReplacingOccurrencesOfString:@"&nbsp;" withString:@" "];
+    // Decode entities first (see ApolloLPCleanDisplayText) — keeps numeric/named
+    // entities out of cached/translated multiline bodies (e.g. Bluesky posts).
+    NSString *clean = ApolloLinkPreviewDecodeEntities(text) ?: text;
     NSRegularExpression *tagRegex = [NSRegularExpression regularExpressionWithPattern:@"<[^>]+>" options:0 error:nil];
     clean = [tagRegex stringByReplacingMatchesInString:clean options:0 range:NSMakeRange(0, clean.length) withTemplate:@" "];
     // \x0B (vertical tab), NOT \v: in ICU regex \v is a class shorthand for

--- a/src/ApolloLinkPreviewFetcher.h
+++ b/src/ApolloLinkPreviewFetcher.h
@@ -8,3 +8,9 @@
 + (BOOL)isTwitterURL:(NSURL *)url;
 
 @end
+
+// Decode HTML entities (named + numeric, e.g. &laquo;->«, &raquo;->», &#8230;->…)
+// for display-time callers in other translation units. The fetcher decodes these
+// when it first stores metadata, but cached and *translated* link-card text bypass
+// that path and would otherwise render raw — so the render choke point decodes too.
+FOUNDATION_EXPORT NSString *ApolloLinkPreviewDecodeEntities(NSString *string);

--- a/src/ApolloLinkPreviewFetcher.m
+++ b/src/ApolloLinkPreviewFetcher.m
@@ -112,12 +112,26 @@ static NSString *ApolloLinkPreviewDecodeCommonNamedEntities(NSString *string) {
     clean = [clean stringByReplacingOccurrencesOfString:@"&bdquo;" withString:@"\""];
     clean = [clean stringByReplacingOccurrencesOfString:@"&ndash;" withString:@"-"];
     clean = [clean stringByReplacingOccurrencesOfString:@"&mdash;" withString:@"-"];
-    clean = [clean stringByReplacingOccurrencesOfString:@"&hellip;" withString:@"..."];
+    clean = [clean stringByReplacingOccurrencesOfString:@"&hellip;" withString:@"…"];
+    // Guillemets (« »), common in Italian/French news headlines (e.g. il messaggero),
+    // were passing through raw into preview cards.
+    clean = [clean stringByReplacingOccurrencesOfString:@"&laquo;" withString:@"«"];
+    clean = [clean stringByReplacingOccurrencesOfString:@"&raquo;" withString:@"»"];
+    clean = [clean stringByReplacingOccurrencesOfString:@"&deg;" withString:@"°"];
+    clean = [clean stringByReplacingOccurrencesOfString:@"&euro;" withString:@"€"];
     clean = [clean stringByReplacingOccurrencesOfString:@"&lt;" withString:@"<"];
     clean = [clean stringByReplacingOccurrencesOfString:@"&gt;" withString:@">"];
     // &amp; last so we don't double-decode embedded entities.
     clean = [clean stringByReplacingOccurrencesOfString:@"&amp;" withString:@"&"];
     return clean;
+}
+
+// Public entity-decode entry point (named + numeric only — no whitespace/tag
+// normalization, since display-time callers handle that). Shared with the link-card
+// render path in ApolloInlineLinkPreviews so cached/translated titles decode too.
+NSString *ApolloLinkPreviewDecodeEntities(NSString *string) {
+    if (![string isKindOfClass:[NSString class]]) return string;
+    return ApolloLinkPreviewDecodeCommonNamedEntities(ApolloLinkPreviewDecodeNumericEntities(string));
 }
 
 static NSString *ApolloLinkPreviewCleanString(NSString *string) {


### PR DESCRIPTION
## What

Link-preview cards could render raw HTML entities in their title/description — e.g. `&laquo;An umbrella…&raquo;` instead of `«An umbrella…»` — most visibly on **translated** cards (Italian/French news headlines).

## Why

The fetcher already decodes entities when it first stores metadata (`ApolloLinkPreviewCleanString`), but the card **render** path (`ApolloLPCleanDisplayText` / `ApolloLPCleanMultilineDisplayText`) only decoded `&nbsp;`. Two cases slip through:

- **Cached cards** whose stored text predates a decode pass.
- **Translated cards** — the translator returns text with the entities untouched and overwrites the already-decoded original, so the raw `&laquo;` reaches the screen.

## Fix

Decode at the single render choke point both original and translated text flow through. The fetcher's named+numeric decoder is exposed as `ApolloLinkPreviewDecodeEntities(...)` and called (before tag-stripping) in both display cleaners. Because it runs at render time, it also cleans up already-cached entries. A few more named entities are mapped while here (`«` `»` `°` `€`, and `&hellip;` → a real `…`).

## Testing

Built for device + simulator. Verified on an Italian news card (`il messaggero`) that guillemets render correctly in both the original and translated states, in feed and comments.
