### PR TITLE
Improve user flair selector: old/emoji flair systems, custom-emoji picker, and clearer empty states

### DIFF
--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -1,4 +1,5 @@
 #import "ApolloCommon.h"
+#import "ApolloState.h"
 #import <objc/message.h>
 #import <objc/runtime.h>
 
@@ -49,29 +50,6 @@ static __thread __unsafe_unretained id tApolloUserFlairCustomRowOption = nil;
 @property (nonatomic, copy) NSString *templateID;
 @property (nonatomic, copy) NSString *initialText;
 + (instancetype)sessionWithSelectorAdapter:(ApolloUserFlairSelectorAdapter *)selectorAdapter optionAdapter:(ApolloUserFlairOptionAdapter *)optionAdapter subredditName:(NSString *)subredditName templateID:(NSString *)templateID initialText:(NSString *)initialText;
-@end
-
-@interface ApolloUserFlairTextFieldObserver : NSObject
-@property (nonatomic, weak) UIAlertController *alert;
-@property (nonatomic, weak) UIAlertAction *saveAction;
-@end
-
-@implementation ApolloUserFlairTextFieldObserver
-
-- (void)textFieldChanged:(UITextField *)textField {
-    NSString *text = textField.text ?: @"";
-    if (text.length > kApolloUserFlairMaxLength) {
-        text = [text substringToIndex:kApolloUserFlairMaxLength];
-        textField.text = text;
-    }
-
-    self.alert.message = [NSString stringWithFormat:@"Preview: %@\n\n%lu/%lu characters",
-        text.length > 0 ? text : @"(empty)",
-        (unsigned long)text.length,
-        (unsigned long)kApolloUserFlairMaxLength];
-    self.saveAction.enabled = text.length <= kApolloUserFlairMaxLength;
-}
-
 @end
 
 #pragma mark - Runtime Access
@@ -566,72 +544,465 @@ static BOOL ApolloUserFlairCommitEditedSession(ApolloUserFlairEditSession *sessi
     return [session.selectorAdapter performNativeUpdate];
 }
 
+#pragma mark - Subreddit Emoji Picker
+
+// Reddit caps user flair at 64 text characters and 10 emojis. An emoji is inserted
+// into the flair text as a :name: token, which Reddit renders back as the image.
+static const NSUInteger kApolloUserFlairMaxEmojis = 10;
+
+static NSRegularExpression *ApolloUserFlairEmojiTokenRegex(void) {
+    static NSRegularExpression *regex = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        regex = [NSRegularExpression regularExpressionWithPattern:@":[A-Za-z0-9_+\\-]+:" options:0 error:NULL];
+    });
+    return regex;
+}
+
+// Cache of the user-flair-allowed emoji list per subreddit (lowercased key).
+// Each item: @{ @"name": <token without colons>, @"url": <png url> }.
+static NSMutableDictionary<NSString *, NSArray *> *ApolloUserFlairEmojiListCache(void) {
+    static NSMutableDictionary *cache = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ cache = [NSMutableDictionary dictionary]; });
+    return cache;
+}
+
+static void ApolloUserFlairFetchEmojis(NSString *subreddit, void (^completion)(NSArray *emojis)) {
+    NSString *key = subreddit.lowercaseString;
+    if (key.length == 0) { if (completion) completion(@[]); return; }
+    NSArray *cached;
+    @synchronized (ApolloUserFlairEmojiListCache()) { cached = ApolloUserFlairEmojiListCache()[key]; }
+    if (cached) { if (completion) completion(cached); return; }
+
+    NSString *token = [sLatestRedditBearerToken copy];
+    NSString *enc = [subreddit stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]] ?: subreddit;
+    NSString *urlStr = token.length
+        ? [NSString stringWithFormat:@"https://oauth.reddit.com/api/v1/%@/emojis/all?raw_json=1", enc]
+        : [NSString stringWithFormat:@"https://www.reddit.com/api/v1/%@/emojis/all.json?raw_json=1", enc];
+    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlStr]];
+    if (token.length) [req setValue:[@"Bearer " stringByAppendingString:token] forHTTPHeaderField:@"Authorization"];
+    [req setValue:@"Apollo iOS" forHTTPHeaderField:@"User-Agent"];
+    req.timeoutInterval = 20;
+    [[[NSURLSession sharedSession] dataTaskWithRequest:req completionHandler:^(NSData *data, NSURLResponse *resp, NSError *error) {
+        NSMutableArray *emojis = [NSMutableArray array];
+        id json = data ? [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL] : nil;
+        if ([json isKindOfClass:[NSDictionary class]]) {
+            for (NSString *group in (NSDictionary *)json) {
+                id g = ((NSDictionary *)json)[group];
+                if (![g isKindOfClass:[NSDictionary class]]) continue;
+                for (NSString *name in (NSDictionary *)g) {
+                    id meta = ((NSDictionary *)g)[name];
+                    if (![meta isKindOfClass:[NSDictionary class]]) continue;
+                    if (![meta[@"user_flair_allowed"] boolValue]) continue;
+                    NSString *url = meta[@"url"];
+                    if (![url isKindOfClass:[NSString class]] || url.length == 0) continue;
+                    [emojis addObject:@{ @"name": name, @"url": url }];
+                }
+            }
+        }
+        [emojis sortUsingComparator:^NSComparisonResult(NSDictionary *a, NSDictionary *b) {
+            return [a[@"name"] caseInsensitiveCompare:b[@"name"]];
+        }];
+        ApolloLog(@"[UserFlair] fetched %lu user-flair emoji for r/%@", (unsigned long)emojis.count, subreddit);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            @synchronized (ApolloUserFlairEmojiListCache()) { ApolloUserFlairEmojiListCache()[key] = emojis; }
+            if (completion) completion(emojis);
+        });
+    }] resume];
+}
+
+static NSCache<NSString *, UIImage *> *ApolloUserFlairEmojiImageCache(void) {
+    static NSCache *cache = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ cache = [NSCache new]; cache.countLimit = 800; });
+    return cache;
+}
+
+static void ApolloUserFlairLoadEmojiImage(NSString *urlStr, void (^completion)(UIImage *image)) {
+    if (urlStr.length == 0) { if (completion) completion(nil); return; }
+    UIImage *cached = [ApolloUserFlairEmojiImageCache() objectForKey:urlStr];
+    if (cached) { if (completion) completion(cached); return; }
+    NSURL *url = [NSURL URLWithString:urlStr];
+    if (!url) { if (completion) completion(nil); return; }
+    [[[NSURLSession sharedSession] dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *resp, NSError *error) {
+        UIImage *image = data ? [UIImage imageWithData:data scale:UIScreen.mainScreen.scale] : nil;
+        if (image) [ApolloUserFlairEmojiImageCache() setObject:image forKey:urlStr];
+        dispatch_async(dispatch_get_main_queue(), ^{ if (completion) completion(image); });
+    }] resume];
+}
+
+#pragma mark Emoji grid cell
+
+@interface ApolloUserFlairEmojiCell : UICollectionViewCell
+@property (nonatomic, strong) UIImageView *imageView;
+@property (nonatomic, copy) NSString *urlKey;
+@end
+
+@implementation ApolloUserFlairEmojiCell
+- (instancetype)initWithFrame:(CGRect)frame {
+    if ((self = [super initWithFrame:frame])) {
+        _imageView = [[UIImageView alloc] initWithFrame:CGRectInset(self.contentView.bounds, 4, 4)];
+        _imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        _imageView.contentMode = UIViewContentModeScaleAspectFit;
+        [self.contentView addSubview:_imageView];
+    }
+    return self;
+}
+- (void)prepareForReuse {
+    [super prepareForReuse];
+    self.imageView.image = nil;
+    self.urlKey = nil;
+}
+@end
+
+#pragma mark Flair editor view controller
+
+@interface ApolloUserFlairEditorViewController : UIViewController <UICollectionViewDataSource, UICollectionViewDelegateFlowLayout, UISearchBarDelegate, UITextFieldDelegate>
+@property (nonatomic, strong) ApolloUserFlairEditSession *session;
+@property (nonatomic, copy) NSString *subreddit;
+@property (nonatomic, strong) NSArray *allEmojis;       // [{name,url}]
+@property (nonatomic, strong) NSArray *filteredEmojis;
+@property (nonatomic, strong) NSDictionary *emojiURLByName;
+@property (nonatomic, strong) UITextField *textField;
+@property (nonatomic, strong) UILabel *previewLabel;
+@property (nonatomic, strong) UILabel *counterLabel;
+@property (nonatomic, strong) UISearchBar *searchBar;
+@property (nonatomic, strong) UICollectionView *collectionView;
+@property (nonatomic, strong) UIActivityIndicatorView *spinner;
+@property (nonatomic, strong) UIBarButtonItem *saveItem;
+@property (nonatomic, assign) BOOL didFinish;
+@end
+
+@implementation ApolloUserFlairEditorViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Set Flair";
+    self.view.backgroundColor = [UIColor systemBackgroundColor];
+
+    self.navigationItem.leftBarButtonItem =
+        [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelTapped)];
+    self.saveItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemSave target:self action:@selector(saveTapped)];
+    self.navigationItem.rightBarButtonItem = self.saveItem;
+
+    // Preview (rendered flair with inline emoji)
+    UILabel *previewTitle = [UILabel new];
+    previewTitle.text = @"Preview";
+    previewTitle.font = [UIFont preferredFontForTextStyle:UIFontTextStyleFootnote];
+    previewTitle.textColor = [UIColor secondaryLabelColor];
+
+    self.previewLabel = [UILabel new];
+    self.previewLabel.numberOfLines = 2;
+    self.previewLabel.font = [UIFont systemFontOfSize:15];
+    self.previewLabel.textColor = [UIColor labelColor];
+
+    // Text field
+    self.textField = [UITextField new];
+    self.textField.placeholder = @"Flair text";
+    self.textField.borderStyle = UITextBorderStyleRoundedRect;
+    self.textField.clearButtonMode = UITextFieldViewModeWhileEditing;
+    self.textField.autocorrectionType = UITextAutocorrectionTypeDefault;
+    self.textField.returnKeyType = UIReturnKeyDone;
+    self.textField.delegate = self;
+    NSString *initial = self.session.initialText ?: @"";
+    self.textField.text = initial;
+    [self.textField addTarget:self action:@selector(textChanged) forControlEvents:UIControlEventEditingChanged];
+
+    self.counterLabel = [UILabel new];
+    self.counterLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleFootnote];
+    self.counterLabel.textColor = [UIColor secondaryLabelColor];
+    self.counterLabel.textAlignment = NSTextAlignmentRight;
+
+    // Search bar (filter emoji)
+    self.searchBar = [UISearchBar new];
+    self.searchBar.placeholder = @"Search emoji";
+    self.searchBar.delegate = self;
+    self.searchBar.searchBarStyle = UISearchBarStyleMinimal;
+    self.searchBar.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    self.searchBar.hidden = YES; // shown once emoji arrive
+
+    // Emoji grid
+    UICollectionViewFlowLayout *layout = [UICollectionViewFlowLayout new];
+    layout.itemSize = CGSizeMake(44, 44);
+    layout.minimumInteritemSpacing = 6;
+    layout.minimumLineSpacing = 6;
+    layout.sectionInset = UIEdgeInsetsMake(4, 12, 12, 12);
+    self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
+    self.collectionView.backgroundColor = [UIColor clearColor];
+    self.collectionView.dataSource = self;
+    self.collectionView.delegate = self;
+    self.collectionView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
+    self.collectionView.alwaysBounceVertical = YES;
+    [self.collectionView registerClass:[ApolloUserFlairEmojiCell class] forCellWithReuseIdentifier:@"emoji"];
+
+    self.spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+    self.spinner.hidesWhenStopped = YES;
+
+    UIStackView *top = [[UIStackView alloc] initWithArrangedSubviews:@[previewTitle, self.previewLabel, self.textField, self.counterLabel, self.searchBar]];
+    top.axis = UILayoutConstraintAxisVertical;
+    top.spacing = 6;
+    [top setCustomSpacing:2 afterView:previewTitle];
+    [top setCustomSpacing:14 afterView:self.previewLabel];
+    [top setCustomSpacing:2 afterView:self.textField];
+
+    top.translatesAutoresizingMaskIntoConstraints = NO;
+    self.collectionView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.spinner.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:top];
+    [self.view addSubview:self.collectionView];
+    [self.view addSubview:self.spinner];
+
+    UILayoutGuide *safe = self.view.safeAreaLayoutGuide;
+    [NSLayoutConstraint activateConstraints:@[
+        [top.topAnchor constraintEqualToAnchor:safe.topAnchor constant:12],
+        [top.leadingAnchor constraintEqualToAnchor:safe.leadingAnchor constant:16],
+        [top.trailingAnchor constraintEqualToAnchor:safe.trailingAnchor constant:-16],
+        [self.collectionView.topAnchor constraintEqualToAnchor:top.bottomAnchor constant:4],
+        [self.collectionView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [self.collectionView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [self.collectionView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+        [self.spinner.centerXAnchor constraintEqualToAnchor:self.collectionView.centerXAnchor],
+        [self.spinner.topAnchor constraintEqualToAnchor:self.collectionView.topAnchor constant:24],
+    ]];
+
+    [self updateCounterAndPreview];
+    [self loadEmojis];
+}
+
+- (void)loadEmojis {
+    [self.spinner startAnimating];
+    __weak typeof(self) weakSelf = self;
+    ApolloUserFlairFetchEmojis(self.subreddit, ^(NSArray *emojis) {
+        typeof(self) self = weakSelf;
+        if (!self) return;
+        [self.spinner stopAnimating];
+        self.allEmojis = emojis;
+        self.filteredEmojis = emojis;
+        NSMutableDictionary *map = [NSMutableDictionary dictionary];
+        for (NSDictionary *e in emojis) map[e[@"name"]] = e[@"url"];
+        self.emojiURLByName = map;
+        self.searchBar.hidden = (emojis.count <= 24);
+        [self.collectionView reloadData];
+        [self updateCounterAndPreview]; // preview can now resolve tokens to images
+    });
+}
+
+#pragma mark counter + preview
+
+// Counts recognised :emoji: tokens, and reports the length of the remaining text
+// (characters not part of a recognised token). Unknown :x: tokens count as text.
+- (NSUInteger)emojiCountInText:(NSString *)text textLength:(NSUInteger *)outTextLen {
+    NSUInteger emojiCount = 0;
+    NSMutableIndexSet *emojiChars = [NSMutableIndexSet indexSet];
+    NSArray *matches = [ApolloUserFlairEmojiTokenRegex() matchesInString:text options:0 range:NSMakeRange(0, text.length)];
+    for (NSTextCheckingResult *m in matches) {
+        NSString *tok = [text substringWithRange:m.range];
+        NSString *name = [tok substringWithRange:NSMakeRange(1, tok.length - 2)];
+        if (self.emojiURLByName[name]) {
+            emojiCount++;
+            [emojiChars addIndexesInRange:m.range];
+        }
+    }
+    if (outTextLen) *outTextLen = text.length - emojiChars.count;
+    return emojiCount;
+}
+
+- (void)updateCounterAndPreview {
+    NSString *text = self.textField.text ?: @"";
+    NSUInteger textLen = 0;
+    NSUInteger emojiCount = [self emojiCountInText:text textLength:&textLen];
+    BOOL overText = textLen > kApolloUserFlairMaxLength;
+    BOOL overEmoji = emojiCount > kApolloUserFlairMaxEmojis;
+    self.counterLabel.text = [NSString stringWithFormat:@"%lu/%lu chars · %lu/%lu emoji",
+        (unsigned long)textLen, (unsigned long)kApolloUserFlairMaxLength,
+        (unsigned long)emojiCount, (unsigned long)kApolloUserFlairMaxEmojis];
+    self.counterLabel.textColor = (overText || overEmoji) ? [UIColor systemRedColor] : [UIColor secondaryLabelColor];
+    self.saveItem.enabled = !overText && !overEmoji;
+    [self refreshPreview];
+}
+
+- (void)refreshPreview {
+    NSString *text = self.textField.text ?: @"";
+    if (text.length == 0) {
+        self.previewLabel.attributedText = nil;
+        self.previewLabel.text = @"(empty)";
+        self.previewLabel.textColor = [UIColor tertiaryLabelColor];
+        return;
+    }
+    self.previewLabel.textColor = [UIColor labelColor];
+    self.previewLabel.attributedText = [self attributedFlairForText:text];
+}
+
+// Build an attributed string, replacing recognised :name: tokens with inline emoji
+// images (loaded async; refreshes the preview when an image arrives).
+- (NSAttributedString *)attributedFlairForText:(NSString *)text {
+    NSMutableAttributedString *out = [[NSMutableAttributedString alloc] init];
+    NSDictionary *baseAttrs = @{ NSFontAttributeName: [UIFont systemFontOfSize:15], NSForegroundColorAttributeName: [UIColor labelColor] };
+    NSArray *matches = [ApolloUserFlairEmojiTokenRegex() matchesInString:text options:0 range:NSMakeRange(0, text.length)];
+    NSUInteger cursor = 0;
+    __weak typeof(self) weakSelf = self;
+    for (NSTextCheckingResult *m in matches) {
+        NSString *name = [[text substringWithRange:m.range] stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@":"]];
+        NSString *url = self.emojiURLByName[name];
+        if (!url) continue; // leave unknown tokens as literal text (handled below)
+        if (m.range.location > cursor) {
+            [out appendAttributedString:[[NSAttributedString alloc] initWithString:[text substringWithRange:NSMakeRange(cursor, m.range.location - cursor)] attributes:baseAttrs]];
+        }
+        NSTextAttachment *att = [NSTextAttachment new];
+        att.bounds = CGRectMake(0, -3, 18, 18);
+        UIImage *img = [ApolloUserFlairEmojiImageCache() objectForKey:url];
+        if (img) {
+            att.image = img;
+        } else {
+            ApolloUserFlairLoadEmojiImage(url, ^(UIImage *image) {
+                typeof(self) self = weakSelf;
+                if (self && image) [self refreshPreview];
+            });
+        }
+        [out appendAttributedString:[NSAttributedString attributedStringWithAttachment:att]];
+        cursor = m.range.location + m.range.length;
+    }
+    if (cursor < text.length) {
+        [out appendAttributedString:[[NSAttributedString alloc] initWithString:[text substringFromIndex:cursor] attributes:baseAttrs]];
+    }
+    return out;
+}
+
+- (void)textChanged { [self updateCounterAndPreview]; }
+
+#pragma mark actions
+
+- (void)insertEmojiToken:(NSString *)name {
+    NSUInteger textLen = 0;
+    NSUInteger emojiCount = [self emojiCountInText:(self.textField.text ?: @"") textLength:&textLen];
+    if (emojiCount >= kApolloUserFlairMaxEmojis) {
+        [self flashCounter];
+        return;
+    }
+    NSString *token = [NSString stringWithFormat:@":%@:", name];
+    UITextField *tf = self.textField;
+    UITextRange *range = tf.selectedTextRange;
+    if (!range) range = [tf textRangeFromPosition:tf.endOfDocument toPosition:tf.endOfDocument];
+    [tf replaceRange:range withText:token];
+    [self updateCounterAndPreview];
+}
+
+- (void)flashCounter {
+    self.counterLabel.textColor = [UIColor systemRedColor];
+    UISelectionFeedbackGenerator *fb = [UISelectionFeedbackGenerator new];
+    [fb selectionChanged];
+}
+
+- (void)cancelTapped { [self finishAndDismiss]; }
+
+- (void)saveTapped {
+    NSString *text = self.textField.text ?: @"";
+    ApolloUserFlairEditSession *session = self.session;
+    ApolloLog(@"[UserFlair] save tapped subreddit=%@ templateID=%@ textLen=%lu",
+        session.subredditName ?: @"(nil)", session.templateID ?: @"(nil)", (unsigned long)text.length);
+    self.didFinish = YES;
+    UIViewController *presenter = ApolloUserFlairPresenterForController(session.selectorAdapter.controller);
+    UIViewController *flairController = session.selectorAdapter.controller;
+    [self dismissViewControllerAnimated:YES completion:^{
+        if (flairController) objc_setAssociatedObject(flairController, &kApolloUserFlairEditorPresentedKey, nil, OBJC_ASSOCIATION_ASSIGN);
+        if (!ApolloUserFlairCommitEditedSession(session, text)) {
+            ApolloUserFlairShowError(presenter, @"Apollo's native flair update action was unavailable.");
+        }
+    }];
+}
+
+- (void)finishAndDismiss {
+    self.didFinish = YES;
+    UIViewController *flairController = self.session.selectorAdapter.controller;
+    [self dismissViewControllerAnimated:YES completion:^{
+        if (flairController) objc_setAssociatedObject(flairController, &kApolloUserFlairEditorPresentedKey, nil, OBJC_ASSOCIATION_ASSIGN);
+    }];
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
+    // Catch interactive (swipe-down) dismissal so the selector can present again later.
+    if (!self.didFinish) {
+        UIViewController *flairController = self.session.selectorAdapter.controller;
+        if (flairController) objc_setAssociatedObject(flairController, &kApolloUserFlairEditorPresentedKey, nil, OBJC_ASSOCIATION_ASSIGN);
+    }
+}
+
+#pragma mark text field
+
+- (BOOL)textFieldShouldReturn:(UITextField *)textField { [textField resignFirstResponder]; return NO; }
+
+#pragma mark search
+
+- (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText {
+    if (searchText.length == 0) {
+        self.filteredEmojis = self.allEmojis;
+    } else {
+        NSPredicate *p = [NSPredicate predicateWithBlock:^BOOL(NSDictionary *e, NSDictionary *bindings) {
+            return [e[@"name"] rangeOfString:searchText options:NSCaseInsensitiveSearch].location != NSNotFound;
+        }];
+        self.filteredEmojis = [self.allEmojis filteredArrayUsingPredicate:p];
+    }
+    [self.collectionView reloadData];
+}
+
+- (void)searchBarSearchButtonClicked:(UISearchBar *)searchBar { [searchBar resignFirstResponder]; }
+
+#pragma mark collection view
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+    return self.filteredEmojis.count;
+}
+
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+    ApolloUserFlairEmojiCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:@"emoji" forIndexPath:indexPath];
+    if (indexPath.item >= (NSInteger)self.filteredEmojis.count) return cell;
+    NSDictionary *e = self.filteredEmojis[indexPath.item];
+    NSString *url = e[@"url"];
+    cell.urlKey = url;
+    UIImage *cached = [ApolloUserFlairEmojiImageCache() objectForKey:url];
+    if (cached) {
+        cell.imageView.image = cached;
+    } else {
+        // Capture the cell weakly so an in-flight download for a since-recycled cell
+        // doesn't keep it alive while scrolling thousands of emoji; the urlKey guard
+        // still prevents a stale image from landing on a reused cell.
+        __weak ApolloUserFlairEmojiCell *weakCell = cell;
+        ApolloUserFlairLoadEmojiImage(url, ^(UIImage *image) {
+            ApolloUserFlairEmojiCell *strongCell = weakCell;
+            if (image && strongCell && [strongCell.urlKey isEqualToString:url]) strongCell.imageView.image = image;
+        });
+    }
+    return cell;
+}
+
+- (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
+    [collectionView deselectItemAtIndexPath:indexPath animated:NO];
+    if (indexPath.item >= (NSInteger)self.filteredEmojis.count) return;
+    NSDictionary *e = self.filteredEmojis[indexPath.item];
+    [self insertEmojiToken:e[@"name"]];
+}
+
+@end
+
 static void ApolloUserFlairPresentEditor(ApolloUserFlairEditSession *session) {
     UIViewController *controller = session.selectorAdapter.controller;
     if ([objc_getAssociatedObject(controller, &kApolloUserFlairEditorPresentedKey) boolValue]) return;
     objc_setAssociatedObject(controller, &kApolloUserFlairEditorPresentedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-    NSString *templateID = session.templateID;
-    NSString *subredditName = session.subredditName;
-    NSString *initialText = session.initialText ?: @"";
-    if (initialText.length > kApolloUserFlairMaxLength) initialText = [initialText substringToIndex:kApolloUserFlairMaxLength];
+    ApolloUserFlairEditorViewController *editor = [ApolloUserFlairEditorViewController new];
+    editor.session = session;
+    editor.subreddit = session.subredditName;
 
-    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Edit User Flair"
-                                                                   message:[NSString stringWithFormat:@"Preview: %@\n\n%lu/%lu characters",
-                                                                            initialText.length > 0 ? initialText : @"(empty)",
-                                                                            (unsigned long)initialText.length,
-                                                                            (unsigned long)kApolloUserFlairMaxLength]
-                                                            preferredStyle:UIAlertControllerStyleAlert];
+    UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:editor];
+    nav.modalPresentationStyle = UIModalPresentationPageSheet;
 
