### PR TITLE
Picture-in-Picture (PiP) support for videos and GIFs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloVideoSwipeFix.xm \
     $(SRC_DIR)/ApolloVideoPlaybackSpeed.xm \
     $(SRC_DIR)/ApolloVideoHoldSpeed.xm \
+    $(SRC_DIR)/ApolloPictureInPicture.xm \
     $(SRC_DIR)/ApolloMediaPreviewErrorFix.xm \
     $(SRC_DIR)/ApolloSubredditIndexPolish.xm \
     $(SRC_DIR)/ApolloQuickActions.xm \
@@ -94,11 +95,12 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/TranslationSettingsViewController.m \
     $(SRC_DIR)/SavedCategoriesViewController.m \
     $(SRC_DIR)/TagFiltersViewController.m \
+    $(SRC_DIR)/PictureInPictureViewController.m \
     $(SRC_DIR)/Defaults.m \
     $(SRC_DIR)/UIWindow+Apollo.m \
     $(SRC_DIR)/fishhook.c \
     $(SSZIPARCHIVE_FILES)
-ApolloReborn_FRAMEWORKS = UIKit Security AVFoundation OSLog NaturalLanguage ImageIO StoreKit Photos PhotosUI SafariServices SystemConfiguration WebKit AuthenticationServices CoreImage SwiftUI
+ApolloReborn_FRAMEWORKS = UIKit Security AVFoundation AVKit OSLog NaturalLanguage ImageIO StoreKit Photos PhotosUI SafariServices SystemConfiguration WebKit AuthenticationServices CoreImage SwiftUI
 ApolloReborn_LIBRARIES = z iconv
 # Apple's Translation framework (used by the on-device "apple" translation provider in
 # ApolloAppleTranslation.swift) only exists on iOS 18.0+. Weak-link it so the tweak still

--- a/src/ApolloPictureInPicture.xm
+++ b/src/ApolloPictureInPicture.xm
@@ -2589,10 +2589,30 @@ static BOOL PiPHandleFeedVisibilityEvent(id cellNode) {
 
     if (PiPIsVideoMidpointVisible(videoNode, cellNode)) {
         // The video's feed cell is on screen — never double-display; hand back.
+        // EXCEPT mid back-swipe: the feed slides in behind comments and fires this
+        // before the pop commits, so restoring here tears the card down early (and
+        // even if the gesture is cancelled). Defer to PiPHandleFeedViewControllerAppeared
+        // (viewDidAppear), which runs only on a committed pop; keep the card and
+        // suppress the feed's pause meanwhile.
+        if (ApolloVideoUnmute_IsNavigatingBack()) return YES;
         [controller restoreInline];
         return NO; // %orig's [player play] is harmless
     }
     return YES; // suppress the feed handler's pause of our player
+}
+
+// Find the feed's UITableView. ASTableViewController feeds nest it as a direct
+// subview; ASDKViewController<ASTableNode> feeds (search/lite) ARE the table; the
+// friends feed buries an ASTableNode a couple levels down. Depth-limited DFS
+// covers all three without matching unrelated deep tables.
+static UITableView *PiPFindFeedTableView(UIView *view, int depth) {
+    if (!view || depth < 0) return nil;
+    if ([view isKindOfClass:[UITableView class]]) return (UITableView *)view;
+    for (UIView *subview in view.subviews) {
+        UITableView *found = PiPFindFeedTableView(subview, depth - 1);
+        if (found) return found;
+    }
+    return nil;
 }
 
 // After a back-pop the feed doesn't scroll, so no visibility events fire even
