### PR TITLE
Implement module system and orchestrator for IPA patching scripts

### DIFF
--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Canonical CydiaSubstrate arm64e stripper (provides
+# strip_substrate_arm64e_in_ipa). Mirrors the module used by apply-patches.sh.
+# shellcheck source=scripts/modules/strip-substrate-arm64e.sh
+source "$SCRIPT_DIR/scripts/modules/strip-substrate-arm64e.sh"
 IPA_PATH=""
 DEB_PATH=""
 OUTPUT_IPA="Apollo-Tweaked.ipa"
@@ -80,50 +84,9 @@ echo "Output   : $OUTPUT_IPA"
 # (apt.bingner.com/debs/1443.00/mobilesubstrate_0.9.7113, April 2021). Even
 # though the framework is fat (armv6/armv7/arm64/arm64e) and the arm64 slice
 # is fine, dyld picks the arm64e slice first on an arm64e device and aborts.
-# Strip the arm64e slice in-place; dyld then falls through to arm64.
-strip_arm64e_from_substrate_in_ipa() {
-    local ipa="$1"
-    local work
-    work="$(mktemp -d)"
-
-    if ! (cd "$work" && unzip -q "$ipa"); then
-        echo "Warning: could not unzip IPA for slice fix; leaving as-is."
-        rm -rf "$work"
-        return 0
-    fi
-
-    local framework_bin="$work/Payload/Apollo.app/Frameworks/CydiaSubstrate.framework/CydiaSubstrate"
-    if [[ ! -f "$framework_bin" ]]; then
-        rm -rf "$work"
-        return 0
-    fi
-
-    if ! lipo -info "$framework_bin" 2>/dev/null | grep -qw 'arm64e'; then
-        rm -rf "$work"
-        return 0
-    fi
-
-    echo "Stripping arm64e slice from CydiaSubstrate (iOS 26 dyld fix)..."
-    if ! lipo -remove arm64e "$framework_bin" -output "$framework_bin.new" 2>&1; then
-        echo "Warning: lipo -remove arm64e failed; IPA may crash on iOS 26."
-        rm -rf "$work"
-        return 0
-    fi
-    mv -f "$framework_bin.new" "$framework_bin"
-
-    # The framework's prior code signature covers the now-modified binary —
-    # remove it so the user's signer (Sideloadly/AltStore/cert) re-signs cleanly.
-    rm -rf "$(dirname "$framework_bin")/_CodeSignature"
-
-    rm -f "$ipa"
-    if ! (cd "$work" && zip -qry "$ipa" Payload); then
-        echo "Error: could not re-zip IPA after slice fix."
-        rm -rf "$work"
-        return 1
-    fi
-
-    rm -rf "$work"
-}
+# The strip-substrate-arm64e module (sourced above) handles this; the local
+# injector strips internally, while the azule and cyan paths below call
+# strip_substrate_arm64e_in_ipa on the produced IPA.
 
 LOCAL_INJECTOR="$SCRIPT_DIR/scripts/inject-deb-local.sh"
 if [[ -f "$LOCAL_INJECTOR" ]]; then
@@ -157,7 +120,7 @@ if command -v azule >/dev/null 2>&1; then
             rm -rf "$scratch_dir"
             exit 1
         fi
-        if ! strip_arm64e_from_substrate_in_ipa "$generated"; then
+        if ! strip_substrate_arm64e_in_ipa "$generated"; then
             rm -rf "$scratch_dir"
             exit 1
         fi
@@ -176,6 +139,13 @@ if command -v cyan >/dev/null 2>&1; then
     echo "Using cyan for injection..."
 
     if cyan -i "$IPA_PATH" -f "$DEB_PATH" -o "$OUTPUT_IPA"; then
+        # cyan bundles CydiaSubstrate.framework but does not strip its legacy
+        # arm64e slice, so do it here (previously only the azule path did this,
+        # leaving cyan-built IPAs to crash on arm64e iOS 26 devices).
+        if ! strip_substrate_arm64e_in_ipa "$OUTPUT_IPA"; then
+            echo "Error: arm64e strip failed after cyan injection."
+            exit 1
+        fi
         echo "Injected IPA created at: $OUTPUT_IPA"
         exit 0
     fi

--- a/patch.sh
+++ b/patch.sh
@@ -2,81 +2,22 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-LIQUID_GLASS_ASSETS_CAR="${SCRIPT_DIR}/liquid-glass/prebuilt/Assets.car"
-LIQUID_GLASS_ICONS_REGISTRY="${SCRIPT_DIR}/liquid-glass/icons.json"
-LIQUID_GLASS_ICON_NAME="AppIcon"
-LIQUID_GLASS_IPAD_ICON_FILES=("AppIcon60x60" "AppIcon76x76")
-LIQUID_GLASS_IPHONE_ICON_FILES=("AppIcon60x60")
+MODULES_DIR="${SCRIPT_DIR}/scripts/modules"
 
-load_liquid_glass_alternate_icons() {
-    # Register every icon from icons.json as a CFBundleAlternateIcons entry
-    # (including the primary, so setAlternateIconName:<primary> is a valid
-    # no-op switch back to the primary asset).
-    local i=0 id
-    while id=$(plutil -extract "icons.${i}.id" raw -o - "$LIQUID_GLASS_ICONS_REGISTRY" 2>/dev/null); do
-        echo "$id"
-        ((i++))
-    done
-}
-
-LIQUID_GLASS_ALTERNATE_ICONS=()
-while IFS= read -r line; do
-    [[ -n "$line" ]] && LIQUID_GLASS_ALTERNATE_ICONS+=("$line")
-done < <(load_liquid_glass_alternate_icons)
-
-plist_set_string() {
-    local path="$1"
-    local value="$2"
-
-    if /usr/libexec/PlistBuddy -c "Print :${path}" "Info.plist" &>/dev/null; then
-        /usr/libexec/PlistBuddy -c "Set :${path} ${value}" "Info.plist"
-    else
-        /usr/libexec/PlistBuddy -c "Add :${path} string ${value}" "Info.plist"
-    fi
-}
-
-plist_ensure_dict() {
-    local path="$1"
-
-    if ! /usr/libexec/PlistBuddy -c "Print :${path}" "Info.plist" &>/dev/null; then
-        /usr/libexec/PlistBuddy -c "Add :${path} dict" "Info.plist"
-    fi
-}
-
-plist_replace_string_array() {
-    local path="$1"
-    shift
-
-    if /usr/libexec/PlistBuddy -c "Print :${path}" "Info.plist" &>/dev/null; then
-        /usr/libexec/PlistBuddy -c "Delete :${path}" "Info.plist"
-    fi
-    /usr/libexec/PlistBuddy -c "Add :${path} array" "Info.plist"
-
-    for value in "$@"; do
-        /usr/libexec/PlistBuddy -c "Add :${path}: string ${value}" "Info.plist"
-    done
-}
-
-ensure_liquid_glass_icon_metadata() {
-    plist_ensure_dict "CFBundleIcons"
-    plist_ensure_dict "CFBundleIcons:CFBundlePrimaryIcon"
-    plist_ensure_dict "CFBundleIcons:CFBundleAlternateIcons"
-    plist_ensure_dict "CFBundleIcons~ipad"
-    plist_ensure_dict "CFBundleIcons~ipad:CFBundlePrimaryIcon"
-    plist_ensure_dict "CFBundleIcons~ipad:CFBundleAlternateIcons"
-
-    plist_set_string "CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconName" "${LIQUID_GLASS_ICON_NAME}"
-    plist_set_string "CFBundleIcons~ipad:CFBundlePrimaryIcon:CFBundleIconName" "${LIQUID_GLASS_ICON_NAME}"
-    plist_replace_string_array "CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconFiles" "${LIQUID_GLASS_IPHONE_ICON_FILES[@]}"
-    plist_replace_string_array "CFBundleIcons~ipad:CFBundlePrimaryIcon:CFBundleIconFiles" "${LIQUID_GLASS_IPAD_ICON_FILES[@]}"
-
-    for icon_name in "${LIQUID_GLASS_ALTERNATE_ICONS[@]}"; do
-        plist_ensure_dict "CFBundleIcons:CFBundleAlternateIcons:${icon_name}"
-        plist_ensure_dict "CFBundleIcons~ipad:CFBundleAlternateIcons:${icon_name}"
-        plist_set_string "CFBundleIcons:CFBundleAlternateIcons:${icon_name}:CFBundleIconName" "${icon_name}"
-        plist_set_string "CFBundleIcons~ipad:CFBundleAlternateIcons:${icon_name}:CFBundleIconName" "${icon_name}"
-    done
-}
+# The patch operations now live in shared modules (also used by the
+# apply-patches.sh orchestrator), so patch.sh and the release builder can't
+# drift. This script keeps its long-standing CLI and does a single
+# unpack → apply modules → repack.
+# shellcheck source=scripts/modules/liquid-glass-binary.sh
+source "${MODULES_DIR}/liquid-glass-binary.sh"
+# shellcheck source=scripts/modules/liquid-glass-assets.sh
+source "${MODULES_DIR}/liquid-glass-assets.sh"
+# shellcheck source=scripts/modules/inject-url-schemes.sh
+source "${MODULES_DIR}/inject-url-schemes.sh"
+# shellcheck source=scripts/modules/fix-safari-extension.sh
+source "${MODULES_DIR}/fix-safari-extension.sh"
+# shellcheck source=scripts/modules/fix-openin-extension.sh
+source "${MODULES_DIR}/fix-openin-extension.sh"
 
 # Cleanup on exit (success or failure)
 cleanup() {
@@ -212,196 +153,73 @@ fi
 echo "Extracting ${INPUT_IPA}..."
 rm -rf extract_temp
 unzip -q "${INPUT_IPA}" -d extract_temp
-cd extract_temp
 
-if [ ! -d "Payload" ]; then
+if [ ! -d "extract_temp/Payload" ]; then
     echo "Error: Invalid IPA structure - Payload directory not found"
     exit 1
 fi
 
-# Find the app bundle dynamically
-app_bundle=$(ls Payload/ | grep '\.app$' | head -1)
-if [ -z "$app_bundle" ]; then
+# Find the app bundle dynamically (absolute path so the modules don't depend on
+# the current working directory).
+app_bundle_name=$(ls extract_temp/Payload/ | grep '\.app$' | head -1)
+if [ -z "$app_bundle_name" ]; then
     echo "Error: No .app bundle found in Payload directory"
     exit 1
 fi
-echo "Found app bundle: ${app_bundle}"
+APP_BUNDLE="$(pwd)/extract_temp/Payload/${app_bundle_name}"
+echo "Found app bundle: ${app_bundle_name}"
 
-# Get the executable name from Info.plist
-PLIST_PATH="Payload/${app_bundle}/Info.plist"
-EXECUTABLE_NAME=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$PLIST_PATH")
-echo "Executable name: ${EXECUTABLE_NAME}"
-
-# --- 2. Apply Modifications ---
+# --- 2. Apply Modifications (via shared modules) ---
 echo "Applying modifications..."
-cd "Payload/${app_bundle}"
 
-# --- 2a. Liquid Glass Patch ---
+# 2a. Liquid Glass (binary + assets)
 if [ "${LIQUID_GLASS}" == "true" ]; then
     echo "Applying Liquid Glass patch for iOS 26..."
-
-    # Install vtool if not available
-    if ! command -v vtool &> /dev/null; then
+    # Convenience: auto-install vtool if missing (long-standing patch.sh behavior).
+    if ! command -v vtool &>/dev/null; then
         echo "Installing vtool..."
         brew install vtool
     fi
-
-    # Apply vtool modifications for iOS 26 compatibility
-    echo "Running vtool to set build version for iOS 26..."
-    vtool -set-build-version ios 15.0 19.0 -replace -output "${EXECUTABLE_NAME}" "${EXECUTABLE_NAME}"
-
-    # Check for duplicate @executable_path/Frameworks LC_RPATH entries
-    echo "Checking for duplicate LC_RPATH entries..."
-    executable_path_count=$(otool -l "${EXECUTABLE_NAME}" | grep -A 2 LC_RPATH | grep "@executable_path/Frameworks" | wc -l | tr -d ' ')
-    echo "Found $executable_path_count @executable_path/Frameworks LC_RPATH entries"
-
-    if [ "$executable_path_count" -gt 1 ]; then
-        echo "Removing duplicate @executable_path/Frameworks LC_RPATH entry..."
-        install_name_tool -delete_rpath "@executable_path/Frameworks" "${EXECUTABLE_NAME}"
-        echo "Duplicate LC_RPATH entry removed"
-    fi
-
-    if [ ! -f "${LIQUID_GLASS_ASSETS_CAR}" ]; then
-        echo "Error: Liquid Glass asset catalog not found at ${LIQUID_GLASS_ASSETS_CAR}"
-        exit 1
-    fi
-
-    # Sanity check against a truncated/corrupt asset catalog. The real
-    # Assets.car is ~80 MB; patching with a stub silently produces a broken
-    # IPA that crashes on launch (see issue #314), so fail early with a fix.
-    asset_size=$(wc -c < "${LIQUID_GLASS_ASSETS_CAR}" | tr -d ' ')
-    if [ "${asset_size}" -lt 4096 ]; then
-        echo "Error: ${LIQUID_GLASS_ASSETS_CAR} looks truncated or corrupt (${asset_size} bytes), not the real asset catalog."
-        echo "       Re-fetch the repository contents and try again."
-        exit 1
-    fi
-
-    echo "Replacing Assets.car with prebuilt Liquid Glass asset catalog..."
-    cp "${LIQUID_GLASS_ASSETS_CAR}" "Assets.car"
-
-    echo "Updating app icon metadata for Liquid Glass multi-icon catalog..."
-    ensure_liquid_glass_icon_metadata
+    patch_liquid_glass_binary_in_app "$APP_BUNDLE"
+    patch_liquid_glass_assets_in_app "$APP_BUNDLE"
 fi
 
-# --- 2a-icons. Liquid Glass icons-only Patch ---
-# Same Assets.car + plist work as --liquid-glass, but skip the vtool
-# build-version bump. That bump is what opts the app into the iOS 26 Liquid
-# Glass UI runtime, which replaces several legacy UIKit behaviors (notably
-# the bottom-tab horizontal swipe gesture). Users who want the new icon
-# catalog without that runtime swap can use this variant instead.
+# 2a-icons. Liquid Glass icons-only (assets only, no SDK bump)
 if [ "${LIQUID_GLASS_ICONS_ONLY}" == "true" ]; then
     echo "Applying Liquid Glass icons-only patch (no iOS 26 UI chrome)..."
-
-    if [ ! -f "${LIQUID_GLASS_ASSETS_CAR}" ]; then
-        echo "Error: Liquid Glass asset catalog not found at ${LIQUID_GLASS_ASSETS_CAR}"
-        exit 1
-    fi
-
-    echo "Replacing Assets.car with prebuilt Liquid Glass asset catalog..."
-    cp "${LIQUID_GLASS_ASSETS_CAR}" "Assets.car"
-
-    echo "Updating app icon metadata for Liquid Glass multi-icon catalog..."
-    ensure_liquid_glass_icon_metadata
+    patch_liquid_glass_assets_in_app "$APP_BUNDLE"
 fi
 
-# --- 2b. URL Schemes Patch ---
+# 2b. URL schemes
 if [ -n "$URL_SCHEMES" ]; then
-    echo "Adding custom URL schemes..."
-
-    # Check if CFBundleURLTypes exists and find entry with CFBundleURLSchemes
-    url_type_index=0
-    found_schemes=false
-
-    if /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes" "Info.plist" &>/dev/null; then
-        # CFBundleURLTypes exists, find entry with CFBundleURLSchemes
-        while /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:${url_type_index}" "Info.plist" &>/dev/null; do
-            if /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:${url_type_index}:CFBundleURLSchemes" "Info.plist" &>/dev/null; then
-                found_schemes=true
-                break
-            fi
-            url_type_index=$((url_type_index + 1))
-        done
-
-        if [ "$found_schemes" == "false" ]; then
-            # CFBundleURLTypes exists but no entry has CFBundleURLSchemes, add to first entry
-            echo "Adding CFBundleURLSchemes to existing URL type entry..."
-            /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes array" "Info.plist"
-            url_type_index=0
-            found_schemes=true
-        fi
-    else
-        # CFBundleURLTypes doesn't exist, create it
-        echo "Creating CFBundleURLTypes array..."
-        /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes array" "Info.plist"
-        /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0 dict" "Info.plist"
-        /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes array" "Info.plist"
-        url_type_index=0
-        found_schemes=true
-    fi
-
-    # Get current schemes for display
-    echo "Current URL schemes:"
-    /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:${url_type_index}:CFBundleURLSchemes" "Info.plist" 2>/dev/null || echo "  (none)"
-
-    # Parse comma-separated schemes, trim whitespace, and add each one
-    IFS=',' read -ra SCHEMES <<< "$URL_SCHEMES"
-    for scheme in "${SCHEMES[@]}"; do
-        # Trim leading and trailing whitespace
-        scheme=$(echo "$scheme" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-
-        if [ -n "$scheme" ]; then
-            # Check if scheme already exists (use grep -F for literal match)
-            # PlistBuddy output format has leading spaces, so we check if the scheme appears as a word
-            existing=$(/usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:${url_type_index}:CFBundleURLSchemes" "Info.plist" 2>/dev/null | grep -cxF "    ${scheme}" || true)
-
-            if [ "$existing" -eq 0 ]; then
-                echo "Adding URL scheme: ${scheme}"
-                /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:${url_type_index}:CFBundleURLSchemes: string ${scheme}" "Info.plist"
-            else
-                echo "URL scheme already exists, skipping: ${scheme}"
-            fi
-        fi
-    done
-
-    echo "Updated URL schemes:"
-    /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:${url_type_index}:CFBundleURLSchemes" "Info.plist"
+    inject_url_schemes_in_app "$APP_BUNDLE" "$URL_SCHEMES"
 fi
 
-# --- 2c. Remove Code Signature ---
+# 2c. Extension fixes (operate on the unpacked bundle, before repack — no extra
+# unpack/repack cycle). Each no-ops if its appex is absent.
+if [ "${FIX_SAFARI_EXTENSION}" == "true" ]; then
+    fix_safari_extension_in_app "$APP_BUNDLE"
+fi
+if [ "${FIX_OPENIN_EXTENSION}" == "true" ]; then
+    fix_openin_extension_in_app "$APP_BUNDLE"
+fi
+
+# 2d. Remove code signature
 if [ "${REMOVE_CODE_SIGNATURE}" == "true" ]; then
     echo "Removing code signature..."
-    codesign --remove-signature "${EXECUTABLE_NAME}" || true
+    executable_name=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "${APP_BUNDLE}/Info.plist")
+    codesign --remove-signature "${APP_BUNDLE}/${executable_name}" || true
 else
     echo "Keeping code signature."
 fi
 
-cd ../.. # Back to extract_temp directory
-
 # --- 3. Repackage IPA ---
 echo "Repackaging modified IPA..."
-zip -qr "${OUTPUT_IPA_PATH}" Payload/
-cd .. # Back to original directory
-
-# --- 4. Fix Safari Extension ---
-# Done after repackaging so it operates on the finished IPA (it re-zips in
-# place). No-op if the IPA has no Apollofari.appex.
-if [ "${FIX_SAFARI_EXTENSION}" == "true" ]; then
-    echo "Repairing bundled Safari extension..."
-    bash "${SCRIPT_DIR}/scripts/fix-safari-extension.sh" "${OUTPUT_IPA_PATH}"
-fi
-
-# --- 4b. Fix Open-in-Apollo Action extension ---
-# Same timing/rationale as the Safari fix. No-op if the IPA has no
-# OpenInUIExtension.appex. Resolves the dylib from the openin-extension subproject
-# build output (run 'make package' first, or pass it via the script's --dylib).
-if [ "${FIX_OPENIN_EXTENSION}" == "true" ]; then
-    echo "Repairing bundled Open-in-Apollo action extension..."
-    bash "${SCRIPT_DIR}/scripts/fix-openin-extension.sh" "${OUTPUT_IPA_PATH}"
-fi
+( cd extract_temp && zip -qr "${OUTPUT_IPA_PATH}" Payload/ )
 
 # Note: Cleanup handled by trap on EXIT
 
-# --- 5. Final Verification ---
+# --- 4. Final Verification ---
 file_size=$(wc -c < "${OUTPUT_IPA_PATH}")
 echo "Patched IPA created: ${OUTPUT_IPA_PATH} (Size: ${file_size} bytes)"
 

--- a/scripts/apply-patches.sh
+++ b/scripts/apply-patches.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+set -euo pipefail
+
+# apply-patches.sh — single-unpack IPA patch orchestrator.
+#
+# Unpacks an IPA ONCE, runs a chosen ordered list of patch modules against the
+# single unpacked .app bundle, then repacks ONCE. Each module is a shell
+# function in scripts/modules/<name>.sh operating on an unpacked bundle path
+# (the *_in_app convention modeled on strip-substrate-arm64e.sh).
+#
+# Usage:
+#   apply-patches.sh --ipa <in.ipa> -o <out.ipa> [--deb <tweak.deb>] \
+#     --module <name[:arg1[:arg2...]]> [--module ...]
+#
+# Module names (and their args):
+#   inject-tweak[:<deb>]            inject tweak dylibs (deb defaults to --deb)
+#   strip-substrate-arm64e         strip CydiaSubstrate arm64e slice
+#   patch-bundle-versions:<short>:<build>   set CFBundleShortVersionString/CFBundleVersion
+#   inject-url-schemes:<csv>       append URL schemes to CFBundleURLTypes
+#   fix-safari-extension           repair Apollofari.appex
+#   fix-openin-extension[:<dylib>] repair OpenInUIExtension.appex
+#   inject-widgets[:<appex>]       remove stock widget, inject ApolloRebornWidgets.appex
+#   liquid-glass-binary            vtool SDK bump + LC_RPATH cleanup
+#   liquid-glass-assets            Assets.car swap + icon metadata
+#
+# Example:
+#   apply-patches.sh --ipa Apollo.ipa -o out.ipa --deb tweak.deb \
+#     --module inject-tweak \
+#     --module strip-substrate-arm64e \
+#     --module fix-safari-extension \
+#     --module fix-openin-extension \
+#     --module 'patch-bundle-versions:3.0.0:300' \
+#     --module 'inject-url-schemes:dystopia,redreader' \
+#     --module inject-widgets \
+#     --module liquid-glass-binary \
+#     --module liquid-glass-assets
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULES_DIR="$SCRIPT_DIR/modules"
+
+IPA_PATH=""
+OUTPUT_IPA=""
+DEB_PATH=""
+MODULE_SPECS=()
+
+usage() {
+    sed -n '3,40p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# Map a module name to the shell function it defines. Names that don't map by a
+# simple substitution are listed explicitly.
+module_function() {
+    case "$1" in
+        inject-tweak)            echo "inject_tweak_in_app" ;;
+        strip-substrate-arm64e)  echo "strip_substrate_arm64e_in_app" ;;
+        patch-bundle-versions)   echo "patch_bundle_versions_in_app" ;;
+        inject-url-schemes)      echo "inject_url_schemes_in_app" ;;
+        fix-safari-extension)    echo "fix_safari_extension_in_app" ;;
+        fix-openin-extension)    echo "fix_openin_extension_in_app" ;;
+        inject-widgets)          echo "inject_widgets_in_app" ;;
+        liquid-glass-binary)     echo "patch_liquid_glass_binary_in_app" ;;
+        liquid-glass-assets)     echo "patch_liquid_glass_assets_in_app" ;;
+        *) return 1 ;;
+    esac
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ipa)    IPA_PATH="$2";    shift 2 ;;
+        -o|--output) OUTPUT_IPA="$2"; shift 2 ;;
+        --deb)    DEB_PATH="$2";    shift 2 ;;
+        --module) MODULE_SPECS+=("$2"); shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+[[ -z "$IPA_PATH" ]]    && { echo "Error: --ipa is required" >&2; exit 1; }
+[[ -z "$OUTPUT_IPA" ]]  && { echo "Error: -o/--output is required" >&2; exit 1; }
+[[ ! -f "$IPA_PATH" ]]  && { echo "Error: IPA not found: $IPA_PATH" >&2; exit 1; }
+[[ "${#MODULE_SPECS[@]}" -eq 0 ]] && { echo "Error: at least one --module is required" >&2; exit 1; }
+
+absolute_path() {
+    case "$1" in
+        /*) printf '%s\n' "$1" ;;
+        *)  printf '%s/%s\n' "$PWD" "${1#./}" ;;
+    esac
+}
+IPA_PATH="$(absolute_path "$IPA_PATH")"
+OUTPUT_IPA="$(absolute_path "$OUTPUT_IPA")"
+[[ -n "$DEB_PATH" ]] && DEB_PATH="$(absolute_path "$DEB_PATH")"
+
+# Validate every module up front (name resolvable + file present) so we fail
+# before unpacking rather than mid-pipeline.
+for spec in "${MODULE_SPECS[@]}"; do
+    name="${spec%%:*}"
+    if ! module_function "$name" >/dev/null; then
+        echo "Error: unknown module: $name" >&2; exit 1
+    fi
+    if [[ ! -f "$MODULES_DIR/$name.sh" ]]; then
+        echo "Error: module file not found: $MODULES_DIR/$name.sh" >&2; exit 1
+    fi
+done
+
+work="$(mktemp -d /tmp/apollo-apply-patches-XXXXXX)"
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT
+
+echo "==> Unpacking $(basename "$IPA_PATH")"
+unzip -q "$IPA_PATH" -d "$work"
+
+app_bundle="$(find "$work/Payload" -maxdepth 1 -name '*.app' -type d | head -1)"
+[[ -z "$app_bundle" ]] && { echo "Error: no .app bundle found in IPA." >&2; exit 1; }
+echo "    App bundle: $(basename "$app_bundle")"
+
+for spec in "${MODULE_SPECS[@]}"; do
+    name="${spec%%:*}"
+    # Split the remaining colon-separated args into an array (empty if none).
+    args=()
+    if [[ "$spec" == *:* ]]; then
+        rest="${spec#*:}"
+        IFS=':' read -ra args <<< "$rest"
+    fi
+
+    # inject-tweak defaults its deb argument to --deb when not given inline.
+    if [[ "$name" == "inject-tweak" && "${#args[@]}" -eq 0 ]]; then
+        [[ -z "$DEB_PATH" ]] && { echo "Error: inject-tweak needs a deb (--deb or inline)." >&2; exit 1; }
+        args=("$DEB_PATH")
+    fi
+
+    fn="$(module_function "$name")"
+    # shellcheck source=/dev/null
+    source "$MODULES_DIR/$name.sh"
+    echo "==> Module: $name"
+    # ${args[@]+...} guards against the empty-array "unbound variable" error
+    # under `set -u` on macOS's bash 3.2.
+    "$fn" "$app_bundle" ${args[@]+"${args[@]}"}
+done
+
+# Strip the top-level app signature so the user's signer re-seals cleanly. The
+# individual modules already strip the signatures of bundles they modify.
+rm -rf "$app_bundle/_CodeSignature"
+
+echo "==> Repacking $(basename "$OUTPUT_IPA")"
+rm -f "$OUTPUT_IPA"
+mkdir -p "$(dirname "$OUTPUT_IPA")"
+( cd "$work" && zip -qry "$OUTPUT_IPA" Payload )
+
+file_size=$(wc -c < "$OUTPUT_IPA" | tr -d ' ')
+file_size_mb=$(awk "BEGIN {printf \"%.1f\", ${file_size}/1048576}")
+echo "==> Done: $OUTPUT_IPA (${file_size_mb} MB)"

--- a/scripts/build_release_variants.sh
+++ b/scripts/build_release_variants.sh
@@ -59,93 +59,37 @@ PY
 # shared-key workarounds (Dystopia / RedReader) without manual Info.plist edits.
 DEFAULT_URL_SCHEMES="dystopia,redreader"
 
-# Run patch.sh over a finished IPA to inject DEFAULT_URL_SCHEMES and write the
-# result back in place. Only the standard/no-extensions variants need this: the
-# four Liquid Glass variants below are derived from those two via patch.sh and
-# therefore inherit the already-injected schemes.
-inject_default_url_schemes_in_place() {
-    local ipa="$1"
-    local work output
-    work="$(mktemp -d)"
-    output="$work/$(basename "$ipa")"
-    bash "${REPO_DIR}/patch.sh" "$ipa" --url-schemes "$DEFAULT_URL_SCHEMES" -o "$output"
-    mv -f "$output" "$ipa"
-    rm -rf "$work"
+# The per-variant patch steps are now composed from shared modules run through
+# the single-unpack orchestrator (scripts/apply-patches.sh). The previous inline
+# helpers (inject_default_url_schemes_in_place, set_main_app_bundle_versions_in_ipa,
+# strip_arm64e_from_substrate_in_ipa) each did their own unpack/repack; the
+# orchestrator collapses a variant's whole patch chain into one unpack/repack.
+APPLY_PATCHES="${SCRIPT_DIR}/apply-patches.sh"
+
+# Run apply-patches.sh on an IPA in place (read it, write a temp, move back).
+apply_patches_in_place() {
+    local ipa="$1"; shift
+    local tmp="${ipa}.patched.tmp"
+    bash "$APPLY_PATCHES" --ipa "$ipa" -o "$tmp" "$@"
+    mv -f "$tmp" "$ipa"
 }
 
-set_main_app_bundle_versions_in_ipa() {
-    local ipa="$1"
-    local short_version="$2"
-    local build_version="$3"
-    local work plist app_dir
-    work="$(mktemp -d)"
-
-    if ! (cd "$work" && unzip -q "$ipa"); then
-        echo "Warning: could not unzip IPA for version update; leaving as-is."
-        rm -rf "$work"
-        return 0
+# Build the Reborn widget extension appex once, up front. The inject-widgets
+# module injects this prebuilt appex; fail loudly if xcodegen is missing so a
+# release can't silently ship widget-less.
+build_widget_appex() {
+    if ! command -v xcodegen >/dev/null 2>&1; then
+        echo "Error: xcodegen is required to build and inject Reborn widgets." >&2
+        exit 1
     fi
-
-    plist="$(find "$work/Payload" -maxdepth 2 -name Info.plist -path '*.app/Info.plist' -print -quit)"
-    if [[ -z "$plist" || ! -f "$plist" ]]; then
-        echo "Warning: could not find main app Info.plist in $(basename "$ipa"); leaving as-is."
-        rm -rf "$work"
-        return 0
-    fi
-
-    plutil -replace CFBundleShortVersionString -string "$short_version" "$plist"
-    plutil -replace CFBundleVersion -string "$build_version" "$plist"
-
-    app_dir="$(dirname "$plist")"
-    rm -rf "$app_dir/_CodeSignature"
-
-    rm -f "$ipa"
+    echo "==> Building Reborn widget extension (xcodegen + xcodebuild)"
     (
-        cd "$work"
-        zip -qry "$ipa" Payload
+        cd "${REPO_DIR}/widgets"
+        xcodegen generate
+        xcodebuild -project ApolloRebornWidgets.xcodeproj -scheme ApolloRebornWidgets \
+                   -sdk iphoneos -configuration Release CODE_SIGNING_ALLOWED=NO \
+                   -derivedDataPath build build
     )
-
-    rm -rf "$work"
-}
-
-strip_arm64e_from_substrate_in_ipa() {
-    local ipa="$1"
-    local work
-    work="$(mktemp -d)"
-
-    if ! (cd "$work" && unzip -q "$ipa"); then
-        echo "Warning: could not unzip IPA for slice fix; leaving as-is."
-        rm -rf "$work"
-        return 0
-    fi
-
-    local framework_bin="$work/Payload/Apollo.app/Frameworks/CydiaSubstrate.framework/CydiaSubstrate"
-    if [[ ! -f "$framework_bin" ]]; then
-        rm -rf "$work"
-        return 0
-    fi
-
-    if ! lipo -info "$framework_bin" 2>/dev/null | grep -qw 'arm64e'; then
-        rm -rf "$work"
-        return 0
-    fi
-
-    echo "Stripping arm64e slice from CydiaSubstrate in $(basename "$ipa")..."
-    if ! lipo -remove arm64e "$framework_bin" -output "$framework_bin.new" >/dev/null 2>&1; then
-        echo "Warning: could not strip arm64e from CydiaSubstrate."
-        rm -rf "$work"
-        return 0
-    fi
-    mv -f "$framework_bin.new" "$framework_bin"
-    rm -rf "$(dirname "$framework_bin")/_CodeSignature"
-
-    rm -f "$ipa"
-    (
-        cd "$work"
-        zip -qry "$ipa" Payload
-    )
-
-    rm -rf "$work"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -258,61 +202,67 @@ echo "Output dir    : $OUTPUT_DIR"
 rm -f "$STANDARD_IPA" "$NOEXT_IPA" "$GLASS_IPA" "$NOEXT_GLASS_IPA" \
       "$GLASS_ICONS_IPA" "$NOEXT_GLASS_ICONS_IPA"
 
+# Build the widget appex once; the inject-widgets module injects this prebuilt
+# product into the standard variant (Glass variants inherit it).
+build_widget_appex
+
+# Module spec fragments reused across variants.
+VERSIONS_MODULE="patch-bundle-versions:${TWEAK_VERSION}:${APP_BUILD_VERSION}"
+SCHEMES_MODULE="inject-url-schemes:${DEFAULT_URL_SCHEMES}"
+
 echo ""
 echo "[1/6] Building standard injected IPA..."
+# build-ipa.sh handles tweak injection (+ CydiaSubstrate arm64e strip) on the
+# already-prepared base IPA, preserving its azule/cyan fallback for stock IPAs.
 bash "${REPO_DIR}/build-ipa.sh" --ipa "$IPA_PATH" --deb "$DEB_PATH" -o "$STANDARD_IPA"
-# Repair the bundled "Open in Apollo" Safari extension. The GLASS variant below
-# is derived from $STANDARD_IPA via patch.sh, so it inherits this fix; the two
-# no-extensions variants have no appex and the script no-ops on them.
-bash "${REPO_DIR}/scripts/fix-safari-extension.sh" "$STANDARD_IPA"
-# Repair the bundled "Open in Apollo" Action extension (OpenInUIExtension.appex):
-# inject ApolloOpenInFix.dylib (built by the openin-extension subproject) so the
-# share-sheet action opens links in Apollo from any browser. Same inheritance as
-# the Safari fix above — GLASS is derived from $STANDARD_IPA so it carries this
-# too, and the no-extensions variants have no appex (the script no-ops).
-bash "${REPO_DIR}/scripts/fix-openin-extension.sh" "$STANDARD_IPA"
-set_main_app_bundle_versions_in_ipa "$STANDARD_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
-inject_default_url_schemes_in_place "$STANDARD_IPA"
-
-# Inject the Reborn widget extension into the STANDARD IPA so the GLASS and
-# GLASSICONS variants (both derived from it via patch.sh below) inherit it. The
-# no-extensions variants are built from $IPA_PATH with `cyan -e` and stay
-# appex-free by design — widgets need an extension slot. Fail loudly if xcodegen
-# is missing so release IPAs cannot silently ship without widgets.
-if ! command -v xcodegen >/dev/null 2>&1; then
-    echo "Error: xcodegen is required to build and inject Reborn widgets." >&2
-    exit 1
-fi
-echo "==> Injecting Reborn widgets into standard IPA (Glass variants inherit; no-ext variants omit)"
-bash "${REPO_DIR}/scripts/inject-widgets.sh" --ipa "$STANDARD_IPA" --build -o "${STANDARD_IPA}.ww"
-mv "${STANDARD_IPA}.ww" "$STANDARD_IPA"
+# Everything else for the standard variant in ONE unpack/repack: repair the
+# Safari + Open-in-Apollo extensions, set versions, inject default URL schemes,
+# inject the widget extension. The GLASS and GLASSICONS variants are derived
+# from this IPA below and inherit all of it; the no-extensions variants have no
+# appex and omit the extension/widget modules.
+apply_patches_in_place "$STANDARD_IPA" \
+    --module fix-safari-extension \
+    --module fix-openin-extension \
+    --module "$VERSIONS_MODULE" \
+    --module "$SCHEMES_MODULE" \
+    --module inject-widgets
 
 echo ""
 echo "[2/6] Building no-extensions injected IPA..."
+# `cyan -e` injects the tweak AND strips all PlugIns (the no-extensions variant);
+# the orchestrator then strips the CydiaSubstrate arm64e slice, sets versions,
+# and injects the default URL schemes in one unpack/repack.
 cyan -i "$IPA_PATH" -f "$DEB_PATH" -o "$NOEXT_IPA" -e
-strip_arm64e_from_substrate_in_ipa "$NOEXT_IPA"
-set_main_app_bundle_versions_in_ipa "$NOEXT_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
-inject_default_url_schemes_in_place "$NOEXT_IPA"
+apply_patches_in_place "$NOEXT_IPA" \
+    --module strip-substrate-arm64e \
+    --module "$VERSIONS_MODULE" \
+    --module "$SCHEMES_MODULE"
 
 echo ""
 echo "[3/6] Applying Liquid Glass patch to standard IPA..."
-bash "${REPO_DIR}/patch.sh" "$STANDARD_IPA" --liquid-glass -o "$GLASS_IPA"
-set_main_app_bundle_versions_in_ipa "$GLASS_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
+bash "$APPLY_PATCHES" --ipa "$STANDARD_IPA" -o "$GLASS_IPA" \
+    --module liquid-glass-binary \
+    --module liquid-glass-assets \
+    --module "$VERSIONS_MODULE"
 
 echo ""
 echo "[4/6] Applying Liquid Glass patch to no-extensions IPA..."
-bash "${REPO_DIR}/patch.sh" "$NOEXT_IPA" --liquid-glass -o "$NOEXT_GLASS_IPA"
-set_main_app_bundle_versions_in_ipa "$NOEXT_GLASS_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
+bash "$APPLY_PATCHES" --ipa "$NOEXT_IPA" -o "$NOEXT_GLASS_IPA" \
+    --module liquid-glass-binary \
+    --module liquid-glass-assets \
+    --module "$VERSIONS_MODULE"
 
 echo ""
 echo "[5/6] Applying Liquid Glass icons-only patch to standard IPA..."
-bash "${REPO_DIR}/patch.sh" "$STANDARD_IPA" --liquid-glass-icons -o "$GLASS_ICONS_IPA"
-set_main_app_bundle_versions_in_ipa "$GLASS_ICONS_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
+bash "$APPLY_PATCHES" --ipa "$STANDARD_IPA" -o "$GLASS_ICONS_IPA" \
+    --module liquid-glass-assets \
+    --module "$VERSIONS_MODULE"
 
 echo ""
 echo "[6/6] Applying Liquid Glass icons-only patch to no-extensions IPA..."
-bash "${REPO_DIR}/patch.sh" "$NOEXT_IPA" --liquid-glass-icons -o "$NOEXT_GLASS_ICONS_IPA"
-set_main_app_bundle_versions_in_ipa "$NOEXT_GLASS_ICONS_IPA" "$TWEAK_VERSION" "$APP_BUILD_VERSION"
+bash "$APPLY_PATCHES" --ipa "$NOEXT_IPA" -o "$NOEXT_GLASS_ICONS_IPA" \
+    --module liquid-glass-assets \
+    --module "$VERSIONS_MODULE"
 
 echo ""
 echo "Created:"

--- a/scripts/fix-openin-extension.sh
+++ b/scripts/fix-openin-extension.sh
@@ -1,51 +1,18 @@
 #!/bin/bash
 set -euo pipefail
 
-# Repairs Apollo's bundled "Open in Apollo" share-sheet Action extension
-# (OpenInUIExtension.appex) inside an IPA, in place.
-#
-# The stock -[ActionViewController openURL:] walks the UIResponder chain and
-# calls the DEPRECATED single-arg -[UIApplication openURL:] via performSelector:.
-# iOS 18+ force-fails that exact selector ("BUG IN CLIENT OF UIKIT ... Force
-# returning false (NO)."), so the bundled action does nothing from any browser.
-#
-# We inject ApolloOpenInFix.dylib and add an LC_LOAD_DYLIB to the appex so it
-# loads. Its constructor swizzles -[ActionViewController openURL:] to open the
-# (already apollo://) URL via a NON-deprecated path: responder chain -> real
-# UIApplication -> openURL:options:completionHandler: (Technique A), falling back
-# to -[NSExtensionContext openURL:completionHandler:] (Technique B).
-#
-# Placement: the dylib goes in the SHARED Apollo.app/Frameworks/ (NOT the appex
-# root) and is loaded into the appex via @rpath. This matters for signing: the
-# user's signer (Sideloadly/zsign, AltStore, ...) reliably re-signs dylibs in
-# Frameworks/ -- the main tweak dylib lives there too -- but a loose dylib in the
-# appex root is skipped, left unsigned, and iOS 26's code-signing monitor then
-# kills the extension at launch ("CODESIGNING Invalid Page"). The appex already
-# has an rpath (@executable_path/../../Frameworks) that resolves to the app's
-# Frameworks/, so @rpath/ApolloOpenInFix.dylib loads from there.
-#
-# The tweak dylib can't do this at runtime -- the extension runs in its own
-# process the main-app tweak can't reach -- so the repair happens at IPA-package
-# time. Mirrors scripts/fix-safari-extension.sh.
-#
-# No-op (exit 0) when the IPA has no OpenInUIExtension.appex (no-extensions variants).
+# Thin IPA wrapper around the fix-openin-extension module. The bundle mutation
+# (install ApolloOpenInFix.dylib into Apollo.app/Frameworks/, add an @rpath
+# LC_LOAD_DYLIB to OpenInUIExtension.appex, strip its signature) lives in
+# scripts/modules/fix-openin-extension.sh and is shared with patch.sh and the
+# apply-patches.sh orchestrator. This wrapper only unpacks the IPA, calls the
+# module, and repacks. No-op when the IPA has no OpenInUIExtension.appex.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# shellcheck source=modules/fix-openin-extension.sh
+source "$SCRIPT_DIR/modules/fix-openin-extension.sh"
 
-# Where to find the built dylib. Override with --dylib. When not overridden it is
-# resolved from the openin-extension Theos subproject's build output below — the
-# subproject builds into its OWN .theos/obj (debug for `make package`, the
-# unsuffixed dir for FINALPACKAGE=1 release builds).
 DYLIB_SRC=""
-DYLIB_CANDIDATES=(
-    "${REPO_DIR}/openin-extension/.theos/obj/ApolloOpenInFix.dylib"
-    "${REPO_DIR}/.theos/obj/ApolloOpenInFix.dylib"
-    "${REPO_DIR}/openin-extension/.theos/obj/debug/ApolloOpenInFix.dylib"
-    "${REPO_DIR}/.theos/obj/debug/ApolloOpenInFix.dylib"
-)
-DYLIB_NAME="ApolloOpenInFix.dylib"
-STALE_NAMES=("ApolloOpenInHook.dylib")  # dead prior-attempt artifacts, removed if present
 
 usage() {
     echo "Usage: $0 <path-to-ipa> [--dylib <ApolloOpenInFix.dylib>]"
@@ -74,30 +41,10 @@ if [[ ! -f "$IPA_PATH" ]]; then
     echo "Error: IPA not found: $IPA_PATH"
     exit 1
 fi
-# Resolve the dylib from the subproject build output unless --dylib was given.
-if [[ -z "$DYLIB_SRC" ]]; then
-    for cand in "${DYLIB_CANDIDATES[@]}"; do
-        if [[ -f "$cand" ]]; then DYLIB_SRC="$cand"; break; fi
-    done
-fi
-if [[ -z "$DYLIB_SRC" || ! -f "$DYLIB_SRC" ]]; then
-    echo "Error: ApolloOpenInFix.dylib not found."
-    echo "  Build it first (it is a SUBPROJECT of the root Makefile): make package"
-    echo "  Looked in:"
-    printf '    %s\n' "${DYLIB_CANDIDATES[@]}"
-    echo "  Or pass an explicit --dylib <path>."
-    exit 1
-fi
-for tool in unzip zip otool python3; do
-    if ! command -v "$tool" >/dev/null 2>&1; then
-        echo "Error: required tool '$tool' is not installed."
-        exit 1
-    fi
-done
-
-# Resolve to absolute so the re-zip targets the same file regardless of cwd.
 case "$IPA_PATH" in /*) : ;; *) IPA_PATH="$PWD/$IPA_PATH" ;; esac
-case "$DYLIB_SRC" in /*) : ;; *) DYLIB_SRC="$PWD/$DYLIB_SRC" ;; esac
+if [[ -n "$DYLIB_SRC" ]]; then
+    case "$DYLIB_SRC" in /*) : ;; *) DYLIB_SRC="$PWD/$DYLIB_SRC" ;; esac
+fi
 
 work="$(mktemp -d)"
 cleanup() { rm -rf "$work"; }
@@ -114,55 +61,10 @@ if [[ -z "$app" || ! -d "$app" ]]; then
     exit 1
 fi
 
-appex="$(find "$app/PlugIns" -type d -name "OpenInUIExtension.appex" -print -quit 2>/dev/null || true)"
-if [[ -z "$appex" || ! -d "$appex" ]]; then
-    echo "No OpenInUIExtension.appex in $(basename "$IPA_PATH") — skipping Open-in-Apollo fix."
-    exit 0
-fi
-
-appex_bin="$appex/OpenInUIExtension"
-if [[ ! -f "$appex_bin" ]]; then
-    echo "Error: appex executable missing: $appex_bin"
-    exit 1
-fi
-
-echo "Repairing Open-in-Apollo action extension in $(basename "$IPA_PATH")..."
-
-# Drop any dead prior-attempt dylibs (loose in the appex, or a stale copy of ours).
-for stale in "${STALE_NAMES[@]}" "$DYLIB_NAME"; do
-    if [[ -f "$appex/$stale" ]]; then
-        rm -f "$appex/$stale"
-        echo "  removed stale $appex/$stale"
-    fi
-done
-
-# Place the dylib in the shared Frameworks dir where the signer will sign it,
-# and load it into the appex via @rpath (resolves through the appex's existing
-# @executable_path/../../Frameworks rpath).
-frameworks="$app/Frameworks"
-mkdir -p "$frameworks"
-cp "$DYLIB_SRC" "$frameworks/$DYLIB_NAME"
-echo "  installed Frameworks/$DYLIB_NAME"
-
-# Add the load command (idempotent; verified safe via the header-slack patcher).
-python3 "$SCRIPT_DIR/macho_add_load_dylib.py" "$appex_bin" "@rpath/$DYLIB_NAME"
-
-# Sanity: the load command must now be present.
-if ! otool -L "$appex_bin" | grep -q "@rpath/$DYLIB_NAME"; then
-    echo "Error: LC_LOAD_DYLIB for $DYLIB_NAME not present after patch."
-    exit 1
-fi
-
-# The appex's prior signature covers the now-modified binary — remove it so the
-# user's signer re-seals cleanly (mirrors fix-safari-extension.sh). The app-level
-# seal is left for the signer to regenerate, matching the inject-deb-local flow
-# that likewise adds dylibs to Frameworks/ without stripping the app seal.
-rm -rf "$appex/_CodeSignature"
+fix_openin_extension_in_app "$app" "$DYLIB_SRC"
 
 rm -f "$IPA_PATH"
 if ! (cd "$work" && zip -qry "$IPA_PATH" Payload); then
     echo "Error: could not re-zip IPA after Open-in-Apollo fix."
     exit 1
 fi
-
-echo "Open-in-Apollo extension repaired: Frameworks/$DYLIB_NAME + @rpath LC_LOAD_DYLIB added, appex _CodeSignature removed."

--- a/scripts/fix-safari-extension.sh
+++ b/scripts/fix-safari-extension.sh
@@ -1,25 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
-# Repairs the bundled "Open in Apollo" Safari Web Extension (Apollofari.appex)
-# inside an IPA, in place.
-#
-# The stock extension's "Automatic" mode redirected through
-# https://openinapollo.com, whose auto-open relies on an iOS Smart App Banner
-# bound to the App Store Apollo (app id 979274575). A sideloaded build is not
-# that app, so the banner never fires and users are stranded on the interstitial.
-# We overlay the fixed web assets from safari-extension/ (direct apollo://
-# redirect, no dangling background.js, MutationObserver, /s/ share-link support).
-#
-# The tweak dylib can't do this at runtime — the extension runs in Safari's
-# separate process — so the repair happens at IPA-package time, where the user's
-# signer (AltStore/SideStore/Feather/TrollStore) re-seals the modified appex.
-#
-# No-op (exit 0) when the IPA has no Apollofari.appex (the no-extensions variants).
+# Thin IPA wrapper around the fix-safari-extension module. The bundle mutation
+# (overlay safari-extension/{content.js,manifest.json} onto Apollofari.appex,
+# strip its signature) lives in scripts/modules/fix-safari-extension.sh and is
+# shared with patch.sh and the apply-patches.sh orchestrator. This wrapper only
+# unpacks the IPA, calls the module, and repacks. No-op when the IPA has no
+# Apollofari.appex (the no-extensions variants).
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-ASSET_DIR="${REPO_DIR}/safari-extension"
+# shellcheck source=modules/fix-safari-extension.sh
+source "$SCRIPT_DIR/modules/fix-safari-extension.sh"
 
 usage() {
     echo "Usage: $0 <path-to-ipa>"
@@ -36,24 +27,11 @@ if [[ $# -lt 1 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
 fi
 
 IPA_PATH="$1"
-
 if [[ ! -f "$IPA_PATH" ]]; then
     echo "Error: IPA not found: $IPA_PATH"
     exit 1
 fi
-
-for asset in content.js manifest.json; do
-    if [[ ! -f "$ASSET_DIR/$asset" ]]; then
-        echo "Error: missing overlay asset: $ASSET_DIR/$asset"
-        exit 1
-    fi
-done
-
-# Resolve to absolute so the re-zip targets the same file regardless of cwd.
-case "$IPA_PATH" in
-    /*) : ;;
-    *) IPA_PATH="$PWD/$IPA_PATH" ;;
-esac
+case "$IPA_PATH" in /*) : ;; *) IPA_PATH="$PWD/$IPA_PATH" ;; esac
 
 work="$(mktemp -d)"
 cleanup() { rm -rf "$work"; }
@@ -64,25 +42,16 @@ if ! (cd "$work" && unzip -q "$IPA_PATH"); then
     exit 1
 fi
 
-appex="$(find "$work/Payload" -type d -name "Apollofari.appex" -print -quit 2>/dev/null || true)"
-if [[ -z "$appex" || ! -d "$appex" ]]; then
-    echo "No Apollofari.appex in $(basename "$IPA_PATH") — skipping Safari extension fix."
-    exit 0
+app="$(find "$work/Payload" -maxdepth 1 -type d -name '*.app' -print -quit 2>/dev/null || true)"
+if [[ -z "$app" || ! -d "$app" ]]; then
+    echo "Error: no .app bundle found in IPA."
+    exit 1
 fi
 
-echo "Repairing Safari extension in $(basename "$IPA_PATH")..."
-cp "$ASSET_DIR/content.js" "$appex/content.js"
-cp "$ASSET_DIR/manifest.json" "$appex/manifest.json"
-
-# The appex's prior signature covers the now-modified web assets — remove it so
-# the user's signer re-seals cleanly (mirrors the CydiaSubstrate/main-app
-# handling in build-ipa.sh and build_release_variants.sh).
-rm -rf "$appex/_CodeSignature"
+fix_safari_extension_in_app "$app"
 
 rm -f "$IPA_PATH"
 if ! (cd "$work" && zip -qry "$IPA_PATH" Payload); then
     echo "Error: could not re-zip IPA after Safari extension fix."
     exit 1
 fi
-
-echo "Safari extension repaired: content.js + manifest.json overlaid, _CodeSignature removed."

--- a/scripts/inject-widgets.sh
+++ b/scripts/inject-widgets.sh
@@ -1,19 +1,21 @@
 #!/bin/bash
-# Inject the Apollo Reborn widget extension into an Apollo IPA.
+# Inject the Apollo Reborn widget extension into an Apollo IPA (thin IPA wrapper
+# around the inject-widgets module). Also optionally builds the appex first.
 #
-# A crash-looping widget extension poisons WidgetKit's enumeration of ALL of
-# the host app's widgets, so by default we REMOVE the stock crash-looping
-# AthenaWidgetExtension.appex. Other extensions (Safari, Open-In, Intentions,
-# notifications) are left untouched. The output IPA is unsigned in the sense
-# that our appex has no signature — the user's sideload tool (Feather/AltStore/
-# SideStore/Sideloadly) re-seals the whole bundle with their cert.
+# The actual bundle mutation (remove stock AthenaWidgetExtension.appex, copy in
+# ApolloRebornWidgets.appex) lives in scripts/modules/inject-widgets.sh and is
+# shared with the apply-patches.sh orchestrator. This wrapper only unpacks the
+# IPA, calls the module, and repacks.
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=modules/inject-widgets.sh
+source "$SCRIPT_DIR/modules/inject-widgets.sh"
+
 IPA_PATH=""
 OUTPUT_IPA=""
 APPEX_PATH="$REPO_ROOT/widgets/build/Build/Products/Release-iphoneos/ApolloRebornWidgets.appex"
-KEEP_STOCK=0
 DO_BUILD=0
 
 usage() {
@@ -36,7 +38,7 @@ while [[ $# -gt 0 ]]; do
         -o|--output) OUTPUT_IPA="$2"; shift 2;;
         --appex) APPEX_PATH="$2"; shift 2;;
         --build) DO_BUILD=1; shift;;
-        --keep-stock-widget) KEEP_STOCK=1; shift;;
+        --keep-stock-widget) INJECT_WIDGETS_KEEP_STOCK=1; shift;;
         -h|--help) usage; exit 0;;
         *) echo "Unknown option: $1" >&2; usage; exit 1;;
     esac
@@ -45,7 +47,6 @@ done
 [[ -z "$IPA_PATH" ]] && { echo "error: --ipa is required" >&2; usage; exit 1; }
 [[ ! -f "$IPA_PATH" ]] && { echo "error: IPA not found: $IPA_PATH" >&2; exit 1; }
 [[ -z "$OUTPUT_IPA" ]] && OUTPUT_IPA="${IPA_PATH%.ipa}-Widgets.ipa"
-# Resolve output to an absolute path before we cd anywhere.
 [[ "$OUTPUT_IPA" != /* ]] && OUTPUT_IPA="$PWD/$OUTPUT_IPA"
 
 if [[ "$DO_BUILD" == "1" ]]; then
@@ -72,27 +73,11 @@ unzip -q "$IPA_PATH" -d "$WORK"
 
 APP_DIR="$(find "$WORK/Payload" -maxdepth 1 -name '*.app' -type d | head -1)"
 [[ -z "$APP_DIR" ]] && { echo "error: no .app in Payload" >&2; exit 1; }
-PLUGINS="$APP_DIR/PlugIns"
-mkdir -p "$PLUGINS"
 
-if [[ "$KEEP_STOCK" == "0" ]]; then
-    STOCK="$PLUGINS/AthenaWidgetExtension.appex"
-    if [[ -d "$STOCK" ]]; then
-        echo "==> Removing stock AthenaWidgetExtension.appex (prevents WidgetKit enumeration poisoning)"
-        rm -rf "$STOCK"
-    fi
-fi
-
-echo "==> Injecting $(basename "$APPEX_PATH")"
-rm -rf "$PLUGINS/$(basename "$APPEX_PATH")"
-cp -R "$APPEX_PATH" "$PLUGINS/"
-# Strip any stale signature so the re-signer starts clean.
-rm -rf "$PLUGINS/$(basename "$APPEX_PATH")/_CodeSignature"
+inject_widgets_in_app "$APP_DIR" "$APPEX_PATH"
 
 echo "==> Repacking $OUTPUT_IPA"
 rm -f "$OUTPUT_IPA"
 ( cd "$WORK" && zip -qr "$OUTPUT_IPA" Payload )
 
 echo "==> Done: $OUTPUT_IPA"
-echo "    Remaining PlugIns:"
-ls "$PLUGINS" | sed 's/^/      /'

--- a/scripts/modules/README.md
+++ b/scripts/modules/README.md
@@ -1,0 +1,76 @@
+# Patch modules
+
+Each file here is one **patch module**: a shell function that mutates an
+already-unpacked `Apollo.app` bundle in place. Modules are the single source of
+truth for every IPA modification Apollo-Reborn performs, shared by:
+
+- `scripts/apply-patches.sh` — the orchestrator (unpack once → run modules → repack once)
+- `patch.sh`, `build-ipa.sh`, `scripts/build_release_variants.sh`
+- the workspace `Apollo/scripts/build.sh` (sources these via the sibling checkout)
+- the thin per-IPA wrappers (`scripts/inject-widgets.sh`, `scripts/fix-*-extension.sh`)
+
+## Convention
+
+A module `foo-bar.sh` defines:
+
+```sh
+foo_bar_in_app() {
+    local app_bundle="$1"     # path to an unpacked *.app
+    # ...mutate $app_bundle in place...
+    # strip $app_bundle/_CodeSignature (or the appex's) if you changed a
+    # signed binary/plist, so the user's signer re-seals cleanly.
+}
+```
+
+Rules:
+
+- **Operate on the passed bundle path.** Never assume the current working
+  directory or hardcode `Info.plist`; use `"$app_bundle/Info.plist"`. Plist
+  edits go through the path-taking helpers in `_plist-helpers.sh`.
+- **Be best-effort.** If the module's target (an appex, a framework) is absent,
+  print a short note and `return 0`. The one exception is `inject-tweak`, which
+  hard-fails (`return 2`) when the IPA isn't prepared.
+- **No unpack/repack inside the module.** The orchestrator owns that. (A module
+  may use its own temp dir for intermediate work, e.g. `inject-tweak` extracting
+  a `.deb`, but it must not unzip/rezip the IPA.)
+- Resolve repo-relative asset paths from `${BASH_SOURCE[0]}` (the module file),
+  not from `$0` (the caller).
+
+## Registering a module with the orchestrator
+
+Add one line to the `module_function` case in `scripts/apply-patches.sh` mapping
+the module name to its function:
+
+```sh
+foo-bar)  echo "foo_bar_in_app" ;;
+```
+
+Then it's usable as `--module foo-bar` (or `--module 'foo-bar:arg1:arg2'`, which
+calls `foo_bar_in_app "$app_bundle" arg1 arg2`).
+
+## Adding a new patch (end-to-end)
+
+1. Write `scripts/modules/<feature>.sh` following the convention above.
+2. Register it in `apply-patches.sh` (one `case` line).
+3. Add `--module <feature>` to the relevant variant(s) in
+   `scripts/build_release_variants.sh` (and `Apollo/scripts/build.sh` if it
+   should ship in local builds).
+
+No new unpack/repack script, no edits to the other build paths.
+
+## Current modules
+
+| Module | Function | Purpose |
+|---|---|---|
+| `inject-tweak` | `inject_tweak_in_app` | replace tweak dylibs from a `.deb` (prepared IPA) |
+| `strip-substrate-arm64e` | `strip_substrate_arm64e_in_app` | strip CydiaSubstrate arm64e slice (iOS 26 dyld) |
+| `patch-bundle-versions` | `patch_bundle_versions_in_app` | set `CFBundleShortVersionString` / `CFBundleVersion` |
+| `inject-url-schemes` | `inject_url_schemes_in_app` | append `CFBundleURLTypes` schemes |
+| `fix-safari-extension` | `fix_safari_extension_in_app` | repair `Apollofari.appex` |
+| `fix-openin-extension` | `fix_openin_extension_in_app` | repair `OpenInUIExtension.appex` |
+| `inject-widgets` | `inject_widgets_in_app` | swap stock widget for `ApolloRebornWidgets.appex` |
+| `liquid-glass-binary` | `patch_liquid_glass_binary_in_app` | vtool SDK bump + duplicate `LC_RPATH` removal |
+| `liquid-glass-assets` | `patch_liquid_glass_assets_in_app` | `Assets.car` swap + icon metadata |
+
+`_plist-helpers.sh` is a shared support file (path-taking PlistBuddy helpers),
+not a module.

--- a/scripts/modules/_plist-helpers.sh
+++ b/scripts/modules/_plist-helpers.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Shared PlistBuddy helpers used by patch modules.
+# All functions take an explicit plist path as their first argument,
+# so they work without cd-ing into the app bundle first.
+
+plist_set_string() {
+    local plist="$1" key="$2" value="$3"
+    if /usr/libexec/PlistBuddy -c "Print :${key}" "$plist" &>/dev/null; then
+        /usr/libexec/PlistBuddy -c "Set :${key} ${value}" "$plist"
+    else
+        /usr/libexec/PlistBuddy -c "Add :${key} string ${value}" "$plist"
+    fi
+}
+
+plist_ensure_dict() {
+    local plist="$1" key="$2"
+    if ! /usr/libexec/PlistBuddy -c "Print :${key}" "$plist" &>/dev/null; then
+        /usr/libexec/PlistBuddy -c "Add :${key} dict" "$plist"
+    fi
+}
+
+plist_replace_string_array() {
+    local plist="$1" key="$2"; shift 2
+    if /usr/libexec/PlistBuddy -c "Print :${key}" "$plist" &>/dev/null; then
+        /usr/libexec/PlistBuddy -c "Delete :${key}" "$plist"
+    fi
+    /usr/libexec/PlistBuddy -c "Add :${key} array" "$plist"
+    for value in "$@"; do
+        /usr/libexec/PlistBuddy -c "Add :${key}: string ${value}" "$plist"
+    done
+}

--- a/scripts/modules/fix-openin-extension.sh
+++ b/scripts/modules/fix-openin-extension.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# fix_openin_extension_in_app <app_bundle> [dylib_path]
+#
+# Injects ApolloOpenInFix.dylib into Apollo.app/Frameworks/ and wires an @rpath
+# LC_LOAD_DYLIB into OpenInUIExtension.appex inside an unpacked .app bundle, in
+# place. No-op (return 0) when the bundle has no OpenInUIExtension.appex.
+#
+# The stock action calls the deprecated single-arg -[UIApplication openURL:]
+# which iOS 18+ force-fails. The dylib swizzles it to a non-deprecated path. The
+# dylib goes in the SHARED Frameworks/ (not the appex root) so the user's signer
+# re-signs it; the appex's existing rpath resolves @rpath/ from there.
+
+_OPENIN_MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# modules/ lives under scripts/, so scripts/ is one level up and the repo two.
+_OPENIN_SCRIPT_DIR="$(cd "${_OPENIN_MODULE_DIR}/.." && pwd)"
+_OPENIN_REPO_DIR="$(cd "${_OPENIN_MODULE_DIR}/../.." && pwd)"
+
+_OPENIN_DYLIB_NAME="ApolloOpenInFix.dylib"
+_OPENIN_STALE_NAMES=("ApolloOpenInHook.dylib")
+
+fix_openin_extension_in_app() {
+    local app_bundle="$1"
+    local dylib_src="${2:-}"
+
+    # Resolve the dylib from the openin-extension subproject build output unless
+    # an explicit path was given.
+    if [[ -z "$dylib_src" ]]; then
+        local candidates=(
+            "${_OPENIN_REPO_DIR}/openin-extension/.theos/obj/${_OPENIN_DYLIB_NAME}"
+            "${_OPENIN_REPO_DIR}/.theos/obj/${_OPENIN_DYLIB_NAME}"
+            "${_OPENIN_REPO_DIR}/openin-extension/.theos/obj/debug/${_OPENIN_DYLIB_NAME}"
+            "${_OPENIN_REPO_DIR}/.theos/obj/debug/${_OPENIN_DYLIB_NAME}"
+        )
+        local cand
+        for cand in "${candidates[@]}"; do
+            if [[ -f "$cand" ]]; then dylib_src="$cand"; break; fi
+        done
+    fi
+
+    local appex
+    appex="$(find "$app_bundle/PlugIns" -type d -name "OpenInUIExtension.appex" -print -quit 2>/dev/null || true)"
+    if [[ -z "$appex" || ! -d "$appex" ]]; then
+        echo "No OpenInUIExtension.appex — skipping Open-in-Apollo fix."
+        return 0
+    fi
+
+    if [[ -z "$dylib_src" || ! -f "$dylib_src" ]]; then
+        echo "Error: ApolloOpenInFix.dylib not found. Build it (make package) or pass an explicit path."
+        return 1
+    fi
+
+    local appex_bin="$appex/OpenInUIExtension"
+    if [[ ! -f "$appex_bin" ]]; then
+        echo "Error: appex executable missing: $appex_bin"
+        return 1
+    fi
+
+    echo "Repairing Open-in-Apollo action extension..."
+
+    # Drop any dead prior-attempt dylibs (loose in the appex, or a stale copy).
+    local stale
+    for stale in "${_OPENIN_STALE_NAMES[@]}" "$_OPENIN_DYLIB_NAME"; do
+        if [[ -f "$appex/$stale" ]]; then
+            rm -f "$appex/$stale"
+            echo "  removed stale $appex/$stale"
+        fi
+    done
+
+    local frameworks="$app_bundle/Frameworks"
+    mkdir -p "$frameworks"
+    cp "$dylib_src" "$frameworks/$_OPENIN_DYLIB_NAME"
+    echo "  installed Frameworks/$_OPENIN_DYLIB_NAME"
+
+    python3 "$_OPENIN_SCRIPT_DIR/macho_add_load_dylib.py" "$appex_bin" "@rpath/$_OPENIN_DYLIB_NAME"
+
+    if ! otool -L "$appex_bin" | grep -q "@rpath/$_OPENIN_DYLIB_NAME"; then
+        echo "Error: LC_LOAD_DYLIB for $_OPENIN_DYLIB_NAME not present after patch."
+        return 1
+    fi
+
+    rm -rf "$appex/_CodeSignature"
+    echo "Open-in-Apollo extension repaired: Frameworks/$_OPENIN_DYLIB_NAME + @rpath LC_LOAD_DYLIB added."
+}

--- a/scripts/modules/fix-safari-extension.sh
+++ b/scripts/modules/fix-safari-extension.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# fix_safari_extension_in_app <app_bundle>
+#
+# Overlays the fixed Safari Web Extension assets onto Apollofari.appex inside an
+# unpacked .app bundle, in place. No-op (return 0) when the bundle has no
+# Apollofari.appex (the no-extensions variants).
+#
+# The stock extension's "Automatic" mode redirected through openinapollo.com,
+# whose auto-open relies on an iOS Smart App Banner bound to the App Store
+# Apollo. A sideloaded build is not that app, so the banner never fires. We
+# overlay direct apollo:// redirect assets from safari-extension/.
+
+_SAFARI_MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# modules/ lives under scripts/, so the repo root is two levels up.
+_SAFARI_REPO_DIR="$(cd "${_SAFARI_MODULE_DIR}/../.." && pwd)"
+
+fix_safari_extension_in_app() {
+    local app_bundle="$1"
+    local asset_dir="${_SAFARI_REPO_DIR}/safari-extension"
+
+    local asset
+    for asset in content.js manifest.json; do
+        if [[ ! -f "$asset_dir/$asset" ]]; then
+            echo "Error: missing overlay asset: $asset_dir/$asset"
+            return 1
+        fi
+    done
+
+    local appex
+    appex="$(find "$app_bundle/PlugIns" -type d -name "Apollofari.appex" -print -quit 2>/dev/null || true)"
+    if [[ -z "$appex" || ! -d "$appex" ]]; then
+        echo "No Apollofari.appex — skipping Safari extension fix."
+        return 0
+    fi
+
+    echo "Repairing Safari extension..."
+    cp "$asset_dir/content.js" "$appex/content.js"
+    cp "$asset_dir/manifest.json" "$appex/manifest.json"
+    # The appex's prior signature covers the now-modified web assets.
+    rm -rf "$appex/_CodeSignature"
+    echo "Safari extension repaired: content.js + manifest.json overlaid."
+}

--- a/scripts/modules/inject-tweak.sh
+++ b/scripts/modules/inject-tweak.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# inject_tweak_in_app <app_bundle> <deb_path>
+#
+# Replaces the tweak dylibs inside an already-prepared unpacked .app bundle
+# from a Theos .deb, fixing install names for sideloading.
+#
+# "Already-prepared" means the IPA was processed by azule/cyan at least once so
+# the Apollo binary already has LC_LOAD_DYLIB entries pointing at the tweak
+# dylibs. This fast-path replaces just the dylib files without touching the
+# binary, making it deterministic and suitable for CI iteration.
+#
+# Exits 2 if the IPA is not prepared (no matching load slots). In that case,
+# use azule/cyan on the stock IPA first (once), then call this.
+#
+# Does NOT strip the CydiaSubstrate arm64e slice — run the
+# strip-substrate-arm64e module after this one.
+
+_INJECT_TWEAK_MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+inject_tweak_in_app() {
+    local app_bundle="$1"
+    local deb_path="$2"
+
+    local plist_path="$app_bundle/Info.plist"
+    local executable_name
+    executable_name="$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist_path")"
+    local executable_path="$app_bundle/$executable_name"
+    local frameworks_dir="$app_bundle/Frameworks"
+    mkdir -p "$frameworks_dir"
+
+    # Extract deb into a temp directory.
+    local tmpdir
+    tmpdir="$(mktemp -d /tmp/apollo-inject-tweak-XXXXXX)"
+
+    mkdir -p "$tmpdir/deb"
+    (cd "$tmpdir/deb" && ar -x "$deb_path") || { rm -rf "$tmpdir"; echo "Error: could not unpack .deb"; return 1; }
+
+    local data_archive
+    data_archive="$(ls "$tmpdir/deb/data.tar."* 2>/dev/null | head -1 || true)"
+    if [[ -z "$data_archive" ]]; then
+        rm -rf "$tmpdir"
+        echo "Error: .deb did not contain data.tar.*"
+        return 1
+    fi
+    (cd "$tmpdir/deb" && tar -xf "$data_archive") || { rm -rf "$tmpdir"; echo "Error: could not extract deb data archive"; return 1; }
+
+    local dylib_dir="$tmpdir/deb/Library/MobileSubstrate/DynamicLibraries"
+    if [[ ! -d "$dylib_dir" ]]; then
+        rm -rf "$tmpdir"
+        echo "Error: .deb did not contain MobileSubstrate DynamicLibraries."
+        return 1
+    fi
+
+    shopt -s nullglob
+    local dylibs=("$dylib_dir"/*.dylib)
+    shopt -u nullglob
+    if [[ "${#dylibs[@]}" -eq 0 ]]; then
+        rm -rf "$tmpdir"
+        echo "Error: .deb contained no dylibs to inject."
+        return 1
+    fi
+
+    # Enumerate dylibs already loaded by the main executable.
+    local -a ipa_loaded_dylibs=()
+    while IFS= read -r loaded_path; do
+        [[ -z "$loaded_path" ]] && continue
+        ipa_loaded_dylibs+=("$(basename "$loaded_path")")
+    done < <(otool -L "$executable_path" | tail -n +2 | awk '{print $1}' | grep '\.dylib$' || true)
+
+    _ipa_has_loaded_or_framework() {
+        local name="$1"
+        local item framework_dylib
+        for item in "${ipa_loaded_dylibs[@]}"; do
+            [[ "$item" == "$name" ]] && return 0
+        done
+        for framework_dylib in "$frameworks_dir"/*.dylib; do
+            [[ -f "$framework_dylib" ]] || continue
+            [[ "$(basename "$framework_dylib")" == "$name" ]] && return 0
+        done
+        return 1
+    }
+
+    _resolve_target_dylib_name() {
+        local source_name="$1"
+        if _ipa_has_loaded_or_framework "$source_name"; then
+            printf '%s\n' "$source_name"; return 0
+        fi
+        case "$source_name" in
+            ApolloReborn.dylib)
+                if _ipa_has_loaded_or_framework "ApolloImprovedCustomApi.dylib"; then
+                    echo "Aliasing ApolloReborn.dylib -> ApolloImprovedCustomApi.dylib" >&2
+                    printf '%s\n' "ApolloImprovedCustomApi.dylib"; return 0
+                fi ;;
+        esac
+        return 1
+    }
+
+    _apply_dylib_sideload_fixes() {
+        local dest_path="$1" target_name="$2" source_name="$3"
+        install_name_tool -id "@rpath/$target_name" "$dest_path" 2>/dev/null || true
+        install_name_tool -change \
+            "/Library/Frameworks/CydiaSubstrate.framework/CydiaSubstrate" \
+            "@rpath/CydiaSubstrate.framework/CydiaSubstrate" \
+            "$dest_path" 2>/dev/null || true
+        install_name_tool -change \
+            "/Library/MobileSubstrate/DynamicLibraries/$source_name" \
+            "@rpath/$target_name" \
+            "$dest_path" 2>/dev/null || true
+        if [[ "$source_name" != "$target_name" ]]; then
+            install_name_tool -change \
+                "/Library/MobileSubstrate/DynamicLibraries/$target_name" \
+                "@rpath/$target_name" \
+                "$dest_path" 2>/dev/null || true
+        fi
+    }
+
+    local missing_loads=()
+    local dylib source_name target_name dest_path
+    for dylib in "${dylibs[@]}"; do
+        source_name="$(basename "$dylib")"
+        # ApolloOpenInFix.dylib is appex-only; the fix-openin-extension module
+        # places it in Frameworks/ and wires the load command into the appex binary.
+        if [[ "$source_name" == "ApolloOpenInFix.dylib" ]]; then
+            echo "Skipping $source_name (appex-only; handled by fix-openin-extension module)"
+            continue
+        fi
+        target_name="$(_resolve_target_dylib_name "$source_name" || true)"
+        if [[ -z "$target_name" ]]; then
+            missing_loads+=("$source_name")
+            continue
+        fi
+        dest_path="$frameworks_dir/$target_name"
+        cp "$dylib" "$dest_path"
+        _apply_dylib_sideload_fixes "$dest_path" "$target_name" "$source_name"
+        if otool -L "$dest_path" | grep -Fq '/Library/Frameworks/CydiaSubstrate.framework/CydiaSubstrate'; then
+            rm -rf "$tmpdir"
+            echo "Error: $dest_path still links jailbreak CydiaSubstrate path after install_name_tool."
+            return 1
+        fi
+        if [[ "$source_name" != "$target_name" ]]; then
+            echo "Updated Frameworks/$target_name (from deb $source_name)"
+        else
+            echo "Updated Frameworks/$target_name"
+        fi
+    done
+
+    if [[ "${#missing_loads[@]}" -gt 0 ]]; then
+        rm -rf "$tmpdir"
+        echo "Error: IPA is not already prepared to load: ${missing_loads[*]}"
+        echo "Use azule/cyan once on the stock IPA, then pass the prepared IPA here."
+        return 2
+    fi
+
+    # Copy resource bundle (ApolloReborn.bundle) if present in the deb.
+    local resource_bundle="$tmpdir/deb/Library/Application Support/ApolloReborn/ApolloReborn.bundle"
+    if [[ -d "$resource_bundle" ]]; then
+        local resource_dest="$app_bundle/ApolloRebornResources"
+        mkdir -p "$resource_dest"
+        rsync -a "$resource_bundle/" "$resource_dest/"
+        echo "Copied ApolloReborn resources into app bundle"
+    fi
+
+    rm -rf "$tmpdir"
+}

--- a/scripts/modules/inject-url-schemes.sh
+++ b/scripts/modules/inject-url-schemes.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# inject_url_schemes_in_app <app_bundle> <comma_separated_schemes>
+#
+# Appends custom URL schemes to CFBundleURLTypes in the main app's Info.plist so
+# other apps (e.g. Dystopia, RedReader) can deep-link into Apollo. Idempotent:
+# schemes already present are skipped.
+
+inject_url_schemes_in_app() {
+    local app_bundle="$1"
+    local url_schemes="$2"
+    local plist="$app_bundle/Info.plist"
+
+    [[ -z "$url_schemes" ]] && return 0
+    if [[ ! -f "$plist" ]]; then
+        echo "Error: Info.plist not found: $plist"
+        return 1
+    fi
+
+    echo "Adding custom URL schemes: $url_schemes"
+
+    local url_type_index=0
+    local found_schemes=false
+
+    if /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes" "$plist" &>/dev/null; then
+        while /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:${url_type_index}" "$plist" &>/dev/null; do
+            if /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:${url_type_index}:CFBundleURLSchemes" "$plist" &>/dev/null; then
+                found_schemes=true
+                break
+            fi
+            url_type_index=$((url_type_index + 1))
+        done
+        if [[ "$found_schemes" == "false" ]]; then
+            /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes array" "$plist"
+            url_type_index=0
+            found_schemes=true
+        fi
+    else
+        /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes array"         "$plist"
+        /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0 dict"        "$plist"
+        /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes array" "$plist"
+        url_type_index=0
+        found_schemes=true
+    fi
+
+    local SCHEMES scheme existing
+    IFS=',' read -ra SCHEMES <<< "$url_schemes"
+    for scheme in "${SCHEMES[@]}"; do
+        scheme=$(echo "$scheme" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        [[ -z "$scheme" ]] && continue
+        existing=$(/usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:${url_type_index}:CFBundleURLSchemes" "$plist" 2>/dev/null | grep -cxF "    ${scheme}" || true)
+        if [[ "$existing" -eq 0 ]]; then
+            echo "  + ${scheme}"
+            /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:${url_type_index}:CFBundleURLSchemes: string ${scheme}" "$plist"
+        else
+            echo "  ~ ${scheme} (already present, skipping)"
+        fi
+    done
+
+    # Plist edits invalidate the existing code signature.
+    rm -rf "$app_bundle/_CodeSignature"
+}

--- a/scripts/modules/inject-widgets.sh
+++ b/scripts/modules/inject-widgets.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# inject_widgets_in_app <app_bundle> [appex_path]
+#
+# Removes the stock AthenaWidgetExtension.appex and injects the Apollo Reborn
+# ApolloRebornWidgets.appex into an unpacked .app bundle's PlugIns/, in place.
+#
+# A crash-looping widget extension poisons WidgetKit's enumeration of ALL of the
+# host app's widgets, so the stock AthenaWidgetExtension.appex (which has no
+# valid API keys after the Reddit API shutdown) is removed first.
+#
+# Returns 1 if the appex to inject is missing (caller asked for widgets but the
+# extension wasn't built); pass --keep-stock via the orchestrator to retain the
+# stock widget.
+
+_WIDGETS_MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_WIDGETS_REPO_DIR="$(cd "${_WIDGETS_MODULE_DIR}/../.." && pwd)"
+_WIDGETS_DEFAULT_APPEX="${_WIDGETS_REPO_DIR}/widgets/build/Build/Products/Release-iphoneos/ApolloRebornWidgets.appex"
+
+# Set to 1 to keep the stock AthenaWidgetExtension.appex.
+INJECT_WIDGETS_KEEP_STOCK="${INJECT_WIDGETS_KEEP_STOCK:-0}"
+
+inject_widgets_in_app() {
+    local app_bundle="$1"
+    local appex_path="${2:-$_WIDGETS_DEFAULT_APPEX}"
+
+    if [[ ! -d "$appex_path" ]]; then
+        echo "Error: widget appex not found: $appex_path"
+        return 1
+    fi
+
+    local plugins="$app_bundle/PlugIns"
+    mkdir -p "$plugins"
+
+    if [[ "$INJECT_WIDGETS_KEEP_STOCK" != "1" && -d "$plugins/AthenaWidgetExtension.appex" ]]; then
+        echo "Removing stock AthenaWidgetExtension.appex (prevents WidgetKit enumeration poisoning)..."
+        rm -rf "$plugins/AthenaWidgetExtension.appex"
+    fi
+
+    local appex_name
+    appex_name="$(basename "$appex_path")"
+    rm -rf "$plugins/$appex_name"
+    cp -R "$appex_path" "$plugins/"
+    # Strip any stale signature so the re-signer starts clean.
+    rm -rf "$plugins/$appex_name/_CodeSignature"
+    echo "Injected $appex_name"
+}

--- a/scripts/modules/liquid-glass-assets.sh
+++ b/scripts/modules/liquid-glass-assets.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# patch_liquid_glass_assets_in_app <app_bundle>
+#
+# Applies the iOS 26 Liquid Glass ASSETS patches to an unpacked .app bundle:
+#   * replaces Assets.car with the prebuilt Liquid Glass icon catalog.
+#   * writes the CFBundleIcons / CFBundleIcons~ipad primary + alternate icon
+#     metadata so the in-app alternate icon picker has icons to show.
+#
+# This does NOT bump the SDK version, so IsLiquidGlass() stays off and the iOS 26
+# UI runtime is not activated — that is the liquid-glass-binary module. Used on
+# its own this is the "icons-only" variant. Credit: @ryannair05.
+
+_LG_ASSETS_MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_LG_ASSETS_REPO_DIR="$(cd "${_LG_ASSETS_MODULE_DIR}/../.." && pwd)"
+
+# shellcheck source=_plist-helpers.sh
+source "${_LG_ASSETS_MODULE_DIR}/_plist-helpers.sh"
+
+# Asset sources default to the Apollo-Reborn repo, but callers with their own
+# copy (e.g. the workspace build.sh under scripts/patch-assets/) can override
+# them via these env vars before sourcing/calling.
+_LG_ASSETS_CAR="${LG_ASSETS_CAR:-${_LG_ASSETS_REPO_DIR}/liquid-glass/prebuilt/Assets.car}"
+_LG_ICONS_REGISTRY="${LG_ICONS_REGISTRY:-${_LG_ASSETS_REPO_DIR}/liquid-glass/icons.json}"
+_LG_ICON_NAME="AppIcon"
+_LG_IPAD_ICON_FILES=("AppIcon60x60" "AppIcon76x76")
+_LG_IPHONE_ICON_FILES=("AppIcon60x60")
+
+_lg_load_alternate_icons() {
+    local i=0 id
+    while id=$(plutil -extract "icons.${i}.id" raw -o - "$_LG_ICONS_REGISTRY" 2>/dev/null); do
+        echo "$id"
+        ((i++))
+    done
+}
+
+_lg_ensure_icon_metadata() {
+    local plist="$1"
+    local -a alt_icons=()
+    local line
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && alt_icons+=("$line")
+    done < <(_lg_load_alternate_icons)
+
+    plist_ensure_dict "$plist" "CFBundleIcons"
+    plist_ensure_dict "$plist" "CFBundleIcons:CFBundlePrimaryIcon"
+    plist_ensure_dict "$plist" "CFBundleIcons:CFBundleAlternateIcons"
+    plist_ensure_dict "$plist" "CFBundleIcons~ipad"
+    plist_ensure_dict "$plist" "CFBundleIcons~ipad:CFBundlePrimaryIcon"
+    plist_ensure_dict "$plist" "CFBundleIcons~ipad:CFBundleAlternateIcons"
+
+    plist_set_string "$plist" "CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconName" "$_LG_ICON_NAME"
+    plist_set_string "$plist" "CFBundleIcons~ipad:CFBundlePrimaryIcon:CFBundleIconName" "$_LG_ICON_NAME"
+    plist_replace_string_array "$plist" "CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconFiles" "${_LG_IPHONE_ICON_FILES[@]}"
+    plist_replace_string_array "$plist" "CFBundleIcons~ipad:CFBundlePrimaryIcon:CFBundleIconFiles" "${_LG_IPAD_ICON_FILES[@]}"
+
+    local icon_name
+    for icon_name in "${alt_icons[@]}"; do
+        plist_ensure_dict "$plist" "CFBundleIcons:CFBundleAlternateIcons:${icon_name}"
+        plist_ensure_dict "$plist" "CFBundleIcons~ipad:CFBundleAlternateIcons:${icon_name}"
+        plist_set_string "$plist" "CFBundleIcons:CFBundleAlternateIcons:${icon_name}:CFBundleIconName" "$icon_name"
+        plist_set_string "$plist" "CFBundleIcons~ipad:CFBundleAlternateIcons:${icon_name}:CFBundleIconName" "$icon_name"
+    done
+}
+
+patch_liquid_glass_assets_in_app() {
+    local app_bundle="$1"
+    local plist="$app_bundle/Info.plist"
+
+    if [[ ! -f "$_LG_ASSETS_CAR" ]]; then
+        echo "Error: Liquid Glass asset catalog not found at $_LG_ASSETS_CAR"
+        return 1
+    fi
+
+    # Guard against a truncated/corrupt asset catalog. The real Assets.car is
+    # ~80 MB; patching with a stub silently produces a launch-crashing IPA
+    # (issue #314). Applied unconditionally (the old icons-only path skipped it).
+    local asset_size
+    asset_size=$(wc -c < "$_LG_ASSETS_CAR" | tr -d ' ')
+    if [[ "$asset_size" -lt 4096 ]]; then
+        echo "Error: $_LG_ASSETS_CAR looks truncated or corrupt (${asset_size} bytes), not the real asset catalog."
+        echo "       Re-fetch the repository contents and try again."
+        return 1
+    fi
+
+    echo "Replacing Assets.car with prebuilt Liquid Glass asset catalog..."
+    cp "$_LG_ASSETS_CAR" "$app_bundle/Assets.car"
+
+    echo "Updating app icon metadata for Liquid Glass multi-icon catalog..."
+    _lg_ensure_icon_metadata "$plist"
+
+    rm -rf "$app_bundle/_CodeSignature"
+}

--- a/scripts/modules/liquid-glass-binary.sh
+++ b/scripts/modules/liquid-glass-binary.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# patch_liquid_glass_binary_in_app <app_bundle>
+#
+# Applies the iOS 26 Liquid Glass BINARY patches to the main app executable:
+#   * vtool build-version bump (ios 15.0 / sdk 19.0) — flips IsLiquidGlass() on,
+#     opting the app into the iOS 26 Liquid Glass UI runtime.
+#   * removal of the duplicate @executable_path/Frameworks LC_RPATH entry, which
+#     iOS 26 dyld rejects at launch.
+#
+# This does NOT touch the icon catalog — run the liquid-glass-assets module for
+# that. Credit: @ryannair05.
+
+patch_liquid_glass_binary_in_app() {
+    local app_bundle="$1"
+    local plist="$app_bundle/Info.plist"
+
+    local executable_name
+    executable_name="$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist")"
+    local executable_path="$app_bundle/$executable_name"
+
+    if ! command -v vtool >/dev/null 2>&1; then
+        echo "Error: vtool not installed (brew install vtool)."
+        return 1
+    fi
+
+    echo "vtool: bumping build version to ios 15.0 / sdk 19.0..."
+    vtool -set-build-version ios 15.0 19.0 -replace -output "$executable_path" "$executable_path"
+
+    echo "Checking for duplicate @executable_path/Frameworks LC_RPATH entries..."
+    local rpath_count
+    rpath_count=$(otool -l "$executable_path" | grep -A 2 LC_RPATH | grep "@executable_path/Frameworks" | wc -l | tr -d ' ')
+    echo "  Found $rpath_count entries"
+    if [[ "$rpath_count" -gt 1 ]]; then
+        echo "  Removing duplicate..."
+        install_name_tool -delete_rpath "@executable_path/Frameworks" "$executable_path"
+    fi
+
+    # vtool / install_name_tool invalidate the existing signature.
+    rm -rf "$app_bundle/_CodeSignature"
+}

--- a/scripts/modules/patch-bundle-versions.sh
+++ b/scripts/modules/patch-bundle-versions.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# patch_bundle_versions_in_app <app_bundle> <short_version> <build_version>
+#
+# Sets CFBundleShortVersionString and CFBundleVersion in the main app's
+# Info.plist so that the in-app version display and AltStore/Feather update
+# checks reflect the Apollo-Reborn version rather than the original Apollo
+# version baked into the stock IPA.
+
+patch_bundle_versions_in_app() {
+    local app_bundle="$1"
+    local short_version="$2"
+    local build_version="$3"
+    local plist="$app_bundle/Info.plist"
+
+    if [[ ! -f "$plist" ]]; then
+        echo "Error: Info.plist not found: $plist"
+        return 1
+    fi
+
+    plutil -replace CFBundleShortVersionString -string "$short_version" "$plist"
+    plutil -replace CFBundleVersion            -string "$build_version"  "$plist"
+    # Plist edits invalidate the existing code signature.
+    rm -rf "$app_bundle/_CodeSignature"
+    echo "Bundle versions set: $short_version ($build_version)"
+}

--- a/scripts/modules/strip-substrate-arm64e.sh
+++ b/scripts/modules/strip-substrate-arm64e.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Strip the legacy arm64e slice from bundled CydiaSubstrate. iOS 26 dyld rejects
+# the arm64e.old mach-o subtype and aborts at launch on arm64e devices.
+
+strip_substrate_arm64e_in_app() {
+    local app_bundle="$1"
+    local framework_bin="$app_bundle/Frameworks/CydiaSubstrate.framework/CydiaSubstrate"
+
+    if [[ ! -f "$framework_bin" ]]; then
+        return 0
+    fi
+
+    if ! command -v lipo >/dev/null 2>&1; then
+        echo "Warning: lipo not installed; skipping CydiaSubstrate arm64e strip."
+        return 0
+    fi
+
+    if ! lipo -info "$framework_bin" 2>/dev/null | grep -qw 'arm64e'; then
+        return 0
+    fi
+
+    echo "Stripping arm64e slice from CydiaSubstrate (iOS 26 dyld fix)..."
+    if ! lipo -remove arm64e "$framework_bin" -output "$framework_bin.new" 2>&1; then
+        echo "Warning: lipo -remove arm64e failed; IPA may crash on iOS 26."
+        return 0
+    fi
+    mv -f "$framework_bin.new" "$framework_bin"
+    rm -rf "$(dirname "$framework_bin")/_CodeSignature"
+}
+
+# Thin IPA wrapper: unpack → strip → repack. Used by callers that operate on a
+# whole IPA rather than an unpacked bundle.
+strip_substrate_arm64e_in_ipa() {
+    local ipa="$1"
+    local work
+    work="$(mktemp -d)"
+
+    if ! (cd "$work" && unzip -q "$ipa"); then
+        echo "Warning: could not unzip IPA for slice fix; leaving as-is."
+        rm -rf "$work"
+        return 0
+    fi
+
+    local app_bundle
+    app_bundle="$(find "$work/Payload" -maxdepth 1 -name '*.app' -type d | head -1)"
+    if [[ -n "$app_bundle" ]]; then
+        strip_substrate_arm64e_in_app "$app_bundle"
+    fi
+
+    rm -f "$ipa"
+    if ! (cd "$work" && zip -qry "$ipa" Payload); then
+        echo "Error: could not re-zip IPA after slice fix."
+        rm -rf "$work"
+        return 1
+    fi
+
+    rm -rf "$work"
+}
+
+# Backward-compatible aliases used by inject-deb-local.sh and any callers that
+# pre-date the modules refactor.
+strip_arm64e_from_substrate_in_app() { strip_substrate_arm64e_in_app "$@"; }
+strip_arm64e_from_substrate_in_ipa() { strip_substrate_arm64e_in_ipa "$@"; }

--- a/scripts/strip-substrate-arm64e.sh
+++ b/scripts/strip-substrate-arm64e.sh
@@ -1,56 +1,8 @@
 #!/bin/bash
-# Strip the legacy arm64e slice from bundled CydiaSubstrate. iOS 26 dyld rejects
-# the arm64e.old mach-o subtype and aborts at launch on arm64e devices.
+# Backward-compatibility shim. The canonical implementation now lives in
+# scripts/modules/strip-substrate-arm64e.sh. This file re-exports the same
+# functions (including the legacy strip_arm64e_from_substrate_in_{app,ipa}
+# names) so existing `source`rs keep working.
 
-strip_arm64e_from_substrate_in_app() {
-    local app_bundle="$1"
-    local framework_bin="$app_bundle/Frameworks/CydiaSubstrate.framework/CydiaSubstrate"
-
-    if [[ ! -f "$framework_bin" ]]; then
-        return 0
-    fi
-
-    if ! command -v lipo >/dev/null 2>&1; then
-        echo "Warning: lipo not installed; skipping CydiaSubstrate arm64e strip."
-        return 0
-    fi
-
-    if ! lipo -info "$framework_bin" 2>/dev/null | grep -qw 'arm64e'; then
-        return 0
-    fi
-
-    echo "Stripping arm64e slice from CydiaSubstrate (iOS 26 dyld fix)..."
-    if ! lipo -remove arm64e "$framework_bin" -output "$framework_bin.new" 2>&1; then
-        echo "Warning: lipo -remove arm64e failed; IPA may crash on iOS 26."
-        return 0
-    fi
-    mv -f "$framework_bin.new" "$framework_bin"
-    rm -rf "$(dirname "$framework_bin")/_CodeSignature"
-}
-
-strip_arm64e_from_substrate_in_ipa() {
-    local ipa="$1"
-    local work
-    work="$(mktemp -d)"
-
-    if ! (cd "$work" && unzip -q "$ipa"); then
-        echo "Warning: could not unzip IPA for slice fix; leaving as-is."
-        rm -rf "$work"
-        return 0
-    fi
-
-    local app_bundle
-    app_bundle="$(find "$work/Payload" -maxdepth 1 -name '*.app' -type d | head -1)"
-    if [[ -n "$app_bundle" ]]; then
-        strip_arm64e_from_substrate_in_app "$app_bundle"
-    fi
-
-    rm -f "$ipa"
-    if ! (cd "$work" && zip -qry "$ipa" Payload); then
-        echo "Error: could not re-zip IPA after slice fix."
-        rm -rf "$work"
-        return 1
-    fi
-
-    rm -rf "$work"
-}
+# shellcheck source=modules/strip-substrate-arm64e.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/modules/strip-substrate-arm64e.sh"


### PR DESCRIPTION
This PR significantly refactors how IPA modifications are applied during the build process. Previously, the build pipeline suffered from heavy I/O bottlenecks because individual scripts (like Liquid Glass patching, extension fixing, and URL scheme injection) each performed their own unzip/rezip cycles on the massive IPA file.

This PR introduces a single-unpack/repack orchestrator (`scripts/apply-patches.sh`) and extracts all patching logic into isolated, reusable modules. This drastically improves the performance of generating release variants, as the IPA does not repeatedly get unpacked and repacked, and makes implementing new IPA patches much easier.


## Changes

* **New Orchestrator (`apply-patches.sh`):** Unpacks the IPA exactly once, runs a specified list of patch modules against the unpacked `.app` bundle in memory, and repacks it exactly once.
* **Modularized Patch Logic:** Created `scripts/modules/` to house all in-place mutation logic.
* Extracted features into dedicated modules: `inject-tweak`, `strip-substrate-arm64e`, `patch-bundle-versions`, `inject-url-schemes`, `fix-safari-extension`, `fix-openin-extension`, `inject-widgets`, `liquid-glass-binary`, and `liquid-glass-assets`.
* Added `_plist-helpers.sh` to centralize `PlistBuddy` commands.


* **Simplified Release Pipeline:** `build_release_variants.sh` now builds the Reborn widget extension upfront and composes release variants using the new orchestrator, entirely eliminating redundant packing/unpacking I/O cycles.
* **Cleaned Up `patch.sh`:** Stripped of its sprawling inline logic; it now acts as a localized unpack/repack wrapper that invokes the shared modules.
* **Maintained CLI Backward Compatibility:** Existing standalone scripts (`fix-openin-extension.sh`, `inject-widgets.sh`, etc.) have been converted into thin wrappers that utilize the new modules. Existing CLI workflows will not break.

## Benchmarks/Performance Improvements

Benchmarking the old script against the new orchestrator demonstrates a massive reduction in I/O bottlenecks and CPU overhead. The single-unpack architecture makes generating release variants **2x faster**.

| Metric | Old Pipeline (`patch.sh` loops) | New Pipeline (`apply-patches.sh`) | Improvement |
| :--- | :--- | :--- | :--- |
| **Total Build Time** | 1m 21.4s | 40.7s | 50% faster (2x speedup) |
| **User CPU Time** | 74.37s | 32.51s | 56% reduction |
| **System I/O Time** | 10.11s | 4.90s | 52% reduction |

*Note: Measured via standard shell `time` command during local testing on an M4 MacBook Pro.*