### PR TITLE
Fix render profile Social Links icons at a uniform size

### DIFF
--- a/src/ApolloProfileSocialLinks.m
+++ b/src/ApolloProfileSocialLinks.m
@@ -35,6 +35,11 @@ static CGFloat const kSLPillHGap     = 8.0;    // horizontal gap between pills
 static CGFloat const kSLPillLeadInset = 12.0;
 static CGFloat const kSLPillTrailInset = 14.0;
 static CGFloat const kSLPillIconGap  = 8.0;
+// Canonical square (points) every favicon is normalized to. The 18pt badge/pill
+// views and the sheet's fixed icon box both aspect-fit it. Keeping one canonical
+// size is what makes every icon render uniformly.
+static CGFloat const kSLFaviconCanvas = 28.0;
+static CGFloat const kSLSheetIconBox = 29.0;   // fixed icon column in the sheet — see ApolloSLSheetCell
 
 #pragma mark - Type inference / display names
 
@@ -108,6 +113,74 @@ static UIImage *ApolloSLBundledIconForType(NSString *type) {
     return nil;
 }
 
+// Bounding box (in pixels) of the non-(near-)transparent content of a CGImage.
+// Favicons vary wildly in internal padding — some fill edge-to-edge, others are a
+// centered glyph ringed by transparent margin — so trimming to the real content is
+// what lets every brand glyph render at a consistent visual weight.
+static CGRect ApolloSLAlphaContentRectPx(CGImageRef cg) {
+    size_t w = CGImageGetWidth(cg), h = CGImageGetHeight(cg);
+    if (w == 0 || h == 0) return CGRectZero;
+    size_t bytesPerRow = w * 4;
+    uint8_t *buf = (uint8_t *)calloc(h, bytesPerRow);
+    if (!buf) return CGRectMake(0, 0, w, h);
+    CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
+    CGContextRef ctx = CGBitmapContextCreate(buf, w, h, 8, bytesPerRow, cs,
+                                             kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
+    CGColorSpaceRelease(cs);
+    if (!ctx) { free(buf); return CGRectMake(0, 0, w, h); }
+    CGContextDrawImage(ctx, CGRectMake(0, 0, w, h), cg);
+    CGContextRelease(ctx);
+
+    NSInteger minX = (NSInteger)w, minY = (NSInteger)h, maxX = -1, maxY = -1;
+    const uint8_t alphaThreshold = 12;  // ignore near-transparent antialiasing fuzz
+    for (size_t y = 0; y < h; y++) {
+        uint8_t *row = buf + y * bytesPerRow;
+        for (size_t x = 0; x < w; x++) {
+            if (row[x * 4 + 3] > alphaThreshold) {
+                if ((NSInteger)x < minX) minX = (NSInteger)x;
+                if ((NSInteger)x > maxX) maxX = (NSInteger)x;
+                if ((NSInteger)y < minY) minY = (NSInteger)y;
+                if ((NSInteger)y > maxY) maxY = (NSInteger)y;
+            }
+        }
+    }
+    free(buf);
+    if (maxX < minX || maxY < minY) return CGRectMake(0, 0, w, h);  // fully transparent → keep whole
+    return CGRectMake(minX, minY, maxX - minX + 1, maxY - minY + 1);
+}
+
+// Normalize a raw favicon so every icon renders uniformly regardless of its native
+// pixel size or internal padding: trim the transparent margin, then aspect-fit the
+// content (with a small uniform inset) centered into a kSLFaviconCanvas square.
+// Cheap (favicons are <=64px) and done once per host at cache-store time.
+static UIImage *ApolloSLNormalizedFavicon(UIImage *src) {
+    if (!src) return nil;
+    CGImageRef cg = src.CGImage;
+    if (!cg) return src;  // CIImage-backed / no bitmap — leave alone
+
+    CGRect content = ApolloSLAlphaContentRectPx(cg);
+    if (CGRectIsEmpty(content)) return src;
+    CGImageRef cropped = CGImageCreateWithImageInRect(cg, content);
+    UIImage *trimmed = cropped ? [UIImage imageWithCGImage:cropped scale:1.0 orientation:UIImageOrientationUp] : src;
+    if (cropped) CGImageRelease(cropped);
+
+    CGFloat side = kSLFaviconCanvas;
+    CGFloat inset = side * 0.06;                 // consistent breathing room inside the square
+    CGFloat avail = side - inset * 2.0;
+    CGSize  cs = trimmed.size;
+    CGFloat scale = (cs.width > 0 && cs.height > 0) ? MIN(avail / cs.width, avail / cs.height) : 1.0;
+    if (!isfinite(scale) || scale <= 0) scale = 1.0;
+    CGSize  drawn = CGSizeMake(cs.width * scale, cs.height * scale);
+    CGRect  drawRect = CGRectMake((side - drawn.width) / 2.0, (side - drawn.height) / 2.0, drawn.width, drawn.height);
+
+    UIGraphicsImageRendererFormat *fmt = [UIGraphicsImageRendererFormat preferredFormat];
+    fmt.opaque = NO;
+    UIGraphicsImageRenderer *r = [[UIGraphicsImageRenderer alloc] initWithSize:CGSizeMake(side, side) format:fmt];
+    return [r imageWithActions:^(UIGraphicsImageRendererContext *c) {
+        [trimmed drawInRect:drawRect];
+    }];
+}
+
 static NSCache<NSString *, UIImage *> *ApolloSLFaviconCache(void) {
     static NSCache *cache; static dispatch_once_t once;
     dispatch_once(&once, ^{ cache = [[NSCache alloc] init]; cache.countLimit = 120; });
@@ -160,9 +233,13 @@ static void ApolloSLRequestFaviconForHost(NSString *host, void (^completion)(UII
         // Google returns a 16px globe placeholder for unknown domains; keep it anyway
         // (still better than our generic glyph for most real services).
         UIImage *image = data.length > 0 ? [UIImage imageWithData:data] : nil;
+        // Trim + center into a uniform square here (off the main thread) so the sheet
+        // rows and the header badges all render at a consistent size/weight regardless
+        // of each favicon's native pixel size or internal transparent padding.
+        UIImage *normalized = image ? ApolloSLNormalizedFavicon(image) : nil;
         dispatch_async(dispatch_get_main_queue(), ^{
-            if (image) [ApolloSLFaviconCache() setObject:image forKey:key];
-            drain(image);
+            if (normalized) [ApolloSLFaviconCache() setObject:normalized forKey:key];
+            drain(normalized);
         });
     }] resume];
 }
