### PR TITLE
AI Summaries: fix guardrail/empty errors, reader-mode extraction, hide content-less link summaries

### DIFF
--- a/src/ApolloAISummary.xm
+++ b/src/ApolloAISummary.xm
@@ -1120,12 +1120,134 @@ static NSString *ApolloAIDecodeHTMLEntities(NSString *s) {
     return [s stringByReplacingOccurrencesOfString:@"&amp;" withString:@"&"];
 }
 
-// A small readability pass: drop non-content regions, prefer the <article>/<main>
-// region, pull paragraph prose, decode entities, collapse whitespace, cap length.
+// Reader-mode source #1 (best): the schema.org JSON-LD that most publishers embed
+// for SEO. `articleBody` is clean, already-decoded prose and is frequently present
+// even when the visible DOM is paywalled or JS-rendered — so it's our most
+// reliable way past paywalls/ad junk. Returns the longest articleBody (falling
+// back to the longest description) found across all ld+json blocks, or nil.
+static NSString *ApolloAIExtractJSONLD(NSString *html) {
+    if (html.length == 0) return nil;
+    NSRegularExpressionOptions dotAll =
+        NSRegularExpressionCaseInsensitive | NSRegularExpressionDotMatchesLineSeparators;
+    NSRegularExpression *re = [NSRegularExpression regularExpressionWithPattern:
+        @"<script[^>]*type\\s*=\\s*[\"']application/ld\\+json[\"'][^>]*>(.*?)</script>"
+        options:dotAll error:nil];
+    NSString *bestBody = nil;
+    NSString *bestDesc = nil;
+    for (NSTextCheckingResult *m in [re matchesInString:html options:0 range:NSMakeRange(0, html.length)]) {
+        NSString *json = [html substringWithRange:[m rangeAtIndex:1]];
+        // Some pages wrap JSON-LD in CDATA / HTML comments — strip those markers.
+        json = [json stringByReplacingOccurrencesOfString:@"<!--" withString:@" "];
+        json = [json stringByReplacingOccurrencesOfString:@"-->" withString:@" "];
+        json = [json stringByReplacingOccurrencesOfString:@"//<![CDATA[" withString:@" "];
+        json = [json stringByReplacingOccurrencesOfString:@"<![CDATA[" withString:@" "];
+        json = [json stringByReplacingOccurrencesOfString:@"]]>" withString:@" "];
+        NSData *data = [json dataUsingEncoding:NSUTF8StringEncoding];
+        if (!data) continue;
+        id obj = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+        if (!obj) continue;
+        // Walk arrays, @graph, mainEntity, and nested dicts collecting fields.
+        NSMutableArray *stack = [NSMutableArray arrayWithObject:obj];
+        NSUInteger guard = 0;
+        while (stack.count > 0 && guard++ < 4000) {
+            id node = stack.lastObject;
+            [stack removeLastObject];
+            if ([node isKindOfClass:[NSArray class]]) {
+                [stack addObjectsFromArray:node];
+            } else if ([node isKindOfClass:[NSDictionary class]]) {
+                NSDictionary *d = node;
+                id body = d[@"articleBody"];
+                if ([body isKindOfClass:[NSString class]] && [(NSString *)body length] > bestBody.length) bestBody = body;
+                id desc = d[@"description"];
+                if ([desc isKindOfClass:[NSString class]] && [(NSString *)desc length] > bestDesc.length) bestDesc = desc;
+                id graph = d[@"@graph"]; if (graph) [stack addObject:graph];
+                id mainEntity = d[@"mainEntity"]; if (mainEntity) [stack addObject:mainEntity];
+            }
+        }
+    }
+    NSString *chosen = (bestBody.length >= 200) ? bestBody
+                     : (bestBody.length >= bestDesc.length ? bestBody : bestDesc);
+    if (chosen.length == 0) return nil;
+    // articleBody is usually plain text but can carry inline HTML; clean it.
+    NSRegularExpression *tagRe = [NSRegularExpression regularExpressionWithPattern:@"<[^>]+>" options:0 error:nil];
+    chosen = [tagRe stringByReplacingMatchesInString:chosen options:0 range:NSMakeRange(0, chosen.length) withTemplate:@" "];
+    return ApolloAIDecodeHTMLEntities(chosen);
+}
+
+// Pull the `content` of the first <meta> tag whose name/property equals `key`
+// (attribute order varies, so try both layouts). Decoded + trimmed, or nil.
+static NSString *ApolloAIMetaContent(NSString *html, NSString *key) {
+    if (html.length == 0) return nil;
+    NSString *k = [NSRegularExpression escapedPatternForString:key];
+    // Capture the opening quote (group 1) and backreference it so the value
+    // (group 2) runs to the MATCHING quote — a value containing the other quote
+    // type (e.g. an apostrophe inside a double-quoted description) isn't truncated,
+    // and a mismatched open/close pair isn't accepted.
+    NSArray<NSString *> *patterns = @[
+        [NSString stringWithFormat:@"<meta[^>]*\\b(?:property|name)\\s*=\\s*[\"']%@[\"'][^>]*\\bcontent\\s*=\\s*([\"'])(.*?)\\1", k],
+        [NSString stringWithFormat:@"<meta[^>]*\\bcontent\\s*=\\s*([\"'])(.*?)\\1[^>]*\\b(?:property|name)\\s*=\\s*[\"']%@[\"']", k],
+    ];
+    NSRange scan = NSMakeRange(0, MIN(html.length, (NSUInteger)200000));
+    for (NSString *pat in patterns) {
+        NSRegularExpression *re = [NSRegularExpression regularExpressionWithPattern:pat
+            options:NSRegularExpressionCaseInsensitive error:nil];
+        NSTextCheckingResult *m = [re firstMatchInString:html options:0 range:scan];
+        if (m) {
+            NSString *c = [ApolloAIDecodeHTMLEntities([html substringWithRange:[m rangeAtIndex:2]])
+                           stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+            if (c.length > 0) return c;
+        }
+    }
+    return nil;
+}
+
+// Reader-mode source #3 (thin-page seed): a real og:/meta description beats
+// summarizing leftover nav/cookie junk when the body can't be extracted.
+static NSString *ApolloAIExtractMetaDescription(NSString *html) {
+    for (NSString *key in @[@"og:description", @"twitter:description", @"description"]) {
+        NSString *c = ApolloAIMetaContent(html, key);
+        if (c.length > 0) return c;
+    }
+    return nil;
+}
+
+// The AMP version of an article is a stripped-down, ad-light, frequently
+// un-paywalled page — a strong reader-mode fallback when the canonical page
+// yields no prose. Returns the absolute amphtml URL, or nil.
+static NSString *ApolloAIFindAMPURL(NSString *html, NSURL *base) {
+    if (html.length == 0) return nil;
+    // Quote (group 1) captured + backreferenced so the href (group 2) runs to
+    // the matching quote, mirroring the meta-content extractor above.
+    NSArray<NSString *> *patterns = @[
+        @"<link[^>]*\\brel\\s*=\\s*[\"']amphtml[\"'][^>]*\\bhref\\s*=\\s*([\"'])(.+?)\\1",
+        @"<link[^>]*\\bhref\\s*=\\s*([\"'])(.+?)\\1[^>]*\\brel\\s*=\\s*[\"']amphtml[\"']",
+    ];
+    NSRange scan = NSMakeRange(0, MIN(html.length, (NSUInteger)200000));
+    for (NSString *pat in patterns) {
+        NSRegularExpression *re = [NSRegularExpression regularExpressionWithPattern:pat
+            options:NSRegularExpressionCaseInsensitive error:nil];
+        NSTextCheckingResult *m = [re firstMatchInString:html options:0 range:scan];
+        if (m) {
+            NSString *href = ApolloAIDecodeHTMLEntities([html substringWithRange:[m rangeAtIndex:2]]);
+            NSURL *abs = [NSURL URLWithString:href relativeToURL:base];
+            return abs.absoluteURL.absoluteString ?: href;
+        }
+    }
+    return nil;
+}
+
+// A small readability pass. Prefers, in order: JSON-LD articleBody (cleanest,
+// paywall-resistant), then scraped <article>/<main> <p> prose, then a strip-all
+// fallback, then a meta description for thin pages. Decodes entities, collapses
+// whitespace, caps length.
 static NSString *ApolloAIExtractArticleText(NSString *html) {
     if (html.length == 0) return nil;
-    // Bound regex cost; an article's content sits near the top of the document.
-    if (html.length > 600000) html = [html substringToIndex:600000];
+
+    // Source #1: JSON-LD, computed over the FULL html (the block can sit late).
+    NSString *jsonld = ApolloAIExtractJSONLD(html);
+
+    // Bound regex cost for the DOM scrape; an article's body sits near the top.
+    NSString *capped = html.length > 600000 ? [html substringToIndex:600000] : html;
 
     NSRegularExpressionOptions dotAll =
         NSRegularExpressionCaseInsensitive | NSRegularExpressionDotMatchesLineSeparators;
@@ -1133,8 +1255,8 @@ static NSString *ApolloAIExtractArticleText(NSString *html) {
     NSRegularExpression *noise = [NSRegularExpression regularExpressionWithPattern:
         @"<(script|style|noscript|template|svg|head|nav|header|footer|aside|form|figure)\\b[^>]*>.*?</\\1>"
         options:dotAll error:nil];
-    NSString *s = [noise stringByReplacingMatchesInString:html options:0
-                                                    range:NSMakeRange(0, html.length) withTemplate:@" "];
+    NSString *s = [noise stringByReplacingMatchesInString:capped options:0
+                                                    range:NSMakeRange(0, capped.length) withTemplate:@" "];
 
     // Narrow to the main article region if the page marks one.
     NSString *scope = s;
@@ -1151,7 +1273,7 @@ static NSString *ApolloAIExtractArticleText(NSString *html) {
         if (end > start) { scope = [s substringWithRange:NSMakeRange(start, end - start)]; break; }
     }
 
-    // Articles put body text in <p> tags; menus/chrome rarely do.
+    // Source #2: articles put body text in <p> tags; menus/chrome rarely do.
     NSMutableString *prose = [NSMutableString string];
     NSRegularExpression *pRe = [NSRegularExpression regularExpressionWithPattern:@"<p\\b[^>]*>(.*?)</p>" options:dotAll error:nil];
     NSRegularExpression *tagRe = [NSRegularExpression regularExpressionWithPattern:@"<[^>]+>" options:0 error:nil];
@@ -1163,12 +1285,22 @@ static NSString *ApolloAIExtractArticleText(NSString *html) {
         if (prose.length >= kApolloAIMaxArticleChars) break;
     }
 
+    // Prefer the richest source: JSON-LD articleBody wins when it's longer.
+    NSString *source = @"prose";
     NSString *text = prose;
+    if (jsonld.length > text.length) { text = jsonld; source = @"jsonld"; }
+
+    // Still thin (SPA / clip page / paywall stub)? Try strip-all on the scope,
+    // then a meta description — anything real beats nav junk.
     if (text.length < 200) {
-        // Fallback: strip every tag from the scope.
         NSString *stripped = [tagRe stringByReplacingMatchesInString:scope options:0
                                                                range:NSMakeRange(0, scope.length) withTemplate:@" "];
-        text = ApolloAIDecodeHTMLEntities(stripped);
+        stripped = ApolloAIDecodeHTMLEntities(stripped);
+        if (stripped.length > text.length) { text = stripped; source = @"strip"; }
+    }
+    if (text.length < 200) {
+        NSString *meta = ApolloAIExtractMetaDescription(html);
+        if (meta.length > text.length) { text = meta; source = @"meta"; }
     }
 
     NSRegularExpression *ws = [NSRegularExpression regularExpressionWithPattern:@"\\s+" options:0 error:nil];
@@ -1176,10 +1308,44 @@ static NSString *ApolloAIExtractArticleText(NSString *html) {
     text = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     if (text.length == 0) return nil;
     if (text.length > kApolloAIMaxArticleChars) text = [text substringToIndex:kApolloAIMaxArticleChars];
+    ApolloLog(@"[AISummary] article extracted via %@ (%lu chars)", source, (unsigned long)text.length);
     return text;
 }
 
-// Fetch the article URL off-thread and hand extracted prose back on the MAIN thread.
+// Core single-URL fetch + extract. Calls back on URLSession's own queue (NOT the
+// main thread) with the extracted prose, the raw html (for AMP discovery), and
+// any error. The public wrapper below hops to main and adds the AMP fallback.
+static void ApolloAIFetchAndExtract(NSURL *url, void (^done)(NSString *text, NSString *html, NSError *error)) {
+    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url
+        cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:kApolloAIArticleFetchTimeout];
+    // A real browser UA — some publishers serve a stub to non-browser agents.
+    [req setValue:@"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+        forHTTPHeaderField:@"User-Agent"];
+    [req setValue:@"text/html,application/xhtml+xml,*/*;q=0.8" forHTTPHeaderField:@"Accept"];
+    [req setValue:@"en-US,en;q=0.9" forHTTPHeaderField:@"Accept-Language"];
+
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:req
+        completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            NSString *text = nil, *html = nil;
+            NSError *outErr = error;
+            NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
+            if (!error && http && http.statusCode >= 200 && http.statusCode < 300 &&
+                data.length > 0 && data.length <= kApolloAIArticleFetchMaxBytes) {
+                html = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+                if (!html) html = [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding];
+                if (html) text = ApolloAIExtractArticleText(html);
+            } else if (!error && http && (http.statusCode < 200 || http.statusCode >= 300)) {
+                outErr = [NSError errorWithDomain:@"ApolloAIArticle" code:http.statusCode userInfo:nil];
+            }
+            if (done) done(text, html, outErr);
+        }];
+    [task resume];
+}
+
+// Fetch the article URL off-thread and hand extracted prose back on the MAIN
+// thread. When the canonical page yields little prose (SPA / paywall stub) but
+// advertises an AMP version, refetch that once — it's usually clean, un-paywalled
+// reader content. At most two network requests; AMP pages aren't re-followed.
 static void ApolloAIFetchArticleText(NSString *urlString, void (^completion)(NSString *text, NSError *error)) {
     NSURL *url = urlString.length > 0 ? [NSURL URLWithString:urlString] : nil;
     if (!url) {
@@ -1188,31 +1354,24 @@ static void ApolloAIFetchArticleText(NSString *urlString, void (^completion)(NSS
         });
         return;
     }
-    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url
-        cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:kApolloAIArticleFetchTimeout];
-    // A real browser UA — some publishers serve a stub to non-browser agents.
-    [req setValue:@"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
-        forHTTPHeaderField:@"User-Agent"];
-    [req setValue:@"text/html,application/xhtml+xml,*/*;q=0.8" forHTTPHeaderField:@"Accept"];
-
-    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:req
-        completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-            NSString *text = nil;
-            NSError *outErr = error;
-            NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
-            if (!error && http && http.statusCode >= 200 && http.statusCode < 300 &&
-                data.length > 0 && data.length <= kApolloAIArticleFetchMaxBytes) {
-                NSString *html = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-                if (!html) html = [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding];
-                if (html) text = ApolloAIExtractArticleText(html);
-            } else if (!error && http && (http.statusCode < 200 || http.statusCode >= 300)) {
-                outErr = [NSError errorWithDomain:@"ApolloAIArticle" code:http.statusCode userInfo:nil];
-            }
-            dispatch_async(dispatch_get_main_queue(), ^{
-                if (completion) completion(text, text.length > 0 ? nil : (outErr ?: [NSError errorWithDomain:@"ApolloAIArticle" code:204 userInfo:nil]));
-            });
-        }];
-    [task resume];
+    void (^deliver)(NSString *, NSError *) = ^(NSString *text, NSError *err) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (completion) completion(text, text.length > 0 ? nil
+                : (err ?: [NSError errorWithDomain:@"ApolloAIArticle" code:204 userInfo:nil]));
+        });
+    };
+    ApolloAIFetchAndExtract(url, ^(NSString *text, NSString *html, NSError *err) {
+        // Good enough, or nothing to fall back to → deliver as-is.
+        if (text.length >= 200 || html.length == 0) { deliver(text, err); return; }
+        NSString *amp = ApolloAIFindAMPURL(html, url);
+        NSURL *ampURL = amp.length > 0 ? [NSURL URLWithString:amp] : nil;
+        if (!ampURL || [ampURL.absoluteString isEqualToString:url.absoluteString]) { deliver(text, err); return; }
+        ApolloLog(@"[AISummary] thin extract (%lu chars) — retrying via AMP %@", (unsigned long)text.length, amp);
+        ApolloAIFetchAndExtract(ampURL, ^(NSString *ampText, NSString *ampHtml, NSError *ampErr) {
+            NSString *best = ampText.length > text.length ? ampText : text;
+            deliver(best, best.length > 0 ? nil : (err ?: ampErr));
+        });
+    });
 }
 
 #pragma mark - Summary UI