@@ -2627,14 +2647,7 @@ static void PiPHandleFeedViewControllerAppeared(UIViewController *feedVC) {
 
     if (!controller.active && !sPiPNativeEnabled) return; // nothing to manage
 
-    UIView *rootView = feedVC.view;
-    UITableView *tableView = nil;
-    for (UIView *subview in rootView.subviews) {
-        if ([subview isKindOfClass:[UITableView class]]) {
-            tableView = (UITableView *)subview;
-            break;
-        }
-    }
+    UITableView *tableView = PiPFindFeedTableView(feedVC.view, 4);
     // tableView may be nil (feed not laid out the usual way) — the loop simply
     // doesn't run, and we fall through to the dismiss below.
     for (UITableViewCell *cell in tableView.visibleCells) {
@@ -2821,7 +2834,11 @@ static void PiPHandleFeedViewControllerAppeared(UIViewController *feedVC) {
 // ---------------------------------------------------------------------------
 // Feed view controllers: restore PiP into a visible feed cell right after a
 // back-pop (no scroll events fire on pop, so the visibility hook alone would
-// leave the video double-displayed until the user scrolls).
+// leave the video double-displayed until the user scrolls). MUST cover every
+// feed that hosts LargePostCellNode — the cell's visibility hook defers its
+// restore here during a back-swipe, so a feed without this hook would strand the
+// card: the main/subreddit feed, saved/profile feeds, the search-results and
+// lite/peek feeds, and the friends feed.
 // ---------------------------------------------------------------------------
 %hook PostsViewController
 
@@ -2850,6 +2867,33 @@ static void PiPHandleFeedViewControllerAppeared(UIViewController *feedVC) {
 
 %end
 
+%hook PostsSearchResultsViewController
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    PiPHandleFeedViewControllerAppeared((UIViewController *)self);
+}
+
+%end
+
+%hook LitePostsViewController
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    PiPHandleFeedViewControllerAppeared((UIViewController *)self);
+}
+
+%end
+
+%hook FriendsViewController
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    PiPHandleFeedViewControllerAppeared((UIViewController *)self);
+}
+
+%end
+
 // =============================================================================
 // MARK: - Constructor
 // =============================================================================
@@ -2862,6 +2906,10 @@ static void PiPHandleFeedViewControllerAppeared(UIViewController *feedVC) {
     Class postsVCClass = objc_getClass("_TtC6Apollo19PostsViewController");
     Class savedPostsVCClass = objc_getClass("_TtC6Apollo32SavedPostsCommentsViewController");
     Class profileVCClass = objc_getClass("_TtC6Apollo21ProfileViewController");
+    // Also LargePostCellNode-hosting feeds — see the feed VC hook comment above.
+    Class searchResultsVCClass = objc_getClass("_TtC6Apollo32PostsSearchResultsViewController");
+    Class litePostsVCClass = objc_getClass("_TtC6Apollo23LitePostsViewController");
+    Class friendsVCClass = objc_getClass("_TtC6Apollo21FriendsViewController");
     Class asVideoNodeClass = objc_getClass("ASVideoNode"); // loop kill-switch
 
     ApolloLog(@"[PiP] ctor: TouchHintVideoNode=%p RichMediaNode=%p LargePostCellNode=%p MediaViewerController=%p PostsVC=%p SavedPostsVC=%p ProfileVC=%p ASVideoNode=%p",
@@ -2884,6 +2932,9 @@ static void PiPHandleFeedViewControllerAppeared(UIViewController *feedVC) {
         PostsViewController = postsVCClass,
         SavedPostsCommentsViewController = savedPostsVCClass ?: postsVCClass,
         ProfileViewController = profileVCClass ?: postsVCClass,
+        PostsSearchResultsViewController = searchResultsVCClass ?: postsVCClass,
+        LitePostsViewController = litePostsVCClass ?: postsVCClass,
+        FriendsViewController = friendsVCClass ?: postsVCClass,
         ASVideoNode = asVideoNodeClass
     );
 

--- a/src/ApolloPictureInPicture.xm
+++ b/src/ApolloPictureInPicture.xm
@@ -2408,8 +2408,11 @@ BOOL ApolloPiP_ShouldBlockAudioSessionDowngrade(void) {
     // holding against Apollo's Ambient downgrade.
     if (controller.active && controller.player
         && !controller.player.muted && !controller.cardIsGifContent) return YES;
+    // Protect the inline-armed player's session through the background handoff
+    // window even when muted: System PiP still needs an active Playback session to
+    // start, and in the "All Videos" modes a muted video is eligible.
     AVPlayer *inlinePlayer = controller.inlineNativePlayer;
-    return inlinePlayer && !inlinePlayer.muted && PiPInlineShieldEngaged(inlinePlayer);
+    return inlinePlayer && PiPInlineShieldEngaged(inlinePlayer);
 }
 
 // Consulted by ApolloVideoUnmute.xm's AVPlayer.setMuted: hook — blocks the
@@ -2446,8 +2449,29 @@ void ApolloPiP_NoteInlinePlayerMuted(AVPlayer *player) {
     if (!controller || !player) return;
     if (controller.active) return;
     if (controller.inlineNativePlayer != player) return;
-    ApolloLog(@"[PiP] Inline-armed player muted — disarming system PiP");
-    [controller disarmInlineNativePiPIfIdle];
+
+    // "Unmuted Videos Only": a muted video is no longer eligible, so a home-swipe
+    // must not hand it off — disarm.
+    if (sPiPActivationMode == ApolloPiPActivationModeUnmutedOnly) {
+        ApolloLog(@"[PiP] Inline-armed player muted (Unmuted Only) — disarming system PiP");
+        [controller disarmInlineNativePiPIfIdle];
+        return;
+    }
+
+    // "All Videos" / "All Videos & GIFs": a muted PLAYING video stays eligible, so
+    // keep the arm. Apollo's mute runs the mute dance, which just set the session
+    // to Ambient and deactivated it — that would stop System PiP from auto-starting
+    // on background, so re-assert a Playback session. mixWithOthers since the video
+    // is now silent (won't interrupt the user's audio), matching the muted-video
+    // inline arm.
+    if (@available(iOS 15.0, *)) {
+        AVAudioSession *session = [AVAudioSession sharedInstance];
+        [session setCategory:AVAudioSessionCategoryPlayback
+                        mode:AVAudioSessionModeDefault
+                     options:AVAudioSessionCategoryOptionMixWithOthers error:nil];
+        [session setActive:YES withOptions:0 error:nil];
+        ApolloLog(@"[PiP] Inline-armed player muted (All Videos) — kept armed, re-asserted Playback for handoff");
+    }
 }
 
 // Audio arbitration: a DIFFERENT video is about to play audibly (the user

--- a/src/ApolloPictureInPicture.xm
+++ b/src/ApolloPictureInPicture.xm
@@ -1,0 +1,2694 @@
+#import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
+#import <AVKit/AVKit.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+#import "UserDefaultConstants.h"
+
+// =============================================================================
+// MARK: - Overview
+// =============================================================================
+//
+// In-app Picture-in-Picture for comments-page inline videos (see
+// docs/pip-design.md for the full RE-backed design).
+//
+// When the user scrolls a playing video out of view on a post's comments page,
+// Apollo pauses it via a midpoint test inside
+// -[RichMediaHeaderCellNode cellNodeVisibilityEvent:inScrollView:withCellFrame:]
+// (sub_1002060bc → sub_1002063d8): the moment the video's center crosses under
+// the nav bar, [[videoNode playerLayer] player] is paused synchronously inside
+// that method. We detect the same transition FIRST (our hook in
+// ApolloVideoUnmute.xm consults ApolloPiP_HandleCommentsVisibilityEvent before
+// %orig), take ownership of the AVPlayer, and skip %orig entirely so the pause
+// never happens. The video keeps playing and a floating, draggable card —
+// hosting a SECOND AVPlayerLayer attached to the same AVPlayer, in a
+// tweak-owned passthrough UIWindow — takes over. Scrolling back restores the
+// inline video seamlessly (Apollo's inline layer keeps rendering the whole
+// time: AVFoundation vends frames to every attached layer).
+//
+// While PiP owns a player we must defend it from Apollo's machinery:
+//   - TouchHintVideoNode.didExitVisibleState → mute dance (skip %orig; the
+//     fork's super implementation is a no-op, so nothing is lost)
+//   - RichMediaNode pauseAllAVPlayers notification handler (skip for owned)
+//   - RichMediaNode.didExitPreloadState player teardown for non-shareable
+//     videos (skip while owned — keeps compact-mode v.redd.it players alive)
+//   - LargePostCellNode's feed visibility handler (suppress its pause; restore
+//     PiP into the feed cell when it becomes visible after a back-pop)
+//   - AVAudioSession Ambient/deactivate downgrades while PiP audio is playing
+//     (predicate consumed by the hooks in ApolloVideoUnmute.xm)
+//
+// Scope: Reddit-hosted v.redd.it videos (shareable, plus compact-mode
+// non-shareable fallback players) AND any other inline video that carries
+// audio — Streamable and similar external hosts — gated by PiPIsEligibleVideo.
+// Silent GIFs (also inline ASVideoNodes, but no audio track) and feed-initiated
+// card takeover are intentionally out of scope (see docs/pip-design.md §3).
+//
+// =============================================================================
+
+// Provided by ApolloVideoUnmute.xm (both files are Logos/ObjC++, so the
+// declarations below mangle identically to the definitions there).
+extern AVPlayer *ApolloVideoUnmute_GetPlayerFromVideoNode(id videoNode);
+extern void ApolloVideoUnmute_SyncMuteButtonIcon(id richMediaNode, BOOL isMuted);
+extern void ApolloVideoUnmute_ClearProtectionIfPlayer(AVPlayer *player);
+extern BOOL ApolloVideoUnmute_IsNavigatingBack(void);
+
+// Defined in PictureInPictureViewController.m (plain global — not mangled).
+extern NSString *const ApolloPictureInPictureChangedNotification;
+
+// =============================================================================
+// MARK: - Small helpers (per-TU statics; mirrors ApolloVideoUnmute.xm patterns)
+// =============================================================================
+
+static id PiPGetIvar(id obj, const char *ivarName) {
+    if (!obj) return nil;
+    Ivar ivar = class_getInstanceVariable([obj class], ivarName);
+    return ivar ? object_getIvar(obj, ivar) : nil;
+}
+
+static id PiPRichMediaNodeFromCell(id cellNode) {
+    id richMediaNode = PiPGetIvar(cellNode, "richMediaNode");
+    if (richMediaNode) return richMediaNode;
+    id crosspostNode = PiPGetIvar(cellNode, "crosspostNode");
+    return crosspostNode ? PiPGetIvar(crosspostNode, "richMediaNode") : nil;
+}
+
+static id PiPVideoNodeFromRichMedia(id richMediaNode) {
+    return richMediaNode ? PiPGetIvar(richMediaNode, "videoNode") : nil;
+}
+
+static UIView *PiPViewForNode(id node) {
+    if (!node || ![node respondsToSelector:@selector(view)]) return nil;
+    return ((UIView *(*)(id, SEL))objc_msgSend)(node, @selector(view));
+}
+
+static BOOL PiPNodeIsShareable(id videoNode) {
+    SEL sel = NSSelectorFromString(@"allowPlayerLayerToBeShareable");
+    if (!videoNode || ![videoNode respondsToSelector:sel]) return NO;
+    return ((BOOL (*)(id, SEL))objc_msgSend)(videoNode, sel);
+}
+
+// Does the currently-playing item carry an audio track? This is what separates
+// a real video — which the user can unmute and would want in PiP — from a
+// silent autoplaying GIF (also an inline ASVideoNode), which must never trigger
+// PiP.
+//
+// Must stay non-blocking: this runs on the feed-scroll / unmute main thread, and
+// callers only know rate != 0 (a play rate was REQUESTED), which does NOT imply
+// the asset's keys are loaded. So we read only already-loaded state:
+//   • item.tracks returns the loaded tracks (empty, never blocking, if unloaded)
+//     — a progressive MP4 audio track shows up here.
+//   • availableMediaCharacteristicsWithMediaSelectionOptions is a legacy
+//     SYNCHRONOUS accessor that blocks on a network round-trip if the asset's
+//     keys aren't loaded — HLS (Streamable et al.) exposes audio only here, not
+//     as an item track. We gate it on status == ReadyToPlay, which guarantees the
+//     keys are loaded so the read can't block. (By the time a user unmutes a
+//     playing video the item is ReadyToPlay, so the unmute path still resolves.)
+// An item that isn't ready yet returns NO; a later visibility/scroll re-evaluation
+// (or the comments retry timer) re-checks once it loads.
+static BOOL PiPVideoHasAudio(AVPlayer *player) {
+    AVPlayerItem *item = player.currentItem;
+    if (!item) return NO;
+    for (AVPlayerItemTrack *track in item.tracks) {
+        AVAssetTrack *assetTrack = track.assetTrack;
+        if (assetTrack && [assetTrack.mediaType isEqualToString:AVMediaTypeAudio]) {
+            return YES;
+        }
+    }
+    if (item.status != AVPlayerItemStatusReadyToPlay) return NO;
+    return [[item.asset availableMediaCharacteristicsWithMediaSelectionOptions]
+            containsObject:AVMediaCharacteristicAudible];
+}
+
+// Eligibility: Reddit-hosted videos (shareable v.redd.it, plus the compact-mode
+// non-shareable comments players that still point at a v.redd.it asset URL),
+// PLUS any other inline video that carries audio — Streamable and similar
+// external hosts. The audio requirement is the GIF guard: a silent autoplaying
+// GIF is also an inline ASVideoNode but must never get PiP.
+static BOOL PiPIsEligibleVideo(id videoNode, AVPlayer *player) {
+    if (PiPNodeIsShareable(videoNode)) return YES;
+
+    NSURL *url = nil;
+    AVAsset *asset = player.currentItem.asset;
+    if ([asset isKindOfClass:[AVURLAsset class]]) {
+        url = [(AVURLAsset *)asset URL];
+    }
+    if (!url) {
+        SEL assetURLSel = NSSelectorFromString(@"assetURL");
+        if ([videoNode respondsToSelector:assetURLSel]) {
+            url = ((id (*)(id, SEL))objc_msgSend)(videoNode, assetURLSel);
+        }
+    }
+    NSString *host = url.host.lowercaseString;
+    if (host != nil && [host containsString:@"v.redd.it"]) return YES;
+
+    // Non-Reddit inline video (Streamable etc.): eligible iff it carries audio.
+    return PiPVideoHasAudio(player);
+}
+
+// Midpoint visibility test mirroring Apollo's sub_1002063d8 (and the fork's
+// -[ASVideoNode isVisibleInProperRect]): the video view's center, in window
+// coordinates, must lie between the bottom of the nav bar and the top of the
+// tab bar. We deliberately use the TRUE midpoint (convertRect:bounds) rather
+// than Apollo's frame-vs-bounds quirk — while PiP owns the player only our
+// threshold matters, and the true midpoint is the better UX trigger.
+static BOOL PiPIsVideoMidpointVisible(id videoNode, id cellNode) {
+    UIView *view = PiPViewForNode(videoNode) ?: PiPViewForNode(cellNode);
+    UIWindow *window = view.window;
+    if (!view || !window) return NO;
+
+    CGRect rectInWindow = [view convertRect:view.bounds toView:nil];
+    CGPoint mid = CGPointMake(CGRectGetMidX(rectInWindow), CGRectGetMidY(rectInWindow));
+
+    CGFloat topY = 0.0;
+    CGFloat bottomY = window.bounds.size.height;
+    UIViewController *rootVC = window.rootViewController;
+    if ([rootVC isKindOfClass:[UITabBarController class]]) {
+        UITabBarController *tab = (UITabBarController *)rootVC;
+        if (tab.tabBar.window) {
+            bottomY -= tab.tabBar.bounds.size.height;
+        }
+        UIViewController *selected = tab.selectedViewController;
+        if ([selected isKindOfClass:[UINavigationController class]]) {
+            UINavigationBar *navBar = ((UINavigationController *)selected).navigationBar;
+            if (navBar.window) {
+                topY = CGRectGetMaxY([navBar convertRect:navBar.bounds toView:nil]);
+            }
+        }
+    }
+
+    return mid.y >= topY && mid.y <= bottomY
+        && mid.x >= 0 && mid.x <= window.bounds.size.width;
+}
+
+// Deceleration projection (WWDC18 formula) with a deliberately FAST rate.
+// The scroll-view "normal" rate (0.998) multiplies velocity by ~0.5s of
+// travel — far too floaty for free positioning: even a tiny residual flick at
+// release would glide the card tens of points from where the finger left it.
+// 0.99 gives ~0.1s of momentum: a real fling still tosses the card, a casual
+// release stays put.
+static CGFloat PiPProjectOffset(CGFloat velocity) {
+    CGFloat rate = 0.99;
+    return (velocity / 1000.0) * rate / (1.0 - rate);
+}
+
+// Tracks the last midpoint-visibility we observed per cell node, so we can
+// detect the visible→hidden transition (the "about to pause" moment).
+static const void *kPiPPrevVisibleKey = &kPiPPrevVisibleKey;
+
+// Dedupe flag for the inline native-PiP arm retry chain (the player often
+// does not exist yet at the cell's first visibility event).
+static const void *kPiPArmRetryPendingKey = &kPiPArmRetryPendingKey;
+
+// A loop-suppressed video parks at its end (rate 0, currentTime == duration).
+// Calling play() on an at-end item is a no-op and never re-fires the end
+// notification, so without a rewind the video stays frozen on its last frame
+// once PiP hands it back. Seek a stopped-at-end player to the start so the
+// next play() resumes normal (looping) inline playback.
+static BOOL PiPPlayerStoppedAtEnd(AVPlayer *player) {
+    if (!player || player.rate != 0) return NO;
+    AVPlayerItem *item = player.currentItem;
+    if (!item || !CMTIME_IS_NUMERIC(item.duration)) return NO;
+    CGFloat duration = CMTimeGetSeconds(item.duration);
+    if (duration <= 0) return NO;
+    return CMTimeGetSeconds(item.currentTime) >= duration - 0.25;
+}
+
+static void PiPRewindIfStoppedAtEnd(AVPlayer *player) {
+    if (PiPPlayerStoppedAtEnd(player)) {
+        [player seekToTime:kCMTimeZero toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+    }
+}
+
+// Tighter variant: paused with the playhead AT the end (not merely near it).
+// This is the one spot where play() is a dead no-op even with Loop ON — the
+// end notification only fires when playback REACHES the end, so a paused
+// seek-to-end (system PiP's own skip controls can do this) parks the player
+// where neither Apollo's loop nor our suppression path will ever run again.
+static BOOL PiPPlayerParkedAtExactEnd(AVPlayer *player) {
+    if (!player || player.rate != 0) return NO;
+    AVPlayerItem *item = player.currentItem;
+    if (!item || !CMTIME_IS_NUMERIC(item.duration)) return NO;
+    CGFloat duration = CMTimeGetSeconds(item.duration);
+    if (duration <= 0) return NO;
+    return CMTimeGetSeconds(item.currentTime) >= duration - 0.05;
+}
+
+// =============================================================================
+// MARK: - Window / views
+// =============================================================================
+
+// Passthrough window: only touches inside the floating card are consumed;
+// everything else falls through to Apollo's own windows. Returning consistent
+// results also satisfies iOS 18's double hit-test per UIEvent.
+@interface ApolloPiPWindow : UIWindow
+@property (nonatomic, weak) UIView *interactiveView;
+@end
+
+@implementation ApolloPiPWindow
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    UIView *hit = [super hitTest:point withEvent:event];
+    if (!hit) return nil;
+    UIView *card = self.interactiveView;
+    if (card && !card.hidden && (hit == card || [hit isDescendantOfView:card])) {
+        return hit;
+    }
+    return nil;
+}
+
+// Never become the key window. The status-bar "scroll to top" tap searches
+// ONLY the key window's registered scroll-to-top views (UIKit:
+// _UIScrollsToTopInitiatorView.touchesEnded → -[UIApplication
+// _keyWindowForScreen:] → -[UIWindow _scrollToTopViewsUnderScreenPointIfNecessary:]
+// — it never falls through to other windows). UIKit promotes a window to key
+// when the user touches it (gated on -canBecomeKeyWindow at UIWindow
+// makeKeyWindow), so once the user tapped/dragged the floating card this
+// full-screen overlay — which registers no scroll views — became key and
+// Apollo's feed/comments silently stopped scrolling to top. Declining key
+// keeps Apollo's window key; touch delivery, the overlay buttons, and the
+// card gestures are all hit-test/tracking based and do not need key status
+// (the card hosts no text input / first responder).
+- (BOOL)canBecomeKeyWindow {
+    return NO;
+}
+@end
+
+@interface ApolloPiPRootViewController : UIViewController
+@property (nonatomic, copy) void (^onTransitionToSize)(void);
+@end
+
+@implementation ApolloPiPRootViewController
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.backgroundColor = [UIColor clearColor];
+}
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    __weak __typeof(self) weakSelf = self;
+    [coordinator animateAlongsideTransition:nil completion:^(id<UIViewControllerTransitionCoordinatorContext> ctx) {
+        if (weakSelf.onTransitionToSize) weakSelf.onTransitionToSize();
+    }];
+}
+@end
+
+@interface ApolloPiPPlayerView : UIView
+@property (nonatomic, readonly) AVPlayerLayer *playerLayer;
+@end
+
+@implementation ApolloPiPPlayerView
++ (Class)layerClass { return [AVPlayerLayer class]; }
+- (AVPlayerLayer *)playerLayer { return (AVPlayerLayer *)self.layer; }
+@end
+
+// Controls overlay that re-lays-out its buttons whenever its bounds change
+// (pinch, double-tap resize, rotation — including mid-animation frames).
+// Explicit layout rather than autoresizing masks: masks distribute size deltas
+// by each view's creation-time margins, which would push the asymmetric skip
+// buttons off-center into the corner buttons at other card sizes.
+@interface ApolloPiPOverlayView : UIView
+@property (nonatomic, copy) void (^onLayout)(void);
+@end
+
+@implementation ApolloPiPOverlayView
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    if (self.onLayout) self.onLayout();
+}
+@end
+
+// =============================================================================
+// MARK: - Controller
+// =============================================================================
+
+static void *kPiPRateContext = &kPiPRateContext;
+static void *kPiPMutedContext = &kPiPMutedContext;
+static void *kPiPReadyContext = &kPiPReadyContext;
+static void *kPiPTimeControlContext = &kPiPTimeControlContext;
+
+static const CGFloat kPiPMinWidth = 150.0;
+static const CGFloat kPiPEdgeMargin = 10.0;
+// Default/large card footprints are defined by AREA, not width: a fixed width
+// fraction makes a portrait video balloon to most of the screen (its height =
+// width / aspect). We instead pick a target area calibrated so a 16:9 video
+// lands at ~half the screen width, then preserve that area across any aspect
+// ratio — landscape stays wide-and-short, portrait stays narrow-and-tall with
+// the SAME on-screen footprint. These constants express the calibration as the
+// landscape (16:9) width fraction the area corresponds to.
+static const CGFloat kPiPDefaultLandscapeWidthFraction = 0.5; // spawn size
+static const CGFloat kPiPLargeLandscapeWidthFraction = 0.82;  // double-tap "zoom"
+static const CGFloat kPiPReferenceAspect = 16.0 / 9.0;        // calibration aspect
+static const CGFloat kPiPStashVisibleWidth = 18.0; // sliver left on screen while stashed
+// Below this release speed (pt/s) the card stays exactly where the finger
+// left it — no momentum, no drift.
+static const CGFloat kPiPFlingVelocityThreshold = 250.0;
+// A stash requires a decisive horizontal fling at least this fast.
+static const CGFloat kPiPStashVelocityThreshold = 300.0;
+static const NSTimeInterval kPiPControlsAutoHideDelay = 3.0;
+
+@interface ApolloPiPController : NSObject <UIGestureRecognizerDelegate>
+
+// Ownership state
+@property (nonatomic, strong) AVPlayer *player;
+@property (nonatomic, strong) AVPlayerItem *playerItem;   // keeps item alive for non-shareable
+@property (nonatomic, weak) id richMediaNode;
+@property (nonatomic, weak) id videoNode;
+@property (nonatomic, strong) id link;                    // RDKLink, for same-post detection
+// YES when the taken-over video is NON-shareable (compact mode): its player is
+// not shared with a feed cell, so it can never be reclaimed/restored into the
+// feed. Captured at takeover because videoNode is weak and may be gone by the
+// time we return to the feed.
+@property (nonatomic, assign) BOOL ownedNonShareable;
+@property (nonatomic, assign) BOOL active;
+@property (nonatomic, assign) BOOL restoring;
+@property (nonatomic, assign) NSUInteger generation;      // invalidates stale async blocks
+@property (nonatomic, assign) BOOL resumeOnForeground;
+// YES once this PiP session has played audibly (it claimed the Playback audio
+// session at some point) — closing must hand the session back even if the
+// user muted the card just before closing.
+@property (nonatomic, assign) BOOL sessionClaimedAudibly;
+
+// UI
+@property (nonatomic, strong) ApolloPiPWindow *window;
+@property (nonatomic, strong) ApolloPiPRootViewController *rootViewController;
+@property (nonatomic, strong) UIView *card;
+@property (nonatomic, strong) ApolloPiPPlayerView *playerView;
+@property (nonatomic, strong) ApolloPiPOverlayView *controlsOverlay;
+@property (nonatomic, strong) UIButton *playPauseButton;
+@property (nonatomic, strong) UIButton *muteButton;
+@property (nonatomic, strong) UIButton *closeButton;
+// Optional overlay extras (settings-gated): skip back/ahead by sPiPSkipSeconds,
+// plus a read-only progress strip along the bottom edge.
+@property (nonatomic, strong) UIButton *skipBackButton;
+@property (nonatomic, strong) UIButton *skipForwardButton;
+@property (nonatomic, strong) UIView *progressTrack;
+@property (nonatomic, strong) UIView *progressFill;
+@property (nonatomic, assign) CGFloat progressFraction;  // last computed fill fraction
+@property (nonatomic, strong) NSTimer *controlsTimer;
+@property (nonatomic, strong) UIViewPropertyAnimator *animator;
+@property (nonatomic, assign) CGFloat aspectRatio;        // width / height
+@property (nonatomic, assign) BOOL cardRevealed;
+@property (nonatomic, assign) BOOL observingPlayer;
+@property (nonatomic, strong) AVPlayer *observedPlayer;   // KVO removal safety
+@property (nonatomic, strong) id timeObserverToken;       // periodic progress ticks
+
+// Edge stash (native-PiP-style "swipe off the side to hide")
+@property (nonatomic, assign) NSInteger stashedSide;      // 0 = docked, -1 = left edge, +1 = right edge
+@property (nonatomic, strong) UIImageView *stashHandle;   // chevron tab shown while stashed
+
+// Native (system) PiP — on the floating card's layer while PiP is active
+@property (nonatomic, strong) AVPictureInPictureController *nativePiP;
+// Native (system) PiP — armed on Apollo's INLINE player layer while an
+// eligible video plays on screen (no floating card), so swiping to the home
+// screen hands the inline video to system PiP too.
+@property (nonatomic, strong) AVPictureInPictureController *inlineNativePiP;
+@property (nonatomic, weak) AVPlayer *inlineNativePlayer;
+@property (nonatomic, weak) id inlineNativeVideoNode;
+// An inline player we paused on backgrounding because System PiP never
+// started (avoids a background-audio leak); resumed on foreground.
+@property (nonatomic, weak) AVPlayer *backgroundPausedInlinePlayer;
+
+@end
+
+@implementation ApolloPiPController
+
+// Returns the singleton WITHOUT creating it — used by the hot-path predicates
+// so an untouched feature costs one nil check.
+static ApolloPiPController *sPiPSharedController = nil;
+
++ (instancetype)sharedController {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        sPiPSharedController = [[ApolloPiPController alloc] init];
+    });
+    return sPiPSharedController;
+}
+
+- (instancetype)init {
+    if ((self = [super init])) {
+        _aspectRatio = 16.0 / 9.0;
+
+        NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+        __weak __typeof(self) weakSelf = self;
+        [center addObserverForName:UIApplicationDidEnterBackgroundNotification object:nil
+                             queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+            [weakSelf handleDidEnterBackground];
+        }];
+        [center addObserverForName:UIApplicationWillEnterForegroundNotification object:nil
+                             queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+            [weakSelf handleWillEnterForeground];
+        }];
+        [center addObserverForName:UIApplicationDidBecomeActiveNotification object:nil
+                             queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+            [weakSelf handleDidBecomeActive];
+        }];
+        [center addObserverForName:ApolloPictureInPictureChangedNotification object:nil
+                             queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+            __typeof(self) strongSelf = weakSelf;
+            if (!strongSelf) return;
+            // The mini-player and native PiP are independently togglable.
+            if (!sPiPEnabled && strongSelf.active) {
+                ApolloLog(@"[PiP] Mini-player disabled in settings — closing active PiP");
+                [strongSelf teardownKeepPlaying:NO];
+            }
+            if (!sPiPNativeEnabled) {
+                [strongSelf destroyNativePiP];
+                [strongSelf disarmInlineNativePiPIfIdle];
+            } else if (strongSelf.active) {
+                [strongSelf setupNativePiP];
+            }
+            // (Enabling native PiP with an inline video on screen re-arms on
+            // the next scroll tick via the visibility handler.)
+
+            // Overlay extras (skip buttons / progress bar) toggled while the
+            // card's controls are showing: refresh them in place.
+            if (strongSelf.active && !strongSelf.controlsOverlay.hidden) {
+                [strongSelf syncControlIcons];
+            }
+        }];
+    }
+    return self;
+}
+
+// =============================================================================
+// MARK: Visibility-event entry point
+// =============================================================================
+
+// Returns YES when the caller's %orig must be skipped (we own this cell's
+// player and Apollo's synchronous play/pause must not run).
+- (BOOL)handleVisibilityEventForCell:(id)cellNode
+                       richMediaNode:(id)richMediaNode
+                               event:(unsigned long long)event {
+    if (!richMediaNode) return NO;
+    id videoNode = PiPVideoNodeFromRichMedia(richMediaNode);
+    if (!videoNode) return NO;
+
+    if (self.active) {
+        if (self.restoring) return NO;
+        AVPlayer *player = ApolloVideoUnmute_GetPlayerFromVideoNode(videoNode);
+        BOOL owned = (player && player == self.player)
+                  || (self.videoNode && videoNode == self.videoNode);
+        if (!owned) {
+            // Same post re-opened with a RECREATED player (compact-mode fresh
+            // player, or the shared layer was released while we were away):
+            // identity checks fail but the content is ours. Close the stale
+            // PiP — otherwise the video displays (and can play audio) twice.
+            id cellLink = PiPGetIvar(richMediaNode, "link");
+            if (self.link && cellLink
+                && (cellLink == self.link || [cellLink isEqual:self.link])) {
+                ApolloLog(@"[PiP] Same post re-entered with a new player — closing stale PiP");
+                [self teardownKeepPlaying:NO];
+            }
+            return NO;
+        }
+
+        if (PiPIsVideoMidpointVisible(videoNode, cellNode)) {
+            // The video's inline home is back on screen — hand back. Apollo's
+            // %orig runs after we return NO; its [player play] is harmless.
+            [self restoreInline];
+            return NO;
+        }
+        return YES; // still scrolled away: suppress Apollo's pause
+    }
+
+    // Either feature keeps this handler live: the in-app mini-player
+    // (sPiPEnabled) takes over on scroll-away; System PiP (sPiPNativeEnabled)
+    // arms a system-PiP controller on the inline player while it plays. They
+    // are independent — only the takeover at the bottom requires sPiPEnabled.
+    if (!sPiPEnabled && !sPiPNativeEnabled) return NO;
+    if (event == 2) {
+        // Cell fully gone: clear tracking — a takeover at this point would
+        // pop the card in with no anchor.
+        objc_setAssociatedObject(cellNode, kPiPPrevVisibleKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        if (videoNode == self.inlineNativeVideoNode) {
+            // Leaving the foreground fires a spurious Invisible event for
+            // every visible cell (ASCellNode.didExitVisibleState →
+            // handleVisibilityChange — the same churn the mute-dance shield
+            // guards). Disarming HERE would destroy the controller at the
+            // exact moment iOS evaluates auto-PiP for the home-swipe handoff
+            // ("System PiP enabled but nothing happens"). Background churn is
+            // distinguished from a REAL disappearance racing the home-swipe
+            // (e.g. a flick still decelerating) by geometry: churn leaves the
+            // cell where it was (midpoint still visible), a real scroll-away
+            // moved it off. Disarm for a real in-comments scroll-away — BUT a
+            // back-pop also fires this event while the SAME player is reclaimed
+            // onto the feed (and keeps playing); disarming there kills the
+            // controller mid-reclaim, so defer to the feed side (which re-arms,
+            // and the controller survives the pop intact).
+            BOOL backgroundChurn =
+                [UIApplication sharedApplication].applicationState != UIApplicationStateActive
+                && PiPIsVideoMidpointVisible(videoNode, cellNode);
+            BOOL navigatingBack = ApolloVideoUnmute_IsNavigatingBack();
+            if (!backgroundChurn && !navigatingBack) {
+                [self disarmInlineNativePiPIfIdle];
+            } else {
+                ApolloLog(@"[PiP] Keeping inline native PiP armed through %@ invisible event",
+                          navigatingBack ? @"back-pop" : @"background-churn");
+            }
+        }
+        return NO;
+    }
+    if (event > 2) {
+        // Drag bookkeeping (WillBeginDragging/DidEndDragging): keep the
+        // baseline — clearing it here would blind the next real event.
+        return NO;
+    }
+
+    BOOL visible = PiPIsVideoMidpointVisible(videoNode, cellNode);
+    NSNumber *prev = objc_getAssociatedObject(cellNode, kPiPPrevVisibleKey);
+    objc_setAssociatedObject(cellNode, kPiPPrevVisibleKey, @(visible), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    AVPlayer *player = ApolloVideoUnmute_GetPlayerFromVideoNode(videoNode);
+
+    // System PiP also covers INLINE playback: while an eligible video plays on
+    // screen, keep a system PiP controller armed on Apollo's own inline player
+    // layer so backgrounding hands it off.
+    if (sPiPNativeEnabled && visible) {
+        if (player && player.rate != 0
+            && !(sPiPActivationMode == ApolloPiPActivationModeUnmutedOnly && player.muted)
+            && PiPIsEligibleVideo(videoNode, player)) {
+            [self armInlineNativePiPForVideoNode:videoNode player:player];
+        } else if (!player || player.rate == 0) {
+            // Fresh navigation: the shared layer/player is adopted (and starts
+            // playing) AFTER the cell's first visibility event, and without
+            // scrolling no further events arrive — the controller would never
+            // arm and a home-swipe would not enter PiP. Retry off-event.
+            if (!objc_getAssociatedObject(cellNode, kPiPArmRetryPendingKey)) {
+                objc_setAssociatedObject(cellNode, kPiPArmRetryPendingKey, @YES,
+                                         OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                ApolloLog(@"[PiP] Inline arm: player not ready at visibility event — scheduling retries");
+                [self retryInlineArmForCell:cellNode videoNode:videoNode attempts:4];
+            }
+        }
+    }
+
+    if (!prev || prev.boolValue == visible || visible) return NO;
+
+    // visible → hidden transition: the "about to pause" moment. From here down
+    // is in-app mini-player takeover, which requires its own toggle.
+    if (!sPiPEnabled) return NO;
+    if (!player || player.rate == 0.0f) return NO;
+    if (sPiPActivationMode == ApolloPiPActivationModeUnmutedOnly && player.muted) return NO;
+    if (!PiPIsEligibleVideo(videoNode, player)) return NO;
+    if ([self isInlineNativePiPActive]) return NO; // system PiP owns rendering right now
+
+    [self takeOverFromCell:cellNode richMediaNode:richMediaNode videoNode:videoNode player:player];
+    return YES;
+}
+
+// =============================================================================
+// MARK: Takeover / restore / teardown
+// =============================================================================
+
+- (void)takeOverFromCell:(id)cellNode richMediaNode:(id)richMediaNode
+               videoNode:(id)videoNode player:(AVPlayer *)player {
+    if (self.active) {
+        ApolloLog(@"[PiP] New takeover while active — closing previous PiP");
+        [self teardownKeepPlaying:NO];
+    }
+
+    self.generation++;
+    self.player = player;
+    self.playerItem = player.currentItem;
+    self.richMediaNode = richMediaNode;
+    self.videoNode = videoNode;
+    self.link = PiPGetIvar(richMediaNode, "link");
+    self.ownedNonShareable = !PiPNodeIsShareable(videoNode);
+    self.active = YES;
+    self.restoring = NO;
+    self.resumeOnForeground = NO;
+    self.sessionClaimedAudibly = !player.muted;
+
+    UIView *videoView = PiPViewForNode(videoNode);
+    CGSize videoViewSize = videoView ? videoView.bounds.size : CGSizeZero;
+
+    CGSize presentation = player.currentItem.presentationSize;
+    if (presentation.width > 1 && presentation.height > 1) {
+        self.aspectRatio = presentation.width / presentation.height;
+    } else if (videoViewSize.width > 1 && videoViewSize.height > 1) {
+        // Inline view's aspect as fallback until presentationSize is known.
+        self.aspectRatio = videoViewSize.width / videoViewSize.height;
+    } else {
+        self.aspectRatio = 16.0 / 9.0;
+    }
+
+    ApolloLog(@"[PiP] Taking over player %p (muted=%d, aspect=%.2f)",
+              player, player.muted, self.aspectRatio);
+
+    [self ensureWindowForAnchorView:videoView];
+    [self buildCardIfNeeded];
+
+    self.cardRevealed = NO;
+    self.stashedSide = 0;
+    self.stashHandle.hidden = YES;
+    self.card.hidden = YES;
+    [self hideControlsOverlay]; // also cancels a previous video's fill animation
+    self.progressFraction = 0;  // don't carry the previous video's fill into a layout pass
+    self.playerView.playerLayer.player = player;
+
+    [self installPlayerObservers];
+
+    // Reveal happens on the new layer's readyForDisplay (KVO) so there is no
+    // black flash — the inline layer keeps rendering until then because we
+    // suppressed Apollo's pause. Safety net in case the KVO never fires.
+    NSUInteger generation = self.generation;
+    __weak __typeof(self) weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        __typeof(self) strongSelf = weakSelf;
+        if (strongSelf && strongSelf.active && strongSelf.generation == generation
+            && !strongSelf.cardRevealed) {
+            ApolloLog(@"[PiP] readyForDisplay timeout — revealing card anyway");
+            [strongSelf revealCard];
+        }
+    });
+
+    if (sPiPNativeEnabled) {
+        // The floating card's controller takes over native-PiP duty from the
+        // inline one (only one armed controller at a time).
+        [self disarmInlineNativePiPIfIdle];
+        [self setupNativePiP];
+    }
+}
+
+- (void)restoreInline {
+    if (!self.active || self.restoring) return;
+
+    ApolloLog(@"[PiP] Restoring inline (fade out)");
+
+    // If the clip ran out while the card presented it (Loop off), rewind now —
+    // synchronously, before we return to Apollo's visibility handler, whose
+    // [player play] would otherwise no-op on the at-end item and leave the
+    // inline video frozen on its last frame.
+    PiPRewindIfStoppedAtEnd(self.player);
+
+    if (!self.cardRevealed) {
+        [self teardownKeepPlaying:YES];
+        return;
+    }
+
+    self.restoring = YES;
+    [self cancelAnimator];
+    [self hideControlsOverlay];
+    // Touches must not reach the card while restoring: a gesture would cancel
+    // this animator, its completion (the ONLY path to teardown) would be
+    // skipped, and the state machine would wedge in active+restoring forever.
+    // (Gesture handlers also early-out on restoring as a second line of
+    // defense.)
+    self.card.userInteractionEnabled = NO;
+
+    // Simple fade — the inline video has been rendering the same frames all
+    // along, so the card just dissolves away.
+    __weak __typeof(self) weakSelf = self;
+    UIViewPropertyAnimator *animator =
+        [[UIViewPropertyAnimator alloc] initWithDuration:0.2
+                                                   curve:UIViewAnimationCurveEaseOut
+                                              animations:^{
+            weakSelf.card.alpha = 0.0;
+        }];
+    [animator addCompletion:^(UIViewAnimatingPosition finalPosition) {
+        [weakSelf teardownKeepPlaying:YES];
+    }];
+    self.animator = animator;
+    [animator startAnimation];
+}
+
+// Tear down the floating UI. keepPlaying=YES hands the (still playing) player
+// back to Apollo's inline machinery untouched; keepPlaying=NO applies the
+// state Apollo expects for a scrolled-away video: paused + muted + Ambient.
+- (void)teardownKeepPlaying:(BOOL)keepPlaying {
+    AVPlayer *player = self.player;
+    id richMediaNode = self.richMediaNode;
+    BOOL sessionWasClaimed = self.sessionClaimedAudibly;
+
+    // A player parked at its end (Loop off) must never be handed back as-is:
+    // Apollo's next inline play() would no-op on the at-end item and freeze
+    // the video on its last frame with no recovery (the card's rescue paths
+    // are gone, and rate==0 blocks a fresh takeover). Covers the close (X)
+    // path and a clip that runs out during restoreInline's fade — restore's
+    // own entry rewind can't catch an end that arrives mid-animation.
+    PiPRewindIfStoppedAtEnd(player);
+
+    self.generation++;
+    [self removePlayerObservers];
+    [self destroyNativePiP];
+    [self.controlsTimer invalidate];
+    self.controlsTimer = nil;
+    [self cancelAnimator];
+
+    self.playerView.playerLayer.player = nil;
+    [self.progressFill.layer removeAllAnimations]; // could otherwise run for the clip's remaining length
+    self.card.hidden = YES;
+    self.card.alpha = 1.0;
+    self.card.transform = CGAffineTransformIdentity;
+    self.card.userInteractionEnabled = YES; // restore-path disables it
+    self.cardRevealed = NO;
+    self.stashedSide = 0;
+    self.stashHandle.hidden = YES;
+    self.window.hidden = YES;
+
+    self.active = NO;
+    self.restoring = NO;
+    self.resumeOnForeground = NO;
+    self.sessionClaimedAudibly = NO;
+    self.player = nil;
+    self.playerItem = nil;
+    self.link = nil;
+    self.richMediaNode = nil;
+    self.videoNode = nil;
+
+    if (!keepPlaying && player) {
+        ApolloLog(@"[PiP] Closing — applying scrolled-away state (pause + mute)");
+        [player pause];
+        // Our own AVPlayer.setMuted: hook blocks mutes on the protected player;
+        // drop that protection first so this mute goes through.
+        ApolloVideoUnmute_ClearProtectionIfPlayer(player);
+        [player setMuted:YES];
+        if (richMediaNode) {
+            ApolloVideoUnmute_SyncMuteButtonIcon(richMediaNode, YES);
+        }
+        if (sessionWasClaimed) {
+            // This PiP session claimed the Playback audio session at some
+            // point (even if the card is muted right now) — hand it back,
+            // mirroring the mute dance's T+50ms downgrade, so e.g. the user's
+            // interrupted music gets its resume cue. self.active is already
+            // NO so our own blocking predicate passes this; if ANOTHER
+            // protected player exists, the ApolloVideoUnmute hooks block it,
+            // which is the correct outcome.
+            AVAudioSession *session = [AVAudioSession sharedInstance];
+            [session setCategory:AVAudioSessionCategoryAmbient error:nil];
+            [session setActive:NO
+                   withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
+                         error:nil];
+        }
+    }
+}
+
+- (void)cancelAnimator {
+    if (self.animator.isRunning) {
+        [self.animator stopAnimation:YES];
+    }
+    self.animator = nil;
+}
+
+// =============================================================================
+// MARK: Window + card UI
+// =============================================================================
+
+- (void)ensureWindowForAnchorView:(UIView *)anchorView {
+    UIWindowScene *scene = anchorView.window.windowScene;
+    if (!scene) {
+        for (UIScene *candidate in [UIApplication sharedApplication].connectedScenes) {
+            if ([candidate isKindOfClass:[UIWindowScene class]]
+                && candidate.activationState == UISceneActivationStateForegroundActive) {
+                scene = (UIWindowScene *)candidate;
+                break;
+            }
+        }
+    }
+
+    if (self.window && (!scene || self.window.windowScene == scene)) {
+        self.window.hidden = NO;
+        return;
+    }
+
+    ApolloPiPWindow *window = scene
+        ? [[ApolloPiPWindow alloc] initWithWindowScene:scene]
+        : [[ApolloPiPWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    window.windowLevel = UIWindowLevelNormal + 50; // above app UI, below alerts/keyboard
+    window.backgroundColor = [UIColor clearColor];
+
+    ApolloPiPRootViewController *rootVC = [[ApolloPiPRootViewController alloc] init];
+    __weak __typeof(self) weakSelf = self;
+    rootVC.onTransitionToSize = ^{
+        [weakSelf refitCardAnimated:NO];
+    };
+    window.rootViewController = rootVC;
+
+    self.window = window;
+    self.rootViewController = rootVC;
+    window.hidden = NO;
+
+    if (self.card) {
+        [rootVC.view addSubview:self.card];
+        window.interactiveView = self.card;
+    }
+}
+
+- (void)buildCardIfNeeded {
+    if (self.card) {
+        if (self.card.superview != self.rootViewController.view) {
+            [self.rootViewController.view addSubview:self.card];
+            self.window.interactiveView = self.card;
+        }
+        return;
+    }
+
+    UIView *card = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 200, 112)];
+    card.backgroundColor = [UIColor blackColor];
+    card.layer.cornerRadius = 12.0;
+    card.layer.masksToBounds = YES;
+    card.layer.borderWidth = 0.5;
+    card.layer.borderColor = [UIColor colorWithWhite:1.0 alpha:0.25].CGColor;
+
+    ApolloPiPPlayerView *playerView = [[ApolloPiPPlayerView alloc] initWithFrame:card.bounds];
+    playerView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    playerView.playerLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
+    playerView.userInteractionEnabled = NO;
+    [card addSubview:playerView];
+
+    ApolloPiPOverlayView *overlay = [[ApolloPiPOverlayView alloc] initWithFrame:card.bounds];
+    overlay.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    overlay.backgroundColor = [UIColor colorWithWhite:0 alpha:0.35];
+    overlay.hidden = YES;
+    __weak __typeof(self) weakOverlaySelf = self;
+    overlay.onLayout = ^{
+        [weakOverlaySelf layoutOverlayControls];
+    };
+    [card addSubview:overlay];
+
+    UIImageSymbolConfiguration *bigConfig =
+        [UIImageSymbolConfiguration configurationWithPointSize:26 weight:UIImageSymbolWeightSemibold];
+    UIImageSymbolConfiguration *smallConfig =
+        [UIImageSymbolConfiguration configurationWithPointSize:14 weight:UIImageSymbolWeightSemibold];
+
+    UIButton *(^makeButton)(NSString *, UIImageSymbolConfiguration *, SEL) =
+        ^UIButton *(NSString *symbol, UIImageSymbolConfiguration *config, SEL action) {
+            UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+            [button setImage:[UIImage systemImageNamed:symbol withConfiguration:config]
+                    forState:UIControlStateNormal];
+            button.tintColor = [UIColor whiteColor];
+            [button addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
+            [overlay addSubview:button];
+            return button;
+        };
+
+    // All control frames are owned by layoutOverlayControls (run from the
+    // overlay's layoutSubviews) — no autoresizing masks on the controls.
+    self.playPauseButton = makeButton(@"pause.fill", bigConfig, @selector(playPauseTapped));
+
+    // Optional skip buttons flanking play/pause (hidden unless Skip Buttons is
+    // on AND the card is big enough to host them collision-free — see
+    // layoutOverlayControls; numbered glyphs are applied in syncControlIcons).
+    UIImageSymbolConfiguration *mediumConfig =
+        [UIImageSymbolConfiguration configurationWithPointSize:20 weight:UIImageSymbolWeightSemibold];
+    self.skipBackButton = makeButton(@"gobackward.10", mediumConfig, @selector(skipBackTapped));
+    self.skipBackButton.hidden = YES;
+    self.skipForwardButton = makeButton(@"goforward.10", mediumConfig, @selector(skipForwardTapped));
+    self.skipForwardButton.hidden = YES;
+
+    // Optional read-only progress strip along the bottom edge (hidden unless
+    // Progress Bar is on). The fill is sized from progressFraction on every
+    // layout pass, so resizes keep the filled FRACTION correct between ticks.
+    // Inserted at the back so on short cards (where the strip's band can graze
+    // the center row's bottom edge) it passes UNDER the button glyphs.
+    UIView *progressTrack = [[UIView alloc] initWithFrame:CGRectZero];
+    progressTrack.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.35];
+    progressTrack.layer.cornerRadius = 1.5;
+    progressTrack.layer.masksToBounds = YES;
+    progressTrack.userInteractionEnabled = NO;
+    progressTrack.hidden = YES;
+    [overlay insertSubview:progressTrack atIndex:0];
+    self.progressTrack = progressTrack;
+
+    UIView *progressFill = [[UIView alloc] initWithFrame:CGRectZero];
+    progressFill.backgroundColor = [UIColor whiteColor];
+    progressFill.userInteractionEnabled = NO;
+    [progressTrack addSubview:progressFill];
+    self.progressFill = progressFill;
+
+    self.closeButton = makeButton(@"xmark", smallConfig, @selector(closeTapped));
+    self.muteButton = makeButton(@"speaker.slash.fill", smallConfig, @selector(muteTapped));
+
+    UITapGestureRecognizer *tap =
+        [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
+    UITapGestureRecognizer *doubleTap =
+        [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDoubleTap:)];
+    doubleTap.numberOfTapsRequired = 2;
+    // Deliberately NO requireGestureRecognizerToFail: between them — that
+    // would delay the controls overlay by the double-tap timeout (~350ms),
+    // which reads as lag. Instead the first tap shows controls instantly and
+    // a double-tap re-hides them before resizing (handleDoubleTap).
+    //
+    // delaysTouchesEnded (default YES) would buffer touch-ended delivery to
+    // the overlay BUTTONS while the double-tap window decides, making ✕/mute/
+    // play feel laggy. The delegate additionally routes control-originated
+    // touches straight to the buttons (shouldReceiveTouch:).
+    tap.delaysTouchesEnded = NO;
+    tap.delegate = self;
+    doubleTap.delaysTouchesEnded = NO;
+    doubleTap.delegate = self;
+    [card addGestureRecognizer:tap];
+    [card addGestureRecognizer:doubleTap];
+
+    UIPanGestureRecognizer *pan =
+        [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
+    pan.delegate = self;
+    [card addGestureRecognizer:pan];
+
+    UIPinchGestureRecognizer *pinch =
+        [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(handlePinch:)];
+    pinch.delegate = self;
+    [card addGestureRecognizer:pinch];
+
+    // Chevron tab shown on the exposed sliver while the card is stashed off
+    // an edge (native-PiP-style). Frame is set by updateStashHandleForSide:.
+    UIImageView *stashHandle = [[UIImageView alloc] initWithFrame:CGRectZero];
+    stashHandle.contentMode = UIViewContentModeCenter;
+    stashHandle.tintColor = [UIColor whiteColor];
+    stashHandle.layer.shadowColor = [UIColor blackColor].CGColor;
+    stashHandle.layer.shadowOpacity = 0.6;
+    stashHandle.layer.shadowOffset = CGSizeZero;
+    stashHandle.layer.shadowRadius = 2.0;
+    stashHandle.hidden = YES;
+    [card addSubview:stashHandle];
+    self.stashHandle = stashHandle;
+
+    self.card = card;
+    self.playerView = playerView;
+    self.controlsOverlay = overlay;
+
+    [self.rootViewController.view addSubview:card];
+    self.window.interactiveView = card;
+}
+
+- (void)revealCard {
+    if (!self.active || self.cardRevealed) return;
+    self.cardRevealed = YES;
+
+    // Simple pop-in at the default position — the inline video keeps rendering,
+    // so the card just materializes. It may start hidden (tucked off an edge)
+    // per the Default Position / Hidden by Default settings.
+    [self cancelAnimator];
+    NSInteger startSide = 0;
+    self.card.frame = [self startingFrameStashSide:&startSide];
+    self.stashedSide = startSide;
+    [self updateStashHandleForSide:startSide]; // hides the handle when shown
+    self.card.hidden = NO;
+    self.card.alpha = 0;
+    // A hidden start fades the sliver in; a shown start adds the scale pop.
+    self.card.transform = startSide != 0 ? CGAffineTransformIdentity
+                                         : CGAffineTransformMakeScale(0.88, 0.88);
+    if (startSide == 0) [self syncControlIcons];
+
+    __weak __typeof(self) weakSelf = self;
+    [UIView animateWithDuration:0.35 delay:0
+         usingSpringWithDamping:0.8 initialSpringVelocity:0
+                        options:UIViewAnimationOptionAllowUserInteraction
+                     animations:^{
+        weakSelf.card.alpha = 1.0;
+        weakSelf.card.transform = CGAffineTransformIdentity;
+    } completion:nil];
+}
+
+// =============================================================================
+// MARK: Geometry
+// =============================================================================
+
+// Clamp a desired card WIDTH to the on-screen limits, deriving height from the
+// current aspect ratio (and re-clamping width if a tall video would exceed the
+// height cap). The single sizing primitive everything else funnels through.
+- (CGSize)cardSizeForWidth:(CGFloat)width {
+    CGRect bounds = self.window.bounds;
+    CGFloat aspect = MAX(self.aspectRatio, 0.1);
+    CGFloat maxWidth = bounds.size.width - 2 * kPiPEdgeMargin;
+    width = MAX(kPiPMinWidth, MIN(maxWidth, width));
+    CGFloat height = width / aspect;
+    CGFloat maxHeight = bounds.size.height * 0.5;
+    if (height > maxHeight) {
+        // Tall video: clamp height and re-clamp the recomputed width too —
+        // AspectFill absorbs any residual mismatch for degenerate aspects.
+        height = maxHeight;
+        width = MAX(kPiPMinWidth, MIN(maxWidth, height * aspect));
+    }
+    return CGSizeMake(width, height);
+}
+
+// Card size for a target AREA, preserving the current aspect ratio:
+// width = sqrt(area * aspect), height = sqrt(area / aspect) → width*height = area.
+// Clamps absorb the limits (aspect kept, area approximate at the extremes).
+- (CGSize)cardSizeForArea:(CGFloat)area {
+    if (area <= 0) return [self cardSizeForWidth:kPiPMinWidth];
+    return [self cardSizeForWidth:sqrt(area * MAX(self.aspectRatio, 0.1))];
+}
+
+// The on-screen area a 16:9 card of the given screen-width fraction would
+// occupy — the calibration that turns a "landscape width fraction" into the
+// aspect-independent area target used for every video.
+- (CGFloat)areaForLandscapeWidthFraction:(CGFloat)fraction {
+    CGFloat width = self.window.bounds.size.width * fraction;
+    return width * (width / kPiPReferenceAspect);
+}
+
+// Default spawn size: the calibrated footprint, applied to THIS video's aspect.
+- (CGSize)defaultCardSize {
+    return [self cardSizeForArea:[self areaForLandscapeWidthFraction:kPiPDefaultLandscapeWidthFraction]];
+}
+
+// The size a freshly-revealed card should use. Only Last Position remembers a
+// user-chosen size (as an area fraction, so a differently-shaped next video
+// keeps the same footprint rather than the same width); every fixed-corner
+// Default Position uses the sensible calibrated default each time.
+- (CGSize)spawnCardSize {
+    if (sPiPStartPosition == ApolloPiPStartPositionLastPosition) {
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+        if ([defaults objectForKey:UDKeyPictureInPictureAreaFraction]) {
+            CGFloat areaFraction = [defaults floatForKey:UDKeyPictureInPictureAreaFraction];
+            CGFloat w = self.window.bounds.size.width;
+            if (areaFraction > 0.0001 && !isnan(areaFraction) && w > 1) {
+                return [self cardSizeForArea:areaFraction * w * w];
+            }
+        }
+    }
+    return [self defaultCardSize];
+}
+
+- (CGPoint)centerForCorner:(NSInteger)corner size:(CGSize)size {
+    CGRect bounds = self.window.bounds;
+    UIEdgeInsets insets = self.window.safeAreaInsets;
+    CGFloat leftX = insets.left + kPiPEdgeMargin + size.width / 2;
+    CGFloat rightX = bounds.size.width - insets.right - kPiPEdgeMargin - size.width / 2;
+    CGFloat topY = insets.top + kPiPEdgeMargin + size.height / 2;
+    CGFloat bottomY = bounds.size.height - insets.bottom - kPiPEdgeMargin - size.height / 2;
+    switch (corner) {
+        case 0:  return CGPointMake(leftX, topY);
+        case 1:  return CGPointMake(rightX, topY);
+        case 2:  return CGPointMake(leftX, bottomY);
+        default: return CGPointMake(rightX, bottomY);
+    }
+}
+
+// Record the card's current size as an area fraction (card area / screenWidth²,
+// resolution-independent). Only consumed by spawnCardSize in Last Position mode,
+// but written on every resize so that mode always has the latest footprint.
+- (void)persistCardArea {
+    CGFloat w = self.window.bounds.size.width;
+    if (w < 1) return;
+    CGFloat areaFraction = (self.card.bounds.size.width * self.card.bounds.size.height) / (w * w);
+    [[NSUserDefaults standardUserDefaults] setFloat:(float)areaFraction
+                                             forKey:UDKeyPictureInPictureAreaFraction];
+}
+
+// Free docking: the card may rest anywhere, clamped fully on-screen within
+// the safe area + margin.
+- (CGPoint)clampedCenter:(CGPoint)center forSize:(CGSize)size {
+    CGRect bounds = self.window.bounds;
+    UIEdgeInsets insets = self.window.safeAreaInsets;
+    CGFloat minX = insets.left + kPiPEdgeMargin + size.width / 2;
+    CGFloat maxX = bounds.size.width - insets.right - kPiPEdgeMargin - size.width / 2;
+    CGFloat minY = insets.top + kPiPEdgeMargin + size.height / 2;
+    CGFloat maxY = bounds.size.height - insets.bottom - kPiPEdgeMargin - size.height / 2;
+    if (maxX < minX) maxX = minX;
+    if (maxY < minY) maxY = minY;
+    return CGPointMake(MAX(minX, MIN(maxX, center.x)), MAX(minY, MIN(maxY, center.y)));
+}
+
+// The resting position persists as a NORMALIZED center (fraction of window
+// bounds), so it survives rotation and different card sizes: a new video with
+// a different aspect ratio reuses the same screen-relative spot, re-clamped
+// to fit its own dimensions.
+// Records the resting position: normalized center (so it survives rotation and
+// differing card sizes) plus the hidden side (0 shown, ±1 tucked off an edge),
+// so a Last-Position start restores both. Call at every rest point.
+- (void)persistCardCenter {
+    CGRect bounds = self.window.bounds;
+    if (bounds.size.width < 1 || bounds.size.height < 1) return;
+    CGPoint center = self.card.center;
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setFloat:(float)(center.x / bounds.size.width) forKey:UDKeyPictureInPictureLastCenterX];
+    [defaults setFloat:(float)(center.y / bounds.size.height) forKey:UDKeyPictureInPictureLastCenterY];
+    [defaults setInteger:self.stashedSide forKey:UDKeyPictureInPictureLastStashSide];
+}
+
+- (CGRect)frameForCenter:(CGPoint)center size:(CGSize)size {
+    return CGRectMake(center.x - size.width / 2, center.y - size.height / 2,
+                      size.width, size.height);
+}
+
+// Reads the persisted normalized resting center scaled to the current window
+// bounds. NO when nothing has been persisted yet.
+- (BOOL)readPersistedCenter:(CGPoint *)outCenter {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    if (![defaults objectForKey:UDKeyPictureInPictureLastCenterX]
+        || ![defaults objectForKey:UDKeyPictureInPictureLastCenterY]) {
+        return NO;
+    }
+    CGRect bounds = self.window.bounds;
+    *outCenter = CGPointMake([defaults floatForKey:UDKeyPictureInPictureLastCenterX] * bounds.size.width,
+                             [defaults floatForKey:UDKeyPictureInPictureLastCenterY] * bounds.size.height);
+    return YES;
+}
+
+// Where a fresh card first appears and whether it starts hidden (tucked off an
+// edge). Outputs the stash side (0 = shown, ±1 = hidden left/right) and returns
+// the frame to place the card at:
+//   - Last Position: remembered center + remembered hidden side.
+//   - Corner + Hidden by Default off: docked at the corner.
+//   - Corner + Hidden by Default on: tucked off the corner's edge at the corner's Y.
+- (CGRect)startingFrameStashSide:(NSInteger *)outStashSide {
+    CGSize size = [self spawnCardSize];
+
+    if (sPiPStartPosition == ApolloPiPStartPositionLastPosition) {
+        CGPoint center;
+        BOOL haveCenter = [self readPersistedCenter:&center];
+        NSInteger lastSide = [[NSUserDefaults standardUserDefaults]
+                              integerForKey:UDKeyPictureInPictureLastStashSide];
+        if (haveCenter && (lastSide == -1 || lastSide == 1)) {
+            *outStashSide = lastSide;
+            CGPoint clamped = [self clampedCenter:center forSize:size];
+            return [self stashFrameForSide:lastSide size:size centerY:clamped.y];
+        }
+        *outStashSide = 0;
+        if (!haveCenter) center = [self centerForCorner:ApolloPiPStartPositionTopRight size:size];
+        return [self frameForCenter:[self clampedCenter:center forSize:size] size:size];
+    }
+
+    NSInteger corner = (sPiPStartPosition >= ApolloPiPStartPositionTopLeft
+                        && sPiPStartPosition <= ApolloPiPStartPositionBottomRight)
+        ? sPiPStartPosition : ApolloPiPStartPositionTopRight;
+    CGPoint center = [self clampedCenter:[self centerForCorner:corner size:size] forSize:size];
+    if (sPiPStartHidden) {
+        *outStashSide = (corner == ApolloPiPStartPositionTopLeft
+                         || corner == ApolloPiPStartPositionBottomLeft) ? -1 : 1;
+        return [self stashFrameForSide:*outStashSide size:size centerY:center.y];
+    }
+    *outStashSide = 0;
+    return [self frameForCenter:center size:size];
+}
+
+// Re-fit the card after bounds/size changes (rotation, resize): keep the
+// persisted screen-relative position, re-clamped for the current size.
+- (void)refitCardAnimated:(BOOL)animated {
+    if (!self.active || !self.cardRevealed || self.restoring) return;
+    if (self.stashedSide != 0) {
+        // Rotation while stashed: recompute the stash position for the new bounds.
+        self.card.frame = [self stashFrameForSide:self.stashedSide];
+        [self updateStashHandleForSide:self.stashedSide];
+        return;
+    }
+    // Preserve the card's CURRENT size across the bounds change (re-clamped),
+    // not a persisted fraction — within a session the live card is the source
+    // of truth, so a stale cross-session size can't snap it on rotation.
+    CGSize size = [self cardSizeForWidth:self.card.bounds.size.width];
+    CGPoint center;
+    if (![self readPersistedCenter:&center]) {
+        center = self.card.center;
+    }
+    CGRect frame = [self frameForCenter:[self clampedCenter:center forSize:size] size:size];
+    if (!animated) {
+        self.card.frame = frame;
+        return;
+    }
+    [self cancelAnimator];
+    __weak __typeof(self) weakSelf = self;
+    UIViewPropertyAnimator *animator =
+        [[UIViewPropertyAnimator alloc] initWithDuration:0.45 dampingRatio:0.8 animations:^{
+            weakSelf.card.frame = frame;
+        }];
+    self.animator = animator;
+    [animator startAnimation];
+}
+
+// =============================================================================
+// MARK: Edge stash (native-PiP-style hide)
+// =============================================================================
+
+// Stash frame for a given card size, keeping the given on-screen center Y
+// (clamped). Only kPiPStashVisibleWidth of the card stays on screen.
+- (CGRect)stashFrameForSide:(NSInteger)side size:(CGSize)size centerY:(CGFloat)centerY {
+    CGRect bounds = self.window.bounds;
+    UIEdgeInsets insets = self.window.safeAreaInsets;
+    CGFloat y = centerY - size.height / 2;
+    CGFloat minY = insets.top + kPiPEdgeMargin;
+    CGFloat maxY = bounds.size.height - insets.bottom - kPiPEdgeMargin - size.height;
+    y = MAX(minY, MIN(maxY, y));
+    CGFloat x = (side < 0) ? (kPiPStashVisibleWidth - size.width)
+                           : (bounds.size.width - kPiPStashVisibleWidth);
+    return CGRectMake(x, y, size.width, size.height);
+}
+
+- (CGRect)stashFrameForSide:(NSInteger)side {
+    return [self stashFrameForSide:side size:self.card.bounds.size centerY:self.card.center.y];
+}
+
+- (void)updateStashHandleForSide:(NSInteger)side {
+    if (side == 0) {
+        self.stashHandle.hidden = YES;
+        return;
+    }
+    // Chevron points inward — the direction to pull the card back out.
+    NSString *symbol = (side < 0) ? @"chevron.compact.right" : @"chevron.compact.left";
+    UIImageSymbolConfiguration *config =
+        [UIImageSymbolConfiguration configurationWithPointSize:18 weight:UIImageSymbolWeightBold];
+    self.stashHandle.image = [UIImage systemImageNamed:symbol withConfiguration:config];
+    CGSize cardSize = self.card.bounds.size;
+    CGFloat x = (side < 0) ? (cardSize.width - kPiPStashVisibleWidth) : 0;
+    self.stashHandle.frame = CGRectMake(x, 0, kPiPStashVisibleWidth, cardSize.height);
+    self.stashHandle.hidden = NO;
+    [self.card bringSubviewToFront:self.stashHandle];
+}
+
+- (void)stashToSide:(NSInteger)side {
+    ApolloLog(@"[PiP] Stashing card to %@ edge", side < 0 ? @"left" : @"right");
+    self.stashedSide = side;
+    [self hideControlsOverlay];
+    [self updateStashHandleForSide:side];
+
+    CGRect frame = [self stashFrameForSide:side];
+    [self cancelAnimator];
+    __weak __typeof(self) weakSelf = self;
+    UIViewPropertyAnimator *animator =
+        [[UIViewPropertyAnimator alloc] initWithDuration:0.45 dampingRatio:0.85 animations:^{
+            weakSelf.card.frame = frame;
+        }];
+    self.animator = animator;
+    [animator startAnimation];
+    // Model frame is the stash frame now — record the hidden state + Y.
+    [self persistCardCenter];
+}
+
+- (void)unstash {
+    if (self.stashedSide == 0) return;
+    ApolloLog(@"[PiP] Unstashing card");
+    self.stashedSide = 0;
+    [self updateStashHandleForSide:0];
+    // Pull fully on-screen at the current height: clamping the mostly
+    // offscreen center lands it flush against the stash-side edge.
+    CGPoint center = [self clampedCenter:self.card.center forSize:self.card.bounds.size];
+    CGRect frame = [self frameForCenter:center size:self.card.bounds.size];
+    [self cancelAnimator];
+    __weak __typeof(self) weakSelf = self;
+    UIViewPropertyAnimator *animator =
+        [[UIViewPropertyAnimator alloc] initWithDuration:0.45 dampingRatio:0.8 animations:^{
+            weakSelf.card.frame = frame;
+        }];
+    self.animator = animator;
+    [animator startAnimation];
+    // The animator sets the model frame at start, so this records the
+    // unstashed target position.
+    [self persistCardCenter];
+}
+
+// =============================================================================
+// MARK: Gestures
+// =============================================================================
+
+// Touches that start on a control (the overlay buttons) belong to that
+// control alone: the buttons respond instantly and the card's tap gesture
+// can't toggle the overlay underneath a button press.
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+       shouldReceiveTouch:(UITouch *)touch {
+    return ![touch.view isKindOfClass:[UIControl class]];
+}
+
+// Pan + pinch may run together (system-PiP-like feel); taps stay exclusive.
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+    shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)other {
+    BOOL panOrPinch = [gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]
+                   || [gestureRecognizer isKindOfClass:[UIPinchGestureRecognizer class]];
+    BOOL otherPanOrPinch = [other isKindOfClass:[UIPanGestureRecognizer class]]
+                        || [other isKindOfClass:[UIPinchGestureRecognizer class]];
+    return panOrPinch && otherPanOrPinch;
+}
+
+- (void)handlePan:(UIPanGestureRecognizer *)pan {
+    if (self.restoring) return;
+    UIView *container = self.rootViewController.view;
+    switch (pan.state) {
+        case UIGestureRecognizerStateBegan:
+            [self cancelAnimator];
+            break;
+        case UIGestureRecognizerStateChanged: {
+            CGPoint translation = [pan translationInView:container];
+            CGPoint center = self.card.center;
+            self.card.center = CGPointMake(center.x + translation.x, center.y + translation.y);
+            [pan setTranslation:CGPointZero inView:container];
+            break;
+        }
+        case UIGestureRecognizerStateEnded:
+        case UIGestureRecognizerStateCancelled: {
+            CGPoint velocity = [pan velocityInView:container];
+            CGFloat speed = sqrt(velocity.x * velocity.x + velocity.y * velocity.y);
+            CGPoint center = self.card.center;
+            CGRect bounds = self.window.bounds;
+
+            // Gentle release: the card stays EXACTLY where the finger left it
+            // (clamped on-screen). Only a real fling earns momentum, and even
+            // that is heavily damped (see PiPProjectOffset).
+            CGPoint projected = center;
+            if (speed >= kPiPFlingVelocityThreshold) {
+                projected.x += PiPProjectOffset(velocity.x);
+                projected.y += PiPProjectOffset(velocity.y);
+            }
+
+            NSInteger startSide = self.stashedSide;
+            if (startSide != 0) {
+                // Gesture began from a stash. It may push back into the SAME
+                // edge or pull inward to unstash — never fly across to the
+                // opposite edge.
+                BOOL stillOffSameSide = (startSide < 0)
+                    ? (projected.x < 0)
+                    : (projected.x > bounds.size.width);
+                if (stillOffSameSide) {
+                    [self stashToSide:startSide];
+                    break;
+                }
+                self.stashedSide = 0;
+                [self updateStashHandleForSide:0];
+                projected.x = MAX(kPiPEdgeMargin,
+                                  MIN(bounds.size.width - kPiPEdgeMargin, projected.x));
+            } else {
+                // Stashing requires INTENT: the card physically dragged past
+                // the edge (center offscreen), or a decisive horizontally-
+                // dominant fling toward that edge. Vertical or casual flicks
+                // near an edge never stash.
+                BOOL horizontalFling = fabs(velocity.x) > kPiPStashVelocityThreshold
+                                    && fabs(velocity.x) > fabs(velocity.y);
+                if (center.x < 0 || (projected.x < 0 && horizontalFling && velocity.x < 0)) {
+                    [self stashToSide:-1];
+                    break;
+                }
+                if (center.x > bounds.size.width
+                    || (projected.x > bounds.size.width && horizontalFling && velocity.x > 0)) {
+                    [self stashToSide:1];
+                    break;
+                }
+            }
+
+            // Free positioning: settle where the (possibly projected) release
+            // landed, clamped fully on-screen.
+            CGPoint target = [self clampedCenter:projected forSize:self.card.bounds.size];
+            CGFloat dx = target.x - center.x, dy = target.y - center.y;
+            if (fabs(dx) < 1.0 && fabs(dy) < 1.0) {
+                // Released in place — no settle animation, no drift.
+                [self persistCardCenter];
+                break;
+            }
+            CGFloat distance = MAX(1.0, sqrt(dx * dx + dy * dy));
+            UISpringTimingParameters *spring =
+                [[UISpringTimingParameters alloc] initWithDampingRatio:0.85
+                                                       initialVelocity:CGVectorMake(speed / distance, speed / distance)];
+            UIViewPropertyAnimator *animator =
+                [[UIViewPropertyAnimator alloc] initWithDuration:0.4 timingParameters:spring];
+            __weak __typeof(self) weakSelf = self;
+            [animator addAnimations:^{ weakSelf.card.center = target; }];
+            [self cancelAnimator];
+            self.animator = animator;
+            [animator startAnimation];
+            // Model center is already at the target — record the new resting spot.
+            [self persistCardCenter];
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+- (void)handlePinch:(UIPinchGestureRecognizer *)pinch {
+    if (self.restoring || self.stashedSide != 0) return;
+    static CGFloat startWidth = 0;
+    switch (pinch.state) {
+        case UIGestureRecognizerStateBegan:
+            [self cancelAnimator];
+            startWidth = self.card.bounds.size.width;
+            break;
+        case UIGestureRecognizerStateChanged: {
+            CGRect bounds = self.window.bounds;
+            CGFloat width = startWidth * pinch.scale;
+            width = MAX(kPiPMinWidth, MIN(bounds.size.width - 2 * kPiPEdgeMargin, width));
+            CGFloat height = width / MAX(self.aspectRatio, 0.1);
+            CGPoint center = self.card.center;
+            self.card.bounds = CGRectMake(0, 0, width, height);
+            self.card.center = center;
+            break;
+        }
+        case UIGestureRecognizerStateEnded:
+        case UIGestureRecognizerStateCancelled: {
+            // Remember the new footprint (Last Position size memory).
+            [self persistCardArea];
+            // Stay where pinched; just nudge back on-screen if the resize
+            // pushed an edge out of bounds.
+            [self persistCardCenter];
+            [self refitCardAnimated:YES];
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+// Every hide goes through here: the progress fill's animation runs for the
+// clip's entire remaining length, so leaving it active behind a hidden
+// overlay would burn render-server work for minutes — and a stale previous-
+// video animation could survive a teardown onto the reused fill view.
+- (void)hideControlsOverlay {
+    self.controlsOverlay.hidden = YES;
+    [self.progressFill.layer removeAllAnimations];
+}
+
+- (void)handleTap:(UITapGestureRecognizer *)tap {
+    if (self.restoring) return;
+    if (self.stashedSide != 0) {
+        [self unstash];
+        return;
+    }
+    if (self.controlsOverlay.hidden) {
+        self.controlsOverlay.hidden = NO;
+        [self syncControlIcons];
+        [self restartControlsTimer];
+    } else {
+        [self hideControlsOverlay];
+    }
+}
+
+- (void)handleDoubleTap:(UITapGestureRecognizer *)tap {
+    if (self.restoring || self.stashedSide != 0) return;
+    // The first tap of the double-tap already toggled the controls overlay
+    // (no failure dependency between the recognizers, see buildCardIfNeeded) —
+    // hide it again for a clean resize.
+    [self hideControlsOverlay];
+    [self.controlsTimer invalidate];
+    self.controlsTimer = nil;
+
+    // Toggle between the default and large FOOTPRINTS (area), so the zoom feels
+    // the same for landscape and portrait. Pick whichever the current area is
+    // farther from.
+    CGFloat currentArea = self.card.bounds.size.width * self.card.bounds.size.height;
+    CGFloat defaultArea = [self areaForLandscapeWidthFraction:kPiPDefaultLandscapeWidthFraction];
+    CGFloat largeArea = [self areaForLandscapeWidthFraction:kPiPLargeLandscapeWidthFraction];
+    CGFloat targetArea = (fabs(currentArea - defaultArea) < fabs(currentArea - largeArea))
+        ? largeArea : defaultArea;
+
+    // Resize anchored to the card's nearest screen corner — when the card
+    // sits top-right, its top-right edges stay put and the size change grows
+    // or shrinks inward (center-anchored resizing makes a docked card appear
+    // to jump away from its corner).
+    CGSize newSize = [self cardSizeForArea:targetArea];
+    CGRect old = self.card.frame;
+    CGRect bounds = self.window.bounds;
+    BOOL anchorRight = CGRectGetMidX(old) > bounds.size.width / 2.0;
+    BOOL anchorBottom = CGRectGetMidY(old) > bounds.size.height / 2.0;
+    CGFloat x = anchorRight ? CGRectGetMaxX(old) - newSize.width : CGRectGetMinX(old);
+    CGFloat y = anchorBottom ? CGRectGetMaxY(old) - newSize.height : CGRectGetMinY(old);
+    CGPoint center = [self clampedCenter:CGPointMake(x + newSize.width / 2.0, y + newSize.height / 2.0)
+                                 forSize:newSize];
+    CGRect frame = [self frameForCenter:center size:newSize];
+
+    [self cancelAnimator];
+    __weak __typeof(self) weakSelf = self;
+    UIViewPropertyAnimator *animator =
+        [[UIViewPropertyAnimator alloc] initWithDuration:0.4 dampingRatio:0.85 animations:^{
+            weakSelf.card.frame = frame;
+        }];
+    self.animator = animator;
+    [animator startAnimation];
+    // Model frame is the target now — record the new footprint + position.
+    [self persistCardArea];
+    [self persistCardCenter];
+}
+
+- (void)restartControlsTimer {
+    [self.controlsTimer invalidate];
+    __weak __typeof(self) weakSelf = self;
+    self.controlsTimer = [NSTimer scheduledTimerWithTimeInterval:kPiPControlsAutoHideDelay
+                                                         repeats:NO
+                                                           block:^(NSTimer *timer) {
+        [weakSelf hideControlsOverlay];
+    }];
+}
+
+// =============================================================================
+// MARK: Controls
+// =============================================================================
+
+// Single source of truth for control frames, run on every overlay layout pass
+// (bounds changes from pinch/double-tap/rotation) and from syncControlIcons.
+//
+// Geometry: close/mute pin to the top corners (hit rects end at y=40). The
+// center row (play/pause, optionally flanked by the skip buttons) is sized
+// down on short cards and lowered just enough that the skip buttons' hit
+// rects clear the corner buttons' — at the default ~165x93 card a centered
+// 40pt row would reach y=26, deep into the corners' band. When even that
+// can't fit collision-free (very short/narrow cards), the skip buttons hide
+// and the layout reverts to the original lone centered play/pause.
+- (void)layoutOverlayControls {
+    UIView *overlay = self.controlsOverlay;
+    if (!overlay) return;
+    CGFloat w = overlay.bounds.size.width, h = overlay.bounds.size.height;
+    if (w < 1 || h < 1) return;
+
+    self.closeButton.frame = CGRectMake(6, 6, 34, 34);
+    self.muteButton.frame = CGRectMake(w - 40, 6, 34, 34);
+    self.progressTrack.frame = CGRectMake(10, h - 9, w - 20, 3);
+    [self syncProgressAnimation]; // re-fit the fill (and its animation) to the new track width
+
+    BOOL compact = h < 120; // short card: shrink the row to make room
+    CGFloat ppSize = (sPiPSkipButtons && compact) ? 44 : 52;
+    CGFloat skipSize = compact ? 36 : 40;
+
+    BOOL showSkips = sPiPSkipButtons;
+    CGFloat rowCenterY = h / 2;
+    CGFloat offset = ppSize / 2 + 8 + skipSize / 2; // skip-button center to card center
+    if (showSkips) {
+        CGFloat minRowCenterY = 42 + skipSize / 2;    // skips clear of close/mute (y <= 40)
+        CGFloat maxRowCenterY = h - 4 - ppSize / 2;   // row fully on the card
+        CGFloat maxOffset = w / 2 - 6 - skipSize / 2; // skips fully on the card
+        if (rowCenterY < minRowCenterY) rowCenterY = minRowCenterY;
+        if (offset > maxOffset) offset = maxOffset;
+        if (rowCenterY > maxRowCenterY || offset < ppSize / 2 + 2 + skipSize / 2) {
+            // No collision-free room — drop the skips, restore the lone
+            // centered play/pause.
+            showSkips = NO;
+            ppSize = 52;
+            rowCenterY = h / 2;
+        }
+    }
+
+    self.playPauseButton.frame = CGRectMake(w / 2 - ppSize / 2, rowCenterY - ppSize / 2,
+                                            ppSize, ppSize);
+    self.skipBackButton.hidden = !showSkips;
+    self.skipForwardButton.hidden = !showSkips;
+    if (showSkips) {
+        self.skipBackButton.frame = CGRectMake(w / 2 - offset - skipSize / 2,
+                                               rowCenterY - skipSize / 2, skipSize, skipSize);
+        self.skipForwardButton.frame = CGRectMake(w / 2 + offset - skipSize / 2,
+                                                  rowCenterY - skipSize / 2, skipSize, skipSize);
+    }
+}
+
+- (void)applyProgressFraction {
+    CGRect bounds = self.progressTrack.bounds;
+    self.progressFill.frame = CGRectMake(0, 0, bounds.size.width * self.progressFraction,
+                                         bounds.size.height);
+}
+
+// Continuous progress: rather than stepping the fill once per observer tick,
+// park the model at the true position and run ONE linear animation to the
+// track's end paced at the player's rate — Core Animation then advances the
+// bar every frame. Re-synced (cheaply: cancel + restart from ground truth)
+// on every tick, seek, rate change, and layout pass, so drift from stalls or
+// resizes never exceeds one correction interval.
+- (void)syncProgressAnimation {
+    UIView *fill = self.progressFill;
+    if (!fill) return;
+    [fill.layer removeAllAnimations];
+    [self applyProgressFraction]; // model at the true (player-time) position
+
+    if (!sPiPProgressBar || self.progressTrack.hidden || self.controlsOverlay.hidden) return;
+
+    AVPlayer *player = self.player;
+    AVPlayerItem *item = player.currentItem;
+    if (!player || player.rate <= 0 || !item || !CMTIME_IS_NUMERIC(item.duration)) return;
+    // rate is the DESIRED rate — during a rebuffer it stays 1.0 while media
+    // time is frozen (timeControlStatus == waiting), and neither the media-
+    // time-paced observer nor the rate KVO fires. Animating then would march
+    // the bar over a frozen video; stay static until actually playing (the
+    // timeControlStatus KVO re-syncs on the stall/resume transitions).
+    if (player.timeControlStatus != AVPlayerTimeControlStatusPlaying) return;
+    CGFloat duration = CMTimeGetSeconds(item.duration);
+    if (duration <= 0) return;
+    CGFloat remaining = (duration - CMTimeGetSeconds(item.currentTime)) / player.rate;
+    if (remaining <= 0.05) return; // the end notification re-syncs via the time-jump tick
+
+    CGRect bounds = self.progressTrack.bounds;
+    CGRect fullFrame = CGRectMake(0, 0, bounds.size.width, bounds.size.height);
+    [UIView animateWithDuration:remaining
+                          delay:0
+                        options:UIViewAnimationOptionCurveLinear
+                     animations:^{
+        fill.frame = fullFrame;
+    } completion:nil];
+}
+
+- (void)syncControlIcons {
+    UIImageSymbolConfiguration *bigConfig =
+        [UIImageSymbolConfiguration configurationWithPointSize:26 weight:UIImageSymbolWeightSemibold];
+    UIImageSymbolConfiguration *smallConfig =
+        [UIImageSymbolConfiguration configurationWithPointSize:14 weight:UIImageSymbolWeightSemibold];
+
+    BOOL playing = self.player.rate != 0;
+    [self.playPauseButton setImage:[UIImage systemImageNamed:(playing ? @"pause.fill" : @"play.fill")
+                                           withConfiguration:bigConfig]
+                          forState:UIControlStateNormal];
+
+    BOOL muted = self.player.muted;
+    [self.muteButton setImage:[UIImage systemImageNamed:(muted ? @"speaker.slash.fill" : @"speaker.wave.2.fill")
+                                      withConfiguration:smallConfig]
+                     forState:UIControlStateNormal];
+
+    // Optional extras (settings-gated, re-read on every overlay reveal so
+    // settings changes apply to a live card). Skip-button visibility and all
+    // frames are owned by the layout pass.
+    [self layoutOverlayControls];
+    if (sPiPSkipButtons) {
+        UIImageSymbolConfiguration *mediumConfig =
+            [UIImageSymbolConfiguration configurationWithPointSize:20 weight:UIImageSymbolWeightSemibold];
+        // Numbered glyphs exist for every offered amount (5/10/15/30); plain
+        // gobackward/goforward is a just-in-case fallback.
+        UIImage *backImage = [UIImage systemImageNamed:[NSString stringWithFormat:@"gobackward.%ld", (long)sPiPSkipSeconds]
+                                      withConfiguration:mediumConfig]
+            ?: [UIImage systemImageNamed:@"gobackward" withConfiguration:mediumConfig];
+        UIImage *forwardImage = [UIImage systemImageNamed:[NSString stringWithFormat:@"goforward.%ld", (long)sPiPSkipSeconds]
+                                         withConfiguration:mediumConfig]
+            ?: [UIImage systemImageNamed:@"goforward" withConfiguration:mediumConfig];
+        [self.skipBackButton setImage:backImage forState:UIControlStateNormal];
+        [self.skipForwardButton setImage:forwardImage forState:UIControlStateNormal];
+    }
+
+    self.progressTrack.hidden = !sPiPProgressBar;
+    if (sPiPProgressBar) [self updateProgressBar];
+}
+
+// Read-only progress strip: filled fraction = currentTime / duration,
+// animated continuously between corrections (see syncProgressAnimation).
+// Called from the periodic time observer while the overlay is showing, plus
+// one-shot refreshes on reveal, rate changes, and after seeks.
+- (void)updateProgressBar {
+    AVPlayerItem *item = self.player.currentItem;
+    CGFloat fraction = 0;
+    if (item && CMTIME_IS_NUMERIC(item.duration)) {
+        CGFloat duration = CMTimeGetSeconds(item.duration);
+        if (duration > 0) {
+            fraction = CMTimeGetSeconds(item.currentTime) / duration;
+            fraction = MAX(0.0, MIN(1.0, fraction));
+        }
+    }
+    self.progressFraction = fraction;
+    [self syncProgressAnimation];
+}
+
+- (void)skipBackTapped {
+    [self seekBySeconds:-(NSTimeInterval)sPiPSkipSeconds];
+}
+
+- (void)skipForwardTapped {
+    [self seekBySeconds:(NSTimeInterval)sPiPSkipSeconds];
+}
+
+// Relative seek for the skip buttons. Plain AVPlayer seek on the shared
+// player — the same operation Apollo's fullscreen scrubber performs — so
+// inline state stays consistent. Play/pause state is deliberately untouched
+// (system PiP behaves the same way).
+- (void)seekBySeconds:(NSTimeInterval)offset {
+    AVPlayer *player = self.player;
+    AVPlayerItem *item = player.currentItem;
+    if (!player || !item) return;
+
+    CGFloat target = CMTimeGetSeconds(item.currentTime) + offset;
+    if (target < 0) target = 0;
+    if (CMTIME_IS_NUMERIC(item.duration)) {
+        CGFloat duration = CMTimeGetSeconds(item.duration);
+        // Land forward skips just SHORT of the end, never exactly on it: a
+        // seek-to-end on a PAUSED player posts no end notification, so with
+        // Loop ON neither Apollo's loop nor anything else would ever move the
+        // playhead again and play() would no-op — a dead play button. From
+        // duration-0.1 a subsequent play() reaches the end normally and both
+        // loop paths behave (loop on replays via didPlayToEnd, loop off parks
+        // via the suppression hook + the play button's replay handling).
+        if (duration > 0 && target > duration - 0.1) target = MAX(0, duration - 0.1);
+    }
+    // Zero tolerance: skips land exactly where the label promises (the
+    // periodic time observer also fires on the jump, updating the bar).
+    [player seekToTime:CMTimeMakeWithSeconds(target, 600)
+       toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+    [self restartControlsTimer];
+}
+
+- (void)playPauseTapped {
+    AVPlayer *player = self.player;
+    if (!player) return;
+    if (player.rate != 0) {
+        [player pause];
+    } else {
+        // With looping off, a finished video is parked at the end; tapping play
+        // should replay it from the start rather than no-op at the last frame.
+        // Gated on Loop being off so a video the user merely paused near the
+        // end (loop on) resumes from the pause point instead of rewinding.
+        // Exception: parked at the EXACT end (a paused seek-to-end — system
+        // PiP's own skip controls can do this), play() is a dead no-op with
+        // either loop setting, so always rewind from there.
+        if ((!sPiPLoop && PiPPlayerStoppedAtEnd(player)) || PiPPlayerParkedAtExactEnd(player)) {
+            [player seekToTime:kCMTimeZero toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+        }
+        [player play];
+    }
+    [self restartControlsTimer];
+}
+
+- (void)muteTapped {
+    AVPlayer *player = self.player;
+    if (!player) return;
+    if (player.muted) {
+        // Unmute: session must be Playback + active first — Apollo's default
+        // Ambient silences AVPlayer audio even with muted == NO (mirrors the
+        // native unmute sub_100341894).
+        AVAudioSession *session = [AVAudioSession sharedInstance];
+        [session setCategory:AVAudioSessionCategoryPlayback
+                        mode:AVAudioSessionModeDefault options:0 error:nil];
+        [session setActive:YES withOptions:0 error:nil];
+        [player setMuted:NO];
+        self.sessionClaimedAudibly = YES;
+        if (self.richMediaNode) ApolloVideoUnmute_SyncMuteButtonIcon(self.richMediaNode, NO);
+    } else {
+        BOOL wasPlaying = player.rate != 0;
+        ApolloVideoUnmute_ClearProtectionIfPlayer(player);
+        [player setMuted:YES];
+        if (self.richMediaNode) ApolloVideoUnmute_SyncMuteButtonIcon(self.richMediaNode, YES);
+        // Deliberately do NOT touch the audio session here. Deactivating it —
+        // even after a synchronous pause — raises an ASYNC media-services
+        // interruption that would re-pause the player a beat later. The session
+        // is handed back when the PiP closes (after a real pause);
+        // sessionClaimedAudibly stays set for that.
+        if (wasPlaying) {
+            // Safety net: if anything (interruption, dance stragglers) paused
+            // the player right after the mute, resume it.
+            NSUInteger generation = self.generation;
+            __weak __typeof(self) weakSelf = self;
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)),
+                           dispatch_get_main_queue(), ^{
+                __typeof(self) strongSelf = weakSelf;
+                if (!strongSelf || !strongSelf.active || strongSelf.generation != generation) return;
+                AVPlayer *current = strongSelf.player;
+                if (current && current.rate == 0) {
+                    ApolloLog(@"[PiP] muteTapped: player got paused ~150ms after mute — resuming");
+                    [current play];
+                }
+            });
+        }
+    }
+    [self restartControlsTimer];
+}
+
+- (void)closeTapped {
+    if (self.restoring) return;
+    if (!self.cardRevealed) {
+        [self teardownKeepPlaying:NO];
+        return;
+    }
+    // Quick shrink-and-fade before teardown — reuse the restoring guards so
+    // gestures/visibility events can't interfere mid-animation.
+    self.restoring = YES;
+    self.card.userInteractionEnabled = NO;
+    [self cancelAnimator];
+    [self hideControlsOverlay];
+    __weak __typeof(self) weakSelf = self;
+    UIViewPropertyAnimator *animator =
+        [[UIViewPropertyAnimator alloc] initWithDuration:0.2
+                                                   curve:UIViewAnimationCurveEaseIn
+                                              animations:^{
+            weakSelf.card.alpha = 0.0;
+            weakSelf.card.transform = CGAffineTransformMakeScale(0.85, 0.85);
+        }];
+    [animator addCompletion:^(UIViewAnimatingPosition finalPosition) {
+        [weakSelf teardownKeepPlaying:NO];
+    }];
+    self.animator = animator;
+    [animator startAnimation];
+}
+
+// =============================================================================
+// MARK: Player observation
+// =============================================================================
+
+- (void)installPlayerObservers {
+    [self removePlayerObservers];
+    AVPlayer *player = self.player;
+    if (!player) return;
+    [player addObserver:self forKeyPath:@"rate"
+                options:NSKeyValueObservingOptionNew context:kPiPRateContext];
+    [player addObserver:self forKeyPath:@"muted"
+                options:NSKeyValueObservingOptionNew context:kPiPMutedContext];
+    // Stall/resume transitions (rebuffering keeps rate at 1.0 while media time
+    // freezes) — re-sync the progress animation so it never animates a stall.
+    [player addObserver:self forKeyPath:@"timeControlStatus"
+                options:NSKeyValueObservingOptionNew context:kPiPTimeControlContext];
+    [self.playerView.playerLayer addObserver:self forKeyPath:@"readyForDisplay"
+                                     options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionInitial
+                                     context:kPiPReadyContext];
+
+    // Progress-bar ticks (4 Hz, also fired on seeks/time jumps). Installed
+    // unconditionally while PiP is active so toggling the setting mid-session
+    // just works; the block is a near-free early-out when not needed.
+    __weak __typeof(self) weakSelf = self;
+    self.timeObserverToken = [player addPeriodicTimeObserverForInterval:CMTimeMake(1, 4)
+                                                                  queue:dispatch_get_main_queue()
+                                                             usingBlock:^(CMTime time) {
+        __typeof(self) strongSelf = weakSelf;
+        if (!strongSelf || !strongSelf.active) return;
+        if (!sPiPProgressBar || strongSelf.controlsOverlay.hidden) return;
+        [strongSelf updateProgressBar];
+    }];
+
+    self.observedPlayer = player;
+    self.observingPlayer = YES;
+}
+
+- (void)removePlayerObservers {
+    if (!self.observingPlayer) return;
+    if (self.timeObserverToken) {
+        @try {
+            [self.observedPlayer removeTimeObserver:self.timeObserverToken];
+        } @catch (NSException *exception) {
+            ApolloLog(@"[PiP] removeTimeObserver exception: %@", exception);
+        }
+        self.timeObserverToken = nil;
+    }
+    @try {
+        [self.observedPlayer removeObserver:self forKeyPath:@"rate" context:kPiPRateContext];
+        [self.observedPlayer removeObserver:self forKeyPath:@"muted" context:kPiPMutedContext];
+        [self.observedPlayer removeObserver:self forKeyPath:@"timeControlStatus" context:kPiPTimeControlContext];
+        [self.playerView.playerLayer removeObserver:self forKeyPath:@"readyForDisplay" context:kPiPReadyContext];
+    } @catch (NSException *exception) {
+        ApolloLog(@"[PiP] removeObserver exception: %@", exception);
+    }
+    self.observedPlayer = nil;
+    self.observingPlayer = NO;
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object
+                        change:(NSDictionary *)change context:(void *)context {
+    if (context == kPiPRateContext || context == kPiPMutedContext) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (self.active && !self.controlsOverlay.hidden) [self syncControlIcons];
+        });
+        return;
+    }
+    if (context == kPiPTimeControlContext) {
+        // Stall began or playback resumed: freeze the bar at ground truth /
+        // restart the linear animation. Only matters while the bar is showing.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (self.active && sPiPProgressBar && !self.controlsOverlay.hidden) {
+                [self updateProgressBar];
+            }
+        });
+        return;
+    }
+    if (context == kPiPReadyContext) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (self.active && self.playerView.playerLayer.readyForDisplay) {
+                [self revealCard];
+            }
+        });
+        return;
+    }
+    [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+}
+
+// =============================================================================
+// MARK: Native (system) PiP — optional handoff on app exit
+// =============================================================================
+
+- (void)setupNativePiP {
+    if (@available(iOS 15.0, *)) {
+        if (self.nativePiP) return;
+        if (![AVPictureInPictureController isPictureInPictureSupported]) {
+            ApolloLog(@"[PiP] Native PiP not supported on this device");
+            return;
+        }
+
+        // PiP requires a Playback audio session active BEFORE controller init.
+        // For muted videos use mixWithOthers so we don't interrupt the user's
+        // music just to enable the handoff.
+        AVAudioSession *session = [AVAudioSession sharedInstance];
+        AVAudioSessionCategoryOptions options = self.player.muted
+            ? AVAudioSessionCategoryOptionMixWithOthers : 0;
+        [session setCategory:AVAudioSessionCategoryPlayback
+                        mode:AVAudioSessionModeDefault options:options error:nil];
+        [session setActive:YES withOptions:0 error:nil];
+
+        AVPictureInPictureControllerContentSource *source =
+            [[AVPictureInPictureControllerContentSource alloc] initWithPlayerLayer:self.playerView.playerLayer];
+        AVPictureInPictureController *controller =
+            [[AVPictureInPictureController alloc] initWithContentSource:source];
+        controller.delegate = (id<AVPictureInPictureControllerDelegate>)self;
+        controller.canStartPictureInPictureAutomaticallyFromInline = YES;
+        self.nativePiP = controller;
+        ApolloLog(@"[PiP] Native PiP controller armed (auto-start on background)");
+    }
+}
+
+- (void)destroyNativePiP {
+    if (@available(iOS 15.0, *)) {
+        AVPictureInPictureController *controller = self.nativePiP;
+        if (!controller) return;
+        if (controller.pictureInPictureActive) {
+            [controller stopPictureInPicture];
+        }
+        controller.delegate = nil;
+        self.nativePiP = nil;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Inline-playback native PiP: armed on Apollo's OWN inline AVPlayerLayer while
+// an eligible comments video plays on screen (no floating card involved), so
+// swiping to the home screen mid-watch hands the inline video to system PiP.
+//
+// Scope: a back-pop DISARMS (the comments cell's Invisible event fires while
+// the app is still active), so the controller never carries into the feed on
+// its own. Feed videos arm only through the mute-button unmute path
+// (ApolloPiP_NoteInlineVideoAudible) — deliberate engagement with one video.
+// Untouched muted feed autoplay can therefore never reach system PiP.
+// ---------------------------------------------------------------------------
+
+- (BOOL)isInlineNativePiPActive {
+    if (@available(iOS 15.0, *)) {
+        return self.inlineNativePiP != nil && self.inlineNativePiP.pictureInPictureActive;
+    }
+    return NO;
+}
+
+- (void)armInlineNativePiPForVideoNode:(id)videoNode player:(AVPlayer *)player {
+    if (@available(iOS 15.0, *)) {
+        if (self.active) return; // the floating card's controller owns native PiP
+        if (self.inlineNativePiP) {
+            if (self.inlineNativePlayer == player) {
+                // Already armed on this player — but rebind the bookkeeping node
+                // if it changed. On a back-pop the shared layer is reclaimed from
+                // the comments cell into the FEED cell (same AVPlayer, different
+                // videoNode); refreshing the node keeps disarm decisions keyed on
+                // the current cell, so the comments cell's later Invisible event
+                // (which compares against inlineNativeVideoNode) no longer
+                // disarms it out from under the feed.
+                self.inlineNativeVideoNode = videoNode;
+                return;
+            }
+            if (self.inlineNativePiP.pictureInPictureActive) return; // never retarget mid-PiP
+            [self disarmInlineNativePiPIfIdle];
+        }
+        if (![AVPictureInPictureController isPictureInPictureSupported]) return;
+
+        SEL playerLayerSel = NSSelectorFromString(@"playerLayer");
+        if (![videoNode respondsToSelector:playerLayerSel]) return;
+        id layer = ((id (*)(id, SEL))objc_msgSend)(videoNode, playerLayerSel);
+        if (![layer isKindOfClass:[AVPlayerLayer class]]) return;
+
+        // System PiP needs a Playback session active before controller init.
+        // Best effort for muted videos (mixWithOthers spares the user's music);
+        // unmuted ones already hold a Playback session via the unmute paths.
+        AVAudioSession *session = [AVAudioSession sharedInstance];
+        if (![session.category isEqualToString:AVAudioSessionCategoryPlayback]) {
+            AVAudioSessionCategoryOptions options = player.muted
+                ? AVAudioSessionCategoryOptionMixWithOthers : 0;
+            [session setCategory:AVAudioSessionCategoryPlayback
+                            mode:AVAudioSessionModeDefault options:options error:nil];
+            [session setActive:YES withOptions:0 error:nil];
+        }
+
+        AVPictureInPictureControllerContentSource *source =
+            [[AVPictureInPictureControllerContentSource alloc] initWithPlayerLayer:(AVPlayerLayer *)layer];
+        AVPictureInPictureController *controller =
+            [[AVPictureInPictureController alloc] initWithContentSource:source];
+        controller.delegate = (id<AVPictureInPictureControllerDelegate>)self;
+        controller.canStartPictureInPictureAutomaticallyFromInline = YES;
+        self.inlineNativePiP = controller;
+        self.inlineNativePlayer = player;
+        self.inlineNativeVideoNode = videoNode;
+        ApolloLog(@"[PiP] Inline native PiP armed on player %p", player);
+    }
+}
+
+// Off-event retry for the fresh-navigation case: poll a few times until the
+// player exists and is playing, then arm. Mirrors the unmute feature's 500ms
+// player-not-ready retry (same underlying Apollo timing).
+- (void)retryInlineArmForCell:(id)cellNode videoNode:(id)videoNode attempts:(NSUInteger)attempts {
+    __weak id weakCell = cellNode;
+    __weak id weakVideo = videoNode;
+    __weak __typeof(self) weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        __typeof(self) strongSelf = weakSelf;
+        id cell = weakCell;
+        id video = weakVideo;
+        if (!strongSelf || !cell || !video) return;
+
+        void (^finish)(void) = ^{
+            objc_setAssociatedObject(cell, kPiPArmRetryPendingKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        };
+
+        if (!sPiPNativeEnabled || strongSelf.active) {
+            finish();
+            return;
+        }
+        AVPlayer *player = ApolloVideoUnmute_GetPlayerFromVideoNode(video);
+        if (player && player.rate != 0) {
+            if (!(sPiPActivationMode == ApolloPiPActivationModeUnmutedOnly && player.muted)
+                && PiPIsEligibleVideo(video, player)
+                && PiPIsVideoMidpointVisible(video, cell)) {
+                ApolloLog(@"[PiP] Inline arm retry: player ready — arming");
+                [strongSelf armInlineNativePiPForVideoNode:video player:player];
+            }
+            finish();
+            return;
+        }
+        if (attempts > 1) {
+            [strongSelf retryInlineArmForCell:cell videoNode:video attempts:attempts - 1];
+        } else {
+            ApolloLog(@"[PiP] Inline arm retry: player never became ready — giving up");
+            finish();
+        }
+    });
+}
+
+- (void)disarmInlineNativePiPIfIdle {
+    if (@available(iOS 15.0, *)) {
+        AVPictureInPictureController *controller = self.inlineNativePiP;
+        if (!controller) return;
+        if (controller.pictureInPictureActive) return; // system PiP running — leave it
+        controller.delegate = nil;
+        self.inlineNativePiP = nil;
+        self.inlineNativePlayer = nil;
+        self.inlineNativeVideoNode = nil;
+        ApolloLog(@"[PiP] Inline native PiP disarmed");
+    }
+}
+
+- (void)pictureInPictureControllerWillStartPictureInPicture:(AVPictureInPictureController *)controller {
+    ApolloLog(@"[PiP] Native PiP starting — hiding in-app card");
+    self.card.hidden = YES;
+}
+
+- (void)pictureInPictureControllerDidStopPictureInPicture:(AVPictureInPictureController *)controller {
+    ApolloLog(@"[PiP] Native PiP stopped");
+    if (self.active && self.cardRevealed) self.card.hidden = NO;
+    // Inline system PiP dismissed with the clip parked at its end (Loop off,
+    // e.g. X-closed from the home screen — handleDidBecomeActive's rewind
+    // only covers PiP still active at app activation): rewind so Apollo's
+    // next inline play() isn't a dead no-op. No play() here — the app may
+    // still be backgrounded.
+    if (controller == self.inlineNativePiP) {
+        PiPRewindIfStoppedAtEnd(self.inlineNativePlayer);
+    }
+}
+
+- (void)pictureInPictureController:(AVPictureInPictureController *)controller
+restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:(void (^)(BOOL))completionHandler {
+    ApolloLog(@"[PiP] Native PiP restore requested — showing in-app card");
+    if (self.active && self.cardRevealed) self.card.hidden = NO;
+    completionHandler(YES);
+}
+
+- (void)pictureInPictureController:(AVPictureInPictureController *)controller
+    failedToStartPictureInPictureWithError:(NSError *)error {
+    ApolloLog(@"[PiP] Native PiP failed to start: %@", error);
+}
+
+// =============================================================================
+// MARK: App lifecycle
+// =============================================================================
+
+- (void)handleDidEnterBackground {
+    // Inline-only System PiP (no card): nothing pauses the inline player here —
+    // we rely on iOS auto-starting system PiP. If it doesn't (the user's "Start
+    // PiP Automatically" is off, low power, iOS declines, etc.) the inline
+    // player would keep playing audible video in the background with no PiP
+    // window and no UI to stop it (the shield suppresses the mute dance). Check
+    // shortly after backgrounding and pause if PiP never actually started.
+    if (@available(iOS 15.0, *)) {
+        if (!self.active && self.inlineNativePiP && self.inlineNativePlayer
+            && self.inlineNativePlayer.rate != 0) {
+            __weak __typeof(self) weakSelf = self;
+            __weak AVPlayer *weakInline = self.inlineNativePlayer;
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.7 * NSEC_PER_SEC)),
+                           dispatch_get_main_queue(), ^{
+                __typeof(self) strongSelf = weakSelf;
+                AVPlayer *inlinePlayer = weakInline;
+                if (!strongSelf || !inlinePlayer) return;
+                if (strongSelf.inlineNativePiP.pictureInPictureActive) return; // PiP took over — fine
+                if (inlinePlayer.rate == 0) return;
+                ApolloLog(@"[PiP] Inline System PiP never started on background — pausing to avoid background audio");
+                strongSelf.backgroundPausedInlinePlayer = inlinePlayer;
+                [inlinePlayer pause];
+                // The handoff has definitively failed: drop the shield and —
+                // for an audible video — hand the Playback session back so
+                // audio we interrupted (the user's music) gets its resume cue
+                // now rather than whenever Apollo is next opened. Mirrors the
+                // card-close handback in teardownKeepPlaying:. Foreground
+                // resume re-claims the session (handleWillEnterForeground);
+                // the controller re-arms on the next visibility tick/unmute.
+                [strongSelf disarmInlineNativePiPIfIdle];
+                if (!inlinePlayer.muted) {
+                    ApolloVideoUnmute_ClearProtectionIfPlayer(inlinePlayer);
+                    AVAudioSession *session = [AVAudioSession sharedInstance];
+                    [session setCategory:AVAudioSessionCategoryAmbient error:nil];
+                    [session setActive:NO
+                           withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
+                                 error:nil];
+                }
+            });
+        }
+    }
+
+    if (!self.active) return;
+    BOOL nativeMayTakeOver = NO;
+    if (@available(iOS 15.0, *)) {
+        nativeMayTakeOver = sPiPNativeEnabled && self.nativePiP != nil;
+    }
+    if (nativeMayTakeOver) {
+        // Native PiP may be auto-starting right now — never pause here
+        // (WWDC19 503 guidance).
+        return;
+    }
+    if (self.player.rate != 0) {
+        ApolloLog(@"[PiP] App backgrounded without native PiP — pausing");
+        self.resumeOnForeground = YES;
+        [self.player pause];
+    }
+}
+
+- (void)handleWillEnterForeground {
+    if (self.active && self.resumeOnForeground) {
+        ApolloLog(@"[PiP] App foregrounded — resuming");
+        self.resumeOnForeground = NO;
+        [self.player play];
+    }
+    // Resume an inline player we paused because System PiP didn't start. The
+    // failed-handoff cleanup handed the audio session back (Ambient, which
+    // silences AVPlayer audio even unmuted) — re-claim Playback first so an
+    // audible video comes back audible.
+    AVPlayer *pausedInline = self.backgroundPausedInlinePlayer;
+    if (pausedInline) {
+        self.backgroundPausedInlinePlayer = nil;
+        if (pausedInline.rate == 0) {
+            if (!pausedInline.muted) {
+                AVAudioSession *session = [AVAudioSession sharedInstance];
+                [session setCategory:AVAudioSessionCategoryPlayback
+                                mode:AVAudioSessionModeDefault options:0 error:nil];
+                [session setActive:YES withOptions:0 error:nil];
+            }
+            [pausedInline play];
+        }
+    }
+}
+
+// Returning to Apollo via the app icon or switcher (not the PiP restore
+// button) leaves system PiP floating over the app — collapse it back into
+// the app instead, the way native players do. The stop runs the normal
+// restore/didStop delegate flow: the floating card un-hides, or the inline
+// layer simply resumes rendering. (When the user DID use the restore button,
+// PiP is already stopping by the time this fires and the extra stop is a
+// no-op.)
+- (void)handleDidBecomeActive {
+    if (@available(iOS 15.0, *)) {
+        if (self.nativePiP.pictureInPictureActive) {
+            ApolloLog(@"[PiP] App active with card system PiP still running — dismissing into app");
+            [self.nativePiP stopPictureInPicture];
+        }
+        if (self.inlineNativePiP.pictureInPictureActive) {
+            ApolloLog(@"[PiP] App active with inline system PiP still running — dismissing into app");
+            [self.inlineNativePiP stopPictureInPicture];
+            // If the clip ended during system PiP (Loop off), the inline player
+            // is parked at its last frame; rewind and resume so inline looping
+            // continues instead of freezing. (Player rate/time are independent
+            // of the PiP stop animation, so this is safe to check now.)
+            AVPlayer *inlinePlayer = self.inlineNativePlayer;
+            if (PiPPlayerStoppedAtEnd(inlinePlayer)) {
+                [inlinePlayer seekToTime:kCMTimeZero toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+                [inlinePlayer play];
+            }
+        }
+    }
+}
+
+@end
+
+// =============================================================================
+// MARK: - Exported C API (consumed by ApolloVideoUnmute.xm and hooks below)
+// =============================================================================
+
+BOOL ApolloPiP_HandleCommentsVisibilityEvent(id cellNode, id richMediaNode,
+                                             unsigned long long event) {
+    ApolloPiPController *controller = sPiPSharedController;
+    // Don't spin up the singleton until at least one capability is enabled
+    // (or one is already active).
+    if (!controller && !sPiPEnabled && !sPiPNativeEnabled) return NO;
+    return [[ApolloPiPController sharedController] handleVisibilityEventForCell:cellNode
+                                                                  richMediaNode:richMediaNode
+                                                                          event:event];
+}
+
+BOOL ApolloPiP_IsOwnedPlayer(AVPlayer *player) {
+    ApolloPiPController *controller = sPiPSharedController;
+    return controller && controller.active && player && controller.player == player;
+}
+
+// Loop kill-switch. The inline video's auto-repeat is driven solely by
+// -[ASVideoNode didPlayToEnd:] (a per-item observer on the feed node that
+// seeks to zero and replays). Returns YES when that handler should be
+// suppressed for this item: when "Loop Videos" is off AND the item is the one
+// a PiP mode is actively presenting (the floating card, or system PiP). The
+// player then pauses at the end on its own (actionAtItemEnd defaults to Pause)
+// and nothing restarts it. Only applies while ACTIVELY presenting — a video
+// merely playing inline (even with System PiP armed) keeps looping normally.
+BOOL ApolloPiP_ShouldSuppressLoopForItem(AVPlayerItem *item) {
+    if (sPiPLoop || !item) return NO;
+    ApolloPiPController *controller = sPiPSharedController;
+    if (!controller) return NO;
+    // In-app card presenting this player (covers the card and its system PiP).
+    if (controller.active && controller.player && controller.player.currentItem == item) {
+        return YES;
+    }
+    // Inline-armed system PiP actively showing this player.
+    if (@available(iOS 15.0, *)) {
+        if (controller.inlineNativePiP.pictureInPictureActive
+            && controller.inlineNativePlayer
+            && controller.inlineNativePlayer.currentItem == item) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+// Shield for the INLINE-armed native-PiP player. When the app backgrounds (or
+// system PiP is already running), the window/hierarchy churn (privacy padlock
+// etc.) can fire TouchHintVideoNode.didExitVisibleState and run the mute dance
+// — pausing, muting, and downgrading the session out from under the system PiP
+// handoff ("video continues, audio gone"). Engaged ONLY while the app is
+// non-active or system PiP is active, so normal in-app behavior is untouched.
+static BOOL PiPInlineShieldEngaged(AVPlayer *player) {
+    ApolloPiPController *controller = sPiPSharedController;
+    if (!controller || !player) return NO;
+    if (!controller.inlineNativePiP || controller.inlineNativePlayer != player) return NO;
+    if (controller.inlineNativePiP.pictureInPictureActive) return YES;
+    return [UIApplication sharedApplication].applicationState != UIApplicationStateActive;
+}
+
+BOOL ApolloPiP_ShouldBlockAudioSessionDowngrade(void) {
+    ApolloPiPController *controller = sPiPSharedController;
+    if (!controller) return NO;
+    if (controller.active && controller.player && !controller.player.muted) return YES;
+    AVPlayer *inlinePlayer = controller.inlineNativePlayer;
+    return inlinePlayer && !inlinePlayer.muted && PiPInlineShieldEngaged(inlinePlayer);
+}
+
+// Consulted by ApolloVideoUnmute.xm's AVPlayer.setMuted: hook — blocks the
+// mute dance's T+100ms setMuted:YES on the inline-armed player during the
+// background handoff window.
+BOOL ApolloPiP_ShouldBlockMuteOfPlayer(AVPlayer *player) {
+    return PiPInlineShieldEngaged(player);
+}
+
+// A video just became audible inline (mute-button tap or auto-unmute) — no
+// scroll event fires for that, so arm the inline native-PiP controller here
+// (matters in "Unmuted Videos Only" mode, where the muted autoplay never
+// armed it).
+void ApolloPiP_NoteInlineVideoAudible(id videoNode, AVPlayer *player) {
+    // Inline-arming only needs System PiP — the mini-player toggle is irrelevant.
+    if (!sPiPNativeEnabled || !videoNode || !player) return;
+    ApolloPiPController *controller = [ApolloPiPController sharedController];
+    if (controller.active) return;
+    if (player.rate == 0) return;
+    if (!PiPIsEligibleVideo(videoNode, player)) return;
+    if (!PiPIsVideoMidpointVisible(videoNode, nil)) return;
+    [controller armInlineNativePiPForVideoNode:videoNode player:player];
+}
+
+// A player just got muted and the mute took effect (manual mute button, or the
+// mute dance as a video scrolled off — both reach AVPlayer.setMuted:YES, which
+// the ApolloVideoUnmute hook blocks only during the background handoff). Drop
+// the inline system-PiP arm so a home-swipe can't hand off a muted video: for
+// the feed this enforces requirement #4 (only deliberately-unmuted videos), and
+// for comments it matches "Unmuted Videos Only". No-op while a card presents
+// (it owns the player) or while system PiP is already running.
+void ApolloPiP_NoteInlinePlayerMuted(AVPlayer *player) {
+    ApolloPiPController *controller = sPiPSharedController;
+    if (!controller || !player) return;
+    if (controller.active) return;
+    if (controller.inlineNativePlayer != player) return;
+    ApolloLog(@"[PiP] Inline-armed player muted — disarming system PiP");
+    [controller disarmInlineNativePiPIfIdle];
+}
+
+// Audio arbitration: a DIFFERENT video is about to play audibly (the user
+// unmuted a feed/comments video, or auto-unmute fired on entering another
+// post). The user has moved on to other content, so dismiss the PiP entirely
+// rather than leaving a now-muted card floating.
+//
+// Deliberately does NOT gate on owned.muted: when the new video is unmuted via
+// Apollo's native handler, VideoSharingManager.setActiveAudioPlayer
+// (sub_1005e6124) has ALREADY muted the previous active audio player — our
+// PiP's player — by the time we run (we're called after %orig). Bailing on
+// owned.muted there would leave the card floating muted, the exact symptom
+// being fixed. Same content (the PiP's own video / its shared inline
+// counterpart) is the same AVPlayer object and never matches.
+void ApolloPiP_YieldAudioToPlayer(AVPlayer *newAudiblePlayer) {
+    ApolloPiPController *controller = sPiPSharedController;
+    if (!controller || !controller.active || controller.restoring) return;
+    AVPlayer *owned = controller.player;
+    if (!owned || owned == newAudiblePlayer) return;
+
+    ApolloLog(@"[PiP] Different video unmuted — dismissing PiP");
+    // Clear sessionClaimedAudibly FIRST so the teardown does NOT downgrade the
+    // audio session to Ambient: the newly-audible video owns the Playback
+    // session now, and a downgrade would silence it.
+    //
+    // Tear down SYNCHRONOUSLY (not the animated closeTapped) so controller.active
+    // flips to NO right now. The unmute path arms the NEW video for System PiP
+    // on the very next line (ApolloPiP_NoteInlineVideoAudible), and that arm —
+    // like armInlineNativePiPForVideoNode — early-returns while a card is still
+    // active. An animated/deferred teardown keeps .active YES through its 0.2s
+    // fade and blocks the arm, so a home-swipe right after unmuting would not
+    // enter system PiP. teardownKeepPlaying:NO also pauses + mutes our player,
+    // clears its protection, and syncs the mute-button icon.
+    controller.sessionClaimedAudibly = NO;
+    [controller teardownKeepPlaying:NO];
+}
+
+static BOOL PiPShouldSuppressVideoNodeExit(id videoNode) {
+    ApolloPiPController *controller = sPiPSharedController;
+    if (!controller || !videoNode) return NO;
+    AVPlayer *player = ApolloVideoUnmute_GetPlayerFromVideoNode(videoNode);
+    if (controller.active) {
+        if (videoNode == controller.videoNode) return YES;
+        if (player && player == controller.player) return YES;
+    }
+    // Backgrounding/system-PiP handoff: don't let hierarchy churn fire the
+    // mute dance for the inline-armed player.
+    return player && PiPInlineShieldEngaged(player);
+}
+
+// System PiP on the feed (no card presenting): keep the inline system-PiP
+// controller armed on an eligible UNMUTED, playing, on-screen feed video — one
+// reclaimed after a comments back-pop, or unmuted directly in the feed — so a
+// home-swipe hands it off. UNMUTED-ONLY by design: a feed can show many videos
+// autoplaying muted, and only the one the user deliberately unmuted should
+// trigger system PiP (so this gate is unmuted regardless of Activate For).
+// Disarms the armed video once it's no longer eligible (muted/paused/off-screen).
+static void PiPManageInlineNativeForFeedCell(id cellNode) {
+    if (!sPiPNativeEnabled) return;
+    ApolloPiPController *controller = sPiPSharedController;
+    if (!controller || controller.active) return; // a card owns native PiP
+
+    id richMediaNode = PiPRichMediaNodeFromCell(cellNode);
+    id videoNode = PiPVideoNodeFromRichMedia(richMediaNode);
+    if (!videoNode) return;
+
+    AVPlayer *player = ApolloVideoUnmute_GetPlayerFromVideoNode(videoNode);
+    BOOL eligible = player && player.rate != 0 && !player.muted
+                 && PiPIsEligibleVideo(videoNode, player)
+                 && PiPIsVideoMidpointVisible(videoNode, cellNode);
+    if (eligible) {
+        [controller armInlineNativePiPForVideoNode:videoNode player:player];
+    } else if (videoNode == controller.inlineNativeVideoNode) {
+        [controller disarmInlineNativePiPIfIdle];
+    }
+}
+
+static BOOL PiPHandleFeedVisibilityEvent(id cellNode) {
+    ApolloPiPController *controller = sPiPSharedController;
+    if (!controller) return NO;
+    if (!controller.active) {
+        // No card — manage inline system PiP for an eligible unmuted feed video.
+        PiPManageInlineNativeForFeedCell(cellNode);
+        return NO;
+    }
+
+    id richMediaNode = PiPRichMediaNodeFromCell(cellNode);
+    id videoNode = PiPVideoNodeFromRichMedia(richMediaNode);
+    if (!videoNode) return NO;
+
+    AVPlayer *player = ApolloVideoUnmute_GetPlayerFromVideoNode(videoNode);
+    if (!player || player != controller.player) return NO;
+
+    if (PiPIsVideoMidpointVisible(videoNode, cellNode)) {
+        // The video's feed cell is on screen — never double-display; hand back.
+        [controller restoreInline];
+        return NO; // %orig's [player play] is harmless
+    }
+    return YES; // suppress the feed handler's pause of our player
+}
+
+// After a back-pop the feed doesn't scroll, so no visibility events fire even
+// though the reclaimed video's cell may be fully visible. Walk visible cells
+// once on feed appear: hand a still-presenting card back, or (no card) re-arm
+// inline system PiP for the reclaimed unmuted video — the comments cell's
+// invisible event disarms it during the pop, and without this a home-swipe
+// from the feed would not enter system PiP.
+static void PiPHandleFeedViewControllerAppeared(UIViewController *feedVC) {
+    ApolloPiPController *controller = sPiPSharedController;
+    if (!controller || !feedVC) return;
+
+    // A non-shareable (compact-mode) card's video is never reclaimed into a feed
+    // cell — the compact feed shows a thumbnail, not the shared player — so on
+    // return to the feed there is no inline home to restore into and the card
+    // would otherwise float forever. Dismiss it. Shareable (large-thumbnail)
+    // cards fall through to the restore walk below, untouched.
+    if (controller.active && controller.ownedNonShareable) {
+        ApolloLog(@"[PiP] Returned to feed with a non-shareable (compact) card — dismissing");
+        [controller closeTapped];
+        return;
+    }
+
+    if (!controller.active && !sPiPNativeEnabled) return; // nothing to manage
+
+    UIView *rootView = feedVC.view;
+    UITableView *tableView = nil;
+    for (UIView *subview in rootView.subviews) {
+        if ([subview isKindOfClass:[UITableView class]]) {
+            tableView = (UITableView *)subview;
+            break;
+        }
+    }
+    if (!tableView) return;
+
+    for (UITableViewCell *cell in tableView.visibleCells) {
+        SEL nodeSel = NSSelectorFromString(@"node");
+        if (![cell respondsToSelector:nodeSel]) continue;
+        id cellNode = ((id (*)(id, SEL))objc_msgSend)(cell, nodeSel);
+
+        if (!controller.active) {
+            PiPManageInlineNativeForFeedCell(cellNode);
+            continue;
+        }
+
+        id richMediaNode = PiPRichMediaNodeFromCell(cellNode);
+        id videoNode = PiPVideoNodeFromRichMedia(richMediaNode);
+        if (!videoNode) continue;
+
+        AVPlayer *player = ApolloVideoUnmute_GetPlayerFromVideoNode(videoNode);
+        if (player && player == controller.player
+            && PiPIsVideoMidpointVisible(videoNode, cellNode)) {
+            ApolloLog(@"[PiP] Feed appeared with our video visible — restoring inline");
+            [controller restoreInline];
+            return;
+        }
+    }
+}
+
+// =============================================================================
+// MARK: - Hooks
+// =============================================================================
+
+// ---------------------------------------------------------------------------
+// TouchHintVideoNode.didExitVisibleState fires when a video node fully leaves
+// the screen and is THE trigger for Apollo's mute dance (sub_10058cb30 →
+// sub_1003414cc: pause-all broadcast, Ambient downgrade, setMuted:YES).
+// While PiP owns this node's player, skip it entirely — the fork's super
+// implementation is an empty stub, so nothing else is lost. This also covers
+// the FEED cell hosting the same shared player scrolling away.
+// ---------------------------------------------------------------------------
+%hook TouchHintVideoNode
+
+- (void)didExitVisibleState {
+    if (PiPShouldSuppressVideoNodeExit(self)) {
+        ApolloLog(@"[PiP] Suppressing didExitVisibleState (mute dance) for owned video");
+        return;
+    }
+    %orig;
+}
+
+%end
+
+// ---------------------------------------------------------------------------
+// ASVideoNode.didPlayToEnd: — the sole loop driver for inline v.redd.it video.
+// It seeks to zero and replays when _shouldAutorepeat is set, ignoring the
+// notification's item. Skip it for the item a PiP mode is actively presenting
+// while "Loop Videos" is off; the player then pauses at the end on its own.
+// (Hooks the base ASVideoNode class — TouchHintVideoNode doesn't override it.)
+// ---------------------------------------------------------------------------
+%hook ASVideoNode
+
+- (void)didPlayToEnd:(NSNotification *)notification {
+    id object = [notification object];
+    if ([object isKindOfClass:[AVPlayerItem class]]
+        && ApolloPiP_ShouldSuppressLoopForItem((AVPlayerItem *)object)) {
+        ApolloLog(@"[PiP] Suppressing loop (didPlayToEnd) — video parked at end");
+        return;
+    }
+    %orig;
+}
+
+%end
+
+// ---------------------------------------------------------------------------
+// RichMediaNode hooks:
+//
+// pauseAllAVPlayers...: posted at T+0 of ANY video's mute dance and pauses
+// every registered player unconditionally (sub_1005823dc). Skip for the
+// PiP-owned player so other videos' dances can't pause it.
+//
+// didExitPreloadState: destroys player/asset for NON-shareable videos
+// (sub_10057aff4 → resetToPlaceholder + setPlayer:nil). Compact-mode comments
+// players are non-shareable; skip the teardown while PiP owns one. (Skipping
+// also leaves videoNodeStatus flags intact, which matches reality: the asset
+// and player still exist.)
+// ---------------------------------------------------------------------------
+%hook RichMediaNode
+
+- (void)pauseAllAVPlayersNotificationReceivedWithNotification:(id)notification {
+    id videoNode = PiPGetIvar(self, "videoNode");
+    if (videoNode) {
+        AVPlayer *player = ApolloVideoUnmute_GetPlayerFromVideoNode(videoNode);
+        if (player && (ApolloPiP_IsOwnedPlayer(player) || PiPInlineShieldEngaged(player))) {
+            ApolloLog(@"[PiP] Suppressing pauseAllAVPlayers for owned/shielded video");
+            return;
+        }
+    }
+    %orig;
+}
+
+- (void)didExitPreloadState {
+    id videoNode = PiPGetIvar(self, "videoNode");
+    if (videoNode && !PiPNodeIsShareable(videoNode)) {
+        AVPlayer *player = ApolloVideoUnmute_GetPlayerFromVideoNode(videoNode);
+        if (player && ApolloPiP_IsOwnedPlayer(player)) {
+            ApolloLog(@"[PiP] Suppressing didExitPreloadState teardown for owned non-shareable video");
+            return;
+        }
+    }
+    %orig;
+}
+
+%end
+
+// ---------------------------------------------------------------------------
+// LargePostCellNode: the feed analog of the comments visibility handler (same
+// midpoint test, directly play/pauses shareable players every ≥5pt scroll).
+// While PiP owns a player that lands back on a feed cell (after back-pop
+// reclaim), restore when visible and suppress the pause while hidden.
+// Feed-initiated takeover is intentionally out of scope.
+// ---------------------------------------------------------------------------
+%hook LargePostCellNode
+
+- (void)cellNodeVisibilityEvent:(unsigned long long)event
+                   inScrollView:(id)scrollView
+                  withCellFrame:(CGRect)frame {
+    if (PiPHandleFeedVisibilityEvent(self)) {
+        return;
+    }
+    %orig;
+}
+
+%end
+
+// ---------------------------------------------------------------------------
+// MediaViewerController adopts the shared player layer in viewDidLayoutSubviews
+// (sub_100366fa4) when fullscreen opens. If fullscreen takes the player we own,
+// yield: close the card but keep playback running — fullscreen owns it now.
+// When fullscreen dismisses, native scrolled-away behavior resumes (and a new
+// PiP can engage on the next scroll).
+// ---------------------------------------------------------------------------
+%hook MediaViewerController
+
+- (void)viewDidLayoutSubviews {
+    %orig;
+
+    ApolloPiPController *controller = sPiPSharedController;
+    if (!controller) return;
+    if (!controller.active && !controller.inlineNativePiP) return;
+
+    AVPlayer *fullscreenPlayer = PiPGetIvar(self, "player");
+    if (!fullscreenPlayer) {
+        id container = PiPGetIvar(self, "playerLayerContainerView");
+        id playerLayer = container ? PiPGetIvar(container, "playerLayer") : nil;
+        if ([playerLayer isKindOfClass:[AVPlayerLayer class]]) {
+            fullscreenPlayer = [(AVPlayerLayer *)playerLayer player];
+        }
+    }
+    if (!fullscreenPlayer) return;
+
+    if (controller.active && fullscreenPlayer == controller.player) {
+        ApolloLog(@"[PiP] Fullscreen viewer adopted our player — yielding");
+        [controller teardownKeepPlaying:YES];
+    }
+    // Fullscreen creates its own (dormant) AVPictureInPictureController on the
+    // shared layer — retire our inline one to avoid two controllers on it.
+    if (fullscreenPlayer == controller.inlineNativePlayer) {
+        [controller disarmInlineNativePiPIfIdle];
+    }
+}
+
+%end
+
+// ---------------------------------------------------------------------------
+// Feed view controllers: restore PiP into a visible feed cell right after a
+// back-pop (no scroll events fire on pop, so the visibility hook alone would
+// leave the video double-displayed until the user scrolls).
+// ---------------------------------------------------------------------------
+%hook PostsViewController
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    PiPHandleFeedViewControllerAppeared((UIViewController *)self);
+}
+
+%end
+
+%hook SavedPostsCommentsViewController
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    PiPHandleFeedViewControllerAppeared((UIViewController *)self);
+}
+
+%end
+
+%hook ProfileViewController
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    PiPHandleFeedViewControllerAppeared((UIViewController *)self);
+}
+
+%end
+
+// =============================================================================
+// MARK: - Constructor
+// =============================================================================
+
+%ctor {
+    Class touchHintVideoNodeClass = objc_getClass("_TtC6Apollo18TouchHintVideoNode");
+    Class richMediaNodeClass = objc_getClass("_TtC6Apollo13RichMediaNode");
+    Class largePostCellClass = objc_getClass("_TtC6Apollo17LargePostCellNode");
+    Class mediaViewerClass = objc_getClass("_TtC6Apollo21MediaViewerController");
+    Class postsVCClass = objc_getClass("_TtC6Apollo19PostsViewController");
+    Class savedPostsVCClass = objc_getClass("_TtC6Apollo32SavedPostsCommentsViewController");
+    Class profileVCClass = objc_getClass("_TtC6Apollo21ProfileViewController");
+    Class asVideoNodeClass = objc_getClass("ASVideoNode"); // loop kill-switch
+
+    ApolloLog(@"[PiP] ctor: TouchHintVideoNode=%p RichMediaNode=%p LargePostCellNode=%p MediaViewerController=%p PostsVC=%p SavedPostsVC=%p ProfileVC=%p ASVideoNode=%p",
+              (void *)touchHintVideoNodeClass, (void *)richMediaNodeClass,
+              (void *)largePostCellClass, (void *)mediaViewerClass,
+              (void *)postsVCClass, (void *)savedPostsVCClass, (void *)profileVCClass,
+              (void *)asVideoNodeClass);
+
+    if (!touchHintVideoNodeClass || !richMediaNodeClass || !largePostCellClass
+        || !mediaViewerClass || !postsVCClass || !asVideoNodeClass) {
+        ApolloLog(@"[PiP] ctor: FATAL — required classes not found, PiP disabled");
+        return;
+    }
+
+    %init(
+        TouchHintVideoNode = touchHintVideoNodeClass,
+        RichMediaNode = richMediaNodeClass,
+        LargePostCellNode = largePostCellClass,
+        MediaViewerController = mediaViewerClass,
+        PostsViewController = postsVCClass,
+        SavedPostsCommentsViewController = savedPostsVCClass ?: postsVCClass,
+        ProfileViewController = profileVCClass ?: postsVCClass,
+        ASVideoNode = asVideoNodeClass
+    );
+
+    ApolloLog(@"[PiP] ctor: hooks initialized");
+}

