### PR TITLE
Social Links in Profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloSubredditCustomIconCache.m \
     $(SRC_DIR)/ApolloSubredditDefaultAssets.c \
     $(SRC_DIR)/ApolloUserAvatars.xm \
+    $(SRC_DIR)/ApolloProfileSocialLinks.m \
     $(SRC_DIR)/ApolloSubredditHeaders.xm \
     $(SRC_DIR)/ApolloBannedProfile.xm \
     $(SRC_DIR)/ApolloImageUploadHost.xm \

--- a/src/ApolloProfileSocialLinks.h
+++ b/src/ApolloProfileSocialLinks.h
@@ -1,0 +1,51 @@
+// ApolloProfileSocialLinks.h
+//
+// "Social Links in Profile" — surfaces the social links a redditor has set on
+// their profile (Buy Me a Coffee, Instagram, X, YouTube, custom links, …) inside
+// Apollo's profile header, in the gap between the username line and the bio.
+//
+//   • 1 link   → a long tappable pill: [icon] name   (tap opens the link)
+//   • 2+ links → a row of circular brand badges       (tap anywhere → slide-up
+//                "Social Links" sheet listing them all, each row tappable)
+//
+// Reddit's OAuth API (Apollo's token) can't read social links — about.json omits
+// them and gql 404s our token — so, like Community Highlights / the Sidebar weekly
+// stats, we scrape the server-rendered public profile page in a hidden WKWebView
+// (it sails past Reddit's JS bot-challenge that plain requests get 403'd by).
+// Results are cached per-username. Icons come from each link's domain favicon
+// (bundled coffee glyph for Buy Me a Coffee / Ko-fi), so brands render without a
+// bundled logo set. See ApolloProfileSocialLinks.m.
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+// A single social link parsed from a user's reddit profile.
+@interface ApolloSocialLink : NSObject
+@property(nonatomic, copy) NSString *title;        // display name, e.g. "icpryde"
+@property(nonatomic, copy) NSString *urlString;    // absolute URL string
+@property(nonatomic, copy) NSString *type;         // lowercased token: buymeacoffee, instagram, twitter, custom, …
+@property(nonatomic, strong) NSURL *url;
+@end
+
+// In-header band, added as a subview of ApolloProfileHeaderView (ApolloUserAvatars.xm)
+// and positioned by it between the username line and the bio. Self-manages its data
+// via a cached hidden-WKWebView scrape of the public profile page.
+@interface ApolloProfileSocialLinksView : UIView
+// Assigning a (different) username (re)loads links from cache or kicks off a scrape.
+@property(nonatomic, copy) NSString *username;
+// Presenter used to open links and present the sheet.
+@property(nonatomic, weak) UIViewController *hostViewController;
+// Called on the main queue when the rendered height may have changed (links
+// arrived, toggle flipped) so the host header can re-measure its tableHeaderView.
+@property(nonatomic, copy) void (^heightChangedBlock)(void);
+// 0 when the feature is off or there are no links; otherwise the band height.
+- (CGFloat)preferredHeightForWidth:(CGFloat)width;
+// Pull-to-refresh: drop cached links for the current user and re-scrape.
+- (void)refresh;
+@end
+
+// YES when the "Social Links in Profile" toggle is on (reads sSocialLinksInProfile).
+FOUNDATION_EXPORT BOOL ApolloProfileSocialLinksEnabled(void);
+
+// Posted by Settings when the toggle flips; the band observes it to reload.
+FOUNDATION_EXPORT NSString *const ApolloSocialLinksToggleChangedNotification;

