### PR TITLE
feat(notifications): show a clear "Notifications Unavailable" screen on free-account sideloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixes
+
+- Stop **sideloaded (free Apple ID) builds** from showing the alarming "Error Loading Notifications — contact developer" alert (`no valid "aps-environment" entitlement string found for application`) when enabling notifications. The missing push entitlement is an unavoidable signing-time limitation on free accounts, so the tweak now recognizes that specific failure and lets notification registration and watcher setup proceed. Push delivery still requires a paid Apple Developer account; genuine errors (offline, rate limiting) are unaffected.
+
 ## [v3.2.0] - 2026-06-14
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
-- Stop **sideloaded (free Apple ID) builds** from showing the alarming "Error Loading Notifications — contact developer" alert (`no valid "aps-environment" entitlement string found for application`) when enabling notifications. The missing push entitlement is an unavoidable signing-time limitation on free accounts, so the tweak now recognizes that specific failure and lets notification registration and watcher setup proceed. Push delivery still requires a paid Apple Developer account; genuine errors (offline, rate limiting) are unaffected.
+- Replace the alarming "Error Loading Notifications — contact developer" alert on **sideloaded (free Apple ID) builds** (`no valid "aps-environment" entitlement string found for application`) with a clear, honest explanation. Apple only grants the push entitlement to paid Apple Developer accounts, so push, watchers, and inbox alerts can never be delivered to a free-account sideload. The tweak now detects that signing-time limitation up front, swaps the Notifications settings screen for a non-interactive "Notifications Unavailable" explanation (so nobody gets false hope or is told to "contact developer" for something no developer can fix), and suppresses the misleading error. Builds that can actually receive push (paid-account sideloads, or the App Store binary on a jailbreak) are detected via the entitlement and left untouched; genuine errors (offline, rate limiting) are unaffected.
 
 ## [v3.2.0] - 2026-06-14
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloSettingsTableViewController.m \
     $(SRC_DIR)/ApolloRedditMediaUpload.m \
     $(SRC_DIR)/ApolloNotificationBackend.m \