-    __weak UIAlertController *weakAlert = alert;
-    [alert addTextFieldWithConfigurationHandler:^(UITextField *textField) {
-        textField.text = initialText;
-        textField.placeholder = @"Flair text";
-        textField.clearButtonMode = UITextFieldViewModeWhileEditing;
-        textField.autocorrectionType = UITextAutocorrectionTypeDefault;
-        textField.returnKeyType = UIReturnKeyDone;
-    }];
-
-    __weak UIViewController *weakController = controller;
-    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(__unused UIAlertAction *action) {
-        UIViewController *strongController = weakController;
-        if (strongController) objc_setAssociatedObject(strongController, &kApolloUserFlairEditorPresentedKey, nil, OBJC_ASSOCIATION_ASSIGN);
-    }];
-    [alert addAction:cancelAction];
-
-    UIAlertAction *saveAction = [UIAlertAction actionWithTitle:@"Save" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
-        UIViewController *strongController = weakController;
-        UIAlertController *strongAlert = weakAlert;
-        NSString *text = strongAlert.textFields.firstObject.text ?: @"";
-        if (text.length > kApolloUserFlairMaxLength) text = [text substringToIndex:kApolloUserFlairMaxLength];
-        ApolloLog(@"[UserFlair] save tapped subreddit=%@ templateID=%@ textLen=%lu option=%@",
-            subredditName ?: @"(nil)",
-            templateID ?: @"(nil)",
-            (unsigned long)text.length,
-            session.optionAdapter.option ? NSStringFromClass([session.optionAdapter.option class]) : @"(nil)");
-
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if (!ApolloUserFlairCommitEditedSession(session, text)) {
-                if (strongController) objc_setAssociatedObject(strongController, &kApolloUserFlairEditorPresentedKey, nil, OBJC_ASSOCIATION_ASSIGN);
-                ApolloUserFlairShowError(strongController, @"Apollo's native flair update action was unavailable.");
-            }
-        });
-    }];
-    [alert addAction:saveAction];
-
-    ApolloUserFlairTextFieldObserver *observer = [ApolloUserFlairTextFieldObserver new];
-    observer.alert = alert;
-    observer.saveAction = saveAction;
-    UITextField *textField = alert.textFields.firstObject;
-    [textField addTarget:observer action:@selector(textFieldChanged:) forControlEvents:UIControlEventEditingChanged];
-    objc_setAssociatedObject(alert, @selector(textFieldChanged:), observer, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    [observer textFieldChanged:textField];
-
-    ApolloLog(@"[UserFlair] presenting editor subreddit=%@ templateID=%@ initialLen=%lu",
-        subredditName ?: @"(nil)",
-        templateID ?: @"(nil)",
-        (unsigned long)initialText.length);
-    [[session.selectorAdapter presenter] presentViewController:alert animated:YES completion:nil];
+    ApolloLog(@"[UserFlair] presenting flair editor subreddit=%@ templateID=%@ initialLen=%lu",
+        session.subredditName ?: @"(nil)",
+        session.templateID ?: @"(nil)",
+        (unsigned long)(session.initialText.length));
+    [[session.selectorAdapter presenter] presentViewController:nav animated:YES completion:nil];
 }
 
 #pragma mark - Row Option Capture

--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -6,23 +6,29 @@
 static char kApolloUserFlairEditorPresentedKey;
 static char kApolloUserFlairCapturedOptionsKey;
 static char kApolloUserFlairCollapseModelKey;
+static char kApolloUserFlairCurrentFlairKey;
 
 static const NSUInteger kApolloUserFlairMaxLength = 64;
 
 // The flair selector's flair options live in section 1 of its table.
 static const NSInteger kApolloUserFlairOptionsSection = 1;
 
-// Placeholder shown on the single collapsed "custom flair" row when a subreddit
-// uses the old (empty-template) flair system.
+// Placeholder shown on a blank, editable flair row so it's obvious it's tappable.
 static NSString *const kApolloUserFlairCustomRowText = @"Set custom flair…";
 
 static __thread __unsafe_unretained UIViewController *tApolloUserFlairCaptureController = nil;
 static __thread NSInteger tApolloUserFlairCaptureSection = NSNotFound;
 static __thread NSInteger tApolloUserFlairCaptureRow = NSNotFound;
-// While a collapsed "custom flair" cell is being built, this points at the
-// RDKFlairOption backing that row so its (otherwise empty) getters render the
-// placeholder text instead of nothing. Never mutates the model.
+// While a "custom flair" cell is being built, these let the (otherwise empty)
+// RDKFlairOption getters render either the user's CURRENT flair or the
+// "Set custom flair…" placeholder. They never mutate the model.
 static __thread __unsafe_unretained id tApolloUserFlairCustomRowOption = nil;
+static __thread __unsafe_unretained NSArray *tApolloUserFlairCustomRowFlairs = nil;
+static __thread __unsafe_unretained NSString *tApolloUserFlairCustomRowDisplayText = nil;
+
+// Forward declaration (defined in the collapse section) so the edit session can
+// pre-fill the editor with the user's current flair.
+static NSString *ApolloUserFlairCurrentFlairTextForOption(UIViewController *controller, id option);
 
 @interface ApolloUserFlairOptionAdapter : NSObject
 @property (nonatomic, strong) id option;
@@ -511,11 +517,17 @@ static ApolloUserFlairEditSession *ApolloUserFlairBuildEditSession(UIViewControl
         subredditName ?: @"(nil)");
 
     if (!option || ![selectorAdapter isUserFlairSelector] || !editableKnown || !editable || subredditName.length == 0 || templateID.length == 0) return nil;
+
+    // Pre-fill with the user's CURRENT flair when editing the row it lives on, so
+    // opening the editor shows (and lets you tweak) what you already have.
+    NSString *currentFlairText = ApolloUserFlairCurrentFlairTextForOption(controller, option);
+    NSString *initialText = currentFlairText.length > 0 ? currentFlairText : [optionAdapter displayText];
+
     return [ApolloUserFlairEditSession sessionWithSelectorAdapter:selectorAdapter
                                                     optionAdapter:optionAdapter
                                                     subredditName:subredditName
                                                       templateID:templateID
-                                                     initialText:[optionAdapter displayText]];
+                                                     initialText:initialText];
 }
 
 #pragma mark - Editor
@@ -1079,6 +1091,16 @@ static BOOL ApolloUserFlairOptionIsLabeled(id option) {
     return flairs.count > 0;
 }
 
+// A blank-but-editable template: nothing to show, but you can type into it. These
+// get the "Set custom flair…" placeholder so it's obvious the row is tappable —
+// whether or not the subreddit's templates were collapsed.
+static BOOL ApolloUserFlairOptionIsBlankEditable(id option) {
+    if (!option || ApolloUserFlairOptionIsLabeled(option)) return NO;
+    BOOL editableKnown = NO;
+    BOOL editable = ApolloUserFlairOptionIsEditable(option, &editableKnown);
+    return editableKnown && editable;
+}
+
 @interface ApolloUserFlairCollapseModel : NSObject
 @property (nonatomic) BOOL active;
 // displayRow -> real index into flairOptions
@@ -1147,27 +1169,140 @@ static ApolloUserFlairCollapseModel *ApolloUserFlairCollapseModelFor(UIViewContr
     return model;
 }
 
