### PR TITLE
Keep profile avatar/banner visible regardless of the Show User Profile Pictures toggle

### DIFF
--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -1581,16 +1581,13 @@ static void ApolloProfileInstallOrUpdateHeader(id viewControllerObject) {
     UIView *wrappedHeader = objc_getAssociatedObject(viewControllerObject, kApolloProfileWrappedHeaderKey);
     UIView *originalHeader = objc_getAssociatedObject(viewControllerObject, kApolloProfileOriginalHeaderKey);
 
-    if (!sShowUserAvatars) {
-        if (wrappedHeader && tableView.tableHeaderView == wrappedHeader) {
-            tableView.tableHeaderView = originalHeader;
-            ApolloLog(@"[UserAvatars] Profile header restored native header class=%@ vc=%p", className, viewControllerObject);
-        }
-        objc_setAssociatedObject(viewControllerObject, kApolloProfileHeaderViewKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        objc_setAssociatedObject(viewControllerObject, kApolloProfileWrappedHeaderKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        objc_setAssociatedObject(viewControllerObject, kApolloProfileOriginalHeaderKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        return;
-    }
+    // The custom profile header (avatar + banner + bio + social links) is the
+    // profile page's OWN content, not one of the inline avatars the
+    // "Show User Profile Pictures" toggle governs. It must stay visible
+    // regardless of that toggle — a profile always shows the stuff in it.
+    // (Inline comment/feed/chat/mod-list avatars stay gated on sShowUserAvatars;
+    // the gate is intentionally absent here so toggling the feature off leaves
+    // profile avatars/banners alone and intact.)
 
     NSString *username = ApolloUsernameFromProfileViewController(viewController);
     if (username.length == 0) {
@@ -2335,7 +2332,8 @@ static void ApolloAvatarApplySubredditIconToSharePreview(id postInfo, NSString *
 
 - (void)refreshControlActivatedWithSender:(id)sender {
     %orig;
-    if (!sShowUserAvatars) return;
+    // Profile avatar/banner always refresh on pull-to-refresh, independent of the
+    // inline-avatars toggle (the profile header is always shown — see above).
     NSString *username = ApolloUsernameFromProfileViewController((UIViewController *)self);
     if (username.length == 0) return;
     ApolloProfileHeaderView *header = objc_getAssociatedObject(self, kApolloProfileHeaderViewKey);


### PR DESCRIPTION
## What

The **Show User Profile Pictures** toggle is meant to control the inline avatars Reborn adds next to usernames — in comments, the post feed, the Save-as-Image preview, and the moderator list. It was *also* gating the profile page's own custom header, so turning the feature **off** tore down the profile **avatar, banner, bio and social links** too.

A profile page should always show its own avatar/banner — that's the page's content, not an "added" inline avatar.

## Change

Decouple the custom profile header (and its pull-to-refresh refetch) from `sShowUserAvatars` in `ApolloProfileInstallOrUpdateHeader` and `refreshControlActivatedWithSender:`, so the header is always installed. Every inline-avatar site keeps its gate, so the toggle now behaves uniformly:

- **ON** → avatars shown everywhere they're added (comments, feed, share preview, mod list)
- **OFF** → those avatars hidden (the pre-feature look) — profiles unaffected

| Surface | Gated on toggle? |
|---|---|
| Comment / feed byline avatars | ✅ yes |
| Save-as-Image author avatar | ✅ yes |
| Moderator list avatars | ✅ yes |
| **Profile page avatar / banner / bio** | ❌ always shown (this PR) |

(Any other inline-avatar surface, e.g. direct-chat avatars, follows the same `sShowUserAvatars` gate.)

## Testing

iOS 26 Simulator, toggled in-app both directions:

- **ON** → comment authors show avatars **and** the profile shows its full header.
- **OFF** → comment/byline authors are bare, but the profile header (banner, snoovatar, name, social links, bio, karma) stays intact.

Not yet device-tested.