### PR TITLE
Fix Social Links scraping old reddit for "new reddit off" accounts (#465)

### DIFF
--- a/src/ApolloProfileSocialLinks.m
+++ b/src/ApolloProfileSocialLinks.m
@@ -224,6 +224,32 @@ static NSArray<ApolloSocialLink *> *ApolloSLLinksFromJSON(NSArray *raw) {
 
 @implementation ApolloSLWebFetch
 
+// A single non-persistent (in-memory) WKWebsiteDataStore, reused for every
+// social-links scrape this app session.
+//
+// Why isolate the scrape from the app's shared cookies: Reddit serves the *old*
+// reddit layout at www.reddit.com whenever the logged-in session belongs to an
+// account whose "Use new Reddit as my default experience" preference is disabled.
+// Apollo's OAuth login runs through a www.reddit.com web view, so that account's
+// session + old-reddit preference land in the SHARED default WKWebsiteDataStore.
+// Old reddit has none of the shreddit-* markup the extraction JS targets, so the
+// fallback scrapes footer/sidebar anchors (redditblog.com, posted/commented URLs)
+// and every profile shows the same wrong links. The poison is sticky too —
+// deleting the Apollo account never clears WebKit cookies, so only deleting the
+// whole app cleared it. (Reported on PR #465.)
+//
+// A logged-out, in-memory store sidesteps all of it: with no account session
+// Reddit serves its default (new/shreddit) experience, the scrape can neither
+// poison nor be poisoned by the user's browsing session, and it resets each
+// launch. Shared (not per-scrape) so Reddit's JS bot-challenge cookie warms once
+// per session rather than cold on every profile.
++ (WKWebsiteDataStore *)apollo_scrapeDataStore {
+    static WKWebsiteDataStore *store;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ store = [WKWebsiteDataStore nonPersistentDataStore]; });
+    return store;
+}
+
 - (void)startForUsername:(NSString *)username completion:(void (^)(NSArray<ApolloSocialLink *> *))done {
     // WKWebView must be created/used on the main thread.
     if (![NSThread isMainThread]) {
@@ -238,7 +264,9 @@ static NSArray<ApolloSocialLink *> *ApolloSLLinksFromJSON(NSArray *raw) {
     }
     if (!win) win = UIApplication.sharedApplication.windows.firstObject;
     if (!win) { [self finish:nil]; return; }
-    self.web = [[WKWebView alloc] initWithFrame:win.bounds configuration:[[WKWebViewConfiguration alloc] init]];
+    WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+    config.websiteDataStore = [ApolloSLWebFetch apollo_scrapeDataStore];
+    self.web = [[WKWebView alloc] initWithFrame:win.bounds configuration:config];
     self.web.navigationDelegate = self;
     self.web.alpha = 0.011; self.web.userInteractionEnabled = NO;
     self.web.customUserAgent = @"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";


### PR DESCRIPTION
Fixes the Social Links bug @Uranosphaerite reported on #465: after signing into a Reddit account whose **"Use new Reddit as my default experience"** preference is **disabled**, every profile shows the same wrong links (`redditblog.com` and other footer/old-reddit junk), it can't be cleared by removing the account, and only a full app reinstall fixed it.

### Root cause

The scraper built its hidden `WKWebView` with the **shared default** `WKWebsiteDataStore`:

```objc
self.web = [[WKWebView alloc] initWithFrame:win.bounds configuration:[[WKWebViewConfiguration alloc] init]];
```

Apollo's OAuth login runs through a `www.reddit.com` web view, so signing in deposits that account's **session + old-reddit preference** into that shared, on-disk cookie jar. From then on `www.reddit.com/user/<x>/` serves the **old reddit** layout, which has none of the `shreddit-*` markup the extraction targets — so the fallback scrapes `aside`/`main`/`body` anchors and catches old-reddit footer/posted-link URLs (`redditblog.com`, app-store links, …) identically on every profile.

It was sticky because deleting the Apollo account never clears WebKit's cookies — only wiping the whole app cleared the data store. (Switching the URL to `sh.reddit.com` didn't help either: the opt-out travels with the cookie/logged-in session, not the host.)

### The fix

Scrape through a process-cached, **logged-out, non-persistent (in-memory)** `WKWebsiteDataStore`. With no account session, Reddit serves its default **new/shreddit** experience, and the scrape can neither poison nor be poisoned by the user's browsing session. Profile social links are public, so no login is needed. One shared instance is reused per session so Reddit's JS bot-challenge cookie warms once rather than cold on every profile.

This also **fixes already-affected installs without a reinstall** — the scraper no longer reads the poisoned shared store at all.

### Proof (deterministic sim repro)

Loaded the same profile (`u/spez`) three ways in one session and logged which layout each got + the external anchors it would scrape:

| Path | Layout | Title | Sample anchors |
|---|---|---|---|
| **Ephemeral store @ www (this fix)** | `shreddit:true` ✅ new | `spez (u/spez) - Reddit` | real profile content |
| Default store @ www **+ `redesign_optout=true` cookie** | `shreddit:false, old:true` ❌ | `overview for spez` | **`redditblog.com`**, itunes/play store, `redditinc.com/...` |
| Default store @ `old.reddit.com` | `shreddit:false, old:true` ❌ | `overview for spez` | same junk incl. `redditblog.com` |

The middle row reproduces exactly what @Uranosphaerite screenshotted (including the dead `redditblog.com` link), and confirms the `redesign_optout` cookie forces old reddit **even logged-out**. The ephemeral path ran in the **same session** and was unaffected — proving the isolation. A live profile open with the fix also scraped real links correctly (`found 2 link(s)`), no crash.

### Known tradeoff (NSFW profiles)

Because the scrape is now logged-out, **NSFW-flagged creator profiles** can hit Reddit's over-18/login gate and return no links, where a logged-in session previously got through. In practice many NSFW profiles use the "bypassable blur" variant whose about-markup stays in the DOM (so they still scrape), and a missing band is a far gentler failure than wrong links on *every* profile — but it's a real, narrower regression worth noting. If it matters, a follow-up could fall back to a logged-in scrape only when a logged-out scrape detects the gate.

### Testing

Sim-tested on iOS 26 (Liquid Glass): the deterministic repro above + a live profile scrape through the new store. **Not yet device-tested against an actual opt-out account** — @Uranosphaerite, the PR-build IPAs below should let you confirm: sign in with "Use new Reddit as my default experience" off and check that profiles now show the right links (and that an already-broken install recovers on update, no reinstall needed).