+    $(SRC_DIR)/ApolloPushNotifications.m \
     $(SRC_DIR)/ApolloUserProfileCache.m \
     $(SRC_DIR)/ApolloSubredditInfoCache.m \
     $(SRC_DIR)/ApolloSubredditCustomBannerCache.m \

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Finally, **don't copy these examples verbatim**. If everyone adopts the same "sa
 The legacy Apollo push backends went dark in June 2023 and are otherwise blocked by the tweak. If you run your own instance of [nickclyde/apollo-backend](https://github.com/nickclyde/apollo-backend) (with your own Reddit OAuth `CLIENT_ID` / `CLIENT_SECRET` baked into its env vars), you can set the URL under **Settings > Custom API > Notification Backend** and the tweak will route all `apollopushserver.xyz`, `beta.apollonotifications.com`, and `apolloreq.com` traffic to that host instead. Leave the field empty to keep the current "silently dropped" behavior.
 
 > [!IMPORTANT]
-> APNs delivery requires a real `aps-environment` entitlement, which Apple only grants under a paid Apple Developer team. Free-account sideloads can still register and exercise the watcher CRUD, but push notifications will never actually arrive.
+> APNs delivery requires a real `aps-environment` entitlement, which Apple only grants under a paid Apple Developer team. Free-account sideloads can still register and exercise the watcher CRUD, but push notifications will never actually arrive. (Enabling notifications on a free-account sideload no longer shows the misleading "Error Loading Notifications — contact developer" alert; the tweak recognizes the missing entitlement and lets setup proceed.)
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Finally, **don't copy these examples verbatim**. If everyone adopts the same "sa
 The legacy Apollo push backends went dark in June 2023 and are otherwise blocked by the tweak. If you run your own instance of [nickclyde/apollo-backend](https://github.com/nickclyde/apollo-backend) (with your own Reddit OAuth `CLIENT_ID` / `CLIENT_SECRET` baked into its env vars), you can set the URL under **Settings > Custom API > Notification Backend** and the tweak will route all `apollopushserver.xyz`, `beta.apollonotifications.com`, and `apolloreq.com` traffic to that host instead. Leave the field empty to keep the current "silently dropped" behavior.
 
 > [!IMPORTANT]
-> APNs delivery requires a real `aps-environment` entitlement, which Apple only grants under a paid Apple Developer team. Free-account sideloads can still register and exercise the watcher CRUD, but push notifications will never actually arrive. (Enabling notifications on a free-account sideload no longer shows the misleading "Error Loading Notifications — contact developer" alert; the tweak recognizes the missing entitlement and lets setup proceed.)
+> APNs delivery requires a real `aps-environment` entitlement, which Apple only grants under a paid Apple Developer team. Free-account sideloads can still register and exercise the watcher CRUD, but push notifications will never actually arrive. (On a free-account sideload the tweak detects the missing entitlement and replaces the Notifications settings with a clear "Notifications Unavailable" explanation instead of the misleading "Error Loading Notifications — contact developer" alert.)
 
 ## Known Issues
 

--- a/src/ApolloPushNotifications.h
+++ b/src/ApolloPushNotifications.h
@@ -1,22 +1,39 @@
 #import <Foundation/Foundation.h>
 
+@class UIView;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-// MARK: - Sideload push-registration support
+// MARK: - Sideload push-notification support
 //
-// Apollo registers for remote notifications (watchers, inbox push) the moment a
-// user enables notifications. On a build sideloaded without a paid Apple
-// Developer team there is no `aps-environment` entitlement, so iOS answers
+// APNs delivery requires the `aps-environment` entitlement, which Apple only
+// grants to a paid Apple Developer team and bakes in at signing time. A build
+// sideloaded with a free Apple ID never carries it, so push notifications,
+// watchers, and inbox alerts can never be delivered to that build — no runtime
+// trick can change that.
+//
+// When the user opens Apollo's Notifications settings, Apollo registers for
+// remote notifications; on a free-account sideload iOS answers
 // -application:didFailToRegisterForRemoteNotificationsWithError: with the
 // permanent NSCocoaErrorDomain 3000 ("no valid 'aps-environment' entitlement
-// string found for application"). Apollo then resurfaces that raw error as an
-// alarming "Error Loading Notifications — contact developer" alert.
+// string found for application"), which Apollo resurfaces as an alarming
+// "Error Loading Notifications — contact developer" alert.
 //
-// The helpers below let the tweak recognize that one expected, unfixable
-// condition and substitute a stable stand-in token so registration proceeds,
-// mirroring the existing SKReceiptRefreshRequest sideload fix.
+// Rather than fake a working registration (which would mislead users into
+// thinking push could work), the tweak detects this signing-time limitation up
+// front, replaces the Notifications screen with a clear explanation, and
+// suppresses the misleading error. The helpers below back that behavior.
+
+// YES when the running build carries an `aps-environment` entitlement, i.e. push
+// registration can actually succeed (an App Store build, or a sideload signed
+// with a paid Apple Developer account). NO on a free-account sideload, where
+// push can never be delivered. Determined from the process's own code-signing
+// entitlements, so it is accurate before any registration is attempted. When the
+// entitlement state can't be read it conservatively returns YES, leaving the
+// stock behavior untouched.
+BOOL ApolloPushNotificationsSupported(void);
 
 // YES only when `error` is the missing-`aps-environment`-entitlement failure
 // described above. This is a signing-time condition that can never be resolved
@@ -25,21 +42,13 @@ extern "C" {
 // still surface to the user. Safe to call with nil.
 BOOL ApolloErrorIsMissingPushEntitlement(NSError *error);
 
-// A deterministic, fixed-length (32-byte) stand-in APNs device token derived
-// from `seed` via SHA-256. Pure and side-effect free: the same seed always maps
-// to the same bytes and distinct seeds (practically) never collide. 32 bytes so
-// Apollo hex-encodes it to a 64-character token, matching the real legacy APNs
-// token length. A nil/empty seed falls back to a fixed constant so the result
-// is always well-defined. Push delivery never actually happens on a free
-// account — this only unblocks Apollo's local registration + watcher CRUD.
-NSData *ApolloPlaceholderAPNSDeviceTokenForSeed(NSString *seed);
-
-// Convenience wrapper: resolves a stable per-install seed (the vendor
-// identifier, with a once-generated persisted UUID fallback for the rare case
-// where identifierForVendor is unavailable) and returns
-// ApolloPlaceholderAPNSDeviceTokenForSeed() of it. Stable across launches so a
-// configured self-hosted backend sees a single, consistent device.
-NSData *ApolloPlaceholderAPNSDeviceToken(void);
+// Builds the opaque, non-interactive informational view shown in place of
+// Apollo's Notifications settings on a build that can never receive push (a
+// free-account sideload, no `aps-environment` entitlement). It explains why
+// notifications are unavailable and swallows touches so the disabled controls
+// underneath can't be tapped. Pinning it into the view hierarchy is the
+// caller's responsibility.
+UIView *ApolloMakeNotificationsUnavailableView(void);
 
 #ifdef __cplusplus
 }

--- a/src/ApolloPushNotifications.h
+++ b/src/ApolloPushNotifications.h
@@ -1,0 +1,46 @@
+#import <Foundation/Foundation.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// MARK: - Sideload push-registration support
+//
+// Apollo registers for remote notifications (watchers, inbox push) the moment a
+// user enables notifications. On a build sideloaded without a paid Apple
+// Developer team there is no `aps-environment` entitlement, so iOS answers
+// -application:didFailToRegisterForRemoteNotificationsWithError: with the
+// permanent NSCocoaErrorDomain 3000 ("no valid 'aps-environment' entitlement
+// string found for application"). Apollo then resurfaces that raw error as an
+// alarming "Error Loading Notifications — contact developer" alert.
+//
+// The helpers below let the tweak recognize that one expected, unfixable
+// condition and substitute a stable stand-in token so registration proceeds,
+// mirroring the existing SKReceiptRefreshRequest sideload fix.
+
+// YES only when `error` is the missing-`aps-environment`-entitlement failure
+// described above. This is a signing-time condition that can never be resolved
+// at runtime, so it is treated as an expected sideload state rather than a bug.
+// Returns NO for genuine/transient failures (offline, rate limiting, …) so they
+// still surface to the user. Safe to call with nil.
+BOOL ApolloErrorIsMissingPushEntitlement(NSError *error);
+
+// A deterministic, fixed-length (32-byte) stand-in APNs device token derived
+// from `seed` via SHA-256. Pure and side-effect free: the same seed always maps
+// to the same bytes and distinct seeds (practically) never collide. 32 bytes so
+// Apollo hex-encodes it to a 64-character token, matching the real legacy APNs
+// token length. A nil/empty seed falls back to a fixed constant so the result
+// is always well-defined. Push delivery never actually happens on a free
+// account — this only unblocks Apollo's local registration + watcher CRUD.
+NSData *ApolloPlaceholderAPNSDeviceTokenForSeed(NSString *seed);
+
+// Convenience wrapper: resolves a stable per-install seed (the vendor
+// identifier, with a once-generated persisted UUID fallback for the rare case
+// where identifierForVendor is unavailable) and returns
+// ApolloPlaceholderAPNSDeviceTokenForSeed() of it. Stable across launches so a
+// configured self-hosted backend sees a single, consistent device.
+NSData *ApolloPlaceholderAPNSDeviceToken(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ApolloPushNotifications.m
+++ b/src/ApolloPushNotifications.m
@@ -1,0 +1,72 @@
+#import "ApolloPushNotifications.h"
+#import <CommonCrypto/CommonDigest.h>
+
+// `aps-environment` registration failures come back as NSCocoaErrorDomain 3000.
+// Kept as named constants so the intent is obvious and the defensive fallback
+// below documents why the literal string match also exists.
+static NSString *const kApolloAPSEntitlementErrorDomain = @"NSCocoaErrorDomain";
+static const NSInteger kApolloAPSEntitlementErrorCode = 3000;
+static NSString *const kApolloAPSEntitlementMarker = @"aps-environment";
+
+BOOL ApolloErrorIsMissingPushEntitlement(NSError *error) {
+    if (![error isKindOfClass:[NSError class]]) {
+        return NO;
+    }
+
+    // Canonical signature returned by iOS today.
+    if ([error.domain isEqualToString:kApolloAPSEntitlementErrorDomain] &&
+        error.code == kApolloAPSEntitlementErrorCode) {
+        return YES;
+    }
+
+    // Defensive fallback: match the entitlement string itself, in case Apple
+    // ever changes the domain/code. Covers the localized description directly.
+    NSString *description = error.localizedDescription ?: @"";
+    if ([description rangeOfString:kApolloAPSEntitlementMarker
+                           options:NSCaseInsensitiveSearch].location != NSNotFound) {
+        return YES;
+    }
+
+    // …and any nested underlying error (guarding against self-referential
+    // userInfo to avoid infinite recursion).
+    NSError *underlying = error.userInfo[NSUnderlyingErrorKey];
+    if ([underlying isKindOfClass:[NSError class]] && underlying != error) {
+        return ApolloErrorIsMissingPushEntitlement(underlying);
+    }
+
+    return NO;
+}
+
+NSData *ApolloPlaceholderAPNSDeviceTokenForSeed(NSString *seed) {
+    NSString *normalized = ([seed isKindOfClass:[NSString class]] && seed.length > 0)
+        ? seed
+        : @"apollo-reborn-placeholder-apns-seed";
+    NSData *seedData = [normalized dataUsingEncoding:NSUTF8StringEncoding] ?: [NSData data];
+
+    unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(seedData.bytes, (CC_LONG)seedData.length, digest);
+    return [NSData dataWithBytes:digest length:CC_SHA256_DIGEST_LENGTH];
+}
+
+#ifndef APOLLO_PUSH_NOTIFICATIONS_TESTING
+
+#import <UIKit/UIKit.h>
+
+// Persisted only when identifierForVendor is unavailable (e.g. before first
+// device unlock), so the stand-in token stays stable across launches.
+static NSString *const kApolloPlaceholderAPNSSeedDefaultsKey = @"ApolloPlaceholderAPNSDeviceSeed";
+
+NSData *ApolloPlaceholderAPNSDeviceToken(void) {
+    NSString *seed = [UIDevice currentDevice].identifierForVendor.UUIDString;
+    if (seed.length == 0) {
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+        seed = [defaults stringForKey:kApolloPlaceholderAPNSSeedDefaultsKey];
+        if (seed.length == 0) {
+            seed = [[NSUUID UUID] UUIDString];
+            [defaults setObject:seed forKey:kApolloPlaceholderAPNSSeedDefaultsKey];
+        }
+    }
+    return ApolloPlaceholderAPNSDeviceTokenForSeed(seed);
+}
+
+#endif

--- a/src/ApolloPushNotifications.m
+++ b/src/ApolloPushNotifications.m
@@ -1,5 +1,4 @@
 #import "ApolloPushNotifications.h"
-#import <CommonCrypto/CommonDigest.h>
 
 // `aps-environment` registration failures come back as NSCocoaErrorDomain 3000.
 // Kept as named constants so the intent is obvious and the defensive fallback
@@ -37,36 +36,116 @@ BOOL ApolloErrorIsMissingPushEntitlement(NSError *error) {
     return NO;
 }
 
-NSData *ApolloPlaceholderAPNSDeviceTokenForSeed(NSString *seed) {
-    NSString *normalized = ([seed isKindOfClass:[NSString class]] && seed.length > 0)
-        ? seed
-        : @"apollo-reborn-placeholder-apns-seed";
-    NSData *seedData = [normalized dataUsingEncoding:NSUTF8StringEncoding] ?: [NSData data];
-
-    unsigned char digest[CC_SHA256_DIGEST_LENGTH];
-    CC_SHA256(seedData.bytes, (CC_LONG)seedData.length, digest);
-    return [NSData dataWithBytes:digest length:CC_SHA256_DIGEST_LENGTH];
-}
-
 #ifndef APOLLO_PUSH_NOTIFICATIONS_TESTING
 
 #import <UIKit/UIKit.h>
+#import <Security/Security.h>
 
-// Persisted only when identifierForVendor is unavailable (e.g. before first
-// device unlock), so the stand-in token stays stable across launches.
-static NSString *const kApolloPlaceholderAPNSSeedDefaultsKey = @"ApolloPlaceholderAPNSDeviceSeed";
+// SecTaskCopyValueForEntitlement / SecTaskCreateFromSelf read the *current*
+// process's code-signing entitlements. They ship in Security.framework but
+// aren't in the public SDK headers, so declare the two symbols we need.
+typedef struct __SecTask *ApolloSecTaskRef;
+extern ApolloSecTaskRef SecTaskCreateFromSelf(CFAllocatorRef allocator);
+extern CFTypeRef SecTaskCopyValueForEntitlement(ApolloSecTaskRef task,
+                                                CFStringRef entitlement,
+                                                CFErrorRef *error);
 
-NSData *ApolloPlaceholderAPNSDeviceToken(void) {
-    NSString *seed = [UIDevice currentDevice].identifierForVendor.UUIDString;
-    if (seed.length == 0) {
-        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-        seed = [defaults stringForKey:kApolloPlaceholderAPNSSeedDefaultsKey];
-        if (seed.length == 0) {
-            seed = [[NSUUID UUID] UUIDString];
-            [defaults setObject:seed forKey:kApolloPlaceholderAPNSSeedDefaultsKey];
+BOOL ApolloPushNotificationsSupported(void) {
+    // The answer is fixed at signing time, so compute it once.
+    static BOOL supported = YES;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        ApolloSecTaskRef task = SecTaskCreateFromSelf(NULL);
+        if (!task) {
+            // Couldn't introspect entitlements — stay conservative and leave the
+            // stock notifications screen untouched.
+            return;
         }
+        CFTypeRef value = SecTaskCopyValueForEntitlement(task, CFSTR("aps-environment"), NULL);
+        // Any non-null `aps-environment` value ("development" / "production")
+        // means Apple granted the push entitlement and registration can succeed.
+        supported = (value != NULL);
+        if (value) {
+            CFRelease(value);
+        }
+        CFRelease(task);
+    });
+    return supported;
+}
+
+// MARK: - "Notifications unavailable" screen
+
+static UILabel *ApolloUnavailableLabel(NSString *text, UIFont *font, UIColor *color) {
+    UILabel *label = [[UILabel alloc] init];
+    label.text = text;
+    label.font = font;
+    label.textColor = color;
+    label.numberOfLines = 0;
+    label.textAlignment = NSTextAlignmentCenter;
+    label.adjustsFontForContentSizeCategory = YES;
+    return label;
+}
+
+UIView *ApolloMakeNotificationsUnavailableView(void) {
+    UIView *container = [[UIView alloc] initWithFrame:CGRectZero];
+    // Opaque so it fully hides the stock controls, and interactive so it
+    // swallows every touch meant for the disabled page underneath.
+    container.backgroundColor = [UIColor systemBackgroundColor];
+    container.userInteractionEnabled = YES;
+
+    UIImageSymbolConfiguration *iconConfig =
+        [UIImageSymbolConfiguration configurationWithPointSize:52.0 weight:UIImageSymbolWeightRegular];
+    UIImageView *icon = [[UIImageView alloc] initWithImage:
+        [UIImage systemImageNamed:@"bell.slash" withConfiguration:iconConfig]];
+    icon.tintColor = [UIColor secondaryLabelColor];
+    icon.contentMode = UIViewContentModeScaleAspectFit;
+
+    UILabel *title = ApolloUnavailableLabel(
+        @"Notifications Unavailable",
+        [UIFont preferredFontForTextStyle:UIFontTextStyleTitle2],
+        [UIColor labelColor]);
+    // Bold the title while keeping Dynamic Type scaling.
+    UIFontDescriptor *boldDescriptor =
+        [title.font.fontDescriptor fontDescriptorWithSymbolicTraits:UIFontDescriptorTraitBold];
+    if (boldDescriptor) {
+        title.font = [UIFont fontWithDescriptor:boldDescriptor size:0.0];
     }
-    return ApolloPlaceholderAPNSDeviceTokenForSeed(seed);
+
+    UILabel *body = ApolloUnavailableLabel(
+        @"This copy of Apollo was signed with a free Apple ID, which Apple doesn't grant the push notification entitlement. Push alerts, watchers, and inbox notifications can't be delivered to this build.",
+        [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline],
+        [UIColor secondaryLabelColor]);
+
+    UILabel *footnote = ApolloUnavailableLabel(
+        @"To use notifications, install a build signed with a paid Apple Developer account. Everything else in Apollo keeps working as normal.",
+        [UIFont preferredFontForTextStyle:UIFontTextStyleFootnote],
+        [UIColor secondaryLabelColor]);
+
+    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[icon, title, body, footnote]];
+    stack.axis = UILayoutConstraintAxisVertical;
+    stack.alignment = UIStackViewAlignmentCenter;
+    stack.spacing = 12.0;
+    [stack setCustomSpacing:20.0 afterView:icon];
+    [stack setCustomSpacing:18.0 afterView:body];
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    [container addSubview:stack];
+
+    UILayoutGuide *safe = container.safeAreaLayoutGuide;
+    NSLayoutConstraint *width = [stack.widthAnchor constraintLessThanOrEqualToConstant:360.0];
+    NSLayoutConstraint *centerY = [stack.centerYAnchor constraintEqualToAnchor:safe.centerYAnchor];
+    // Keep the block from floating too low when the safe area is tall.
+    centerY.priority = UILayoutPriorityDefaultHigh;
+    [NSLayoutConstraint activateConstraints:@[
+        [stack.centerXAnchor constraintEqualToAnchor:container.centerXAnchor],
+        centerY,
+        width,
+        [stack.leadingAnchor constraintGreaterThanOrEqualToAnchor:safe.leadingAnchor constant:32.0],
+        [stack.trailingAnchor constraintLessThanOrEqualToAnchor:safe.trailingAnchor constant:-32.0],
+        [stack.topAnchor constraintGreaterThanOrEqualToAnchor:safe.topAnchor constant:24.0],
+        [stack.bottomAnchor constraintLessThanOrEqualToAnchor:safe.bottomAnchor constant:-24.0],
+    ]];
+
+    return container;
 }
 
 #endif

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -14,6 +14,7 @@
 #import "ApolloImageUploadHost.h"
 #import "ApolloImgChestUpload.h"
 #import "ApolloNotificationBackend.h"
+#import "ApolloPushNotifications.h"
 #import "ApolloState.h"
 #import "Tweak.h"
 #import "CustomAPIViewController.h"
@@ -1195,6 +1196,34 @@ static NSURLRequest *ApolloLocalFastFailRequest(NSString *path) {
     if ([delegate respondsToSelector:@selector(requestDidFinish:)]) {
         [delegate requestDidFinish:self];
     }
+}
+%end
+
+// Sideloaded builds signed without a paid Apple Developer team never receive an
+// `aps-environment` entitlement, so -registerForRemoteNotifications always fails
+// with NSCocoaErrorDomain 3000 ("no valid 'aps-environment' entitlement string
+// found for application"). Apollo surfaces that raw error as an alarming
+// "Error Loading Notifications — contact developer" alert and aborts the whole
+// notifications flow, inbox watchers included.
+//
+// This is an expected, signing-time condition — not a runtime bug to report —
+// and the project already supports registration + watcher CRUD on free accounts
+// (push simply never arrives; see the README "Self-hosted notifications" note).
+// So, mirroring the SKReceiptRefreshRequest fake-success hook above, we convert
+// *only* this specific entitlement failure into a deterministic placeholder-token
+// success, letting Apollo's pending APNs continuations resolve and the screen
+// load. Genuine failures (offline, rate limiting, …) fall through to %orig and
+// keep their original error so real problems still surface.
+%hook _TtC6Apollo11AppDelegate
+- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+    if (ApolloErrorIsMissingPushEntitlement(error)) {
+        ApolloLog(@"[Push] Missing aps-environment entitlement (free-account sideload) — substituting a placeholder APNs token so notification setup proceeds. Push delivery still requires a paid Apple Developer account.");
+        // `self` is only forward-declared here, so route the success callback
+        // through the UIApplicationDelegate protocol the class conforms to.
+        [(id<UIApplicationDelegate>)self application:application didRegisterForRemoteNotificationsWithDeviceToken:ApolloPlaceholderAPNSDeviceToken()];
+        return;
+    }
+    %orig;
 }
 %end
 

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1200,30 +1200,76 @@ static NSURLRequest *ApolloLocalFastFailRequest(NSString *path) {
 %end
 
 // Sideloaded builds signed without a paid Apple Developer team never receive an
-// `aps-environment` entitlement, so -registerForRemoteNotifications always fails
-// with NSCocoaErrorDomain 3000 ("no valid 'aps-environment' entitlement string
-// found for application"). Apollo surfaces that raw error as an alarming
-// "Error Loading Notifications — contact developer" alert and aborts the whole
-// notifications flow, inbox watchers included.
+// `aps-environment` entitlement, so APNs registration always fails with
+// NSCocoaErrorDomain 3000 ("no valid 'aps-environment' entitlement string found
+// for application"). Apollo surfaces that raw error as an alarming "Error
+// Loading Notifications — contact developer" alert — telling users to contact a
+// developer about something no developer can fix at runtime.
 //
-// This is an expected, signing-time condition — not a runtime bug to report —
-// and the project already supports registration + watcher CRUD on free accounts
-// (push simply never arrives; see the README "Self-hosted notifications" note).
-// So, mirroring the SKReceiptRefreshRequest fake-success hook above, we convert
-// *only* this specific entitlement failure into a deterministic placeholder-token
-// success, letting Apollo's pending APNs continuations resolve and the screen
-// load. Genuine failures (offline, rate limiting, …) fall through to %orig and
-// keep their original error so real problems still surface.
+// Push, watchers, and inbox alerts genuinely can't be delivered without the
+// entitlement, so faking a successful registration would only mislead users
+// into thinking notifications work. Instead we (1) swallow *only* this specific,
+// unfixable error here so the scary alert never appears, and (2) replace the
+// Notifications settings screen with a clear explanation (see the
+// NotificationsViewController hook below). Genuine, transient failures (offline,
+// rate limiting, …) fall through to %orig and keep their original error so real
+// problems still surface.
 %hook _TtC6Apollo11AppDelegate
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
     if (ApolloErrorIsMissingPushEntitlement(error)) {
-        ApolloLog(@"[Push] Missing aps-environment entitlement (free-account sideload) — substituting a placeholder APNs token so notification setup proceeds. Push delivery still requires a paid Apple Developer account.");
-        // `self` is only forward-declared here, so route the success callback
-        // through the UIApplicationDelegate protocol the class conforms to.
-        [(id<UIApplicationDelegate>)self application:application didRegisterForRemoteNotificationsWithDeviceToken:ApolloPlaceholderAPNSDeviceToken()];
+        ApolloLog(@"[Push] Missing aps-environment entitlement (free-account sideload) — push can never be delivered on this build. Suppressing the misleading registration error; the Notifications screen explains why instead.");
         return;
     }
     %orig;
+}
+%end
+
+// On a build that can never receive push (a free-account sideload with no
+// `aps-environment` entitlement), Apollo's Notifications settings are a dead end:
+// every toggle ends in the suppressed registration error above, and nothing the
+// user enables can ever deliver. Showing the working-looking controls would give
+// folks false hope, so we replace the screen's contents with a clear,
+// non-interactive explanation. Builds that *can* receive push (a paid-account
+// sideload, or the App Store binary on a jailbreak) are detected via the
+// entitlement and left completely untouched.
+//
+// `_TtC6Apollo27NotificationsViewController` is only forward-declared here, so
+// the install logic lives in a C helper taking a plain UIViewController*.
+static void ApolloInstallNotificationsUnavailableOverlay(UIViewController *controller) {
+    if (ApolloPushNotificationsSupported()) {
+        return;
+    }
+    // 'APNU' — unique enough to find our overlay again without a second add.
+    static const NSInteger kApolloNotificationsUnavailableTag = 0x41504E55;
+    UIView *root = controller.view;
+    if (!root || [root viewWithTag:kApolloNotificationsUnavailableTag]) {
+        return;
+    }
+    UIView *overlay = ApolloMakeNotificationsUnavailableView();
+    if (!overlay) {
+        return;
+    }
+    overlay.tag = kApolloNotificationsUnavailableTag;
+    overlay.translatesAutoresizingMaskIntoConstraints = NO;
+    [root addSubview:overlay];
+    [root bringSubviewToFront:overlay];
+    [NSLayoutConstraint activateConstraints:@[
+        [overlay.topAnchor constraintEqualToAnchor:root.topAnchor],
+        [overlay.bottomAnchor constraintEqualToAnchor:root.bottomAnchor],
+        [overlay.leadingAnchor constraintEqualToAnchor:root.leadingAnchor],
+        [overlay.trailingAnchor constraintEqualToAnchor:root.trailingAnchor],
+    ]];
+    ApolloLog(@"[Push] No aps-environment entitlement on this signing — replacing the Notifications screen with the 'unavailable' explanation.");
+}
+
+%hook _TtC6Apollo27NotificationsViewController
+- (void)viewDidLoad {
+    %orig;
+    ApolloInstallNotificationsUnavailableOverlay((UIViewController *)self);
+}
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    ApolloInstallNotificationsUnavailableOverlay((UIViewController *)self);
 }
 %end
 

--- a/tests/push_notifications_manual_checklist.md
+++ b/tests/push_notifications_manual_checklist.md
@@ -1,22 +1,34 @@
 # Push Notification Sideload Manual Validation
 
 Push registration is device-only — it cannot be exercised in the iOS Simulator —
-so verify these on a **free-account sideloaded** device build (no paid Apple
-Developer team).
+so verify these on real builds.
 
-- Enable notifications on a watcher (e.g. a post or your inbox). Confirm the
-  flow completes **without** the "Error Loading Notifications — contact
-  developer" alert that quotes `no valid "aps-environment" entitlement string`.
-- Confirm the notifications/inbox screen loads and watcher CRUD (add, list,
-  delete) works as before. Actual push delivery is still expected **not** to
-  arrive on a free account — this fix only removes the misleading error and
-  unblocks setup.
+## Free-account sideload (no `aps-environment` entitlement)
+
+- Open **Settings → Notifications**. Confirm it shows the non-interactive
+  **"Notifications Unavailable"** screen (bell.slash icon + explanation) instead
+  of the live controls.
+- Confirm **no** "Error Loading Notifications — contact developer" alert appears
+  (the one that quotes `no valid "aps-environment" entitlement string`).
+- Confirm the explanatory screen swallows taps — nothing underneath can be
+  toggled — and that the navigation bar / back button still work.
 - Stream the tweak log (`scripts/run-in-sim.sh --logs` on device-equivalent
-  tooling, or Console.app) and confirm a single `[Push] Missing aps-environment
-  entitlement …` line appears when registration is attempted.
-- On a **paid** Apple Developer build (real `aps-environment` entitlement),
-  confirm registration succeeds normally and the placeholder path is never hit
-  (no `[Push] Missing aps-environment …` log line).
-- Force a genuine failure (e.g. airplane mode at registration time) and confirm
-  the original error handling still applies — the placeholder substitution must
-  only trigger for the entitlement error.
+  tooling, or Console.app). Confirm a `No aps-environment entitlement … replacing
+  the Notifications screen` line appears, and — if registration is attempted — a
+  single `Missing aps-environment entitlement … Suppressing the misleading
+  registration error` line (and **no** "contact developer" alert).
+
+## Paid Apple Developer sideload (real `aps-environment` entitlement)
+
+- Open **Settings → Notifications**. Confirm the **stock** notifications screen
+  appears unchanged (no "Notifications Unavailable" overlay) and registration
+  succeeds normally.
+- Confirm the suppression path is never hit (no `Missing aps-environment …` or
+  `replacing the Notifications screen` log lines).
+
+## Genuine failures are unaffected
+
+- Force a real registration failure (e.g. airplane mode at registration time on
+  a paid build) and confirm Apollo's original error handling still applies — the
+  entitlement-error suppression must trigger *only* for the missing-entitlement
+  case, never for transient failures.