@@ -368,6 +445,61 @@ static void ApolloSLFetchLinks(NSString *username, void (^completion)(NSArray<Ap
 // preferred browser), falling back to the system opener.
 static void ApolloSocialLinkOpenURL(NSURL *url, UIViewController *opener);
 
+// Sheet row cell with a FIXED-size icon box so every icon type — favicon, bundled
+// coffee glyph, or placeholder — lands in the same column at the same size, and the
+// title/subtitle of every row line up. (The default UITableViewCell sizes its
+// imageView to each image's natural size, which is what let differently-sized icons
+// stagger the text indentation.)
+@interface ApolloSLSheetCell : UITableViewCell
+@property (nonatomic, strong) UIImageView *iconBox;
+@property (nonatomic, strong) UILabel *titleLabel2;
+@property (nonatomic, strong) UILabel *subtitleLabel2;
+@end
+
+@implementation ApolloSLSheetCell
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:UITableViewCellStyleDefault reuseIdentifier:reuseIdentifier];
+    if (self) {
+        _iconBox = [[UIImageView alloc] init];
+        _iconBox.contentMode = UIViewContentModeScaleAspectFit;
+        _iconBox.clipsToBounds = YES;
+        [self.contentView addSubview:_iconBox];
+
+        _titleLabel2 = [[UILabel alloc] init];
+        _titleLabel2.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+        _titleLabel2.adjustsFontForContentSizeCategory = YES;
+        _titleLabel2.textColor = [UIColor labelColor];
+        [self.contentView addSubview:_titleLabel2];
+
+        _subtitleLabel2 = [[UILabel alloc] init];
+        _subtitleLabel2.font = [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline];
+        _subtitleLabel2.adjustsFontForContentSizeCategory = YES;
+        _subtitleLabel2.textColor = [UIColor secondaryLabelColor];
+        [self.contentView addSubview:_subtitleLabel2];
+
+        self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    }
+    return self;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGFloat leftPad = 16.0, gap = 12.0, rightPad = 8.0;
+    CGFloat w = self.contentView.bounds.size.width;
+    CGFloat h = self.contentView.bounds.size.height;
+    self.iconBox.frame = CGRectMake(leftPad, (h - kSLSheetIconBox) / 2.0, kSLSheetIconBox, kSLSheetIconBox);
+    CGFloat tx = leftPad + kSLSheetIconBox + gap;
+    CGFloat tw = MAX(0.0, w - tx - rightPad);
+    CGSize ts = [self.titleLabel2 sizeThatFits:CGSizeMake(tw, CGFLOAT_MAX)];
+    CGSize ss = [self.subtitleLabel2 sizeThatFits:CGSizeMake(tw, CGFLOAT_MAX)];
+    CGFloat spacing = 2.0;
+    CGFloat blockH = ts.height + spacing + ss.height;
+    CGFloat top = (h - blockH) / 2.0;
+    self.titleLabel2.frame = CGRectMake(tx, top, tw, ts.height);
+    self.subtitleLabel2.frame = CGRectMake(tx, top + ts.height + spacing, tw, ss.height);
+}
+@end
+
 @interface ApolloSocialLinksSheetViewController : UITableViewController
 @property (nonatomic, copy) NSArray<ApolloSocialLink *> *links;
 @property (nonatomic, weak) UIViewController *opener;
