### PR TITLE
Restore the follow-thread Live Activity in the Reborn widget

### DIFF
--- a/widgets/Sources/ApolloRebornWidgetBundle.swift
+++ b/widgets/Sources/ApolloRebornWidgetBundle.swift
@@ -13,6 +13,9 @@ struct ApolloRebornWidgetBundle: WidgetBundle {
         ApolloQuickActionsWidget()
         CalendarWidget()
         HeadlineWidget()
+        // Restores the "follow thread" Live Activity that the stock
+        // AthenaWidgetExtension used to render (removed in the widget swap).
+        FollowThreadLiveActivity()
     }
 }
 

--- a/widgets/Sources/FollowThreadActivity.swift
+++ b/widgets/Sources/FollowThreadActivity.swift
@@ -1,0 +1,57 @@
+import ActivityKit
+import Foundation
+
+/// Re-declaration of Apollo's own `FollowThreadActivityAttributes`, so the
+/// Apollo-Reborn widget extension can render the "follow thread" Live Activity.
+///
+/// ## Why this lives here
+/// Apollo's main binary still *starts* the activity (`LiveActivityHelper` calls
+/// `Activity<FollowThreadActivityAttributes>.request(...)`) and mints the APNs
+/// push token, but the activity's **UI** (`FollowThreadLiveActivity`, an
+/// `ActivityConfiguration`) shipped only inside the stock
+/// `AthenaWidgetExtension.appex`. Reborn removes that extension (it crash-loops
+/// without API keys and poisons WidgetKit enumeration), which also dropped the
+/// Live Activity renderer — so pushed updates were accepted by APNs (HTTP 200)
+/// but had nothing on-device to draw them. Declaring the configuration in
+/// `ApolloRebornWidgets.appex` restores it.
+///
+/// ## Why a separate-module re-declaration works
+/// ActivityKit routes a running activity to the `ActivityConfiguration` whose
+/// attributes type has the same **unqualified** name (`FollowThreadActivity\
+/// Attributes`); the module differs (`Apollo` vs `ApolloRebornWidgets`). This
+/// is the standard "shared attributes" pattern and is exactly how the stock
+/// `AthenaWidgetExtension` — itself a separate module — rendered this same
+/// activity. The attributes are passed app→widget via `Codable`, so the stored
+/// property names must match Apollo's struct verbatim.
+///
+/// ## Why the `ContentState` keys are load-bearing
+/// Pushed updates arrive as the APNs `content-state` JSON and are decoded into
+/// `ContentState` by key (Swift synthesizes `CodingKeys` from the property
+/// names). These names must match BOTH Apollo's struct AND the apollo-backend
+/// `DynamicIslandNotification` JSON tags
+/// (`internal/worker/live_activities.go`) — `postTotalComments`, `postScore`,
+/// `commentId`, `commentAuthor`, `commentBody`, `commentAge`, `commentScore`.
+/// A mismatch makes ActivityKit silently drop every update.
+struct FollowThreadActivityAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        /// Total comments on the post (always sent).
+        var postTotalComments: Int
+        /// Post score / upvotes (always sent).
+        var postScore: Int
+        /// The most recent surfaced comment (all optional — absent until the
+        /// backend finds a fresh top-level comment).
+        var commentAuthor: String?
+        var commentScore: Int?
+        /// Comment creation time as a Unix timestamp in **seconds**
+        /// (`comment.CreatedAt.Unix()` on the backend), not a duration.
+        var commentAge: Double?
+        var commentBody: String?
+        var commentId: String?
+    }
+
+    /// Static, set once when the activity starts; never changes via push.
+    let postID: String
+    let postTitle: String
+    let postAuthor: String
+    let subreddit: String
+}