--- a/src/ApolloPictureInPicture.xm
+++ b/src/ApolloPictureInPicture.xm
@@ -2239,6 +2239,7 @@ restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:(void (^)(BOOL)
                 AVPlayer *inlinePlayer = weakInline;
                 if (!strongSelf || !inlinePlayer) return;
                 if (strongSelf.inlineNativePiP.pictureInPictureActive) return; // PiP took over — fine
+                if ([UIApplication sharedApplication].applicationState != UIApplicationStateBackground) return; // user already returned — don't pause a foreground video
                 if (inlinePlayer.rate == 0) return;
                 ApolloLog(@"[PiP] Inline System PiP never started on background — pausing to avoid background audio");
                 strongSelf.backgroundPausedInlinePlayer = inlinePlayer;
@@ -2269,8 +2270,29 @@ restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:(void (^)(BOOL)
         nativeMayTakeOver = sPiPNativeEnabled && self.nativePiP != nil;
     }
     if (nativeMayTakeOver) {
-        // Native PiP may be auto-starting right now — never pause here
-        // (WWDC19 503 guidance).
+        // Don't pause synchronously — System PiP may be auto-starting (WWDC19
+        // 503). But iOS can decline auto-start ("Start PiP Automatically" off,
+        // low power), and then nothing stops the card's player — an unmuted card
+        // keeps playing audibly in the background with no PiP window. Failsafe
+        // (mirrors the inline path): pause shortly after if PiP never started.
+        if (@available(iOS 15.0, *)) {
+            __weak __typeof(self) weakSelf = self;
+            __weak AVPlayer *weakCardPlayer = self.player;
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.7 * NSEC_PER_SEC)),
+                           dispatch_get_main_queue(), ^{
+                __typeof(self) strongSelf = weakSelf;
+                AVPlayer *cardPlayer = weakCardPlayer;
+                if (!strongSelf || !cardPlayer) return;
+                // Card gone or took over a different player — nothing to pause.
+                if (!strongSelf.active || strongSelf.player != cardPlayer) return;
+                if ([UIApplication sharedApplication].applicationState != UIApplicationStateBackground) return;
+                if (strongSelf.nativePiP.pictureInPictureActive) return; // PiP took over — fine
+                if (cardPlayer.rate == 0) return; // already paused
+                ApolloLog(@"[PiP] Card System PiP never started on background — pausing to avoid background audio");
+                strongSelf.resumeOnForeground = YES;
+                [cardPlayer pause];
+            });
+        }
         return;
     }
     if (self.player.rate != 0) {
@@ -2583,16 +2605,13 @@ static void PiPHandleFeedViewControllerAppeared(UIViewController *feedVC) {
     ApolloPiPController *controller = sPiPSharedController;
     if (!controller || !feedVC) return;
 
-    // An active card is comments-born and floats above forward navigation and tab
-    // switches BY DESIGN (a passthrough window over whatever is shown). Only a
-    // back-pop "returns to the feed" the video lives in, where the card must hand
-    // back to its inline home or dismiss. viewDidAppear fires for both directions,
-    // so distinguish them by THIS VC's own state: isMovingToParent is YES only
-    // when the VC is being PUSHED (forward nav, e.g. tapping a subreddit/user link
-    // in comments), and NO when it re-appears because a child was popped off it
-    // (the back-pop we want). Checking the appearing VC's own flag avoids the
-    // cross-VC timing race an interactive swipe-pop has with sIsNavigatingBack
-    // (CommentsVC.viewDidDisappear can clear that flag before this fires).
+    // An active card floats above forward navigation by design; only a back-pop
+    // "returns to the feed" the video lives in, where the card hands back inline
+    // or dismisses. Distinguish via THIS VC's own state: isMovingToParent is YES
+    // only when it's being pushed (forward nav, e.g. a subreddit/user link in
+    // comments), NO when revealed by a child pop (the back-pop we want). Using the
+    // appearing VC's own flag avoids the cross-VC race an interactive swipe-pop has
+    // with sIsNavigatingBack (CommentsVC.viewDidDisappear can clear it first).
     if (controller.active && [feedVC isMovingToParentViewController]) return;
 
     // A non-shareable (compact-mode) card's video is never reclaimed into a feed

--- a/src/ApolloPictureInPicture.xm
+++ b/src/ApolloPictureInPicture.xm
@@ -2583,13 +2583,25 @@ static void PiPHandleFeedViewControllerAppeared(UIViewController *feedVC) {
     ApolloPiPController *controller = sPiPSharedController;
     if (!controller || !feedVC) return;
 
+    // An active card is comments-born and floats above forward navigation and tab
+    // switches BY DESIGN (a passthrough window over whatever is shown). Only a
+    // back-pop "returns to the feed" the video lives in, where the card must hand
+    // back to its inline home or dismiss. viewDidAppear fires for both directions,
+    // so distinguish them by THIS VC's own state: isMovingToParent is YES only
+    // when the VC is being PUSHED (forward nav, e.g. tapping a subreddit/user link
+    // in comments), and NO when it re-appears because a child was popped off it
+    // (the back-pop we want). Checking the appearing VC's own flag avoids the
+    // cross-VC timing race an interactive swipe-pop has with sIsNavigatingBack
+    // (CommentsVC.viewDidDisappear can clear that flag before this fires).
+    if (controller.active && [feedVC isMovingToParentViewController]) return;
+
     // A non-shareable (compact-mode) card's video is never reclaimed into a feed
-    // cell — the compact feed shows a thumbnail, not the shared player — so on
-    // return to the feed there is no inline home to restore into and the card
-    // would otherwise float forever. Dismiss it. Shareable (large-thumbnail)
-    // cards fall through to the restore walk below, untouched.
+    // cell — the compact feed shows a thumbnail, not the shared player — so on a
+    // back-pop there is no inline home to restore into; dismiss it (it would
+    // otherwise float forever). Shareable (large-thumbnail) cards fall through to
+    // the restore walk below.
     if (controller.active && controller.ownedNonShareable) {
-        ApolloLog(@"[PiP] Returned to feed with a non-shareable (compact) card — dismissing");
+        ApolloLog(@"[PiP] Back-pop to feed with a non-shareable (compact) card — dismissing");
         [controller closeTapped];
         return;
     }
@@ -2604,8 +2616,8 @@ static void PiPHandleFeedViewControllerAppeared(UIViewController *feedVC) {
             break;
         }
     }
-    if (!tableView) return;
-
+    // tableView may be nil (feed not laid out the usual way) — the loop simply
+    // doesn't run, and we fall through to the dismiss below.
     for (UITableViewCell *cell in tableView.visibleCells) {
         SEL nodeSel = NSSelectorFromString(@"node");
         if (![cell respondsToSelector:nodeSel]) continue;
@@ -2627,6 +2639,18 @@ static void PiPHandleFeedViewControllerAppeared(UIViewController *feedVC) {
             [controller restoreInline];
             return;
         }
+    }
+
+    // Back-popped, still presenting after the restore walk: our video's feed cell
+    // isn't on screen — scrolled below the autoplay threshold, or off-screen
+    // entirely — so there is no visible inline home to hand back to. Without this a
+    // shareable (large-thumbnail) card floats over the feed until the user happens
+    // to scroll the cell into view. Dismiss it instead; the shared player returns
+    // to its feed-cell paused/muted state and re-autoplays when the cell scrolls
+    // back on screen, matching normal feed behavior.
+    if (controller.active) {
+        ApolloLog(@"[PiP] Back-pop to feed, our video's cell not on screen — dismissing card");
+        [controller closeTapped];
     }
 }
 

--- a/src/ApolloPictureInPicture.xm
+++ b/src/ApolloPictureInPicture.xm
@@ -91,9 +91,9 @@ static BOOL PiPNodeIsShareable(id videoNode) {
 }
 
 // Does the currently-playing item carry an audio track? This is what separates
-// a real video — which the user can unmute and would want in PiP — from a
-// silent autoplaying GIF (also an inline ASVideoNode), which must never trigger
-// PiP.
+// a real video — which the user can unmute — from a silent autoplaying GIF (also
+// an inline ASVideoNode) in the strict eligibility check below. (GIFs are still
+// admitted to PiP, but separately, by URL in "All Videos & GIFs" mode.)
 //
 // Must stay non-blocking: this runs on the feed-scroll / unmute main thread, and
 // callers only know rate != 0 (a play rate was REQUESTED), which does NOT imply
@@ -122,30 +122,74 @@ static BOOL PiPVideoHasAudio(AVPlayer *player) {
             containsObject:AVMediaCharacteristicAudible];
 }
 