-// One reusable RDKFlair carrying the placeholder text, so the collapsed row
+static id ApolloUserFlairMakeTextFlair(NSString *text) {
+    Class flairClass = objc_getClass("RDKFlair");
+    SEL initSEL = @selector(initWithRawText:);
+    if (!flairClass || ![flairClass instancesRespondToSelector:initSEL]) return nil;
+    return ((id (*)(id, SEL, id))objc_msgSend)([flairClass alloc], initSEL, text ?: @"");
+}
+
+// An emoji piece must look exactly like Reddit's own: flairType "emoji", the bare
+// emoji name in emojiLabel, the image URL, and a NIL text. Crucially `text` must be
+// nil (not @"") — the native flair cell treats any non-nil text as a text run and
+// renders it instead of loading the emoji image.
+static id ApolloUserFlairMakeEmojiFlair(NSString *name, NSString *imageURL) {
+    id flair = ApolloUserFlairMakeTextFlair(@"");
+    if (!flair) return nil;
+    NSURL *url = imageURL.length ? [NSURL URLWithString:imageURL] : nil;
+    @try { [flair setValue:nil forKey:@"text"]; } @catch (__unused NSException *e) {}
+    @try { [flair setValue:@"emoji" forKey:@"flairType"]; } @catch (__unused NSException *e) {}
+    @try { if (name.length) [flair setValue:name forKey:@"emojiLabel"]; } @catch (__unused NSException *e) {}
+    @try { if (url) [flair setValue:url forKey:@"imageURL"]; } @catch (__unused NSException *e) {}
+    return flair;
+}
+
+// One reusable RDKFlair carrying the placeholder text, so a blank editable row
 // renders through Apollo's normal flair cell layout instead of as a blank pill.
-static NSArray *ApolloUserFlairCustomRowSyntheticFlairs(void) {
+static NSArray *ApolloUserFlairPlaceholderFlairs(void) {
     static NSArray *cached = nil;
     static dispatch_once_t once;
     dispatch_once(&once, ^{
-        Class flairClass = objc_getClass("RDKFlair");
-        SEL initSEL = @selector(initWithRawText:);
-        if (flairClass && [flairClass instancesRespondToSelector:initSEL]) {
-            id flair = ((id (*)(id, SEL, id))objc_msgSend)([flairClass alloc], initSEL, kApolloUserFlairCustomRowText);
-            if (flair) cached = @[flair];
-        }
-        if (!cached) {
-            // The synthetic flair is what makes the collapsed row render its label;
-            // without it the row falls back to Apollo's empty rendering (still a
-            // single collapsed row, just unlabelled). Surface the failure so a
-            // future RDKFlair API change doesn't degrade silently.
-            ApolloLog(@"[UserFlair] warning: could not build synthetic RDKFlair; custom-flair row will render unlabelled");
-        }
+        id flair = ApolloUserFlairMakeTextFlair(kApolloUserFlairCustomRowText);
+        if (flair) cached = @[flair];
+        else ApolloLog(@"[UserFlair] warning: could not build placeholder RDKFlair; custom-flair row will render unlabelled");
     });
     return cached;
+}
+
+// Build RDKFlair pieces from a flair_text string so the user's CURRENT flair
+// renders in the row. Recognised :token: emoji become image pieces (using the
+// subreddit's emoji map); everything else stays text. Unknown tokens remain as
+// literal text. Returns nil if nothing could be built.
+static NSArray *ApolloUserFlairPiecesFromFlairText(NSString *flairText, NSString *subredditLowercase) {
+    if (flairText.length == 0) return nil;
+    NSDictionary *map = nil;
+    NSArray *emojis = nil;
+    @synchronized (ApolloUserFlairEmojiListCache()) { emojis = ApolloUserFlairEmojiListCache()[subredditLowercase]; }
+    if (emojis.count) {
+        NSMutableDictionary *m = [NSMutableDictionary dictionary];
+        for (NSDictionary *e in emojis) { if (e[@"name"] && e[@"url"]) m[e[@"name"]] = e[@"url"]; }
+        map = m;
+    }
+
+    NSMutableArray *pieces = [NSMutableArray array];
+    NSArray *matches = [ApolloUserFlairEmojiTokenRegex() matchesInString:flairText options:0 range:NSMakeRange(0, flairText.length)];
+    NSUInteger cursor = 0;
+    for (NSTextCheckingResult *m in matches) {
+        NSString *name = [[flairText substringWithRange:m.range] stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@":"]];
+        NSString *url = map[name];
+        if (!url) continue; // unknown token: leave it inside the surrounding text run
+        if (m.range.location > cursor) {
+            id t = ApolloUserFlairMakeTextFlair([flairText substringWithRange:NSMakeRange(cursor, m.range.location - cursor)]);
+            if (t) [pieces addObject:t];
+        }
+        id e = ApolloUserFlairMakeEmojiFlair(name, url);
+        if (e) [pieces addObject:e];
+        cursor = m.range.location + m.range.length;
+    }
+    if (cursor < flairText.length) {
+        id t = ApolloUserFlairMakeTextFlair([flairText substringFromIndex:cursor]);
+        if (t) [pieces addObject:t];
+    }
+    return pieces.count ? pieces : nil;
+}
+
+#pragma mark - Current Flair (so the user can see their existing flair)
+
+// Stored on the controller: @{ @"text": flair_text, @"templateID": id-or-@"" }.
+// Fetched once per controller from Reddit's flairselector `current`.
+static void ApolloUserFlairFetchCurrentFlair(UIViewController *controller, NSString *subreddit) {
+    if (!controller || subreddit.length == 0) return;
+    if (objc_getAssociatedObject(controller, &kApolloUserFlairCurrentFlairKey)) return; // already fetched
+    // Mark as in-flight so we don't fire twice (numberOfRows is called repeatedly).
+    objc_setAssociatedObject(controller, &kApolloUserFlairCurrentFlairKey, @{}, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    NSString *token = [sLatestRedditBearerToken copy];
+    if (token.length == 0) return;
+    NSString *enc = [subreddit stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]] ?: subreddit;
+    __weak UIViewController *weakController = controller;
+
+    // Fetch the emoji map FIRST so :token: flairs can render as images, then the
+    // current flair, then reload the table once both are available.
+    ApolloUserFlairFetchEmojis(subreddit, ^(NSArray *emojis) {
+        (void)emojis;
+        NSString *urlStr = [NSString stringWithFormat:@"https://oauth.reddit.com/r/%@/api/flairselector?raw_json=1", enc];
+        NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlStr]];
+        req.HTTPMethod = @"POST";
+        [req setValue:[@"Bearer " stringByAppendingString:token] forHTTPHeaderField:@"Authorization"];
+        [req setValue:@"Apollo iOS" forHTTPHeaderField:@"User-Agent"];
+        [req setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+        req.HTTPBody = [NSData data];
+        [[[NSURLSession sharedSession] dataTaskWithRequest:req completionHandler:^(NSData *data, NSURLResponse *resp, NSError *error) {
+            id json = data ? [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL] : nil;
+            id current = [json isKindOfClass:[NSDictionary class]] ? json[@"current"] : nil;
+            NSString *text = nil, *templateID = nil;
+            if ([current isKindOfClass:[NSDictionary class]]) {
+                id t = current[@"flair_text"]; if ([t isKindOfClass:[NSString class]]) text = t;
+                id tid = current[@"flair_template_id"]; if ([tid isKindOfClass:[NSString class]]) templateID = tid;
+            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                UIViewController *strongController = weakController;
+                if (!strongController) return;
+                objc_setAssociatedObject(strongController, &kApolloUserFlairCurrentFlairKey,
+                    @{ @"text": text ?: @"", @"templateID": templateID ?: @"" }, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                id tableNode = ApolloUserFlairRawObjectIvar(strongController, @"tableNode");
+                BOOL reloaded = [tableNode respondsToSelector:@selector(reloadData)];
+                if (reloaded) ((void (*)(id, SEL))objc_msgSend)(tableNode, @selector(reloadData));
+                ApolloLog(@"[UserFlair] current flair r/%@ textLen=%lu template=%@ reloaded=%d", subreddit, (unsigned long)text.length, templateID.length ? @"yes" : @"none", reloaded);
+            });
+        }] resume];
+    });
+}
+
+// The user's current flair_text IF it belongs on this option's row: either the
+// template ids match, or the flair is free-form (no template) and this is a
+// blank editable row. Returns nil otherwise.
+static NSString *ApolloUserFlairCurrentFlairTextForOption(UIViewController *controller, id option) {
+    NSDictionary *current = objc_getAssociatedObject(controller, &kApolloUserFlairCurrentFlairKey);
+    NSString *text = current[@"text"];
+    if (![text isKindOfClass:[NSString class]] || text.length == 0) return nil;
+    NSString *templateID = current[@"templateID"];
+    NSString *optionID = ApolloUserFlairOptionIdentifier(option);
+    if (templateID.length > 0) {
+        return [templateID isEqualToString:optionID] ? text : nil;
+    }
+    // Free-form flair (no template): show it on the blank editable "custom" row.
+    return ApolloUserFlairOptionIsBlankEditable(option) ? text : nil;
 }
 
 // YES when the presenter chain contains Apollo's flair selector. Used to scope
