### PR TITLE
Add 'Include Link' (#481) and 'Share as Video' (#380) options to Share as Image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloFlairColors.xm \
     $(SRC_DIR)/ApolloNativeActionMenus.xm \
     $(SRC_DIR)/ApolloShareAsImageGallery.xm \
+    $(SRC_DIR)/ApolloShareAsImageLink.xm \
     $(SRC_DIR)/ApolloTranslation.xm \
     $(SRC_DIR)/ApolloVideoUnmute.xm \
     $(SRC_DIR)/ApolloVideoSwipeFix.xm \

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloNativeActionMenus.xm \
     $(SRC_DIR)/ApolloShareAsImageGallery.xm \
     $(SRC_DIR)/ApolloShareAsImageLink.xm \
+    $(SRC_DIR)/ApolloShareAsVideo.xm \
     $(SRC_DIR)/ApolloTranslation.xm \
     $(SRC_DIR)/ApolloVideoUnmute.xm \
     $(SRC_DIR)/ApolloVideoSwipeFix.xm \

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloShareAsImageGallery.xm \
     $(SRC_DIR)/ApolloShareAsImageLink.xm \
     $(SRC_DIR)/ApolloShareAsVideo.xm \
+    $(SRC_DIR)/ApolloShareAsImagePreviewFix.xm \
     $(SRC_DIR)/ApolloTranslation.xm \
     $(SRC_DIR)/ApolloVideoUnmute.xm \
     $(SRC_DIR)/ApolloVideoSwipeFix.xm \

--- a/src/ApolloShareAsImageGallery.xm
+++ b/src/ApolloShareAsImageGallery.xm
@@ -607,7 +607,22 @@ static void ApolloShareGalleryPrepare(id previewNode) {
     NSNumber *stateNum = objc_getAssociatedObject(previewNode, &kApolloShareGalleryStateKey);
     ApolloShareGalleryState state = stateNum ? (ApolloShareGalleryState)stateNum.integerValue
                                              : ApolloShareGalleryStateNone;
-    if (state != ApolloShareGalleryStateNone) return; // already placeholder/applied
+    if (state == ApolloShareGalleryStateApplied) {
+        // Toggling a preview option (e.g. "Include Post Details") makes Apollo
+        // rebuild the node and RESET imageForImagePost/linkButtonNode back to its
+        // native compact link card. Our state is still "Applied", so without this
+        // the collage would be lost and the compact card would show. Re-assert the
+        // cached collage when we detect the reset. Comment / non-gallery shares
+        // never cache a collage, so they no-op here.
+        UIImage *cached = objc_getAssociatedObject(previewNode, &kApolloShareGalleryCollageKey);
+        if ([cached isKindOfClass:[UIImage class]] &&
+            ApolloShareIvarObject(previewNode, "imageForImagePost") == nil) {
+            ApolloLog(@"[ShareGallery] collage reset by a toggle, re-injecting cached image");
+            ApolloShareGalleryInstallImageOnMain(previewNode, cached, YES);
+        }
+        return;
+    }
+    if (state != ApolloShareGalleryStateNone) return; // placeholder in flight
 
     // Comment-share mode: when the user is sharing a COMMENT (not the post),
     // the node still carries the post's `link` ivar, but the shared image

--- a/src/ApolloShareAsImageGallery.xm
+++ b/src/ApolloShareAsImageGallery.xm
@@ -105,6 +105,17 @@ static void ApolloShareSetIvarBool(id obj, const char *name, BOOL value) {
     base[offset] = value ? 1 : 0;
 }
 
+// Reads a Swift Bool ivar (a single byte at the ivar offset). Returns NO when the
+// ivar is missing. Mirror of ApolloShareSetIvarBool's offset math.
+static BOOL ApolloShareIvarBool(id obj, const char *name) {
+    if (!obj || !name) return NO;
+    Ivar ivar = class_getInstanceVariable(object_getClass(obj), name);
+    if (!ivar) return NO;
+    ptrdiff_t offset = ivar_getOffset(ivar);
+    const unsigned char *base = (const unsigned char *)(__bridge const void *)obj;
+    return base[offset] != 0;
+}
+
 #pragma mark - Gallery model extraction
 
 // Pulls the ordered list of still-image URLs out of an RDKLink's gallery.
@@ -624,13 +635,21 @@ static void ApolloShareGalleryPrepare(id previewNode) {
     }
     if (state != ApolloShareGalleryStateNone) return; // placeholder in flight
 
-    // Comment-share mode: when the user is sharing a COMMENT (not the post),
-    // the node still carries the post's `link` ivar, but the shared image
-    // should be the comment itself — not the post's gallery/video/spoiler
-    // media. Injecting imageForImagePost here is what made the post images
-    // leak into comment shares, so leave Apollo's native comment rendering
-    // completely alone in this mode.
-    if (ApolloShareIvarObject(previewNode, "comment") != nil) {
+    // Comment-share mode: when the user is sharing a COMMENT (not the post), the
+    // shared image is normally just the comment, so we must NOT touch the post's
+    // media — injecting imageForImagePost there is what made the post's gallery
+    // image leak into a plain comment share.
+    //
+    // EXCEPTION: when the user enables "Include Post Text, Poll, or Image" (the
+    // includePostTextPollOrImage toggle, which only appears in comment mode), Apollo
+    // ALSO renders the underlying post's media region above the comment — and for a
+    // gallery/video/spoiler post that region falls back to Apollo's compact link
+    // card (imageForImagePost stays nil), exactly as it does for a post share. In
+    // that case we DO want to inject the collage/poster into the post media region;
+    // the comment itself (baseCommentNode) is laid out separately and is left
+    // untouched. So only bail here when the post media is NOT being shown.
+    if (ApolloShareIvarObject(previewNode, "comment") != nil &&
+        !ApolloShareIvarBool(previewNode, "includePostTextPollOrImage")) {
         objc_setAssociatedObject(previewNode, &kApolloShareGalleryStateKey,
                                  @(ApolloShareGalleryStateApplied),
                                  OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/src/ApolloShareAsImageLink.xm
+++ b/src/ApolloShareAsImageLink.xm
@@ -25,6 +25,18 @@
 // No hardcoded binary addresses: everything is ObjC-runtime ivar access (ivar
 // names from class-dump headers) plus public UIKit selectors, with defensive
 // guards throughout.
+//
+// MODULE ORDERING (Makefile ApolloReborn_FILES): this module is listed after
+// ApolloShareAsImageGallery and before ApolloShareAsVideo, i.e.
+// Gallery -> Link -> Video -> PreviewFix. All four hook
+// _TtC6Apollo26ShareAsImageViewController (and the first three also
+// SourdoughPresentationController); they compose via %ctor/%init() order. This
+// module's option row stacks one row below Gallery's in its viewDidLayoutSubviews
+// pass, and ApolloShareAsVideo's share-button hook installs after ours (so it is
+// outermost and can suppress the native share). The link-append below is written to
+// be idempotent (see ApolloShareLinkAlreadyHasLinkSource), so it no longer depends
+// on that hook order to avoid a double link — but if you reorder these in the
+// Makefile, re-verify the option-row layout still stacks correctly.
 
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
@@ -285,22 +297,49 @@ static void ApolloShareLinkLayoutRow(id vc) {
     ApolloLog(@"[ShareLink] share tapped includeLink=%d", (int)sActiveShareIncludeLink);
     %orig;
     // Safety net: clear the handshake shortly after, in case no activity sheet is
-    // built (the init hook also clears it immediately on a successful append).
+    // built (the init hook also clears it immediately on a successful append). Reset
+    // both fields so neither is left latched into a later, unrelated share.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)),
-                   dispatch_get_main_queue(), ^{ sActiveShareVC = nil; });
+                   dispatch_get_main_queue(), ^{ sActiveShareVC = nil; sActiveShareIncludeLink = NO; });
 }
 
 %end
+
+// Does this share sheet ALREADY carry one of our Reddit-link item sources? Both this
+// module (ApolloShareLinkItemSource) and ApolloShareAsVideo (ApolloSVLinkItemSource)
+// attach one when their feature is on, and ApolloShareAsVideo presents its OWN
+// activity sheet — whose initWithActivityItems: flows through THIS very hook. When
+// the video path took over the share (both toggles on) it already added the link, so
+// re-appending here would produce a double link. Gating on this makes the append
+// idempotent regardless of Makefile hook order or how long the handshake timer below
+// stays open — directly addressing the latent double-link path. We match the two
+// concrete source classes (this module's directly; the video module's via a runtime
+// objc_getClass lookup so there's no hard link/symbol or Makefile-order dependency),
+// rather than an open-ended name match that could false-positive on a native class.
+static BOOL ApolloShareLinkAlreadyHasLinkSource(NSArray *items) {
+    if (![items isKindOfClass:[NSArray class]]) return NO;
+    Class svLinkClass = objc_getClass("ApolloSVLinkItemSource"); // ApolloShareAsVideo's link source, if loaded
+    for (id item in items) {
+        if ([item isKindOfClass:[ApolloShareLinkItemSource class]]) return YES;
+        if (svLinkClass && [item isKindOfClass:svLinkClass]) return YES;
+    }
+    return NO;
+}
 
 %hook UIActivityViewController
 
 - (instancetype)initWithActivityItems:(NSArray *)activityItems
                 applicationActivities:(NSArray *)applicationActivities {
+    // This hook fires for EVERY UIActivityViewController in the app; the
+    // sActiveShareVC handshake (set only by the share-as-image Share tap) scopes it,
+    // and the link-source check keeps us from double-appending onto the video path's
+    // own sheet.
     id vc = sActiveShareVC;
-    if (vc && sActiveShareIncludeLink) {
+    if (vc && sActiveShareIncludeLink && !ApolloShareLinkAlreadyHasLinkSource(activityItems)) {
         NSURL *url = ApolloShareLinkURLForVC(vc);
         if ([url isKindOfClass:[NSURL class]]) {
-            sActiveShareVC = nil; // consume the handshake so we only append once
+            sActiveShareVC = nil;          // consume the handshake so we only append once
+            sActiveShareIncludeLink = NO;  // reset too, so the flag is never left latched
             ApolloShareLinkItemSource *source = [[ApolloShareLinkItemSource alloc] init];
             source.url = url;
             NSMutableArray *items = [activityItems isKindOfClass:[NSArray class]]

--- a/src/ApolloShareAsImageLink.xm
+++ b/src/ApolloShareAsImageLink.xm
@@ -1,0 +1,366 @@
+// ApolloShareAsImageLink.xm
+//
+// "Include Link" option for Share as Image (issue #481).
+//
+// Apollo's ShareAsImageViewController (_TtC6Apollo26ShareAsImageViewController)
+// renders a post or comment into a shareable image and presents the system
+// share sheet (UIActivityViewController) when the user taps "Share". This module
+// adds one extra options row — "Include Link" — beneath the native Watermark
+// row. When the toggle is ON, the Reddit URL of the shared post/comment is
+// appended to the share sheet's items, so apps like Messages and Mail attach the
+// image AND a tappable link to the original thread. The preference persists in
+// NSUserDefaults and defaults OFF (opt-in, preserves stock behaviour).
+//
+// Two halves:
+//   1. UI — a UILabel + UISwitch (+ hairline separator) created in viewDidLoad,
+//      styled from the native Watermark row, positioned one row below Watermark in
+//      viewDidLayoutSubviews. The hosting bottom-sheet is made one row taller by a
+//      hook on SourdoughPresentationController.frameOfPresentedViewInContainerView
+//      (the loop-free way to grow it), so the Share button is never clipped.
+//   2. Share interception — shareButtonTappedWithSender: records the active VC
+//      and the toggle state, then the UIActivityViewController designated
+//      initializer hook appends the link (via a UIActivityItemSource that keeps
+//      photo-only activities image-only) while that flag is set.
+//
+// No hardcoded binary addresses: everything is ObjC-runtime ivar access (ivar
+// names from class-dump headers) plus public UIKit selectors, with defensive
+// guards throughout.
+
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import "ApolloCommon.h"
+
+// Persisted preference: whether "Include Link" is on. Default NO.
+static NSString *const kApolloShareIncludeLinkKey = @"ApolloShareAsImageIncludeLink";
+
+// Display text for the new options row.
+static NSString *const kApolloShareIncludeLinkTitle = @"Include Link";
+
+// Associated-object keys for the views we add to the VC. Repo idiom: bare
+// `static char` whose address is the key (avoids -fmerge-all-constants aliasing).
+static char kApolloShareLinkLabelKey;     // strong UILabel
+static char kApolloShareLinkSwitchKey;    // strong UISwitch
+static char kApolloShareLinkSeparatorKey; // strong UIView
+
+// Active-share handshake between the button tap and the share-sheet construction.
+// Set on the main thread in shareButtonTappedWithSender:, read in the
+// UIActivityViewController init hook, both on the main thread.
+static __weak id sActiveShareVC = nil;
+static BOOL sActiveShareIncludeLink = NO;
+
+#pragma mark - Runtime ivar helpers
+
+static id ApolloShareLinkIvarObject(id obj, const char *name) {
+    if (!obj || !name) return nil;
+    Ivar ivar = class_getInstanceVariable(object_getClass(obj), name);
+    if (!ivar) return nil;
+    @try { return object_getIvar(obj, ivar); } @catch (__unused NSException *e) { return nil; }
+}
+
+// Reads a Swift CGFloat (== double on arm64) stored ivar by raw offset.
+static double ApolloShareLinkIvarDouble(id obj, const char *name) {
+    if (!obj || !name) return 0.0;
+    Ivar ivar = class_getInstanceVariable(object_getClass(obj), name);
+    if (!ivar) return 0.0;
+    ptrdiff_t offset = ivar_getOffset(ivar);
+    const unsigned char *base = (const unsigned char *)(__bridge const void *)obj;
+    double value = 0.0;
+    memcpy(&value, base + offset, sizeof(double));
+    return value;
+}
+
+#pragma mark - Link resolution
+
+// RDKLink.permalink returns a *relative* NSURL (just the path, e.g.
+// "/r/sub/comments/id/title/"), which is useless once handed to
+// Messages/Mail. Resolve any scheme-less URL against the reddit web host so the
+// recipient gets a tappable absolute link. Already-absolute URLs pass through.
+static NSURL *ApolloShareLinkAbsoluteURL(NSURL *url) {
+    if (![url isKindOfClass:[NSURL class]]) return nil;
+    if (url.scheme.length > 0 && url.host.length > 0) return url;
+    NSString *path = url.absoluteString ?: @"";
+    if (path.length == 0) return nil;
+    if (![path hasPrefix:@"/"]) path = [@"/" stringByAppendingString:path];
+    NSURL *abs = [NSURL URLWithString:[@"https://www.reddit.com" stringByAppendingString:path]];
+    return abs ?: url;
+}
+
+// Resolves the Reddit URL to attach for the share-as-image VC. Always the whole
+// post thread — even when sharing a comment, we link to the post, not the
+// specific comment. The `link` ivar holds the post in both post- and comment-
+// share modes, so this is uniform. Prefer the canonical reddit permalink,
+// falling back to the link's content URL. Returns nil if nothing usable is found.
+static NSURL *ApolloShareLinkURLForVC(id vc) {
+    if (!vc) return nil;
+
+    id link = ApolloShareLinkIvarObject(vc, "link");
+    if (link) {
+        @try {
+            if ([link respondsToSelector:@selector(permalink)]) {
+                id permalink = ((id (*)(id, SEL))objc_msgSend)(link, @selector(permalink));
+                if ([permalink isKindOfClass:[NSURL class]]) return ApolloShareLinkAbsoluteURL((NSURL *)permalink);
+            }
+        } @catch (__unused NSException *e) {}
+        @try {
+            if ([link respondsToSelector:@selector(URL)]) {
+                id url = ((id (*)(id, SEL))objc_msgSend)(link, @selector(URL));
+                if ([url isKindOfClass:[NSURL class]]) return ApolloShareLinkAbsoluteURL((NSURL *)url);
+            }
+        } @catch (__unused NSException *e) {}
+    }
+
+    return nil;
+}
+
+#pragma mark - Activity item source
+
+// Supplies the link URL to the share sheet. Returns the URL for sharing/messaging
+// activities but nil for photo-only destinations (Save to Photos, Assign to
+// Contact, Print) so those keep operating on the image alone.
+@interface ApolloShareLinkItemSource : NSObject <UIActivityItemSource>
+@property (nonatomic, strong) NSURL *url;
+@end
+
+@implementation ApolloShareLinkItemSource
+
+- (id)activityViewControllerPlaceholderItem:(UIActivityViewController *)activityViewController {
+    return self.url ?: (id)[NSNull null];
+}
+
+- (id)activityViewController:(UIActivityViewController *)activityViewController
+         itemForActivityType:(UIActivityType)activityType {
+    if (!self.url) return nil;
+    if ([activityType isEqualToString:UIActivityTypeSaveToCameraRoll] ||
+        [activityType isEqualToString:UIActivityTypeAssignToContact] ||
+        [activityType isEqualToString:UIActivityTypePrint]) {
+        return nil; // keep these image-only
+    }
+    return self.url;
+}
+
+@end
+
+#pragma mark - Options row UI
+
+// Builds (once) the Include Link label + switch + separator and adds them to the
+// same container as the native Watermark row. Styling is copied from the
+// Watermark row so the new row matches the current theme.
+static void ApolloShareLinkInstallRow(id vc) {
+    if (!vc) return;
+    if (objc_getAssociatedObject(vc, &kApolloShareLinkSwitchKey)) return; // already built
+
+    UILabel *watermarkLabel = (UILabel *)ApolloShareLinkIvarObject(vc, "watermarkRowTitleLabel");
+    UISwitch *watermarkSwitch = (UISwitch *)ApolloShareLinkIvarObject(vc, "watermarkRowSwitch");
+    if (![watermarkLabel isKindOfClass:[UILabel class]] ||
+        ![watermarkSwitch isKindOfClass:[UISwitch class]]) {
+        ApolloLog(@"[ShareLink] install: watermark row not found — skipping row");
+        return;
+    }
+
+    UIView *container = watermarkLabel.superview;
+    if (!container) {
+        ApolloLog(@"[ShareLink] install: watermark label has no superview — skipping row");
+        return;
+    }
+
+    // Label — mirror the native row's font/colour/alignment.
+    UILabel *label = [[UILabel alloc] init];
+    label.text = kApolloShareIncludeLinkTitle;
+    label.font = watermarkLabel.font;
+    label.textColor = watermarkLabel.textColor;
+    label.textAlignment = watermarkLabel.textAlignment;
+    label.numberOfLines = watermarkLabel.numberOfLines;
+    [container addSubview:label];
+
+    // Switch — mirror the native switch tint, seed from the saved preference.
+    UISwitch *toggle = [[UISwitch alloc] init];
+    toggle.onTintColor = watermarkSwitch.onTintColor;
+    toggle.on = [[NSUserDefaults standardUserDefaults] boolForKey:kApolloShareIncludeLinkKey];
+    [toggle addTarget:vc action:@selector(apollo_shareIncludeLinkToggled:)
+     forControlEvents:UIControlEventValueChanged];
+    [container addSubview:toggle];
+
+    // Hairline separator matching the existing ones.
+    UIView *separator = [[UIView alloc] init];
+    NSArray *separators = (NSArray *)ApolloShareLinkIvarObject(vc, "separators");
+    UIView *templateSep = [separators isKindOfClass:[NSArray class]] ? [separators lastObject] : nil;
+    separator.backgroundColor = [templateSep isKindOfClass:[UIView class]]
+        ? templateSep.backgroundColor
+        : [UIColor colorWithWhite:0.5 alpha:0.3];
+    [container addSubview:separator];
+
+    objc_setAssociatedObject(vc, &kApolloShareLinkLabelKey, label, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(vc, &kApolloShareLinkSwitchKey, toggle, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(vc, &kApolloShareLinkSeparatorKey, separator, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    ApolloLog(@"[ShareLink] options row installed (on=%d)", (int)toggle.on);
+}
+
+// Native gap between the last options row and the Share button (matches Apollo's
+// own row→button spacing). Used to place our relocated button consistently.
+static const CGFloat kApolloShareLinkButtonGap = 20.0;
+
+// Positions our "Include Link" row directly below the Watermark row and nudges the
+// Share button down to sit beneath it. This ONLY moves subviews — it never touches
+// the presented view's own frame. The sheet is made one row taller by the
+// SourdoughPresentationController hook below, so there's room for the relocated
+// button without us fighting the presentation controller (an earlier frame-based
+// grow here caused a layout feedback loop / watchdog hang when a native toggle
+// changed the content height). Recomputed from live native frames every pass, so
+// it stays correct across content toggles, theme changes, and rotation.
+static void ApolloShareLinkLayoutRow(id vc) {
+    UILabel *label = (UILabel *)objc_getAssociatedObject(vc, &kApolloShareLinkLabelKey);
+    UISwitch *toggle = (UISwitch *)objc_getAssociatedObject(vc, &kApolloShareLinkSwitchKey);
+    UIView *separator = (UIView *)objc_getAssociatedObject(vc, &kApolloShareLinkSeparatorKey);
+    if (!label || !toggle) return;
+
+    UILabel *watermarkLabel = (UILabel *)ApolloShareLinkIvarObject(vc, "watermarkRowTitleLabel");
+    UISwitch *watermarkSwitch = (UISwitch *)ApolloShareLinkIvarObject(vc, "watermarkRowSwitch");
+    if (![watermarkLabel isKindOfClass:[UILabel class]] ||
+        ![watermarkSwitch isKindOfClass:[UISwitch class]]) return;
+
+    CGRect wl = watermarkLabel.frame;
+    CGRect ws = watermarkSwitch.frame;
+
+    // Row pitch: prefer the native rowHeight ivar; fall back to the label height.
+    double pitch = ApolloShareLinkIvarDouble(vc, "rowHeight");
+    if (pitch <= 1.0) pitch = wl.size.height > 0 ? wl.size.height : 44.0;
+
+    toggle.frame = CGRectOffset(ws, 0, pitch);
+    // "Include Link" is wider than "Watermark"; widen the label to fill the space
+    // up to the switch so it isn't truncated (the native frame fits its own text).
+    CGFloat labelW = MAX(wl.size.width, CGRectGetMinX(toggle.frame) - 8.0 - wl.origin.x);
+    label.frame = CGRectMake(wl.origin.x, wl.origin.y + pitch, labelW, wl.size.height);
+
+    // Separator: clone the bottom-most native separator's geometry, shifted down.
+    NSArray *separators = (NSArray *)ApolloShareLinkIvarObject(vc, "separators");
+    UIView *templateSep = [separators isKindOfClass:[NSArray class]] ? [separators lastObject] : nil;
+    if (separator && [templateSep isKindOfClass:[UIView class]]) {
+        separator.frame = CGRectOffset(templateSep.frame, 0, pitch);
+        separator.hidden = templateSep.hidden;
+    } else if (separator) {
+        separator.frame = CGRectMake(wl.origin.x, CGRectGetMaxY(label.frame) + 0.5,
+                                     wl.size.width, 1.0 / [UIScreen mainScreen].scale);
+    }
+
+    // Place the Share button just below our row (the sheet was grown by one row to
+    // make room — see the presentation-controller hook). Deterministic + idempotent:
+    // Apollo re-lays the button each %orig pass, we always re-anchor it under our row.
+    UIView *shareButton = (UIView *)ApolloShareLinkIvarObject(vc, "shareButton");
+    if ([shareButton isKindOfClass:[UIView class]]) {
+        CGRect bf = shareButton.frame;
+        bf.origin.y = CGRectGetMaxY(label.frame) + kApolloShareLinkButtonGap;
+        shareButton.frame = bf;
+    }
+}
+
+#pragma mark - Hooks
+
+%hook _TtC6Apollo26ShareAsImageViewController
+
+- (void)viewDidLoad {
+    %orig;
+    // DIAGNOSTIC: confirm the share-as-image VC actually loads (post vs comment).
+    BOOL isComment = ApolloShareLinkIvarObject(self, "comment") != nil;
+    ApolloLog(@"[ShareLink] viewDidLoad comment=%d", (int)isComment);
+    ApolloShareLinkInstallRow(self);
+}
+
+- (void)viewDidLayoutSubviews {
+    %orig;
+    ApolloShareLinkLayoutRow(self);
+}
+
+%new
+- (void)apollo_shareIncludeLinkToggled:(UISwitch *)sender {
+    BOOL on = [sender isKindOfClass:[UISwitch class]] ? sender.isOn : NO;
+    [[NSUserDefaults standardUserDefaults] setBool:on forKey:kApolloShareIncludeLinkKey];
+    ApolloLog(@"[ShareLink] toggle -> %d", (int)on);
+}
+
+- (void)shareButtonTappedWithSender:(id)sender {
+    sActiveShareVC = self;
+    sActiveShareIncludeLink = [[NSUserDefaults standardUserDefaults] boolForKey:kApolloShareIncludeLinkKey];
+    ApolloLog(@"[ShareLink] share tapped includeLink=%d", (int)sActiveShareIncludeLink);
+    %orig;
+    // Safety net: clear the handshake shortly after, in case no activity sheet is
+    // built (the init hook also clears it immediately on a successful append).
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{ sActiveShareVC = nil; });
+}
+
+%end
+
+%hook UIActivityViewController
+
+- (instancetype)initWithActivityItems:(NSArray *)activityItems
+                applicationActivities:(NSArray *)applicationActivities {
+    id vc = sActiveShareVC;
+    if (vc && sActiveShareIncludeLink) {
+        NSURL *url = ApolloShareLinkURLForVC(vc);
+        if ([url isKindOfClass:[NSURL class]]) {
+            sActiveShareVC = nil; // consume the handshake so we only append once
+            ApolloShareLinkItemSource *source = [[ApolloShareLinkItemSource alloc] init];
+            source.url = url;
+            NSMutableArray *items = [activityItems isKindOfClass:[NSArray class]]
+                ? [activityItems mutableCopy] : [NSMutableArray array];
+            [items addObject:source];
+            ApolloLog(@"[ShareLink] appended link to share sheet: %@", url.absoluteString);
+            return %orig(items, applicationActivities);
+        }
+        ApolloLog(@"[ShareLink] share active but no link resolved — leaving items unchanged");
+    }
+    return %orig;
+}
+
+%end
+
+// The Share-as-Image preview is hosted in a custom bottom-sheet presentation
+// controller that sizes the sheet to Apollo's native content. We add an extra
+// "Include Link" row, so ask the controller for one row more height (extending the
+// sheet upward, bottom edge anchored). Doing it here — in the controller's own
+// frame method — is the loop-free way to grow the sheet: UIKit applies the
+// returned frame, there's nothing to fight, and it's recomputed automatically on
+// every content/size change (toggles, rotation). Only affects the Share-as-Image VC.
+%hook _TtC6Apollo31SourdoughPresentationController
+
+- (CGRect)frameOfPresentedViewInContainerView {
+    CGRect frame = %orig;
+    @try {
+        // Never let our adjustment produce a degenerate frame — that can abort the
+        // presentation transition (the comment preview is taller, so a naive
+        // origin.y -= pitch could go off the top). Bail on anything non-finite.
+        if (!isfinite(frame.origin.y) || !isfinite(frame.size.height) ||
+            frame.size.height <= 1.0) {
+            return frame;
+        }
+        id presented = [(UIPresentationController *)self presentedViewController];
+        Class shareVCClass = objc_getClass("_TtC6Apollo26ShareAsImageViewController");
+        if (shareVCClass && [presented isKindOfClass:shareVCClass]) {
+            double pitch = ApolloShareLinkIvarDouble(presented, "rowHeight");
+            if (pitch <= 1.0 || !isfinite(pitch)) pitch = 50.0;
+            // Grow upward but clamp the top to the container (never negative), and
+            // keep the bottom edge anchored. If there isn't a full pitch of room
+            // above, grow by only what's available.
+            CGFloat nativeBottom = frame.origin.y + frame.size.height;
+            CGFloat newTop = MAX(0.0, frame.origin.y - pitch);
+            frame.origin.y = newTop;
+            frame.size.height = nativeBottom - newTop;
+        }
+    } @catch (__unused NSException *e) {}
+    return frame;
+}
+
+%end
+
+%ctor {
+    @autoreleasepool {
+        if (objc_getClass("_TtC6Apollo26ShareAsImageViewController")) {
+            %init();
+            ApolloLog(@"[ShareLink] module loaded");
+        } else {
+            ApolloLog(@"[ShareLink] ShareAsImageViewController not found — skipping");
+        }
+    }
+}

--- a/src/ApolloShareAsImagePreviewFix.xm
+++ b/src/ApolloShareAsImagePreviewFix.xm
@@ -12,11 +12,15 @@
 //       loading AFTER present and grows the node, but that internal Texture
 //       re-measure never drives the view controller's viewDidLayoutSubviews — so the
 //       initial (short, squished) snapshot sticks. Any settings toggle or drag
-//       forces a relayout, which is why it "fixes itself." Fix: after present, force
-//       a few view-controller relayouts (the same path a toggle takes) so the
-//       snapshot is refreshed once the media has loaded and the node measures its
-//       true height. The native re-snapshot is size-gated, so a relayout that finds
-//       nothing changed is a no-op.
+//       forces a relayout, which is why it "fixes itself." Fix: after present, drive
+//       Apollo's own relayout (the same path a toggle takes) on a short polling loop
+//       that OBSERVES the preview node's measured size rather than firing on a fixed
+//       time ladder. It stops as soon as the node has grown (async media arrived) AND
+//       the snapshot has caught up to the node's size — the exact size comparison
+//       Apollo's re-snapshot gate uses — so a fast (cached) load settles in a pass or
+//       two, while a slow/cold-cache load that finishes seconds later is still picked
+//       up (the old fixed 3.5s ceiling could miss it). The native re-snapshot is
+//       size-gated, so a relayout that finds nothing changed is a no-op.
 //
 //   #3  UPWARD-DRAG GLITCH. Press-dragging the preview sheet UPWARD lifts it off the
 //       bottom of the screen: the pan handler moves the presented view's origin.y up
@@ -38,6 +42,13 @@
 //       you can tweak options and try again).
 //
 // Pure ObjC-runtime access + public UIKit; no hardcoded binary addresses.
+//
+// MODULE ORDERING (Makefile ApolloReborn_FILES): this module is listed LAST of the
+// four Share-as-Image modules (Gallery -> Link -> Video -> PreviewFix), so its hooks
+// install last and wrap the others. In particular its presentViewController: hook is
+// outermost, so it sees the activity sheet whether the native image share or
+// ApolloShareAsVideo's own share presents it — which is exactly what the
+// auto-dismiss (#4) needs. Keep it last if you reorder the Makefile.
 
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
@@ -47,6 +58,23 @@
 // Associated-object key: marks that the post-present snapshot refresh has been
 // armed for this VC (so we only schedule it once).
 static char kApolloSIPFRefreshArmedKey;
+
+#pragma mark - Runtime helpers
+
+static id ApolloSIPFIvarObject(id obj, const char *name) {
+    if (!obj || !name) return nil;
+    Ivar ivar = class_getInstanceVariable(object_getClass(obj), name);
+    if (!ivar) return nil;
+    @try { return object_getIvar(obj, ivar); } @catch (__unused NSException *e) { return nil; }
+}
+
+// The preview node's measured bounds size. The concrete ASDisplayNode class isn't
+// headered here, so reach `bounds` via objc_msgSend (CGRect-returning), guarded.
+static CGSize ApolloSIPFNodeSize(id node) {
+    if (!node || ![node respondsToSelector:@selector(bounds)]) return CGSizeZero;
+    @try { CGRect b = ((CGRect (*)(id, SEL))objc_msgSend)(node, @selector(bounds)); return b.size; }
+    @catch (__unused NSException *e) { return CGSizeZero; }
+}
 
 // Forces Apollo's own preview relayout + re-snapshot. This mirrors the relayout a
 // settings toggle performs (lay out the presentation container, then the VC view):
@@ -65,28 +93,75 @@ static void ApolloSIPFForceRelayout(UIViewController *vc) {
     [vc.view layoutIfNeeded];
 }
 
+// Self-rescheduling snapshot poll. Each pass forces a relayout (which drives Apollo's
+// size-gated re-snapshot), then OBSERVES the preview node's height vs the snapshot's:
+//   * `match`  = the snapshot height now equals the node height (Apollo re-snapshotted
+//                at the node's current size — the exact comparison its own gate uses).
+//   * `stable` = the node height also hasn't changed since the previous pass.
+// We STOP once the snapshot has matched a STABLE node height for a few consecutive
+// passes (the card stopped resizing and the snapshot reflects it — squish resolved),
+// or at a hard attempt cap (~10s of backed-off polling) as a backstop. This exits
+// fast both when the media was already cached (matches within a pass or two) AND after
+// a slow/cold-cache load finishes growing the card seconds later — which the old fixed
+// 3.5s ladder could miss. While the card is still actively resizing, the height keeps
+// changing so `stable` resets and we keep polling. A relayout that finds nothing
+// changed is a native no-op, so the trailing confirmation passes are cheap.
+static void ApolloSIPFPollSnapshot(UIViewController *vc, int attempt, CGFloat prevNodeHeight, int stableCount) {
+    if (![vc isViewLoaded] || !vc.viewIfLoaded.window) return; // dismissed — stop
+
+    ApolloSIPFForceRelayout(vc);
+
+    CGFloat nodeH = ApolloSIPFNodeSize(ApolloSIPFIvarObject(vc, "previewNode")).height;
+    UIImageView *snap = (UIImageView *)ApolloSIPFIvarObject(vc, "previewSnapshotImageView");
+    UIImage *snapImg = [snap isKindOfClass:[UIImageView class]] ? snap.image : nil;
+    CGFloat snapH = [snapImg isKindOfClass:[UIImage class]] ? snapImg.size.height : 0.0;
+
+    BOOL match  = nodeH > 1.0 && snapH > 1.0 && fabs(nodeH - snapH) < 1.0;
+    BOOL stable = match && prevNodeHeight > 1.0 && fabs(nodeH - prevNodeHeight) < 1.0;
+    stableCount = stable ? stableCount + 1 : 0;
+
+    if (stableCount >= 3) { // snapshot has matched a settled node height for several passes
+        ApolloLog(@"[SharePreviewFix] snapshot settled after %d pass(es)", attempt + 1);
+        return;
+    }
+    if (attempt >= 24) {
+        ApolloLog(@"[SharePreviewFix] snapshot poll finished after %d passes", attempt + 1);
+        return;
+    }
+
+    double delay = MIN(0.1 + 0.05 * attempt, 0.5); // gentle backoff, capped at 0.5s
+    int nextAttempt = attempt + 1;
+    CGFloat nextPrev = nodeH;
+    int nextStable = stableCount;
+    __weak UIViewController *weakVC = vc;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        UIViewController *strongVC = weakVC;
+        if (strongVC) ApolloSIPFPollSnapshot(strongVC, nextAttempt, nextPrev, nextStable);
+    });
+}
+
 %hook _TtC6Apollo26ShareAsImageViewController
 
 - (void)viewDidLayoutSubviews {
     %orig;
 
-    // Arm a short series of relayouts once, on the first layout after present, so
-    // the snapshot is refreshed as soon as any async comment/post media loads (it's
-    // usually already cached from the thread the user shared from, so this resolves
-    // almost immediately). Idempotent and self-limiting; each relayout is a no-op if
-    // nothing changed.
+    // Arm the snapshot poll once, on the first layout after present. It observes the
+    // preview node's size and refreshes the snapshot as soon as any async comment/post
+    // media loads (usually already cached, so it settles almost immediately).
+    // Idempotent and self-limiting.
     if ([objc_getAssociatedObject(self, &kApolloSIPFRefreshArmedKey) boolValue]) return;
     objc_setAssociatedObject(self, &kApolloSIPFRefreshArmedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
+    // Defer the first pass to the next runloop turn (don't relayout synchronously from
+    // within viewDidLayoutSubviews).
     __weak __typeof__(self) weakSelf = self;
-    static const double kDelays[] = { 0.1, 0.3, 0.6, 1.2, 2.0, 3.5 };
-    for (size_t i = 0; i < sizeof(kDelays) / sizeof(kDelays[0]); i++) {
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kDelays[i] * NSEC_PER_SEC)),
-                       dispatch_get_main_queue(), ^{
-            ApolloSIPFForceRelayout((UIViewController *)weakSelf);
-        });
-    }
-    ApolloLog(@"[SharePreviewFix] armed snapshot refreshes");
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        __typeof__(self) strongSelf = weakSelf;
+        if (strongSelf) ApolloSIPFPollSnapshot((UIViewController *)strongSelf, 0, -1.0, 0);
+    });
+    ApolloLog(@"[SharePreviewFix] armed snapshot poll");
 }
 
 // #4: auto-dismiss the preview once a share completes. Both the native image share

--- a/src/ApolloShareAsImagePreviewFix.xm
+++ b/src/ApolloShareAsImagePreviewFix.xm
@@ -1,0 +1,166 @@
+// ApolloShareAsImagePreviewFix.xm
+//
+// Two preview-only fixes for Apollo's "Share as Image" sheet
+// (_TtC6Apollo26ShareAsImageViewController), found while finishing #484.
+//
+//   #1  SQUISHED COMMENT MEDIA. When you Share-as-Image a comment that contains an
+//       inline GIF/image, the preview renders the media squished into a short card
+//       until you toggle an option or drag the sheet. Apollo snapshots the preview
+//       node into `previewSnapshotImageView` ONCE on present, and in
+//       viewDidLayoutSubviews only RE-snapshots when the preview node's frame SIZE
+//       differs from the current snapshot's size. A comment's media finishes
+//       loading AFTER present and grows the node, but that internal Texture
+//       re-measure never drives the view controller's viewDidLayoutSubviews — so the
+//       initial (short, squished) snapshot sticks. Any settings toggle or drag
+//       forces a relayout, which is why it "fixes itself." Fix: after present, force
+//       a few view-controller relayouts (the same path a toggle takes) so the
+//       snapshot is refreshed once the media has loaded and the node measures its
+//       true height. The native re-snapshot is size-gated, so a relayout that finds
+//       nothing changed is a no-op.
+//
+//   #3  UPWARD-DRAG GLITCH. Press-dragging the preview sheet UPWARD lifts it off the
+//       bottom of the screen: the pan handler moves the presented view's origin.y up
+//       by up to ~40pt (rubber-banded) while keeping its height fixed, so the card's
+//       bottom edge rises and exposes an empty gap beneath it that snaps back on
+//       release — it reads as a glitch. Dragging up serves no purpose (the sheet
+//       already shows all of its content; only a downward drag dismisses), so we
+//       clamp the presented view during the drag so it can never rise above its
+//       resting top. Downward (dismiss) drags are untouched.
+//
+//   #4  SHEET STAYS OPEN AFTER A SHARE COMPLETES. Tapping Share presents the iOS
+//       activity sheet on top of the preview; after you actually save/message/mail
+//       the image or video, the activity sheet dismisses but the preview sheet is
+//       left sitting there. Both share paths (Apollo's native image share and our
+//       own video share) present the activity sheet FROM the preview view controller,
+//       so we hook its presentViewController: and wrap the activity sheet's
+//       completion handler to also dismiss the preview — but only when the share
+//       actually COMPLETED (cancelling the activity sheet leaves the preview up so
+//       you can tweak options and try again).
+//
+// Pure ObjC-runtime access + public UIKit; no hardcoded binary addresses.
+
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import "ApolloCommon.h"
+
+// Associated-object key: marks that the post-present snapshot refresh has been
+// armed for this VC (so we only schedule it once).
+static char kApolloSIPFRefreshArmedKey;
+
+// Forces Apollo's own preview relayout + re-snapshot. This mirrors the relayout a
+// settings toggle performs (lay out the presentation container, then the VC view):
+// the native viewDidLayoutSubviews re-snapshots the preview node whenever its frame
+// size has changed since the last snapshot — exactly what happens once a comment's
+// async media finishes loading and the node measures its true height.
+static void ApolloSIPFForceRelayout(UIViewController *vc) {
+    if (![vc isViewLoaded] || !vc.viewIfLoaded.window) return;
+    UIPresentationController *pc = vc.presentationController;
+    UIView *container = pc.containerView;
+    if (container) {
+        [container setNeedsLayout];
+        [container layoutIfNeeded];
+    }
+    [vc.view setNeedsLayout];
+    [vc.view layoutIfNeeded];
+}
+
+%hook _TtC6Apollo26ShareAsImageViewController
+
+- (void)viewDidLayoutSubviews {
+    %orig;
+
+    // Arm a short series of relayouts once, on the first layout after present, so
+    // the snapshot is refreshed as soon as any async comment/post media loads (it's
+    // usually already cached from the thread the user shared from, so this resolves
+    // almost immediately). Idempotent and self-limiting; each relayout is a no-op if
+    // nothing changed.
+    if ([objc_getAssociatedObject(self, &kApolloSIPFRefreshArmedKey) boolValue]) return;
+    objc_setAssociatedObject(self, &kApolloSIPFRefreshArmedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    __weak __typeof__(self) weakSelf = self;
+    static const double kDelays[] = { 0.1, 0.3, 0.6, 1.2, 2.0, 3.5 };
+    for (size_t i = 0; i < sizeof(kDelays) / sizeof(kDelays[0]); i++) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kDelays[i] * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            ApolloSIPFForceRelayout((UIViewController *)weakSelf);
+        });
+    }
+    ApolloLog(@"[SharePreviewFix] armed snapshot refreshes");
+}
+
+// #4: auto-dismiss the preview once a share completes. Both the native image share
+// and our video share present a UIActivityViewController from this view controller,
+// so wrap that activity sheet's completion handler (preserving any existing one,
+// e.g. the video share's temp-file cleanup) and dismiss the preview when the user
+// actually completed a share. Cancelling leaves the preview open.
+- (void)presentViewController:(UIViewController *)vcToPresent
+                     animated:(BOOL)animated
+                   completion:(void (^)(void))completion {
+    @try {
+        if ([vcToPresent isKindOfClass:[UIActivityViewController class]]) {
+            UIActivityViewController *avc = (UIActivityViewController *)vcToPresent;
+            __weak __typeof__(self) weakSelf = self;
+            void (^existing)(UIActivityType, BOOL, NSArray *, NSError *) = avc.completionWithItemsHandler;
+            avc.completionWithItemsHandler = ^(UIActivityType activityType, BOOL completed,
+                                               NSArray *returnedItems, NSError *activityError) {
+                if (existing) existing(activityType, completed, returnedItems, activityError);
+                if (!completed) return; // cancelled — keep the preview up
+                __typeof__(self) strongSelf = weakSelf;
+                UIViewController *previewVC = (UIViewController *)strongSelf;
+                if (previewVC.viewIfLoaded.window) {
+                    [previewVC dismissViewControllerAnimated:YES completion:nil];
+                    ApolloLog(@"[SharePreviewFix] share completed — dismissed preview");
+                }
+            };
+        }
+    } @catch (__unused NSException *e) {}
+    %orig;
+}
+
+%end
+
+%hook _TtC6Apollo31SourdoughPresentationController
+
+// After the native pan moves the sheet, clamp the presented view so an upward drag
+// can never lift it above its resting top (which would expose an empty gap under the
+// card). Only acts while the gesture is actively dragging the Share-as-Image sheet;
+// the end-of-gesture dismiss/snap-back animation runs untouched.
+- (void)pannedWithPanGestureRecognizer:(id)gestureRecognizer {
+    %orig;
+    @try {
+        if (![gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) return;
+        UIGestureRecognizerState state = ((UIPanGestureRecognizer *)gestureRecognizer).state;
+        if (state != UIGestureRecognizerStateBegan && state != UIGestureRecognizerStateChanged) return;
+
+        UIPresentationController *pc = (UIPresentationController *)self;
+        id presented = [pc presentedViewController];
+        Class shareVCClass = objc_getClass("_TtC6Apollo26ShareAsImageViewController");
+        if (!shareVCClass || ![presented isKindOfClass:shareVCClass]) return;
+
+        UIView *presentedView = [(UIViewController *)presented view];
+        if (![presentedView isKindOfClass:[UIView class]]) return;
+
+        CGRect resting = [pc frameOfPresentedViewInContainerView];
+        if (!isfinite(resting.origin.y)) return;
+
+        CGRect frame = presentedView.frame;
+        if (frame.origin.y < resting.origin.y - 0.5) {
+            frame.origin.y = resting.origin.y;
+            presentedView.frame = frame;
+        }
+    } @catch (__unused NSException *e) {}
+}
+
+%end
+
+%ctor {
+    @autoreleasepool {
+        if (objc_getClass("_TtC6Apollo26ShareAsImageViewController")) {
+            %init();
+            ApolloLog(@"[SharePreviewFix] module loaded");
+        } else {
+            ApolloLog(@"[SharePreviewFix] ShareAsImageViewController not found — skipping");
+        }
+    }
+}

--- a/src/ApolloShareAsVideo.xm
+++ b/src/ApolloShareAsVideo.xm
@@ -1,0 +1,1112 @@
+// ApolloShareAsVideo.xm
+//
+// "Share as Video" option for Share as Image (issue #380).
+//
+// Apollo's ShareAsImageViewController (_TtC6Apollo26ShareAsImageViewController)
+// renders a post into a shareable card image. For a VIDEO post the card shows a
+// static poster thumbnail in its media region (injected by
+// ApolloShareAsImageGallery). This module adds one extra options row — "Share as
+// Video" — shown only for video posts. When the toggle is ON and the user taps
+// Share, instead of exporting the flat image we export an MP4: the very same card
+// (title, byline, watermark — everything the user toggled) as a static backdrop,
+// with the post's real video PLAYING inside the media region, sound included.
+//
+// How the video is built (AVFoundation, no FFmpeg — works on device and sim):
+//   1. Card image  = the rendered card snapshot Apollo already shows
+//      (previewSnapshotImageView.image).
+//   2. Media rect  = the preview node's imageNode frame (posts) or the largest
+//      inline image/video node inside baseCommentNode (comments), converted into
+//      card space and normalised, so the video lands exactly over the poster/GIF.
+//   3. Video asset = a progressive, exportable source:
+//        * v.redd.it  -> parse DASHPlaylist.mpd for the lowest-bitrate video MP4
+//          + the audio MP4 (both progressive; AVFoundation muxes them in the
+//          composition). Falls back to RDKVideo.fallbackURL (video-only) if the
+//          manifest can't be parsed.
+//        * direct .mp4 (e.g. imgur) -> used as-is.
+//        * comment inline Giphy -> its progressive giphy.mp4.
+//      The playing AVPlayer is NOT used: v.redd.it plays as HLS, which
+//      AVAssetExportSession cannot export. We drive everything off the post's
+//      RDKLink / comment, always present whether or not the video is on screen.
+//   4. Composite  = AVMutableComposition (video + audio) exported with a custom
+//      AVVideoCompositing (ApolloSVCompositor): each frame is drawn with Core
+//      Graphics — the card first, then the source video aspect-filled into the
+//      media rect on top. A custom compositor is used instead of
+//      AVVideoCompositionCoreAnimationTool, which hangs/traps in the iOS Simulator.
+//      Output is a temp .mp4 handed to the share sheet in place of the image.
+//
+// The export is asynchronous (seconds), so when the toggle is ON we SUPPRESS
+// Apollo's native (synchronous, image-only) share, show a progress overlay, build
+// the video, then present our own UIActivityViewController with the file. Any
+// failure falls back to Apollo's normal image share so the button never dead-ends.
+//
+// Coexists with ApolloShareAsImageLink's "Include Link" row: our row anchors to
+// the Share button's current position and pushes the button down (after %orig) so
+// it stacks below whatever other modules added. When the Include Link option is on,
+// the exported video carries the post link too — added to our share sheet for
+// messaging/mail (not Save Video) — exactly as Include Link does for the image.
+//
+// No hardcoded binary addresses: everything is ObjC-runtime ivar access (ivar
+// names from class-dump headers) plus public AVFoundation/UIKit, guarded.
+
+#import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import "ApolloCommon.h"
+
+#pragma mark - Tunables
+
+// Persisted preference: whether "Share as Video" is on. Default NO (opt-in).
+static NSString *const kApolloShareVideoKey = @"ApolloShareAsImageShareVideo";
+static NSString *const kApolloShareVideoTitle = @"Share as Video";
+
+// Cap the exported clip so a 40-minute v.redd.it post doesn't produce a giant
+// file / minutes-long export. Most Reddit videos are far shorter than this.
+static const NSTimeInterval kApolloShareVideoMaxSeconds = 180.0;
+
+// Native gap between the last options row and the Share button.
+static const CGFloat kApolloShareVideoButtonGap = 20.0;
+
+#pragma mark - Associated-object keys
+
+// Repo idiom: bare `static char` whose address is the key.
+static char kApolloShareVideoLabelKey;     // strong UILabel
+static char kApolloShareVideoSwitchKey;    // strong UISwitch
+static char kApolloShareVideoSeparatorKey; // strong UIView
+static char kApolloShareVideoIsVideoKey;   // NSNumber(BOOL): post is an exportable video
+static char kApolloShareVideoExportingKey; // NSNumber(BOOL): an export is in flight
+static char kApolloShareVideoHUDKey;       // strong UIView (progress overlay)
+static char kApolloShareVideoSessionKey;   // strong AVAssetExportSession (in flight)
+static char kApolloShareVideoForceNativeKey; // NSNumber(BOOL): force the native image share once
+
+#pragma mark - Runtime ivar helpers
+
+static id ApolloSVIvarObject(id obj, const char *name) {
+    if (!obj || !name) return nil;
+    Ivar ivar = class_getInstanceVariable(object_getClass(obj), name);
+    if (!ivar) return nil;
+    @try { return object_getIvar(obj, ivar); } @catch (__unused NSException *e) { return nil; }
+}
+
+static double ApolloSVIvarDouble(id obj, const char *name) {
+    if (!obj || !name) return 0.0;
+    Ivar ivar = class_getInstanceVariable(object_getClass(obj), name);
+    if (!ivar) return 0.0;
+    ptrdiff_t offset = ivar_getOffset(ivar);
+    const unsigned char *base = (const unsigned char *)(__bridge const void *)obj;
+    double value = 0.0;
+    memcpy(&value, base + offset, sizeof(double));
+    return value;
+}
+
+// Calls a 0-arg selector returning an object, guarded.
+static id ApolloSVCall(id obj, SEL sel) {
+    if (!obj || !sel || ![obj respondsToSelector:sel]) return nil;
+    @try { return ((id (*)(id, SEL))objc_msgSend)(obj, sel); }
+    @catch (__unused NSException *e) { return nil; }
+}
+
+// Calls a 0-arg selector returning a double, guarded.
+static double ApolloSVCallDouble(id obj, SEL sel) {
+    if (!obj || !sel || ![obj respondsToSelector:sel]) return 0.0;
+    @try { return ((double (*)(id, SEL))objc_msgSend)(obj, sel); }
+    @catch (__unused NSException *e) { return 0.0; }
+}
+
+// Calls a 1-arg (object) selector returning an object, guarded.
+static id ApolloSVCall1(id obj, SEL sel, id arg) {
+    if (!obj || !sel || ![obj respondsToSelector:sel]) return nil;
+    @try { return ((id (*)(id, SEL, id))objc_msgSend)(obj, sel, arg); }
+    @catch (__unused NSException *e) { return nil; }
+}
+
+#pragma mark - Video source model
+
+// Returns the post's best RDKVideo (direct, then crosspost, then the readonly
+// convenience), or nil. Used both to decide whether to show the toggle and to
+// resolve the exportable asset.
+static id ApolloSVBestVideo(id link) {
+    if (!link) return nil;
+    // mediaVideo  — a native v.redd.it video post.
+    // crossPostVideo — a crossposted video.
+    // previewVideo — Reddit's downloadable reddit_video_preview MP4 generated for
+    //   EXTERNAL video link posts (YouTube/Vimeo/etc.); this is what Apollo's
+    //   "Download Video…" saves, and it's hosted on v.redd.it, so it's exportable.
+    // video — the readonly convenience.
+    SEL order[] = { @selector(mediaVideo), @selector(crossPostVideo), @selector(previewVideo), @selector(video) };
+    for (int i = 0; i < 4; i++) { id v = ApolloSVCall(link, order[i]); if (v) return v; }
+    id parent = ApolloSVCall(link, @selector(crosspostParent));
+    if (parent && parent != link) {
+        for (int i = 0; i < 4; i++) { id v = ApolloSVCall(parent, order[i]); if (v) return v; }
+    }
+    return nil;
+}
+
+static BOOL ApolloSVHostContains(NSURL *url, NSString *needle) {
+    return [url isKindOfClass:[NSURL class]] && [(url.host ?: @"") rangeOfString:needle].location != NSNotFound;
+}
+
+static BOOL ApolloSVIsMP4(NSURL *url) {
+    return [url isKindOfClass:[NSURL class]] &&
+           [[(url.path ?: @"") pathExtension] caseInsensitiveCompare:@"mp4"] == NSOrderedSame;
+}
+
+// Rewrites a GIF-ish media URL to a progressive .mp4 AVFoundation can export, or
+// returns nil if there's no known mp4 form (i.redd.it .gif / Redgifs HLS / etc.).
+// Giphy and imgur both serve an .mp4 at the same path as the .gif.
+static NSURL *ApolloSVToExportableMP4(NSURL *url) {
+    if (![url isKindOfClass:[NSURL class]]) return nil;
+    if (ApolloSVIsMP4(url)) return url;
+    NSString *host = url.host ?: @"";
+    NSString *ext = url.pathExtension.lowercaseString;
+    NSString *s = url.absoluteString;
+    if (([host containsString:@"giphy.com"] || [host containsString:@"imgur.com"]) &&
+        ([ext isEqualToString:@"gif"] || [ext isEqualToString:@"gifv"])) {
+        NSString *base = [s substringToIndex:s.length - ext.length - 1]; // drop ".gif"/".gifv"
+        return [NSURL URLWithString:[base stringByAppendingString:@".mp4"]];
+    }
+    return nil;
+}
+
+// SYNCHRONOUS feasibility check (decides whether the toggle is shown). True when
+// the post has a video we can produce a progressive, exportable file for:
+//   * a v.redd.it video (we'll resolve its DASH MP4 + audio at export time), or
+//   * a direct .mp4 URL.
+// HLS-only sources (Streamable / redgifs with no progressive form) return NO, so
+// the toggle simply never appears for them.
+static BOOL ApolloSVPostIsExportableVideo(id link) {
+    id video = ApolloSVBestVideo(link);
+    if (!video) return NO;
+
+    NSURL *url   = (NSURL *)ApolloSVCall(video, @selector(URL));
+    NSURL *fb    = (NSURL *)ApolloSVCall(video, @selector(fallbackURL));
+    NSURL *small = (NSURL *)ApolloSVCall(video, @selector(smallerURL));
+
+    if (ApolloSVHostContains(url, @"v.redd.it") || ApolloSVHostContains(fb, @"v.redd.it")) return YES;
+    if (ApolloSVIsMP4(url) || ApolloSVIsMP4(fb) || ApolloSVIsMP4(small)) return YES;
+    return NO;
+}
+
+// SYNCHRONOUS feasibility for a COMMENT share: the comment carries an inline GIF
+// we can export. v1 covers Giphy (the comment GIF picker's source) — it has a
+// progressive .mp4 form. Detection only needs the comment object, not layout.
+static BOOL ApolloSVCommentExportable(id comment) {
+    if (!comment) return NO;
+    NSDictionary *giphy = (NSDictionary *)ApolloSVCall(comment, @selector(inlineGiphyIDsToURLs));
+    if ([giphy isKindOfClass:[NSDictionary class]] && giphy.count > 0) return YES;
+    return NO;
+}
+
+// First Giphy id on the comment, and its progressive .mp4. Apollo's resolver gives
+// an mp4-or-gif URL; we coerce to mp4 (same path) and fall back to the canonical
+// media.giphy.com path built from the id.
+static NSURL *ApolloSVCommentGiphyMP4(id comment) {
+    if (!comment) return nil;
+    NSDictionary *giphy = (NSDictionary *)ApolloSVCall(comment, @selector(inlineGiphyIDsToURLs));
+    if (![giphy isKindOfClass:[NSDictionary class]] || giphy.count == 0) return nil;
+    NSString *gid = nil;
+    for (id k in giphy) { if ([k isKindOfClass:[NSString class]] && [k length]) { gid = k; break; } }
+    if (!gid) return nil;
+    NSString *bareID = [gid hasPrefix:@"giphy|"] ? [gid substringFromIndex:6] : gid;
+
+    id resolved = ApolloSVCall1(comment, @selector(mp4OrGIFURLForInlineGiphyWithID:), gid);
+    NSURL *url = [resolved isKindOfClass:[NSURL class]] ? (NSURL *)resolved
+               : ([resolved isKindOfClass:[NSString class]] ? [NSURL URLWithString:(NSString *)resolved] : nil);
+    NSURL *mp4 = ApolloSVToExportableMP4(url);
+    if (mp4) return mp4;
+    return [NSURL URLWithString:[NSString stringWithFormat:@"https://media.giphy.com/media/%@/giphy.mp4", bareID]];
+}
+
+// Extracts the v.redd.it asset id (first path component) from a v.redd.it URL.
+static NSString *ApolloSVRedditAssetID(NSURL *url) {
+    if (![url isKindOfClass:[NSURL class]]) return nil;
+    if (!ApolloSVHostContains(url, @"v.redd.it")) return nil;
+    for (NSString *comp in url.pathComponents) {
+        if (comp.length > 0 && ![comp isEqualToString:@"/"]) return comp;
+    }
+    return nil;
+}
+
+// Finds the lowest-bitrate <BaseURL>…</BaseURL> MP4 for the given DASH content
+// type ("video" or "audio"). Reddit orders Representations ascending by bitrate,
+// so the first match after the matching AdaptationSet is the smallest. Mirrors
+// ApolloInlineImages' poster parser, generalised to either track.
+static NSURL *ApolloSVLowestDashURL(NSData *mpdData, NSURL *mpdURL, NSString *contentType) {
+    if (mpdData.length == 0 || !mpdURL) return nil;
+    NSString *xml = [[NSString alloc] initWithData:mpdData encoding:NSUTF8StringEncoding];
+    if (xml.length == 0) return nil;
+
+    NSRange searchRange = NSMakeRange(0, xml.length);
+    NSString *marker = [NSString stringWithFormat:@"contentType=\"%@\"", contentType];
+    NSRange set = [xml rangeOfString:marker];
+    if (set.location != NSNotFound) {
+        // Bound the search to this AdaptationSet so we don't pick the other track's
+        // BaseURL: stop at the next "<AdaptationSet" after the marker.
+        NSUInteger start = set.location;
+        NSRange rest = NSMakeRange(start, xml.length - start);
+        NSRange next = [xml rangeOfString:@"<AdaptationSet"
+                                  options:0
+                                    range:NSMakeRange(start + marker.length, xml.length - start - marker.length)];
+        NSUInteger end = (next.location != NSNotFound) ? next.location : xml.length;
+        searchRange = NSMakeRange(start, end - start);
+        (void)rest;
+    } else if (![contentType isEqualToString:@"video"]) {
+        // No audio AdaptationSet -> no audio track.
+        return nil;
+    }
+
+    NSRegularExpression *re = [NSRegularExpression
+        regularExpressionWithPattern:@"<BaseURL>([^<]+\\.mp4)</BaseURL>" options:0 error:nil];
+    NSTextCheckingResult *m = [re firstMatchInString:xml options:0 range:searchRange];
+    if (!m || m.numberOfRanges < 2) return nil;
+    NSString *relative = [xml substringWithRange:[m rangeAtIndex:1]];
+    return [NSURL URLWithString:relative relativeToURL:mpdURL].absoluteURL;
+}
+
+// Resolves the progressive video URL (+ optional audio URL) for the post. Async
+// because the v.redd.it path fetches the DASH manifest. Calls back on the main
+// queue; videoURL is nil if nothing exportable could be resolved.
+static void ApolloSVResolveSources(id link, void (^completion)(NSURL *videoURL, NSURL *audioURL, CGSize naturalSize)) {
+    void (^done)(NSURL *, NSURL *, CGSize) = ^(NSURL *v, NSURL *a, CGSize s) {
+        dispatch_async(dispatch_get_main_queue(), ^{ completion(v, a, s); });
+    };
+
+    id video = ApolloSVBestVideo(link);
+    if (!video) { done(nil, nil, CGSizeZero); return; }
+
+    NSURL *url   = (NSURL *)ApolloSVCall(video, @selector(URL));
+    NSURL *fb    = (NSURL *)ApolloSVCall(video, @selector(fallbackURL));
+    NSURL *small = (NSURL *)ApolloSVCall(video, @selector(smallerURL));
+
+    double w = ApolloSVCallDouble(video, @selector(width));
+    double h = ApolloSVCallDouble(video, @selector(height));
+    CGSize natural = (w > 0 && h > 0) ? CGSizeMake(w, h) : CGSizeZero;
+
+    NSString *assetID = ApolloSVRedditAssetID(url) ?: ApolloSVRedditAssetID(fb);
+    if (assetID.length > 0) {
+        NSURL *mpd = [NSURL URLWithString:[NSString stringWithFormat:@"https://v.redd.it/%@/DASHPlaylist.mpd", assetID]];
+        NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:mpd
+                                                          cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                      timeoutInterval:10.0];
+        ApolloLog(@"[ShareVideo] resolving v.redd.it asset=%@", assetID);
+        NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:req
+            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            NSInteger status = [response isKindOfClass:[NSHTTPURLResponse class]]
+                ? ((NSHTTPURLResponse *)response).statusCode : 0;
+            NSURL *videoURL = nil, *audioURL = nil;
+            if (!error && status >= 200 && status < 300 && data.length) {
+                videoURL = ApolloSVLowestDashURL(data, mpd, @"video");
+                audioURL = ApolloSVLowestDashURL(data, mpd, @"audio");
+            }
+            if (!videoURL) {
+                // Manifest unavailable/unparseable: fall back to the API's
+                // progressive fallback MP4 (video-only, no audio).
+                videoURL = ApolloSVIsMP4(fb) ? fb : (ApolloSVIsMP4(url) ? url : nil);
+                audioURL = nil;
+            }
+            ApolloLog(@"[ShareVideo] v.redd.it resolved video=%@ audio=%@",
+                      videoURL ? @"yes" : @"no", audioURL ? @"yes" : @"no");
+            done(videoURL, audioURL, natural);
+        }];
+        [task resume];
+        return;
+    }
+
+    // Direct progressive MP4 (e.g. imgur). No separate audio track to fetch; if
+    // the file itself carries audio the composition picks it up from this asset.
+    NSURL *direct = ApolloSVIsMP4(url) ? url : (ApolloSVIsMP4(fb) ? fb : (ApolloSVIsMP4(small) ? small : nil));
+    ApolloLog(@"[ShareVideo] direct mp4 resolved=%@", direct ? @"yes" : @"no");
+    done(direct, nil, natural);
+}
+
+#pragma mark - Card image + media rect
+
+// ASDisplayNode geometry accessors via objc_msgSend (ASDisplayNode isn't headered
+// here). bounds is a CGRect property; convertRect:toNode: maps into card space.
+static CGRect ApolloSVNodeBounds(id node) {
+    if (!node || ![node respondsToSelector:@selector(bounds)]) return CGRectZero;
+    @try { return ((CGRect (*)(id, SEL))objc_msgSend)(node, @selector(bounds)); }
+    @catch (__unused NSException *e) { return CGRectZero; }
+}
+
+static CGRect ApolloSVConvertRectToNode(id from, CGRect rect, id toNode) {
+    if (!from || !toNode || ![from respondsToSelector:@selector(convertRect:toNode:)]) return CGRectZero;
+    @try { return ((CGRect (*)(id, SEL, CGRect, id))objc_msgSend)(from, @selector(convertRect:toNode:), rect, toNode); }
+    @catch (__unused NSException *e) { return CGRectZero; }
+}
+
+// The card image Apollo already rendered for the preview. Points; .scale is the
+// screen scale (pixels = size * scale).
+static UIImage *ApolloSVCardImage(id vc) {
+    UIImageView *iv = (UIImageView *)ApolloSVIvarObject(vc, "previewSnapshotImageView");
+    if ([iv isKindOfClass:[UIImageView class]] && [iv.image isKindOfClass:[UIImage class]]) return iv.image;
+    return nil;
+}
+
+// Recursively collects image/video display nodes under `node` (matched by class
+// name, since the concrete Texture classes aren't headered here).
+static void ApolloSVCollectMediaNodes(id node, int depth, NSMutableArray *out) {
+    if (!node || depth > 8) return;
+    NSArray *subs = nil;
+    if ([node respondsToSelector:@selector(subnodes)]) {
+        @try { subs = ((id (*)(id, SEL))objc_msgSend)(node, @selector(subnodes)); }
+        @catch (__unused NSException *e) {}
+    }
+    if (![subs isKindOfClass:[NSArray class]]) return;
+    for (id sub in subs) {
+        const char *cn = class_getName(object_getClass(sub));
+        NSString *cls = cn ? @(cn) : @"";
+        if ([cls containsString:@"ImageNode"] || [cls containsString:@"VideoNode"]) [out addObject:sub];
+        ApolloSVCollectMediaNodes(sub, depth + 1, out);
+    }
+}
+
+// The largest-area image/video node under `root` — for a comment cell this is the
+// inline GIF, not the small author avatar.
+static id ApolloSVLargestMediaNode(id root) {
+    NSMutableArray *nodes = [NSMutableArray array];
+    ApolloSVCollectMediaNodes(root, 0, nodes);
+    id best = nil; CGFloat bestArea = 0;
+    for (id n in nodes) {
+        CGRect b = ApolloSVNodeBounds(n);
+        CGFloat area = b.size.width * b.size.height;
+        if (area > bestArea) { bestArea = area; best = n; }
+    }
+    return bestArea > 400 ? best : nil; // ignore avatars / tiny nodes
+}
+
+// The media region as a fraction (0..1) of the card. For a post it's the preview's
+// imageNode; for a comment it's the largest media node inside baseCommentNode.
+static BOOL ApolloSVMediaRectNormalized(id vc, CGRect *outNorm) {
+    id previewNode = ApolloSVIvarObject(vc, "previewNode");
+    if (!previewNode) return NO;
+
+    id mediaNode = nil;
+    if (ApolloSVIvarObject(vc, "comment") != nil) {
+        id baseCommentNode = ApolloSVIvarObject(previewNode, "baseCommentNode");
+        mediaNode = ApolloSVLargestMediaNode(baseCommentNode ?: previewNode);
+    } else {
+        mediaNode = ApolloSVIvarObject(previewNode, "imageNode");
+    }
+    if (!mediaNode) return NO;
+
+    CGRect cardBounds = ApolloSVNodeBounds(previewNode);
+    CGRect mediaBounds = ApolloSVNodeBounds(mediaNode);
+    if (cardBounds.size.width <= 1 || cardBounds.size.height <= 1) return NO;
+    if (mediaBounds.size.width <= 1 || mediaBounds.size.height <= 1) return NO;
+
+    CGRect mediaInCard = ApolloSVConvertRectToNode(mediaNode, mediaBounds, previewNode);
+    if (mediaInCard.size.width <= 1 || mediaInCard.size.height <= 1) return NO;
+
+    CGRect norm = CGRectMake(mediaInCard.origin.x / cardBounds.size.width,
+                             mediaInCard.origin.y / cardBounds.size.height,
+                             mediaInCard.size.width / cardBounds.size.width,
+                             mediaInCard.size.height / cardBounds.size.height);
+    // Sanity-clamp to the card.
+    if (norm.origin.x < -0.01 || norm.origin.y < -0.01 ||
+        CGRectGetMaxX(norm) > 1.01 || CGRectGetMaxY(norm) > 1.01) return NO;
+    *outNorm = norm;
+    return YES;
+}
+
+#pragma mark - Custom video compositor (Core Graphics — works in sim AND on device)
+
+// AVVideoCompositionCoreAnimationTool hangs/SIGTRAPs mid-export in the iOS
+// Simulator (it depends on a Core Animation render-server path the sim doesn't
+// fully support). So we composite every frame ourselves with Core Graphics: draw
+// the static card, then the live video frame on top, clipped to the media rect
+// (aspect-fill, so it covers the poster exactly). Plain CG works everywhere and
+// removes the CALayer coordinate-flip guesswork. AVAssetExportSession still muxes
+// the audio track for us — only the video is custom-composited.
+//
+// One export runs at a time (guarded by the exporting flag), so the per-export
+// draw parameters are handed to the compositor through file statics.
+static CGImageRef sSVCardCG = NULL;          // +1 retained full card image
+static CGSize sSVRenderSize;                 // output pixels
+static CGRect sSVMediaRect;                  // media rect, pixels, UIKit top-left
+static CGAffineTransform sSVVideoPreferred;  // source video preferredTransform
+static int32_t sSVVideoTrackID;
+
+static void ApolloSVSetCompositorParams(CGImageRef card, CGSize renderSize, CGRect mediaRect,
+                                        CGAffineTransform pref, int32_t trackID) {
+    if (sSVCardCG) { CGImageRelease(sSVCardCG); sSVCardCG = NULL; }
+    sSVCardCG = card ? CGImageRetain(card) : NULL;
+    sSVRenderSize = renderSize;
+    sSVMediaRect = mediaRect;
+    sSVVideoPreferred = pref;
+    sSVVideoTrackID = trackID;
+}
+
+// CVPixelBuffer (BGRA) -> UIImage, mapping the source preferredTransform to a
+// UIImageOrientation so portrait clips recorded as rotated landscape draw upright.
+static UIImage *ApolloSVImageFromBuffer(CVPixelBufferRef buf, CGAffineTransform pref) {
+    if (!buf) return nil;
+    CVPixelBufferLockBaseAddress(buf, kCVPixelBufferLock_ReadOnly);
+    size_t w = CVPixelBufferGetWidth(buf), h = CVPixelBufferGetHeight(buf);
+    CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
+    CGContextRef bctx = CGBitmapContextCreate(CVPixelBufferGetBaseAddress(buf), w, h, 8,
+        CVPixelBufferGetBytesPerRow(buf), cs,
+        kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little);
+    CGImageRef cg = bctx ? CGBitmapContextCreateImage(bctx) : NULL;
+    if (bctx) CGContextRelease(bctx);
+    CGColorSpaceRelease(cs);
+    CVPixelBufferUnlockBaseAddress(buf, kCVPixelBufferLock_ReadOnly);
+    if (!cg) return nil;
+    UIImageOrientation orient = UIImageOrientationUp;
+    CGFloat a = pref.a, b = pref.b, c = pref.c, d = pref.d;
+    if (a == 0 && b == 1 && c == -1 && d == 0)       orient = UIImageOrientationRight; // 90° CW
+    else if (a == 0 && b == -1 && c == 1 && d == 0)  orient = UIImageOrientationLeft;  // 90° CCW
+    else if (a == -1 && b == 0 && c == 0 && d == -1) orient = UIImageOrientationDown;  // 180°
+    UIImage *img = [UIImage imageWithCGImage:cg scale:1.0 orientation:orient];
+    CGImageRelease(cg);
+    return img;
+}
+
+@interface ApolloSVCompositor : NSObject <AVVideoCompositing>
+@end
+
+@implementation ApolloSVCompositor
+
+- (NSDictionary *)sourcePixelBufferAttributes {
+    return @{ (id)kCVPixelBufferPixelFormatTypeKey: @[@(kCVPixelFormatType_32BGRA)] };
+}
+- (NSDictionary *)requiredPixelBufferAttributesForRenderContext {
+    return @{ (id)kCVPixelBufferPixelFormatTypeKey: @[@(kCVPixelFormatType_32BGRA)] };
+}
+- (void)renderContextChanged:(AVVideoCompositionRenderContext *)newRenderContext {}
+
+- (void)startVideoCompositionRequest:(AVAsynchronousVideoCompositionRequest *)request {
+    @autoreleasepool {
+        CVPixelBufferRef dst = [request.renderContext newPixelBuffer];
+        if (!dst) {
+            [request finishWithError:[NSError errorWithDomain:@"ApolloShareVideo" code:10 userInfo:nil]];
+            return;
+        }
+        CVPixelBufferRef src = [request sourceFrameByTrackID:sSVVideoTrackID];
+
+        CVPixelBufferLockBaseAddress(dst, 0);
+        size_t w = CVPixelBufferGetWidth(dst), h = CVPixelBufferGetHeight(dst);
+        CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
+        CGContextRef ctx = CGBitmapContextCreate(CVPixelBufferGetBaseAddress(dst), w, h, 8,
+            CVPixelBufferGetBytesPerRow(dst), cs,
+            kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little);
+
+        if (ctx) {
+            // Draw in UIKit (top-left) coordinates.
+            CGContextTranslateCTM(ctx, 0, h);
+            CGContextScaleCTM(ctx, 1, -1);
+            UIGraphicsPushContext(ctx);
+
+            [[UIColor blackColor] setFill];
+            UIRectFill(CGRectMake(0, 0, w, h));
+
+            // The full card (header, title, poster, watermark) — full frame.
+            if (sSVCardCG) {
+                [[UIImage imageWithCGImage:sSVCardCG] drawInRect:CGRectMake(0, 0, w, h)];
+            }
+            // The live video frame, aspect-filled into the media rect (covers poster).
+            UIImage *frame = ApolloSVImageFromBuffer(src, sSVVideoPreferred);
+            if (frame && frame.size.width > 0 && frame.size.height > 0) {
+                CGContextSaveGState(ctx);
+                CGContextClipToRect(ctx, sSVMediaRect);
+                CGFloat sc = MAX(sSVMediaRect.size.width / frame.size.width,
+                                 sSVMediaRect.size.height / frame.size.height);
+                CGSize ds = CGSizeMake(frame.size.width * sc, frame.size.height * sc);
+                CGRect dr = CGRectMake(CGRectGetMidX(sSVMediaRect) - ds.width / 2.0,
+                                       CGRectGetMidY(sSVMediaRect) - ds.height / 2.0,
+                                       ds.width, ds.height);
+                [frame drawInRect:dr];
+                CGContextRestoreGState(ctx);
+            }
+
+            UIGraphicsPopContext();
+            CGContextRelease(ctx);
+        }
+        CGColorSpaceRelease(cs);
+        CVPixelBufferUnlockBaseAddress(dst, 0);
+
+        [request finishWithComposedVideoFrame:dst];
+        CVPixelBufferRelease(dst);
+    }
+}
+
+@end
+
+#pragma mark - Composition / export
+
+// Even-rounds a dimension (H.264 requires even width/height).
+static CGFloat ApolloSVEven(CGFloat v) { long n = lround(v); if (n & 1) n += 1; return (CGFloat)n; }
+
+// Builds and exports the composited MP4. Calls progress(0..1) on the main queue
+// during export and completion(outURL,error) on the main queue when finished.
+// Keeps strong refs to its CALayers/session on `vc` so nothing is reclaimed
+// mid-export.
+static void ApolloSVExport(id vc, UIImage *card, CGRect mediaNorm,
+                           NSURL *videoURL, NSURL *audioURL,
+                           void (^progress)(float p),
+                           void (^completion)(NSURL *outURL, NSError *error)) {
+    void (^fail)(NSString *) = ^(NSString *why) {
+        ApolloLog(@"[ShareVideo] export FAIL: %@", why);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion(nil, [NSError errorWithDomain:@"ApolloShareVideo" code:1
+                                            userInfo:@{NSLocalizedDescriptionKey: why ?: @"unknown"}]);
+        });
+    };
+
+    if (![card isKindOfClass:[UIImage class]] || !videoURL) { fail(@"missing card or video url"); return; }
+
+    // Output canvas = the card rasterised to pixels, but capped to ~720px wide so
+    // shared files stay reasonable (HighestQuality at the device's full 3× scale
+    // produced ~68 MB for ~55s). Text stays crisp at this width.
+    CGFloat baseScale = card.scale > 0 ? card.scale : 2.0;
+    CGFloat scale = MIN(baseScale, 720.0 / MAX(card.size.width, 1.0));
+    if (scale < 1.0) scale = 1.0;
+    CGSize renderSize = CGSizeMake(ApolloSVEven(card.size.width * scale),
+                                   ApolloSVEven(card.size.height * scale));
+    // Media rect in pixels (UIKit top-left) where the video is composited.
+    CGRect mediaPx = CGRectMake(mediaNorm.origin.x * renderSize.width,
+                                mediaNorm.origin.y * renderSize.height,
+                                mediaNorm.size.width * renderSize.width,
+                                mediaNorm.size.height * renderSize.height);
+
+    AVURLAsset *videoAsset = [AVURLAsset URLAssetWithURL:videoURL
+        options:@{AVURLAssetPreferPreciseDurationAndTimingKey: @YES}];
+    AVURLAsset *audioAsset = audioURL ? [AVURLAsset URLAssetWithURL:audioURL
+        options:@{AVURLAssetPreferPreciseDurationAndTimingKey: @YES}] : nil;
+
+    NSMutableArray *keysToLoad = [NSMutableArray arrayWithObject:videoAsset];
+    if (audioAsset) [keysToLoad addObject:audioAsset];
+
+    dispatch_group_t group = dispatch_group_create();
+    for (AVURLAsset *a in keysToLoad) {
+        dispatch_group_enter(group);
+        [a loadValuesAsynchronouslyForKeys:@[@"tracks", @"duration"] completionHandler:^{
+            dispatch_group_leave(group);
+        }];
+    }
+
+    dispatch_group_notify(group, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        NSError *err = nil;
+        if ([videoAsset statusOfValueForKey:@"tracks" error:&err] != AVKeyValueStatusLoaded) {
+            fail([NSString stringWithFormat:@"video tracks not loaded: %@", err.localizedDescription]); return;
+        }
+        AVAssetTrack *srcVideo = [[videoAsset tracksWithMediaType:AVMediaTypeVideo] firstObject];
+        if (!srcVideo) { fail(@"no video track"); return; }
+
+        // Audio: prefer the separate audio asset (v.redd.it), else the video file's
+        // own audio (direct mp4).
+        AVAssetTrack *srcAudio = nil;
+        AVURLAsset *audioHost = nil;
+        if (audioAsset && [audioAsset statusOfValueForKey:@"tracks" error:nil] == AVKeyValueStatusLoaded) {
+            srcAudio = [[audioAsset tracksWithMediaType:AVMediaTypeAudio] firstObject];
+            audioHost = audioAsset;
+        }
+        if (!srcAudio) {
+            srcAudio = [[videoAsset tracksWithMediaType:AVMediaTypeAudio] firstObject];
+            audioHost = videoAsset;
+        }
+
+        // Clip duration: shortest available track, capped.
+        CMTime vDur = videoAsset.duration;
+        CMTime dur = vDur;
+        if (srcAudio && CMTIME_IS_NUMERIC(audioHost.duration)) dur = CMTimeMinimum(dur, audioHost.duration);
+        CMTime cap = CMTimeMakeWithSeconds(kApolloShareVideoMaxSeconds, 600);
+        if (CMTIME_COMPARE_INLINE(dur, >, cap)) dur = cap;
+        if (!CMTIME_IS_NUMERIC(dur) || CMTimeGetSeconds(dur) <= 0) { fail(@"bad duration"); return; }
+        CMTimeRange range = CMTimeRangeMake(kCMTimeZero, dur);
+
+        AVMutableComposition *comp = [AVMutableComposition composition];
+        AVMutableCompositionTrack *vTrack = [comp addMutableTrackWithMediaType:AVMediaTypeVideo
+                                                             preferredTrackID:kCMPersistentTrackID_Invalid];
+        NSError *insErr = nil;
+        if (![vTrack insertTimeRange:range ofTrack:srcVideo atTime:kCMTimeZero error:&insErr]) {
+            fail([NSString stringWithFormat:@"video insert: %@", insErr.localizedDescription]); return;
+        }
+        if (srcAudio) {
+            AVMutableCompositionTrack *aTrack = [comp addMutableTrackWithMediaType:AVMediaTypeAudio
+                                                                 preferredTrackID:kCMPersistentTrackID_Invalid];
+            CMTime aDur = CMTimeMinimum(range.duration, audioHost.duration);
+            [aTrack insertTimeRange:CMTimeRangeMake(kCMTimeZero, aDur) ofTrack:srcAudio atTime:kCMTimeZero error:nil];
+        }
+
+        // Video composition driven by our custom Core Graphics compositor (the
+        // per-frame draw uses card + media rect + preferredTransform passed below).
+        AVMutableVideoCompositionLayerInstruction *li =
+            [AVMutableVideoCompositionLayerInstruction videoCompositionLayerInstructionWithAssetTrack:vTrack];
+        AVMutableVideoCompositionInstruction *inst = [AVMutableVideoCompositionInstruction videoCompositionInstruction];
+        inst.timeRange = range;
+        inst.layerInstructions = @[li];
+
+        AVMutableVideoComposition *vc2 = [AVMutableVideoComposition videoComposition];
+        vc2.renderSize = renderSize;
+        float fps = srcVideo.nominalFrameRate;
+        if (fps < 1 || fps > 60 || !isfinite(fps)) fps = 30.0;
+        vc2.frameDuration = CMTimeMake(1, (int32_t)lround(fps));
+        vc2.instructions = @[inst];
+        vc2.customVideoCompositorClass = [ApolloSVCompositor class];
+
+        // Hand the per-frame draw parameters to the compositor (one export at a time).
+        ApolloSVSetCompositorParams(card.CGImage, renderSize, mediaPx, srcVideo.preferredTransform, vTrack.trackID);
+
+        NSString *outPath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"ApolloPost.mp4"];
+        [[NSFileManager defaultManager] removeItemAtPath:outPath error:nil];
+        NSURL *outURL = [NSURL fileURLWithPath:outPath];
+
+        AVAssetExportSession *ex = [[AVAssetExportSession alloc] initWithAsset:comp
+                                                                   presetName:AVAssetExportPresetHighestQuality];
+        if (!ex) { fail(@"could not create export session"); return; }
+        ex.videoComposition = vc2;
+        ex.outputURL = outURL;
+        ex.outputFileType = AVFileTypeMPEG4;
+        ex.shouldOptimizeForNetworkUse = YES;
+
+        // Keep the session alive on the VC for the export's lifetime.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            objc_setAssociatedObject(vc, &kApolloShareVideoSessionKey, ex, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        });
+
+        // Progress polling.
+        __block BOOL finished = NO;
+        dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0,
+            dispatch_get_global_queue(QOS_CLASS_UTILITY, 0));
+        dispatch_source_set_timer(timer, dispatch_time(DISPATCH_TIME_NOW, 0), (uint64_t)(0.1 * NSEC_PER_SEC), (uint64_t)(0.05 * NSEC_PER_SEC));
+        dispatch_source_set_event_handler(timer, ^{
+            if (finished) return;
+            float p = ex.progress;
+            dispatch_async(dispatch_get_main_queue(), ^{ if (progress) progress(p); });
+        });
+        dispatch_resume(timer);
+
+        ApolloLog(@"[ShareVideo] export start render=%.0fx%.0f media=%@ dur=%.1fs audio=%d",
+                  renderSize.width, renderSize.height, NSStringFromCGRect(mediaPx),
+                  CMTimeGetSeconds(range.duration), srcAudio != nil);
+
+        [ex exportAsynchronouslyWithCompletionHandler:^{
+            finished = YES;
+            dispatch_source_cancel(timer);
+            AVAssetExportSessionStatus st = ex.status;
+            ApolloSVSetCompositorParams(NULL, CGSizeZero, CGRectZero, CGAffineTransformIdentity, 0);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                objc_setAssociatedObject(vc, &kApolloShareVideoSessionKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                if (st == AVAssetExportSessionStatusCompleted) {
+                    ApolloLog(@"[ShareVideo] export OK -> %@", outPath);
+                    completion(outURL, nil);
+                } else {
+                    NSError *e = ex.error;
+                    ApolloLog(@"[ShareVideo] export status=%ld err=%@", (long)st, e.localizedDescription);
+                    completion(nil, e ?: [NSError errorWithDomain:@"ApolloShareVideo" code:(NSInteger)st userInfo:nil]);
+                }
+            });
+        }];
+    });
+}
+
+#pragma mark - Progress HUD
+
+static void ApolloSVHideHUD(id vc) {
+    UIView *hud = (UIView *)objc_getAssociatedObject(vc, &kApolloShareVideoHUDKey);
+    if ([hud isKindOfClass:[UIView class]]) {
+        [UIView animateWithDuration:0.2 animations:^{ hud.alpha = 0; }
+                         completion:^(__unused BOOL done) { [hud removeFromSuperview]; }];
+    }
+    objc_setAssociatedObject(vc, &kApolloShareVideoHUDKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static void ApolloSVShowHUD(id vc) {
+    UIViewController *v = (UIViewController *)vc;
+    // The share sheet's own root view is a UIVisualEffectView on iOS 26 — you
+    // can't addSubview: to one directly (it asserts). Host the overlay on the
+    // window instead (covers the whole sheet, which is what we want for a blocking
+    // "preparing…" spinner); fall back to the effect view's contentView.
+    UIView *host = v.viewIfLoaded.window;
+    if (!host) {
+        UIView *root = v.viewIfLoaded;
+        host = [root isKindOfClass:[UIVisualEffectView class]]
+            ? [(UIVisualEffectView *)root contentView] : root;
+    }
+    if (![host isKindOfClass:[UIView class]]) return;
+
+    UIView *dim = [[UIView alloc] initWithFrame:host.bounds];
+    dim.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    dim.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.35];
+    dim.alpha = 0.0;
+
+    UIView *card = [[UIView alloc] init];
+    card.translatesAutoresizingMaskIntoConstraints = NO;
+    card.backgroundColor = [UIColor colorWithWhite:0.12 alpha:0.96];
+    card.layer.cornerRadius = 14.0;
+    [dim addSubview:card];
+
+    UIActivityIndicatorView *spinner = [[UIActivityIndicatorView alloc]
+        initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+    spinner.color = [UIColor whiteColor];
+    spinner.translatesAutoresizingMaskIntoConstraints = NO;
+    [spinner startAnimating];
+    [card addSubview:spinner];
+
+    UILabel *label = [[UILabel alloc] init];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.text = @"Preparing video…";
+    label.textColor = [UIColor whiteColor];
+    label.font = [UIFont systemFontOfSize:15 weight:UIFontWeightMedium];
+    [card addSubview:label];
+
+    [host addSubview:dim];
+    [NSLayoutConstraint activateConstraints:@[
+        [card.centerXAnchor constraintEqualToAnchor:dim.centerXAnchor],
+        [card.centerYAnchor constraintEqualToAnchor:dim.centerYAnchor],
+        [spinner.leadingAnchor constraintEqualToAnchor:card.leadingAnchor constant:20],
+        [spinner.centerYAnchor constraintEqualToAnchor:card.centerYAnchor],
+        [label.leadingAnchor constraintEqualToAnchor:spinner.trailingAnchor constant:12],
+        [label.trailingAnchor constraintEqualToAnchor:card.trailingAnchor constant:-20],
+        [label.centerYAnchor constraintEqualToAnchor:card.centerYAnchor],
+        [card.heightAnchor constraintEqualToConstant:54],
+    ]];
+
+    objc_setAssociatedObject(vc, &kApolloShareVideoHUDKey, dim, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(dim, @selector(text), label, OBJC_ASSOCIATION_ASSIGN); // quick label handle
+    [UIView animateWithDuration:0.2 animations:^{ dim.alpha = 1.0; }];
+}
+
+static void ApolloSVUpdateHUD(id vc, float p) {
+    UIView *hud = (UIView *)objc_getAssociatedObject(vc, &kApolloShareVideoHUDKey);
+    UILabel *label = [hud isKindOfClass:[UIView class]] ? objc_getAssociatedObject(hud, @selector(text)) : nil;
+    if ([label isKindOfClass:[UILabel class]]) {
+        int pct = (int)roundf(MAX(0, MIN(1, p)) * 100);
+        label.text = [NSString stringWithFormat:@"Preparing video… %d%%", pct];
+    }
+}
+
+#pragma mark - Share orchestration
+
+// RDKLink.permalink is relative ("/r/.../comments/..."); resolve to an absolute
+// reddit URL. Mirrors the Include Link feature so a video share can carry the link.
+static NSURL *ApolloSVAbsoluteURL(NSURL *url) {
+    if (![url isKindOfClass:[NSURL class]]) return nil;
+    if (url.scheme.length > 0 && url.host.length > 0) return url;
+    NSString *path = url.absoluteString ?: @"";
+    if (path.length == 0) return nil;
+    if (![path hasPrefix:@"/"]) path = [@"/" stringByAppendingString:path];
+    return [NSURL URLWithString:[@"https://www.reddit.com" stringByAppendingString:path]] ?: url;
+}
+
+static NSURL *ApolloSVPostURL(id vc) {
+    id link = ApolloSVIvarObject(vc, "link");
+    NSURL *u = (NSURL *)ApolloSVCall(link, @selector(permalink));
+    if ([u isKindOfClass:[NSURL class]]) return ApolloSVAbsoluteURL(u);
+    u = (NSURL *)ApolloSVCall(link, @selector(URL));
+    if ([u isKindOfClass:[NSURL class]]) return ApolloSVAbsoluteURL(u);
+    return nil;
+}
+
+// Supplies the post link to messaging/mail activities (not Save Video / Assign to
+// Contact / Print), so an exported video can be shared WITH a tappable link —
+// matching how the Include Link option behaves for the image.
+@interface ApolloSVLinkItemSource : NSObject <UIActivityItemSource>
+@property (nonatomic, strong) NSURL *url;
+@end
+@implementation ApolloSVLinkItemSource
+- (id)activityViewControllerPlaceholderItem:(UIActivityViewController *)avc { return self.url ?: (id)[NSNull null]; }
+- (id)activityViewController:(UIActivityViewController *)avc itemForActivityType:(UIActivityType)t {
+    if (!self.url) return nil;
+    if ([t isEqualToString:UIActivityTypeSaveToCameraRoll] ||
+        [t isEqualToString:UIActivityTypeAssignToContact] ||
+        [t isEqualToString:UIActivityTypePrint]) return nil;
+    return self.url;
+}
+@end
+
+static void ApolloSVPresentShare(id vc, NSURL *fileURL) {
+    UIViewController *v = (UIViewController *)vc;
+    if (!v.viewIfLoaded.window) {
+        // VC was dismissed mid-export; clean up the temp file and bail quietly.
+        [[NSFileManager defaultManager] removeItemAtURL:fileURL error:nil];
+        return;
+    }
+    // If the (separate) Include Link option is on, attach the post link too — a
+    // shared video carries it just like a shared image does.
+    NSMutableArray *items = [NSMutableArray arrayWithObject:fileURL];
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"ApolloShareAsImageIncludeLink"]) {
+        NSURL *postURL = ApolloSVPostURL(vc);
+        if (postURL) {
+            ApolloSVLinkItemSource *src = [[ApolloSVLinkItemSource alloc] init];
+            src.url = postURL;
+            [items addObject:src];
+        }
+    }
+    UIActivityViewController *avc = [[UIActivityViewController alloc]
+        initWithActivityItems:items applicationActivities:nil];
+    avc.completionWithItemsHandler = ^(__unused UIActivityType activityType, __unused BOOL completed,
+                                        __unused NSArray *items, __unused NSError *error) {
+        [[NSFileManager defaultManager] removeItemAtURL:fileURL error:nil];
+    };
+    // iPad popover anchor.
+    if (avc.popoverPresentationController) {
+        avc.popoverPresentationController.sourceView = v.view;
+        avc.popoverPresentationController.sourceRect = CGRectMake(CGRectGetMidX(v.view.bounds),
+                                                                  CGRectGetMaxY(v.view.bounds) - 40, 1, 1);
+    }
+    [v presentViewController:avc animated:YES completion:nil];
+}
+
+// Re-runs the share, forcing Apollo's native image path (one-shot flag consumed by
+// the shareButtonTapped hook). Used when video export can't be produced.
+static void ApolloSVFallbackToNative(id vc) {
+    if (![vc respondsToSelector:@selector(shareButtonTappedWithSender:)]) return;
+    objc_setAssociatedObject(vc, &kApolloShareVideoForceNativeKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ((void (*)(id, SEL, id))objc_msgSend)(vc, @selector(shareButtonTappedWithSender:), nil);
+}
+
+// Resolves the exportable source for either a post (v.redd.it / direct mp4) or a
+// comment (inline Giphy → progressive mp4). Calls back on the main queue.
+static void ApolloSVResolveForVC(id vc, void (^completion)(NSURL *videoURL, NSURL *audioURL)) {
+    id comment = ApolloSVIvarObject(vc, "comment");
+    if (comment) {
+        NSURL *mp4 = ApolloSVCommentGiphyMP4(comment);
+        ApolloLog(@"[ShareVideo] comment giphy mp4=%@", mp4.absoluteString ?: @"-");
+        dispatch_async(dispatch_get_main_queue(), ^{ completion(mp4, nil); });
+        return;
+    }
+    ApolloSVResolveSources(ApolloSVIvarObject(vc, "link"), ^(NSURL *v, NSURL *a, __unused CGSize n) {
+        completion(v, a);
+    });
+}
+
+// Entry point when the user taps Share with the toggle ON. Returns YES if it took
+// over the share (caller must NOT call %orig), NO to let the native image share
+// proceed.
+static BOOL ApolloSVBeginVideoShare(id vc) {
+    if ([objc_getAssociatedObject(vc, &kApolloShareVideoExportingKey) boolValue]) return YES; // already in flight
+
+    id comment = ApolloSVIvarObject(vc, "comment");
+    BOOL exportable = comment ? ApolloSVCommentExportable(comment)
+                              : ApolloSVPostIsExportableVideo(ApolloSVIvarObject(vc, "link"));
+    if (!exportable) return NO;
+
+    UIImage *card = ApolloSVCardImage(vc);
+    CGRect mediaNorm = CGRectZero;
+    if (!card || !ApolloSVMediaRectNormalized(vc, &mediaNorm)) {
+        ApolloLog(@"[ShareVideo] card/mediaRect unavailable — falling back to image share");
+        return NO;
+    }
+
+    objc_setAssociatedObject(vc, &kApolloShareVideoExportingKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloSVShowHUD(vc);
+
+    __weak id weakVC = vc;
+    ApolloSVResolveForVC(vc, ^(NSURL *videoURL, NSURL *audioURL) {
+        id strongVC = weakVC;
+        if (!strongVC) return;
+        if (!videoURL) {
+            ApolloLog(@"[ShareVideo] no exportable source — falling back to image share");
+            objc_setAssociatedObject(strongVC, &kApolloShareVideoExportingKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            ApolloSVHideHUD(strongVC);
+            // Best-effort: re-trigger the native (image) share so the tap isn't lost.
+            ApolloSVFallbackToNative(strongVC);
+            return;
+        }
+        ApolloSVExport(strongVC, card, mediaNorm, videoURL, audioURL,
+            ^(float p) { ApolloSVUpdateHUD(weakVC, p); },
+            ^(NSURL *outURL, NSError *error) {
+                id sVC = weakVC;
+                if (!sVC) { if (outURL) [[NSFileManager defaultManager] removeItemAtURL:outURL error:nil]; return; }
+                objc_setAssociatedObject(sVC, &kApolloShareVideoExportingKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                ApolloSVHideHUD(sVC);
+                if (outURL && !error) {
+                    ApolloSVPresentShare(sVC, outURL);
+                } else {
+                    // Soft failure: fall back to Apollo's image share.
+                    ApolloSVFallbackToNative(sVC);
+                }
+            });
+    });
+    return YES;
+}
+
+#pragma mark - Options row UI
+
+static void ApolloSVInstallRow(id vc) {
+    if (!vc) return;
+    if (objc_getAssociatedObject(vc, &kApolloShareVideoSwitchKey)) return; // already built
+
+    // Shown for video posts AND for comments carrying an exportable inline GIF.
+    id comment = ApolloSVIvarObject(vc, "comment");
+    BOOL isVideo = comment ? ApolloSVCommentExportable(comment)
+                           : ApolloSVPostIsExportableVideo(ApolloSVIvarObject(vc, "link"));
+    objc_setAssociatedObject(vc, &kApolloShareVideoIsVideoKey, @(isVideo), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (!isVideo) {
+        ApolloLog(@"[ShareVideo] viewDidLoad: no exportable %@ media — no row", comment ? @"comment" : @"post");
+        return;
+    }
+
+    UILabel *watermarkLabel = (UILabel *)ApolloSVIvarObject(vc, "watermarkRowTitleLabel");
+    UISwitch *watermarkSwitch = (UISwitch *)ApolloSVIvarObject(vc, "watermarkRowSwitch");
+    if (![watermarkLabel isKindOfClass:[UILabel class]] || ![watermarkSwitch isKindOfClass:[UISwitch class]]) {
+        ApolloLog(@"[ShareVideo] watermark row not found — skipping row");
+        return;
+    }
+    UIView *container = watermarkLabel.superview;
+    if (!container) return;
+
+    UILabel *label = [[UILabel alloc] init];
+    label.text = kApolloShareVideoTitle;
+    label.font = watermarkLabel.font;
+    label.textColor = watermarkLabel.textColor;
+    label.textAlignment = watermarkLabel.textAlignment;
+    label.numberOfLines = watermarkLabel.numberOfLines;
+    [container addSubview:label];
+
+    UISwitch *toggle = [[UISwitch alloc] init];
+    toggle.onTintColor = watermarkSwitch.onTintColor;
+    toggle.on = [[NSUserDefaults standardUserDefaults] boolForKey:kApolloShareVideoKey];
+    [toggle addTarget:vc action:@selector(apollo_shareVideoToggled:) forControlEvents:UIControlEventValueChanged];
+    [container addSubview:toggle];
+
+    UIView *separator = [[UIView alloc] init];
+    NSArray *separators = (NSArray *)ApolloSVIvarObject(vc, "separators");
+    UIView *templateSep = [separators isKindOfClass:[NSArray class]] ? [separators lastObject] : nil;
+    separator.backgroundColor = [templateSep isKindOfClass:[UIView class]]
+        ? templateSep.backgroundColor : [UIColor colorWithWhite:0.5 alpha:0.3];
+    [container addSubview:separator];
+
+    objc_setAssociatedObject(vc, &kApolloShareVideoLabelKey, label, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(vc, &kApolloShareVideoSwitchKey, toggle, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(vc, &kApolloShareVideoSeparatorKey, separator, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloLog(@"[ShareVideo] options row installed (on=%d)", (int)toggle.on);
+}
+
+// Width helper: prefer the native separator width, fall back to the label's.
+static CGFloat ApolloSVRowWidth(id vc, CGRect wl) {
+    NSArray *separators = (NSArray *)ApolloSVIvarObject(vc, "separators");
+    UIView *templateSep = [separators isKindOfClass:[NSArray class]] ? [separators lastObject] : nil;
+    if ([templateSep isKindOfClass:[UIView class]] && templateSep.frame.size.width > 1) return templateSep.frame.size.width;
+    return wl.size.width;
+}
+
+// Anchors our row at the Share button's CURRENT position and pushes the button
+// down by one row. Runs AFTER %orig, so whatever native/other modules placed the
+// button, we stack below it — no coupling to other added rows.
+static void ApolloSVLayoutRow(id vc) {
+    UILabel *label = (UILabel *)objc_getAssociatedObject(vc, &kApolloShareVideoLabelKey);
+    UISwitch *toggle = (UISwitch *)objc_getAssociatedObject(vc, &kApolloShareVideoSwitchKey);
+    UIView *separator = (UIView *)objc_getAssociatedObject(vc, &kApolloShareVideoSeparatorKey);
+    if (!label || !toggle) return;
+
+    UILabel *watermarkLabel = (UILabel *)ApolloSVIvarObject(vc, "watermarkRowTitleLabel");
+    UISwitch *watermarkSwitch = (UISwitch *)ApolloSVIvarObject(vc, "watermarkRowSwitch");
+    UIView *shareButton = (UIView *)ApolloSVIvarObject(vc, "shareButton");
+    if (![watermarkLabel isKindOfClass:[UILabel class]] || ![watermarkSwitch isKindOfClass:[UISwitch class]] ||
+        ![shareButton isKindOfClass:[UIView class]]) return;
+
+    CGRect wl = watermarkLabel.frame;
+    CGRect ws = watermarkSwitch.frame;
+
+    // Place our row one row-pitch below the row directly above it, so the spacing
+    // matches the native rows (rather than inheriting the larger row→button gap).
+    // Whatever placed the Share button put it at (rowAbove.maxY + buttonGap), so
+    // rowAbove.label.y = button.y - labelHeight - buttonGap, and our row sits one
+    // pitch below that: button.y + pitch - labelHeight - buttonGap.
+    double pitch = ApolloSVIvarDouble(vc, "rowHeight");
+    if (pitch <= 1.0 || !isfinite(pitch)) pitch = wl.size.height + 16.0;
+    CGRect bf = shareButton.frame;
+    CGFloat rowY = bf.origin.y + pitch - wl.size.height - kApolloShareVideoButtonGap;
+
+    CGFloat labelW = MAX(wl.size.width, ws.origin.x - 8.0 - wl.origin.x);
+    label.frame = CGRectMake(wl.origin.x, rowY, labelW, wl.size.height);
+    // Switch keeps its native x; vertically centred against the label.
+    toggle.frame = CGRectMake(ws.origin.x, rowY + (wl.size.height - ws.size.height) / 2.0,
+                              ws.size.width, ws.size.height);
+
+    if (separator) {
+        CGFloat hair = 1.0 / [UIScreen mainScreen].scale;
+        separator.frame = CGRectMake(wl.origin.x, CGRectGetMaxY(label.frame) - hair, ApolloSVRowWidth(vc, wl), hair);
+    }
+
+    // Push the Share button below our row.
+    bf.origin.y = CGRectGetMaxY(label.frame) + kApolloShareVideoButtonGap;
+    shareButton.frame = bf;
+}
+
+#pragma mark - Hooks
+
+%hook _TtC6Apollo26ShareAsImageViewController
+
+- (void)viewDidLoad {
+    %orig;
+    ApolloSVInstallRow(self);
+}
+
+- (void)viewDidLayoutSubviews {
+    %orig;
+    ApolloSVLayoutRow(self);
+}
+
+%new
+- (void)apollo_shareVideoToggled:(UISwitch *)sender {
+    BOOL on = [sender isKindOfClass:[UISwitch class]] ? sender.isOn : NO;
+    [[NSUserDefaults standardUserDefaults] setBool:on forKey:kApolloShareVideoKey];
+    ApolloLog(@"[ShareVideo] toggle -> %d", (int)on);
+}
+
+- (void)shareButtonTappedWithSender:(id)sender {
+    // One-shot fallback: a prior video-export attempt failed and asked for the
+    // native image share. Consume the flag and go straight to %orig.
+    if ([objc_getAssociatedObject(self, &kApolloShareVideoForceNativeKey) boolValue]) {
+        objc_setAssociatedObject(self, &kApolloShareVideoForceNativeKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        %orig;
+        return;
+    }
+    BOOL on = [[NSUserDefaults standardUserDefaults] boolForKey:kApolloShareVideoKey];
+    BOOL isVideo = [objc_getAssociatedObject(self, &kApolloShareVideoIsVideoKey) boolValue];
+    if (on && isVideo && ![objc_getAssociatedObject(self, &kApolloShareVideoExportingKey) boolValue]) {
+        if (ApolloSVBeginVideoShare(self)) {
+            ApolloLog(@"[ShareVideo] took over share (video export)");
+            return; // suppress native image share
+        }
+    }
+    %orig;
+}
+
+%end
+
+// Grow the bottom sheet by one row when our row is installed (video posts), so the
+// relocated Share button isn't clipped. Mirrors the loop-free approach used by
+// ApolloShareAsImageLink; gated on our row's presence so non-video posts (and
+// other modules' rows) are unaffected by us.
+%hook _TtC6Apollo31SourdoughPresentationController
+
+- (CGRect)frameOfPresentedViewInContainerView {
+    CGRect frame = %orig;
+    @try {
+        if (!isfinite(frame.origin.y) || !isfinite(frame.size.height) || frame.size.height <= 1.0) return frame;
+        id presented = [(UIPresentationController *)self presentedViewController];
+        Class shareVCClass = objc_getClass("_TtC6Apollo26ShareAsImageViewController");
+        if (shareVCClass && [presented isKindOfClass:shareVCClass] &&
+            objc_getAssociatedObject(presented, &kApolloShareVideoSwitchKey)) {
+            double pitch = ApolloSVIvarDouble(presented, "rowHeight");
+            if (pitch <= 1.0 || !isfinite(pitch)) pitch = 50.0;
+            // Our row is one pitch below the row above it (even spacing) and the
+            // button follows below it, so the sheet needs exactly one more row of
+            // height.
+            CGFloat grow = pitch;
+            CGFloat nativeBottom = frame.origin.y + frame.size.height;
+            CGFloat newTop = MAX(0.0, frame.origin.y - grow);
+            frame.origin.y = newTop;
+            frame.size.height = nativeBottom - newTop;
+        }
+    } @catch (__unused NSException *e) {}
+    return frame;
+}
+
+%end
+
+%ctor {
+    @autoreleasepool {
+        if (objc_getClass("_TtC6Apollo26ShareAsImageViewController")) {
+            %init();
+            ApolloLog(@"[ShareVideo] module loaded");
+        } else {
+            ApolloLog(@"[ShareVideo] ShareAsImageViewController not found — skipping");
+        }
+    }
+}

--- a/src/ApolloShareAsVideo.xm
+++ b/src/ApolloShareAsVideo.xm
@@ -47,6 +47,17 @@
 //
 // No hardcoded binary addresses: everything is ObjC-runtime ivar access (ivar
 // names from class-dump headers) plus public AVFoundation/UIKit, guarded.
+//
+// MODULE ORDERING (Makefile ApolloReborn_FILES): this module is listed AFTER
+// ApolloShareAsImageLink and BEFORE ApolloShareAsImagePreviewFix, i.e.
+// Gallery -> Link -> Video -> PreviewFix. %ctor/%init() runs in that order, so this
+// module's shareButtonTappedWithSender: hook installs last and is therefore the
+// OUTERMOST link in the chain — it runs first and, when the video toggle is on,
+// suppresses the native image share before Link's handler runs. Each module's row
+// also stacks below the previous one's in its post-%orig viewDidLayoutSubviews pass.
+// If you reorder these in the Makefile, re-verify the share-button chain and the row
+// layout. (The Include-Link double-append guard in ApolloShareAsImageLink no longer
+// depends on this order — see that file — but the layout stacking still does.)
 
 #import <UIKit/UIKit.h>
 #import <AVFoundation/AVFoundation.h>
@@ -419,23 +430,40 @@ static BOOL ApolloSVMediaRectNormalized(id vc, CGRect *outNorm) {
 // removes the CALayer coordinate-flip guesswork. AVAssetExportSession still muxes
 // the audio track for us — only the video is custom-composited.
 //
-// One export runs at a time (guarded by the exporting flag), so the per-export
-// draw parameters are handed to the compositor through file statics.
-static CGImageRef sSVCardCG = NULL;          // +1 retained full card image
-static CGSize sSVRenderSize;                 // output pixels
-static CGRect sSVMediaRect;                  // media rect, pixels, UIKit top-left
-static CGAffineTransform sSVVideoPreferred;  // source video preferredTransform
-static int32_t sSVVideoTrackID;
+// Per-export draw parameters travel WITH the composition, as a custom
+// AVVideoCompositionInstruction (the documented pattern — cf. Apple's AVCustomEdit),
+// rather than through file statics. The compositor reads them back per frame from
+// request.videoCompositionInstruction, so two exports running at once (e.g. two
+// Share-as-Image sheets in iPad multi-window) can never clobber each other's card,
+// media rect, or transform. Combined with the unique per-export temp filename in
+// ApolloSVExport, nothing about the export relies on only one running at a time.
+@interface ApolloSVInstruction : NSObject <AVVideoCompositionInstruction>
+// AVVideoCompositionInstruction protocol requirements (declared readwrite here):
+@property (nonatomic, assign) CMTimeRange timeRange;
+@property (nonatomic, assign) BOOL enablePostProcessing;
+@property (nonatomic, assign) BOOL containsTweening;
+@property (nonatomic, strong) NSArray<NSValue *> *requiredSourceTrackIDs;
+@property (nonatomic, assign) CMPersistentTrackID passthroughTrackID;
+// Our per-frame draw inputs:
+@property (nonatomic, assign) CGImageRef cardImage;             // retained (see setter)
+@property (nonatomic, assign) CGRect mediaRect;                 // pixels, UIKit top-left
+@property (nonatomic, assign) CGAffineTransform videoPreferred; // source preferredTransform
+@property (nonatomic, assign) int32_t videoTrackID;
+@end
 
-static void ApolloSVSetCompositorParams(CGImageRef card, CGSize renderSize, CGRect mediaRect,
-                                        CGAffineTransform pref, int32_t trackID) {
-    if (sSVCardCG) { CGImageRelease(sSVCardCG); sSVCardCG = NULL; }
-    sSVCardCG = card ? CGImageRetain(card) : NULL;
-    sSVRenderSize = renderSize;
-    sSVMediaRect = mediaRect;
-    sSVVideoPreferred = pref;
-    sSVVideoTrackID = trackID;
+@implementation ApolloSVInstruction
+// CGImageRef isn't ARC-managed; retain on set, release the old one + on dealloc, so
+// the card image lives exactly as long as the instruction (i.e. the export).
+- (void)setCardImage:(CGImageRef)cardImage {
+    if (cardImage == _cardImage) return;
+    if (cardImage) CGImageRetain(cardImage);
+    if (_cardImage) CGImageRelease(_cardImage);
+    _cardImage = cardImage;
 }
+- (void)dealloc {
+    if (_cardImage) CGImageRelease(_cardImage);
+}
+@end
 
 // CVPixelBuffer (BGRA) -> UIImage, mapping the source preferredTransform to a
 // UIImageOrientation so portrait clips recorded as rotated landscape draw upright.
@@ -452,11 +480,19 @@ static UIImage *ApolloSVImageFromBuffer(CVPixelBufferRef buf, CGAffineTransform 
     CGColorSpaceRelease(cs);
     CVPixelBufferUnlockBaseAddress(buf, kCVPixelBufferLock_ReadOnly);
     if (!cg) return nil;
+    // Map the source preferredTransform to a UIImageOrientation. All eight
+    // orientations are covered (the four mirrored ones included) so a flipped clip
+    // would still draw upright; real v.redd.it/Giphy sources won't be mirrored, but
+    // this is exhaustive rather than falling through to Up.
     UIImageOrientation orient = UIImageOrientationUp;
     CGFloat a = pref.a, b = pref.b, c = pref.c, d = pref.d;
-    if (a == 0 && b == 1 && c == -1 && d == 0)       orient = UIImageOrientationRight; // 90° CW
-    else if (a == 0 && b == -1 && c == 1 && d == 0)  orient = UIImageOrientationLeft;  // 90° CCW
-    else if (a == -1 && b == 0 && c == 0 && d == -1) orient = UIImageOrientationDown;  // 180°
+    if (a == 0 && b == 1 && c == -1 && d == 0)       orient = UIImageOrientationRight;        // 90° CW
+    else if (a == 0 && b == -1 && c == 1 && d == 0)  orient = UIImageOrientationLeft;         // 90° CCW
+    else if (a == -1 && b == 0 && c == 0 && d == -1) orient = UIImageOrientationDown;         // 180°
+    else if (a == -1 && b == 0 && c == 0 && d == 1)  orient = UIImageOrientationUpMirrored;   // horizontal flip
+    else if (a == 1 && b == 0 && c == 0 && d == -1)  orient = UIImageOrientationDownMirrored; // vertical flip
+    else if (a == 0 && b == -1 && c == -1 && d == 0) orient = UIImageOrientationLeftMirrored;
+    else if (a == 0 && b == 1 && c == 1 && d == 0)   orient = UIImageOrientationRightMirrored;
     UIImage *img = [UIImage imageWithCGImage:cg scale:1.0 orientation:orient];
     CGImageRelease(cg);
     return img;
@@ -477,12 +513,28 @@ static UIImage *ApolloSVImageFromBuffer(CVPixelBufferRef buf, CGAffineTransform 
 
 - (void)startVideoCompositionRequest:(AVAsynchronousVideoCompositionRequest *)request {
     @autoreleasepool {
+        // Per-export draw parameters ride on the instruction (no shared file state).
+        ApolloSVInstruction *inst = nil;
+        id rawInst = request.videoCompositionInstruction;
+        if ([rawInst isKindOfClass:[ApolloSVInstruction class]]) inst = (ApolloSVInstruction *)rawInst;
+        if (!inst) {
+            // Should never happen — only our instruction is installed on the video
+            // composition. Fail loudly rather than composing an all-black frame, so an
+            // unexpected instruction type surfaces as an export error (which falls back
+            // to the native image share) instead of a silently-broken black video.
+            [request finishWithError:[NSError errorWithDomain:@"ApolloShareVideo" code:11 userInfo:nil]];
+            return;
+        }
+
         CVPixelBufferRef dst = [request.renderContext newPixelBuffer];
         if (!dst) {
             [request finishWithError:[NSError errorWithDomain:@"ApolloShareVideo" code:10 userInfo:nil]];
             return;
         }
-        CVPixelBufferRef src = [request sourceFrameByTrackID:sSVVideoTrackID];
+        CVPixelBufferRef src = [request sourceFrameByTrackID:inst.videoTrackID];
+        CGImageRef cardCG = inst.cardImage;
+        CGRect mediaRect = inst.mediaRect;
+        CGAffineTransform pref = inst.videoPreferred;
 
         CVPixelBufferLockBaseAddress(dst, 0);
         size_t w = CVPixelBufferGetWidth(dst), h = CVPixelBufferGetHeight(dst);
@@ -501,19 +553,19 @@ static UIImage *ApolloSVImageFromBuffer(CVPixelBufferRef buf, CGAffineTransform 
             UIRectFill(CGRectMake(0, 0, w, h));
 
             // The full card (header, title, poster, watermark) — full frame.
-            if (sSVCardCG) {
-                [[UIImage imageWithCGImage:sSVCardCG] drawInRect:CGRectMake(0, 0, w, h)];
+            if (cardCG) {
+                [[UIImage imageWithCGImage:cardCG] drawInRect:CGRectMake(0, 0, w, h)];
             }
             // The live video frame, aspect-filled into the media rect (covers poster).
-            UIImage *frame = ApolloSVImageFromBuffer(src, sSVVideoPreferred);
+            UIImage *frame = ApolloSVImageFromBuffer(src, pref);
             if (frame && frame.size.width > 0 && frame.size.height > 0) {
                 CGContextSaveGState(ctx);
-                CGContextClipToRect(ctx, sSVMediaRect);
-                CGFloat sc = MAX(sSVMediaRect.size.width / frame.size.width,
-                                 sSVMediaRect.size.height / frame.size.height);
+                CGContextClipToRect(ctx, mediaRect);
+                CGFloat sc = MAX(mediaRect.size.width / frame.size.width,
+                                 mediaRect.size.height / frame.size.height);
                 CGSize ds = CGSizeMake(frame.size.width * sc, frame.size.height * sc);
-                CGRect dr = CGRectMake(CGRectGetMidX(sSVMediaRect) - ds.width / 2.0,
-                                       CGRectGetMidY(sSVMediaRect) - ds.height / 2.0,
+                CGRect dr = CGRectMake(CGRectGetMidX(mediaRect) - ds.width / 2.0,
+                                       CGRectGetMidY(mediaRect) - ds.height / 2.0,
                                        ds.width, ds.height);
                 [frame drawInRect:dr];
                 CGContextRestoreGState(ctx);
@@ -629,13 +681,20 @@ static void ApolloSVExport(id vc, UIImage *card, CGRect mediaNorm,
             [aTrack insertTimeRange:CMTimeRangeMake(kCMTimeZero, aDur) ofTrack:srcAudio atTime:kCMTimeZero error:nil];
         }
 
-        // Video composition driven by our custom Core Graphics compositor (the
-        // per-frame draw uses card + media rect + preferredTransform passed below).
-        AVMutableVideoCompositionLayerInstruction *li =
-            [AVMutableVideoCompositionLayerInstruction videoCompositionLayerInstructionWithAssetTrack:vTrack];
-        AVMutableVideoCompositionInstruction *inst = [AVMutableVideoCompositionInstruction videoCompositionInstruction];
+        // Video composition driven by our custom Core Graphics compositor. The
+        // per-frame draw inputs (card, media rect, preferredTransform, track id) are
+        // carried ON the instruction (ApolloSVInstruction) rather than via shared
+        // statics, so concurrent exports can't clobber each other.
+        ApolloSVInstruction *inst = [[ApolloSVInstruction alloc] init];
         inst.timeRange = range;
-        inst.layerInstructions = @[li];
+        inst.enablePostProcessing = NO;
+        inst.containsTweening = NO;
+        inst.passthroughTrackID = kCMPersistentTrackID_Invalid; // never pass through — always composite
+        inst.requiredSourceTrackIDs = @[@(vTrack.trackID)];
+        inst.cardImage = card.CGImage;
+        inst.mediaRect = mediaPx;
+        inst.videoPreferred = srcVideo.preferredTransform;
+        inst.videoTrackID = vTrack.trackID;
 
         AVMutableVideoComposition *vc2 = [AVMutableVideoComposition videoComposition];
         vc2.renderSize = renderSize;
@@ -645,10 +704,11 @@ static void ApolloSVExport(id vc, UIImage *card, CGRect mediaNorm,
         vc2.instructions = @[inst];
         vc2.customVideoCompositorClass = [ApolloSVCompositor class];
 
-        // Hand the per-frame draw parameters to the compositor (one export at a time).
-        ApolloSVSetCompositorParams(card.CGImage, renderSize, mediaPx, srcVideo.preferredTransform, vTrack.trackID);
-
-        NSString *outPath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"ApolloPost.mp4"];
+        // Unique temp filename per export (don't reuse a fixed "ApolloPost.mp4"), so
+        // two concurrent exports can't overwrite each other's output mid-flight.
+        NSString *outName = [NSString stringWithFormat:@"ApolloShareVideo-%@.mp4",
+                             [[NSProcessInfo processInfo] globallyUniqueString]];
+        NSString *outPath = [NSTemporaryDirectory() stringByAppendingPathComponent:outName];
         [[NSFileManager defaultManager] removeItemAtPath:outPath error:nil];
         NSURL *outURL = [NSURL fileURLWithPath:outPath];
 
@@ -685,7 +745,8 @@ static void ApolloSVExport(id vc, UIImage *card, CGRect mediaNorm,
             finished = YES;
             dispatch_source_cancel(timer);
             AVAssetExportSessionStatus st = ex.status;
-            ApolloSVSetCompositorParams(NULL, CGSizeZero, CGRectZero, CGAffineTransformIdentity, 0);
+            // No shared compositor state to tear down — the instruction (and its
+            // retained card image) is released with the composition after export.
             dispatch_async(dispatch_get_main_queue(), ^{
                 objc_setAssociatedObject(vc, &kApolloShareVideoSessionKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
                 if (st == AVAssetExportSessionStatusCompleted) {
@@ -703,16 +764,28 @@ static void ApolloSVExport(id vc, UIImage *card, CGRect mediaNorm,
 
 #pragma mark - Progress HUD
 
-static void ApolloSVHideHUD(id vc) {
-    UIView *hud = (UIView *)objc_getAssociatedObject(vc, &kApolloShareVideoHUDKey);
-    if ([hud isKindOfClass:[UIView class]]) {
+// Tears a HUD overlay off the screen directly, by view reference — no VC needed.
+// This is what makes the HUD impossible to orphan: the export blocks capture the
+// overlay view strongly, so even if the VC (and its associated-object handle) is
+// gone, the overlay can still be removed. Idempotent and main-thread-safe.
+static void ApolloSVRemoveHUDView(UIView *hud) {
+    if (![hud isKindOfClass:[UIView class]]) return;
+    dispatch_block_t teardown = ^{
         [UIView animateWithDuration:0.2 animations:^{ hud.alpha = 0; }
                          completion:^(__unused BOOL done) { [hud removeFromSuperview]; }];
-    }
+    };
+    if ([NSThread isMainThread]) teardown();
+    else dispatch_async(dispatch_get_main_queue(), teardown);
+}
+
+static void ApolloSVHideHUD(id vc) {
+    ApolloSVRemoveHUDView((UIView *)objc_getAssociatedObject(vc, &kApolloShareVideoHUDKey));
     objc_setAssociatedObject(vc, &kApolloShareVideoHUDKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-static void ApolloSVShowHUD(id vc) {
+// Returns the dim overlay view so callers can hold it strongly for the export's
+// lifetime (see ApolloSVRemoveHUDView).
+static UIView *ApolloSVShowHUD(id vc) {
     UIViewController *v = (UIViewController *)vc;
     // The share sheet's own root view is a UIVisualEffectView on iOS 26 — you
     // can't addSubview: to one directly (it asserts). Host the overlay on the
@@ -724,7 +797,7 @@ static void ApolloSVShowHUD(id vc) {
         host = [root isKindOfClass:[UIVisualEffectView class]]
             ? [(UIVisualEffectView *)root contentView] : root;
     }
-    if (![host isKindOfClass:[UIView class]]) return;
+    if (![host isKindOfClass:[UIView class]]) return nil;
 
     UIView *dim = [[UIView alloc] initWithFrame:host.bounds];
     dim.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
@@ -766,6 +839,7 @@ static void ApolloSVShowHUD(id vc) {
     objc_setAssociatedObject(vc, &kApolloShareVideoHUDKey, dim, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(dim, @selector(text), label, OBJC_ASSOCIATION_ASSIGN); // quick label handle
     [UIView animateWithDuration:0.2 animations:^{ dim.alpha = 1.0; }];
+    return dim;
 }
 
 static void ApolloSVUpdateHUD(id vc, float p) {
@@ -891,12 +965,17 @@ static BOOL ApolloSVBeginVideoShare(id vc) {
     }
 
     objc_setAssociatedObject(vc, &kApolloShareVideoExportingKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    ApolloSVShowHUD(vc);
+    // Hold the HUD overlay STRONGLY in the export blocks below. If the VC is
+    // deallocated mid-export, ApolloSVHideHUD (keyed off the VC's associated object)
+    // never fires, so without this strong handle the overlay would stay stuck on the
+    // window with no way to dismiss it. Capturing the view lets every exit path tear
+    // it down regardless of the VC's fate.
+    UIView *hud = ApolloSVShowHUD(vc);
 
     __weak id weakVC = vc;
     ApolloSVResolveForVC(vc, ^(NSURL *videoURL, NSURL *audioURL) {
         id strongVC = weakVC;
-        if (!strongVC) return;
+        if (!strongVC) { ApolloSVRemoveHUDView(hud); return; }
         if (!videoURL) {
             ApolloLog(@"[ShareVideo] no exportable source — falling back to image share");
             objc_setAssociatedObject(strongVC, &kApolloShareVideoExportingKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -909,7 +988,11 @@ static BOOL ApolloSVBeginVideoShare(id vc) {
             ^(float p) { ApolloSVUpdateHUD(weakVC, p); },
             ^(NSURL *outURL, NSError *error) {
                 id sVC = weakVC;
-                if (!sVC) { if (outURL) [[NSFileManager defaultManager] removeItemAtURL:outURL error:nil]; return; }
+                if (!sVC) {
+                    ApolloSVRemoveHUDView(hud); // VC gone — tear the overlay down ourselves
+                    if (outURL) [[NSFileManager defaultManager] removeItemAtURL:outURL error:nil];
+                    return;
+                }
                 objc_setAssociatedObject(sVC, &kApolloShareVideoExportingKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
                 ApolloSVHideHUD(sVC);
                 if (outURL && !error) {


### PR DESCRIPTION
Combines two related *Share as Image* enhancements into one PR (they coordinate, so they ship together). Closes #481. Closes #380.

---

## 1. Include Link (#481)

A new **Include Link** toggle in the *Share as Image* options. When on, the post's Reddit URL is appended to the system share sheet alongside the rendered image — so apps like Messages and Mail attach the image **and** a tappable link back to the thread ("1 Link and 1 Image").

- Styled to match the native rows and **persists** in `NSUserDefaults` (defaults **off**).
- Always links to the **post thread** (`RDKLink.permalink`, resolved to an absolute `https://www.reddit.com/...` URL).
- Supplied via a `UIActivityItemSource` that returns the link only for messaging-type activities, so **Save to Photos / Assign to Contact stay image-only**.
- The bottom sheet grows one row taller so the **Share button is never clipped** (clamped on-screen so it can't abort the presentation).
- New self-contained module `src/ApolloShareAsImageLink.xm`.

## 2. Share as Video (#380)

A new **Share as Video** toggle, shown for **video posts** (and **comments containing an inline GIF**). When on, instead of the static card with a thumbnail, it composites the post's **real video playing inside the card's media region** and exports an **MP4**, then shares the file.

- **v.redd.it**: parses `DASHPlaylist.mpd` for the lowest-bitrate progressive video **and audio** MP4 and muxes them via `AVMutableComposition` — no FFmpeg, so it works on device and in the simulator. Detected from `RDKLink.mediaVideo` / `crossPostVideo` / `previewVideo` (the last covers external-link video posts, whose downloadable clip Reddit hosts on v.redd.it).
- **Comments**: resolves the inline Giphy to its progressive `.mp4`; the GIF plays inside the comment card.
- Compositing uses a **custom `AVVideoCompositing`** (Core Graphics) rather than `AVVideoCompositionCoreAnimationTool`, which hangs in the iOS Simulator.
- A progress overlay shows during export; output is capped (~720px wide, 3 min) so shared files stay reasonable.
- New self-contained module `src/ApolloShareAsVideo.xm`.

**Works with Include Link:** when the Include Link option is on, the exported video carries the post link too — added for messaging/mail (Save Video stays video-only), exactly as Include Link does for the image.

## 3. Gallery fix (drive-by)

Also fixes a pre-existing Share-as-Image bug: a multi-image **gallery** post's collage was replaced by the compact link card when toggling a preview option (e.g. *Include Post Details*). The collage is now re-asserted across those rebuilds.

---

## Testing

- **Include Link** — device-tested (iPhone, iOS 26 / Liquid Glass) + simulator: image + tappable link arrive in Mail/Messages; Save to Photos stays image-only.
- **Share as Video** — simulator-tested (iOS 26 / Liquid Glass): v.redd.it video posts export with audio, comment Giphy exports, the Include-Link greying and gallery fix verified. **Device testing to follow.**

### Preview fixes (follow-up commit)
Several *Share as Image* preview-sheet issues are now fixed (the rendered/exported output was always correct — these were preview-only):
- **Squished comment media** — a comment's inline GIF/image rendered at the wrong aspect until you toggled an option or dragged the sheet (Apollo snapshots the preview once on present and only re-snapshots on a frame-*size* change, so media that loads afterward never refreshed). It now refreshes after present.
- **Gallery under *Include Post Details*** — sharing a comment with the post shown rendered a multi-image gallery post as the compact link card; the collage now injects in that case too.
- **Upward-drag glitch** — dragging the preview up lifted the sheet off the bottom of the screen, exposing a gap under the card; it's now clamped to its resting position.
- **Auto-dismiss after sharing** — the preview stayed open after a share completed; it now dismisses once you actually save/send (cancelling leaves it open).

New self-contained module `src/ApolloShareAsImagePreviewFix.xm`.

---

### Include Link screenshots

|  |  |
| :--: | :--: |
| <img width="250" alt="Include Link toggle in the Share as Image preview" src="https://github.com/user-attachments/assets/6f048be5-bfba-4f2f-86a0-c5d87e3bcbc6"><br>**The toggle** — *Include Link* added to the options (shown on). | <img width="250" alt="Mail compose with the Reddit link in the body and the rendered image attached" src="https://github.com/user-attachments/assets/b736b642-c404-4c08-91ae-e08dc5149a04"><br>**Shared to Mail** — Reddit URL in the body, rendered image attached. |
| <img width="250" alt="Messages compose showing the rendered card and a tappable link preview" src="https://github.com/user-attachments/assets/0592ce3b-0487-4fc1-8f01-36a340ddc671"><br>**Shared to Messages** — rendered card **and** a tappable link (1 Link + 1 Image). | <img width="250" alt="Close-up of the Mail body showing the Reddit link above the shared card" src="https://github.com/user-attachments/assets/2fa367e8-49e0-4115-92c1-f58bc9b2a74e"><br>**Mail, closer look.** |

### Share as Video screenshots

|  |  |
| :--: | :--: |
| <img width="250" alt="Share as Image preview with the new Share as Video toggle on" src="https://github.com/user-attachments/assets/403fbc17-fbf7-46bd-8d57-e717cb561dd1"><br>**1. The toggle** — the new *Share as Video* option. *Include Link* looks dimmed in this earlier screenshot, but it **no longer greys out**: a video can be sent via Messages/Mail just like an image, so with Include Link on the post link rides along with the exported video. (Toggle Share as Video off to share the static thumbnail instead.) | <img width="250" alt="Exported video of a v.redd.it post with Include Post Details on, the real video playing inside the post card" src="https://github.com/user-attachments/assets/ec79effe-99a2-40d9-9ccf-749b71d5e4c0"><br>**2. Video post** — the post card with the real video playing inside (here with *Include Post Details* on). |
| <img width="250" alt="Share as Video on a comment that contains a GIF; the preview thumbnail now displays at the correct aspect" src="https://github.com/user-attachments/assets/6bf0656c-3649-49b9-86d9-d7faa82032ab"><br>**3. Comment GIFs** — works on inline comment GIFs too, and the preview now displays at the correct aspect (the earlier squish is fixed in this PR). | <img width="250" alt="Saving the exported video, with the post info embedded around the playing video" src="https://github.com/user-attachments/assets/8feaebc7-eabe-4e65-9532-72098c7c8df8"><br>**4. Saving** — exporting the `.mp4` with the post info embedded around the video. |
| <img width="250" alt="The exported video playing in the Photos app: a real video file with the post card embedded around it" src="https://github.com/user-attachments/assets/5ae59347-70c8-4463-bcdc-929266eb8050"><br>**5. The result** — a real video file in Photos: the post card embedded around the playing, audible video. |  |