--- a/src/ApolloProfileSocialLinks.m
+++ b/src/ApolloProfileSocialLinks.m
@@ -1,0 +1,764 @@
+// ApolloProfileSocialLinks.m  — see ApolloProfileSocialLinks.h for the overview.
+
+#import "ApolloProfileSocialLinks.h"
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+#import <WebKit/WebKit.h>
+#import <objc/runtime.h>
+
+// Symbols are wired up incrementally; tolerate not-yet-used helpers under -Werror.
+#pragma clang diagnostic ignored "-Wunused-function"
+
+NSString *const ApolloSocialLinksToggleChangedNotification = @"ApolloSocialLinksToggleChangedNotification";
+
+BOOL ApolloProfileSocialLinksEnabled(void) {
+    return sSocialLinksInProfile;
+}
+
+#pragma mark - Model
+
+@implementation ApolloSocialLink
+@end
+
+#pragma mark - Layout constants
+
+static CGFloat const kSLPillHeight   = 30.0;   // name-pill capsule height
+static CGFloat const kSLBadgeSize    = 30.0;   // circular badge diameter
+static CGFloat const kSLBadgeGap     = 8.0;
+static CGFloat const kSLIconSize     = 18.0;
+static NSUInteger const kSLMaxBadges = 8;      // beyond this we show a "+N" badge
+static NSUInteger const kSLPillThreshold = 3;  // <=3 links -> name pills; >3 -> icon badges + sheet
+static CGFloat const kSLHeaderHeight = 16.0;   // the "Social Links" caption
+static CGFloat const kSLHeaderGap    = 5.0;    // gap below the header, above the items
+static CGFloat const kSLPillRowGap   = 8.0;    // vertical gap between wrapped pill rows
+static CGFloat const kSLPillHGap     = 8.0;    // horizontal gap between pills
+static CGFloat const kSLPillLeadInset = 12.0;
+static CGFloat const kSLPillTrailInset = 14.0;
+static CGFloat const kSLPillIconGap  = 8.0;
+
+#pragma mark - Type inference / display names
+
+// Map a URL host (or "mailto:") to a stable lowercased type token.
+static NSString *ApolloSLTypeForHost(NSString *host) {
+    NSString *h = host.lowercaseString ?: @"";
+    NSArray<NSArray<NSString *> *> *map = @[
+        @[@"buymeacoffee.com", @"buymeacoffee"], @[@"buymeacoff.ee", @"buymeacoffee"],
+        @[@"ko-fi.com", @"kofi"], @[@"patreon.com", @"patreon"],
+        @[@"paypal.me", @"paypal"], @[@"paypal.com", @"paypal"],
+        @[@"cash.app", @"cashapp"], @[@"venmo.com", @"venmo"],
+        @[@"instagram.com", @"instagram"], @[@"twitter.com", @"twitter"],
+        @[@"x.com", @"twitter"], @[@"t.co", @"twitter"],
+        @[@"tiktok.com", @"tiktok"], @[@"youtube.com", @"youtube"], @[@"youtu.be", @"youtube"],
+        @[@"twitch.tv", @"twitch"], @[@"discord.gg", @"discord"], @[@"discord.com", @"discord"],
+        @[@"spotify.com", @"spotify"], @[@"soundcloud.com", @"soundcloud"],
+        @[@"facebook.com", @"facebook"], @[@"fb.com", @"facebook"],
+        @[@"github.com", @"github"], @[@"onlyfans.com", @"onlyfans"],
+        @[@"linktr.ee", @"linktree"], @[@"snapchat.com", @"snapchat"],
+        @[@"linkedin.com", @"linkedin"], @[@"pinterest.com", @"pinterest"],
+        @[@"tumblr.com", @"tumblr"], @[@"threads.net", @"threads"],
+        @[@"bsky.app", @"bluesky"], @[@"mastodon", @"mastodon"],
+        @[@"steamcommunity.com", @"steam"], @[@"twitch.com", @"twitch"],
+        @[@"mailto:", @"email"],
+    ];
+    for (NSArray<NSString *> *pair in map) {
+        if ([h rangeOfString:pair[0]].location != NSNotFound) return pair[1];
+    }
+    return @"custom";
+}
+
+// Friendly label for the type, used when a link has no text of its own.
+static NSString *ApolloSLDisplayNameForType(NSString *type) {
+    static NSDictionary<NSString *, NSString *> *names;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        names = @{
+            @"buymeacoffee": @"Buy Me a Coffee", @"kofi": @"Ko-fi", @"patreon": @"Patreon",
+            @"paypal": @"PayPal", @"cashapp": @"Cash App", @"venmo": @"Venmo",
+            @"instagram": @"Instagram", @"twitter": @"X", @"tiktok": @"TikTok",
+            @"youtube": @"YouTube", @"twitch": @"Twitch", @"discord": @"Discord",
+            @"spotify": @"Spotify", @"soundcloud": @"SoundCloud", @"facebook": @"Facebook",
+            @"github": @"GitHub", @"onlyfans": @"OnlyFans", @"linktree": @"Linktree",
+            @"snapchat": @"Snapchat", @"linkedin": @"LinkedIn", @"pinterest": @"Pinterest",
+            @"tumblr": @"Tumblr", @"threads": @"Threads", @"bluesky": @"Bluesky",
+            @"mastodon": @"Mastodon", @"steam": @"Steam", @"email": @"Email",
+        };
+    });
+    return names[type] ?: @"Link";
+}
+
+#pragma mark - Icons (bundled coffee + favicon + placeholder)
+
+static UIImage *ApolloSLPlaceholderIcon(void) {
+    static UIImage *icon;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        if (@available(iOS 13.0, *)) {
+            icon = [[UIImage systemImageNamed:@"link"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+        }
+    });
+    return icon;
+}
+
+// Coffee/Ko-fi reuse the bundled buy-me-a-coffee glyph (nicer than the favicon and
+// matches the rest of the tweak). Other types fall through to favicons.
+static UIImage *ApolloSLBundledIconForType(NSString *type) {
+    if ([type isEqualToString:@"buymeacoffee"] || [type isEqualToString:@"kofi"]) {
+        return ApolloBuyMeACoffeeSettingsIcon(kSLIconSize);
+    }
+    return nil;
+}
+
+static NSCache<NSString *, UIImage *> *ApolloSLFaviconCache(void) {
+    static NSCache *cache; static dispatch_once_t once;
+    dispatch_once(&once, ^{ cache = [[NSCache alloc] init]; cache.countLimit = 120; });
+    return cache;
+}
+
+// host(lower) -> completions waiting on the in-flight favicon fetch. Coalesces
+// concurrent requests so every caller is notified, not just the first.
+static NSMutableDictionary<NSString *, NSMutableArray *> *ApolloSLFaviconPending(void) {
+    static NSMutableDictionary *d; static dispatch_once_t once;
+    dispatch_once(&once, ^{ d = [NSMutableDictionary dictionary]; });
+    return d;
+}
+
+static UIImage *ApolloSLFaviconCachedForHost(NSString *host) {
+    if (host.length == 0) return nil;
+    return [ApolloSLFaviconCache() objectForKey:host.lowercaseString];
+}
+
+// Fetch the domain favicon (Google S2, 64px PNG — independent of Reddit's bot wall).
+// completion runs on the main queue with nil on failure.
+// Called on the main queue (icon requests originate from view/cell layout). The
+// completion runs on the main queue with nil on failure.
+static void ApolloSLRequestFaviconForHost(NSString *host, void (^completion)(UIImage *image)) {
+    NSString *key = host.lowercaseString ?: @"";
+    if (key.length == 0) { if (completion) completion(nil); return; }
+    UIImage *cached = [ApolloSLFaviconCache() objectForKey:key];
+    if (cached) { if (completion) completion(cached); return; }
+
+    // Queue the completion; if a fetch is already running for this host, just wait
+    // on it (every waiter gets the image once it arrives).
+    NSMutableArray *waiters = ApolloSLFaviconPending()[key];
+    if (waiters) { if (completion) [waiters addObject:[completion copy]]; return; }
+    waiters = [NSMutableArray array];
+    if (completion) [waiters addObject:[completion copy]];
+    ApolloSLFaviconPending()[key] = waiters;
+
+    void (^drain)(UIImage *) = ^(UIImage *image) {
+        NSArray *toNotify = ApolloSLFaviconPending()[key];
+        [ApolloSLFaviconPending() removeObjectForKey:key];
+        for (void (^w)(UIImage *) in toNotify) w(image);
+    };
+
+    NSString *urlString = [NSString stringWithFormat:@"https://www.google.com/s2/favicons?sz=64&domain=%@", key];
+    NSURL *url = [NSURL URLWithString:urlString];
+    if (!url) { drain(nil); return; }
+    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url];
+    req.timeoutInterval = 12.0;
+    [[[NSURLSession sharedSession] dataTaskWithRequest:req completionHandler:^(NSData *data, NSURLResponse *resp, NSError *err) {
+        // Google returns a 16px globe placeholder for unknown domains; keep it anyway
+        // (still better than our generic glyph for most real services).
+        UIImage *image = data.length > 0 ? [UIImage imageWithData:data] : nil;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (image) [ApolloSLFaviconCache() setObject:image forKey:key];
+            drain(image);
+        });
+    }] resume];
+}
+
+#pragma mark - Links cache + scrape
+
+static NSCache<NSString *, NSArray<ApolloSocialLink *> *> *ApolloSLLinksCache(void) {
+    static NSCache *cache; static dispatch_once_t once;
+    dispatch_once(&once, ^{ cache = [[NSCache alloc] init]; cache.countLimit = 80; });
+    return cache;
+}
+
+// username(lower) -> NSMutableArray of completion blocks waiting on the in-flight scrape.
+static NSMutableDictionary<NSString *, NSMutableArray *> *ApolloSLPending(void) {
+    static NSMutableDictionary *d; static dispatch_once_t once;
+    dispatch_once(&once, ^{ d = [NSMutableDictionary dictionary]; });
+    return d;
+}
+
+// Retains in-flight scrapers (one per username) so they aren't deallocated mid-load.
+static NSMutableDictionary *ApolloSLFetchers(void) {
+    static NSMutableDictionary *d; static dispatch_once_t once;
+    dispatch_once(&once, ^{ d = [NSMutableDictionary dictionary]; });
+    return d;
+}
+
+// Build ApolloSocialLink objects from the scraper's parsed JSON dicts.
+static NSArray<ApolloSocialLink *> *ApolloSLLinksFromJSON(NSArray *raw) {
+    NSMutableArray<ApolloSocialLink *> *links = [NSMutableArray array];
+    NSMutableSet<NSString *> *seen = [NSMutableSet set];
+    for (id obj in (raw ?: @[])) {
+        if (![obj isKindOfClass:[NSDictionary class]]) continue;
+        NSString *urlString = obj[@"url"];
+        if (![urlString isKindOfClass:[NSString class]] || urlString.length == 0) continue;
+        if ([seen containsObject:urlString]) continue;
+        [seen addObject:urlString];
+        NSURL *url = [NSURL URLWithString:urlString];
+        ApolloSocialLink *link = [ApolloSocialLink new];
+        link.urlString = urlString;
+        link.url = url;
+        NSString *host = [urlString hasPrefix:@"mailto:"] ? @"mailto:" : (url.host ?: @"");
+        link.type = ApolloSLTypeForHost(host);
+        NSString *title = [obj[@"title"] isKindOfClass:[NSString class]] ? [obj[@"title"] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] : nil;
+        link.title = title.length > 0 ? title : ApolloSLDisplayNameForType(link.type);
+        [links addObject:link];
+        if (links.count >= 12) break;
+    }
+    return links;
+}
+
+@interface ApolloSLWebFetch : NSObject <WKNavigationDelegate>
+@property (nonatomic, strong) WKWebView *web;
+@property (nonatomic, copy) NSString *username;
+@property (nonatomic, copy) void (^done)(NSArray<ApolloSocialLink *> *links);
+@property (nonatomic) int polls;
+@property (nonatomic) int emptyAfterReady;
+@property (nonatomic) BOOL sawProfile;   // the real shreddit profile page loaded (not the bot interstitial)
+@end
+
+@implementation ApolloSLWebFetch
+
+- (void)startForUsername:(NSString *)username completion:(void (^)(NSArray<ApolloSocialLink *> *))done {
+    // WKWebView must be created/used on the main thread.
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{ [self startForUsername:username completion:done]; });
+        return;
+    }
+    self.username = username; self.done = done; self.polls = 0; self.emptyAfterReady = 0; self.sawProfile = NO;
+    UIWindow *win = nil;
+    for (UIScene *s in UIApplication.sharedApplication.connectedScenes) {
+        if (![s isKindOfClass:[UIWindowScene class]]) continue;
+        for (UIWindow *w in ((UIWindowScene *)s).windows) { if (w.isKeyWindow) win = w; }
+    }
+    if (!win) win = UIApplication.sharedApplication.windows.firstObject;
+    if (!win) { [self finish:nil]; return; }
+    self.web = [[WKWebView alloc] initWithFrame:win.bounds configuration:[[WKWebViewConfiguration alloc] init]];
+    self.web.navigationDelegate = self;
+    self.web.alpha = 0.011; self.web.userInteractionEnabled = NO;
+    self.web.customUserAgent = @"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+    [win insertSubview:self.web atIndex:0];
+    NSString *urlString = [NSString stringWithFormat:@"https://www.reddit.com/user/%@/", username];
+    [self.web loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:urlString]]];
+    ApolloLog(@"[SocialLinks][web] loading u/%@", username);
+    [self pollAfter:3.0];
+}
+
+- (void)pollAfter:(double)d {
+    __weak typeof(self) ws = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(d * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{ [ws poll]; });
+}
+
+// JS: extract social links from the public profile page, with diagnostics so the
+// selector can be refined against real markup (logged via [SocialLinks][web]).
+- (NSString *)extractionJS {
+    return
+    @"(function(){"
+    "function reddit(h){h=(h||'').toLowerCase();return h.indexOf('reddit.com')>=0||h.indexOf('redd.it')>=0||h.indexOf('redditstatic')>=0||h.indexOf('redditmedia')>=0||h.indexOf('reddithelp')>=0||h==='';}"
+    "function inFeed(a){try{return !!(a.closest&&a.closest('shreddit-feed,article,shreddit-post,[data-testid=\"post-container\"],nav,header'));}catch(e){return false;}}"
+    "var out=[],seen={};"
+    "function push(a,scoped){try{var href=a.href||a.getAttribute('href');if(!href)return;if(href.indexOf('javascript:')===0)return;if(seen[href])return;var host=a.hostname||'';if(!scoped){if(reddit(host))return;if(inFeed(a))return;}var txt=(a.textContent||'').trim().replace(/\\s+/g,' ');out.push({url:href,title:txt});seen[href]=1;}catch(e){}}"
+    "var sels=['shreddit-social-links a','customizable-social-links a','profile-social-links a','a[data-testid=\"social-link\"]','faceplate-tracker[noun=\"social_link\"] a','[slot=\"social-links\"] a','[bundlename*=\"social\"] a'];"
+    "for(var s=0;s<sels.length;s++){var els=document.querySelectorAll(sels[s]);for(var j=0;j<els.length;j++)push(els[j],true);}"
+    "if(out.length===0){var scope=document.querySelector('shreddit-async-loader[bundlename*=\"profile\"]')||document.querySelector('aside')||document.querySelector('main')||document.body;if(scope){var as=scope.querySelectorAll('a[href]');for(var k=0;k<as.length;k++)push(as[k],false);}}"
+    "var diag=[];var all=document.querySelectorAll('a[href]');for(var m=0;m<all.length&&diag.length<24;m++){var a2=all[m];if(!reddit(a2.hostname)&&!inFeed(a2)){var p=a2.parentElement;diag.push({h:a2.href,t:(a2.textContent||'').trim().slice(0,28),pt:p?p.tagName.toLowerCase():'',pc:p?(((p.getAttribute('class')||'')+'|'+(p.getAttribute('slot')||''))).slice(0,46):''});}}"
+    "var profile=!!document.querySelector('shreddit-app')&&(document.title||'').toLowerCase().indexOf('verification')<0;"
+    "return JSON.stringify({links:out,total:all.length,diag:diag,ready:document.readyState,profile:profile});"
+    "})()";
+}
+
+- (void)poll {
+    if (!self.web) return;
+    self.polls++;
+    __weak typeof(self) ws = self;
+    [self.web evaluateJavaScript:[self extractionJS] completionHandler:^(id res, NSError *e) {
+        typeof(self) ss = ws; if (!ss) return;
+        if (e) ApolloLog(@"[SocialLinks][web] u/%@ JS error (poll#%d): %@", ss.username, ss.polls, e.localizedDescription);
+        NSString *s = [res isKindOfClass:[NSString class]] ? res : @"{}";
+        NSDictionary *j = [NSJSONSerialization JSONObjectWithData:[s dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
+        if (![j isKindOfClass:[NSDictionary class]]) j = @{};
+        NSArray *rawLinks = [j[@"links"] isKindOfClass:[NSArray class]] ? j[@"links"] : @[];
+        NSString *ready = [j[@"ready"] isKindOfClass:[NSString class]] ? j[@"ready"] : @"";
+        // Only the REAL profile page counts — not Reddit's "please wait for verification"
+        // interstitial (which is itself a fully-loaded page with no links).
+        BOOL profileLoaded = [j[@"profile"] boolValue];
+        if (profileLoaded) ss.sawProfile = YES;
+
+        if (rawLinks.count > 0) {
+            NSArray<ApolloSocialLink *> *links = ApolloSLLinksFromJSON(rawLinks);
+            ApolloLog(@"[SocialLinks][web] u/%@ found %lu link(s) (poll#%d)", ss.username, (unsigned long)links.count, ss.polls);
+            [ss finish:links];
+            return;
+        }
+
+        if (profileLoaded) {
+            ss.emptyAfterReady++;
+            // Diagnostics on the first empty pass over the loaded profile — this is what
+            // we read to lock the real selector against live markup if extraction misses.
+            id diag = j[@"diag"];
+            if (ss.emptyAfterReady == 1 && [diag isKindOfClass:[NSArray class]]) {
+                ApolloLog(@"[SocialLinks][web] u/%@ no links yet (ready=%@ anchors=%@). external-anchor diag: %@",
+                          ss.username, ready, j[@"total"], diag);
+            }
+            // Give hydration a few extra polls past the loaded profile, then accept "none".
+            if (ss.emptyAfterReady >= 3) {
+                ApolloLog(@"[SocialLinks][web] u/%@ resolved: no social links", ss.username);
+                [ss finish:@[]];
+                return;
+            }
+        }
+
+        if (ss.polls >= 8) {
+            // Saw the real profile but no links → cache "none" (don't re-scrape every visit).
+            // Never reached the profile (stuck on interstitial / load failure) → nil so it retries.
+            ApolloLog(@"[SocialLinks][web] u/%@ timed out (ready=%@ sawProfile=%d)", ss.username, ready, ss.sawProfile);
+            [ss finish:(ss.sawProfile ? @[] : nil)];
+            return;
+        }
+        [ss pollAfter:2.0];
+    }];
+}
+
+- (void)finish:(NSArray<ApolloSocialLink *> *)links {
+    if (self.web) { self.web.navigationDelegate = nil; [self.web stopLoading]; [self.web removeFromSuperview]; self.web = nil; }
+    void (^d)(NSArray *) = self.done; self.done = nil;
+    if (d) d(links);
+}
+
+- (void)webView:(WKWebView *)wv didFinishNavigation:(WKNavigation *)nav {}
+
+@end
+
+// completion(links) on the main queue — synchronous on a warm cache, else after the
+// scrape. links is an (possibly empty) array on success, or nil on failure (not cached
+// so a later visit retries).
+static void ApolloSLFetchLinks(NSString *username, void (^completion)(NSArray<ApolloSocialLink *> *links)) {
+    NSString *key = username.lowercaseString ?: @"";
+    if (key.length == 0) { if (completion) completion(nil); return; }
+
+    NSArray<ApolloSocialLink *> *cached = [ApolloSLLinksCache() objectForKey:key];
+    if (cached) { if (completion) completion(cached); return; }
+
+    // Queue this completion; if a scrape is already running, just wait on it.
+    NSMutableArray *waiters = ApolloSLPending()[key];
+    if (waiters) { if (completion) [waiters addObject:[completion copy]]; return; }
+    waiters = [NSMutableArray array];
+    if (completion) [waiters addObject:[completion copy]];
+    ApolloSLPending()[key] = waiters;
+
+    ApolloSLWebFetch *fetch = [[ApolloSLWebFetch alloc] init];
+    ApolloSLFetchers()[key] = fetch;
+    [fetch startForUsername:username completion:^(NSArray<ApolloSocialLink *> *links) {
+        if (links) [ApolloSLLinksCache() setObject:links forKey:key];  // cache success (incl. empty)
+        NSArray *toNotify = ApolloSLPending()[key];
+        [ApolloSLPending() removeObjectForKey:key];
+        [ApolloSLFetchers() removeObjectForKey:key];
+        for (void (^waiter)(NSArray *) in toNotify) waiter(links);
+    }];
+}
+
+#pragma mark - Slide-up "Social Links" sheet
+
+// Open a social link the way Apollo opens external links (in-app browser / user's
+// preferred browser), falling back to the system opener.
+static void ApolloSocialLinkOpenURL(NSURL *url, UIViewController *opener);
+
+@interface ApolloSocialLinksSheetViewController : UITableViewController
+@property (nonatomic, copy) NSArray<ApolloSocialLink *> *links;
+@property (nonatomic, weak) UIViewController *opener;
+@end
+
+@implementation ApolloSocialLinksSheetViewController
+
+- (instancetype)init { return [super initWithStyle:UITableViewStyleInsetGrouped]; }
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Social Links";
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemClose
+                                                                                           target:self action:@selector(apollo_close)];
+}
+
+- (void)apollo_close { [self dismissViewControllerAnimated:YES completion:nil]; }
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section { return self.links.count; }
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"SLSheetCell"];
+    if (!cell) cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"SLSheetCell"];
+    ApolloSocialLink *link = self.links[indexPath.row];
+
+    cell.textLabel.text = link.title;
+    cell.detailTextLabel.text = link.url.host ?: link.urlString;
+    cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+
+    // Bundled glyph, else cached favicon, else placeholder + async swap.
+    UIImage *bundled = ApolloSLBundledIconForType(link.type);
+    UIImage *favicon = ApolloSLFaviconCachedForHost(link.url.host);
+    cell.imageView.image = bundled ?: (favicon ?: ApolloSLPlaceholderIcon());
+    cell.imageView.tintColor = [UIColor secondaryLabelColor];
+    if (!bundled && !favicon) {
+        NSString *wantHost = link.url.host;
+        __weak typeof(self) weakSelf = self;  // don't keep the sheet alive past a dismiss
+        __weak UITableView *weakTable = tableView;
+        ApolloSLRequestFaviconForHost(wantHost, ^(UIImage *image) {
+            typeof(self) strongSelf = weakSelf;
+            UITableView *strongTable = weakTable;
+            if (!image || !strongSelf || !strongTable) return;
+            UITableViewCell *live = [strongTable cellForRowAtIndexPath:indexPath];
+            // Guard against cell reuse pointing at a different link now.
+            if (live && indexPath.row < (NSInteger)strongSelf.links.count &&
+                [strongSelf.links[indexPath.row].url.host isEqualToString:wantHost]) {
+                live.imageView.image = image;
+                live.imageView.tintColor = nil;
+                [live setNeedsLayout];
+            }
+        });
+    }
+    return cell;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    ApolloSocialLink *link = self.links[indexPath.row];
+    UIViewController *opener = self.opener;
+    NSURL *url = link.url;
+    [self dismissViewControllerAnimated:YES completion:^{
+        ApolloSocialLinkOpenURL(url, opener);
+    }];
+}
+
+@end
+
+static void ApolloSocialLinkOpenURL(NSURL *url, UIViewController *opener) {
+    if (!url) return;
+    NSString *scheme = url.scheme.lowercaseString;
+    BOOL web = [scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"];
+    if (web && opener) {
+        ApolloPresentWebURLFromViewController(opener, url);
+        return;
+    }
+    // Non-web schemes (mailto:, tel:, app links) — hand off to the system.
+    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+}
+
+#pragma mark - Name pill (<=3 links)
+
+// A capsule showing [icon] name for one link; tappable, opens that link.
+@interface ApolloSLPillView : UIView
+@property (nonatomic, strong) UIImageView *iconView;
+@property (nonatomic, strong) UILabel *titleLabel;
+@property (nonatomic, strong) ApolloSocialLink *link;
+- (CGFloat)preferredWidthForMaxWidth:(CGFloat)maxWidth;
+@end
+
+@implementation ApolloSLPillView
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.backgroundColor = [UIColor tertiarySystemFillColor];
+        self.layer.cornerRadius = kSLPillHeight / 2.0;
+        self.clipsToBounds = YES;
+        _iconView = [[UIImageView alloc] init];
+        _iconView.contentMode = UIViewContentModeScaleAspectFit;
+        _iconView.clipsToBounds = YES;
+        _iconView.layer.cornerRadius = 3.0;
+        [self addSubview:_iconView];
+        _titleLabel = [[UILabel alloc] init];
+        _titleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline];
+        _titleLabel.adjustsFontForContentSizeCategory = YES;
+        _titleLabel.textColor = [UIColor labelColor];
+        _titleLabel.numberOfLines = 1;
+        _titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
+        [self addSubview:_titleLabel];
+    }
+    return self;
+}
+- (CGFloat)preferredWidthForMaxWidth:(CGFloat)maxWidth {
+    CGFloat textW = [self.titleLabel sizeThatFits:CGSizeMake(CGFLOAT_MAX, kSLPillHeight)].width;
+    CGFloat w = ceil(kSLPillLeadInset + kSLIconSize + kSLPillIconGap + textW + kSLPillTrailInset);
+    return MIN(w, MAX(60.0, maxWidth));  // truncates rather than overflowing the band
+}
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    self.iconView.frame = CGRectMake(kSLPillLeadInset, (kSLPillHeight - kSLIconSize) / 2.0, kSLIconSize, kSLIconSize);
+    CGFloat lx = CGRectGetMaxX(self.iconView.frame) + kSLPillIconGap;
+    self.titleLabel.frame = CGRectMake(lx, 0, MAX(0, self.bounds.size.width - lx - kSLPillTrailInset), kSLPillHeight);
+}
+@end
+
+#pragma mark - Band view
+
+@interface ApolloProfileSocialLinksView ()
+@property (nonatomic, strong) NSArray<ApolloSocialLink *> *links;
+@property (nonatomic, copy) NSString *loadedUsername;   // username the current links/build belong to
+@property (nonatomic, strong) UILabel *headerLabel;     // "Social Links"
+@property (nonatomic, strong) NSMutableArray<ApolloSLPillView *> *pillViews;  // <=3 links
+@property (nonatomic, strong) UIView *badgeRow;         // >3 links: icon badges, tap -> sheet
+@end
+
+@implementation ApolloProfileSocialLinksView
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.backgroundColor = [UIColor clearColor];
+        _links = @[];
+        _pillViews = [NSMutableArray array];
+
+        _headerLabel = [[UILabel alloc] init];
+        _headerLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleCaption1];
+        _headerLabel.adjustsFontForContentSizeCategory = YES;
+        _headerLabel.textColor = [UIColor secondaryLabelColor];
+        _headerLabel.text = @"Social Links";
+        _headerLabel.hidden = YES;
+        [self addSubview:_headerLabel];
+
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(apollo_toggleChanged)
+                                                     name:ApolloSocialLinksToggleChangedNotification object:nil];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)apollo_toggleChanged {
+    // Force a rebuild against the new enabled state (reload re-checks the flag).
+    self.loadedUsername = nil;
+    [self reload];
+}
+
+- (void)setUsername:(NSString *)username {
+    NSString *normalized = [username stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (normalized.length == 0) {
+        _username = nil;
+        self.links = @[];
+        self.loadedUsername = nil;
+        [self rebuildContent];
+        return;
+    }
+    if ([_username isEqualToString:normalized]) return;
+    _username = [normalized copy];
+    [self reload];
+}
+
+- (void)reload {
+    if (!ApolloProfileSocialLinksEnabled() || self.username.length == 0) {
+        self.links = @[];
+        self.loadedUsername = nil;
+        [self rebuildContent];
+        [self notifyHeightChanged];
+        return;
+    }
+    // Already resolved this username (links or confirmed none)? nothing to do.
+    // loadedUsername is only set on a non-nil result, so failures still retry.
+    if ([self.loadedUsername isEqualToString:self.username]) return;
+
+    NSString *want = self.username;
+    __weak typeof(self) weakSelf = self;  // don't keep the band alive past the scrape
+    ApolloSLFetchLinks(want, ^(NSArray<ApolloSocialLink *> *links) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        // Drop stale results if the band was reused for another profile meanwhile.
+        if (![strongSelf.username isEqualToString:want]) return;
+        strongSelf.links = links ?: @[];
+        strongSelf.loadedUsername = (links != nil) ? want : nil;  // nil result = failure, allow retry
+        [strongSelf rebuildContent];
+        [strongSelf notifyHeightChanged];
+    });
+}
+
+// Pull-to-refresh: drop the cached links for this user and re-scrape.
+- (void)refresh {
+    if (self.username.length == 0) return;
+    [ApolloSLLinksCache() removeObjectForKey:self.username.lowercaseString];
+    self.loadedUsername = nil;
+    [self reload];
+}
+
+- (void)notifyHeightChanged {
+    if (self.heightChangedBlock) self.heightChangedBlock();
+}
+
+- (CGFloat)preferredHeightForWidth:(CGFloat)width {
+    if (!ApolloProfileSocialLinksEnabled() || self.links.count == 0) return 0.0;
+    return [self apollo_layoutForWidth:width apply:NO];
+}
+
+// Computes the header + items layout for `width` and returns the total height.
+// When apply==YES it also sets the subview frames (keeps height and layout in sync).
+- (CGFloat)apollo_layoutForWidth:(CGFloat)width apply:(BOOL)apply {
+    if (!ApolloProfileSocialLinksEnabled() || self.links.count == 0) return 0.0;
+    if (width <= 1.0) return kSLHeaderHeight + kSLHeaderGap + kSLPillHeight;  // pre-sizing estimate
+
+    if (apply) self.headerLabel.frame = CGRectMake(0.0, 0.0, width, kSLHeaderHeight);
+    CGFloat y = kSLHeaderHeight + kSLHeaderGap;
+
+    if (self.links.count <= kSLPillThreshold) {
+        // Name pills, left-aligned, wrapping to more rows when they don't fit one line.
+        CGFloat x = 0.0, rowTop = y;
+        for (ApolloSLPillView *pill in self.pillViews) {
+            CGFloat pw = [pill preferredWidthForMaxWidth:width];
+            if (x > 0.0 && x + pw > width + 0.5) { x = 0.0; rowTop += kSLPillHeight + kSLPillRowGap; }
+            if (apply) pill.frame = CGRectMake(x, rowTop, pw, kSLPillHeight);
+            x += pw + kSLPillHGap;
+        }
+        return rowTop + kSLPillHeight;
+    }
+
+    // >3 links: one row of icon badges (tap anywhere -> sheet).
+    NSUInteger n = self.badgeRow.subviews.count;
+    CGFloat rowW = n * kSLBadgeSize + (n > 0 ? (n - 1) * kSLBadgeGap : 0.0);
+    if (apply) {
+        self.badgeRow.frame = CGRectMake(0.0, y, rowW, kSLBadgeSize);
+        CGFloat bx = 0.0;
+        for (UIView *badge in self.badgeRow.subviews) {
+            badge.frame = CGRectMake(bx, 0.0, kSLBadgeSize, kSLBadgeSize);
+            bx += kSLBadgeSize + kSLBadgeGap;
+        }
+    }
+    return y + kSLBadgeSize;
+}
+
+#pragma mark Content build
+
+- (void)rebuildContent {
+    for (ApolloSLPillView *p in self.pillViews) [p removeFromSuperview];
+    [self.pillViews removeAllObjects];
+    [self.badgeRow removeFromSuperview];
+    self.badgeRow = nil;
+
+    BOOL show = ApolloProfileSocialLinksEnabled() && self.links.count > 0;
+    self.headerLabel.hidden = !show;
+    if (!show) { [self setNeedsLayout]; return; }
+
+    if (self.links.count <= kSLPillThreshold) {
+        [self buildPills];
+    } else {
+        [self buildBadgeRow];
+    }
+    [self setNeedsLayout];
+}
+
+// <=3 links → a name pill ([icon] title) per link, each opening its own link.
+- (void)buildPills {
+    for (ApolloSocialLink *link in self.links) {
+        ApolloSLPillView *pill = [[ApolloSLPillView alloc] init];
+        pill.link = link;
+        pill.titleLabel.text = link.title;
+        [self applyIcon:pill.iconView forLink:link];
+        UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(apollo_pillTapped:)];
+        [pill addGestureRecognizer:tap];
+        [self addSubview:pill];
+        [self.pillViews addObject:pill];
+    }
+}
+
+// >3 links → a row of circular brand badges (capped, with a "+N" overflow badge).
+// kSLMaxBadges (8) = 296pt, which fits the band on every iPhone/iPad (the band is
+// full profile-header width minus insets, ≥ ~280pt even on a 320pt SE screen).
+- (void)buildBadgeRow {
+    self.badgeRow = [[UIView alloc] init];
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(apollo_badgeRowTapped)];
+    [self.badgeRow addGestureRecognizer:tap];
+
+    NSUInteger shown = MIN(self.links.count, kSLMaxBadges);
+    BOOL overflow = self.links.count > kSLMaxBadges;
+    if (overflow) shown = kSLMaxBadges - 1;  // reserve a slot for the "+N" badge
+
+    for (NSUInteger i = 0; i < shown; i++) {
+        ApolloSocialLink *link = self.links[i];
+        UIView *badge = [self badgeContainer];
+        UIImageView *icon = [[UIImageView alloc] initWithFrame:CGRectMake((kSLBadgeSize - kSLIconSize) / 2.0, (kSLBadgeSize - kSLIconSize) / 2.0, kSLIconSize, kSLIconSize)];
+        icon.contentMode = UIViewContentModeScaleAspectFit;
+        icon.clipsToBounds = YES;
+        icon.layer.cornerRadius = 3.0;
+        [self applyIcon:icon forLink:link];
+        [badge addSubview:icon];
+        [self.badgeRow addSubview:badge];
+    }
+    if (overflow) {
+        UIView *badge = [self badgeContainer];
+        UILabel *more = [[UILabel alloc] initWithFrame:badge.bounds];
+        more.textAlignment = NSTextAlignmentCenter;
+        more.font = [UIFont systemFontOfSize:12.0 weight:UIFontWeightSemibold];
+        more.textColor = [UIColor secondaryLabelColor];
+        more.text = [NSString stringWithFormat:@"+%lu", (unsigned long)(self.links.count - shown)];
+        [badge addSubview:more];
+        [self.badgeRow addSubview:badge];
+    }
+    [self addSubview:self.badgeRow];
+}
+
+- (UIView *)badgeContainer {
+    UIView *badge = [[UIView alloc] initWithFrame:CGRectMake(0, 0, kSLBadgeSize, kSLBadgeSize)];
+    badge.backgroundColor = [UIColor tertiarySystemFillColor];
+    badge.layer.cornerRadius = kSLBadgeSize / 2.0;
+    badge.clipsToBounds = YES;
+    return badge;
+}
+
+// Sets the best icon available now and, when needed, async-swaps in the favicon.
+- (void)applyIcon:(UIImageView *)icon forLink:(ApolloSocialLink *)link {
+    UIImage *bundled = ApolloSLBundledIconForType(link.type);
+    if (bundled) { icon.image = bundled; icon.tintColor = nil; return; }
+    UIImage *favicon = ApolloSLFaviconCachedForHost(link.url.host);
+    if (favicon) { icon.image = favicon; icon.tintColor = nil; return; }
+    icon.image = ApolloSLPlaceholderIcon();
+    icon.tintColor = [UIColor secondaryLabelColor];
+    __weak UIImageView *weakIcon = icon;
+    ApolloSLRequestFaviconForHost(link.url.host, ^(UIImage *image) {
+        if (image && weakIcon) { weakIcon.image = image; weakIcon.tintColor = nil; }
+    });
+}
+
+#pragma mark Layout
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    if (self.headerLabel.hidden || self.links.count == 0) return;
+    if (self.bounds.size.width <= 1.0) return;  // not sized yet — re-laid when the header gives us a width
+    [self apollo_layoutForWidth:self.bounds.size.width apply:YES];
+}
+
+#pragma mark Interaction
+
+// <=3 case: tapping a name pill opens its own link.
+- (void)apollo_pillTapped:(UITapGestureRecognizer *)gesture {
+    ApolloSLPillView *pill = (ApolloSLPillView *)gesture.view;
+    if (![pill isKindOfClass:[ApolloSLPillView class]] || !pill.link) return;
+    ApolloLog(@"[SocialLinks] open link %@", pill.link.urlString);
+    ApolloSocialLinkOpenURL(pill.link.url, self.hostViewController);
+}
+
+// >3 case: tapping the badge row opens the full sheet.
+- (void)apollo_badgeRowTapped {
+    if (self.links.count == 0) return;
+    UIViewController *host = self.hostViewController;
+    if (!host) { ApolloLog(@"[SocialLinks] tap: no host VC to present sheet"); return; }
+
+    ApolloSocialLinksSheetViewController *sheet = [[ApolloSocialLinksSheetViewController alloc] init];
+    sheet.links = self.links;
+    sheet.opener = host;
+    UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:sheet];
+    if (@available(iOS 15.0, *)) {
+        UISheetPresentationController *sc = nav.sheetPresentationController;
+        if (sc) {
+            sc.detents = @[[UISheetPresentationControllerDetent mediumDetent], [UISheetPresentationControllerDetent largeDetent]];
+            sc.prefersGrabberVisible = YES;
+        }
+    }
+    nav.modalPresentationStyle = UIModalPresentationPageSheet;
+    [host presentViewController:nav animated:YES completion:nil];
+    ApolloLog(@"[SocialLinks] presented sheet with %lu links", (unsigned long)self.links.count);
+}
+
+@end

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -26,6 +26,12 @@ extern NSInteger sUnmuteCommentsVideos;
 extern BOOL sProxyImgurDDG;
 extern BOOL sShowUserAvatars;
 extern BOOL sUseProfileAvatarTabIcon;
