### PR TITLE
Hide redundant "GIF" label beneath inline GIFs (#392)

### DIFF
--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -2985,9 +2985,25 @@ static NSArray *ApolloBuildLeavesForTextNode(ASTextNode *textNode,
         for (NSInteger n = (NSInteger)pIdx.count - 1; n >= 0; n--) {
             NSUInteger ri = [pIdx[n] unsignedIntegerValue];
             NSRange r = [ranges[ri] rangeValue];
-            if ([isBareURL[ri] boolValue] || [isDefaultGifLabel[ri] boolValue]) {
-                [remaining deleteCharactersInRange:NSMakeRange(r.location - pStart, r.length)];
+            if (![isBareURL[ri] boolValue] && ![isDefaultGifLabel[ri] boolValue]) continue;
+            NSUInteger loc = r.location - pStart;
+            NSUInteger len = r.length;
+            // If the removed label sits between two spaces (mid-sentence, e.g.
+            // "lol [gif](url) so funny"), also consume one flanking space so we
+            // don't leave a doubled interior space. ApolloTrimAttributedString
+            // only trims the string's leading/trailing whitespace, not interior
+            // runs. Checked against the current `remaining` state, which is safe
+            // because we delete highest-location ranges first, leaving the chars
+            // at and before `loc` untouched for lower-location ranges.
+            NSString *s = remaining.string;
+            if (loc >= 1 && loc + len < s.length) {
+                NSCharacterSet *ws = [NSCharacterSet whitespaceCharacterSet];
+                if ([ws characterIsMember:[s characterAtIndex:loc - 1]] &&
+                    [ws characterIsMember:[s characterAtIndex:loc + len]]) {
+                    len += 1; // drop the trailing space of the pair
+                }
             }
+            [remaining deleteCharactersInRange:NSMakeRange(loc, len)];
         }
 
         NSAttributedString *trimmed = ApolloTrimAttributedString(remaining);

--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -916,6 +916,19 @@ static BOOL ApolloRangeTextLooksLikeBareURL(NSAttributedString *attr, NSRange ra
     return [text rangeOfString:path].location != NSNotFound;
 }
 
+// A comment/post inline GIF is written in markdown as `[GIF](url)` (or
+// `![gif](url)`), so once we render the GIF inline the decomposed text node
+// would still show a redundant "GIF" label directly beneath it. Issue #392:
+// when the link/alt text is exactly the default word "gif" we drop it (the GIF
+// is self-evidently a GIF). Custom alt text like `[my dancing cat](url)` is NOT
+// the default word, so it is kept and shown beneath the image as before.
+static BOOL ApolloRangeTextIsDefaultGIFLabel(NSAttributedString *attr, NSRange range) {
+    if (range.location + range.length > attr.string.length) return NO;
+    NSString *text = [[attr.string substringWithRange:range]
+                      stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    return [text caseInsensitiveCompare:@"gif"] == NSOrderedSame;
+}
+
 static CGFloat ApolloAspectRatioFromURL(NSURL *url) {
     NSURLComponents *c = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
     NSString *w = nil, *h = nil;
@@ -2833,6 +2846,9 @@ static NSArray *ApolloBuildLeavesForTextNode(ASTextNode *textNode,
     NSMutableArray<NSNumber *> *isVideoURL = [NSMutableArray array];
     NSMutableArray<NSNumber *> *isImageChestURL = [NSMutableArray array];
     NSMutableArray<NSNumber *> *isBareURL = [NSMutableArray array];
+    // Issue #392: the link/alt text is just the default word "gif" — drop the
+    // redundant label beneath the inline GIF (custom alt text stays visible).
+    NSMutableArray<NSNumber *> *isDefaultGifLabel = [NSMutableArray array];
     NSMutableSet<NSString *> *seenAbs = [NSMutableSet set];
     NSUInteger imageChestPostLinkCount = ApolloUniqueImageChestPostLinkCount(attr);
     NSDictionary *hostMediaMetadata = ApolloMediaMetadataForHost(hostMarkdownNode);
@@ -2879,6 +2895,7 @@ static NSArray *ApolloBuildLeavesForTextNode(ASTextNode *textNode,
             if (!abs.length || [seenAbs containsObject:abs]) continue;
             BOOL imageChestURL = ApolloImageChestIsPostURL(url);
             BOOL bareURL = ApolloRangeTextLooksLikeBareURL(attr, fullRange, url);
+            BOOL defaultGifLabel = ApolloRangeTextIsDefaultGIFLabel(attr, fullRange);
             [seenAbs addObject:abs];
             ApolloRegisterInlineSuppressionURL(url);
             ApolloRegisterInlineSuppressionURL(normalized);
@@ -2888,6 +2905,7 @@ static NSArray *ApolloBuildLeavesForTextNode(ASTextNode *textNode,
             [isVideoURL addObject:@(isVideo)];
             [isImageChestURL addObject:@(imageChestURL)];
             [isBareURL addObject:@(bareURL)];
+            [isDefaultGifLabel addObject:@(defaultGifLabel)];
         }
     }];
 
@@ -2961,11 +2979,13 @@ static NSArray *ApolloBuildLeavesForTextNode(ASTextNode *textNode,
         [leaves addObjectsFromArray:prefixImageNodes];
 
         NSMutableAttributedString *remaining = [[attr attributedSubstringFromRange:pRange] mutableCopy];
-        // Reverse-order deletion of bare-URL ranges (paragraph-relative).
+        // Reverse-order deletion of redundant label ranges (paragraph-relative):
+        // bare URLs (the text just repeats the link) and default "GIF" labels
+        // (issue #392 — the GIF is shown inline, so its "GIF" caption is noise).
         for (NSInteger n = (NSInteger)pIdx.count - 1; n >= 0; n--) {
             NSUInteger ri = [pIdx[n] unsignedIntegerValue];
             NSRange r = [ranges[ri] rangeValue];
-            if ([isBareURL[ri] boolValue]) {
+            if ([isBareURL[ri] boolValue] || [isDefaultGifLabel[ri] boolValue]) {
                 [remaining deleteCharactersInRange:NSMakeRange(r.location - pStart, r.length)];
             }
         }


### PR DESCRIPTION
Closes #392.

### What
When **Inline Media Previews** is on, an inline GIF in a comment/self-post is written in markdown as `[GIF](url)`. After we render the GIF inline, the decomposed link text still draws a redundant **“GIF”** caption directly beneath the image it describes — exactly what #392 asks to remove.

This drops that caption **only when the link/alt text is exactly the default word “gif”** (case-insensitive, whitespace-trimmed). The GIF itself is unchanged and remains tappable, so no information or behavior is lost — the label was just a duplicate of "this is a GIF", which the inline GIF already makes obvious.

### Custom alt text is preserved
This directly addresses the question @JeffreyCA raised on the issue. The change is purely additive to the existing "redundant label" pruning that already removes bare-URL captions:

```objc
if ([isBareURL[ri] boolValue] || [isDefaultGifLabel[ri] boolValue]) {
    [remaining deleteCharactersInRange:...];   // drop the redundant caption
}
```

`isDefaultGifLabel` is true **only** for text that equals `"gif"`. Custom link text such as `[my dancing cat](url)` does not match, so it keeps `isDefaultGifLabel = NO` (and isn't a bare URL either) and is rendered beneath the image exactly as before. The issue author confirmed this is the desired behavior: hide only when the text is just “Gif”.

No new setting — there's nothing to lose by hiding a label that carries no information the GIF doesn't already convey.

### Implementation
All in `src/ApolloInlineImages.xm`, inside `ApolloBuildLeavesForTextNode`:
- New helper `ApolloRangeTextIsDefaultGIFLabel()` — trims the range's text and case-insensitively compares it to `"gif"`.
- A parallel `isDefaultGifLabel` flag is collected alongside the existing `isBareURL` flag and OR'd into the existing reverse-order range-deletion loop. Per-range deletion means mixed paragraphs (`look at this [GIF](url) lol`) only lose the “GIF” token, not the surrounding text.

##Screenshot
<img width="426" height="462" alt="Screenshot 2026-06-15 at 5 38 45 PM" src="https://github.com/user-attachments/assets/9c20787e-b1a4-49f0-b7f4-b9ddb3d33319" />

### Testing
- iOS 26 Simulator (Liquid Glass), inline media previews on: the “GIF” caption that previously sat beneath inline GIF comments is gone; the GIF still renders and opens fullscreen on tap; the next comment follows immediately. Verified both visually and via the accessibility tree (no standalone “GIF” text element remains).
- Custom-alt-text path is unchanged by construction (see above) — not separately reproduced since it needs a live custom-labeled GIF comment.
- Not yet device-tested.