--- a/tests/push_notifications_manual_checklist.md
+++ b/tests/push_notifications_manual_checklist.md
@@ -1,0 +1,22 @@
+# Push Notification Sideload Manual Validation
+
+Push registration is device-only — it cannot be exercised in the iOS Simulator —
+so verify these on a **free-account sideloaded** device build (no paid Apple
+Developer team).
+
+- Enable notifications on a watcher (e.g. a post or your inbox). Confirm the
+  flow completes **without** the "Error Loading Notifications — contact
+  developer" alert that quotes `no valid "aps-environment" entitlement string`.
+- Confirm the notifications/inbox screen loads and watcher CRUD (add, list,
+  delete) works as before. Actual push delivery is still expected **not** to
+  arrive on a free account — this fix only removes the misleading error and
+  unblocks setup.
+- Stream the tweak log (`scripts/run-in-sim.sh --logs` on device-equivalent
+  tooling, or Console.app) and confirm a single `[Push] Missing aps-environment
+  entitlement …` line appears when registration is attempted.
+- On a **paid** Apple Developer build (real `aps-environment` entitlement),
+  confirm registration succeeds normally and the placeholder path is never hit
+  (no `[Push] Missing aps-environment …` log line).
+- Force a genuine failure (e.g. airplane mode at registration time) and confirm
+  the original error handling still applies — the placeholder substitution must
+  only trigger for the entitlement error.