+// When ON, a redditor's profile social links (Buy Me a Coffee, Instagram, X, …) are
+// shown in the profile header between the username and bio: a tappable pill for a
+// single link, or a row of brand badges that opens a slide-up sheet for several.
+// Rendered inside the tweak's custom profile header, so it needs sShowUserAvatars ON.
+// See ApolloProfileSocialLinks.{h,m}.
+extern BOOL sSocialLinksInProfile;
 extern BOOL sShowSubredditHeaders;
 extern BOOL sAutoHideTabBarShowOnIdle;
 extern BOOL sModernSubredditDividers;

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -25,6 +25,7 @@ NSInteger sUnmuteCommentsVideos = 0; // 0=Default, 1=Remember from Full Screen, 
 BOOL sProxyImgurDDG = NO;
 BOOL sShowUserAvatars = NO;
 BOOL sUseProfileAvatarTabIcon = NO;
+BOOL sSocialLinksInProfile = YES;
 BOOL sShowSubredditHeaders = NO;
 BOOL sAutoHideTabBarShowOnIdle = NO;
 BOOL sModernSubredditDividers = YES;

--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -8,6 +8,7 @@
 #import "ApolloUserProfileCache.h"
 #import "ApolloSubredditInfoCache.h"
 #import "ApolloBannedProfile.h"