@@ -1223,6 +1358,8 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
 
 - (NSInteger)tableNode:(id)tableNode numberOfRowsInSection:(NSInteger)section {
     if (section == kApolloUserFlairOptionsSection) {
+        NSString *sub = ApolloUserFlairCleanSubredditName(ApolloUserFlairSubredditNameFromObject((UIViewController *)self, 0));
+        ApolloUserFlairFetchCurrentFlair((UIViewController *)self, sub);
         ApolloUserFlairCollapseModel *model = ApolloUserFlairCollapseModelFor((UIViewController *)self);
         if (model.active) return (NSInteger)model.realRows.count;
     }
@@ -1246,13 +1383,51 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
 
     id originalBlock = %orig(tableNode, effectiveIndexPath);
     if (!originalBlock) return originalBlock;
+    (void)isCustomRow;
 
-    // For the collapsed "custom flair" row, look up the backing option so its
-    // getters can render the placeholder while this cell is being built.
-    __unsafe_unretained id customRowOption = nil;
-    if (isCustomRow) {
+    // Decide what this row should render via the option's (otherwise empty) getters:
+    //  - the user's CURRENT flair, if it belongs on this row (so you can see it); or
+    //  - a "Set custom flair…" placeholder, if the row is blank but editable.
+    // Labelled rows that aren't the current flair are left to Apollo.
+    // These are STRONG so the async cell block retains them — the synthetic flair
+    // pieces are freshly built (autoreleased) and would otherwise dangle.
+    id customRowOption = nil;
+    NSArray *customRowFlairs = nil;
+    NSString *customRowText = nil;
+    {
         NSArray *options = ApolloUserFlairControllerOptions((UIViewController *)self);
-        if (realRow >= 0 && realRow < (NSInteger)options.count) customRowOption = options[realRow];
+        if (realRow >= 0 && realRow < (NSInteger)options.count) {
+            id opt = options[realRow];
+            NSString *currentText = ApolloUserFlairCurrentFlairTextForOption((UIViewController *)self, opt);
+            // When templates are collapsed into one representative row, the current
+            // flair may live on a different (hidden) empty template — they're all
+            // equivalent, so show it on the representative regardless of which one.
+            if (currentText.length == 0 && isCustomRow) {
+                NSDictionary *cur = objc_getAssociatedObject((UIViewController *)self, &kApolloUserFlairCurrentFlairKey);
+                NSString *t = cur[@"text"];
+                if ([t isKindOfClass:[NSString class]] && t.length > 0) currentText = t;
+            }
+            BOOL blankEditable = ApolloUserFlairOptionIsBlankEditable(opt);
+            if (currentText.length > 0) {
+                NSString *sub = ApolloUserFlairCleanSubredditName(ApolloUserFlairSubredditNameFromObject((UIViewController *)self, 0));
+                NSArray *pieces = ApolloUserFlairPiecesFromFlairText(currentText, sub.lowercaseString);
+                if (pieces.count) {
+                    customRowOption = opt;
+                    customRowFlairs = pieces;
+                    customRowText = currentText;
+                } else if (blankEditable) {
+                    // Have a current flair but couldn't build pieces (e.g. RDKFlair
+                    // unavailable) — don't leave a blank row; show the placeholder.
+                    customRowOption = opt;
+                    customRowFlairs = ApolloUserFlairPlaceholderFlairs();
+                    customRowText = kApolloUserFlairCustomRowText;
+                }
+            } else if (blankEditable) {
+                customRowOption = opt;
+                customRowFlairs = ApolloUserFlairPlaceholderFlairs();
+                customRowText = kApolloUserFlairCustomRowText;
+            }
+        }
     }
 
     id copiedBlock = [originalBlock copy];
@@ -1265,12 +1440,16 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
         NSInteger previousSection = tApolloUserFlairCaptureSection;
         NSInteger previousRow = tApolloUserFlairCaptureRow;
         id previousCustomOption = tApolloUserFlairCustomRowOption;
+        NSArray *previousCustomFlairs = tApolloUserFlairCustomRowFlairs;
+        NSString *previousCustomText = tApolloUserFlairCustomRowDisplayText;
         id node = nil;
 
         tApolloUserFlairCaptureController = strongController;
         tApolloUserFlairCaptureSection = kApolloUserFlairOptionsSection;
         tApolloUserFlairCaptureRow = captureRow;
         tApolloUserFlairCustomRowOption = customRowOption;
+        tApolloUserFlairCustomRowFlairs = customRowFlairs;
+        tApolloUserFlairCustomRowDisplayText = customRowText;
         @try {
             node = ((id (^)(void))copiedBlock)();
         } @finally {
@@ -1278,6 +1457,8 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
             tApolloUserFlairCaptureSection = previousSection;
             tApolloUserFlairCaptureRow = previousRow;
             tApolloUserFlairCustomRowOption = previousCustomOption;
+            tApolloUserFlairCustomRowFlairs = previousCustomFlairs;
+            tApolloUserFlairCustomRowDisplayText = previousCustomText;
         }
 
         return node;
@@ -1324,8 +1505,8 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
 - (NSString *)textRepresentation {
     NSString *textRepresentation = %orig;
     ApolloUserFlairCaptureOptionIfNeeded(self);
-    if (tApolloUserFlairCustomRowOption && tApolloUserFlairCustomRowOption == self) {
-        return kApolloUserFlairCustomRowText;
+    if (tApolloUserFlairCustomRowOption && tApolloUserFlairCustomRowOption == self && tApolloUserFlairCustomRowDisplayText) {
+        return tApolloUserFlairCustomRowDisplayText;
     }
     return textRepresentation;
 }
@@ -1339,9 +1520,8 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
 - (NSArray *)flairs {
     NSArray *flairs = %orig;
     ApolloUserFlairCaptureOptionIfNeeded(self);
-    if (tApolloUserFlairCustomRowOption && tApolloUserFlairCustomRowOption == self) {
-        NSArray *synthetic = ApolloUserFlairCustomRowSyntheticFlairs();
-        if (synthetic) return synthetic;
+    if (tApolloUserFlairCustomRowOption && tApolloUserFlairCustomRowOption == self && tApolloUserFlairCustomRowFlairs) {
+        return tApolloUserFlairCustomRowFlairs;
     }
     return flairs;
 }

--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -7,6 +7,15 @@ static char kApolloUserFlairEditorPresentedKey;
 static char kApolloUserFlairCapturedOptionsKey;
 static char kApolloUserFlairCollapseModelKey;
 static char kApolloUserFlairCurrentFlairKey;
+static char kApolloUserFlairCssByTemplateKey;   // template_id -> css_class (trimmed)
+static char kApolloUserFlairSpriteMapKey;        // css_class -> @{url,x,y,w,h,round}
+static char kApolloUserFlairSpriteFetchedKey;    // @YES once sprite-data fetch started
+// Per-option PERSISTENT display flairs for old-reddit css-class templates. Unlike
+// the thread-local override below, this is read by Apollo's async ASDK layout pass
+// (which runs after the node block returns, when the thread-local is gone), so the
+// sprite/name actually renders. Only `flairs` is overridden — textRepresentation is
+// left as the template's real (empty) text so committing the selection is unchanged.
+static char kApolloUserFlairOptionDisplayFlairsKey;
 
 static const NSUInteger kApolloUserFlairMaxLength = 64;
 
@@ -1201,7 +1210,17 @@ static ApolloUserFlairCollapseModel *ApolloUserFlairCollapseModelFor(UIViewContr
     ApolloUserFlairCollapseModel *cached = objc_getAssociatedObject(controller, &kApolloUserFlairCollapseModelKey);
     if (cached && cached.sourcePtr == (__bridge const void *)options) return cached;
 
-    ApolloUserFlairCollapseModel *model = ApolloUserFlairBuildCollapseModel(options);
+    ApolloUserFlairCollapseModel *model;
+    NSDictionary *cssByTemplate = objc_getAssociatedObject(controller, &kApolloUserFlairCssByTemplateKey);
+    if ([cssByTemplate isKindOfClass:[NSDictionary class]] && cssByTemplate.count > 0) {
+        // These are real old-reddit flairs (rendered via css_class sprites/names) —
+        // show every one as its own row instead of collapsing to a "custom" row.
+        model = [ApolloUserFlairCollapseModel new];
+        model.customRealRow = NSNotFound;
+        model.active = NO;
+    } else {
+        model = ApolloUserFlairBuildCollapseModel(options);
+    }
     model.sourcePtr = (__bridge const void *)options;
     objc_setAssociatedObject(controller, &kApolloUserFlairCollapseModelKey, model, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     if (model.active) {
@@ -1348,6 +1367,260 @@ static NSString *ApolloUserFlairCurrentFlairTextForOption(UIViewController *cont
     return ApolloUserFlairOptionIsBlankEditable(option) ? text : nil;
 }
 
+#pragma mark - Old-Reddit CSS Sprite Flairs
+//
+// Subreddits like r/nintendo keep their "real" flairs in the old-reddit stylesheet:
+// each template carries a flair_css_class whose image is a region of a sprite sheet
+// defined in CSS. New Reddit / Apollo drop the css_class + sprite, so these come back
+// as blank "custom" templates. We recover them: fetch flairselector (template_id ->
+// css_class) and the stylesheet, parse the common single-sheet sprite pattern, crop
+// each flair's region, and render the real avatar in the selector. Subreddits whose
+// CSS we can't safely parse (e.g. r/dbz's multi-sheet attribute selectors) fall back
+// to the prettified css_class name; genuinely-empty subs keep the collapse behaviour.
+
+static NSString *ApolloUserFlairRegexSub(NSString *s, NSString *pattern, NSString *tmpl) {
+    if (s.length == 0) return s;
+    return [s stringByReplacingOccurrencesOfString:pattern withString:tmpl
+              options:NSRegularExpressionSearch range:NSMakeRange(0, s.length)];
+}
+
+// Prettify a css_class for display: drop a trailing numeric variant, split camelCase
+// and separators, title-case. "princessPeach"->"Princess Peach", "Beerus-001"->"Beerus".
+static NSString *ApolloUserFlairPrettifyClass(NSString *cssClass) {
+    NSString *s = [cssClass stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (s.length == 0) return nil;
+    s = ApolloUserFlairRegexSub(s, @"[-_]?[0-9]{1,4}$", @"");
+    s = ApolloUserFlairRegexSub(s, @"[-_]+", @" ");
+    s = ApolloUserFlairRegexSub(s, @"([a-z])([A-Z])", @"$1 $2");
+    s = ApolloUserFlairRegexSub(s, @"([A-Za-z])([0-9])", @"$1 $2");
+    s = ApolloUserFlairRegexSub(s, @"([0-9])([A-Za-z])", @"$1 $2");
+    s = ApolloUserFlairRegexSub(s, @"\\s+", @" ");
+    s = [s stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    if (s.length == 0) return nil;
+    return [s capitalizedString];
+}
+
+static NSCache<NSString *, UIImage *> *ApolloUserFlairSheetCache(void) {
+    static NSCache *c = nil; static dispatch_once_t o;
+    dispatch_once(&o, ^{ c = [NSCache new]; c.countLimit = 8; });
+    return c;
+}
+
+// css_class -> cropped sprite file:// URL (so the native flair cell can load it).
+static NSMutableDictionary<NSString *, NSString *> *ApolloUserFlairSpriteFileCache(void) {
+    static NSMutableDictionary *d = nil; static dispatch_once_t o;
+    dispatch_once(&o, ^{ d = [NSMutableDictionary dictionary]; });
+    return d;
+}
+
+// Filename prefix that marks our locally-cropped sprite files, recognised by the
+// ASNetworkImageNode hook below (its HTTP-only downloader can't load file:// URLs,
+// so we intercept and set the in-memory cropped UIImage directly).
+static NSString *const kApolloUserFlairSpriteFilePrefix = @"apolloflair_";
+
+// file path -> cropped UIImage, so the image-node hook serves the exact crop
+// without re-decoding from disk (and at the right scale).
+static NSMutableDictionary<NSString *, UIImage *> *ApolloUserFlairSpriteImageByPath(void) {
+    static NSMutableDictionary *d = nil; static dispatch_once_t o;
+    dispatch_once(&o, ^{ d = [NSMutableDictionary dictionary]; });
+    return d;
+}
+
+static NSString *ApolloUserFlairFirstGroup(NSString *str, NSString *pattern) {
+    NSRegularExpression *re = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:NULL];
+    NSTextCheckingResult *m = [re firstMatchInString:str options:0 range:NSMakeRange(0, str.length)];
+    return (m && m.numberOfRanges > 1) ? [str substringWithRange:[m rangeAtIndex:1]] : nil;
+}
+
+// Parse the common single-sprite-sheet pattern. Returns css_class -> @{url,x,y,w,h,round}
+// or nil when the stylesheet uses a layout we can't safely map (multiple sheets,
+// attribute selectors, etc.) so callers fall back to names.
+static NSDictionary *ApolloUserFlairParseSpriteCSS(NSString *css, NSArray *images) {
+    if (css.length == 0) return nil;
+    NSMutableDictionary *imgURL = [NSMutableDictionary dictionary];
+    for (NSDictionary *im in images) {
+        if ([im[@"name"] isKindOfClass:[NSString class]] && [im[@"url"] isKindOfClass:[NSString class]]) imgURL[im[@"name"]] = im[@"url"];
+    }
+
+    NSRegularExpression *ruleRe = [NSRegularExpression regularExpressionWithPattern:@"([^{}]*)\\{([^{}]*)\\}" options:0 error:NULL];
+    NSArray *rules = [ruleRe matchesInString:css options:0 range:NSMakeRange(0, css.length)];
+
+    // Base rule: a plain `.flair` / `.flair:before` (NOT .flair-x, NOT .flair[attr])
+    // with background-image url + width + height. Reject subs with >1 distinct flair
+    // sheet (multi-sheet) — too ambiguous to map by class alone.
+    NSString *sheetURL = nil; CGFloat W = 0, H = 0; BOOL round = NO;
+    NSMutableSet *flairSheets = [NSMutableSet set];
+    for (NSTextCheckingResult *m in rules) {
+        NSString *sel = [css substringWithRange:[m rangeAtIndex:1]];
+        NSString *body = [css substringWithRange:[m rangeAtIndex:2]];
+        if ([body rangeOfString:@"background-image"].location == NSNotFound) continue;
+        if ([body rangeOfString:@"background-position"].location != NSNotFound) continue;
+        // does this rule target flairs (a bare .flair token)?
+        if ([sel rangeOfString:@"\\.flair(?![\\w\\[-])" options:NSRegularExpressionSearch].location == NSNotFound) continue;
+        NSString *nm = ApolloUserFlairFirstGroup(body, @"background-image\\s*:\\s*url\\(\\s*[\"']?%%([^%]+)%%");
+        NSString *resolved = nm ? imgURL[nm] : nil;
+        if (!resolved) {
+            NSString *direct = ApolloUserFlairFirstGroup(body, @"background-image\\s*:\\s*url\\(\\s*[\"']?(https?://[^\"')]+)");
+            if (direct) resolved = direct;
+        }
+        if (!resolved) continue;
+        [flairSheets addObject:resolved];
+        if (!sheetURL) {
+            NSString *ws = ApolloUserFlairFirstGroup(body, @"width\\s*:\\s*([0-9.]+)px");
+            NSString *hs = ApolloUserFlairFirstGroup(body, @"height\\s*:\\s*([0-9.]+)px");
+            if (ws.doubleValue > 0 && hs.doubleValue > 0) {
+                sheetURL = resolved; W = ws.doubleValue; H = hs.doubleValue;
+                round = ([body rangeOfString:@"border-radius"].location != NSNotFound);
+            }
+        }
+    }
+    if (!sheetURL || flairSheets.count != 1) return nil; // unparseable / multi-sheet
+
+    NSRegularExpression *clsRe = [NSRegularExpression regularExpressionWithPattern:@"\\.flair-([A-Za-z0-9_-]+)" options:0 error:NULL];
+    NSRegularExpression *posRe = [NSRegularExpression regularExpressionWithPattern:@"background-position\\s*:\\s*(-?[0-9.]+)(?:px)?\\s+(-?[0-9.]+)(?:px)?" options:0 error:NULL];
+    NSMutableDictionary *map = [NSMutableDictionary dictionary];
+    for (NSTextCheckingResult *m in rules) {
+        NSString *sel = [css substringWithRange:[m rangeAtIndex:1]];
+        NSString *body = [css substringWithRange:[m rangeAtIndex:2]];
+        NSTextCheckingResult *bp = [posRe firstMatchInString:body options:0 range:NSMakeRange(0, body.length)];
+        if (!bp) continue;
+        CGFloat bx = [[body substringWithRange:[bp rangeAtIndex:1]] doubleValue];
+        CGFloat by = [[body substringWithRange:[bp rangeAtIndex:2]] doubleValue];
+        CGFloat w = W, h = H;
+        NSString *ws = ApolloUserFlairFirstGroup(body, @"width\\s*:\\s*([0-9.]+)px");
+        NSString *hs = ApolloUserFlairFirstGroup(body, @"height\\s*:\\s*([0-9.]+)px");
+        if (ws.doubleValue > 0) w = ws.doubleValue;
+        if (hs.doubleValue > 0) h = hs.doubleValue;
+        for (NSTextCheckingResult *cm in [clsRe matchesInString:sel options:0 range:NSMakeRange(0, sel.length)]) {
+            NSString *cls = [sel substringWithRange:[cm rangeAtIndex:1]];
+            if (map[cls]) continue;
+            map[cls] = @{ @"url": sheetURL, @"x": @(-bx), @"y": @(-by), @"w": @(w), @"h": @(h), @"round": @(round) };
+        }
+    }
+    return map.count ? map : nil;
+}
+
+// Crop css_class's sprite from its (already-downloaded) sheet, write a temp PNG, and
+// return a file:// URL. nil if the sheet isn't cached yet or the region is invalid.
+static NSString *ApolloUserFlairSpriteFileForClass(UIViewController *controller, NSString *cssClass) {
+    if (cssClass.length == 0) return nil;
+    NSString *cached;
+    @synchronized (ApolloUserFlairSpriteFileCache()) { cached = ApolloUserFlairSpriteFileCache()[cssClass]; }
+    if (cached) return cached;
+    NSDictionary *spriteMap = objc_getAssociatedObject(controller, &kApolloUserFlairSpriteMapKey);
+    NSDictionary *region = spriteMap[cssClass];
+    if (![region isKindOfClass:[NSDictionary class]]) return nil;
+    UIImage *sheet = [ApolloUserFlairSheetCache() objectForKey:region[@"url"]];
+    if (!sheet || !sheet.CGImage) return nil;
+    CGFloat scale = sheet.scale > 0 ? sheet.scale : 1.0;
+    CGRect r = CGRectMake([region[@"x"] doubleValue] * scale, [region[@"y"] doubleValue] * scale,
+                          [region[@"w"] doubleValue] * scale, [region[@"h"] doubleValue] * scale);
+    size_t sw = CGImageGetWidth(sheet.CGImage), sh = CGImageGetHeight(sheet.CGImage);
+    if (r.size.width <= 0 || r.size.height <= 0 || r.origin.x < 0 || r.origin.y < 0 ||
+        CGRectGetMaxX(r) > sw + 1 || CGRectGetMaxY(r) > sh + 1) return nil;
+    CGImageRef crop = CGImageCreateWithImageInRect(sheet.CGImage, r);
+    if (!crop) return nil;
+    UIImage *img = [UIImage imageWithCGImage:crop scale:scale orientation:UIImageOrientationUp];
+    CGImageRelease(crop);
+    NSData *png = UIImagePNGRepresentation(img);
+    if (!png) return nil;
+    NSString *safe = [cssClass stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet alphanumericCharacterSet]] ?: @"f";
+    NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"%@%@.png", kApolloUserFlairSpriteFilePrefix, safe]];
+    if (![png writeToFile:path atomically:YES]) return nil;
+    // Keep the exact crop in memory so the ASNetworkImageNode hook can serve it
+    // directly (its HTTP downloader can't load file:// URLs).
+    @synchronized (ApolloUserFlairSpriteImageByPath()) { ApolloUserFlairSpriteImageByPath()[path] = img; }
+    NSString *fileURL = [[NSURL fileURLWithPath:path] absoluteString];
+    @synchronized (ApolloUserFlairSpriteFileCache()) { ApolloUserFlairSpriteFileCache()[cssClass] = fileURL; }
+    return fileURL;
+}
+
+// css_class for an option (via the template_id -> css_class map). nil if none.
+static NSString *ApolloUserFlairCssClassForOption(UIViewController *controller, id option) {
+    NSDictionary *byTemplate = objc_getAssociatedObject(controller, &kApolloUserFlairCssByTemplateKey);
+    if (![byTemplate isKindOfClass:[NSDictionary class]] || byTemplate.count == 0) return nil;
+    NSString *tid = ApolloUserFlairOptionIdentifier(option);
+    NSString *css = tid ? byTemplate[tid] : nil;
+    return css.length ? css : nil;
+}
+
+// Fetch flairselector (css_class per template) + the stylesheet (sprite sheets), then
+// reload so rows can render real sprites/names. One-shot per controller.
+static void ApolloUserFlairFetchSpriteData(UIViewController *controller, NSString *subreddit) {
+    if (!controller || subreddit.length == 0) return;
+    if (objc_getAssociatedObject(controller, &kApolloUserFlairSpriteFetchedKey)) return;
+    objc_setAssociatedObject(controller, &kApolloUserFlairSpriteFetchedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    NSString *token = [sLatestRedditBearerToken copy];
+    if (token.length == 0) return;
+    NSString *enc = [subreddit stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]] ?: subreddit;
+    __weak UIViewController *wc = controller;
+
+    void (^reload)(void) = ^{
+        UIViewController *c = wc; if (!c) return;
+        // Drop the cached collapse model so it rebuilds (css-class subs stop collapsing).
+        objc_setAssociatedObject(c, &kApolloUserFlairCollapseModelKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        id tableNode = ApolloUserFlairRawObjectIvar(c, @"tableNode");
+        if ([tableNode respondsToSelector:@selector(reloadData)]) ((void (*)(id, SEL))objc_msgSend)(tableNode, @selector(reloadData));
+    };
+
+    NSMutableURLRequest *fs = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://oauth.reddit.com/r/%@/api/flairselector?raw_json=1", enc]]];
+    fs.HTTPMethod = @"POST"; fs.HTTPBody = [NSData data];
+    [fs setValue:[@"Bearer " stringByAppendingString:token] forHTTPHeaderField:@"Authorization"];
+    [fs setValue:@"Apollo iOS" forHTTPHeaderField:@"User-Agent"];
+    [fs setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+    [[[NSURLSession sharedSession] dataTaskWithRequest:fs completionHandler:^(NSData *data, NSURLResponse *r, NSError *e) {
+        id j = data ? [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL] : nil;
+        NSArray *choices = [j isKindOfClass:[NSDictionary class]] ? j[@"choices"] : nil;
+        NSMutableDictionary *byTemplate = [NSMutableDictionary dictionary];
+        for (NSDictionary *ch in (choices ?: @[])) {
+            NSString *tid = ch[@"flair_template_id"];
+            NSString *css = ch[@"flair_css_class"];
+            if ([tid isKindOfClass:[NSString class]] && [css isKindOfClass:[NSString class]]) {
+                NSString *trimmed = [css stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+                if (trimmed.length) byTemplate[tid] = trimmed;
+            }
+        }
+        if (byTemplate.count == 0) return; // no css-class flairs — leave default behaviour
+        dispatch_async(dispatch_get_main_queue(), ^{
+            UIViewController *c = wc; if (!c) return;
+            objc_setAssociatedObject(c, &kApolloUserFlairCssByTemplateKey, byTemplate, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            ApolloLog(@"[UserFlair] css-class flairs: %lu templates", (unsigned long)byTemplate.count);
+            reload(); // show prettified names immediately
+
+            // Now fetch the stylesheet + parse + download sprite sheets.
+            NSMutableURLRequest *ss = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://oauth.reddit.com/r/%@/about/stylesheet?raw_json=1", enc]]];
+            [ss setValue:[@"Bearer " stringByAppendingString:token] forHTTPHeaderField:@"Authorization"];
+            [ss setValue:@"Apollo iOS" forHTTPHeaderField:@"User-Agent"];
+            [[[NSURLSession sharedSession] dataTaskWithRequest:ss completionHandler:^(NSData *d2, NSURLResponse *r2, NSError *e2) {
+                id j2 = d2 ? [NSJSONSerialization JSONObjectWithData:d2 options:0 error:NULL] : nil;
+                NSDictionary *dd = [j2 isKindOfClass:[NSDictionary class]] ? j2[@"data"] : nil;
+                NSString *cssStr = [dd[@"stylesheet"] isKindOfClass:[NSString class]] ? dd[@"stylesheet"] : nil;
+                NSArray *imgs = [dd[@"images"] isKindOfClass:[NSArray class]] ? dd[@"images"] : @[];
+                NSDictionary *spriteMap = cssStr ? ApolloUserFlairParseSpriteCSS(cssStr, imgs) : nil;
+                if (spriteMap.count == 0) { ApolloLog(@"[UserFlair] sprite CSS not parseable — using names"); return; }
+                NSSet *sheetURLs = [NSSet setWithArray:[spriteMap.allValues valueForKeyPath:@"url"]];
+                ApolloLog(@"[UserFlair] sprite map: %lu classes, %lu sheet(s)", (unsigned long)spriteMap.count, (unsigned long)sheetURLs.count);
+                dispatch_group_t grp = dispatch_group_create();
+                for (NSString *u in sheetURLs) {
+                    if ([ApolloUserFlairSheetCache() objectForKey:u]) continue;
+                    NSURL *url = [NSURL URLWithString:u]; if (!url) continue;
+                    dispatch_group_enter(grp);
+                    [[[NSURLSession sharedSession] dataTaskWithURL:url completionHandler:^(NSData *id_, NSURLResponse *ir, NSError *ie) {
+                        UIImage *im = id_ ? [UIImage imageWithData:id_] : nil;
+                        if (im) [ApolloUserFlairSheetCache() setObject:im forKey:u];
+                        dispatch_group_leave(grp);
+                    }] resume];
+                }
+                dispatch_group_notify(grp, dispatch_get_main_queue(), ^{
+                    UIViewController *c2 = wc; if (!c2) return;
+                    objc_setAssociatedObject(c2, &kApolloUserFlairSpriteMapKey, spriteMap, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                    reload(); // now sprites can crop+render
+                });
+            }] resume];
+        });
+    }] resume];
+}
+
 // YES when the presenter chain contains Apollo's flair selector. Used to scope
 // alert suppression to that screen. NOTE: Apollo presents this alert *before* it
 // stores self.flairOptions (verified in the binary), so the collapse model is not
@@ -1403,6 +1676,7 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
     if (section == kApolloUserFlairOptionsSection) {
         NSString *sub = ApolloUserFlairCleanSubredditName(ApolloUserFlairSubredditNameFromObject((UIViewController *)self, 0));
         ApolloUserFlairFetchCurrentFlair((UIViewController *)self, sub);
+        ApolloUserFlairFetchSpriteData((UIViewController *)self, sub);
         ApolloUserFlairCollapseModel *model = ApolloUserFlairCollapseModelFor((UIViewController *)self);
         if (model.active) return (NSInteger)model.realRows.count;
     }
@@ -1452,34 +1726,74 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
             }
         } else if (realRow >= 0 && realRow < (NSInteger)options.count) {
             id opt = options[realRow];
-            NSString *currentText = ApolloUserFlairCurrentFlairTextForOption((UIViewController *)self, opt);
-            // When templates are collapsed into one representative row, the current
-            // flair may live on a different (hidden) empty template — they're all
-            // equivalent, so show it on the representative regardless of which one.
-            if (currentText.length == 0 && isCustomRow) {
-                NSDictionary *cur = objc_getAssociatedObject((UIViewController *)self, &kApolloUserFlairCurrentFlairKey);
-                NSString *t = cur[@"text"];
-                if ([t isKindOfClass:[NSString class]] && t.length > 0) currentText = t;
-            }
-            BOOL blankEditable = ApolloUserFlairOptionIsBlankEditable(opt);
-            if (currentText.length > 0) {
-                NSString *sub = ApolloUserFlairCleanSubredditName(ApolloUserFlairSubredditNameFromObject((UIViewController *)self, 0));
-                NSArray *pieces = ApolloUserFlairPiecesFromFlairText(currentText, sub.lowercaseString);
+
+            // Old-reddit CSS-class flair: show the prettified class name as the row
+            // label, plus the real cropped sprite (when the stylesheet parsed) as an
+            // image alongside it. Both are persisted on the option so Apollo's async
+            // layout pass renders them (the thread-locals are cleared by then);
+            // textRepresentation drives the label, `flairs` the sprite image. The
+            // committed selection is the bare template (we never touch the model).
+            NSString *cssClass = ApolloUserFlairCssClassForOption((UIViewController *)self, opt);
+            if (cssClass) {
+                NSString *name = ApolloUserFlairPrettifyClass(cssClass);
+                NSString *spriteFile = ApolloUserFlairSpriteFileForClass((UIViewController *)self, cssClass);
+                // The selector cell renders an option's `flairs` pieces (it ignores
+                // textRepresentation), so build the row from pieces: the real cropped
+                // sprite (when the stylesheet parsed) followed by the prettified class
+                // name, so near-identical sprites (e.g. the many Marios) stay legible.
+                // When the sheet can't be parsed we fall back to the name alone.
+                NSMutableArray *pieces = [NSMutableArray array];
+                if (spriteFile) {
+                    id sprite = ApolloUserFlairMakeEmojiFlair(cssClass, spriteFile);
+                    if (sprite) [pieces addObject:sprite];
+                }
+                if (name.length) {
+                    NSString *label = pieces.count ? [@" " stringByAppendingString:name] : name;
+                    id text = ApolloUserFlairMakeTextFlair(label);
+                    if (text) [pieces addObject:text];
+                }
                 if (pieces.count) {
+                    // Persist on the option so Apollo's async layout pass renders it
+                    // (the thread-local override below is cleared by then). Only
+                    // `flairs` is overridden — textRepresentation is left as the
+                    // template's real (empty) text, so committing selects the bare
+                    // template, never our synthetic display text.
+                    objc_setAssociatedObject(opt, &kApolloUserFlairOptionDisplayFlairsKey, pieces, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
                     customRowOption = opt;
                     customRowFlairs = pieces;
-                    customRowText = currentText;
+                }
+            }
+
+            if (!customRowOption) {
+                NSString *currentText = ApolloUserFlairCurrentFlairTextForOption((UIViewController *)self, opt);
+                // When templates are collapsed into one representative row, the current
+                // flair may live on a different (hidden) empty template — they're all
+                // equivalent, so show it on the representative regardless of which one.
+                if (currentText.length == 0 && isCustomRow) {
+                    NSDictionary *cur = objc_getAssociatedObject((UIViewController *)self, &kApolloUserFlairCurrentFlairKey);
+                    NSString *t = cur[@"text"];
+                    if ([t isKindOfClass:[NSString class]] && t.length > 0) currentText = t;
+                }
+                BOOL blankEditable = ApolloUserFlairOptionIsBlankEditable(opt);
+                if (currentText.length > 0) {
+                    NSString *sub = ApolloUserFlairCleanSubredditName(ApolloUserFlairSubredditNameFromObject((UIViewController *)self, 0));
+                    NSArray *pieces = ApolloUserFlairPiecesFromFlairText(currentText, sub.lowercaseString);
+                    if (pieces.count) {
+                        customRowOption = opt;
+                        customRowFlairs = pieces;
+                        customRowText = currentText;
+                    } else if (blankEditable) {
+                        // Have a current flair but couldn't build pieces (e.g. RDKFlair
+                        // unavailable) — don't leave a blank row; show the placeholder.
+                        customRowOption = opt;
+                        customRowFlairs = ApolloUserFlairPlaceholderFlairs();
+                        customRowText = kApolloUserFlairCustomRowText;
+                    }
                 } else if (blankEditable) {
-                    // Have a current flair but couldn't build pieces (e.g. RDKFlair
-                    // unavailable) — don't leave a blank row; show the placeholder.
                     customRowOption = opt;
                     customRowFlairs = ApolloUserFlairPlaceholderFlairs();
                     customRowText = kApolloUserFlairCustomRowText;
                 }
-            } else if (blankEditable) {
-                customRowOption = opt;
-                customRowFlairs = ApolloUserFlairPlaceholderFlairs();
-                customRowText = kApolloUserFlairCustomRowText;
             }
         }
     }
@@ -1551,6 +1865,14 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
         ((void (*)(id, SEL))objc_msgSend)(tableNode, @selector(reloadData));
     }
 
+    // Old-reddit css-class flairs are preset character templates, not free-text:
+    // selecting one is the whole interaction (Update then commits the bare
+    // template). Don't pop the text editor for these — only for genuinely
+    // editable/custom rows.
+    if (tappedOption && objc_getAssociatedObject(tappedOption, &kApolloUserFlairOptionDisplayFlairsKey)) {
+        return;
+    }
+
     __weak UIViewController *weakController = (UIViewController *)self;
     dispatch_async(dispatch_get_main_queue(), ^{
         UIViewController *strongController = weakController;
@@ -1590,7 +1912,44 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
     if (tApolloUserFlairCustomRowOption && tApolloUserFlairCustomRowOption == self && tApolloUserFlairCustomRowFlairs) {
         return tApolloUserFlairCustomRowFlairs;
     }
+    // Persistent css-class sprite/name override (read by the async layout pass).
+    NSArray *display = objc_getAssociatedObject(self, &kApolloUserFlairOptionDisplayFlairsKey);
+    if ([display isKindOfClass:[NSArray class]] && display.count) return display;
     return flairs;
+}
+
+%end
+
+// Our cropped old-reddit sprites live on disk as file:// URLs, but Apollo's flair
+// emoji images load through ASNetworkImageNode's HTTP-only downloader, which can't
+// fetch file:// (the request silently produces no image — blank rows). Intercept the
+// URL setter: when it's one of our sprite files, set the cached cropped UIImage
+// directly and skip the network path entirely. Real (https) emoji URLs are untouched.
+static BOOL ApolloUserFlairTrySetSpriteImage(id imageNode, NSURL *url) {
+    if (![url isKindOfClass:[NSURL class]] || !url.isFileURL) return NO;
+    NSString *path = url.path;
+    if (![[path lastPathComponent] hasPrefix:kApolloUserFlairSpriteFilePrefix]) return NO;
+    UIImage *img = nil;
+    @synchronized (ApolloUserFlairSpriteImageByPath()) { img = ApolloUserFlairSpriteImageByPath()[path]; }
+    if (!img) img = [UIImage imageWithContentsOfFile:path];
+    if (!img) return NO;
+    if ([imageNode respondsToSelector:@selector(setImage:)]) {
+        ((void (*)(id, SEL, UIImage *))objc_msgSend)(imageNode, @selector(setImage:), img);
+        return YES;
+    }
+    return NO;
+}
+
+%hook ASNetworkImageNode
+
+- (void)setURL:(NSURL *)URL {
+    if (ApolloUserFlairTrySetSpriteImage(self, URL)) return;
+    %orig;
+}
+
+- (void)setURL:(NSURL *)URL resetToDefault:(BOOL)reset {
+    if (ApolloUserFlairTrySetSpriteImage(self, URL)) return;
+    %orig;
 }
 
 %end

--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -441,13 +441,20 @@ static UIViewController *ApolloUserFlairPresenterForController(UIViewController 
 }
 
 // First http(s) URL embedded in a string (NSDataDetector handles "Go to <url> ..."
-// instruction text). nil when there's no link.
-static NSURL *ApolloUserFlairFirstURL(NSString *text) {
+// instruction text, and promotes bare domains like "flair.x.com" to http). nil when
+// there's no web link. The http/https-only filter is deliberate — it rejects
+// mailto:/custom-scheme deeplinks that a malicious flair could otherwise smuggle
+// into the in-app browser. outRange (optional) receives the matched URL's range.
+static NSURL *ApolloUserFlairFirstURL(NSString *text, NSRange *outRange) {
+    if (outRange) *outRange = NSMakeRange(NSNotFound, 0);
     if (text.length == 0) return nil;
     NSDataDetector *det = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:NULL];
     NSTextCheckingResult *m = [det firstMatchInString:text options:0 range:NSMakeRange(0, text.length)];
     NSURL *url = m.URL;
-    if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) return url;
+    if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
+        if (outRange) *outRange = m.range;
+        return url;
+    }
     return nil;
 }
 
@@ -467,6 +474,53 @@ static void ApolloUserFlairOpenURLInApp(UIViewController *controller, NSURL *url
     if ([[UIApplication sharedApplication] respondsToSelector:@selector(openURL:options:completionHandler:)]) {
         [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
     }
+}
+
+// YES when a flair row is really an "external flair tool" link — an instruction
+// whose text is essentially just a URL (e.g. r/anime "Go to https://flair.r-anime.moe
+// to get your flair!", r/CFB "More flair options at https://flair.redditcfb.com!") —
+// rather than a selectable flair. We then open it in-app instead of committing it.
+// Deliberately independent of editability: some subs mark the tool row editable, and
+// the old non-editable gate let users commit the instruction text as their flair.
+// Never hijacks a real flair: bails on image/emoji flairs, and only fires when the
+// URL dominates the text (or there's explicit flair-tool phrasing / a known tool host).
+static BOOL ApolloUserFlairOptionIsLinkInstruction(id option, NSURL **outURL) {
+    if (outURL) *outURL = nil;
+    if (!option) return NO;
+    // A real badge/sprite/emoji flair that merely mentions a URL must NOT be hijacked.
+    for (id f in ApolloUserFlairObjectArray(option, @[@"flairs"])) {
+        if (ApolloUserFlairObjectString(f, @[@"imageURL"]).length > 0) return NO;
+    }
+    NSString *text = ApolloUserFlairOptionText(option);
+    if (text.length == 0) return NO;
+    NSRange r = NSMakeRange(NSNotFound, 0);
+    NSURL *url = ApolloUserFlairFirstURL(text, &r);
+    if (!url) return NO;
+
+    NSString *trimmed = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    // (a) The URL dominates: it's basically the whole text, or only a short
+    //     instruction wraps it ("Go to <url> to get your flair!").
+    NSUInteger urlLen = (r.location == NSNotFound) ? 0 : r.length;
+    NSString *remainder = (r.location != NSNotFound) ? [text stringByReplacingCharactersInRange:r withString:@""] : text;
+    NSMutableCharacterSet *strip = [[NSCharacterSet whitespaceAndNewlineCharacterSet] mutableCopy];
+    [strip formUnionWithCharacterSet:[NSCharacterSet punctuationCharacterSet]];
+    [strip formUnionWithCharacterSet:[NSCharacterSet symbolCharacterSet]];
+    remainder = [remainder stringByTrimmingCharactersInSet:strip];
+    BOOL dominant = (urlLen >= trimmed.length) || (remainder.length <= 40);
+    // (b) Explicit flair-tool phrasing (covers longer instructions on other subs).
+    BOOL keyword = NO;
+    NSString *low = text.lowercaseString;
+    for (NSString *kw in @[@"get your flair", @"set your flair", @"more flair", @"flair options", @"flair tool", @"flair page", @"your flair"]) {
+        if ([low containsString:kw]) { keyword = YES; break; }
+    }
+    // (c) Known external flair-tool hosts (a "flair"-prefixed subdomain, or flairwizard).
+    NSString *host = url.host.lowercaseString;
+    NSString *firstLabel = [[host componentsSeparatedByString:@"."] firstObject];
+    BOOL knownDomain = host && ([firstLabel containsString:@"flair"] ||
+                                [host rangeOfString:@"flairwizard"].location != NSNotFound);
+    if (!(dominant || keyword || knownDomain)) return NO;
+    if (outURL) *outURL = url;
+    return YES;
 }
 
 @implementation ApolloUserFlairSelectorAdapter
@@ -1908,16 +1962,18 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
         return;
     }
 
-    // Some subreddits expose a single NON-editable template whose "text" is just an
-    // instruction to use an external flair tool (e.g. r/anime: "Go to
-    // https://flair.r-anime.moe to get your flair!"). There's nothing to apply, so
-    // open the link in an in-app browser instead of selecting/committing it.
+    // Some subreddits surface their flair through an EXTERNAL tool, exposing a row
+    // whose "text" is just an instruction with a link (e.g. r/anime: "Go to
+    // https://flair.r-anime.moe to get your flair!", r/CFB: "More flair options at
+    // https://flair.redditcfb.com!"). There's nothing to apply, so open the link in
+    // an in-app browser instead of selecting/committing it. ApolloUserFlairOptionIsLinkInstruction
+    // works regardless of whether the row is editable (an editable tool row would
+    // otherwise pop the editor pre-filled with the instruction string) and won't
+    // hijack real image/text flairs.
     {
         id opt = ApolloUserFlairCapturedOptionAtIndexPath((UIViewController *)self, effectiveIndexPath);
-        BOOL editableKnown = NO;
-        BOOL editable = ApolloUserFlairOptionIsEditable(opt, &editableKnown);
-        NSURL *link = ApolloUserFlairFirstURL(ApolloUserFlairOptionText(opt));
-        if (link && editableKnown && !editable) {
+        NSURL *link = nil;
+        if (ApolloUserFlairOptionIsLinkInstruction(opt, &link) && link) {
             if ([tableNode respondsToSelector:@selector(deselectRowAtIndexPath:animated:)]) {
                 ((void (*)(id, SEL, NSIndexPath *, BOOL))objc_msgSend)(tableNode, @selector(deselectRowAtIndexPath:animated:), indexPath, NO);
             }

--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -440,6 +440,35 @@ static UIViewController *ApolloUserFlairPresenterForController(UIViewController 
     return presenter ?: controller;
 }
 
+// First http(s) URL embedded in a string (NSDataDetector handles "Go to <url> ..."
+// instruction text). nil when there's no link.
+static NSURL *ApolloUserFlairFirstURL(NSString *text) {
+    if (text.length == 0) return nil;
+    NSDataDetector *det = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:NULL];
+    NSTextCheckingResult *m = [det firstMatchInString:text options:0 range:NSMakeRange(0, text.length)];
+    NSURL *url = m.URL;
+    if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) return url;
+    return nil;
+}
+
+// Open a URL in an in-app browser (SFSafariViewController), keeping the user inside
+// Apollo — used for subreddits whose only "flair" option is a link to an external
+// flair tool (e.g. r/anime's flair.r-anime.moe). Falls back to the system opener.
+static void ApolloUserFlairOpenURLInApp(UIViewController *controller, NSURL *url) {
+    if (!url || !controller) return;
+    Class sfvc = objc_getClass("SFSafariViewController");
+    if (sfvc) {
+        id vc = ((id (*)(id, SEL, NSURL *))objc_msgSend)([sfvc alloc], @selector(initWithURL:), url);
+        if ([vc isKindOfClass:[UIViewController class]]) {
+            [controller presentViewController:vc animated:YES completion:nil];
+            return;
+        }
+    }
+    if ([[UIApplication sharedApplication] respondsToSelector:@selector(openURL:options:completionHandler:)]) {
+        [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+    }
+}
+
 @implementation ApolloUserFlairSelectorAdapter
 
 + (instancetype)adapterWithController:(UIViewController *)controller {
@@ -1363,8 +1392,18 @@ static NSString *ApolloUserFlairCurrentFlairTextForOption(UIViewController *cont
     if (templateID.length > 0) {
         return [templateID isEqualToString:optionID] ? text : nil;
     }
-    // Free-form flair (no template): show it on the blank editable "custom" row.
-    return ApolloUserFlairOptionIsBlankEditable(option) ? text : nil;
+    // Free-form flair (no template id): show it on the blank editable "custom" row,
+    // OR on the sole editable template (e.g. r/soccer's single emoji template, whose
+    // applied flair is free-form). Without this the row/editor fall back to the
+    // template's generic default, so a changed flair looks like it never applied and
+    // editing it would silently discard the user's real flair.
+    if (ApolloUserFlairOptionIsBlankEditable(option)) return text;
+    NSArray *options = ApolloUserFlairControllerOptions(controller);
+    if (options.count == 1) {
+        BOOL editableKnown = NO;
+        if (ApolloUserFlairOptionIsEditable(option, &editableKnown) && editableKnown) return text;
+    }
+    return nil;
 }
 
 #pragma mark - Old-Reddit CSS Sprite Flairs
@@ -1853,6 +1892,25 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
         [info addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
         [ApolloUserFlairPresenterForController((UIViewController *)self) presentViewController:info animated:YES completion:nil];
         return;
+    }
+
+    // Some subreddits expose a single NON-editable template whose "text" is just an
+    // instruction to use an external flair tool (e.g. r/anime: "Go to
+    // https://flair.r-anime.moe to get your flair!"). There's nothing to apply, so
+    // open the link in an in-app browser instead of selecting/committing it.
+    {
+        id opt = ApolloUserFlairCapturedOptionAtIndexPath((UIViewController *)self, effectiveIndexPath);
+        BOOL editableKnown = NO;
+        BOOL editable = ApolloUserFlairOptionIsEditable(opt, &editableKnown);
+        NSURL *link = ApolloUserFlairFirstURL(ApolloUserFlairOptionText(opt));
+        if (link && editableKnown && !editable) {
+            if ([tableNode respondsToSelector:@selector(deselectRowAtIndexPath:animated:)]) {
+                ((void (*)(id, SEL, NSIndexPath *, BOOL))objc_msgSend)(tableNode, @selector(deselectRowAtIndexPath:animated:), indexPath, NO);
+            }
+            ApolloUserFlairOpenURLInApp((UIViewController *)self, link);
+            ApolloLog(@"[UserFlair] flair-tool link row -> opened %@ in-app", link.absoluteString);
+            return;
+        }
     }
 
     id tappedOption = ApolloUserFlairCapturedOptionAtIndexPath((UIViewController *)self, effectiveIndexPath);

--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -16,6 +16,10 @@ static const NSInteger kApolloUserFlairOptionsSection = 1;
 // Placeholder shown on a blank, editable flair row so it's obvious it's tappable.
 static NSString *const kApolloUserFlairCustomRowText = @"Set custom flair…";
 
+// Shown when a subreddit's flair is enabled but every template is empty AND not
+// editable — there is genuinely nothing to pick (the case is broken on the web too).
+static NSString *const kApolloUserFlairNoFlairsRowText = @"No usable flairs in this community";
+
 static __thread __unsafe_unretained UIViewController *tApolloUserFlairCaptureController = nil;
 static __thread NSInteger tApolloUserFlairCaptureSection = NSNotFound;
 static __thread NSInteger tApolloUserFlairCaptureRow = NSNotFound;
@@ -1082,13 +1086,34 @@ static NSArray *ApolloUserFlairControllerOptions(UIViewController *controller) {
     return nil;
 }
 
-// "Labelled" = something the user can actually tell apart: non-empty text or at
-// least one flair piece (e.g. an emoji-only flair).
+// Some subreddits build "blank" flairs out of invisible characters (e.g. r/dbz uses
+// U+2800 BRAILLE PATTERN BLANK). Treat text made up only of whitespace / invisibles
+// as empty so those dead templates don't count as real flairs.
+static BOOL ApolloUserFlairStringIsBlank(NSString *s) {
+    if (s.length == 0) return YES;
+    static NSCharacterSet *blanks = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        NSMutableCharacterSet *m = [[NSCharacterSet whitespaceAndNewlineCharacterSet] mutableCopy];
+        // braille blank, ZWSP/ZWNJ/ZWJ, word joiner, BOM, hangul fillers, NBSP, MVS
+        [m addCharactersInString:@"⠀​‌‍⁠﻿ㅤᅟ ᠎"];
+        blanks = [m copy];
+    });
+    return [s stringByTrimmingCharactersInSet:blanks].length == 0;
+}
+
+// "Labelled" = something the user can actually tell apart: real (visible) text, an
+// emoji label, or an image. A flair piece that exists but is visually empty (no
+// real text, no emoji, no image — e.g. r/dbz's blank-character templates) does NOT
+// count, otherwise we'd keep a wall of blank pills instead of collapsing them.
 static BOOL ApolloUserFlairOptionIsLabeled(id option) {
-    NSString *text = ApolloUserFlairOptionText(option);
-    if (text.length > 0) return YES;
+    NSString *text = ApolloUserFlairOptionText(option); // covers text + emoji labels
+    if (!ApolloUserFlairStringIsBlank(text)) return YES;
     NSArray *flairs = ApolloUserFlairObjectArray(option, @[@"flairs"]);
-    return flairs.count > 0;
+    for (id f in flairs) {
+        if (ApolloUserFlairObjectString(f, @[@"imageURL"]).length > 0) return YES;
+    }
+    return NO;
 }
 
 // A blank-but-editable template: nothing to show, but you can type into it. These
@@ -1105,8 +1130,11 @@ static BOOL ApolloUserFlairOptionIsBlankEditable(id option) {
 @property (nonatomic) BOOL active;
 // displayRow -> real index into flairOptions
 @property (nonatomic, strong) NSArray<NSNumber *> *realRows;
-// real index of the single representative "custom flair" row (or NSNotFound)
+// real index of the single representative collapsed row (or NSNotFound)
 @property (nonatomic) NSInteger customRealRow;
+// YES = the representative row is an "no usable flairs" notice (empties are all
+// non-editable); NO = it's a tappable "Set custom flair…" / current-flair row.
+@property (nonatomic) BOOL infoMode;
 // identity of the flairOptions array this model was computed from
 @property (nonatomic) const void *sourcePtr;
 @end
@@ -1121,7 +1149,9 @@ static ApolloUserFlairCollapseModel *ApolloUserFlairBuildCollapseModel(NSArray *
 
     NSMutableArray<NSNumber *> *labeledRows = [NSMutableArray array];
     NSInteger firstEmptyEditable = NSNotFound;
+    NSInteger firstEmptyNonEditable = NSNotFound;
     NSInteger emptyEditableCount = 0;
+    NSInteger emptyNonEditableCount = 0;
 
     for (NSInteger i = 0; i < (NSInteger)options.count; i++) {
         id option = options[i];
@@ -1134,19 +1164,34 @@ static ApolloUserFlairCollapseModel *ApolloUserFlairBuildCollapseModel(NSArray *
         if (editableKnown && editable) {
             emptyEditableCount++;
             if (firstEmptyEditable == NSNotFound) firstEmptyEditable = i;
+        } else {
+            // Empty AND non-editable: no text, can't be typed into — useless on mobile
+            // (and on the web). Some subs have a whole wall of these.
+            emptyNonEditableCount++;
+            if (firstEmptyNonEditable == NSNotFound) firstEmptyNonEditable = i;
         }
-        // Empty AND non-editable templates carry no usable information on mobile
-        // (no text, can't be typed into) — they are dropped from the collapsed list.
     }
 
-    // Only collapse when the "endless blank rows" problem actually exists: two or
-    // more empty editable templates. One empty editable row is fine as-is.
-    if (emptyEditableCount >= 2 && firstEmptyEditable != NSNotFound) {
+    // Collapse once the "endless blank rows" problem exists (>=2 empty templates).
+    if (emptyEditableCount + emptyNonEditableCount >= 2) {
         NSMutableArray<NSNumber *> *rows = [labeledRows mutableCopy];
-        [rows addObject:@(firstEmptyEditable)];
+        if (emptyEditableCount >= 1) {
+            // At least one editable template — offer a single "Set custom flair…"
+            // row, drop the rest (incl. blank non-editables).
+            [rows addObject:@(firstEmptyEditable)];
+            model.customRealRow = firstEmptyEditable;
+            model.infoMode = NO;
+        } else if (labeledRows.count == 0) {
+            // The whole subreddit is blank, non-editable templates — replace the
+            // wall with one explanatory notice.
+            [rows addObject:@(firstEmptyNonEditable)];
+            model.customRealRow = firstEmptyNonEditable;
+            model.infoMode = YES;
+        }
+        // else: real flairs plus a wall of blanks — just keep the real ones (the
+        // blanks are dropped) with no notice and no custom row.
         model.realRows = rows;
-        model.customRealRow = firstEmptyEditable;
-        model.active = YES;
+        model.active = (rows.count != options.count);
     }
     return model;
 }
@@ -1163,8 +1208,9 @@ static ApolloUserFlairCollapseModel *ApolloUserFlairCollapseModelFor(UIViewContr
     model.sourcePtr = (__bridge const void *)options;
     objc_setAssociatedObject(controller, &kApolloUserFlairCollapseModelKey, model, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     if (model.active) {
-        ApolloLog(@"[UserFlair] old-flair collapse: %lu options -> %lu rows (custom row real index %ld)",
-            (unsigned long)options.count, (unsigned long)model.realRows.count, (long)model.customRealRow);
+        ApolloLog(@"[UserFlair] old-flair collapse: %lu options -> %lu rows (rep index %ld, %@)",
+            (unsigned long)options.count, (unsigned long)model.realRows.count, (long)model.customRealRow,
+            model.infoMode ? @"no-usable-flairs notice" : @"custom flair row");
     }
     return model;
 }
@@ -1396,7 +1442,18 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
     NSString *customRowText = nil;
     {
         NSArray *options = ApolloUserFlairControllerOptions((UIViewController *)self);
-        if (realRow >= 0 && realRow < (NSInteger)options.count) {
+        BOOL isInfoRow = (model.active && model.infoMode && realRow == model.customRealRow);
+        if (isInfoRow) {
+            // The whole subreddit's flair is empty + non-editable: show one notice
+            // instead of a wall of dead rows. Tapping it explains (see didSelect).
+            id opt = (realRow < (NSInteger)options.count) ? options[realRow] : nil;
+            if (opt) {
+                id piece = ApolloUserFlairMakeTextFlair(kApolloUserFlairNoFlairsRowText);
+                customRowOption = opt;
+                customRowFlairs = piece ? @[piece] : nil;
+                customRowText = kApolloUserFlairNoFlairsRowText;
+            }
+        } else if (realRow >= 0 && realRow < (NSInteger)options.count) {
             id opt = options[realRow];
             NSString *currentText = ApolloUserFlairCurrentFlairTextForOption((UIViewController *)self, opt);
             // When templates are collapsed into one representative row, the current
@@ -1472,6 +1529,19 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
     if (model.active && indexPath.row >= 0 && indexPath.row < (NSInteger)model.realRows.count) {
         effectiveIndexPath = [NSIndexPath indexPathForRow:[model.realRows[indexPath.row] integerValue]
                                                inSection:kApolloUserFlairOptionsSection];
+    }
+
+    // The "no usable flairs" notice isn't a real choice — explain instead of selecting.
+    if (model.active && model.infoMode && effectiveIndexPath.row == model.customRealRow) {
+        if ([tableNode respondsToSelector:@selector(deselectRowAtIndexPath:animated:)]) {
+            ((void (*)(id, SEL, NSIndexPath *, BOOL))objc_msgSend)(tableNode, @selector(deselectRowAtIndexPath:animated:), indexPath, NO);
+        }
+        UIAlertController *info = [UIAlertController alertControllerWithTitle:@"No Usable Flairs"
+            message:@"This community has flair enabled, but every flair option is empty and can't be edited, so there's nothing to apply. That's the subreddit's own setup — not an Apollo limitation."
+            preferredStyle:UIAlertControllerStyleAlert];
+        [info addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+        [ApolloUserFlairPresenterForController((UIViewController *)self) presentViewController:info animated:YES completion:nil];
+        return;
     }
 
     id tappedOption = ApolloUserFlairCapturedOptionAtIndexPath((UIViewController *)self, effectiveIndexPath);

--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -4,12 +4,24 @@
 
 static char kApolloUserFlairEditorPresentedKey;
 static char kApolloUserFlairCapturedOptionsKey;
+static char kApolloUserFlairCollapseModelKey;
 
 static const NSUInteger kApolloUserFlairMaxLength = 64;
+
+// The flair selector's flair options live in section 1 of its table.
+static const NSInteger kApolloUserFlairOptionsSection = 1;
+
+// Placeholder shown on the single collapsed "custom flair" row when a subreddit
+// uses the old (empty-template) flair system.
+static NSString *const kApolloUserFlairCustomRowText = @"Set custom flair…";
 
 static __thread __unsafe_unretained UIViewController *tApolloUserFlairCaptureController = nil;
 static __thread NSInteger tApolloUserFlairCaptureSection = NSNotFound;
 static __thread NSInteger tApolloUserFlairCaptureRow = NSNotFound;
+// While a collapsed "custom flair" cell is being built, this points at the
+// RDKFlairOption backing that row so its (otherwise empty) getters render the
+// placeholder text instead of nothing. Never mutates the model.
+static __thread __unsafe_unretained id tApolloUserFlairCustomRowOption = nil;
 
 @interface ApolloUserFlairOptionAdapter : NSObject
 @property (nonatomic, strong) id option;
@@ -667,35 +679,234 @@ static BOOL ApolloUserFlairMaybePresentEditorForOption(UIViewController *control
     return YES;
 }
 
+#pragma mark - Old Flair System Collapse
+//
+// Subreddits still on Reddit's "old" CSS-class flair system expose their flair
+// templates with NO text and NO emoji — only an editable flag and a UUID. On
+// mobile they are indistinguishable, so Apollo renders a wall of identical blank
+// rows (r/nintendo returns 346) and shows a scary "Apollo is unable to interact"
+// alert. We collapse every empty-but-editable template into a single, labelled
+// "Set custom flair…" row that opens the text editor, and suppress the alert.
+// Labelled templates (text or emoji) and ordinary (new-system) subreddits are
+// left exactly as Apollo presents them.
+
+// Returns the controller's flairOptions as an NSArray. The Swift
+// `[RDKFlairOption]?` ivar bridges to a _ContiguousArrayStorage which responds
+// to NSArray selectors (verified at runtime); nil/empty read back safely.
+static NSArray *ApolloUserFlairControllerOptions(UIViewController *controller) {
+    id raw = ApolloUserFlairRawObjectIvar(controller, @"flairOptions");
+    if ([raw isKindOfClass:[NSArray class]]) return (NSArray *)raw;
+    return nil;
+}
+
+// "Labelled" = something the user can actually tell apart: non-empty text or at
+// least one flair piece (e.g. an emoji-only flair).
+static BOOL ApolloUserFlairOptionIsLabeled(id option) {
+    NSString *text = ApolloUserFlairOptionText(option);
+    if (text.length > 0) return YES;
+    NSArray *flairs = ApolloUserFlairObjectArray(option, @[@"flairs"]);
+    return flairs.count > 0;
+}
+
+@interface ApolloUserFlairCollapseModel : NSObject
+@property (nonatomic) BOOL active;
+// displayRow -> real index into flairOptions
+@property (nonatomic, strong) NSArray<NSNumber *> *realRows;
+// real index of the single representative "custom flair" row (or NSNotFound)
+@property (nonatomic) NSInteger customRealRow;
+// identity of the flairOptions array this model was computed from
+@property (nonatomic) const void *sourcePtr;
+@end
+
+@implementation ApolloUserFlairCollapseModel
+@end
+
+static ApolloUserFlairCollapseModel *ApolloUserFlairBuildCollapseModel(NSArray *options) {
+    ApolloUserFlairCollapseModel *model = [ApolloUserFlairCollapseModel new];
+    model.customRealRow = NSNotFound;
+    model.active = NO;
+
+    NSMutableArray<NSNumber *> *labeledRows = [NSMutableArray array];
+    NSInteger firstEmptyEditable = NSNotFound;
+    NSInteger emptyEditableCount = 0;
+
+    for (NSInteger i = 0; i < (NSInteger)options.count; i++) {
+        id option = options[i];
+        if (ApolloUserFlairOptionIsLabeled(option)) {
+            [labeledRows addObject:@(i)];
+            continue;
+        }
+        BOOL editableKnown = NO;
+        BOOL editable = ApolloUserFlairOptionIsEditable(option, &editableKnown);
+        if (editableKnown && editable) {
+            emptyEditableCount++;
+            if (firstEmptyEditable == NSNotFound) firstEmptyEditable = i;
+        }
+        // Empty AND non-editable templates carry no usable information on mobile
+        // (no text, can't be typed into) — they are dropped from the collapsed list.
+    }
+
+    // Only collapse when the "endless blank rows" problem actually exists: two or
+    // more empty editable templates. One empty editable row is fine as-is.
+    if (emptyEditableCount >= 2 && firstEmptyEditable != NSNotFound) {
+        NSMutableArray<NSNumber *> *rows = [labeledRows mutableCopy];
+        [rows addObject:@(firstEmptyEditable)];
+        model.realRows = rows;
+        model.customRealRow = firstEmptyEditable;
+        model.active = YES;
+    }
+    return model;
+}
+
+static ApolloUserFlairCollapseModel *ApolloUserFlairCollapseModelFor(UIViewController *controller) {
+    if (!controller) return nil;
+    NSArray *options = ApolloUserFlairControllerOptions(controller);
+    if (!options) return nil;
+
+    ApolloUserFlairCollapseModel *cached = objc_getAssociatedObject(controller, &kApolloUserFlairCollapseModelKey);
+    if (cached && cached.sourcePtr == (__bridge const void *)options) return cached;
+
+    ApolloUserFlairCollapseModel *model = ApolloUserFlairBuildCollapseModel(options);
+    model.sourcePtr = (__bridge const void *)options;
+    objc_setAssociatedObject(controller, &kApolloUserFlairCollapseModelKey, model, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (model.active) {
+        ApolloLog(@"[UserFlair] old-flair collapse: %lu options -> %lu rows (custom row real index %ld)",
+            (unsigned long)options.count, (unsigned long)model.realRows.count, (long)model.customRealRow);
+    }
+    return model;
+}
+
+// One reusable RDKFlair carrying the placeholder text, so the collapsed row
+// renders through Apollo's normal flair cell layout instead of as a blank pill.
+static NSArray *ApolloUserFlairCustomRowSyntheticFlairs(void) {
+    static NSArray *cached = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        Class flairClass = objc_getClass("RDKFlair");
+        SEL initSEL = @selector(initWithRawText:);
+        if (flairClass && [flairClass instancesRespondToSelector:initSEL]) {
+            id flair = ((id (*)(id, SEL, id))objc_msgSend)([flairClass alloc], initSEL, kApolloUserFlairCustomRowText);
+            if (flair) cached = @[flair];
+        }
+        if (!cached) {
+            // The synthetic flair is what makes the collapsed row render its label;
+            // without it the row falls back to Apollo's empty rendering (still a
+            // single collapsed row, just unlabelled). Surface the failure so a
+            // future RDKFlair API change doesn't degrade silently.
+            ApolloLog(@"[UserFlair] warning: could not build synthetic RDKFlair; custom-flair row will render unlabelled");
+        }
+    });
+    return cached;
+}
+
+// YES when the presenter chain contains Apollo's flair selector. Used to scope
+// alert suppression to that screen. NOTE: Apollo presents this alert *before* it
+// stores self.flairOptions (verified in the binary), so the collapse model is not
+// yet computable here — we deliberately key off the controller's presence, not
+// its model. The alert's title is unique to this one situation, so this is safe.
+static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter) {
+    Class flairClass = objc_getClass("_TtC6Apollo27FlairSelectorViewController");
+    if (!flairClass) return NO;
+
+    NSMutableArray<UIViewController *> *candidates = [NSMutableArray array];
+    if (presenter) [candidates addObject:presenter];
+    if ([presenter isKindOfClass:[UINavigationController class]]) {
+        UINavigationController *nav = (UINavigationController *)presenter;
+        [candidates addObjectsFromArray:nav.viewControllers];
+    }
+    if (presenter.presentedViewController) [candidates addObject:presenter.presentedViewController];
+
+    for (UIViewController *candidate in candidates) {
+        if ([candidate isKindOfClass:flairClass]) return YES;
+    }
+    return NO;
+}
+
 #pragma mark - Hooks
+
+// Swallow Apollo's "Subreddit Uses 'Old' Flair System" alert app-wide. The alert
+// claims Apollo "is unable to properly interact" with the subreddit, which is no
+// longer true once we collapse the empty templates into a usable custom-flair
+// row. We only suppress it when Apollo's flair selector is the screen presenting
+// it (the alert is presented off the selector's nav container, not the controller
+// itself, hence this global hook); its title is unique to this one situation.
+%hook UIViewController
+
+- (void)presentViewController:(UIViewController *)viewControllerToPresent animated:(BOOL)flag completion:(void (^)(void))completion {
+    if ([viewControllerToPresent isKindOfClass:[UIAlertController class]]) {
+        NSString *title = [(UIAlertController *)viewControllerToPresent title] ?: @"";
+        if ([title localizedCaseInsensitiveContainsString:@"Old"] &&
+            [title localizedCaseInsensitiveContainsString:@"Flair System"] &&
+            ApolloUserFlairPresenterHasFlairSelector((UIViewController *)self)) {
+            ApolloLog(@"[UserFlair] suppressed old-flair-system alert (presenter=%@)", NSStringFromClass([self class]));
+            if (completion) completion();
+            return;
+        }
+    }
+    %orig;
+}
+
+%end
 
 %hook _TtC6Apollo27FlairSelectorViewController
 
+- (NSInteger)tableNode:(id)tableNode numberOfRowsInSection:(NSInteger)section {
+    if (section == kApolloUserFlairOptionsSection) {
+        ApolloUserFlairCollapseModel *model = ApolloUserFlairCollapseModelFor((UIViewController *)self);
+        if (model.active) return (NSInteger)model.realRows.count;
+    }
+    return %orig;
+}
+
 - (id)tableNode:(id)tableNode nodeBlockForRowAtIndexPath:(NSIndexPath *)indexPath {
-    id originalBlock = %orig;
-    if (!originalBlock || indexPath.section != 1) return originalBlock;
+    if (indexPath.section != kApolloUserFlairOptionsSection) return %orig;
+
+    // Map the displayed row back to the real flairOptions index when collapsed.
+    ApolloUserFlairCollapseModel *model = ApolloUserFlairCollapseModelFor((UIViewController *)self);
+    NSInteger realRow = indexPath.row;
+    BOOL isCustomRow = NO;
+    NSIndexPath *effectiveIndexPath = indexPath;
+    if (model.active) {
+        if (indexPath.row < 0 || indexPath.row >= (NSInteger)model.realRows.count) return %orig;
+        realRow = [model.realRows[indexPath.row] integerValue];
+        isCustomRow = (realRow == model.customRealRow);
+        effectiveIndexPath = [NSIndexPath indexPathForRow:realRow inSection:kApolloUserFlairOptionsSection];
+    }
+
+    id originalBlock = %orig(tableNode, effectiveIndexPath);
+    if (!originalBlock) return originalBlock;
+
+    // For the collapsed "custom flair" row, look up the backing option so its
+    // getters can render the placeholder while this cell is being built.
+    __unsafe_unretained id customRowOption = nil;
+    if (isCustomRow) {
+        NSArray *options = ApolloUserFlairControllerOptions((UIViewController *)self);
+        if (realRow >= 0 && realRow < (NSInteger)options.count) customRowOption = options[realRow];
+    }
 
     id copiedBlock = [originalBlock copy];
     __weak UIViewController *weakController = (UIViewController *)self;
-    NSInteger section = indexPath.section;
-    NSInteger row = indexPath.row;
+    NSInteger captureRow = realRow;
 
     return [^id {
         UIViewController *strongController = weakController;
         UIViewController *previousController = tApolloUserFlairCaptureController;
         NSInteger previousSection = tApolloUserFlairCaptureSection;
         NSInteger previousRow = tApolloUserFlairCaptureRow;
+        id previousCustomOption = tApolloUserFlairCustomRowOption;
         id node = nil;
 
         tApolloUserFlairCaptureController = strongController;
-        tApolloUserFlairCaptureSection = section;
-        tApolloUserFlairCaptureRow = row;
+        tApolloUserFlairCaptureSection = kApolloUserFlairOptionsSection;
+        tApolloUserFlairCaptureRow = captureRow;
+        tApolloUserFlairCustomRowOption = customRowOption;
         @try {
             node = ((id (^)(void))copiedBlock)();
         } @finally {
             tApolloUserFlairCaptureController = previousController;
             tApolloUserFlairCaptureSection = previousSection;
             tApolloUserFlairCaptureRow = previousRow;
+            tApolloUserFlairCustomRowOption = previousCustomOption;
         }
 
         return node;
@@ -703,8 +914,24 @@ static BOOL ApolloUserFlairMaybePresentEditorForOption(UIViewController *control
 }
 
 - (void)tableNode:(id)tableNode didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    id tappedOption = ApolloUserFlairCapturedOptionAtIndexPath((UIViewController *)self, indexPath);
-    %orig;
+    NSIndexPath *effectiveIndexPath = indexPath;
+    ApolloUserFlairCollapseModel *model = (indexPath.section == kApolloUserFlairOptionsSection)
+        ? ApolloUserFlairCollapseModelFor((UIViewController *)self) : nil;
+    if (model.active && indexPath.row >= 0 && indexPath.row < (NSInteger)model.realRows.count) {
+        effectiveIndexPath = [NSIndexPath indexPathForRow:[model.realRows[indexPath.row] integerValue]
+                                               inSection:kApolloUserFlairOptionsSection];
+    }
+
+    id tappedOption = ApolloUserFlairCapturedOptionAtIndexPath((UIViewController *)self, effectiveIndexPath);
+    %orig(tableNode, effectiveIndexPath);
+
+    // When collapsed, the displayed row index differs from the real index Apollo
+    // just selected, so the checkmark may land on the wrong (off-screen) row.
+    // Reload so the visible rows recompute their checkmark from currentFlairID.
+    if (model.active && [tableNode respondsToSelector:@selector(reloadData)]) {
+        ((void (*)(id, SEL))objc_msgSend)(tableNode, @selector(reloadData));
+    }
+
     __weak UIViewController *weakController = (UIViewController *)self;
     dispatch_async(dispatch_get_main_queue(), ^{
         UIViewController *strongController = weakController;
@@ -726,6 +953,9 @@ static BOOL ApolloUserFlairMaybePresentEditorForOption(UIViewController *control
 - (NSString *)textRepresentation {
     NSString *textRepresentation = %orig;
     ApolloUserFlairCaptureOptionIfNeeded(self);
+    if (tApolloUserFlairCustomRowOption && tApolloUserFlairCustomRowOption == self) {
+        return kApolloUserFlairCustomRowText;
+    }
     return textRepresentation;
 }
 
@@ -738,6 +968,10 @@ static BOOL ApolloUserFlairMaybePresentEditorForOption(UIViewController *control
 - (NSArray *)flairs {
     NSArray *flairs = %orig;
     ApolloUserFlairCaptureOptionIfNeeded(self);
+    if (tApolloUserFlairCustomRowOption && tApolloUserFlairCustomRowOption == self) {
+        NSArray *synthetic = ApolloUserFlairCustomRowSyntheticFlairs();
+        if (synthetic) return synthetic;
+    }
     return flairs;
 }
 

--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -1772,7 +1772,21 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
             // layout pass renders them (the thread-locals are cleared by then);
             // textRepresentation drives the label, `flairs` the sprite image. The
             // committed selection is the bare template (we never touch the model).
+            //
+            // Only do this for templates that have NO real text of their own. Some
+            // subs (e.g. r/steinsgate) give each template BOTH a css class AND a real
+            // flair_text name ("suzuha amane") — for those the name is the right label,
+            // so leave them to Apollo's native rendering instead of prettifying the
+            // css class into nonsense like "Avatar Img Sg Rc 0".
             NSString *cssClass = ApolloUserFlairCssClassForOption((UIViewController *)self, opt);
+            // Use the template's REAL text only (textRepresentation / flair_text), NOT
+            // ApolloUserFlairOptionText — that falls back to the `flairs` getter, which
+            // we override with our synthetic sprite+name, so it would read back our own
+            // label on re-render and wrongly suppress the sprite (feedback loop).
+            NSString *realText = ApolloUserFlairObjectString(opt, @[@"textRepresentation", @"text", @"flairText", @"flair_text", @"plainText"]);
+            if (cssClass && !ApolloUserFlairStringIsBlank(realText)) {
+                cssClass = nil; // labeled template — render its real name natively
+            }
             if (cssClass) {
                 NSString *name = ApolloUserFlairPrettifyClass(cssClass);
                 NSString *spriteFile = ApolloUserFlairSpriteFileForClass((UIViewController *)self, cssClass);

--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -1172,26 +1172,23 @@ static ApolloUserFlairCollapseModel *ApolloUserFlairBuildCollapseModel(NSArray *
         }
     }
 
-    // Collapse once the "endless blank rows" problem exists (>=2 empty templates).
-    if (emptyEditableCount + emptyNonEditableCount >= 2) {
-        NSMutableArray<NSNumber *> *rows = [labeledRows mutableCopy];
+    // Collapse only when the subreddit is ENTIRELY empty templates (>=2 of them) and
+    // has no real flairs. Then the whole list becomes a single representative row at
+    // real index 0 — an identity mapping, which keeps the table-row remapping trivial
+    // and safe. Subreddits that mix real flairs with a few blanks are left native
+    // (their blank editable rows still get the "Set custom flair…" placeholder via the
+    // per-row path; a handful of dead rows is fine and avoids fragile remapping).
+    if (labeledRows.count == 0 && emptyEditableCount + emptyNonEditableCount >= 2) {
         if (emptyEditableCount >= 1) {
-            // At least one editable template — offer a single "Set custom flair…"
-            // row, drop the rest (incl. blank non-editables).
-            [rows addObject:@(firstEmptyEditable)];
+            model.realRows = @[@(firstEmptyEditable)];
             model.customRealRow = firstEmptyEditable;
             model.infoMode = NO;
-        } else if (labeledRows.count == 0) {
-            // The whole subreddit is blank, non-editable templates — replace the
-            // wall with one explanatory notice.
-            [rows addObject:@(firstEmptyNonEditable)];
+        } else {
+            model.realRows = @[@(firstEmptyNonEditable)];
             model.customRealRow = firstEmptyNonEditable;
             model.infoMode = YES;
         }
-        // else: real flairs plus a wall of blanks — just keep the real ones (the
-        // blanks are dropped) with no notice and no custom row.
-        model.realRows = rows;
-        model.active = (rows.count != options.count);
+        model.active = YES;
     }
     return model;
 }

--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -100,26 +100,49 @@ static NSString *ApolloUserFlairSwiftStringIvar(id object, NSString *name) {
 
         ptrdiff_t offset = ivar_getOffset(ivar);
         uint8_t *base = (uint8_t *)(__bridge void *)object + offset;
-        uint64_t low = 0;
-        uint64_t high = 0;
+        uint64_t low = 0;   // _countAndFlags (word 0)
+        uint64_t high = 0;  // _object / BridgeObject (word 1)
         memcpy(&low, base, sizeof(low));
         memcpy(&high, base + sizeof(low), sizeof(high));
 
         uint8_t discriminator = (uint8_t)(high >> 56);
-        if (discriminator < 0xE0 || discriminator > 0xEF) return nil;
 
-        NSUInteger length = discriminator - 0xE0;
-        if (length == 0 || length > 15) return nil;
+        // Small string: up to 15 UTF-8 bytes stored inline across both words; the
+        // discriminator byte is 0xE0 | count.
+        if (discriminator >= 0xE0 && discriminator <= 0xEF) {
+            NSUInteger length = discriminator - 0xE0;
+            if (length == 0 || length > 15) return nil;
 
-        char buffer[16] = {0};
-        for (NSUInteger i = 0; i < length && i < 8; i++) {
-            buffer[i] = (char)((low >> (i * 8)) & 0xFF);
+            char buffer[16] = {0};
+            for (NSUInteger i = 0; i < length && i < 8; i++) {
+                buffer[i] = (char)((low >> (i * 8)) & 0xFF);
+            }
+            for (NSUInteger i = 8; i < length; i++) {
+                buffer[i] = (char)((high >> ((i - 8) * 8)) & 0xFF);
+            }
+            return [[NSString alloc] initWithBytes:buffer length:length encoding:NSUTF8StringEncoding];
         }
-        for (NSUInteger i = 8; i < length; i++) {
-            buffer[i] = (char)((high >> ((i - 8) * 8)) & 0xFF);
-        }
 
-        return [[NSString alloc] initWithBytes:buffer length:length encoding:NSUTF8StringEncoding];
+        // Large string (>15 bytes, OR any string that was bridged in from an NSString —
+        // e.g. a subreddit name passed through Apollo's ObjC RDKClient API, which never
+        // takes the inline small-string form). Word 1 is a Swift BridgeObject whose
+        // payload (with the top discriminator byte cleared) is the backing storage
+        // object. Both Swift's native __StringStorage and a lazily-bridged Cocoa string
+        // are NSString subclasses, so we read the value by messaging that pointer as an
+        // NSString. Guard hard: a bad read must never crash the flair selector.
+        uintptr_t storagePtr = (uintptr_t)(high & 0x00FFFFFFFFFFFFFFULL);
+        if (storagePtr < 0x1000) return nil; // not a plausible heap pointer
+        @try {
+            id storage = (__bridge id)(void *)storagePtr;
+            if ([storage isKindOfClass:[NSString class]]) {
+                // Copy out of Swift's storage so we own a stable, ObjC-managed string.
+                NSString *value = [(NSString *)storage copy];
+                if (value.length > 0) return value;
+            }
+        } @catch (__unused NSException *exception) {
+            return nil;
+        }
+        return nil;
     }
     return nil;
 }
@@ -1401,6 +1424,17 @@ static void ApolloUserFlairFetchCurrentFlair(UIViewController *controller, NSStr
     NSString *enc = [subreddit stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]] ?: subreddit;
     __weak UIViewController *weakController = controller;
 
+    // Reddit's /api/flairselector `current` reliably returns the applied flair_text but
+    // often omits flair_template_id (comes back empty), so we can't map the flair back
+    // to its row from the response alone. Apollo's own selector, however, resolves the
+    // applied template into its `currentFlairID` ivar (a Swift String) — that's what
+    // drives its native checkmark. Capture it synchronously now (at open, before the
+    // user taps anything) so we can use it as the authoritative template id when the
+    // server's is missing. Without this the editor pre-fills the template's DEFAULT text
+    // and re-saving silently overwrites the user's real flair.
+    NSString *nativeTemplateID = ApolloUserFlairSwiftStringIvar(controller, @"currentFlairID");
+    if (![nativeTemplateID isKindOfClass:[NSString class]]) nativeTemplateID = nil;
+
     // Fetch the emoji map FIRST so :token: flairs can render as images, then the
     // current flair, then reload the table once both are available.
     ApolloUserFlairFetchEmojis(subreddit, ^(NSArray *emojis) {
@@ -1420,6 +1454,9 @@ static void ApolloUserFlairFetchCurrentFlair(UIViewController *controller, NSStr
                 id t = current[@"flair_text"]; if ([t isKindOfClass:[NSString class]]) text = t;
                 id tid = current[@"flair_template_id"]; if ([tid isKindOfClass:[NSString class]]) templateID = tid;
             }
+            // The server frequently omits flair_template_id; fall back to the template id
+            // Apollo itself resolved (its native checkmark source), captured above.
+            if (templateID.length == 0 && nativeTemplateID.length > 0) templateID = nativeTemplateID;
             dispatch_async(dispatch_get_main_queue(), ^{
                 UIViewController *strongController = weakController;
                 if (!strongController) return;


### PR DESCRIPTION
## What this does

Apollo's user flair selector mostly worked with Reddit's "new" flair system. On subreddits using the **old (CSS-class)** system, **emoji-based** flair, or that simply have empty/placeholder flair, it showed a scary alert, walls of blank rows, or nothing usable — which made it look like Apollo was broken when it usually wasn't.

This reworks the selector (building on the editable-flair support from #255) so it behaves gracefully across the full range of flair setups. Everything lives in `src/ApolloUserFlair.xm`.

### Old (CSS-class) flair system — e.g. r/nintendo, r/dbz
Subreddits like r/nintendo and r/dbz keep their real flairs (character avatars) as **old-reddit CSS-class sprite flairs**: a single sprite sheet plus per-class crop positions, defined in the subreddit stylesheet. New reddit, the official app, and Apollo all show these as a wall of blank "custom" templates because none of them look at the stylesheet — and Apollo also popped a scary "Apollo is unable to interact" alert.

Apollo now detects the system a subreddit actually uses and renders it:
- Fetches the `flairselector` (template → css class) and the subreddit stylesheet, parses the common single-sheet sprite pattern, and crops each class's avatar out of the downloaded sheet.
- Shows every template as its own row with the **real cropped sprite plus the prettified class name** — so the many near-identical Marios stay legible. r/nintendo's 346 templates become a browsable, picture-labelled list instead of a blank wall.
- When the stylesheet can't be parsed (multi-sheet or unusual layouts) it falls back to the **prettified names** alone, so the list is still usable.
- Some subs (e.g. r/steinsgate) give each template **both** a css class *and* a real `flair_text` name ("Kurisu Makise"). Those keep their real names — the sprite/prettified-class path only kicks in for templates that have no text of their own, so a named list never gets turned into gibberish like "Avatar Img Sg Rc 0".
- Picking a sprite template just selects it (Update then commits the bare template) — no free-text editor, since these are preset character flairs.
- The "Subreddit Uses 'Old' Flair System" alert is suppressed (it claimed Apollo "is unable to properly interact", which isn't true).

### Subreddit emoji picker — e.g. r/soccer
- Lots of subreddits build flair from custom emoji (r/soccer has ~2,500 club/nation crests; r/nintendo allows the Reddit snoomoji). The editor now has a **searchable emoji picker** that inserts `:name:` tokens (which Reddit renders back as images), with a live rendered preview and Reddit's 64-character / 10-emoji limits enforced.

### See your existing flair
- The selector now shows the flair you **actually have applied** (fetched from Reddit's `flairselector`), rendered with its emoji, and pre-fills the editor with it so you can tweak what you already have — instead of only ever showing the blank templates.
- This also covers subreddits with a **single editable template whose applied flair is free-form** (e.g. r/soccer, where everyone shares one `:r_soccer_user:`-based emoji template). The applied flair has no template id, so it used to fall back to the template's generic default — making a change look like it never applied (and silently dropping it when you re-opened the editor). The real applied flair is now shown on the row and pre-filled for editing.

### External flair tools
- Lots of subreddits drive flair through an external website rather than in-app templates — they expose a row whose text is just an instruction with a link (r/anime: *"Go to https://flair.r-anime.moe to get your flair!"*, r/CFB: *"More flair options at https://flair.redditcfb.com!"*). Tapping that row now **opens the tool in an in-app browser** so you stay inside Apollo, instead of trying to apply the instruction text as your flair.
- Detection is general (not hard-coded to one sub) and editability-independent: a row is treated as a tool link when it's essentially just a URL/instruction (the URL dominates the text, or it uses flair-tool phrasing like "more flair", or it points at a known flair-tool host). It **bails on real flairs** — a team badge or emoji flair that merely contains a URL is never hijacked, and rows without a link behave exactly as before. The check runs before selection, so it never commits the instruction as your flair.

### Clear empty states
- Subreddits whose flair is **entirely empty + non-editable** (no text, no emoji, no css class — nothing to pick, broken on the web too) show a single **"No usable flairs in this community"** notice; tapping it explains it's the subreddit's configuration, not an Apollo limitation — so users don't blame Apollo.
- Blank-but-editable rows show a "Set custom flair…" placeholder so it's obvious they're tappable.

### Left untouched
- New-system labelled subreddits — text, emoji, or image flairs (r/CFB, r/wow, r/formula1, r/batman, r/PoliticalCompassMemes, …) — render exactly as before. Subreddits that mix real flairs with a few blanks keep their real flairs.

### Scope / limitations
- This improves the flair **selector** (picking your own flair). Rendering an *applied* old-CSS sprite flair next to usernames in feeds/comments is **out of scope** — those sprites live only in the subreddit's CSS stylesheet, so new Reddit and the official Reddit app don't render them either (they only appear on old.reddit.com). Apollo follows the same behavior: an applied old-system flair with no text shows blank outside old.reddit, which is a Reddit-platform limitation, not an Apollo bug.

## Implementation notes
- The sprite/name overrides are persisted on each `RDKFlairOption` via associated objects, because Apollo's `FlairSelectionNode` reads `flairs` on a background layout pass that runs after the per-row override has been torn down. Only `flairs` is overridden — `textRepresentation` is left as the template's real (empty) text, so committing a selection is unchanged.
- Apollo loads flair images through `ASNetworkImageNode`'s HTTP-only downloader, which can't fetch the `file://` URLs of our locally cropped sprites. Its URL setter is hooked to detect our sprite files and set the cached cropped `UIImage` directly, bypassing the network path; real (https) emoji URLs are untouched.

## Testing

Simulator-tested across ~18 subreddits spanning every flair configuration — old-system sprite, old-system name-fallback, emoji-based, image, text, editable, all-blank, mixed, and no-template — with no crashes, correct rendering, and graceful empty states throughout. A live select/commit round-trip on r/nintendo's sprite flairs applied and reverted correctly; live flair saves (text and `:emoji:`) round-tripped to Reddit and were reverted.

Server-side persistence was verified directly: editing the r/soccer flair and re-opening showed the change reflected by Reddit's live `flairselector` query (not just a local UI update), then reverted. r/soccer's single free-form template now renders and pre-fills the real applied flair.

A fresh robustness sweep covered a diverse handful with no crashes or regressions: r/CFB (266 old-css templates → real team names + logo emoji), r/PoliticalCompassMemes (emoji + text), r/wow (icon-only emoji flairs), r/steinsgate (css + real names), r/wallstreetbets & r/leagueoflegends (user flair disabled → Apollo's own "Flair Not Permitted" alert, untouched).

External flair-tool links were verified general and non-destructive: r/anime (flair.r-anime.moe) and r/CFB (flair.redditcfb.com — its row reads as *editable*, which the earlier non-editable-only gate missed) both open in an in-app browser; tapping a real CFB team-logo flair selects normally and does **not** open the browser (the image-flair bail), and rows with no link are unchanged. Not yet device-tested.

## Screenshots
| <img width="250" alt="Simulator Screenshot - Apollo-Sim - 2026-06-16 at 20 35 37" src="https://github.com/user-attachments/assets/23ed9523-6d90-4acf-965f-827940bad2ad" /> | <img width="250" alt="Simulator Screenshot - Apollo-Sim - 2026-06-16 at 20 35 33" src="https://github.com/user-attachments/assets/c0c84a64-931d-46a9-ab0a-5de02fd12332" /> |
| --- | --- |
| <img width="250" alt="Simulator Screenshot - Apollo-Sim - 2026-06-16 at 20 31 49" src="https://github.com/user-attachments/assets/c5b2391a-3d9c-44c7-a20d-9a97b08b7e59" /> | <img width="250" alt="Simulator Screenshot - Apollo-Sim - 2026-06-16 at 20 31 28" src="https://github.com/user-attachments/assets/11b3920d-e6be-45d7-a68c-a19bc52e5b20" /> |