--- a/src/ApolloAISummary.xm
+++ b/src/ApolloAISummary.xm
@@ -241,6 +241,16 @@ static NSMutableSet<NSString *> *sCommentGenerationScheduled;
 // loading<->error as the retry schedule and comment captures re-fire.
 static NSMutableSet<NSString *> *sPostFailed;
 static NSMutableSet<NSString *> *sCommentFailed;
+// fullNames whose link/article post box is currently HIDDEN — the page had no
+// usable prose to summarize (score-card / SPA / paywall stub), or the model
+// couldn't summarize the little there was. Distinct from sPostFailed: a
+// suppressed post shows NO box at all (not an error triangle), and we don't
+// re-fetch it while it's on screen. Keeping it separate is essential — folding
+// it into sPostFailed makes ApolloAIRestoreStateForHeader flip the hidden box
+// back to the error triangle every time a header recycles. Like sPostFailed,
+// it is cleared in viewDidDisappear, so each reopen gets a fresh attempt
+// (a content-less page just re-hides; a transient failure recovers).
+static NSMutableSet<NSString *> *sPostSuppressed;
 static NSMutableSet<NSString *> *sTimedOutRequests;
 // "post|fullName" / "comment|fullName" keys for boxes the user TAPPED to generate
 // while Tap-to-Summarize is on. The generation pass consumes the marker and
