### PR TITLE
Upload inline images to Reddit in keyless Web JSON mode (cookie + modhash)

### DIFF
--- a/src/ApolloImageUploadHost.xm
+++ b/src/ApolloImageUploadHost.xm
@@ -2652,12 +2652,12 @@ static void ApolloLogUnhandledImgurUploadRequestOnce(NSURLRequest *request, NSSt
 // Keyless Web JSON mode + Imgur upload provider + no Imgur API key configured =
 // the Imgur upload will fail with a generic error. Surface a clear, actionable
 // message once per launch instead, telling the user how to make uploads work.
-// Shown once when an image upload is attempted in a keyless Web JSON session with
-// no Imgur key. Native Reddit upload can't work here — its media lease
-// (www.reddit.com/api/media/asset.json) requires a real OAuth bearer and 403s for
-// cookie auth — so Imgur is the only path, and it needs an Imgur API key. The
-// message must NOT suggest switching the provider to Reddit (that doesn't upload
-// keylessly), which the earlier copy incorrectly advised.
+// Shown once when an upload in a keyless Web JSON session can't use the Reddit
+// cookie path and there's no Imgur key to fall back to. Inline IMAGE uploads now
+// go to Reddit via the cookie + modhash web lease (image_upload_s3.json — see
+// ApolloShouldUseCookieRedditUpload), but videos (and the rare read-only session
+// with no modhash) still need Imgur, which requires an Imgur API key. The message
+// must NOT suggest switching the provider to Reddit — that's automatic for images.
 static void ApolloWarnKeylessUploadUnavailableOnce(void) {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -2670,8 +2670,8 @@ static void ApolloWarnKeylessUploadUnavailableOnce(void) {
             }
             if (!top) return;
             UIAlertController *alert = [UIAlertController
-                alertControllerWithTitle:@"Image Upload Needs an Imgur Key"
-                                 message:@"You're signed in without API keys. Reddit's image-upload API requires an API key, so it isn't available in Web JSON Mode — Apollo uploads images via Imgur instead, which needs an Imgur API key. Add one under Settings → Apollo to upload images."
+                alertControllerWithTitle:@"This Upload Needs an Imgur Key"
+                                 message:@"In Web JSON Mode, Apollo uploads images straight to Reddit — but videos go through Imgur, which needs an Imgur API key. Add one under Settings → Apollo to upload videos, or attach an image instead."
                           preferredStyle:UIAlertControllerStyleAlert];
             [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
             [top presentViewController:alert animated:YES completion:nil];
@@ -2692,6 +2692,25 @@ static NSString *ApolloRedditUploadBearerToken(void) {
     return nil;
 }
 
+// Whether a keyless Web JSON image upload should go to Reddit via the cookie +
+// modhash web lease (image_upload_s3.json — Hydra's path) instead of falling back
+// to Imgur. True only when: it's an Imgur-host upload request, there's no real
+// bearer (just the synthetic placeholder), a usable cookie session WITH a modhash
+// exists (writes need the modhash), and it's an image. The web lease is image-only,
+// so we bail on a video Content-Type; and a native-video post enters this hook with
+// a poster-image body (the video file is swapped in downstream), so we also bail
+// when a video upload context is/was in flight. Videos keep falling back to Imgur.
+static BOOL ApolloShouldUseCookieRedditUpload(NSURLRequest *request) {
+    if (!ApolloIsImgurImageUploadRequest(request)) return NO;
+    if (![ApolloRedditUploadBearerToken() isEqualToString:ApolloWebJSONSyntheticBearerToken]) return NO;
+    if (!ApolloWebJSONHasUsableSession()) return NO;
+    if (sWebSessionModhash.length == 0) return NO;
+    NSString *mimeType = ApolloMediaMIMETypeForFilename(nil, [request valueForHTTPHeaderField:@"Content-Type"]);
+    if (ApolloMediaMIMETypeIsVideo(mimeType)) return NO;
+    if (ApolloMediaComposerRecentlyHadSelectedVideoContextForUpload()) return NO;
+    return YES;
+}
+
 static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *mediaFileURL, NSString *filename, NSString *mimeType,
                                                   NSData *videoPosterData, NSDictionary *videoContext, NSURL *originalURL, ApolloRedditNativeUploadAttempt *attempt,
                                                   void (^completionHandler)(NSData *, NSURLResponse *, NSError *)) {
@@ -2704,6 +2723,9 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
     // "All media assets must be owned by the submitter of this post".
     NSString *composeToken = ApolloMediaComposerActivePostingBearerToken();
     NSString *token = ApolloRedditUploadBearerToken();
+    // Keyless Web JSON: no real bearer (just the synthetic placeholder), so the
+    // lease goes to the old-reddit web endpoint with cookie + modhash instead.
+    BOOL cookieMode = [token isEqualToString:ApolloWebJSONSyntheticBearerToken];
     if (composeToken.length > 0 && ![composeToken isEqualToString:sLatestRedditBearerToken]) {
         ApolloLog(@"[RedditUpload] Using temporary posting account token for upload (differs from last captured Reddit token)");
     } else if ([token isEqualToString:ApolloWebJSONSyntheticBearerToken]) {
@@ -2719,7 +2741,9 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
     ApolloUpdateActiveUploadAlertProgress(0.0);
     ApolloRedditMediaUploadCompletion mediaCompletion = ^(NSURL *mediaURL, NSString *assetID, NSString *webSocketURL, NSError *error) {
         if (ApolloRedditNativeUploadAttemptIsCancelled(attempt, @"media-upload-completion")) return;
-        if (error || !mediaURL || assetID.length == 0) {
+        // Cookie uploads (image_upload_s3.json) never return an asset_id — the S3
+        // <Location> URL is the whole payload — so only require it off the cookie path.
+        if (error || !mediaURL || (!cookieMode && assetID.length == 0)) {
             ApolloLog(@"[RedditUpload] Upload failed: %@", error.localizedDescription);
             if (videoContext) ApolloMediaComposerCompleteVideoUploadContext(videoContext, YES, @"media-upload-error");
             completionHandler(nil, nil, error ?: [NSError errorWithDomain:@"ApolloRedditMediaUpload" code:50
@@ -2795,9 +2819,13 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
         completeSyntheticUpload();
     };
     if (mediaFileURL) {
-        attempt.mediaOperation = ApolloUploadMediaFileToRedditCancellable(mediaFileURL, filename, mimeType, token, userAgent, progressHandler, mediaCompletion);
+        attempt.mediaOperation = cookieMode
+            ? ApolloUploadMediaFileToRedditViaCookieCancellable(mediaFileURL, filename, mimeType, sWebSessionCookieHeader, sWebSessionModhash, userAgent, progressHandler, mediaCompletion)
+            : ApolloUploadMediaFileToRedditCancellable(mediaFileURL, filename, mimeType, token, userAgent, progressHandler, mediaCompletion);
     } else {
-        attempt.mediaOperation = ApolloUploadMediaDataToRedditCancellable(mediaData, filename, mimeType, token, userAgent, progressHandler, mediaCompletion);
+        attempt.mediaOperation = cookieMode
+            ? ApolloUploadMediaDataToRedditViaCookieCancellable(mediaData, filename, mimeType, sWebSessionCookieHeader, sWebSessionModhash, userAgent, progressHandler, mediaCompletion)
+            : ApolloUploadMediaDataToRedditCancellable(mediaData, filename, mimeType, token, userAgent, progressHandler, mediaCompletion);
     }
 }
 
@@ -2859,17 +2887,22 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
         return %orig(ApolloRedditUploadFastFailRequest(), bodyData ?: [NSData data], chestWrapped);
     }
 
-    // Keyless Web JSON session: there's no real OAuth bearer (only the synthetic
-    // placeholder), and Reddit's media lease (asset.json) 403s for cookie auth, so
-    // native Reddit upload can't work regardless of the provider setting. Fall back
-    // to Apollo's default Imgur path instead of attempting the doomed lease; if no
-    // Imgur key is configured either, warn once with accurate guidance.
+    // Keyless Web JSON session (no real OAuth bearer, just the synthetic
+    // placeholder). Inline IMAGE uploads now go to Reddit via the cookie + modhash
+    // web lease (image_upload_s3.json — see ApolloShouldUseCookieRedditUpload); the
+    // native-upload path below drives it when cookieMode is set, overriding the
+    // (default-Imgur) provider since a cookie-signed-in user's images belong on
+    // Reddit. ImgChest with its own key already returned above. For anything the
+    // web lease can't take — a video, or a read-only session with no modhash — fall
+    // back to Apollo's Imgur path and warn once if no Imgur key is set either.
+    BOOL cookieUpload = ApolloShouldUseCookieRedditUpload(request);
     if (ApolloIsImgurImageUploadRequest(request)
-        && [ApolloRedditUploadBearerToken() isEqualToString:ApolloWebJSONSyntheticBearerToken]) {
+        && [ApolloRedditUploadBearerToken() isEqualToString:ApolloWebJSONSyntheticBearerToken]
+        && !cookieUpload) {
         if (sImgurClientId.length == 0) ApolloWarnKeylessUploadUnavailableOnce();
         return %orig;
     }
-    if (sImageUploadProvider != ImageUploadProviderReddit || !completionHandler || !ApolloIsImgurImageUploadRequest(request)) {
+    if ((sImageUploadProvider != ImageUploadProviderReddit && !cookieUpload) || !completionHandler || !ApolloIsImgurImageUploadRequest(request)) {
         if (sImageUploadProvider == ImageUploadProviderReddit && completionHandler) ApolloLogUnhandledImgurUploadRequestOnce(request, @"fromData");
         return %orig;
     }
@@ -2980,15 +3013,19 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
         return %orig(ApolloRedditUploadFastFailRequest(), fileURL, chestWrapped);
     }
 
-    // See the fromData: hook — keyless Web JSON sessions can't do native Reddit
-    // upload (asset.json 403s for cookie auth), so fall back to Apollo's Imgur path
-    // and warn once when no Imgur key is set, rather than attempting the lease.
+    // See the fromData: hook. Keyless Web JSON image uploads go to Reddit via the
+    // cookie + modhash web lease (image_upload_s3.json); the native-upload path
+    // below drives it when cookieMode is set. Videos / read-only sessions (no
+    // modhash) can't take that path, so they fall back to Imgur (warn once if no
+    // Imgur key). ImgChest with its own key already returned above.
+    BOOL cookieUpload = ApolloShouldUseCookieRedditUpload(request);
     if (ApolloIsImgurImageUploadRequest(request)
-        && [ApolloRedditUploadBearerToken() isEqualToString:ApolloWebJSONSyntheticBearerToken]) {
+        && [ApolloRedditUploadBearerToken() isEqualToString:ApolloWebJSONSyntheticBearerToken]
+        && !cookieUpload) {
         if (sImgurClientId.length == 0) ApolloWarnKeylessUploadUnavailableOnce();
         return %orig;
     }
-    if (sImageUploadProvider != ImageUploadProviderReddit || !completionHandler || !ApolloIsImgurImageUploadRequest(request)) {
+    if ((sImageUploadProvider != ImageUploadProviderReddit && !cookieUpload) || !completionHandler || !ApolloIsImgurImageUploadRequest(request)) {
         if (sImageUploadProvider == ImageUploadProviderReddit && completionHandler) ApolloLogUnhandledImgurUploadRequestOnce(request, @"fromFile");
         return %orig;
     }

--- a/src/ApolloRedditMediaUpload.h
+++ b/src/ApolloRedditMediaUpload.h
@@ -36,6 +36,27 @@ ApolloRedditMediaUploadOperation *ApolloUploadMediaFileToRedditCancellable(NSURL
                                                                            NSString *userAgent,
                                                                            ApolloRedditMediaUploadProgress progressHandler,
                                                                            ApolloRedditMediaUploadCompletion completion);
+// Keyless (Web JSON) variants: upload an image to Reddit using a harvested web
+// session cookie + modhash instead of an OAuth bearer (POST www.reddit.com/api/
+// image_upload_s3.json — Hydra's path). The completion's assetID/webSocketURL are
+// always nil (the web lease returns none); the mediaURL is the real S3 Location.
+// Image MIME types only.
+ApolloRedditMediaUploadOperation *ApolloUploadMediaDataToRedditViaCookieCancellable(NSData *mediaData,
+                                                                                    NSString *filename,
+                                                                                    NSString *mimeType,
+                                                                                    NSString *cookieHeader,
+                                                                                    NSString *modhash,
+                                                                                    NSString *userAgent,
+                                                                                    ApolloRedditMediaUploadProgress progressHandler,
+                                                                                    ApolloRedditMediaUploadCompletion completion);
+ApolloRedditMediaUploadOperation *ApolloUploadMediaFileToRedditViaCookieCancellable(NSURL *mediaFileURL,
+                                                                                    NSString *filename,
+                                                                                    NSString *mimeType,
+                                                                                    NSString *cookieHeader,
+                                                                                    NSString *modhash,
+                                                                                    NSString *userAgent,
+                                                                                    ApolloRedditMediaUploadProgress progressHandler,
+                                                                                    ApolloRedditMediaUploadCompletion completion);
 void ApolloUploadMediaDataToReddit(NSData *mediaData,
                                    NSString *filename,
                                    NSString *mimeType,

--- a/src/ApolloRedditMediaUpload.m
+++ b/src/ApolloRedditMediaUpload.m
@@ -1,5 +1,6 @@
 #import "ApolloRedditMediaUpload.h"
 #import "ApolloCommon.h"
+#import "ApolloWebJSON.h"
 
 #import <objc/runtime.h>
 
@@ -403,6 +404,84 @@ NSData *ApolloSyntheticImgurUploadResponseData(NSURL *mediaURL, NSString *mimeTy
     return [NSJSONSerialization dataWithJSONObject:syntheticResponse options:0 error:nil];
 }
 
+// Shared second half of a Reddit media upload: POST the file (plus the lease's
+// returned form fields) to the S3 endpoint the lease handed back, then parse the
+// <Location> URL out of the S3 XML response and report it. assetID/webSocketURL
+// are passed straight through to `completion` — the oauth lease supplies them; the
+// keyless cookie lease (image_upload_s3.json) has none and passes nil. They're
+// never needed to perform the upload itself, so nil is safe.
+static void ApolloPerformRedditMediaS3Upload(NSURL *actionURL,
+                                             NSDictionary<NSString *, NSString *> *fields,
+                                             NSData *mediaData,
+                                             NSURL *mediaFileURL,
+                                             NSString *filename,
+                                             NSString *mimeType,
+                                             NSString *assetID,
+                                             NSString *webSocketURL,
+                                             ApolloRedditMediaUploadOperation *operation,
+                                             ApolloRedditMediaUploadCompletion completion) {
+    if (operation.cancelled) {
+        completion(nil, nil, nil, ApolloRedditUploadCancelledError());
+        return;
+    }
+
+    NSString *s3Boundary = ApolloBoundary();
+    NSMutableURLRequest *s3Request = [NSMutableURLRequest requestWithURL:actionURL];
+    s3Request.HTTPMethod = @"POST";
+    [s3Request setValue:[@"multipart/form-data; boundary=" stringByAppendingString:s3Boundary] forHTTPHeaderField:@"Content-Type"];
+    NSError *bodyFileError = nil;
+    unsigned long long s3BodyLength = 0;
+    NSURL *s3BodyURL = ApolloMultipartBodyFileForFields(fields, mediaData, mediaFileURL, filename, mimeType, s3Boundary, &s3BodyLength, &bodyFileError);
+    if (!s3BodyURL) {
+        completion(nil, assetID, webSocketURL, bodyFileError ?: ApolloRedditUploadError(47, @"Could not prepare Reddit media storage upload"));
+        return;
+    }
+    [s3Request setValue:[NSString stringWithFormat:@"%llu", s3BodyLength] forHTTPHeaderField:@"Content-Length"];
+
+    ApolloLog(@"[RedditUpload] Uploading %@ to Reddit media storage", filename);
+
+    __block NSURLSessionUploadTask *s3Task = nil;
+    s3Task = [ApolloRedditMediaUploadProgressSession() uploadTaskWithRequest:s3Request fromFile:s3BodyURL completionHandler:^(NSData *s3Data, NSURLResponse *s3Response, NSError *s3Error) {
+        [[NSFileManager defaultManager] removeItemAtURL:s3BodyURL error:nil];
+        objc_setAssociatedObject(s3Task, &kApolloRedditMediaUploadProgressOperationKey, nil, OBJC_ASSOCIATION_ASSIGN);
+        [operation apolloClearStorageTask:s3Task];
+        if (operation.cancelled) {
+            completion(nil, nil, nil, ApolloRedditUploadCancelledError());
+            return;
+        }
+        if (s3Error) {
+            completion(nil, assetID, webSocketURL, s3Error);
+            return;
+        }
+
+        NSInteger s3StatusCode = [(NSHTTPURLResponse *)s3Response statusCode];
+        if (![s3Response isKindOfClass:[NSHTTPURLResponse class]] || s3StatusCode < 200 || s3StatusCode >= 300 || s3Data.length == 0) {
+            completion(nil, assetID, webSocketURL, ApolloRedditUploadError(s3StatusCode ?: 30, @"Reddit media storage upload failed"));
+            return;
+        }
+
+        NSError *xmlError = nil;
+        NSURL *imageURL = ApolloLocationURLFromS3Response(s3Data, &xmlError);
+        if (!imageURL) {
+            completion(nil, assetID, webSocketURL, xmlError);
+            return;
+        }
+
+        ApolloLog(@"[RedditUpload] Uploaded media: %@ assetID=%@", imageURL.absoluteString, assetID ?: @"(none)");
+        ApolloRedditMediaUploadProgress handler = operation.progressHandler;
+        if (handler) handler(1.0, (int64_t)s3BodyLength, (int64_t)s3BodyLength);
+        completion(imageURL, assetID, webSocketURL, nil);
+    }];
+    objc_setAssociatedObject(s3Task, &kApolloRedditMediaUploadProgressOperationKey, operation, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (![operation apolloSetStorageTask:s3Task]) {
+        objc_setAssociatedObject(s3Task, &kApolloRedditMediaUploadProgressOperationKey, nil, OBJC_ASSOCIATION_ASSIGN);
+        [[NSFileManager defaultManager] removeItemAtURL:s3BodyURL error:nil];
+        completion(nil, nil, nil, ApolloRedditUploadCancelledError());
+        return;
+    }
+    [s3Task resume];
+}
+
 static void ApolloRequestRedditMediaAsset(NSData *mediaData,
                                           NSURL *mediaFileURL,
                                           NSString *filename,
@@ -489,66 +568,131 @@ static void ApolloRequestRedditMediaAsset(NSData *mediaData,
             return;
         }
 
+        ApolloPerformRedditMediaS3Upload(actionURL, fields, mediaData, mediaFileURL, filename, mimeType, assetID, webSocketURL, operation, completion);
+    }];
+    if (![operation apolloSetAssetTask:task]) {
+        completion(nil, nil, nil, ApolloRedditUploadCancelledError());
+        return;
+    }
+    [task resume];
+}
+
+// Percent-encode a value for an application/x-www-form-urlencoded body. Encodes
+// everything outside the RFC 3986 unreserved set (so "/" in a MIME type and any
+// odd filename characters are escaped).
+static NSString *ApolloFormURLEncode(NSString *value) {
+    NSMutableCharacterSet *allowed = [NSMutableCharacterSet alphanumericCharacterSet];
+    [allowed addCharactersInString:@"-._~"];
+    return [value stringByAddingPercentEncodingWithAllowedCharacters:allowed] ?: @"";
+}
+
+// Keyless lease variant: instead of the oauth media/asset.json lease (which needs
+// a real Bearer and 403s for cookie auth), POST the old-reddit web lease
+// www.reddit.com/api/image_upload_s3.json with cookie + X-Modhash. This is
+// Hydra's proven keyless upload path. Reddit returns the FLAT {action, fields}
+// S3-presigned shape (no asset/asset_id/websocket_url), so the completion's
+// assetID/webSocketURL are always nil — the S3 <Location> URL is the whole
+// payload. Image only (the endpoint doesn't take video).
+static void ApolloRequestRedditMediaAssetViaCookie(NSData *mediaData,
+                                                   NSURL *mediaFileURL,
+                                                   NSString *filename,
+                                                   NSString *mimeType,
+                                                   NSString *cookieHeader,
+                                                   NSString *modhash,
+                                                   NSString *userAgent,
+                                                   ApolloRedditMediaUploadOperation *operation,
+                                                   ApolloRedditMediaUploadCompletion completion) {
+    if (operation.cancelled) {
+        completion(nil, nil, nil, ApolloRedditUploadCancelledError());
+        return;
+    }
+
+    NSURL *url = [NSURL URLWithString:@"https://www.reddit.com/api/image_upload_s3.json"];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+    request.HTTPMethod = @"POST";
+    [request setValue:cookieHeader forHTTPHeaderField:@"Cookie"];
+    if (modhash.length > 0) [request setValue:modhash forHTTPHeaderField:@"X-Modhash"];
+    [request setValue:userAgent forHTTPHeaderField:@"User-Agent"];
+    [request setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+    // Tag so the Web JSON chokepoint (Tweak.xm) leaves this request untouched — we
+    // set the Cookie header ourselves; re-pointing or counting it would be circular.
+    [request setValue:@"1" forHTTPHeaderField:ApolloWebJSONProbeHeader];
+    // Don't let a session cookie jar override the header we just set.
+    request.HTTPShouldHandleCookies = NO;
+    NSString *body = [NSString stringWithFormat:@"filepath=%@&mimetype=%@&raw_json=1",
+                      ApolloFormURLEncode(filename), ApolloFormURLEncode(mimeType)];
+    request.HTTPBody = [body dataUsingEncoding:NSUTF8StringEncoding];
+
+    unsigned long long mediaLength = mediaFileURL ? ApolloFileSizeForURL(mediaFileURL) : (unsigned long long)mediaData.length;
+    ApolloLog(@"[RedditUpload] Requesting keyless web media lease for %@ (%@, %@ bytes)", filename, mimeType, @(mediaLength));
+
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (operation.cancelled) {
             completion(nil, nil, nil, ApolloRedditUploadCancelledError());
             return;
         }
-
-        NSString *s3Boundary = ApolloBoundary();
-        NSMutableURLRequest *s3Request = [NSMutableURLRequest requestWithURL:actionURL];
-        s3Request.HTTPMethod = @"POST";
-        [s3Request setValue:[@"multipart/form-data; boundary=" stringByAppendingString:s3Boundary] forHTTPHeaderField:@"Content-Type"];
-        NSError *bodyFileError = nil;
-        unsigned long long s3BodyLength = 0;
-        NSURL *s3BodyURL = ApolloMultipartBodyFileForFields(fields, mediaData, mediaFileURL, filename, mimeType, s3Boundary, &s3BodyLength, &bodyFileError);
-        if (!s3BodyURL) {
-            completion(nil, assetID, webSocketURL, bodyFileError ?: ApolloRedditUploadError(47, @"Could not prepare Reddit media storage upload"));
+        if (error) {
+            completion(nil, nil, nil, error);
             return;
         }
-        [s3Request setValue:[NSString stringWithFormat:@"%llu", s3BodyLength] forHTTPHeaderField:@"Content-Length"];
 
-        ApolloLog(@"[RedditUpload] Uploading %@ to Reddit media storage", filename);
+        NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
+        NSInteger statusCode = http.statusCode;
 
-        __block NSURLSessionUploadTask *s3Task = nil;
-        s3Task = [ApolloRedditMediaUploadProgressSession() uploadTaskWithRequest:s3Request fromFile:s3BodyURL completionHandler:^(NSData *s3Data, NSURLResponse *s3Response, NSError *s3Error) {
-            [[NSFileManager defaultManager] removeItemAtURL:s3BodyURL error:nil];
-            objc_setAssociatedObject(s3Task, &kApolloRedditMediaUploadProgressOperationKey, nil, OBJC_ASSOCIATION_ASSIGN);
-            [operation apolloClearStorageTask:s3Task];
-            if (operation.cancelled) {
-                completion(nil, nil, nil, ApolloRedditUploadCancelledError());
-                return;
-            }
-            if (s3Error) {
-                completion(nil, assetID, webSocketURL, s3Error);
-                return;
-            }
-
-            NSInteger s3StatusCode = [(NSHTTPURLResponse *)s3Response statusCode];
-            if (![s3Response isKindOfClass:[NSHTTPURLResponse class]] || s3StatusCode < 200 || s3StatusCode >= 300 || s3Data.length == 0) {
-                completion(nil, assetID, webSocketURL, ApolloRedditUploadError(s3StatusCode ?: 30, @"Reddit media storage upload failed"));
-                return;
-            }
-
-            NSError *xmlError = nil;
-            NSURL *imageURL = ApolloLocationURLFromS3Response(s3Data, &xmlError);
-            if (!imageURL) {
-                completion(nil, assetID, webSocketURL, xmlError);
-                return;
-            }
-
-            ApolloLog(@"[RedditUpload] Uploaded media: %@ assetID=%@", imageURL.absoluteString, assetID);
-            ApolloRedditMediaUploadProgress handler = operation.progressHandler;
-            if (handler) handler(1.0, (int64_t)s3BodyLength, (int64_t)s3BodyLength);
-            completion(imageURL, assetID, webSocketURL, nil);
-        }];
-        objc_setAssociatedObject(s3Task, &kApolloRedditMediaUploadProgressOperationKey, operation, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        if (![operation apolloSetStorageTask:s3Task]) {
-            objc_setAssociatedObject(s3Task, &kApolloRedditMediaUploadProgressOperationKey, nil, OBJC_ASSOCIATION_ASSIGN);
-            [[NSFileManager defaultManager] removeItemAtURL:s3BodyURL error:nil];
-            completion(nil, nil, nil, ApolloRedditUploadCancelledError());
+        // Expired/revoked cookie → Reddit serves its 403 text/html block page.
+        // Surface the same "session expired" prompt the chokepoint observer would
+        // (this request carries the probe header, so it bypasses that observer).
+        NSString *contentType = [[http.allHeaderFields[@"Content-Type"] description] lowercaseString] ?: @"";
+        if (statusCode == 403 && [contentType containsString:@"text/html"]) {
+            ApolloLog(@"[RedditUpload] Keyless web media lease got a 403 HTML block page — session likely expired");
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [[NSNotificationCenter defaultCenter] postNotificationName:ApolloWebJSONSessionExpiredNotification object:nil];
+            });
+            completion(nil, nil, nil, ApolloRedditUploadError(403, @"Reddit web session expired — sign in again"));
             return;
         }
-        [s3Task resume];
+
+        if (!http || statusCode < 200 || statusCode >= 300 || data.length == 0) {
+            completion(nil, nil, nil, ApolloRedditUploadError(statusCode ?: 20, @"Reddit did not provide upload fields"));
+            return;
+        }
+
+        NSError *jsonError = nil;
+        NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
+        if (![json isKindOfClass:[NSDictionary class]]) {
+            completion(nil, nil, nil, jsonError ?: ApolloRedditUploadError(21, @"Reddit upload field response was not JSON"));
+            return;
+        }
+
+        // Flat shape: action + fields live at the top level (no args/asset wrapper).
+        NSString *action = [json[@"action"] isKindOfClass:[NSString class]] ? json[@"action"] : nil;
+        NSArray *fieldArray = [json[@"fields"] isKindOfClass:[NSArray class]] ? json[@"fields"] : nil;
+        if (action.length == 0 || fieldArray.count == 0) {
+            completion(nil, nil, nil, ApolloRedditUploadError(22, @"Reddit upload field response was incomplete"));
+            return;
+        }
+
+        NSMutableDictionary<NSString *, NSString *> *fields = [NSMutableDictionary dictionary];
+        for (id item in fieldArray) {
+            if (![item isKindOfClass:[NSDictionary class]]) continue;
+            NSString *name = [item[@"name"] isKindOfClass:[NSString class]] ? item[@"name"] : nil;
+            NSString *value = [item[@"value"] isKindOfClass:[NSString class]] ? item[@"value"] : nil;
+            if (name.length > 0 && value) fields[name] = value;
+        }
+        if (fields.count == 0) {
+            completion(nil, nil, nil, ApolloRedditUploadError(23, @"Reddit upload field response had no usable fields"));
+            return;
+        }
+
+        NSString *actionURLString = [action hasPrefix:@"//"] ? [@"https:" stringByAppendingString:action] : action;
+        NSURL *actionURL = [NSURL URLWithString:actionURLString];
+        if (!actionURL) {
+            completion(nil, nil, nil, ApolloRedditUploadError(24, @"Reddit upload field response had an invalid upload URL"));
+            return;
+        }
+
+        // No asset_id/websocket from the web lease — pass nil for both.
+        ApolloPerformRedditMediaS3Upload(actionURL, fields, mediaData, mediaFileURL, filename, mimeType, nil, nil, operation, completion);
     }];
     if (![operation apolloSetAssetTask:task]) {
         completion(nil, nil, nil, ApolloRedditUploadCancelledError());
@@ -609,6 +753,63 @@ ApolloRedditMediaUploadOperation *ApolloUploadMediaFileToRedditCancellable(NSURL
     NSString *resolvedUserAgent = userAgent.length > 0 ? userAgent : @"Apollo-Reborn/RedditMediaUpload";
 
     ApolloRequestRedditMediaAsset(nil, mediaFileURL, resolvedFilename, resolvedMIMEType, bearerToken, resolvedUserAgent, operation, safeCompletion);
+    return operation;
+}
+
+ApolloRedditMediaUploadOperation *ApolloUploadMediaDataToRedditViaCookieCancellable(NSData *mediaData,
+                                                                                    NSString *filename,
+                                                                                    NSString *mimeType,
+                                                                                    NSString *cookieHeader,
+                                                                                    NSString *modhash,
+                                                                                    NSString *userAgent,
+                                                                                    ApolloRedditMediaUploadProgress progressHandler,
+                                                                                    ApolloRedditMediaUploadCompletion completion) {
+    ApolloRedditMediaUploadOperation *operation = [ApolloRedditMediaUploadOperation new];
+    operation.progressHandler = progressHandler;
+    ApolloRedditMediaUploadCompletion safeCompletion = completion ?: ^(__unused NSURL *mediaURL, __unused NSString *assetID, __unused NSString *webSocketURL, __unused NSError *error) {};
+    if (mediaData.length == 0) {
+        safeCompletion(nil, nil, nil, ApolloRedditUploadError(1, @"Media data was empty"));
+        return operation;
+    }
+    if (cookieHeader.length == 0) {
+        safeCompletion(nil, nil, nil, ApolloRedditUploadError(2, @"No Reddit web session cookie available"));
+        return operation;
+    }
+
+    NSString *resolvedMIMEType = ApolloMediaMIMETypeForFilename(filename, mimeType);
+    NSString *resolvedFilename = ApolloNormalizedFilename(filename, resolvedMIMEType);
+    NSString *resolvedUserAgent = userAgent.length > 0 ? userAgent : @"Apollo-Reborn/RedditMediaUpload";
+
+    ApolloRequestRedditMediaAssetViaCookie(mediaData, nil, resolvedFilename, resolvedMIMEType, cookieHeader, modhash, resolvedUserAgent, operation, safeCompletion);
+    return operation;
+}
+
+ApolloRedditMediaUploadOperation *ApolloUploadMediaFileToRedditViaCookieCancellable(NSURL *mediaFileURL,
+                                                                                    NSString *filename,
+                                                                                    NSString *mimeType,
+                                                                                    NSString *cookieHeader,
+                                                                                    NSString *modhash,
+                                                                                    NSString *userAgent,
+                                                                                    ApolloRedditMediaUploadProgress progressHandler,
+                                                                                    ApolloRedditMediaUploadCompletion completion) {
+    ApolloRedditMediaUploadOperation *operation = [ApolloRedditMediaUploadOperation new];
+    operation.progressHandler = progressHandler;
+    ApolloRedditMediaUploadCompletion safeCompletion = completion ?: ^(__unused NSURL *mediaURL, __unused NSString *assetID, __unused NSString *webSocketURL, __unused NSError *error) {};
+    unsigned long long fileSize = ApolloFileSizeForURL(mediaFileURL);
+    if (![mediaFileURL isKindOfClass:[NSURL class]] || !mediaFileURL.isFileURL || fileSize == 0) {
+        safeCompletion(nil, nil, nil, ApolloRedditUploadError(1, @"Media file was empty"));
+        return operation;
+    }
+    if (cookieHeader.length == 0) {
+        safeCompletion(nil, nil, nil, ApolloRedditUploadError(2, @"No Reddit web session cookie available"));
+        return operation;
+    }
+
+    NSString *resolvedMIMEType = ApolloMediaMIMETypeForFilename(filename ?: mediaFileURL.lastPathComponent, mimeType);
+    NSString *resolvedFilename = ApolloNormalizedFilename(filename.length > 0 ? filename : mediaFileURL.lastPathComponent, resolvedMIMEType);
+    NSString *resolvedUserAgent = userAgent.length > 0 ? userAgent : @"Apollo-Reborn/RedditMediaUpload";
+
+    ApolloRequestRedditMediaAssetViaCookie(nil, mediaFileURL, resolvedFilename, resolvedMIMEType, cookieHeader, modhash, resolvedUserAgent, operation, safeCompletion);
     return operation;
 }
 

--- a/src/ApolloWebJSON.h
+++ b/src/ApolloWebJSON.h
@@ -89,6 +89,14 @@ extern NSString *const ApolloWebJSONSessionExpiredNotification;
 // capture path must ignore it to avoid poisoning sLatestRedditBearerToken.
 extern NSString *const ApolloWebJSONSyntheticBearerToken;
 
+// Request header marking a request the Web JSON layer issued itself: the
+// /api/me.json session-verification probe and the keyless image-upload lease
+// (ApolloRedditMediaUpload.m). Both the rewrite (ApolloWebJSONRewriteRequest)
+// and the block-page expiry counter (ApolloWebJSONNoteResponse) bail when it's
+// present, so a request that already carries the cookie isn't re-pointed or
+// counted circularly. Value: "X-Apollo-WebJSON-Probe".
+extern NSString *const ApolloWebJSONProbeHeader;
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ApolloWebJSON.m
+++ b/src/ApolloWebJSON.m
@@ -9,10 +9,13 @@
 NSString *const ApolloWebJSONSessionExpiredNotification = @"ApolloWebJSONSessionExpiredNotification";
 NSString *const ApolloWebJSONSyntheticBearerToken = @"apollo-webjson-cookie-session";
 
-// Marks our own /api/me.json session-verification probe so it bypasses the
-// request rewrite and the block-page expiry counter (it already targets
-// www.reddit.com with the cookie, and counting its response would be circular).
-static NSString *const kApolloWebJSONProbeHeader = @"X-Apollo-WebJSON-Probe";
+// Marks a request the Web JSON layer issued itself (the /api/me.json
+// session-verification probe, and the keyless image-upload lease in
+// ApolloRedditMediaUpload.m) so it bypasses the request rewrite and the
+// block-page expiry counter — it already targets www.reddit.com with the
+// cookie, and re-pointing/counting its response would be circular. Declared in
+// ApolloWebJSON.h so other TUs (the upload module) can tag their own requests.
+NSString *const ApolloWebJSONProbeHeader = @"X-Apollo-WebJSON-Probe";
 
 #pragma mark - Keychain-backed credential storage (item 4)
 
@@ -180,16 +183,20 @@ static BOOL ApolloWebJSONWritePathIsRoutable(NSString *path) {
     if ([path hasPrefix:@"/api/v1/revoke_token"]) return NO;
     if ([path hasPrefix:@"/api/v1/authorize"]) return NO;
     // Native media uploads POST a lease to oauth.reddit.com/api/media/asset.json
-    // with a bearer token, and the lease ALWAYS stays on the oauth path. With real
-    // API keys the bearer authenticates it there; in the keyless escape hatch there
-    // is no real bearer, so the upload host short-circuits to the Imgur path and
-    // never issues this lease (a spike confirmed www.reddit.com/api/media/asset.json
-    // returns Reddit's 403 block page for cookie+modhash auth — it requires real
-    // OAuth, so routing the lease to www would only break it, including for a
-    // real-account user who also has Web JSON Mode enabled). The big multipart PUT
-    // goes to AWS S3 (self-authenticating) and is untouched either way.
+    // with a bearer token, and that lease ALWAYS stays on the oauth path. With real
+    // API keys the bearer authenticates it there; routing it to www would break it
+    // (www.reddit.com/api/media/asset.json returns Reddit's 403 block page for
+    // cookie+modhash auth — it requires real OAuth). The big multipart PUT goes to
+    // AWS S3 (self-authenticating) and is untouched either way.
     if ([path hasPrefix:@"/api/media/"]) return NO;
     if ([path isEqualToString:@"/api/v1/media/asset.json"]) return NO;
+    // Keyless image uploads use the old-reddit web lease www.reddit.com/api/
+    // image_upload_s3.json, which the upload host (ApolloRedditMediaUpload.m)
+    // builds and authenticates itself (cookie + X-Modhash, tagged with
+    // ApolloWebJSONProbeHeader). Leave it alone so the chokepoint doesn't
+    // double-process it — the probe header already makes the rewrite bail above,
+    // but exclude it here too as a belt-and-suspenders guard.
+    if ([path isEqualToString:@"/api/image_upload_s3.json"]) return NO;
     return YES;
 }
 
@@ -200,7 +207,7 @@ NSURLRequest *ApolloWebJSONRewriteRequest(NSURLRequest *request) {
 
     // Our own session-verification probe already targets www.reddit.com with the
     // cookie set; leave it untouched so we don't recurse through the rewrite.
-    if ([request valueForHTTPHeaderField:kApolloWebJSONProbeHeader].length > 0) return nil;
+    if ([request valueForHTTPHeaderField:ApolloWebJSONProbeHeader].length > 0) return nil;
 
     // No session → leave the oauth path untouched. Without the cookie the web
     // host serves its 403 block page, which is strictly worse than oauth.
@@ -324,7 +331,7 @@ static void ApolloWebJSONVerifySessionThenAnnounce(void) {
     NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://www.reddit.com/api/me.json"]];
     [req setValue:cookie forHTTPHeaderField:@"Cookie"];
     [req setValue:([sUserAgent length] > 0 ? sUserAgent : defaultUserAgent) forHTTPHeaderField:@"User-Agent"];
-    [req setValue:@"1" forHTTPHeaderField:kApolloWebJSONProbeHeader];
+    [req setValue:@"1" forHTTPHeaderField:ApolloWebJSONProbeHeader];
     req.HTTPShouldHandleCookies = NO;
     req.timeoutInterval = 15.0;
 
@@ -361,7 +368,7 @@ void ApolloWebJSONNoteResponse(NSURLRequest *request, NSURLResponse *response) {
     if (sSessionExpiredAnnounced) return;
     if (![response isKindOfClass:[NSHTTPURLResponse class]]) return;
     // Our verification probe must not feed its own result back into the counter.
-    if ([request valueForHTTPHeaderField:kApolloWebJSONProbeHeader].length > 0) return;
+    if ([request valueForHTTPHeaderField:ApolloWebJSONProbeHeader].length > 0) return;
 
     NSURL *url = request.URL;
     if (![url.host.lowercaseString isEqualToString:@"www.reddit.com"]) return;
@@ -434,7 +441,7 @@ static NSDictionary *ApolloWebJSONFetchModernThingData(NSString *fullname) {
     NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlStr]];
     [req setValue:cookie forHTTPHeaderField:@"Cookie"];
     [req setValue:([sUserAgent length] > 0 ? sUserAgent : defaultUserAgent) forHTTPHeaderField:@"User-Agent"];
-    [req setValue:@"1" forHTTPHeaderField:kApolloWebJSONProbeHeader];
+    [req setValue:@"1" forHTTPHeaderField:ApolloWebJSONProbeHeader];
     req.HTTPShouldHandleCookies = NO;
     req.timeoutInterval = 15.0;
 


### PR DESCRIPTION
## What

In keyless **Web JSON mode** there's no real OAuth bearer, so attaching an image to a comment or selftext body previously fell back to Imgur (and warned when no Imgur key was set). Reddit's oauth media lease (`oauth.reddit.com/api/media/asset.json`) 403s for cookie auth — but old-reddit's web lease (`www.reddit.com/api/image_upload_s3.json`) authenticates with just the harvested **cookie + `X-Modhash`**, which Web JSON mode already holds. This routes keyless inline image uploads there instead, so they land on Reddit's own CDN rather than Imgur.

This is the same keyless path Hydra uses; it reuses the exact credentials our Web JSON session already harvests.

Screenshot:

<img width="590" height="1278" alt="IMG_4550" src="https://github.com/user-attachments/assets/de64e638-86d5-470d-a24d-cfd9721bd891" />


## How

- **`ApolloRedditMediaUpload.{h,m}`** — extract the shared S3 upload phase into `ApolloPerformRedditMediaS3Upload`; add `ApolloRequestRedditMediaAssetViaCookie` (POST `image_upload_s3.json`, cookie + `X-Modhash`, form-urlencoded body, flat `{action,fields}` parse, 403 block-page detection → session-expired notification) and two public `…ViaCookieCancellable` entry points.
- **`ApolloImageUploadHost.xm`** — `ApolloShouldUseCookieRedditUpload` gate (image-only, synthetic bearer, usable session *with* modhash, not a video context); drive the cookie lease from the native-upload path, overriding the default-Imgur provider; relax the `asset_id` hard-fail in cookie mode (the web lease returns none); refresh the keyless-upload warning copy (images go to Reddit, videos still need Imgur).
- **`ApolloWebJSON.{h,m}`** — promote the probe-header constant to the header so the upload TU can tag its lease; exclude `/api/image_upload_s3.json` from write routing so the chokepoint doesn't double-process it.

## Scope

| Upload path | Works keylessly? |
|---|---|
| Inline image in a **comment** body | ✅ Yes (falls back to `![image](url)` markdown — no `asset_id` needed) |
| Inline image in a **selftext post** body | ✅ Yes (same fallback) |
| Native `kind=image` **post** / **gallery** / **video** post | ❌ No — needs an `asset_id` the web lease can't provide; keeps using Imgur |

Image MIME only. Real-account users with a genuine bearer are unaffected (the gate only fires for the synthetic placeholder token, i.e. exactly today's "fall back to Imgur" case).

## Testing

- Both simulator and device builds compile clean.
- **Device-confirmed working** by @nick.clyde — inline image attached in a comment uploads to Reddit via the cookie lease and renders correctly.
- Regression: with a real bearer (real API keys) the oauth path is unchanged; with no modhash / video the Imgur fallback + warning still fire.