-// Eligibility: Reddit-hosted videos (shareable v.redd.it, plus the compact-mode
-// non-shareable comments players that still point at a v.redd.it asset URL),
+// The source URL of the playing item — preferring the player's AVURLAsset, then
+// the node's assetURL (works even when videoNode is gone, e.g. a weak inline ref
+// cleared by the time a loop observer fires).
+static NSURL *PiPAssetURLForNode(id videoNode, AVPlayer *player) {
+    AVAsset *asset = player.currentItem.asset;
+    if ([asset isKindOfClass:[AVURLAsset class]]) {
+        return [(AVURLAsset *)asset URL];
+    }
+    SEL assetURLSel = NSSelectorFromString(@"assetURL");
+    if (videoNode && [videoNode respondsToSelector:assetURLSel]) {
+        return ((id (*)(id, SEL))objc_msgSend)(videoNode, assetURLSel);
+    }
+    return nil;
+}
+
+// Strict eligibility: Reddit-hosted videos (shareable v.redd.it, plus compact-
+// mode non-shareable comments players that still point at a v.redd.it asset URL),
 // PLUS any other inline video that carries audio — Streamable and similar
-// external hosts. The audio requirement is the GIF guard: a silent autoplaying
-// GIF is also an inline ASVideoNode but must never get PiP.
+// external hosts. The audio requirement excludes silent GIFs here; GIFs are
+// admitted separately, by URL in "All Videos & GIFs" mode (PiPNodeURLIsGif).
 static BOOL PiPIsEligibleVideo(id videoNode, AVPlayer *player) {
     if (PiPNodeIsShareable(videoNode)) return YES;
 
-    NSURL *url = nil;
-    AVAsset *asset = player.currentItem.asset;
-    if ([asset isKindOfClass:[AVURLAsset class]]) {
-        url = [(AVURLAsset *)asset URL];
-    }
-    if (!url) {
-        SEL assetURLSel = NSSelectorFromString(@"assetURL");
-        if ([videoNode respondsToSelector:assetURLSel]) {
-            url = ((id (*)(id, SEL))objc_msgSend)(videoNode, assetURLSel);
-        }
-    }
+    NSURL *url = PiPAssetURLForNode(videoNode, player);
     NSString *host = url.host.lowercaseString;
     if (host != nil && [host containsString:@"v.redd.it"]) return YES;
 
     // Non-Reddit inline video (Streamable etc.): eligible iff it carries audio.
     return PiPVideoHasAudio(player);
+}
+
+// Is this content a GIF by origin URL? Reddit serves GIFs from i.redd.it /
+// preview.redd.it with a .gif path — and crucially the MP4 playback variant
+// keeps ".gif?format=mp4", so the URL still says GIF even though the clip plays
+// as an MP4 that can carry a SILENT audio track (which makes the audio heuristic
+// wrongly call it a video). imgur uses .gifv; Giphy uses giphy.com. The ".gif"
+// substring is safe against real videos: v.redd.it / Streamable / YouTube URLs
+// never contain it, and Reddit signature query params are hex (no "gif").
+static BOOL PiPNodeURLIsGif(id videoNode, AVPlayer *player) {
+    NSString *s = PiPAssetURLForNode(videoNode, player).absoluteString.lowercaseString;
+    if (!s) return NO;
+    return [s containsString:@".gif"] || [s containsString:@"giphy.com"];
+}
+
+// GIF content for PiP purposes (always loops, no audio, no mute button): a GIF
+// by origin URL, OR a non-strictly-eligible silent inline video. At takeover the
+// eligibility gate has already required ReadyToPlay for the non-URL case, so a
+// !PiPIsEligibleVideo result there is a genuinely silent clip, not a still-
+// loading audio video.
+static BOOL PiPNodeIsGifContent(id videoNode, AVPlayer *player) {
+    return PiPNodeURLIsGif(videoNode, player) || !PiPIsEligibleVideo(videoNode, player);
+}
+
+// GIFs are admitted to PiP only in the most inclusive Activate For mode,
+// "All Videos & GIFs".
+static inline BOOL PiPGifsActivated(void) {
+    return sPiPActivationMode == ApolloPiPActivationModeAllVideosAndGifs;
+}
+
+// Eligible to arm inline / feed System PiP (the swipe-home handoff, no floating
+// card). GIF-first, mirroring the card gate: a GIF (by URL) qualifies only in
+// "All Videos & GIFs"; everything else uses the strict audio-bearing check. The
+// URL check must come first — a GIF has no audio, and a compact-mode comments
+// player isn't ReadyToPlay at arm time, so the audio check can't yet see the
+// GIF-as-MP4's silent track.
+static BOOL PiPIsEligibleForInlineNativePiP(id videoNode, AVPlayer *player) {
+    if (PiPNodeURLIsGif(videoNode, player)) return PiPGifsActivated();
+    return PiPIsEligibleVideo(videoNode, player);
 }
 
 // Midpoint visibility test mirroring Apollo's sub_1002063d8 (and the fork's