+#import "ApolloProfileSocialLinks.h"
 
 static NSString *const ApolloUserAvatarsToggleChangedNotification = @"ApolloUserAvatarsToggleChangedNotification";
 static NSString *const ApolloProfileTabAvatarIconChangedNotification = @"ApolloProfileTabAvatarIconChangedNotification";
@@ -61,6 +62,7 @@ static const void *kApolloProfileTabAppliedImageKey = &kApolloProfileTabAppliedI
 @property(nonatomic, strong) UILabel *usernameLabel;
 @property(nonatomic, strong) UIButton *editProfileButton;
 @property(nonatomic, strong) UILabel *aboutLabel;
+@property(nonatomic, strong) ApolloProfileSocialLinksView *socialLinksView;
 @property(nonatomic, weak) UIViewController *hostViewController;
 @property(nonatomic, copy) NSString *username;
 @property(nonatomic, copy) void (^heightInvalidationBlock)(void);
@@ -152,6 +154,19 @@ static void ApolloProfileScheduleTabAvatarRefresh(NSString *reason);
         _aboutLabel.numberOfLines = 0;
         _aboutLabel.adjustsFontForContentSizeCategory = YES;
         [self addSubview:_aboutLabel];
+
+        // Social-links band, positioned between the username line and the bio.
+        // It self-manages its data; when its rendered height changes (links arrive,
+        // toggle flips) it re-measures the header so the tableHeaderView grows.
+        _socialLinksView = [[ApolloProfileSocialLinksView alloc] init];
+        __weak ApolloProfileHeaderView *weakSelf = self;
+        _socialLinksView.heightChangedBlock = ^{
+            ApolloProfileHeaderView *strongSelf = weakSelf;
+            if (!strongSelf) return;
+            [strongSelf setNeedsLayout];
+            if (strongSelf.heightInvalidationBlock) strongSelf.heightInvalidationBlock();
+        };
+        [self addSubview:_socialLinksView];
     }
     return self;
 }