--- a/tests/push_notifications_tests.m
+++ b/tests/push_notifications_tests.m
@@ -2,7 +2,7 @@
 
 #import "ApolloPushNotifications.h"
 
-// Standalone unit tests for the pure push-registration helpers. Build & run with:
+// Standalone unit tests for the pure push-notification helpers. Build & run with:
 //
 //   clang -fobjc-arc -framework Foundation \
 //       -DAPOLLO_PUSH_NOTIFICATIONS_TESTING \
@@ -10,8 +10,9 @@
 //       src/ApolloPushNotifications.m tests/push_notifications_tests.m \
 //       -o /tmp/push_notifications_tests && /tmp/push_notifications_tests
 //
-// APOLLO_PUSH_NOTIFICATIONS_TESTING compiles out the UIKit-dependent convenience
-// wrapper, leaving only the pure, device-independent logic under test.
+// APOLLO_PUSH_NOTIFICATIONS_TESTING compiles out the UIKit/Security-dependent
+// pieces (the entitlement check and the "notifications unavailable" view),
+// leaving only the pure, device-independent error classification under test.
 
 static void Require(BOOL condition, NSString *message) {
     if (!condition) {
@@ -51,31 +52,12 @@ static void TestIgnoresTransientErrors(void) {
     Require(!ApolloErrorIsMissingPushEntitlement(nil), @"nil is not an entitlement error");
 }
 
-static void TestPlaceholderTokenIsDeterministicAndSized(void) {
-    NSData *a1 = ApolloPlaceholderAPNSDeviceTokenForSeed(@"vendor-id-A");
-    NSData *a2 = ApolloPlaceholderAPNSDeviceTokenForSeed(@"vendor-id-A");
-    NSData *b = ApolloPlaceholderAPNSDeviceTokenForSeed(@"vendor-id-B");
-
-    Require(a1.length == 32, @"token is 32 bytes (a 64-char hex APNs token)");
-    Require([a1 isEqualToData:a2], @"the same seed always yields the same token");
-    Require(![a1 isEqualToData:b], @"different seeds yield different tokens");
-}
-
-static void TestPlaceholderTokenHandlesEmptySeed(void) {
-    NSData *empty = ApolloPlaceholderAPNSDeviceTokenForSeed(@"");
-    NSData *nilSeed = ApolloPlaceholderAPNSDeviceTokenForSeed(nil);
-    Require(empty.length == 32, @"empty seed still yields a 32-byte token");
-    Require([empty isEqualToData:nilSeed], @"empty and nil seeds fall back to the same deterministic token");
-}
-
 int main(void) {
     @autoreleasepool {
         TestDetectsCanonicalEntitlementError();
         TestDetectsByDescriptionAcrossDomainChanges();
         TestDetectsWrappedUnderlyingError();
         TestIgnoresTransientErrors();
-        TestPlaceholderTokenIsDeterministicAndSized();
-        TestPlaceholderTokenHandlesEmptySeed();
         NSLog(@"push_notifications_tests passed");
     }
     return 0;

--- a/tests/push_notifications_tests.m
+++ b/tests/push_notifications_tests.m
@@ -1,0 +1,82 @@
+#import <Foundation/Foundation.h>
+
+#import "ApolloPushNotifications.h"
+
+// Standalone unit tests for the pure push-registration helpers. Build & run with:
+//
+//   clang -fobjc-arc -framework Foundation \
+//       -DAPOLLO_PUSH_NOTIFICATIONS_TESTING \
+//       -I src \
+//       src/ApolloPushNotifications.m tests/push_notifications_tests.m \
+//       -o /tmp/push_notifications_tests && /tmp/push_notifications_tests
+//
+// APOLLO_PUSH_NOTIFICATIONS_TESTING compiles out the UIKit-dependent convenience
+// wrapper, leaving only the pure, device-independent logic under test.
+
+static void Require(BOOL condition, NSString *message) {
+    if (!condition) {
+        @throw [NSException exceptionWithName:@"PushNotificationsTestFailure" reason:message userInfo:nil];
+    }
+}
+
+static void TestDetectsCanonicalEntitlementError(void) {
+    NSError *canonical = [NSError errorWithDomain:NSCocoaErrorDomain
+                                             code:3000
+                                         userInfo:@{NSLocalizedDescriptionKey: @"no valid \"aps-environment\" entitlement string found for application"}];
+    Require(ApolloErrorIsMissingPushEntitlement(canonical), @"NSCocoaErrorDomain/3000 is recognized");
+}
+
+static void TestDetectsByDescriptionAcrossDomainChanges(void) {
+    NSError *future = [NSError errorWithDomain:@"SomeFutureAPNSDomain"
+                                          code:42
+                                      userInfo:@{NSLocalizedDescriptionKey: @"No valid aps-environment entitlement string found"}];
+    Require(ApolloErrorIsMissingPushEntitlement(future), @"description fallback survives a domain/code change");
+}
+
+static void TestDetectsWrappedUnderlyingError(void) {
+    NSError *canonical = [NSError errorWithDomain:NSCocoaErrorDomain
+                                             code:3000
+                                         userInfo:@{NSLocalizedDescriptionKey: @"no valid aps-environment entitlement"}];
+    NSError *wrapped = [NSError errorWithDomain:@"OuterDomain"
+                                           code:1
+                                       userInfo:@{NSUnderlyingErrorKey: canonical}];
+    Require(ApolloErrorIsMissingPushEntitlement(wrapped), @"underlying entitlement error is detected");
+}
+
+static void TestIgnoresTransientErrors(void) {
+    NSError *offline = [NSError errorWithDomain:NSURLErrorDomain
+                                           code:NSURLErrorNotConnectedToInternet
+                                       userInfo:@{NSLocalizedDescriptionKey: @"The Internet connection appears to be offline."}];
+    Require(!ApolloErrorIsMissingPushEntitlement(offline), @"transient network failure is not misclassified");
+    Require(!ApolloErrorIsMissingPushEntitlement(nil), @"nil is not an entitlement error");
+}
+
+static void TestPlaceholderTokenIsDeterministicAndSized(void) {
+    NSData *a1 = ApolloPlaceholderAPNSDeviceTokenForSeed(@"vendor-id-A");
+    NSData *a2 = ApolloPlaceholderAPNSDeviceTokenForSeed(@"vendor-id-A");
+    NSData *b = ApolloPlaceholderAPNSDeviceTokenForSeed(@"vendor-id-B");
+
+    Require(a1.length == 32, @"token is 32 bytes (a 64-char hex APNs token)");
+    Require([a1 isEqualToData:a2], @"the same seed always yields the same token");
+    Require(![a1 isEqualToData:b], @"different seeds yield different tokens");
+}
+
+static void TestPlaceholderTokenHandlesEmptySeed(void) {
+    NSData *empty = ApolloPlaceholderAPNSDeviceTokenForSeed(@"");
+    NSData *nilSeed = ApolloPlaceholderAPNSDeviceTokenForSeed(nil);
+    Require(empty.length == 32, @"empty seed still yields a 32-byte token");
+    Require([empty isEqualToData:nilSeed], @"empty and nil seeds fall back to the same deterministic token");
+}
+
+int main(void) {
+    @autoreleasepool {
+        TestDetectsCanonicalEntitlementError();
+        TestDetectsByDescriptionAcrossDomainChanges();
+        TestDetectsWrappedUnderlyingError();
+        TestIgnoresTransientErrors();
+        TestPlaceholderTokenIsDeterministicAndSized();
+        TestPlaceholderTokenHandlesEmptySeed();
+        NSLog(@"push_notifications_tests passed");
+    }
+    return 0;
+}


### PR DESCRIPTION
## The problem

On a build sideloaded with a free Apple ID (no paid Apple Developer team), opening **Settings → Notifications** pops this alert and aborts the notifications flow:

<img width="1003" height="1998" alt="image" src="https://github.com/user-attachments/assets/a72ebe92-103b-4f70-a460-52468b68fde0" />


> **Error Loading Notifications**
> There was an error while loading notifications, please contact developer if this persists.
>
> Error log: `no valid "aps-environment" entitlement string found for application`

### Why it happens

APNs registration requires the `aps-environment` entitlement, which Apple only issues to a paid Apple Developer team and bakes in at signing time. A free-account sideload can never obtain it at runtime, so iOS calls `-application:didFailToRegisterForRemoteNotificationsWithError:` with the permanent `NSCocoaErrorDomain` code `3000`. Apollo surfaces that raw error through its generic "contact developer" UI, so an unavoidable signing limitation reads like an app bug pointing users at a developer for something no developer can fix.

## The approach

Push genuinely can't work on these builds, so rather than suppress the error and let the flow look like it succeeded (which would give users false hope), this detects the limitation up front and explains it.

- **Detect, don't guess.** `ApolloPushNotificationsSupported()` reads the running process's own `aps-environment` entitlement via `SecTaskCopyValueForEntitlement`. Builds that can actually receive push — paid-account sideloads, or the App Store binary on a jailbreak — are detected and left completely untouched.
- **Explain instead of erroring.** When the entitlement is absent, a `%hook` on `_TtC6Apollo27NotificationsViewController` overlays an opaque, non-interactive **"Notifications Unavailable"** view that says why notifications can't work and what to do about it. There's nothing misleading to toggle.
- **Only the unfixable error is suppressed.** The `_TtC6Apollo11AppDelegate` hook swallows the specific missing-entitlement failure so the scary alert never shows. Genuine, transient failures (offline, rate limiting, …) fall through to `%orig` and keep their original handling.

### Why this is better than leaving the popup

- It triggers only for builds that genuinely can't receive push, so working configurations are unaffected.
- Users get an explanation and a next step (install a paid-signed build) instead of a generic error that reads like a bug.
- It catches the case before they start toggling, so nobody is left wondering whether they did something wrong.
- It cuts the support churn from people reporting the "contact developer" error for what is really an Apple signing limitation.
- Real errors still surface, so no genuine failure reporting is lost.

## What's in here

- `src/ApolloPushNotifications.{h,m}` — `ApolloPushNotificationsSupported()` (entitlement check), `ApolloErrorIsMissingPushEntitlement()` (the one error to swallow, with a defensive fallback on the `aps-environment` string and nested errors), and `ApolloMakeNotificationsUnavailableView()` (the explanatory view, built with system semantic colors / Dynamic Type so it follows Apollo's theme).
- `src/Tweak.xm` — thin hooks next to the related StoreKit sideload fix; all the logic lives in the helper.
- `tests/push_notifications_tests.m` — standalone unit tests for the pure error-classification logic.
- `tests/push_notifications_manual_checklist.md` — device steps (push registration is device-only and can't be exercised in the Simulator).
- `README.md` / `CHANGELOG.md` — notes documenting the behavior.

## The new screen (free-account sideload)

![Notifications Unavailable screen](https://raw.githubusercontent.com/federgilad/Apollo-Reborn/assets-pr492/notifications-unavailable.png)

## Testing

- Unit tests pass:
  ```
  clang -fobjc-arc -framework Foundation -DAPOLLO_PUSH_NOTIFICATIONS_TESTING \
      -I src src/ApolloPushNotifications.m tests/push_notifications_tests.m \
      -o /tmp/push_notifications_tests && /tmp/push_notifications_tests
  # → push_notifications_tests passed
  ```
- Tweak compiles, links, and signs cleanly (simulator build:
  `make TARGET=simulator:clang:latest:14.0 LOGOS_DEFAULT_GENERATOR=internal APOLLO_SIM_BUILD=1`).
- ⚠️ Push registration is device-only and can't be verified in the Simulator. Steps for a free vs. paid build are in `tests/push_notifications_manual_checklist.md`.