@@ -368,6 +412,11 @@ static const NSTimeInterval kPiPControlsAutoHideDelay = 3.0;
 // session at some point) — closing must hand the session back even if the
 // user muted the card just before closing.
 @property (nonatomic, assign) BOOL sessionClaimedAudibly;
+// YES when this card holds GIF content — silent inline content with no audio
+// track. Such a card must never claim the Playback session audibly (it would
+// interrupt the user's music for a silent GIF) nor block Apollo's Ambient
+// downgrade; the mute button is hidden for it too.
+@property (nonatomic, assign) BOOL cardIsGifContent;
 
 // UI
 @property (nonatomic, strong) ApolloPiPWindow *window;
@@ -460,6 +509,20 @@ static ApolloPiPController *sPiPSharedController = nil;
             }
             // (Enabling native PiP with an inline video on screen re-arms on
             // the next scroll tick via the visibility handler.)
+
+            // Re-evaluate an inline-armed (not-yet-handed-off) controller against
+            // the possibly-changed activation mode — switching away from "All
+            // Videos & GIFs" must disarm a GIF that armed inline System PiP, or
+            // it would still hand off on background. No visibility event fires on
+            // a settings change, so the visibility-handler disarm can't catch it.
+            if (sPiPNativeEnabled && strongSelf.inlineNativePiP
+                && !strongSelf.inlineNativePiP.pictureInPictureActive
+                && strongSelf.inlineNativePlayer
+                && !PiPIsEligibleForInlineNativePiP(strongSelf.inlineNativeVideoNode,
+                                                    strongSelf.inlineNativePlayer)) {
+                ApolloLog(@"[PiP] Activation mode change made the inline-armed video ineligible — disarming");
+                [strongSelf disarmInlineNativePiPIfIdle];
+            }
 
             // Overlay extras (skip buttons / progress bar) toggled while the
             // card's controls are showing: refresh them in place.