@@ -206,6 +221,7 @@ static CGFloat const ApolloProfileTextTopGap = 12.0;
 static CGFloat const ApolloProfileAboutSideInset = 20.0;
 static CGFloat const ApolloProfileAboutMaxHeight = 220.0; // ~10 lines @ footnote font, covers 200+ chars at full width
 static CGFloat const ApolloProfileBottomPadding = 16.0;
+static CGFloat const ApolloProfileSocialAboutGap = 8.0;   // gap below the social band, above the bio
 
 - (CGRect)apollo_avatarFrame {
     CGFloat borderSize = ApolloProfileAvatarDiameter + 6.0;
@@ -228,11 +244,11 @@ static CGFloat const ApolloProfileBottomPadding = 16.0;
     return MIN(ApolloProfileAboutMaxHeight, MAX(18.0, ceil(rect.size.height)));
 }
 
-// Computes the y-coordinate where the about text should start, full-width,
-// based on the bottom of whichever of (avatar/snoovatar, displayName/username
-// stack) reaches further down. This ensures the about text always sits below
-// the avatar — no empty space wasted beneath the picture when about is long.
-- (CGFloat)apollo_aboutYForWidth:(CGFloat)width {
+// The y-coordinate where the post-name content (the social band, else the bio)
+// starts — full-width, below whichever of the avatar/snoovatar or the
+// displayName/username stack reaches further down. No empty space is wasted
+// beneath the picture when the bio is long.
+- (CGFloat)apollo_socialYForWidth:(CGFloat)width {
     BOOL showSnoovatar = !self.snoovatarImageView.hidden;
     CGRect mediaFrame = showSnoovatar ? [self apollo_snoovatarFrame] : [self apollo_avatarFrame];
     CGFloat mediaBottom = CGRectGetMaxY(mediaFrame);
@@ -247,8 +263,24 @@ static CGFloat const ApolloProfileBottomPadding = 16.0;
     CGFloat usernameBottom = displayNameY + displayNameH + usernameTopGap + usernameH;
     (void)textWidth;
 
-    CGFloat candidateY = MAX(mediaBottom + ApolloProfileTextTopGap, usernameBottom + 10.0);
-    return candidateY;
+    return MAX(mediaBottom + ApolloProfileTextTopGap, usernameBottom + 10.0);
+}
+
+// Height the social-links band wants at this header width (0 when off / no links).
+- (CGFloat)apollo_socialHeightForWidth:(CGFloat)width {
+    if (!self.socialLinksView) return 0.0;
+    CGFloat bandWidth = MAX(120.0, width - ApolloProfileAboutSideInset * 2.0);
+    return [self.socialLinksView preferredHeightForWidth:bandWidth];
+}
+
+// The about text sits below the social band (which sits below the name stack /
+// avatar). When the band is empty it collapses to zero and the bio sits where it
+// always did.
+- (CGFloat)apollo_aboutYForWidth:(CGFloat)width {
+    CGFloat socialY = [self apollo_socialYForWidth:width];
+    CGFloat socialH = [self apollo_socialHeightForWidth:width];
+    if (socialH > 0.0) return socialY + socialH + ApolloProfileSocialAboutGap;
+    return socialY;
 }
 
 - (CGFloat)preferredHeightForWidth:(CGFloat)width {
@@ -291,6 +323,12 @@ static CGFloat const ApolloProfileBottomPadding = 16.0;
     self.usernameLabel.frame = CGRectMake(textX, CGRectGetMaxY(self.displayNameLabel.frame) + 1.0, textWidth, 18.0);
 
     CGFloat aboutWidth = MAX(120.0, width - ApolloProfileAboutSideInset * 2.0);
+
+    CGFloat socialY = [self apollo_socialYForWidth:width];
+    CGFloat socialH = [self apollo_socialHeightForWidth:width];
+    self.socialLinksView.frame = CGRectMake(ApolloProfileAboutSideInset, socialY, aboutWidth, socialH);
+    self.socialLinksView.hidden = (socialH <= 0.0);
+
     CGFloat aboutHeight = [self apollo_aboutHeightForWidth:aboutWidth];
     CGFloat aboutY = [self apollo_aboutYForWidth:width];
     self.aboutLabel.frame = CGRectMake(ApolloProfileAboutSideInset, aboutY, aboutWidth, aboutHeight);
@@ -315,6 +353,9 @@ static CGFloat const ApolloProfileBottomPadding = 16.0;
     self.displayNameLabel.hidden = self.displayNameLabel.text.length == 0;
     self.usernameLabel.hidden = self.usernameLabel.text.length == 0;
     self.aboutLabel.hidden = self.aboutLabel.text.length == 0;
+    // Feed the social-links band the username so it can load/render (no-op if the
+    // username is unchanged; the band re-measures the header when links arrive).
+    self.socialLinksView.username = username;
     [self setNeedsLayout];
     if (self.heightInvalidationBlock) {
         self.heightInvalidationBlock();
@@ -1571,6 +1612,7 @@ static void ApolloProfileInstallOrUpdateHeader(id viewControllerObject) {
         objc_setAssociatedObject(viewControllerObject, kApolloProfileOriginalHeaderKey, originalHeader, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
     header.hostViewController = viewController;
+    header.socialLinksView.hostViewController = viewController;
     header.username = username;
     [header apollo_updateEditProfileButtonColors];
     __weak UIViewController *weakProfileController = viewController;
@@ -2225,6 +2267,7 @@ static void ApolloAvatarApplySubredditIconToSharePreview(id postInfo, NSString *
     if (!header) return;
     ApolloLog(@"[UserAvatars] Pull-to-refresh forcing avatar/banner refetch for u/%@", username);
     ApolloProfileLoadImages(header, username, YES);
+    [header.socialLinksView refresh];
 }
 
 - (void)redditAccountChangedWithNotification:(id)notification {

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -8,6 +8,7 @@
 #import "ApolloSubredditCustomIconCache.h"
 #import "ApolloSubredditInfoCache.h"
 #import "ApolloBannedProfile.h"
+#import "ApolloProfileSocialLinks.h"
 #import "UserDefaultConstants.h"
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <Security/Security.h>
@@ -682,7 +683,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionBackupRestore: return 4;
         case SectionAPIKeys: return 11; // 7 text fields + OAuth switch + Can't sign in? + API key setup guide + Copy Widget Setup Code
         case SectionGeneral: return sShowDeletedComments ? 11 : 10;
-        case SectionMedia: return 13 + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows);
+        case SectionMedia: return 14 + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows);
         case SectionSubreddits: return sSubredditListEnhancements ? 8 : 7;
         case SectionNotificationBackend: return 3; // URL + Registration Token + Test Connection
         case SectionAbout: return 5; // GitHub + Reddit + Thanks To + Export Logs + Version
@@ -1211,6 +1212,11 @@ typedef NS_ENUM(NSInteger, Tag) {
                                             label:@"Profile Picture Tab Icon"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon]
                                            action:@selector(profileTabAvatarSwitchToggled:)];
+        case 13:
+            return [self switchCellWithIdentifier:@"Cell_Media_SocialLinks"
+                                            label:@"Social Links in Profile"
+                                               on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeySocialLinksInProfile]
+                                           action:@selector(socialLinksInProfileSwitchToggled:)];
         default: return [[UITableViewCell alloc] init];
     }
 }