@@ -380,6 +512,8 @@ static void ApolloSocialLinkOpenURL(NSURL *url, UIViewController *opener);
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.title = @"Social Links";
+    self.tableView.rowHeight = 58.0;   // room for the fixed icon box + two text lines
+    [self.tableView registerClass:[ApolloSLSheetCell class] forCellReuseIdentifier:@"SLSheetCell"];
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemClose
                                                                                            target:self action:@selector(apollo_close)];
 }
@@ -389,20 +523,18 @@ static void ApolloSocialLinkOpenURL(NSURL *url, UIViewController *opener);
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section { return self.links.count; }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"SLSheetCell"];
-    if (!cell) cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"SLSheetCell"];
+    ApolloSLSheetCell *cell = [tableView dequeueReusableCellWithIdentifier:@"SLSheetCell" forIndexPath:indexPath];
     ApolloSocialLink *link = self.links[indexPath.row];
 
-    cell.textLabel.text = link.title;
-    cell.detailTextLabel.text = link.url.host ?: link.urlString;
-    cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
-    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    cell.titleLabel2.text = link.title;
+    cell.subtitleLabel2.text = link.url.host ?: link.urlString;
 
-    // Bundled glyph, else cached favicon, else placeholder + async swap.
+    // Bundled glyph, else cached (already-normalized) favicon, else placeholder + async swap.
+    // Every image lands in the cell's fixed icon box (aspect-fit), so all rows align.
     UIImage *bundled = ApolloSLBundledIconForType(link.type);
     UIImage *favicon = ApolloSLFaviconCachedForHost(link.url.host);