@@ -561,13 +624,26 @@ static ApolloPiPController *sPiPSharedController = nil;
 
     AVPlayer *player = ApolloVideoUnmute_GetPlayerFromVideoNode(videoNode);
 
+    // A visible GIF should be playing — GIFs autoplay and loop — but Apollo
+    // pauses the comments-header GIF while it's off-screen and doesn't auto-resume
+    // it on the way back, leaving it at rate==0 (which blocks both the inline arm
+    // and a fresh takeover). Nudge a loaded, visible, paused GIF back to playing.
+    if (sPiPEnabled && PiPGifsActivated() && visible && !self.active
+        && player && player.rate == 0
+        && player.currentItem.status == AVPlayerItemStatusReadyToPlay
+        && PiPNodeURLIsGif(videoNode, player)) {
+        ApolloLog(@"[PiP] Resuming paused visible GIF for re-activation");
+        PiPRewindIfStoppedAtEnd(player);
+        [player play];
+    }
+
     // System PiP also covers INLINE playback: while an eligible video plays on
     // screen, keep a system PiP controller armed on Apollo's own inline player
     // layer so backgrounding hands it off.
     if (sPiPNativeEnabled && visible) {
         if (player && player.rate != 0
             && !(sPiPActivationMode == ApolloPiPActivationModeUnmutedOnly && player.muted)
-            && PiPIsEligibleVideo(videoNode, player)) {
+            && PiPIsEligibleForInlineNativePiP(videoNode, player)) {
             [self armInlineNativePiPForVideoNode:videoNode player:player];
         } else if (!player || player.rate == 0) {
             // Fresh navigation: the shared layer/player is adopted (and starts
@@ -580,6 +656,12 @@ static ApolloPiPController *sPiPSharedController = nil;
                 ApolloLog(@"[PiP] Inline arm: player not ready at visibility event — scheduling retries");
                 [self retryInlineArmForCell:cellNode videoNode:videoNode attempts:4];
             }
+        } else if (videoNode == self.inlineNativeVideoNode) {
+            // Playing but no longer eligible (e.g. switched away from "All Videos
+            // & GIFs" while this GIF stayed visible) — disarm, mirroring the feed
+            // path's arm/disarm symmetry. Otherwise a stale GIF would still hand
+            // off to System PiP on background in a mode that excludes GIFs.
+            [self disarmInlineNativePiPIfIdle];
         }
     }
 
@@ -589,8 +671,30 @@ static ApolloPiPController *sPiPSharedController = nil;
     // is in-app mini-player takeover, which requires its own toggle.
     if (!sPiPEnabled) return NO;
     if (!player || player.rate == 0.0f) return NO;
-    if (sPiPActivationMode == ApolloPiPActivationModeUnmutedOnly && player.muted) return NO;
-    if (!PiPIsEligibleVideo(videoNode, player)) return NO;
+    // "All Videos & GIFs" widens the in-app card to GIFs the strict audio guard
+    // otherwise rejects. (The inline System-PiP arm admits GIFs in the same mode
+    // via PiPIsEligibleForInlineNativePiP; the feed stays GIF-free because feed
+    // GIFs autoplay muted.)
+    BOOL gifByURL = PiPNodeURLIsGif(videoNode, player);
+    BOOL strictlyEligible = PiPIsEligibleVideo(videoNode, player);
+    if (gifByURL || !strictlyEligible) {
+        // GIF content: a GIF by origin URL (e.g. a Reddit .gif served as MP4,
+        // which is strictly eligible only because its MP4 carries a silent audio
+        // track), or a non-strictly-eligible silent inline video. Admit only in
+        // the "All Videos & GIFs" activation mode. For the non-URL case require
+        // ReadyToPlay so a still-loading audio video (transiently not strictly
+        // eligible) re-evaluates on the strict path instead of slipping in here;
+        // URL-identified GIFs are reliable pre-load. GIFs bypass Unmuted-Only —
+        // no audio to unmute.
+        if (!PiPGifsActivated()) return NO;
+        if (!gifByURL) {
+            AVPlayerItem *item = player.currentItem;
+            if (!item || item.status != AVPlayerItemStatusReadyToPlay) return NO;
+        }
+    } else if (sPiPActivationMode == ApolloPiPActivationModeUnmutedOnly && player.muted) {
+        // Unmuted-Only governs audio-bearing videos.
+        return NO;
+    }
     if ([self isInlineNativePiPActive]) return NO; // system PiP owns rendering right now
 
     [self takeOverFromCell:cellNode richMediaNode:richMediaNode videoNode:videoNode player:player];
@@ -615,10 +719,15 @@ static ApolloPiPController *sPiPSharedController = nil;
     self.videoNode = videoNode;
     self.link = PiPGetIvar(richMediaNode, "link");
     self.ownedNonShareable = !PiPNodeIsShareable(videoNode);
+    // GIF content (always loops, no audio session, no mute button): a GIF by
+    // origin URL — incl. a Reddit .gif served as MP4 that carries a silent audio
+    // track and would otherwise read as a video — or a non-strictly-eligible
+    // silent inline video. v.redd.it/Streamable real videos stay non-GIF.
+    self.cardIsGifContent = PiPNodeIsGifContent(videoNode, player);
     self.active = YES;
     self.restoring = NO;
     self.resumeOnForeground = NO;
-    self.sessionClaimedAudibly = !player.muted;
+    self.sessionClaimedAudibly = !player.muted && !self.cardIsGifContent;
 
     UIView *videoView = PiPViewForNode(videoNode);
     CGSize videoViewSize = videoView ? videoView.bounds.size : CGSizeZero;
@@ -721,6 +830,7 @@ static ApolloPiPController *sPiPSharedController = nil;
     AVPlayer *player = self.player;
     id richMediaNode = self.richMediaNode;
     BOOL sessionWasClaimed = self.sessionClaimedAudibly;
+    BOOL wasGifContent = self.cardIsGifContent;
 
     // A player parked at its end (Loop off) must never be handed back as-is:
     // Apollo's next inline play() would no-op on the at-end item and freeze
@@ -752,13 +862,20 @@ static ApolloPiPController *sPiPSharedController = nil;
     self.restoring = NO;
     self.resumeOnForeground = NO;
     self.sessionClaimedAudibly = NO;
+    self.cardIsGifContent = NO;
     self.player = nil;
     self.playerItem = nil;
     self.link = nil;
     self.richMediaNode = nil;
     self.videoNode = nil;
 