@@ -2091,6 +2097,12 @@ typedef NS_ENUM(NSInteger, Tag) {
     sUseProfileAvatarTabIcon = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sUseProfileAvatarTabIcon forKey:UDKeyUseProfileAvatarTabIcon];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloProfileTabAvatarIconChangedNotification" object:nil];
+}
+
+- (void)socialLinksInProfileSwitchToggled:(UISwitch *)sender {
+    sSocialLinksInProfile = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sSocialLinksInProfile forKey:UDKeySocialLinksInProfile];
+    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloSocialLinksToggleChangedNotification object:nil];
 }
 
 - (void)promptClearAllCachesFromSourceView:(UIView *)sourceView {

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1210,6 +1210,7 @@ static void initializeRandomSources() {
                                     UDKeyImageUploadProvider: @(ImageUploadProviderImgur),
                                     UDKeyShowUserAvatars: @NO,
                                     UDKeyUseProfileAvatarTabIcon: @NO,
+                                    UDKeySocialLinksInProfile: @YES,
                                     UDKeyShowSubredditHeaders: @NO,
                                     UDKeyAutoHideTabBarShowOnIdle: @NO,
                                     UDKeyEnableBulkTranslation: @NO,
@@ -1283,6 +1284,7 @@ static void initializeRandomSources() {
     sImageUploadProvider = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyImageUploadProvider];
     sShowUserAvatars = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars];
     sUseProfileAvatarTabIcon = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon];