@@ -343,6 +353,7 @@ static void ApolloAIEnsureState(void) {
         sCommentGenerationScheduled = [NSMutableSet set];
         sPostFailed = [NSMutableSet set];
         sCommentFailed = [NSMutableSet set];
+        sPostSuppressed = [NSMutableSet set];
         sTimedOutRequests = [NSMutableSet set];
         sTapRequested = [NSMutableSet set];
         ApolloAILoadPersistedSummaries();
@@ -377,6 +388,7 @@ NSUInteger ApolloAIClearSummaryCache(void) {
     [sCommentGenerationScheduled removeAllObjects];
     [sPostFailed removeAllObjects];
     [sCommentFailed removeAllObjects];
+    [sPostSuppressed removeAllObjects];
     [sTimedOutRequests removeAllObjects];
     [sTapRequested removeAllObjects];
     [sLinkSummaryPosts removeAllObjects];
@@ -1709,7 +1721,12 @@ static void ApolloAIShowLoadingIfIdle(NSString *fullName, BOOL isPost) {
 // box. Mirrors the caches / in-flight / failed bookkeeping.
 static void ApolloAIRestoreStateForHeader(id headerNode, NSString *fullName) {
     if (!headerNode || fullName.length == 0) return;
-    if (sPostSummaryCache[fullName].length > 0) {
+    if ([sPostSuppressed containsObject:fullName]) {
+        // No usable article content — keep the box hidden on recycle. Must be
+        // checked BEFORE sPostFailed, or a recycled header would surface the
+        // error triangle for a post we deliberately hid.
+        ApolloAISetBoxState(headerNode, YES, ApolloAIBoxStateNone, nil);
+    } else if (sPostSummaryCache[fullName].length > 0) {
         ApolloAISetBoxState(headerNode, YES, ApolloAIBoxStateReady, sPostSummaryCache[fullName]);
     } else if ([sPostFailed containsObject:fullName]) {
         ApolloAISetBoxState(headerNode, YES, ApolloAIBoxStateError, nil);
@@ -1724,6 +1741,25 @@ static void ApolloAIRestoreStateForHeader(id headerNode, NSString *fullName) {
                [sCapturedComments[fullName] count] >= kApolloAIMinComments) {
         ApolloAISetBoxState(headerNode, NO, ApolloAIBoxStateLoading, nil);
     }
+}
+
+// Hide a post's link/article box: the linked page yielded no usable prose
+// (score-card, JS-only SPA, paywall stub), or the model couldn't make a summary
+// of what little there was. The user wants nothing rather than a scary
+// "couldn't summarize" triangle on such links, so we mark the post suppressed
+// (recycled headers stay hidden, no re-fetch while on screen) and clear the
+// in-flight / failed / link-mode bookkeeping that could resurrect a box. The
+// suppression is per-view — viewDidDisappear clears it, so a reopen re-attempts.
+static void ApolloAISuppressLinkSummary(NSString *fullName) {
+    if (fullName.length == 0) return;
+    [sPostInFlight removeObject:fullName];
+    [sPostRequestIDs removeObjectForKey:fullName];
+    [sPostFailed removeObject:fullName];        // NOT an error — don't show the triangle
+    [sLinkSummaryPosts removeObject:fullName];
+    [sBothSummaryPosts removeObject:fullName];
+    [sPostSuppressed addObject:fullName];
+    ApolloAISetBoxStateOnMatchingHeaders(fullName, YES, ApolloAIBoxStateNone, nil);
+    ApolloAIForceHeaderRemeasure(fullName);     // drop the box from the layout now
 }
 
 // Short, user-facing message for a generation error shown inside the box. The
@@ -1839,6 +1875,14 @@ static void ApolloAIScheduleGenerationTimeout(NSString *fullName, BOOL isPost, N
         [inFlight removeObject:fullName];
         [requestIDs removeObjectForKey:fullName];
         [(ApolloFoundationModels *)ApolloAIBridge() cancelRequest:requestID];
+        // A pure link/article post that times out has nothing to show but the
+        // article it couldn't fetch/summarize — hide it rather than leave a
+        // triangle, same as a no-prose result.
+        if (isPost && [sLinkSummaryPosts containsObject:fullName]) {
+            ApolloLog(@"[AISummary] link summary timed out for %@ — hiding", fullName);
+            ApolloAISuppressLinkSummary(fullName);
+            return;
+        }
         NSMutableSet *failed = isPost ? sPostFailed : sCommentFailed;
         [failed addObject:fullName];
         ApolloAISetBoxStateOnMatchingHeaders(
@@ -2145,6 +2189,17 @@ maximumResponseTokens:responseTokens
                         }
                         return;
                     }
+                    // Pure link/article post (no body to fall back on): if the
+                    // model can't summarize the little prose we scraped, the user
+                    // wants nothing rather than a "couldn't summarize" triangle.
+                    // Hide it. (Both / post-fallback summaries keep the error —
+                    // there the post body itself is the thing that failed.)
+                    if ([sLinkSummaryPosts containsObject:fullName]) {
+                        ApolloLog(@"[AISummary] link summary unusable for %@ (%@) — hiding", fullName,
+                                  error ? error.localizedDescription : @"empty");
+                        ApolloAISuppressLinkSummary(fullName);
+                        return;
+                    }
                     [sPostFailed addObject:fullName];
                     NSString *msg = error ? ApolloAIFriendlyError(error) : @"The model returned an empty summary.";
                     ApolloLog(@"[AISummary] link summary error: %@", error ? error.localizedDescription : @"(empty)");
@@ -2224,17 +2279,14 @@ static void ApolloAIGenerateLinkSummaryForController(NSString *articleURL, NSStr
                 return;
             }
             // No body either — a video-clip page (streamff/streamin/etc.), a
-            // JS-rendered SPA (Bluesky/Twitter), a paywall, and so on. Don't show
-            // an error card: just HIDE the box, as if the post weren't a
-            // summarizable article. Marked failed so we don't re-fetch every scroll.
-            [sPostInFlight removeObject:fullName];
-            [sPostRequestIDs removeObjectForKey:fullName];
-            [sPostFailed addObject:fullName];
-            [sLinkSummaryPosts removeObject:fullName];
+            // JS-rendered SPA (Bluesky/Twitter), a paywall, a bare score-card
+            // (fifa.com match centre), and so on. Don't show an error card: just
+            // HIDE the box, as if the post weren't a summarizable article, and
+            // suppress it so we don't re-fetch every scroll or flip back to an
+            // error triangle on header recycle.
             ApolloLog(@"[AISummary] no article prose for %@ — hiding link summary (%@)", fullName,
                       fetchError ? fetchError.localizedDescription : @"too little text");
-            ApolloAISetBoxStateOnMatchingHeaders(fullName, YES, ApolloAIBoxStateNone, nil);
-            ApolloAIForceHeaderRemeasure(fullName);   // drop the loading card from layout
+            ApolloAISuppressLinkSummary(fullName);
             return;
         }
         sArticleTextCache[fullName] = articleText;
@@ -2320,7 +2372,14 @@ static void ApolloAIGenerateForController(UIViewController *vc) {
     BOOL cacheValid = sPostSummaryCache[fullName].length > 0 &&
         [sPostSummaryMode[fullName] integerValue] == desiredMode;
     NSString *postTapKey = [@"post|" stringByAppendingString:fullName];
-    if (cacheValid) {
+    if ([sPostSuppressed containsObject:fullName]) {
+        // A pure-link post we already determined has no usable article content:
+        // keep it hidden and never re-fetch or re-offer a "Tap to summarize"
+        // prompt. (Self-text posts are never suppressed, so the body still
+        // summarizes normally on a different post that happens to share nothing
+        // here.)
+        ApolloAISetBoxStateOnMatchingHeaders(fullName, YES, ApolloAIBoxStateNone, nil);
+    } else if (cacheValid) {
         ApolloAISetBoxStateOnMatchingHeaders(fullName, YES, ApolloAIBoxStateReady, sPostSummaryCache[fullName]);
     } else if (sEnableTapToSummarize && (haveBody || haveArticle) &&
                ![sTapRequested containsObject:postTapKey] &&
@@ -2622,6 +2681,15 @@ static void ApolloAILogTableStructure(UIViewController *vc) {
         [sCommentRequestIDs removeObjectForKey:fullName];
         [sPostFailed removeObject:fullName];
         [sCommentFailed removeObject:fullName];
+        // Suppression is per-view, exactly like sPostFailed above: a link we hid
+        // because it had no usable prose (or failed transiently — model still
+        // downloading, a flaky network, a slow fetch that timed out) gets a fresh
+        // attempt the next time the post is opened. A genuinely content-less page
+        // (fifa.com score card) simply re-fetches, re-detects "no prose" and
+        // re-hides — cheap, and it never shows the error triangle — while a
+        // transient failure recovers on reopen instead of staying hidden for the
+        // whole session.
+        [sPostSuppressed removeObject:fullName];
         if (sPostSummaryCache[fullName].length == 0) {
             ApolloAISetBoxStateOnMatchingHeaders(fullName, YES, ApolloAIBoxStateNone, nil);
         }

--- a/src/ApolloFoundationModels.swift
+++ b/src/ApolloFoundationModels.swift
@@ -185,6 +185,15 @@ public final class ApolloFoundationModels: NSObject {
                     }
                     if !latest.isEmpty || Task.isCancelled { break }
                 }
+                // A cancellation can surface as a clean end-of-stream (the loop
+                // finishing without `streamResponse` throwing `CancellationError`),
+                // especially when the break above fires on `Task.isCancelled`.
+                // Re-check here and route through the catch's code-6 sentinel
+                // instead of falling through as an empty/partial success — otherwise
+                // the ObjC side never sees the navigation-cancellation code and
+                // marks the post failed/suppressed (and won't regenerate on reopen,
+                // since `onComplete` lands after `viewDidDisappear` clears the set).
+                if Task.isCancelled { throw CancellationError() }
                 aiLog.debug("completed \(identifier, privacy: .public) after \(String(describing: ContinuousClock.now - startedAt), privacy: .public)")
                 onComplete(latest, nil)
             } catch {

--- a/src/ApolloFoundationModels.swift
+++ b/src/ApolloFoundationModels.swift
@@ -39,6 +39,30 @@ public final class ApolloFoundationModels: NSObject {
     private var preparedSessions: [String: Any] = [:]
     private var activeTasks: [String: Task<Void, Never>] = [:]
 
+    /// The on-device model used for every summary. We deliberately do NOT use
+    /// `SystemLanguageModel.default`: its default safety guardrail frequently
+    /// false-positives on ordinary news / political Reddit threads, throwing
+    /// `guardrailViolation` ("Detected content likely to be unsafe") and refusing
+    /// to summarize them — the single most common failure users hit.
+    /// `.permissiveContentTransformations` is Apple's sanctioned guardrail set for
+    /// content-transformation use cases (summarizing / rewriting text the user is
+    /// already reading), which is exactly what AI Summaries does. Genuinely unsafe
+    /// content can still trip it; that surfaces as our usual code-7 error. Stored
+    /// untyped (`Any?`) so the property needs no availability annotation; built
+    /// lazily on first use under an `#available` check. Built once and reused so we
+    /// don't re-prepare guardrail assets per session.
+    private static var cachedModel: Any?
+
+    #if canImport(FoundationModels)
+    @available(iOS 26.0, *)
+    private static func summarizationModel() -> SystemLanguageModel {
+        if let model = cachedModel as? SystemLanguageModel { return model }
+        let model = SystemLanguageModel(guardrails: .permissiveContentTransformations)
+        cachedModel = model
+        return model
+    }
+    #endif
+
     /// Mirrors `SystemLanguageModel.Availability`, flattened to an Int so ObjC
     /// can branch without bridging the Swift enum.
     ///   0 = available
@@ -80,7 +104,7 @@ public final class ApolloFoundationModels: NSObject {
         #if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
             guard !identifier.isEmpty, preparedSessions[identifier] == nil else { return }
-            let session = LanguageModelSession(instructions: instructions)
+            let session = LanguageModelSession(model: Self.summarizationModel(), instructions: instructions)
             preparedSessions[identifier] = session
             session.prewarm()
         }
@@ -124,28 +148,42 @@ public final class ApolloFoundationModels: NSObject {
         // heavy work on its own executor and only resumes here to deliver
         // snapshots, so the callbacks land on the main thread for free.
         let task = Task { @MainActor in
+            // A fresh, permissive-guardrail session built from `instructions`.
+            // Used when no prepared session was staged, and for the single
+            // empty-response retry below.
+            func makeSession() -> LanguageModelSession {
+                LanguageModelSession(model: Self.summarizationModel(), instructions: instructions)
+            }
+            let options = GenerationOptions(
+                sampling: .greedy,
+                maximumResponseTokens: maximumResponseTokens > 0 ? maximumResponseTokens : nil
+            )
             do {
                 let startedAt = ContinuousClock.now
-                let session: LanguageModelSession
-                if let prepared = preparedSessions.removeValue(forKey: identifier) as? LanguageModelSession {
-                    session = prepared
-                } else {
-                    session = LanguageModelSession(instructions: instructions)
-                }
-                let options = GenerationOptions(
-                    sampling: .greedy,
-                    maximumResponseTokens: maximumResponseTokens > 0 ? maximumResponseTokens : nil
-                )
+                // Reuse the prewarmed prepared session if one was staged.
+                var session = (preparedSessions.removeValue(forKey: identifier) as? LanguageModelSession) ?? makeSession()
                 var latest = ""
                 var loggedFirstToken = false
-                for try await snapshot in session.streamResponse(to: text, options: options) {
-                    latest = snapshot.content
-                    if !loggedFirstToken, !latest.isEmpty {
-                        loggedFirstToken = true
-                        let elapsed = ContinuousClock.now - startedAt
-                        aiLog.debug("first text \(identifier, privacy: .public) after \(String(describing: elapsed), privacy: .public)")
+                // The model very occasionally streams nothing and ends cleanly
+                // (no thrown error, empty content). Retry once on a fresh session
+                // before surfacing an "empty summary" error — the empty turn is not
+                // fed back into the transcript that way.
+                for attempt in 0..<2 {
+                    if attempt > 0 {
+                        session = makeSession()
+                        latest = ""
+                        aiLog.debug("empty response for \(identifier, privacy: .public); retrying once")
                     }
-                    onPartial(latest)
+                    for try await snapshot in session.streamResponse(to: text, options: options) {
+                        latest = snapshot.content
+                        if !loggedFirstToken, !latest.isEmpty {
+                            loggedFirstToken = true
+                            let elapsed = ContinuousClock.now - startedAt
+                            aiLog.debug("first text \(identifier, privacy: .public) after \(String(describing: elapsed), privacy: .public)")
+                        }
+                        onPartial(latest)
+                    }
+                    if !latest.isEmpty || Task.isCancelled { break }
                 }
                 aiLog.debug("completed \(identifier, privacy: .public) after \(String(describing: ContinuousClock.now - startedAt), privacy: .public)")
                 onComplete(latest, nil)


### PR DESCRIPTION
Hey @jordanearle — this is the "few errors that occur from time to time with summarizing" fix I mentioned. Branched off `je/foundation-models-test` and targeting your branch so you can merge it straight in (or cherry-pick — it's two files: the Swift bridge + `ApolloAISummary.xm`).

### What was actually going wrong

I dug into a device log of the failures. It wasn't paywalls/network — the recurring hard error is **Apple's on-device safety guardrail** tripping on ordinary threads:

```
[AISummary] comment summary error: Detected content likely to be unsafe
```

That's `LanguageModelSession.GenerationError.guardrailViolation`. The **default** guardrail false-positives constantly on news/political/edgy discussions (Russia/Ukraine threads, heated drama subs, etc.) and just refuses. A second, rarer one was the model streaming nothing and ending cleanly → `(empty)`.

### Fixes

- **Permissive guardrails (the main fix).** Summary sessions now use `SystemLanguageModel(guardrails: .permissiveContentTransformations)` instead of `.default`. That's Apple's sanctioned guardrail set for *content-transformation* use cases — summarizing/rewriting text the user is already reading — which is exactly what we do. It dramatically cuts the false "unsafe" refusals. (Genuinely unsafe content can still trip it; that surfaces as the normal error.) `@available(iOS 26.0+)`, weak-linked, so older OSes are unaffected.
- **Empty-response retry.** One retry on a fresh session when the model returns an empty (no-throw) response before showing the "empty summary" error.
- **Reader-mode article extraction.** For link/article summaries, extraction now prefers **JSON-LD `articleBody`** (clean prose publishers embed for SEO, often present even behind paywalls) → existing `<article>/<main>` `<p>` scrape → strip-all → an **`og:`/meta description** seed for thin pages. The fetcher also does one **AMP refetch** (`rel=amphtml`) when the canonical page yields <200 chars, since AMP pages are stripped-down and frequently un-paywalled. All additive — well-structured pages resolve exactly as before; the new sources only win when they're longer, and meta/AMP only fire on thin extractions.

### Follow-up: hide the link summary when there's nothing to grab (`6c05424`)

Some link posts point at a page with **no readable prose at all** — a fifa.com match score-card, a JS-only SPA, a paywall stub. Extraction correctly reports "no content," but the box wasn't actually disappearing: it showed the orange ⚠️ "Link summary" triangle that never resolves.

The cause was a small state-machine bug, not extraction. The no-prose path marked the post *failed* (to avoid re-fetching on every scroll), and the header-restore path treats "failed" as *"show the error card"* — so the moment a Texture comment-header cell recycled, the hidden box flipped right back to the triangle (a hide↔error oscillation).

Fix: a separate *"suppressed"* state meaning **no usable content — stay hidden, no re-fetch while on screen, never an error triangle**, kept distinct from the real-error state. Pure link/article posts (no body to fall back on) are now suppressed instead of error-flagged on a no-prose/too-thin fetch, a model failure/empty result, or a generation timeout. Self-text post summaries and comment summaries still show a real error card on genuine failure — only content-less article *links* are hidden.

Suppression is **per-view**: it's cleared in `viewDidDisappear`, exactly like the existing failed-state, so each reopen gets a fresh attempt. A genuinely content-less page just re-fetches, re-detects "no prose" and re-hides (cheap, no triangle), while a *transient* failure (model still downloading, flaky network, a slow fetch that timed out) recovers on reopen rather than staying hidden for the whole session.

### Testing

Sim-tested (Apollo-Sim, glass). The clearest results:

- A thread that previously hard-failed with *"Detected content likely to be unsafe"* now produces a real discussion summary.
- The exact fifa.com score-card link from the report: extraction returns "no content" → box hidden, **never** flips to the triangle on cell recycle, and re-attempts cleanly on reopen.

Link/article extraction verified with no regression on well-structured pages (identical extracted lengths), and JSON-LD/`og` parsing checked against real publisher HTML. Reviewed the diff for the obvious footguns (Swift retry/cancellation, the model cache, AMP loop-bounding, regex quote handling) and adversarially reviewed the suppression change (which is how the transient-failure recovery above got added).

**Not device-tested yet** — same as last time, all yours to take, leave, or tweak. Same `#485` build dependency as this PR.