--- a/widgets/Sources/FollowThreadLiveActivity.swift
+++ b/widgets/Sources/FollowThreadLiveActivity.swift
@@ -1,0 +1,204 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+/// The "follow thread" Live Activity UI, restored into the Reborn widget
+/// extension. Renders the Lock Screen / banner presentation and the Dynamic
+/// Island. Purely presentational — it draws `context.state` (pushed by
+/// apollo-backend) over `context.attributes` (set when the activity started),
+/// does no networking, and needs no API key, so it can't crash-loop the way the
+/// stock `AthenaWidgetExtension` did. See `FollowThreadActivityAttributes`.
+///
+/// Structure mirrors what reverse-engineering the stock `AthenaWidgetExtension`
+/// recovered: the Dynamic Island was composed of three named subviews —
+/// `DynamicIslandPostScoreView`, `DynamicIslandPostTotalCommentsView`, and
+/// `DynamicIslandRecentTopCommentView` — kept here as the same three pieces.
+/// The stock binary used adaptive `labelColor`/`secondaryLabelColor` (not a
+/// forced palette) and the Apollo mark, so this uses `.primary`/`.secondary`
+/// over the system material plus the `ApolloAvatar` asset. Exact paddings/fonts
+/// weren't recoverable (type-erased SwiftUI), so those are a tasteful match.
+struct FollowThreadLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: FollowThreadActivityAttributes.self) { context in
+            FollowThreadLockScreenView(attributes: context.attributes, state: context.state)
+        } dynamicIsland: { context in
+            islandPresentation(context)
+        }
+    }
+
+    private func islandPresentation(_ context: ActivityViewContext<FollowThreadActivityAttributes>) -> DynamicIsland {
+        DynamicIsland {
+            DynamicIslandExpandedRegion(.leading) {
+                DynamicIslandPostScoreView(score: context.state.postScore)
+            }
+            DynamicIslandExpandedRegion(.trailing) {
+                DynamicIslandPostTotalCommentsView(total: context.state.postTotalComments)
+            }
+            DynamicIslandExpandedRegion(.bottom) {
+                DynamicIslandRecentTopCommentView(attributes: context.attributes, state: context.state)
+            }
+        } compactLeading: {
+            ApolloMark()
+        } compactTrailing: {
+            Text(context.state.postTotalComments.abbreviated)
+                .monospacedDigit().foregroundStyle(.secondary)
+        } minimal: {
+            ApolloMark()
+        }
+        .keylineTint(apolloBlue)
+        .widgetURL(threadURL(context.attributes))
+    }
+}
+
+// MARK: - Dynamic Island subviews (named to match the stock extension)
+
+private struct DynamicIslandPostScoreView: View {
+    let score: Int
+    var body: some View {
+        Label(score.abbreviated, systemImage: "arrow.up")
+            .font(.caption).fontWeight(.semibold)
+            .labelStyle(.titleAndIcon).monospacedDigit()
+            .foregroundStyle(.primary)
+    }
+}
+
+private struct DynamicIslandPostTotalCommentsView: View {
+    let total: Int
+    var body: some View {
+        Label(total.abbreviated, systemImage: "bubble.right")
+            .font(.caption)
+            .labelStyle(.titleAndIcon).monospacedDigit()
+            .foregroundStyle(.secondary)
+    }
+}
+
+private struct DynamicIslandRecentTopCommentView: View {
+    let attributes: FollowThreadActivityAttributes
+    let state: FollowThreadActivityAttributes.ContentState
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(attributes.postTitle)
+                .font(.subheadline).fontWeight(.semibold)
+                .lineLimit(1)
+            if let info = ThreadCommentInfo(state) {
+                HStack(spacing: 4) {
+                    Text("u/\(info.author)").fontWeight(.semibold).foregroundStyle(apolloBlue)
+                    Text(info.body).foregroundStyle(.secondary)
+                }
+                .font(.caption).lineLimit(1)
+            } else {
+                Text("Following — waiting for new comments…")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Lock Screen / banner
+
+private struct FollowThreadLockScreenView: View {
+    let attributes: FollowThreadActivityAttributes
+    let state: FollowThreadActivityAttributes.ContentState
+
+    var body: some View {
+        let info = ThreadCommentInfo(state)
+        VStack(alignment: .leading, spacing: 8) {
+            // Header: Apollo mark + subreddit + live post stats.
+            HStack(spacing: 6) {
+                ApolloMark(size: 16)
+                Text("r/\(attributes.subreddit)")
+                    .font(.caption).fontWeight(.semibold)
+                Spacer(minLength: 8)
+                DynamicIslandPostScoreView(score: state.postScore)
+                DynamicIslandPostTotalCommentsView(total: state.postTotalComments)
+            }
+
+            Text(attributes.postTitle)
+                .font(.subheadline).fontWeight(.semibold)
+                .lineLimit(2)
+
+            Divider()
+
+            if let info {
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 6) {
+                        Text("u/\(info.author)")
+                            .fontWeight(.semibold).foregroundStyle(apolloBlue)
+                        if let score = info.score {
+                            Label(score.abbreviated, systemImage: "arrow.up")
+                                .labelStyle(.titleAndIcon)
+                        }
+                        if let age = info.age {
+                            Label { Text(age, style: .relative) } icon: { Image(systemName: "clock") }
+                                .labelStyle(.titleAndIcon)
+                        }
+                    }
+                    .font(.caption2).foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                    Text(info.body)
+                        .font(.caption)
+                        .lineLimit(3)
+                }
+            } else {
+                HStack(spacing: 6) {
+                    ProgressView().scaleEffect(0.7)
+                    Text("Following this thread — newest comments will appear here.")
+                        .font(.caption).foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+        }
+        .padding(16)
+        .widgetURL(threadURL(attributes))
+    }
+}
+
+// MARK: - Shared bits
+
+/// Apollo's signature accent blue (matches `BlueGradient`'s top stop). Used as
+/// an accent only; body text uses adaptive `.primary`/`.secondary`, matching the
+/// stock extension's use of `labelColor`/`secondaryLabelColor`.
+private let apolloBlue = Color(red: 0.16, green: 0.45, blue: 0.96)
+
+/// The Apollo mascot mark (the stock activity rendered `apolloIcon`). Reuses the
+/// `ApolloAvatar` asset the other Reborn widgets brand with.
+private struct ApolloMark: View {
+    var size: CGFloat = 18
+    var body: some View {
+        Image("ApolloAvatar")
+            .resizable().scaledToFit()
+            .frame(width: size, height: size)
+            .clipShape(Circle())
+    }
+}
+
+/// Normalized "latest comment" view model. `nil` when no comment has been
+/// surfaced yet (the backend sends only post stats until a fresh top-level
+/// comment turns up), so call sites can branch on presence cleanly.
+private struct ThreadCommentInfo {
+    let author: String
+    let body: String
+    let score: Int?
+    let age: Date?
+
+    init?(_ state: FollowThreadActivityAttributes.ContentState) {
+        let body = state.commentBody?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let author = state.commentAuthor ?? ""
+        guard !body.isEmpty || !author.isEmpty else { return nil }
+        self.author = author.isEmpty ? "someone" : author
+        self.body = body.isEmpty ? "(no text)" : body
+        self.score = state.commentScore
+        // `commentAge` is a Unix timestamp in seconds (see ContentState).
+        self.age = state.commentAge.map { Date(timeIntervalSince1970: $0) }
+    }
+}
+
+/// Deep link back into Apollo for the followed post, so tapping the activity
+/// opens the thread. Uses the `apollo://` scheme Apollo registers.
+private func threadURL(_ attributes: FollowThreadActivityAttributes) -> URL? {
+    let id = attributes.postID.replacingOccurrences(of: "t3_", with: "")
+    guard !id.isEmpty else { return nil }
+    return URL(string: "apollo://reddit.com/r/\(attributes.subreddit)/comments/\(id)")
+}


### PR DESCRIPTION
## Problem

The "Reborn widgets" swap (#406) removes the stock `AthenaWidgetExtension.appex` — the only bundle that declared the follow-thread Live Activity's `ActivityConfiguration` (`FollowThreadLiveActivity`). Apollo's main binary still *starts* the activity and registers an APNs push token, so a self-hosted apollo-backend keeps polling and pushing updates (APNs returns 200) — but with no installed extension to render or decode them, the Live Activity never appears or updates.

Regular push notifications were unaffected (they need no extension), which is why this presented as a backend/cert problem. Device-log signature: `(ActivityKit) Fetched descriptors for content states: []`.

## Fix

Port the activity's UI into `ApolloRebornWidgets.appex`:

- **`FollowThreadActivity.swift`** — re-declares `FollowThreadActivityAttributes` + `ContentState`. ActivityKit routes by the **unqualified** attributes type name, so a separate-module re-declaration matches what the main app starts (exactly how the stock `AthenaWidgetExtension`, its own module, rendered it). The `ContentState` keys must match Apollo's struct **and** the apollo-backend `DynamicIslandNotification` JSON tags, or pushed updates silently fail to decode.
- **`FollowThreadLiveActivity.swift`** — the `ActivityConfiguration`: Lock Screen / banner + Dynamic Island. Structure mirrors the stock extension's three named subviews (`DynamicIslandPostScoreView`, `DynamicIslandPostTotalCommentsView`, `DynamicIslandRecentTopCommentView`) recovered from reflection metadata; adaptive system colors + the Apollo mark match the original.
- Register `FollowThreadLiveActivity()` in the widget bundle.

Purely presentational (no networking / API key), so it can't crash-loop WidgetKit enumeration the way the stock extension did — the reason #406 removed it.

## Testing

- Widget extension builds clean (`xcodegen` + `xcodebuild`, Release/iphoneos); the appex links `ActivityKit` and contains the configuration.
- Backend `content-state` JSON decodes into the shipped `ContentState` (full update + the `omitempty` "no comment yet" case).
- **Confirmed working on a real device** against a self-hosted apollo-backend.

## Install note

Live Activities need a **Standard / GLASS** build (the No-Extensions variants strip widgets), and on iOS 26 the widget extension only launches if the installer sets the appex main-binary flag — **AltStore Classic / SideStore** (or Apple `codesign`), not Sideloadly/Feather.
