### PR TITLE
Login Fallback on older iOSes - Visual UI improvments

### DIFF
--- a/src/ApolloManualSignInViewController.m
+++ b/src/ApolloManualSignInViewController.m
@@ -152,9 +152,11 @@ static NSString *ARExtractParam(NSString *urlString, NSString *name);
         self.scrollView.verticalScrollIndicatorInsets = inset;
     } completion:^(BOOL finished) {
         if (bottomInset > 0 && self.codeTextView.isFirstResponder) {
-            CGRect target = [self.scrollView convertRect:self.codeTextView.bounds
-                                                fromView:self.codeTextView];
-            [self.scrollView scrollRectToVisible:CGRectInset(target, 0, -12) animated:YES];
+            CGFloat maxOffsetY = self.scrollView.contentSize.height - self.scrollView.bounds.size.height + self.scrollView.adjustedContentInset.bottom;
+            if (maxOffsetY > 0) {
+                CGPoint bottomOffset = CGPointMake(0, maxOffsetY);
+                [self.scrollView setContentOffset:bottomOffset animated:YES];
+            }
         }
     }];
 }

--- a/src/ApolloWebAuthViewController.m
+++ b/src/ApolloWebAuthViewController.m
@@ -71,6 +71,15 @@
 
     ApolloLog(@"[WebAuth] Loading auth URL: %@", self.authURL);
     [self.webView loadRequest:[NSURLRequest requestWithURL:self.authURL]];
+    // Automate transition to manual sign-in for iOS 15.3.1 and below.
+    if (@available(iOS 15.4, *)) {
+        // iOS 15.4+ is supported. Let the web view load normally.
+    } else {
+        ApolloLog(@"[WebAuth] iOS <= 15.3.1 detected. Automating manual sign-in fallback.");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self _showManualSignIn];
+        });
+    }
 }
 
 - (BOOL)_isModernRedditSupported {


### PR DESCRIPTION
For iOS <15.4, redirect to manual sign in automatically

Fix Camera Scroll position when keyboard is hidden.

|Auto redirect to Manual Sign in|Scroll fix on keyboard close|
| ---------------------- | ---------------------- |
| ![1](https://files.catbox.moe/mw05gc.gif) | ![2](https://files.catbox.moe/29v4q2.gif) |