+    sSocialLinksInProfile = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeySocialLinksInProfile];
     sShowSubredditHeaders = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowSubredditHeaders];
     sAutoHideTabBarShowOnIdle = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyAutoHideTabBarShowOnIdle];
     sModernSubredditDividers = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyModernSubredditDividers];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -43,6 +43,7 @@ static NSString *const UDKeyProxyImgurDDG = @"ProxyImgurDDG";
 static NSString *const UDKeyImageUploadProvider = @"ImageUploadProvider";
 static NSString *const UDKeyShowUserAvatars = @"ShowUserAvatars";
 static NSString *const UDKeyUseProfileAvatarTabIcon = @"UseProfileAvatarTabIcon";
+static NSString *const UDKeySocialLinksInProfile = @"SocialLinksInProfile";
 static NSString *const UDKeyShowSubredditHeaders = @"ShowSubredditHeaders";
 static NSString *const UDKeyAutoHideTabBarShowOnIdle = @"AutoHideTabBarShowOnIdle";
 // Render image URLs (i.redd.it, preview.redd.it, i.imgur.com, generic .png/.jpg/.jpeg/.webp)


### PR DESCRIPTION
Surfaces a redditor's profile **social links** (Buy Me a Coffee, Instagram, X, YouTube, custom links, …) in Apollo's profile header, in the gap between the `u/username` line and the bio, under a **"Social Links"** header.

