### PR TITLE
Fix Community Highlights: old-reddit web-scrape poisoning + stale carousel on in-place subreddit switch

### DIFF
--- a/src/ApolloSubredditHighlights.xm
+++ b/src/ApolloSubredditHighlights.xm
@@ -97,6 +97,7 @@ static const void *kApolloHLActiveSubKey       = &kApolloHLActiveSubKey;      //
 static const void *kApolloHLContainerKey       = &kApolloHLContainerKey;      // ApolloHLHeaderContainerView on the VC (headers-on coexistence)
 static char kApolloHLHiddenRowsKey;            // NSMutableSet<NSNumber*> of de-duped sticky rows, per ASTableNode
 static char kApolloHLStickyCountKey;           // NSNumber (REST sticky count N) per feed ASTableNode — breaker rule
+static char kApolloHLSwitchPendingKey;         // BOOL on the VC — an in-place-switch re-install is already scheduled
 
 #pragma mark - Subreddit detection (adapted from ApolloSubredditHeaders.xm)
 
@@ -1853,6 +1854,41 @@ static void ApolloHLCollapseOrphanSeparators(UIViewController *vc) {
 #pragma mark - Hooks
 
 %hook UITableView
+
+// Catch an in-place subreddit switch (the nav-title "jump bar": tap the sub name,
+// type another sub) under a REUSED PostsViewController. On that path Apollo swaps
+// the feed's contents in place — the table re-lays-out repeatedly — but the VC's
+// viewDidLayoutSubviews (which drives ApolloHLInstall) does NOT fire, so the
+// standalone carousel keeps showing the PREVIOUS sub's highlights on the new feed.
+// The feed table's own layoutSubviews DOES fire throughout the switch, so detect
+// the stale carousel here and re-run install. Only managed feed tables (those
+// currently hosting our carousel) are inspected — a single associated-object read
+// short-circuits every other UITableView in the app.
+- (void)layoutSubviews {
+    %orig;
+    if (!sCommunityHighlights || sShowSubredditHeaders) return;
+    if (![objc_getAssociatedObject(self, kApolloHLManagedTableKey) boolValue]) return;
+    UIViewController *vc = objc_getAssociatedObject(self, kApolloHLManagedVCKey);
+    if (!vc) return;
+    NSString *installed = objc_getAssociatedObject(vc, kApolloHLSubredditKey); // carousel's sub
+    if (installed.length == 0) return;
+    NSString *current = ApolloHLSubredditName(vc); // nil for special feeds (all/home/popular/…)
+    if ([installed isEqualToString:current]) return; // still the same sub → nothing to do
+    // The VC now shows a different sub (or a special feed) than the installed carousel.
+    // Re-run install on the next runloop turn — NOT inline: ApolloHLInstall sets
+    // tableHeaderView, which would re-enter layoutSubviews. Guard so a single
+    // re-install is scheduled per switch rather than one per layout pass.
+    if ([objc_getAssociatedObject(vc, &kApolloHLSwitchPendingKey) boolValue]) return;
+    objc_setAssociatedObject(vc, &kApolloHLSwitchPendingKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    __weak UIViewController *weakVC = vc;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *strongVC = weakVC;
+        if (!strongVC) return;
+        objc_setAssociatedObject(strongVC, &kApolloHLSwitchPendingKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloLog(@"[Highlights] in-place subreddit switch → rebuilding carousel for %@", ApolloHLSubredditName(strongVC) ?: @"(special feed)");
+        ApolloHLInstall(strongVC);
+    });
+}
 
 - (void)setTableHeaderView:(UIView *)tableHeaderView {
     if (![objc_getAssociatedObject(self, kApolloHLManagedTableKey) boolValue]) { %orig; return; }

--- a/src/ApolloSubredditHighlights.xm
+++ b/src/ApolloSubredditHighlights.xm
@@ -475,6 +475,36 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
 @property (nonatomic) int polls;
 @end
 @implementation ApolloHLWebFetch
+
+// A single non-persistent (in-memory) WKWebsiteDataStore, reused for every
+// highlights scrape this app session.
+//
+// Why isolate the scrape from the app's shared cookies: Reddit serves the *old*
+// reddit layout at www.reddit.com whenever the logged-in session belongs to an
+// account whose "Use new Reddit as my default experience" preference is disabled.
+// Apollo's OAuth login runs through a www.reddit.com web view, so that account's
+// session + old-reddit preference land in the SHARED default WKWebsiteDataStore.
+// Old reddit renders none of the "Community Highlights" carousel markup this
+// scraper looks for, so the web upgrade silently finds nothing and the carousel
+// stays stuck on just the two stickied posts the REST listing returns — exactly
+// the "only got the first 2 posts" symptom. The poison is sticky too: deleting
+// the Apollo account never clears WebKit cookies, so only deleting the whole app
+// cleared it. (Same root cause as the Social Links scrape fixed in #496; reported
+// there by @Uranosphaerite as also affecting Community Highlights / #463.)
+//
+// A logged-out, in-memory store sidesteps all of it: with no account session
+// Reddit serves its default (new/shreddit) experience — which DOES carry the
+// highlights carousel — so the scrape can neither poison nor be poisoned by the
+// user's browsing session, and it resets each launch. Shared (not per-scrape) so
+// Reddit's JS bot-challenge cookie warms once per session rather than cold on
+// every subreddit. Highlights are public, so no login is needed.
++ (WKWebsiteDataStore *)apollo_scrapeDataStore {
+    static WKWebsiteDataStore *store;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ store = [WKWebsiteDataStore nonPersistentDataStore]; });
+    return store;
+}
+
 - (void)startForSub:(NSString *)sub completion:(void (^)(NSArray<ApolloHLItem *> *))done {
     self.sub = sub; self.done = done; self.polls = 0;
     UIWindow *win = nil;
@@ -484,7 +514,9 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
     }
     if (!win) win = UIApplication.sharedApplication.windows.firstObject;
     if (!win) { [self finish:nil]; return; }