-    if (!keepPlaying && player) {
+    if (!keepPlaying && wasGifContent && player) {
+        // A GIF should keep looping inline, so leave it as-is rather than
+        // pausing/muting — a pause would block the next takeover (rate==0) and
+        // Apollo won't auto-resume it. It's silent, so off-screen playback is
+        // harmless; scrolling back re-activates the card normally.
+        ApolloLog(@"[PiP] Closing GIF — leaving it playing inline (loops)");
+    } else if (!keepPlaying && player) {
         ApolloLog(@"[PiP] Closing — applying scrolled-away state (pause + mute)");
         [player pause];
         // Our own AVPlayer.setMuted: hook blocks mutes on the protected player;
@@ -1540,6 +1657,9 @@ static ApolloPiPController *sPiPSharedController = nil;
 
     self.closeButton.frame = CGRectMake(6, 6, 34, 34);
     self.muteButton.frame = CGRectMake(w - 40, 6, 34, 34);
+    // A silent GIF has no audio to toggle — hide the mute control for it (also
+    // avoids an unmute tap spuriously claiming the Playback session).
+    self.muteButton.hidden = self.cardIsGifContent;
     self.progressTrack.frame = CGRectMake(10, h - 9, w - 20, 3);
     [self syncProgressAnimation]; // re-fit the fill (and its animation) to the new track width
 
@@ -1908,10 +2028,11 @@ static ApolloPiPController *sPiPSharedController = nil;
         }
 
         // PiP requires a Playback audio session active BEFORE controller init.
-        // For muted videos use mixWithOthers so we don't interrupt the user's
-        // music just to enable the handoff.
+        // For muted videos — and silent GIFs, which never produce sound — use
+        // mixWithOthers so we don't interrupt the user's music just to enable
+        // the handoff.
         AVAudioSession *session = [AVAudioSession sharedInstance];
-        AVAudioSessionCategoryOptions options = self.player.muted
+        AVAudioSessionCategoryOptions options = (self.player.muted || self.cardIsGifContent)
             ? AVAudioSessionCategoryOptionMixWithOthers : 0;
         [session setCategory:AVAudioSessionCategoryPlayback
                         mode:AVAudioSessionModeDefault options:options error:nil];
@@ -1985,11 +2106,13 @@ static ApolloPiPController *sPiPSharedController = nil;
         if (![layer isKindOfClass:[AVPlayerLayer class]]) return;
 
         // System PiP needs a Playback session active before controller init.
-        // Best effort for muted videos (mixWithOthers spares the user's music);
-        // unmuted ones already hold a Playback session via the unmute paths.
+        // Best effort for muted videos — and silent GIFs, which never produce
+        // sound — use mixWithOthers so the handoff doesn't interrupt the user's
+        // music; unmuted real videos already hold a Playback session via the
+        // unmute paths. Mirrors the card's setupNativePiP GIF handling.
         AVAudioSession *session = [AVAudioSession sharedInstance];
         if (![session.category isEqualToString:AVAudioSessionCategoryPlayback]) {
-            AVAudioSessionCategoryOptions options = player.muted
+            AVAudioSessionCategoryOptions options = (player.muted || PiPNodeURLIsGif(videoNode, player))
                 ? AVAudioSessionCategoryOptionMixWithOthers : 0;
             [session setCategory:AVAudioSessionCategoryPlayback
                             mode:AVAudioSessionModeDefault options:options error:nil];
@@ -2034,7 +2157,7 @@ static ApolloPiPController *sPiPSharedController = nil;
         AVPlayer *player = ApolloVideoUnmute_GetPlayerFromVideoNode(video);
         if (player && player.rate != 0) {
             if (!(sPiPActivationMode == ApolloPiPActivationModeUnmutedOnly && player.muted)
-                && PiPIsEligibleVideo(video, player)
+                && PiPIsEligibleForInlineNativePiP(video, player)
                 && PiPIsVideoMidpointVisible(video, cell)) {
                 ApolloLog(@"[PiP] Inline arm retry: player ready — arming");
                 [strongSelf armInlineNativePiPForVideoNode:video player:player];
@@ -2247,14 +2370,18 @@ BOOL ApolloPiP_ShouldSuppressLoopForItem(AVPlayerItem *item) {
     if (!controller) return NO;
     // In-app card presenting this player (covers the card and its system PiP).
     if (controller.active && controller.player && controller.player.currentItem == item) {
-        return YES;
+        // GIFs always loop in PiP regardless of the Loop Videos setting; other
+        // content honors the (off) setting and stops at its end.
+        return !controller.cardIsGifContent;
     }
-    // Inline-armed system PiP actively showing this player.
+    // Inline-armed system PiP actively showing this player. A Reddit .gif-as-MP4
+    // is strictly eligible (silent audio track) so it can arm here too; keep it
+    // looping. URL-only GIF check — the only GIFs that arm inline are URL-GIFs.
     if (@available(iOS 15.0, *)) {
         if (controller.inlineNativePiP.pictureInPictureActive
             && controller.inlineNativePlayer
             && controller.inlineNativePlayer.currentItem == item) {
-            return YES;
+            return !PiPNodeURLIsGif(controller.inlineNativeVideoNode, controller.inlineNativePlayer);
         }
     }
     return NO;
@@ -2277,7 +2404,10 @@ static BOOL PiPInlineShieldEngaged(AVPlayer *player) {
 BOOL ApolloPiP_ShouldBlockAudioSessionDowngrade(void) {
     ApolloPiPController *controller = sPiPSharedController;
     if (!controller) return NO;
-    if (controller.active && controller.player && !controller.player.muted) return YES;
+    // A silent GIF card produces no sound, so there is no audio session worth
+    // holding against Apollo's Ambient downgrade.
+    if (controller.active && controller.player
+        && !controller.player.muted && !controller.cardIsGifContent) return YES;
     AVPlayer *inlinePlayer = controller.inlineNativePlayer;
     return inlinePlayer && !inlinePlayer.muted && PiPInlineShieldEngaged(inlinePlayer);
 }
@@ -2299,7 +2429,7 @@ void ApolloPiP_NoteInlineVideoAudible(id videoNode, AVPlayer *player) {
     ApolloPiPController *controller = [ApolloPiPController sharedController];
     if (controller.active) return;
     if (player.rate == 0) return;
-    if (!PiPIsEligibleVideo(videoNode, player)) return;
+    if (!PiPIsEligibleForInlineNativePiP(videoNode, player)) return;
     if (!PiPIsVideoMidpointVisible(videoNode, nil)) return;
     [controller armInlineNativePiPForVideoNode:videoNode player:player];
 }
@@ -2386,7 +2516,7 @@ static void PiPManageInlineNativeForFeedCell(id cellNode) {
 
     AVPlayer *player = ApolloVideoUnmute_GetPlayerFromVideoNode(videoNode);
     BOOL eligible = player && player.rate != 0 && !player.muted
-                 && PiPIsEligibleVideo(videoNode, player)
+                 && PiPIsEligibleForInlineNativePiP(videoNode, player)
                  && PiPIsVideoMidpointVisible(videoNode, cellNode);
     if (eligible) {
         [controller armInlineNativePiPForVideoNode:videoNode player:player];

--- a/src/ApolloSettings.xm
+++ b/src/ApolloSettings.xm
@@ -6,6 +6,7 @@
 #import "SavedCategoriesViewController.h"
 #import "TranslationSettingsViewController.h"
 #import "TagFiltersViewController.h"
+#import "PictureInPictureViewController.h"
 
 // MARK: - Settings View Controller (Custom API row injection)
 
@@ -78,14 +79,14 @@ static UIImage *createSettingsIcon(NSString *sfSymbolName, UIColor *bgColor) {
     sApolloLastSettingsVC = (UIViewController *)self;
 }
 
-// Inject a new section 1 (Custom API + Saved Categories) between Tip Jar (section 0) and General (original section 1)
+// Inject a new section 1 (the tweak's settings rows; see the row list in numberOfRowsInSection:) between Tip Jar (section 0) and General (original section 1)
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
     return %orig + 1;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    if (section == 1) return 4; // Custom API, Saved Categories, Translation, Tag Filters
+    if (section == 1) return 5; // Custom API, Saved Categories, Translation, Tag Filters, Picture-in-Picture
     if (section > 1) return %orig(tableView, section - 1);
     return %orig;
 }
@@ -120,9 +121,14 @@ static UIImage *createSettingsIcon(NSString *sfSymbolName, UIColor *bgColor) {
         } else if (indexPath.row == 2) {
             cell.textLabel.text = @"Translation";
             cell.imageView.image = createSettingsIcon(@"globe", [UIColor systemIndigoColor]);
-        } else {
+        } else if (indexPath.row == 3) {
             cell.textLabel.text = @"Tag Filters";
             cell.imageView.image = createSettingsIcon(@"eye.slash.fill", [UIColor systemRedColor]);
+        } else {
+            cell.textLabel.text = @"Picture-in-Picture";
+            // systemBlue mirrors iOS' own Settings > General > Picture in
+            // Picture icon and avoids the neighbors' teal/orange/indigo/red.
+            cell.imageView.image = createSettingsIcon(@"pip.enter", [UIColor systemBlueColor]);
         }
         return cell;
     }
@@ -162,8 +168,11 @@ static UIImage *createSettingsIcon(NSString *sfSymbolName, UIColor *bgColor) {
         } else if (indexPath.row == 2) {
             TranslationSettingsViewController *vc = [[TranslationSettingsViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
             [((UIViewController *)self).navigationController pushViewController:vc animated:YES];
-        } else {
+        } else if (indexPath.row == 3) {
             TagFiltersViewController *vc = [[TagFiltersViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
+            [((UIViewController *)self).navigationController pushViewController:vc animated:YES];
+        } else {
+            PictureInPictureViewController *vc = [[PictureInPictureViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
             [((UIViewController *)self).navigationController pushViewController:vc animated:YES];
         }
         return;

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -172,8 +172,9 @@ extern NSString *sWebSessionUsername;
 // Picture-in-Picture: floating in-app mini-player for comments-page videos
 // scrolled out of view. See ApolloPictureInPicture.xm and docs/pip-design.md.
 typedef NS_ENUM(NSInteger, ApolloPiPActivationMode) {
-    ApolloPiPActivationModeAllVideos = 0,   // any playing video (muted or not)
-    ApolloPiPActivationModeUnmutedOnly = 1, // only videos playing unmuted
+    ApolloPiPActivationModeAllVideos = 0,       // any playing video (muted or not)
+    ApolloPiPActivationModeUnmutedOnly = 1,     // only videos playing unmuted
+    ApolloPiPActivationModeAllVideosAndGifs = 2, // all videos PLUS silent GIFs (in-app card)
 };
 // Where a fresh PiP card first appears. 0–3 match the corner indices used by
 // the geometry code (TL/TR/BL/BR); LastPosition restores the remembered

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -169,6 +169,40 @@ extern NSString *sWebSessionModhash;
 // data.name), captured at login. Used by the identity layer to label the
 // cookie account. nil until a successful harvest.
 extern NSString *sWebSessionUsername;
+// Picture-in-Picture: floating in-app mini-player for comments-page videos
+// scrolled out of view. See ApolloPictureInPicture.xm and docs/pip-design.md.
+typedef NS_ENUM(NSInteger, ApolloPiPActivationMode) {
+    ApolloPiPActivationModeAllVideos = 0,   // any playing video (muted or not)
+    ApolloPiPActivationModeUnmutedOnly = 1, // only videos playing unmuted
+};
+// Where a fresh PiP card first appears. 0–3 match the corner indices used by
+// the geometry code (TL/TR/BL/BR); LastPosition restores the remembered
+// screen-relative center, re-clamped for the new video's card size.
+typedef NS_ENUM(NSInteger, ApolloPiPStartPosition) {
+    ApolloPiPStartPositionTopLeft = 0,
+    ApolloPiPStartPositionTopRight = 1,
+    ApolloPiPStartPositionBottomLeft = 2,
+    ApolloPiPStartPositionBottomRight = 3,
+    ApolloPiPStartPositionLastPosition = 4,
+};
+extern BOOL sPiPEnabled;          // in-app floating mini-player
+extern NSInteger sPiPActivationMode;
+extern NSInteger sPiPStartPosition;
+// Hand off to iOS' system Picture in Picture when the app backgrounds.
+// Independent of sPiPEnabled — works for the inline player on its own.
+extern BOOL sPiPNativeEnabled;
+// Replay the clip when it reaches the end while PiP is presenting it.
+// Default YES (Apollo's native inline behavior).
+extern BOOL sPiPLoop;
+// Open the miniplayer tucked off the edge (hidden). Applies to corner
+// Starting Positions only; Last Position remembers hidden state itself.
+extern BOOL sPiPStartHidden;
+// Optional extra controls on the floating window's overlay. Skip buttons jump
+// back/ahead by sPiPSkipSeconds (5/10/15/30); the progress bar is a read-only
+// playback position indicator along the bottom edge. Both default OFF.
+extern BOOL sPiPSkipButtons;
+extern NSInteger sPiPSkipSeconds;
+extern BOOL sPiPProgressBar;
 
 // Tag filter feature (NSFW / Spoiler).
 extern BOOL sTagFilterEnabled;

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -57,6 +57,15 @@ BOOL sWebJSONEnabled = NO;
 NSString *sWebSessionCookieHeader = nil;
 NSString *sWebSessionModhash = nil;
 NSString *sWebSessionUsername = nil;
+BOOL sPiPEnabled = NO;
+NSInteger sPiPActivationMode = ApolloPiPActivationModeUnmutedOnly;
+NSInteger sPiPStartPosition = ApolloPiPStartPositionTopRight;
+BOOL sPiPNativeEnabled = NO;
+BOOL sPiPLoop = YES;
+BOOL sPiPStartHidden = NO;
+BOOL sPiPSkipButtons = NO;
+NSInteger sPiPSkipSeconds = 10;
+BOOL sPiPProgressBar = NO;
 
 BOOL sTagFilterEnabled = NO;
 NSString *sTagFilterMode = @"blur";

--- a/src/ApolloVideoUnmute.xm
+++ b/src/ApolloVideoUnmute.xm
@@ -31,6 +31,38 @@
 // =============================================================================
 
 // =============================================================================
+// MARK: - Picture-in-Picture coordination (ApolloPictureInPicture.xm)
+// =============================================================================
+//
+// The PiP module owns the floating-player feature; this module consults it at
+// the points where the two features' policies meet (see docs/pip-design.md):
+//   - ApolloPiP_HandleCommentsVisibilityEvent: called BEFORE %orig in the
+//     comments visibility hooks. Returns YES when PiP owns that cell's player,
+//     in which case %orig must be skipped — Apollo's midpoint-test pause/play
+//     runs synchronously inside %orig (sub_1002060bc) and must not touch a
+//     PiP-owned player. The ASCellNode base implementation is a single ret,
+//     so skipping loses nothing else.
+//   - ApolloPiP_IsOwnedPlayer: exempts the PiP player from the post-pop
+//     "prevent invisible background audio" kill below.
+//   - ApolloPiP_ShouldBlockAudioSessionDowngrade: extends the AVAudioSession
+//     blocking predicates while PiP plays audibly.
+//   - ApolloPiP_ShouldBlockMuteOfPlayer: extends the AVPlayer.setMuted: block
+//     to the inline-armed native-PiP player during background handoff.
+//   - ApolloPiP_YieldAudioToPlayer: mutes an audible PiP card when a tweak
+//     unmute path makes a different video audible (audio arbitration).
+//   - ApolloPiP_NoteInlineVideoAudible: lets the inline native-PiP controller
+//     arm on unmutes, which produce no scroll/visibility event.
+// Both files are Logos/ObjC++, so these declarations mangle identically.
+extern BOOL ApolloPiP_HandleCommentsVisibilityEvent(id cellNode, id richMediaNode,
+                                                    unsigned long long event);
+extern BOOL ApolloPiP_IsOwnedPlayer(AVPlayer *player);
+extern BOOL ApolloPiP_ShouldBlockAudioSessionDowngrade(void);
+extern BOOL ApolloPiP_ShouldBlockMuteOfPlayer(AVPlayer *player);
+extern void ApolloPiP_YieldAudioToPlayer(AVPlayer *newAudiblePlayer);
+extern void ApolloPiP_NoteInlineVideoAudible(id videoNode, AVPlayer *player);
+extern void ApolloPiP_NoteInlinePlayerMuted(AVPlayer *player);
+
+// =============================================================================
 // MARK: - State Variables
 // =============================================================================
 
@@ -357,6 +389,11 @@ static void UnmuteRichMediaNode(id richMediaNode, id videoNode) {
 
     BOOL alreadyUnmuted = ![player isMuted];
 
+    // This video is about to play audibly — if a PiP card is playing a
+    // DIFFERENT video with sound, mute it first (the native activeAudioPlayer
+    // arbitration only covers Apollo's own unmute path, not ours).
+    ApolloPiP_YieldAudioToPlayer(player);
+
     // Even when the player is already unmuted (e.g. re-entry from feed where
     // audio was playing), we must establish protection (sAutoUnmutedPlayer +
     // Playback session). Without this, the mute dance from the feed cell
@@ -405,6 +442,10 @@ static void UnmuteRichMediaNode(id richMediaNode, id videoNode) {
 
     // Step 5: Sync the mute button icon to "unmuted" state (always)
     SyncMuteButtonIcon(richMediaNode, NO);
+
+    // Now audible — let the inline native-PiP controller arm if enabled
+    // (no scroll event fires for a programmatic unmute).
+    ApolloPiP_NoteInlineVideoAudible(videoNode, player);
 
     ApolloLog(@"[VideoUnmute] Auto-unmute complete for player %p", player);
 }
@@ -537,9 +578,10 @@ static void HandleCommentsRichMediaVisibilityEvent(id visibilityOwner,
 // RichMediaHeaderCellNode: the comments header video cell
 // ---------------------------------------------------------------------------
 // cellNodeVisibilityEvent: fires when the cell's visibility changes in the
-// scroll view (visible, invisible, rect changed, etc). Two responsibilities:
+// scroll view (visible, invisible, rect changed, etc). Two responsibilities
+// (both skipped while PiP owns this cell's player, and on event=1 ticks):
 //
-// 1. Icon sync (ALWAYS, native bug fix, runs on every visibility event):
+// 1. Icon sync (native bug fix, runs on visible/invisible events):
 //    For shareable videos, the button setup code (sub_100582a0c) checks
 //    [videoNode player] to set the initial isMuted state. But for shareable
 //    videos, [videoNode player] is nil (the player is on the playerLayer).
@@ -556,8 +598,15 @@ static void HandleCommentsRichMediaVisibilityEvent(id visibilityOwner,
 - (void)cellNodeVisibilityEvent:(unsigned long long)event
                    inScrollView:(id)scrollView
                   withCellFrame:(CGRect)frame {
-    %orig;
     id richMediaNode = GetIvarObject(self, "richMediaNode");
+    // PiP first: it may take over (scroll-away) or restore (scroll-back) on
+    // this event. YES = PiP owns this cell's player and %orig must be skipped
+    // so Apollo's synchronous play/pause never touches it. The unmute handling
+    // below is also skipped — protection state must not change under PiP.
+    if (ApolloPiP_HandleCommentsVisibilityEvent(self, richMediaNode, event)) {
+        return;
+    }
+    %orig;
     // event=1 (VisibleRectChanged) fires on every layout tick during scroll.
     // Skip the verbose path entirely — the icon-sync inside SyncMuteButtonIcon
     // is a no-op when state already matches, but the log line itself floods.
@@ -573,18 +622,22 @@ static void HandleCommentsRichMediaVisibilityEvent(id visibilityOwner,
 - (void)cellNodeVisibilityEvent:(unsigned long long)event
                    inScrollView:(id)scrollView
                   withCellFrame:(CGRect)frame {
+    id crosspostRichMediaNode = GetCrosspostRichMediaNodeFromOwner(self);
+    // PiP first (see RichMediaHeaderCellNode above) — covers crosspost videos.
+    if (ApolloPiP_HandleCommentsVisibilityEvent(self, crosspostRichMediaNode, event)) {
+        return;
+    }
     %orig;
 
     // event=1 (VisibleRectChanged) fires on every layout tick during scroll.
     // Skip entirely — nothing for us to do on rect-change ticks.
     if (event == 1) return;
 
-    id richMediaNode = GetCrosspostRichMediaNodeFromOwner(self);
-    if (!richMediaNode) return;
+    if (!crosspostRichMediaNode) return;
 
     ApolloLog(@"[VideoUnmute] CommentsHeaderCellNode visibility event=%llu for crosspost rich media",
               event);
-    HandleCommentsRichMediaVisibilityEvent(self, richMediaNode, event,
+    HandleCommentsRichMediaVisibilityEvent(self, crosspostRichMediaNode, event,
                                            @"comments crosspost video");
 }
 
@@ -665,6 +718,16 @@ static void HandleCommentsRichMediaVisibilityEvent(id visibilityOwner,
     if (wasMutedAndPaused && playerForResume && ![playerForResume isMuted]) {
         ApolloLog(@"[VideoUnmute] Mute button unmuted a force-paused video — resuming playback");
         [playerForResume play];
+    }
+
+    // If the tap unmuted this video, mute any audible PiP card playing a
+    // different video (native activeAudioPlayer arbitration misses players
+    // that were unmuted by the tweak rather than by Apollo), and give the
+    // inline native-PiP controller a chance to arm (no scroll event fires
+    // for a mute-button tap).
+    if (playerForResume && ![playerForResume isMuted]) {
+        ApolloPiP_YieldAudioToPlayer(playerForResume);
+        ApolloPiP_NoteInlineVideoAudible(videoNodeForResume, playerForResume);
     }
 }
 
@@ -891,7 +954,19 @@ static void HandleCommentsRichMediaVisibilityEvent(id visibilityOwner,
         ApolloLog(@"[VideoUnmute] AVPlayer.setMuted:YES — BLOCKED (protecting auto-unmuted player)");
         return;
     }
+    // Same for the inline-armed native-PiP player during the background
+    // handoff window (the dance's T+100ms setMuted:YES would silence the
+    // system PiP that just took the video).
+    if (muted && !sIsAutoUnmuting && ApolloPiP_ShouldBlockMuteOfPlayer(self)) {
+        ApolloLog(@"[VideoUnmute] AVPlayer.setMuted:YES — BLOCKED (PiP background handoff shield)");
+        return;
+    }
     %orig;
+    // The mute took effect (not blocked): if this is the inline-armed system-PiP
+    // player, drop the arm so a home-swipe can't hand off a now-muted video.
+    if (muted && !sIsAutoUnmuting) {
+        ApolloPiP_NoteInlinePlayerMuted(self);
+    }
 }
 
 %end
@@ -906,13 +981,20 @@ static void HandleCommentsRichMediaVisibilityEvent(id visibilityOwner,
 // Safety: sAutoUnmutedPlayer is __weak — auto-nils when the player deallocates,
 // making these hooks transparent pass-throughs automatically.
 // ---------------------------------------------------------------------------
+// A PiP video playing audibly needs the same session protection as an
+// auto-unmuted one: other videos' mute dances (T+50ms) downgrade the session
+// to Ambient + inactive GLOBALLY, which would silence PiP audio.
+static BOOL ShouldProtectAudioSession(void) {
+    return sAutoUnmutedPlayer != nil || ApolloPiP_ShouldBlockAudioSessionDowngrade();
+}
+
 %hook AVAudioSession
 
 - (BOOL)setCategory:(AVAudioSessionCategory)category
                 mode:(AVAudioSessionMode)mode
              options:(AVAudioSessionCategoryOptions)options
                error:(NSError **)error {
-    if (sAutoUnmutedPlayer && [category isEqualToString:AVAudioSessionCategoryAmbient]) {
+    if (ShouldProtectAudioSession() && [category isEqualToString:AVAudioSessionCategoryAmbient]) {
         ApolloLog(@"[VideoUnmute] Blocking setCategory:Ambient (mode:options: variant)");
         return YES;
     }
@@ -920,7 +1002,7 @@ static void HandleCommentsRichMediaVisibilityEvent(id visibilityOwner,
 }
 
 - (BOOL)setCategory:(AVAudioSessionCategory)category error:(NSError **)error {
-    if (sAutoUnmutedPlayer && [category isEqualToString:AVAudioSessionCategoryAmbient]) {
+    if (ShouldProtectAudioSession() && [category isEqualToString:AVAudioSessionCategoryAmbient]) {
         ApolloLog(@"[VideoUnmute] Blocking setCategory:Ambient (short variant)");
         return YES;
     }
@@ -930,8 +1012,8 @@ static void HandleCommentsRichMediaVisibilityEvent(id visibilityOwner,
 - (BOOL)setActive:(BOOL)active
       withOptions:(AVAudioSessionSetActiveOptions)options
             error:(NSError **)error {
-    if (!active && sAutoUnmutedPlayer) {
-        ApolloLog(@"[VideoUnmute] Blocking setActive:NO while auto-unmuted player active");
+    if (!active && ShouldProtectAudioSession()) {
+        ApolloLog(@"[VideoUnmute] Blocking setActive:NO while protected player active");
         return YES;
     }
     return %orig;
@@ -1065,7 +1147,11 @@ static void HandleCommentsRichMediaVisibilityEvent(id visibilityOwner,
 
                     ApolloLog(@"[VideoUnmute] Mute dance window expired — clearing protection (visibleOnFeed=%d)", visibleOnFeed);
 
-                    if (!visibleOnFeed && p) {
+                    if (p && ApolloPiP_IsOwnedPlayer(p)) {
+                        // The player lives on in the floating PiP card — it is
+                        // intentionally audible/visible off-feed. Don't kill it.
+                        ApolloLog(@"[VideoUnmute] Player is PiP-owned — skipping post-pop mute/pause");
+                    } else if (!visibleOnFeed && p) {
                         // Player is not on any visible feed cell (compact mode
                         // or no matching cell). Mute + pause + reset audio
                         // session to prevent invisible background audio.
@@ -1191,6 +1277,37 @@ void ApolloVideoUnmute_FixDisconnectedPlayerLayer(id postsViewController) {
     if (!foundDisconnected) {
         ApolloLog(@"[VideoUnmute] FixDisconnectedPlayerLayer: no disconnected playerLayer found");
     }
+}
+
+// =============================================================================
+// MARK: - Exported helpers for ApolloPictureInPicture.xm
+// =============================================================================
+
+AVPlayer *ApolloVideoUnmute_GetPlayerFromVideoNode(id videoNode) {
+    return GetPlayerFromVideoNode(videoNode);
+}
+
+void ApolloVideoUnmute_SyncMuteButtonIcon(id richMediaNode, BOOL isMuted) {
+    SyncMuteButtonIcon(richMediaNode, isMuted);
+}
+
+// Drops auto-unmute protection for a specific player so a deliberate mute
+// (e.g. the PiP card's mute button / close) can pass the AVPlayer.setMuted:
+// block above.
+void ApolloVideoUnmute_ClearProtectionIfPlayer(AVPlayer *player) {
+    if (player && sAutoUnmutedPlayer == player) {
+        ApolloLog(@"[VideoUnmute] Clearing auto-unmute protection at PiP's request");
+        sAutoUnmutedPlayer = nil;
+    }
+}
+
+// YES while a CommentsVC is being popped back to its feed (set in
+// viewWillDisappear when isMovingFromParentViewController, cleared in
+// viewDidDisappear). The comments cell fires its Invisible event during the
+// pop; PiP consults this so it does not disarm the inline system-PiP
+// controller mid-reclaim — the same player keeps playing on the feed.
+BOOL ApolloVideoUnmute_IsNavigatingBack(void) {
+    return sIsNavigatingBack;
 }
 
 // =============================================================================

--- a/src/PictureInPictureViewController.h
+++ b/src/PictureInPictureViewController.h
@@ -1,0 +1,4 @@
+#import <UIKit/UIKit.h>
+
+@interface PictureInPictureViewController : UITableViewController
+@end

--- a/src/PictureInPictureViewController.m
+++ b/src/PictureInPictureViewController.m
@@ -1,0 +1,526 @@
+#import "PictureInPictureViewController.h"
+#import "ApolloState.h"
+#import "UserDefaultConstants.h"
+
+extern NSString *const ApolloPictureInPictureChangedNotification;
+NSString *const ApolloPictureInPictureChangedNotification = @"ApolloPictureInPictureChangedNotification";
+
+// Options live under the feature they belong to: the core miniplayer rows and
+// its overlay-control rows get sibling "In-App PiP…" sections; Activate For
+// and Loop apply to both features and sit in their own clearly-labeled
+// section. Longer explanations live as grey description text inside the cells
+// themselves (the repo-wide subtitle-cell pattern) rather than as footers.
+typedef NS_ENUM(NSInteger, PictureInPictureSection) {
+    PictureInPictureSectionMiniplayer = 0, // "In-App PiP": toggle, position, hidden start
+    PictureInPictureSectionControls,       // "In-App PiP Controls": overlay extras
+    PictureInPictureSectionAutoPiP,        // "System PiP": leave-app handoff toggle
+    PictureInPictureSectionShared,         // "Global Options": Activate For, Loop Videos
+    PictureInPictureSectionCount,
+};
+
+// Row KINDS for the In-App PiP section. Hidden by Default is absent (not
+// greyed) while Default Position is Last Position — which remembers its own
+// hidden state — via miniplayerRows/miniplayerRowAtIndex:.
+typedef NS_ENUM(NSInteger, PictureInPictureMiniplayerRow) {
+    PictureInPictureMiniplayerRowToggle = 0,
+    PictureInPictureMiniplayerRowStartPosition,
+    PictureInPictureMiniplayerRowStartHidden,
+};
+
+// Row KINDS for the Window Controls section. Skip Amount is hidden (the row
+// is absent, not greyed) while Show Skip Buttons is off — index<->kind
+// mapping goes through controlsRows/controlsRowAtIndex:.
+typedef NS_ENUM(NSInteger, PictureInPictureControlsRow) {
+    PictureInPictureControlsRowSkipButtons = 0,
+    PictureInPictureControlsRowSkipSeconds,
+    PictureInPictureControlsRowProgressBar,
+};
+
+typedef NS_ENUM(NSInteger, PictureInPictureSharedRow) {
+    PictureInPictureSharedRowActivation = 0,
+    PictureInPictureSharedRowLoop,
+    PictureInPictureSharedRowCount,
+};
+
+@implementation PictureInPictureViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Picture-in-Picture";
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.tableView reloadData];
+}
+
+#pragma mark - Helpers
+
+- (void)postChange {
+    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloPictureInPictureChangedNotification
+                                                        object:nil];
+}
+
+// Switch row with optional grey description text inside the cell (subtitle
+// style, repo-wide pattern — see CustomAPIViewController). nil description
+// gives the plain single-line row.
+- (UITableViewCell *)switchCellLabel:(NSString *)label description:(NSString *)description
+                                  on:(BOOL)on enabled:(BOOL)enabled action:(SEL)action {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:nil];
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+    cell.textLabel.text = label;
+    cell.textLabel.enabled = enabled;
+    cell.detailTextLabel.text = description;
+    cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+    cell.detailTextLabel.numberOfLines = 0;
+    UISwitch *sw = [[UISwitch alloc] init];
+    sw.on = on;
+    sw.enabled = enabled;
+    [sw addTarget:self action:action forControlEvents:UIControlEventValueChanged];
+    cell.accessoryView = sw;
+    return cell;
+}
+
+- (UITableViewCell *)switchCellLabel:(NSString *)label on:(BOOL)on enabled:(BOOL)enabled action:(SEL)action {
+    return [self switchCellLabel:label description:nil on:on enabled:enabled action:action];
+}
+
+// Multi-choice row matching the repo-wide pattern (CustomAPIViewController's
+// "Body Link Previews"/"Autoplay Inline GIFs" etc.): Value1 cell, tap presents
+// an anchored action sheet with a "(Current)" suffix on the active choice.
+- (UITableViewCell *)valueCellLabel:(NSString *)label detail:(NSString *)detail enabled:(BOOL)enabled {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:nil];
+    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+    cell.textLabel.text = label;
+    cell.textLabel.enabled = enabled;
+    cell.detailTextLabel.text = detail;
+    cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+    return cell;
+}
+
+- (NSString *)activationModeText {
+    switch (sPiPActivationMode) {
+        case ApolloPiPActivationModeUnmutedOnly: return @"Unmuted Videos Only";
+        default:                                 return @"All Videos";
+    }
+}
+
+- (NSString *)startPositionText {
+    switch (sPiPStartPosition) {
+        case ApolloPiPStartPositionTopLeft:      return @"Top Left";
+        case ApolloPiPStartPositionBottomLeft:   return @"Bottom Left";
+        case ApolloPiPStartPositionBottomRight:  return @"Bottom Right";
+        case ApolloPiPStartPositionLastPosition: return @"Last Position";
+        default:                                 return @"Top Right";
+    }
+}
+
+- (NSString *)skipSecondsText {
+    return [NSString stringWithFormat:@"%ld Seconds", (long)sPiPSkipSeconds];
+}
+
+// The In-App PiP section's rows in display order. Hidden by Default appears
+// only for fixed-corner Default Positions; Last Position remembers its own
+// hidden state, so the row is omitted there.
+- (NSArray<NSNumber *> *)miniplayerRows {
+    NSMutableArray<NSNumber *> *rows = [NSMutableArray arrayWithObjects:
+        @(PictureInPictureMiniplayerRowToggle),
+        @(PictureInPictureMiniplayerRowStartPosition), nil];
+    if (sPiPStartPosition != ApolloPiPStartPositionLastPosition) {
+        [rows addObject:@(PictureInPictureMiniplayerRowStartHidden)];
+    }
+    return rows;
+}
+
+- (PictureInPictureMiniplayerRow)miniplayerRowAtIndex:(NSInteger)index {
+    NSArray<NSNumber *> *rows = [self miniplayerRows];
+    if (index < 0 || index >= (NSInteger)rows.count) return PictureInPictureMiniplayerRowToggle;
+    return (PictureInPictureMiniplayerRow)rows[(NSUInteger)index].integerValue;
+}
+
+- (NSIndexPath *)indexPathForMiniplayerRow:(PictureInPictureMiniplayerRow)row {
+    NSUInteger index = [[self miniplayerRows] indexOfObject:@(row)];
+    if (index == NSNotFound) return nil;
+    return [NSIndexPath indexPathForRow:(NSInteger)index inSection:PictureInPictureSectionMiniplayer];
+}
+
+// The Window Controls section's rows in display order. Skip Amount appears
+// only while Show Skip Buttons is on.
+- (NSArray<NSNumber *> *)controlsRows {
+    NSMutableArray<NSNumber *> *rows = [NSMutableArray arrayWithObject:@(PictureInPictureControlsRowSkipButtons)];
+    if (sPiPSkipButtons) [rows addObject:@(PictureInPictureControlsRowSkipSeconds)];
+    [rows addObject:@(PictureInPictureControlsRowProgressBar)];
+    return rows;
+}
+
+- (PictureInPictureControlsRow)controlsRowAtIndex:(NSInteger)index {
+    NSArray<NSNumber *> *rows = [self controlsRows];
+    if (index < 0 || index >= (NSInteger)rows.count) return PictureInPictureControlsRowSkipButtons;
+    return (PictureInPictureControlsRow)rows[(NSUInteger)index].integerValue;
+}
+
+- (NSIndexPath *)indexPathForControlsRow:(PictureInPictureControlsRow)row {
+    NSUInteger index = [[self controlsRows] indexOfObject:@(row)];
+    if (index == NSNotFound) return nil;
+    return [NSIndexPath indexPathForRow:(NSInteger)index inSection:PictureInPictureSectionControls];
+}
+
+// UIAlertAction accepts an image via the long-stable "image" KVC key.
+// Takes the first symbol name that resolves (fallback chain); purely
+// cosmetic, so failures are ignored.
+static void PiPSetSheetActionIcon(UIAlertAction *action, NSArray<NSString *> *symbolNames) {
+    for (NSString *name in symbolNames) {
+        UIImage *image = [UIImage systemImageNamed:name];
+        if (!image) continue;
+        @try {
+            [action setValue:image forKey:@"image"];
+        } @catch (NSException *exception) {}
+        return;
+    }
+}
+
+- (void)presentActivationModeSheetFromSourceView:(UIView *)sourceView {
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Activate For"
+                                                                   message:nil
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+
+    NSString *allTitle = (sPiPActivationMode == ApolloPiPActivationModeAllVideos)
+        ? @"All Videos (Current)" : @"All Videos";
+    NSString *unmutedTitle = (sPiPActivationMode == ApolloPiPActivationModeUnmutedOnly)
+        ? @"Unmuted Videos Only (Current)" : @"Unmuted Videos Only";
+
+    __weak __typeof(self) weakSelf = self;
+    [sheet addAction:[UIAlertAction actionWithTitle:allTitle style:UIAlertActionStyleDefault
+                                            handler:^(__unused UIAlertAction *action) {
+        [weakSelf setActivationMode:ApolloPiPActivationModeAllVideos];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:unmutedTitle style:UIAlertActionStyleDefault
+                                            handler:^(__unused UIAlertAction *action) {
+        [weakSelf setActivationMode:ApolloPiPActivationModeUnmutedOnly];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    if (popover && sourceView) {
+        popover.sourceView = sourceView;
+        popover.sourceRect = sourceView.bounds;
+    }
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+- (void)presentStartPositionSheetFromSourceView:(UIView *)sourceView {
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Default Position"
+                                                                   message:nil
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+
+    NSArray<NSString *> *titles = @[@"Top Left", @"Top Right", @"Bottom Left", @"Bottom Right", @"Last Position"];
+    // Corner glyphs show a small rect docked in the matching corner; Last
+    // Position uses the center-inset rect from the same family ("wherever
+    // you left it"), with the history glyph as fallback.
+    NSArray<NSArray<NSString *> *> *symbols = @[
+        @[@"rectangle.inset.topleft.filled"],
+        @[@"rectangle.inset.topright.filled"],
+        @[@"rectangle.inset.bottomleft.filled"],
+        @[@"rectangle.inset.bottomright.filled"],
+        @[@"rectangle.center.inset.filled", @"clock.arrow.circlepath"],
+    ];
+    __weak __typeof(self) weakSelf = self;
+    for (NSInteger position = ApolloPiPStartPositionTopLeft;
+         position <= ApolloPiPStartPositionLastPosition; position++) {
+        NSString *title = (sPiPStartPosition == position)
+            ? [titles[(NSUInteger)position] stringByAppendingString:@" (Current)"]
+            : titles[(NSUInteger)position];
+        UIAlertAction *action = [UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault
+                                                       handler:^(__unused UIAlertAction *a) {
+            [weakSelf setStartPosition:position];
+        }];
+        PiPSetSheetActionIcon(action, symbols[(NSUInteger)position]);
+        [sheet addAction:action];
+    }
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    if (popover && sourceView) {
+        popover.sourceView = sourceView;
+        popover.sourceRect = sourceView.bounds;
+    }
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+- (void)presentSkipSecondsSheetFromSourceView:(UIView *)sourceView {
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Skip Amount"
+                                                                   message:nil
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+
+    __weak __typeof(self) weakSelf = self;
+    for (NSNumber *seconds in @[@5, @10, @15, @30]) {
+        NSString *title = [NSString stringWithFormat:@"%@ Seconds", seconds];
+        if (sPiPSkipSeconds == seconds.integerValue) {
+            title = [title stringByAppendingString:@" (Current)"];
+        }
+        UIAlertAction *action = [UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault
+                                                       handler:^(__unused UIAlertAction *a) {
+            [weakSelf setSkipSeconds:seconds.integerValue];
+        }];
+        [sheet addAction:action];
+    }
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    if (popover && sourceView) {
+        popover.sourceView = sourceView;
+        popover.sourceRect = sourceView.bounds;
+    }
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+#pragma mark - Table view data source
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return PictureInPictureSectionCount;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    switch (section) {
+        case PictureInPictureSectionMiniplayer: return (NSInteger)[self miniplayerRows].count;
+        case PictureInPictureSectionControls:   return (NSInteger)[self controlsRows].count;
+        case PictureInPictureSectionAutoPiP:    return 1;
+        case PictureInPictureSectionShared:     return PictureInPictureSharedRowCount;
+        default:                                return 0;
+    }
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
+    switch (section) {
+        case PictureInPictureSectionMiniplayer: return @"In-App PiP";
+        case PictureInPictureSectionControls:   return @"In-App PiP Controls";
+        case PictureInPictureSectionAutoPiP:    return @"System PiP";
+        case PictureInPictureSectionShared:     return @"Global Options";
+        default:                                return nil;
+    }
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
+    switch (section) {
+        case PictureInPictureSectionAutoPiP:
+            return @"This doesn't apply to fullscreen videos, which Apollo already supports. "
+                   @"In feeds, only unmuted videos can trigger it.";
+        default:
+            return nil;
+    }
+}
+
+// Shared (Global Options) rows stay live while either capability is on.
+- (BOOL)anyPiPEnabled {
+    return sPiPEnabled || sPiPNativeEnabled;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == PictureInPictureSectionMiniplayer) {
+        switch ([self miniplayerRowAtIndex:indexPath.row]) {
+            case PictureInPictureMiniplayerRowToggle:
+                return [self switchCellLabel:@"Enable In-App PiP"
+                                 description:@"Video playback continues in miniplayer as you scroll through comments."
+                                          on:sPiPEnabled
+                                     enabled:YES
+                                      action:@selector(miniPlayerChanged:)];
+            case PictureInPictureMiniplayerRowStartPosition:
+                return [self valueCellLabel:@"Default Position"
+                                     detail:[self startPositionText]
+                                    enabled:sPiPEnabled];
+            case PictureInPictureMiniplayerRowStartHidden:
+                // Only present for fixed corners (Last Position remembers its
+                // own hidden state), so no Last-Position greying needed here.
+                return [self switchCellLabel:@"Hidden by Default"
+                                 description:@"Miniplayer starts in hidden state against edge of screen."
+                                          on:sPiPStartHidden
+                                     enabled:sPiPEnabled
+                                      action:@selector(startHiddenChanged:)];
+        }
+    }
+    if (indexPath.section == PictureInPictureSectionControls) {
+        switch ([self controlsRowAtIndex:indexPath.row]) {
+            case PictureInPictureControlsRowSkipButtons:
+                return [self switchCellLabel:@"Show Skip Buttons"
+                                          on:sPiPSkipButtons
+                                     enabled:sPiPEnabled
+                                      action:@selector(skipButtonsChanged:)];
+            case PictureInPictureControlsRowSkipSeconds:
+                return [self valueCellLabel:@"Skip Amount"
+                                     detail:[self skipSecondsText]
+                                    enabled:sPiPEnabled];
+            case PictureInPictureControlsRowProgressBar:
+                return [self switchCellLabel:@"Show Progress Bar"
+                                          on:sPiPProgressBar
+                                     enabled:sPiPEnabled
+                                      action:@selector(progressBarChanged:)];
+        }
+    }
+    if (indexPath.section == PictureInPictureSectionAutoPiP) {
+        // Mirrors Apple's own toggle wording for this behavior
+        // (Settings > General > Picture in Picture: "Start PiP Automatically").
+        return [self switchCellLabel:@"Enable PiP When Leaving App"
+                         description:@"Video playback continues in system PiP window when leaving Apollo."
+                                  on:sPiPNativeEnabled
+                             enabled:YES
+                              action:@selector(nativeChanged:)];
+    }
+    if (indexPath.section == PictureInPictureSectionShared) {
+        if (indexPath.row == PictureInPictureSharedRowActivation) {
+            return [self valueCellLabel:@"Activate For"
+                                 detail:[self activationModeText]
+                                enabled:[self anyPiPEnabled]];
+        }
+        return [self switchCellLabel:@"Loop Videos"
+                                  on:sPiPLoop
+                             enabled:[self anyPiPEnabled]
+                              action:@selector(loopChanged:)];
+    }
+    return [[UITableViewCell alloc] init];
+}
+
+#pragma mark - Table view delegate
+
+- (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == PictureInPictureSectionMiniplayer) {
+        return [self miniplayerRowAtIndex:indexPath.row] == PictureInPictureMiniplayerRowStartPosition && sPiPEnabled;
+    }
+    if (indexPath.section == PictureInPictureSectionControls) {
+        return [self controlsRowAtIndex:indexPath.row] == PictureInPictureControlsRowSkipSeconds && sPiPEnabled;
+    }
+    if (indexPath.section == PictureInPictureSectionShared) {
+        return indexPath.row == PictureInPictureSharedRowActivation && [self anyPiPEnabled];
+    }
+    return NO;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+    if (indexPath.section == PictureInPictureSectionMiniplayer
+        && [self miniplayerRowAtIndex:indexPath.row] == PictureInPictureMiniplayerRowStartPosition && sPiPEnabled) {
+        [self presentStartPositionSheetFromSourceView:cell];
+    } else if (indexPath.section == PictureInPictureSectionControls
+               && [self controlsRowAtIndex:indexPath.row] == PictureInPictureControlsRowSkipSeconds
+               && sPiPEnabled) {
+        [self presentSkipSecondsSheetFromSourceView:cell];
+    } else if (indexPath.section == PictureInPictureSectionShared
+               && indexPath.row == PictureInPictureSharedRowActivation && [self anyPiPEnabled]) {
+        [self presentActivationModeSheetFromSourceView:cell];
+    }
+}
+
+#pragma mark - Actions
+
+- (void)miniPlayerChanged:(UISwitch *)sw {
+    sPiPEnabled = sw.on;
+    [[NSUserDefaults standardUserDefaults] setBool:sw.on forKey:UDKeyPictureInPictureEnabled];
+    [self postChange];
+    // Refresh dependent enabled-states: the other rows of this section that
+    // currently exist (reloading the toggle row itself would interrupt the
+    // switch animation), the Window Controls section, and the Shared section.
+    NSMutableArray<NSIndexPath *> *paths = [NSMutableArray array];
+    NSInteger rowCount = (NSInteger)[self miniplayerRows].count;
+    for (NSInteger row = 1; row < rowCount; row++) {
+        [paths addObject:[NSIndexPath indexPathForRow:row inSection:PictureInPictureSectionMiniplayer]];
+    }
+    [self.tableView reloadRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationNone];
+    NSMutableIndexSet *sections = [NSMutableIndexSet indexSetWithIndex:PictureInPictureSectionControls];
+    [sections addIndex:PictureInPictureSectionShared];
+    [self.tableView reloadSections:sections withRowAnimation:UITableViewRowAnimationNone];
+}
+
+- (void)startHiddenChanged:(UISwitch *)sw {
+    sPiPStartHidden = sw.on;
+    [[NSUserDefaults standardUserDefaults] setBool:sw.on forKey:UDKeyPictureInPictureStartHidden];
+    [self postChange];
+}
+
+- (void)skipButtonsChanged:(UISwitch *)sw {
+    BOOL wasOn = sPiPSkipButtons;
+    sPiPSkipButtons = sw.on;
+    [[NSUserDefaults standardUserDefaults] setBool:sw.on forKey:UDKeyPictureInPictureSkipButtons];
+    [self postChange];
+    if (wasOn == sw.on) return;
+    // Skip Amount is hidden (not greyed) while Show Skip Buttons is off —
+    // insert/remove its row. Its display index is constant (the only row
+    // above it is always present), so the same path works for both directions.
+    NSIndexPath *path = [NSIndexPath indexPathForRow:PictureInPictureControlsRowSkipSeconds
+                                           inSection:PictureInPictureSectionControls];
+    if (sw.on) {
+        [self.tableView insertRowsAtIndexPaths:@[path] withRowAnimation:UITableViewRowAnimationFade];
+    } else {
+        [self.tableView deleteRowsAtIndexPaths:@[path] withRowAnimation:UITableViewRowAnimationFade];
+    }
+}
+
+- (void)progressBarChanged:(UISwitch *)sw {
+    sPiPProgressBar = sw.on;
+    [[NSUserDefaults standardUserDefaults] setBool:sw.on forKey:UDKeyPictureInPictureProgressBar];
+    [self postChange];
+}
+
+- (void)setSkipSeconds:(NSInteger)seconds {
+    sPiPSkipSeconds = seconds;
+    [[NSUserDefaults standardUserDefaults] setInteger:seconds forKey:UDKeyPictureInPictureSkipSeconds];
+    [self postChange];
+    NSIndexPath *indexPath = [self indexPathForControlsRow:PictureInPictureControlsRowSkipSeconds];
+    if (indexPath && [[self.tableView indexPathsForVisibleRows] containsObject:indexPath]) {
+        [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
+    }
+}
+
+- (void)nativeChanged:(UISwitch *)sw {
+    sPiPNativeEnabled = sw.on;
+    [[NSUserDefaults standardUserDefaults] setBool:sw.on forKey:UDKeyPictureInPictureNative];
+    [self postChange];
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:PictureInPictureSectionShared]
+                  withRowAnimation:UITableViewRowAnimationNone];
+}
+
+- (void)loopChanged:(UISwitch *)sw {
+    sPiPLoop = sw.on;
+    [[NSUserDefaults standardUserDefaults] setBool:sw.on forKey:UDKeyPictureInPictureLoop];
+    [self postChange];
+}
+
+- (void)setActivationMode:(NSInteger)mode {
+    sPiPActivationMode = mode;
+    [[NSUserDefaults standardUserDefaults] setInteger:mode forKey:UDKeyPictureInPictureActivation];
+    [self postChange];
+    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:PictureInPictureSharedRowActivation
+                                                inSection:PictureInPictureSectionShared];
+    if ([[self.tableView indexPathsForVisibleRows] containsObject:indexPath]) {
+        [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
+    }
+}
+
+- (void)setStartPosition:(NSInteger)position {
+    BOOL hadHiddenRow = (sPiPStartPosition != ApolloPiPStartPositionLastPosition);
+    sPiPStartPosition = position;
+    [[NSUserDefaults standardUserDefaults] setInteger:position forKey:UDKeyPictureInPictureStartPosition];
+    [self postChange];
+
+    // Hidden by Default exists only for fixed corners — insert/remove its row
+    // when crossing the Last Position boundary, and refresh the Default
+    // Position detail. Both go in one performBatchUpdates: a standalone reload
+    // run after the row count has already changed trips UIKit's invalid-batch
+    // assertion. Hidden by Default's display index is constant (Toggle and
+    // Default Position always precede it), so the path is fixed.
+    BOOL hasHiddenRow = (position != ApolloPiPStartPositionLastPosition);
+    NSIndexPath *positionPath = [NSIndexPath indexPathForRow:PictureInPictureMiniplayerRowStartPosition
+                                                  inSection:PictureInPictureSectionMiniplayer];
+    NSIndexPath *hiddenPath = [NSIndexPath indexPathForRow:PictureInPictureMiniplayerRowStartHidden
+                                                 inSection:PictureInPictureSectionMiniplayer];
+    [self.tableView performBatchUpdates:^{
+        if (hadHiddenRow && !hasHiddenRow) {
+            [self.tableView deleteRowsAtIndexPaths:@[hiddenPath] withRowAnimation:UITableViewRowAnimationFade];
+        } else if (!hadHiddenRow && hasHiddenRow) {
+            [self.tableView insertRowsAtIndexPaths:@[hiddenPath] withRowAnimation:UITableViewRowAnimationFade];
+        }
+        [self.tableView reloadRowsAtIndexPaths:@[positionPath] withRowAnimation:UITableViewRowAnimationNone];
+    } completion:nil];
+}
+
+@end

--- a/src/PictureInPictureViewController.m
+++ b/src/PictureInPictureViewController.m
@@ -101,8 +101,9 @@ typedef NS_ENUM(NSInteger, PictureInPictureSharedRow) {
 
 - (NSString *)activationModeText {
     switch (sPiPActivationMode) {
-        case ApolloPiPActivationModeUnmutedOnly: return @"Unmuted Videos Only";
-        default:                                 return @"All Videos";
+        case ApolloPiPActivationModeUnmutedOnly:    return @"Unmuted Videos Only";
+        case ApolloPiPActivationModeAllVideosAndGifs: return @"All Videos & GIFs";
+        default:                                    return @"All Videos";
     }
 }
 
@@ -185,19 +186,26 @@ static void PiPSetSheetActionIcon(UIAlertAction *action, NSArray<NSString *> *sy
                                                                    message:nil
                                                             preferredStyle:UIAlertControllerStyleActionSheet];
 
-    NSString *allTitle = (sPiPActivationMode == ApolloPiPActivationModeAllVideos)
-        ? @"All Videos (Current)" : @"All Videos";
+    // Increasing inclusiveness: unmuted videos → all videos → all videos + GIFs.
     NSString *unmutedTitle = (sPiPActivationMode == ApolloPiPActivationModeUnmutedOnly)
         ? @"Unmuted Videos Only (Current)" : @"Unmuted Videos Only";
+    NSString *allTitle = (sPiPActivationMode == ApolloPiPActivationModeAllVideos)
+        ? @"All Videos (Current)" : @"All Videos";
+    NSString *gifsTitle = (sPiPActivationMode == ApolloPiPActivationModeAllVideosAndGifs)
+        ? @"All Videos & GIFs (Current)" : @"All Videos & GIFs";
 
     __weak __typeof(self) weakSelf = self;
+    [sheet addAction:[UIAlertAction actionWithTitle:unmutedTitle style:UIAlertActionStyleDefault
+                                            handler:^(__unused UIAlertAction *action) {
+        [weakSelf setActivationMode:ApolloPiPActivationModeUnmutedOnly];
+    }]];
     [sheet addAction:[UIAlertAction actionWithTitle:allTitle style:UIAlertActionStyleDefault
                                             handler:^(__unused UIAlertAction *action) {
         [weakSelf setActivationMode:ApolloPiPActivationModeAllVideos];
     }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:unmutedTitle style:UIAlertActionStyleDefault
+    [sheet addAction:[UIAlertAction actionWithTitle:gifsTitle style:UIAlertActionStyleDefault
                                             handler:^(__unused UIAlertAction *action) {
-        [weakSelf setActivationMode:ApolloPiPActivationModeUnmutedOnly];
+        [weakSelf setActivationMode:ApolloPiPActivationModeAllVideosAndGifs];
     }]];
     [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
 

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1295,6 +1295,15 @@ static void initializeRandomSources() {
                                     UDKeyLibreTranslateURL: @"https://libretranslate.de/translate",
                                     UDKeyLibreTranslateAPIKey: @"",
                                     UDKeyTranslationSkipLanguages: @[],
+                                    UDKeyPictureInPictureEnabled: @NO,
+                                    UDKeyPictureInPictureActivation: @(ApolloPiPActivationModeUnmutedOnly),
+                                    UDKeyPictureInPictureStartPosition: @(ApolloPiPStartPositionTopRight),
+                                    UDKeyPictureInPictureNative: @NO,
+                                    UDKeyPictureInPictureLoop: @YES,
+                                    UDKeyPictureInPictureStartHidden: @NO,
+                                    UDKeyPictureInPictureSkipButtons: @NO,
+                                    UDKeyPictureInPictureSkipSeconds: @10,
+                                    UDKeyPictureInPictureProgressBar: @NO,
                                     UDKeyTagFilterEnabled: @NO,
                                     UDKeyTagFilterMode: @"blur",
                                     UDKeyTagFilterNSFW: @YES,
@@ -1432,6 +1441,28 @@ static void initializeRandomSources() {
                                                   usingBlock:^(NSNotification *note) {
         [ApolloWebSessionLoginViewController presentExpiredSessionPrompt];
     }];
+    // Picture-in-Picture hydration.
+    sPiPEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyPictureInPictureEnabled];
+    sPiPActivationMode = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyPictureInPictureActivation];
+    if (sPiPActivationMode < ApolloPiPActivationModeAllVideos || sPiPActivationMode > ApolloPiPActivationModeUnmutedOnly) {
+        sPiPActivationMode = ApolloPiPActivationModeAllVideos;
+        [standardDefaults setInteger:sPiPActivationMode forKey:UDKeyPictureInPictureActivation];
+    }
+    sPiPStartPosition = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyPictureInPictureStartPosition];
+    if (sPiPStartPosition < ApolloPiPStartPositionTopLeft || sPiPStartPosition > ApolloPiPStartPositionLastPosition) {
+        sPiPStartPosition = ApolloPiPStartPositionTopRight;
+        [standardDefaults setInteger:sPiPStartPosition forKey:UDKeyPictureInPictureStartPosition];
+    }
+    sPiPNativeEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyPictureInPictureNative];
+    sPiPLoop = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyPictureInPictureLoop];
+    sPiPStartHidden = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyPictureInPictureStartHidden];
+    sPiPSkipButtons = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyPictureInPictureSkipButtons];
+    sPiPSkipSeconds = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyPictureInPictureSkipSeconds];
+    if (sPiPSkipSeconds != 5 && sPiPSkipSeconds != 10 && sPiPSkipSeconds != 15 && sPiPSkipSeconds != 30) {
+        sPiPSkipSeconds = 10;
+        [standardDefaults setInteger:sPiPSkipSeconds forKey:UDKeyPictureInPictureSkipSeconds];
+    }
+    sPiPProgressBar = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyPictureInPictureProgressBar];
 
     // Tag filter feature hydration.
     sTagFilterEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyTagFilterEnabled];

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1444,8 +1444,8 @@ static void initializeRandomSources() {
     // Picture-in-Picture hydration.
     sPiPEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyPictureInPictureEnabled];
     sPiPActivationMode = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyPictureInPictureActivation];
-    if (sPiPActivationMode < ApolloPiPActivationModeAllVideos || sPiPActivationMode > ApolloPiPActivationModeUnmutedOnly) {
-        sPiPActivationMode = ApolloPiPActivationModeAllVideos;
+    if (sPiPActivationMode < ApolloPiPActivationModeAllVideos || sPiPActivationMode > ApolloPiPActivationModeAllVideosAndGifs) {
+        sPiPActivationMode = ApolloPiPActivationModeUnmutedOnly; // matches the registered default
         [standardDefaults setInteger:sPiPActivationMode forKey:UDKeyPictureInPictureActivation];
     }
     sPiPStartPosition = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyPictureInPictureStartPosition];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -78,7 +78,7 @@ static NSString *const UDKeyTranslationSkipLanguages = @"TranslationSkipLanguage
 
 // Picture-in-Picture: floating in-app mini-player for comments-page videos.
 static NSString *const UDKeyPictureInPictureEnabled = @"PictureInPictureEnabled";       // master switch
-// 0 = All Videos, 1 = Unmuted Videos Only (ApolloPiPActivationMode).
+// 0 = All Videos, 1 = Unmuted Videos Only, 2 = All Videos & GIFs (ApolloPiPActivationMode).
 static NSString *const UDKeyPictureInPictureActivation = @"PictureInPictureActivation";
 // Hand off to iOS' system Picture in Picture when the app backgrounds.
 static NSString *const UDKeyPictureInPictureNative = @"PictureInPictureNative";

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -76,6 +76,38 @@ static NSString *const UDKeyLibreTranslateAPIKey = @"LibreTranslateAPIKey";
 // Array<String> of 2-letter language codes to leave untranslated (detected source language).
 static NSString *const UDKeyTranslationSkipLanguages = @"TranslationSkipLanguages";
 
+// Picture-in-Picture: floating in-app mini-player for comments-page videos.
+static NSString *const UDKeyPictureInPictureEnabled = @"PictureInPictureEnabled";       // master switch
+// 0 = All Videos, 1 = Unmuted Videos Only (ApolloPiPActivationMode).
+static NSString *const UDKeyPictureInPictureActivation = @"PictureInPictureActivation";
+// Hand off to iOS' system Picture in Picture when the app backgrounds.
+static NSString *const UDKeyPictureInPictureNative = @"PictureInPictureNative";
+// Replay videos in the PiP window when they reach the end. Default YES.
+static NSString *const UDKeyPictureInPictureLoop = @"PictureInPictureLoop";
+// Open the miniplayer tucked off the edge (hidden) for corner Starting
+// Positions. Ignored for Last Position, which remembers hidden state itself.
+static NSString *const UDKeyPictureInPictureStartHidden = @"PictureInPictureStartHidden";
+// Optional overlay extras on the floating window. Skip buttons jump back or
+// ahead by SkipSeconds (5/10/15/30, default 10); the progress bar is a
+// read-only playback position strip. Both default NO.
+static NSString *const UDKeyPictureInPictureSkipButtons = @"PictureInPictureSkipButtons";
+static NSString *const UDKeyPictureInPictureSkipSeconds = @"PictureInPictureSkipSeconds";
+static NSString *const UDKeyPictureInPictureProgressBar = @"PictureInPictureProgressBar";
+// 0–3 = fixed corner (TL/TR/BL/BR), 4 = remember last position (ApolloPiPStartPosition).
+static NSString *const UDKeyPictureInPictureStartPosition = @"PictureInPictureStartPosition";
+// Internal (no settings UI): persisted floating-card geometry. The resting
+// position is a normalized center (fraction of window bounds) so it survives
+// rotation and differing video aspect ratios. The size is stored as an AREA
+// fraction (card area / screenWidth²) rather than a width fraction, so a
+// remembered footprint applied to a differently-shaped next video stays the
+// same size on screen instead of ballooning (portrait) — only Last Position
+// reuses it; fixed corners always spawn at the calibrated default.
+static NSString *const UDKeyPictureInPictureAreaFraction = @"PictureInPictureAreaFraction";
+static NSString *const UDKeyPictureInPictureLastCenterX = @"PictureInPictureLastCenterX";
+static NSString *const UDKeyPictureInPictureLastCenterY = @"PictureInPictureLastCenterY";
+// Whether the card was hidden (tucked off an edge) at rest: 0 = no, -1/+1 = left/right edge.
+static NSString *const UDKeyPictureInPictureLastStashSide = @"PictureInPictureLastStashSide";
+
 // Tag filters (NSFW / Spoiler) — hide or blur posts in the feed based on
 // Reddit's built-in tags. Brand Affiliate is intentionally absent because
 // Apollo's RDKLink does not deserialize that field.


### PR DESCRIPTION
Adds an in-app Picture-in-Picture (PiP) miniplayer for videos as you scroll through the comments. Drag the floating window to reposition it, swipe it to the side to hide it, or double-tap to resize. Optional handoff to the iOS system PiP when leaving the app so the video playback continues over other apps.

https://github.com/user-attachments/assets/d441ce48-4032-47e0-ac0f-54b8ade90914

### Highlights

- **Floating miniplayer** with free-form docking and stashing.
- **System PiP handoff** when backgrounding the app, armed on the inline player while an eligible video plays.
- **Eligible content**: v.redd.it videos, audio-bearing external videos (e.g. Streamable), and — optionally — GIFs (which always loop).
- **Overlay controls**: mute and close, with optional rewind/forward skip buttons (5/10/15/30s) and a read-only progress bar.

### Settings

A dedicated Picture-in-Picture settings page enables the in-app miniplayer and system PiP independently, chooses the activation scope (unmuted videos only, all videos, or all videos & GIFs), toggles looping, picks a default position (a fixed corner or the last position used), and can start the miniplayer hidden against an edge.

### Screenshots

| In-app PiP | System PiP | Settings |
| --- | --- | --- |
| <img width="400" alt="IMG_3716" src="https://github.com/user-attachments/assets/b3a5b53d-5b4d-475f-b708-563e4f2660e9" /> | <img width="400" alt="IMG_3717" src="https://github.com/user-attachments/assets/aab0dbff-1477-439b-8562-c1b7a9d8fab5" /> | <img width="400" alt="IMG_3712" src="https://github.com/user-attachments/assets/31e179c2-d544-4cf3-a2fc-a19a94fe4135" />  |