### Behaviour
- **≤ 3 links** → a name pill (`[icon] name`) per link, each tapping straight through to its own link.
- **> 3 links** → a row of brand badges; tapping anywhere opens a slide-up **Social Links** sheet listing them all (icon + name + domain), each tappable.
- **0 links** → nothing; the band collapses and the bio reflows up.

### How the data is fetched
Reddit's OAuth API doesn't expose profile social links — `about.json` omits them and the GraphQL endpoint 404s the app token — so they're scraped from the **server-rendered public profile page** in a hidden `WKWebView` (the same approach used elsewhere for DOM-only data; the real WebKit clears Reddit's JS bot-challenge). Results are cached per-username; pull-to-refresh re-scrapes. Link **icons** come from each link's domain favicon, with the bundled coffee glyph for Buy Me a Coffee / Ko-fi and an SF `link` placeholder while loading.

### Settings
New **"Social Links in Profile"** toggle under Settings → Media (default **on**). It renders inside the tweak's custom profile header, so it requires **Show User Profile Pictures** to be enabled.

### Implementation
- New module `src/ApolloProfileSocialLinks.{h,m}` — model, scraper + cache, the in-header band view (`ApolloProfileSocialLinksView`), the name-pill view, and the sheet.
- Integrates into `ApolloProfileHeaderView` (`src/ApolloUserAvatars.xm`): the band sits between the username and bio and re-measures the table header when links arrive (dynamic height).
- Standard toggle wiring (`ApolloState`, `UserDefaultConstants`, `Tweak.xm` register/hydrate, a switch row + handler in `CustomAPIViewController`).

### Screenshots

<table>
<tr>
<td align="center"><img src="https://github.com/user-attachments/assets/f7f41a63-8db0-4969-bd67-c2ab16379852" height="420" /></td>
<td align="center"><img src="https://github.com/user-attachments/assets/9c9c2e83-7d0c-499d-8f38-5080539af0c0" height="420" /></td>
</tr>
<tr>
<td valign="top"><b>≤ 3 links → name pills</b><br/>Each link shows as a tappable pill (icon + name) under the “Social Links” header — here a Buy Me a Coffee link and a custom link, each opening its own URL.</td>
<td valign="top"><b>&gt; 3 links → brand badges</b><br/>With more than three, they collapse to a row of brand badges (Instagram, X, TikTok, Facebook, YouTube); tapping anywhere opens a slide-up sheet listing them all.</td>
</tr>
</table>

### Testing
Sim-tested on iOS 26 (Liquid Glass): single-link pill, multi-link badges + sheet, the no-links case, the on/off toggle, and per-link tap-through all verified. Each link opens in Apollo's in-app browser. **Not yet device-tested.**