-    self.web = [[WKWebView alloc] initWithFrame:win.bounds configuration:[[WKWebViewConfiguration alloc] init]];
+    WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+    config.websiteDataStore = [ApolloHLWebFetch apollo_scrapeDataStore];
+    self.web = [[WKWebView alloc] initWithFrame:win.bounds configuration:config];
     self.web.navigationDelegate = self;
     self.web.alpha = 0.011; self.web.userInteractionEnabled = NO;
     [win insertSubview:self.web atIndex:0];


### PR DESCRIPTION
Follow-up to #463 (Community Highlights) applying the same fix that #496 made to the profile Social Links scrape.

### The bug
@Uranosphaerite reported (on #496) that Community Highlights is affected by the same old-reddit poisoning, since it also loads a www.reddit.com page in a hidden `WKWebView`:

> I think that #463 is also affected by this bug since it also loads the web page in the background. I tested on r/bleach since it was used as an example and only got the first 2 posts (had the web highlights setting on). Also, when I switched subs the highlights from the previous sub stayed on the screen.

### Root cause
The "Load All Highlights (Web)" upgrade built its hidden `WKWebView` with the shared default `WKWebsiteDataStore`. Apollo's OAuth login runs through a www.reddit.com web view, so signing into an account whose **"Use new Reddit as my default experience"** preference is **off** deposits that account's session + old-reddit preference into the shared, on-disk cookie jar. www.reddit.com then serves the **old reddit** layout, which has none of the "Community Highlights" carousel markup the scraper looks for — so the web upgrade silently finds nothing and the carousel stays stuck on just the two stickied posts the REST listing returns (the *"only got the first 2 posts"* symptom). It's sticky because deleting the Apollo account never clears WebKit cookies — only deleting the whole app did.

### The fix
Scrape through a process-cached, **logged-out, non-persistent (in-memory) `WKWebsiteDataStore`** instead — exactly what #496 did for Social Links. With no account session, Reddit serves its default new/shreddit experience (which *does* carry the highlights carousel), and the scrape can neither poison nor be poisoned by the user's browsing session. Highlights are public, so no login is needed. This also repairs already-affected installs without an app reinstall, since the scraper no longer touches the poisoned shared store.

The "previous sub's highlights stayed on screen" symptom is a side effect of the same failure: against a dead old-reddit page the hidden web view polls for the full ~16s timeout and resolves to nothing, leaving stale state up. With the fix the scrape resolves on the first poll and tears its web view down promptly.

### Testing
Simulator (iOS 26, Liquid Glass), web highlights toggle on, logged-out scrape store:
- **r/bleach**: `web upgrade r/bleach: 2 → 6` — extracted all 6 highlights on poll #1.
- **r/formula1** (after switching subs): `web upgrade r/formula1: 2 → 4` — shows formula1's own carousel, no stale bleach cards.

Confirms the isolated store still serves the carousel (feature intact) and that switching subs no longer carries the previous sub's highlights. Sim-tested; not yet device-tested.

Thanks to @Uranosphaerite for catching and reporting this.