-    cell.imageView.image = bundled ?: (favicon ?: ApolloSLPlaceholderIcon());
-    cell.imageView.tintColor = [UIColor secondaryLabelColor];
+    cell.iconBox.image = bundled ?: (favicon ?: ApolloSLPlaceholderIcon());
+    cell.iconBox.tintColor = (bundled || favicon) ? nil : [UIColor secondaryLabelColor];
     if (!bundled && !favicon) {
         NSString *wantHost = link.url.host;
         __weak typeof(self) weakSelf = self;  // don't keep the sheet alive past a dismiss
@@ -411,13 +543,12 @@ static void ApolloSocialLinkOpenURL(NSURL *url, UIViewController *opener);
             typeof(self) strongSelf = weakSelf;
             UITableView *strongTable = weakTable;
             if (!image || !strongSelf || !strongTable) return;
-            UITableViewCell *live = [strongTable cellForRowAtIndexPath:indexPath];
+            ApolloSLSheetCell *live = (ApolloSLSheetCell *)[strongTable cellForRowAtIndexPath:indexPath];
             // Guard against cell reuse pointing at a different link now.
-            if (live && indexPath.row < (NSInteger)strongSelf.links.count &&
+            if ([live isKindOfClass:[ApolloSLSheetCell class]] && indexPath.row < (NSInteger)strongSelf.links.count &&
                 [strongSelf.links[indexPath.row].url.host isEqualToString:wantHost]) {
-                live.imageView.image = image;
-                live.imageView.tintColor = nil;
-                [live setNeedsLayout];
+                live.iconBox.image = image;
+                live.iconBox.tintColor = nil;
             }
         });
     }


### PR DESCRIPTION
## What

The Social Links icons on a profile rendered at inconsistent sizes — in both the header badge row and the slide-up "Social Links" sheet, some glyphs appeared large and edge-to-edge while others looked small and floating.

## Why

The icons are per-domain favicons (Google S2). They arrive at different native pixel sizes (16/32/64px) **and** with different internal transparent padding — some fill their canvas edge-to-edge (e.g. the Facebook circle, the YouTube rounded rect), others are a small centered glyph ringed by transparent margin. Two consequences:

- The sheet's default `UITableViewCell` sizes its `imageView` to each image's **natural point size**, so low-resolution favicons rendered small and high-res ones large.
- Under aspect-fit in the fixed-size badge view, the padded glyphs looked shrunken next to the edge-to-edge ones.

## Fix

One file, `src/ApolloProfileSocialLinks.m`:

1. **Normalize every favicon once, at the cache store chokepoint** (`ApolloSLNormalizedFavicon`): trim the transparent margin (alpha bounding box), then aspect-fit the trimmed content — with a small uniform inset — centered into a single canonical 28pt square. Because this happens at the one place every favicon is cached, the name pills, the header badge row, and the sheet all inherit a uniform image with no per-call-site change. The work runs off the main thread on the `NSURLSession` completion (`UIGraphicsImageRenderer` is background-thread safe); the result is stored/drained on the main queue.

2. **Fixed-size sheet icon box** (`ApolloSLSheetCell`): a small custom cell with a fixed icon column, so every icon type — favicon, bundled coffee glyph, or placeholder fallback — lands at the same size and the title/subtitle of every row line up. (The default cell sized its imageView to each image, which staggered the text indentation across rows.)

## Before / After

| Before | After |
| :---: | :---: |
| <img width="320" alt="Before — inconsistent icon sizes" src="https://github.com/user-attachments/assets/a626e6fc-2a8a-4734-9bbb-ee8b400ae2c7" /> | <img width="320" alt="After — uniform icon sizes" src="https://github.com/user-attachments/assets/4cfd8841-5bc6-45e8-b6da-b6871245618d" /> |
| Favicons arrive at different pixel sizes and padding, so the icons render at **inconsistent sizes** — some large and edge-to-edge, others small and floating — and the sheet rows don't line up. | Each favicon is trimmed and aspect-fit into a **uniform square**, and the sheet uses a fixed icon box, so every icon renders at the same size and the rows align. |

## Testing

Tested in the iOS 26 Simulator on profiles with multiple links — `u/Espn`, `u/PlayStation`, `u/NASA` (5 links each). Both the header badge row and the sheet now render every icon at a consistent size, including the placeholder fallback for a domain with no favicon (`blog.playstation.com`). Not yet device-tested.
