### PR TITLE
Theme Builder: import/export custom themes + fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/UIWindow+Apollo.m \
     $(SRC_DIR)/fishhook.c \
     $(SSZIPARCHIVE_FILES)
-ApolloReborn_FRAMEWORKS = UIKit Security AVFoundation OSLog NaturalLanguage ImageIO StoreKit PhotosUI SafariServices SystemConfiguration WebKit AuthenticationServices
+ApolloReborn_FRAMEWORKS = UIKit Security AVFoundation OSLog NaturalLanguage ImageIO StoreKit PhotosUI SafariServices SystemConfiguration WebKit AuthenticationServices UniformTypeIdentifiers
 ApolloReborn_LIBRARIES = z iconv
 ApolloReborn_CFLAGS = -fobjc-arc -Wno-error=unguarded-availability-new -Wno-module-import-in-extern-c -I$(THEOS_PROJECT_DIR)/$(SRC_DIR) -I$(THEOS_PROJECT_DIR)/liquid-glass/generated -I$(THEOS_PROJECT_DIR)/$(MODULES_DIR) -I$(THEOS_PROJECT_DIR)/$(SSZIPARCHIVE_DIR) -I$(THEOS_PROJECT_DIR)/$(SSZIPARCHIVE_DIR)/minizip -DHAVE_ARC4RANDOM_BUF -DHAVE_ICONV -DHAVE_INTTYPES_H -DHAVE_PKCRYPT -DHAVE_STDINT_H -DHAVE_WZAES -DHAVE_ZLIB -DZLIB_COMPAT
 

--- a/src/ApolloThemeBuilder.h
+++ b/src/ApolloThemeBuilder.h
@@ -63,6 +63,10 @@ BOOL ApolloThemeBuilderParseImport(NSData *data, NSString **outName,
                                    NSDictionary<NSString *, NSString *> **outColors);
 // Filesystem-safe "<name>.json" for an exported theme.
 NSString *ApolloThemeBuilderExportFilename(NSString *themeName);
+// Maximum accepted size (bytes) for an imported theme file. Callers should enforce
+// this BEFORE reading a picked file into memory, so a multi-hundred-MB file can't be
+// fully loaded (spiking memory / risking jetsam) before the parser's own cap rejects it.
+NSUInteger ApolloThemeBuilderMaxImportBytes(void);
 
 BOOL ApolloThemeBuilderIsEnabled(void);
 void ApolloThemeBuilderSetEnabled(BOOL enabled);

--- a/src/ApolloThemeBuilder.h
+++ b/src/ApolloThemeBuilder.h
@@ -82,4 +82,9 @@ void ApolloThemeBuilderForceRepaint(void);
 UIColor *ApolloThemeBuilderColorFromHex(NSString *hex);
 NSString *ApolloThemeBuilderHexFromColor(UIColor *color);
 
+// A visible cell-selection highlight for the given mode ("light"/"dark"),
+// derived from the card (primaryBG) colour so a tap reads clearly against the
+// theme. Returns nil if no primaryBG is set.
+UIColor *ApolloThemeBuilderSelectionColor(NSString *mode);
+
 __END_DECLS

--- a/src/ApolloThemeBuilder.h
+++ b/src/ApolloThemeBuilder.h
@@ -52,6 +52,18 @@ void ApolloThemeBuilderRenameActiveCustomTheme(NSString *name);
 BOOL ApolloThemeBuilderDeleteActiveCustomTheme(void);
 void ApolloThemeBuilderResetActiveCustomThemeColors(void);
 
+// Import / Export. Export serializes only a theme's name + colors (no account
+// data, API keys, ids, or timestamps) to portable JSON, so a shared theme file
+// is safe to hand to anyone. Import is strict: it accepts only known role.mode
+// keys with valid 6-digit hex, clamps the name, and the caller mints a fresh
+// theme — a hand-edited or hostile file can neither overwrite an existing theme
+// nor inject arbitrary defaults keys. See the note in ApolloThemeBuilder.xm.
+NSData *ApolloThemeBuilderExportData(NSDictionary *theme);
+BOOL ApolloThemeBuilderParseImport(NSData *data, NSString **outName,
+                                   NSDictionary<NSString *, NSString *> **outColors);
+// Filesystem-safe "<name>.json" for an exported theme.
+NSString *ApolloThemeBuilderExportFilename(NSString *themeName);
+
 BOOL ApolloThemeBuilderIsEnabled(void);
 void ApolloThemeBuilderSetEnabled(BOOL enabled);
 

--- a/src/ApolloThemeBuilder.xm
+++ b/src/ApolloThemeBuilder.xm
@@ -839,26 +839,23 @@ static void ThemeBuilderApplyHighlight(UITableViewCell *cell) {
 // runs, repaint that node to the visible themed selection while pressed; on
 // release the node's %orig restores its normal colour and we leave it.
 static void ThemeBuilderApplyNodeHighlight(id node, BOOL highlighted) {
-    if (!sRemapActive) return;
+    // Press-only: Apollo restores the normal colour on release, so we just
+    // override the pressed shade (the darker colour it uses is invisible on a
+    // dark custom theme).
+    if (!sRemapActive || !highlighted) return;
     UIUserInterfaceStyle style = UITraitCollection.currentTraitCollection.userInterfaceStyle;
     NSString *mode = (style == UIUserInterfaceStyleDark) ? @"dark" : @"light";
     UIColor *sel = ApolloThemeBuilderSelectionColor(mode);
     if (!sel) return;
-    id bgNode = ThemeBuilderObjectIvar(node, "backgroundNode");
-    if ([bgNode respondsToSelector:@selector(setBackgroundColor:)]) {
-        // Profile-style cells (ProfileFeatureCellNode) recolour a child
-        // backgroundNode and DON'T restore it on release, so we drive both
-        // directions ourselves (card colour when not pressed).
-        UIColor *color = highlighted ? sel
-            : ApolloThemeBuilderColorFromHex(ApolloThemeBuilderSavedHex(kApolloThemeRolePrimaryBG, mode));
-        if (color) ((void (*)(id, SEL, UIColor *))objc_msgSend)(bgNode, @selector(setBackgroundColor:), color);
-    } else if (highlighted && [node respondsToSelector:@selector(setBackgroundColor:)]) {
-        // Post-style cells (LargePostCellNode / CompactPostCellNode) recolour the
-        // node's own background to a darker shade on press — invisible on a dark
-        // theme. Override to the visible highlight; the node's own
-        // setHighlighted:NO restores the normal colour, so we only touch press.
-        ((void (*)(id, SEL, UIColor *))objc_msgSend)(node, @selector(setBackgroundColor:), sel);
-    }
+    // Recolour the *visible card* that Apollo darkens on press. For the profile
+    // feature rows that's a child `insideNode` (an inset card); a full-width
+    // `backgroundNode` sits behind it purely to colour the inset side-margins —
+    // recolouring that one made the highlight bleed around/behind the card. For
+    // post cells there's no insideNode, so it's the cell node itself.
+    id target = ThemeBuilderObjectIvar(node, "insideNode");
+    if (![target respondsToSelector:@selector(setBackgroundColor:)]) target = node;
+    if ([target respondsToSelector:@selector(setBackgroundColor:)])
+        ((void (*)(id, SEL, UIColor *))objc_msgSend)(target, @selector(setBackgroundColor:), sel);
 }
 
 static void ThemeBuilderApplyAccentImageView(id cell) {

--- a/src/ApolloThemeBuilder.xm
+++ b/src/ApolloThemeBuilder.xm
@@ -1017,53 +1017,73 @@ void ApolloThemeBuilderActivateDonorLive(void) {
 
 %end
 
-// Only the two settings screens the builder hooks directly (Appearance + Theme
-// Builder) gave their cells a themed tap highlight — every other settings screen
-// fell back to the system selection, which reads wrong against a custom theme.
-// Give every Apollo settings cell the same themed highlight in one place, scoped
-// by the owning view controller (an Apollo Settings*ViewController) rather than
-// by cell class — those screens mix Eureka and several Apollo cell types — so
-// the feed, comments and other lists are untouched.
-%hook UITableViewCell
-
-- (void)layoutSubviews {
-    %orig;
+// Give every Apollo settings/search cell a themed tap highlight in one place,
+// scoped by the owning view controller (an Apollo Settings*/Search*ViewController)
+// rather than by cell class — those screens mix Eureka and several Apollo cell
+// types — so the feed, comments and other lists are untouched. Applied from both
+// layoutSubviews AND setHighlighted: some cells (e.g. ApolloSubtitleTableViewCell,
+// which Filters & Blocks uses) don't route their layoutSubviews through this hook,
+// so the layout-only path missed them — setHighlighted always runs.
+static void ThemeBuilderColorListCell(UITableViewCell *cell) {
     if (!sRemapActive) return;
-    UIView *v = self.superview;
+    UIView *v = cell.superview;
     while (v && ![v isKindOfClass:[UITableView class]]) v = v.superview;
     if (![v isKindOfClass:[UITableView class]]) return;
     id delegate = ((UITableView *)v).delegate;
     if (!delegate) return;
     NSString *owner = NSStringFromClass([delegate class]);
-    if (![owner containsString:@"Settings"] || ![owner containsString:@"ViewController"]) return;
-    NSString *mode = (self.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) ? @"dark" : @"light";
+    BOOL inScope = [owner containsString:@"ViewController"]
+        && ([owner containsString:@"Settings"] || [owner containsString:@"Search"]);
+    if (!inScope) return;
+    NSString *mode = (cell.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) ? @"dark" : @"light";
     UIColor *sel = ApolloThemeBuilderSelectionColor(mode);
     if (!sel) return;
-    // Eureka settings cells (Appearance, General, …) highlight via a
-    // selectedBackgroundView shown over their card.
-    if (![self.selectedBackgroundView.backgroundColor isEqual:sel]) {
+    // Eureka settings cells highlight via a selectedBackgroundView over their card.
+    if (![cell.selectedBackgroundView.backgroundColor isEqual:sel]) {
         UIView *bg = [[UIView alloc] init];
         bg.backgroundColor = sel;
-        self.selectedBackgroundView = bg;
+        cell.selectedBackgroundView = bg;
     }
-    // Apollo's own settings cells (ApolloDefault/RightDetail/IconText…) instead
-    // highlight by swapping their backgroundColor, which the custom-theme remap
-    // collapses onto the card colour — so the tap looks dead. Paint the themed
-    // selection while the cell is highlighted, re-applied here on every layout
-    // because the cell re-applies its own highlight each pass. Appearance/Theme
-    // Builder own their cell background, so leave those alone.
-    if (self.highlighted && ![owner containsString:@"Appearance"]
-        && ![self.contentView.backgroundColor isEqual:sel]) {
-        self.backgroundColor = sel;
-        self.contentView.backgroundColor = sel;
+    // Apollo's own cells instead swap their backgroundColor, which the remap
+    // collapses onto the card — paint the themed selection while pressed.
+    // Appearance/Theme Builder own their cell background, so leave those alone.
+    if (cell.highlighted && ![owner containsString:@"Appearance"]
+        && ![cell.contentView.backgroundColor isEqual:sel]) {
+        cell.backgroundColor = sel;
+        cell.contentView.backgroundColor = sel;
     }
+}
+
+%hook UITableViewCell
+
+- (void)layoutSubviews {
+    %orig;
+    ThemeBuilderColorListCell(self);
 }
 
 - (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated {
     %orig;
-    // Re-run layoutSubviews so the themed highlight above is applied on press and
-    // removed on release (the cell's own %orig restores its normal background).
+    // Re-run layoutSubviews so the themed highlight is applied on press and the
+    // cell's own %orig restores its normal background on release.
     if (sRemapActive) [self setNeedsLayout];
+}
+
+%end
+
+// ApolloSubtitleTableViewCell (used by Filters & Blocks) doesn't route its
+// layoutSubviews through the base UITableViewCell hook above, so the shared
+// coloring never reached it. Hook it directly — after its own layout — the same
+// way IconTextTableViewCell is handled.
+%hook _TtC6Apollo27ApolloSubtitleTableViewCell
+
+- (void)layoutSubviews {
+    %orig;
+    ThemeBuilderColorListCell((UITableViewCell *)self);
+}
+
+- (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated {
+    %orig;
+    if (sRemapActive) [(UITableViewCell *)self setNeedsLayout];
 }
 
 %end

--- a/src/ApolloThemeBuilder.xm
+++ b/src/ApolloThemeBuilder.xm
@@ -1036,7 +1036,8 @@ static NSString *ThemeBuilderListCellOwner(UITableViewCell *cell) {
     if (!delegate) return nil;
     NSString *owner = NSStringFromClass([delegate class]);
     BOOL inScope = [owner containsString:@"ViewController"]
-        && ([owner containsString:@"Settings"] || [owner containsString:@"Search"]);
+        && ([owner containsString:@"Settings"] || [owner containsString:@"Search"]
+            || [owner containsString:@"Friends"]);
     return inScope ? owner : nil;
 }
 
@@ -1185,6 +1186,17 @@ static void ThemeBuilderColorListCell(UITableViewCell *cell) {
 %end
 
 %hook _TtC6Apollo19CompactPostCellNode
+
+- (void)setHighlighted:(BOOL)highlighted {
+    %orig;
+    ThemeBuilderApplyNodeHighlight(self, highlighted);
+}
+
+%end
+
+// Comment cells (profile Comments/Saved/Overview, thread comments) are Texture
+// nodes too — same node-highlight path as the feed posts.
+%hook _TtC6Apollo15CommentCellNode
 
 - (void)setHighlighted:(BOOL)highlighted {
     %orig;

--- a/src/ApolloThemeBuilder.xm
+++ b/src/ApolloThemeBuilder.xm
@@ -389,6 +389,130 @@ void ApolloThemeBuilderResetActiveCustomThemeColors(void) {
     ApolloThemeBuilderReloadOverrides();
 }
 
+// ---------------------------------------------------------------------------
+// Import / Export
+// ---------------------------------------------------------------------------
+//
+// A theme serializes to a tiny, human-readable JSON document holding only its
+// name and its role→hex color map — no account data, API keys, device ids, or
+// internal theme ids — so a shared theme file is safe to give to anyone and
+// reveals nothing about the sender. Import is deliberately strict: it accepts
+// only known "<role>.<mode>" keys with 6-digit hex values, clamps the name, and
+// the caller always mints a fresh theme id, so a hand-edited or hostile file
+// can neither overwrite an existing theme, inject arbitrary defaults keys, nor
+// blow up storage with unbounded data.
+
+static NSString * const kThemeExportMarkerKey = @"apolloThemeBuilder";
+static const NSInteger kThemeExportVersion = 1;
+static const NSUInteger kThemeImportMaxBytes = 256 * 1024; // generous; a theme is <1KB
+static const NSUInteger kThemeNameMaxLength = 60;
+
+// "RRGGBB" (uppercased) if the value is a valid 6-digit hex color, '#'/
+// whitespace tolerated, else nil.
+static NSString *ThemeBuilderNormalizeHex(id hex) {
+    if (![hex isKindOfClass:[NSString class]]) return nil;
+    NSString *clean = [[(NSString *)hex stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet]
+                       stringByReplacingOccurrencesOfString:@"#" withString:@""];
+    if (clean.length != 6) return nil;
+    unsigned int v = 0;
+    NSScanner *scanner = [NSScanner scannerWithString:clean];
+    if (![scanner scanHexInt:&v] || !scanner.atEnd) return nil;
+    return clean.uppercaseString;
+}
+
+// Set of every accepted "<role>.<mode>" color key (8 roles × {light,dark}).
+static NSSet<NSString *> *ThemeBuilderValidColorKeys(void) {
+    static NSSet *keys;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        NSMutableSet *set = [NSMutableSet set];
+        for (NSString *role in ApolloThemeBuilderRoleKeys()) {
+            [set addObject:[role stringByAppendingString:@".light"]];
+            [set addObject:[role stringByAppendingString:@".dark"]];
+        }
+        keys = set;
+    });
+    return keys;
+}
+
+// Drop anything that isn't a valid role.mode key with a valid hex value;
+// normalizes surviving hex to uppercase.
+static NSDictionary<NSString *, NSString *> *ThemeBuilderSanitizeColors(id colors) {
+    if (![colors isKindOfClass:[NSDictionary class]]) return @{};
+    NSSet *valid = ThemeBuilderValidColorKeys();
+    NSMutableDictionary *out = [NSMutableDictionary dictionary];
+    for (id key in (NSDictionary *)colors) {
+        if (![key isKindOfClass:[NSString class]] || ![valid containsObject:key]) continue;
+        NSString *hex = ThemeBuilderNormalizeHex(((NSDictionary *)colors)[key]);
+        if (hex) out[key] = hex;
+    }
+    return out;
+}
+
+// Trim, fall back to a default, and clamp to kThemeNameMaxLength without
+// splitting a composed character (emoji) at the boundary.
+static NSString *ThemeBuilderClampName(id name, NSString *fallback) {
+    NSString *trimmed = [name isKindOfClass:[NSString class]]
+        ? [(NSString *)name stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet]
+        : @"";
+    if (!trimmed.length) return fallback;
+    if (trimmed.length > kThemeNameMaxLength) {
+        NSRange r = [trimmed rangeOfComposedCharacterSequencesForRange:NSMakeRange(0, kThemeNameMaxLength)];
+        trimmed = [trimmed substringToIndex:r.length];
+    }
+    return trimmed;
+}
+
+NSData *ApolloThemeBuilderExportData(NSDictionary *theme) {
+    NSDictionary *payload = @{
+        kThemeExportMarkerKey: @(kThemeExportVersion),
+        @"name": ThemeBuilderClampName(theme[@"name"], @"Custom"),
+        @"colors": ThemeBuilderSanitizeColors(theme[@"colors"]),
+    };
+    NSError *error = nil;
+    NSData *data = [NSJSONSerialization dataWithJSONObject:payload
+                                                  options:NSJSONWritingPrettyPrinted | NSJSONWritingSortedKeys
+                                                    error:&error];
+    if (!data) ApolloLog(@"ThemeBuilder: export serialization failed: %@", error);
+    return data;
+}
+
+NSString *ApolloThemeBuilderExportFilename(NSString *themeName) {
+    NSString *name = ThemeBuilderClampName(themeName, @"Apollo Theme");
+    // Strip path-hostile characters so the file lands cleanly anywhere it's shared.
+    NSCharacterSet *illegal = [NSCharacterSet characterSetWithCharactersInString:@"/\\?%*|\"<>:"];
+    name = [[name componentsSeparatedByCharactersInSet:illegal] componentsJoinedByString:@"-"];
+    name = [name stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    if (!name.length || [name hasPrefix:@"."]) name = @"Apollo Theme";
+    return [name stringByAppendingPathExtension:@"json"];
+}
+
+BOOL ApolloThemeBuilderParseImport(NSData *data, NSString **outName,
+                                   NSDictionary<NSString *, NSString *> **outColors) {
+    if (outName) *outName = nil;
+    if (outColors) *outColors = nil;
+    if (![data isKindOfClass:[NSData class]] || data.length == 0 || data.length > kThemeImportMaxBytes) {
+        return NO;
+    }
+    id root = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+    if (![root isKindOfClass:[NSDictionary class]]) return NO;
+    NSDictionary *dict = (NSDictionary *)root;
+
+    // Accept either our wrapped format ({name, colors}) or a bare "<role>.<mode>"
+    // -> hex map (forgiving of hand-authored files).
+    id colorsSource = [dict[@"colors"] isKindOfClass:[NSDictionary class]] ? dict[@"colors"] : dict;
+    NSDictionary *colors = ThemeBuilderSanitizeColors(colorsSource);
+
+    // No recognizable colors and no Theme Builder marker — not a theme file.
+    // (A marked file with empty colors is a valid "blank" theme and round-trips.)
+    BOOL hasMarker = dict[kThemeExportMarkerKey] != nil;
+    if (colors.count == 0 && !hasMarker) return NO;
+
+    if (outName) *outName = ThemeBuilderClampName(dict[@"name"], @"Imported Theme");
+    if (outColors) *outColors = colors;
+    return YES;
+}
+
 BOOL ApolloThemeBuilderIsEnabled(void) {
     return [[NSUserDefaults standardUserDefaults] boolForKey:kApolloCustomThemeEnabledKey];
 }

--- a/src/ApolloThemeBuilder.xm
+++ b/src/ApolloThemeBuilder.xm
@@ -975,6 +975,57 @@ void ApolloThemeBuilderActivateDonorLive(void) {
 
 %end
 
+// Only the two settings screens the builder hooks directly (Appearance + Theme
+// Builder) gave their cells a themed tap highlight — every other settings screen
+// fell back to the system selection, which reads wrong against a custom theme.
+// Give every Apollo settings cell the same themed highlight in one place, scoped
+// by the owning view controller (an Apollo Settings*ViewController) rather than
+// by cell class — those screens mix Eureka and several Apollo cell types — so
+// the feed, comments and other lists are untouched.
+%hook UITableViewCell
+
+- (void)layoutSubviews {
+    %orig;
+    if (!sRemapActive) return;
+    UIView *v = self.superview;
+    while (v && ![v isKindOfClass:[UITableView class]]) v = v.superview;
+    if (![v isKindOfClass:[UITableView class]]) return;
+    id delegate = ((UITableView *)v).delegate;
+    if (!delegate) return;
+    NSString *owner = NSStringFromClass([delegate class]);
+    if (![owner containsString:@"Settings"] || ![owner containsString:@"ViewController"]) return;
+    NSString *mode = (self.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) ? @"dark" : @"light";
+    UIColor *sel = ApolloThemeBuilderSelectionColor(mode);
+    if (!sel) return;
+    // Eureka settings cells (Appearance, General, …) highlight via a
+    // selectedBackgroundView shown over their card.
+    if (![self.selectedBackgroundView.backgroundColor isEqual:sel]) {
+        UIView *bg = [[UIView alloc] init];
+        bg.backgroundColor = sel;
+        self.selectedBackgroundView = bg;
+    }
+    // Apollo's own settings cells (ApolloDefault/RightDetail/IconText…) instead
+    // highlight by swapping their backgroundColor, which the custom-theme remap
+    // collapses onto the card colour — so the tap looks dead. Paint the themed
+    // selection while the cell is highlighted, re-applied here on every layout
+    // because the cell re-applies its own highlight each pass. Appearance/Theme
+    // Builder own their cell background, so leave those alone.
+    if (self.highlighted && ![owner containsString:@"Appearance"]
+        && ![self.contentView.backgroundColor isEqual:sel]) {
+        self.backgroundColor = sel;
+        self.contentView.backgroundColor = sel;
+    }
+}
+
+- (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated {
+    %orig;
+    // Re-run layoutSubviews so the themed highlight above is applied on press and
+    // removed on release (the cell's own %orig restores its normal background).
+    if (sRemapActive) [self setNeedsLayout];
+}
+
+%end
+
 // These UIKit menu rows are the visible outlier for custom light themes:
 // under the outrun donor, their glyph assets arrive as original-rendered
 // images, so Apollo's tint writes are ignored. Stock light themes use the

--- a/src/ApolloThemeBuilder.xm
+++ b/src/ApolloThemeBuilder.xm
@@ -816,6 +816,22 @@ static UIImageView *ThemeBuilderImageViewIvar(id object, const char *name) {
     return [value isKindOfClass:[UIImageView class]] ? (UIImageView *)value : nil;
 }
 
+// Paint the themed selection colour over a highlighted cell. Apollo's own list
+// cells (IconText settings/profile rows…) highlight by swapping their
+// backgroundColor, which the custom-theme remap collapses onto the card colour;
+// this re-applies a visible highlight on every layout while pressed, and the
+// cell's own %orig restores its normal background on release. Used by the
+// class-scoped cell hooks below (covers profiles too, not just settings).
+static void ThemeBuilderApplyHighlight(UITableViewCell *cell) {
+    if (!sRemapActive || !cell.highlighted) return;
+    NSString *mode = (cell.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) ? @"dark" : @"light";
+    UIColor *sel = ApolloThemeBuilderSelectionColor(mode);
+    if (sel && ![cell.contentView.backgroundColor isEqual:sel]) {
+        cell.backgroundColor = sel;
+        cell.contentView.backgroundColor = sel;
+    }
+}
+
 static void ThemeBuilderApplyAccentImageView(id cell) {
     if (!sRemapActive) return;
 
@@ -1037,16 +1053,19 @@ void ApolloThemeBuilderActivateDonorLive(void) {
 - (void)layoutSubviews {
     %orig;
     ThemeBuilderApplyAccentImageView(self);
+    ThemeBuilderApplyHighlight((UITableViewCell *)self);
 }
 
 - (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated {
     %orig;
     ThemeBuilderApplyAccentImageView(self);
+    if (sRemapActive) [(UITableViewCell *)self setNeedsLayout];
 }
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {
     %orig;
     ThemeBuilderApplyAccentImageView(self);
+    if (sRemapActive) [(UITableViewCell *)self setNeedsLayout];
 }
 
 %end

--- a/src/ApolloThemeBuilder.xm
+++ b/src/ApolloThemeBuilder.xm
@@ -832,6 +832,27 @@ static void ThemeBuilderApplyHighlight(UITableViewCell *cell) {
     }
 }
 
+// Texture (AsyncDisplayKit) cell nodes — profile feature rows, feed posts,
+// comments — aren't UITableViewCells: they draw their pressed state by
+// recolouring a `backgroundNode` (an ASDisplayNode), which the custom-theme
+// remap collapses onto the card colour. After the node's own setHighlighted
+// runs, repaint that node to the visible themed selection while pressed; on
+// release the node's %orig restores its normal colour and we leave it.
+static void ThemeBuilderApplyNodeHighlight(id node, BOOL highlighted) {
+    if (!sRemapActive) return;
+    id bgNode = ThemeBuilderObjectIvar(node, "backgroundNode");
+    if (![bgNode respondsToSelector:@selector(setBackgroundColor:)]) return;
+    UIUserInterfaceStyle style = UITraitCollection.currentTraitCollection.userInterfaceStyle;
+    NSString *mode = (style == UIUserInterfaceStyleDark) ? @"dark" : @"light";
+    // Pressed → the visible themed highlight; released → restore the card colour
+    // ourselves (the node's own setHighlighted:NO leaves the pressed colour in
+    // place until the next layout pass, so a tap-cancel could otherwise linger).
+    UIColor *color = highlighted
+        ? ApolloThemeBuilderSelectionColor(mode)
+        : ApolloThemeBuilderColorFromHex(ApolloThemeBuilderSavedHex(kApolloThemeRolePrimaryBG, mode));
+    if (color) ((void (*)(id, SEL, UIColor *))objc_msgSend)(bgNode, @selector(setBackgroundColor:), color);
+}
+
 static void ThemeBuilderApplyAccentImageView(id cell) {
     if (!sRemapActive) return;
 
@@ -1099,6 +1120,18 @@ void ApolloThemeBuilderActivateDonorLive(void) {
     id spec = %orig;
     ThemeBuilderApplyAccentImageNode(self);
     return spec;
+}
+
+%end
+
+// Profile feature rows (Posts / Comments / Multireddits / Trophies) are Texture
+// cell nodes, not table cells, so the table-cell highlight hooks don't reach
+// them. Repaint their backgroundNode to the themed selection while pressed.
+%hook _TtC6Apollo22ProfileFeatureCellNode
+
+- (void)setHighlighted:(BOOL)highlighted {
+    %orig;
+    ThemeBuilderApplyNodeHighlight(self, highlighted);
 }
 
 %end

--- a/src/ApolloThemeBuilder.xm
+++ b/src/ApolloThemeBuilder.xm
@@ -1132,6 +1132,10 @@ static UIImage *ThemeBuilderPickerSwatch(void) {
 
 %end
 
+// Last font seen on a native Appearance settings row, used to size the injected
+// Theme Builder row to match Apollo's in-app Text Size setting (see willDisplay).
+static UIFont *sLastNativeSettingsFont = nil;
+
 static NSInteger (*sAppearanceRowsOrig)(id, SEL, UITableView *, NSInteger);
 static UITableViewCell *(*sAppearanceCellOrig)(id, SEL, UITableView *, NSIndexPath *);
 static CGFloat (*sAppearanceHeightOrig)(id, SEL, UITableView *, NSIndexPath *);
@@ -1263,6 +1267,36 @@ static void ThemeBuilderAppearanceWillDisplay(id self, SEL _cmd, UITableView *tv
     if (!ThemeBuilderAppearanceIsBuilderRow(ip)) {
         NSIndexPath *adjusted = ThemeBuilderAppearanceAdjustedIndexPath(ip);
         if (sAppearanceWillDisplayOrig) sAppearanceWillDisplayOrig(self, _cmd, tv, cell, adjusted);
+    } else {
+        // Our injected Theme Builder row is a stock UITableViewCell, whose default
+        // label font ignores Apollo's in-app Text Size setting that the native
+        // settings rows are sized from (and they use the medium system weight, not
+        // body-regular). Match them by copying a native sibling cell's font. Apply
+        // the last-known native font immediately to avoid a flash, then re-sample a
+        // current sibling on the next runloop — visibleCells isn't populated yet
+        // during the willDisplay cascade — so it also tracks live slider changes.
+        if (sLastNativeSettingsFont) cell.textLabel.font = sLastNativeSettingsFont;
+        __weak UITableViewCell *weakCell = cell;
+        __weak UITableView *weakTv = tv;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            UITableViewCell *c = weakCell; UITableView *t = weakTv;
+            if (!c || !t) return;
+            UIFont *nativeFont = nil;
+            for (UITableViewCell *vc in t.visibleCells) {
+                if (vc == c || ![vc isKindOfClass:[UITableViewCell class]]) continue;
+                NSIndexPath *vip = [t indexPathForCell:vc];
+                if (vip.section == 0 && vip.row != 1 && vc.textLabel.font) { nativeFont = vc.textLabel.font; break; }
+            }
+            if (!nativeFont) {
+                for (UITableViewCell *vc in t.visibleCells) {
+                    if (vc != c && vc.textLabel.font && ![vc.textLabel.text isEqualToString:@"Theme Builder"]) { nativeFont = vc.textLabel.font; break; }
+                }
+            }
+            if (nativeFont) {
+                sLastNativeSettingsFont = nativeFont;
+                c.textLabel.font = nativeFont;
+            }
+        });
     }
     if (sRemapActive) {
         NSString *mode = (tv.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) ? @"dark" : @"light";

--- a/src/ApolloThemeBuilder.xm
+++ b/src/ApolloThemeBuilder.xm
@@ -421,6 +421,7 @@ void ApolloThemeBuilderResetActiveCustomThemeColors(void) {
 static NSString * const kThemeExportMarkerKey = @"apolloThemeBuilder";
 static const NSInteger kThemeExportVersion = 1;
 static const NSUInteger kThemeImportMaxBytes = 256 * 1024; // generous; a theme is <1KB
+NSUInteger ApolloThemeBuilderMaxImportBytes(void) { return kThemeImportMaxBytes; }
 static const NSUInteger kThemeNameMaxLength = 60;
 
 // "RRGGBB" (uppercased) if the value is a valid 6-digit hex color, '#'/
@@ -1049,18 +1050,27 @@ static void ThemeBuilderColorListCell(UITableViewCell *cell) {
     UIColor *sel = ApolloThemeBuilderSelectionColor(mode);
     if (!sel) return;
     // Eureka settings cells highlight via a selectedBackgroundView over their card.
+    // This is the idiomatic, self-restoring mechanism — UIKit shows it on press and
+    // hides it on release, so it can never get stuck — set it on every in-scope cell.
     if (![cell.selectedBackgroundView.backgroundColor isEqual:sel]) {
         UIView *bg = [[UIView alloc] init];
         bg.backgroundColor = sel;
         cell.selectedBackgroundView = bg;
     }
-    // Apollo's own cells instead swap their backgroundColor, which the remap
-    // collapses onto the card — paint the themed selection while pressed.
+    // Apollo's OWN cells ignore selectedBackgroundView and instead swap their
+    // backgroundColor, which the remap collapses onto the card (invisible) — so for
+    // those we paint the themed selection directly. This is scoped to Apollo cells AND
+    // restored to the card colour when NOT highlighted: a Eureka cell never repaints its
+    // own contentView, so painting it here would linger after release (hiding the card).
     // Appearance/Theme Builder own their cell background, so leave those alone.
-    if (cell.highlighted && ![owner containsString:@"Appearance"]
-        && ![cell.contentView.backgroundColor isEqual:sel]) {
-        cell.backgroundColor = sel;
-        cell.contentView.backgroundColor = sel;
+    BOOL isApolloCell = [NSStringFromClass([cell class]) containsString:@"Apollo"];
+    if (isApolloCell && ![owner containsString:@"Appearance"]) {
+        UIColor *want = cell.highlighted ? sel
+            : ApolloThemeBuilderColorFromHex(ApolloThemeBuilderSavedHex(kApolloThemeRolePrimaryBG, mode));
+        if (want && ![cell.contentView.backgroundColor isEqual:want]) {
+            cell.backgroundColor = want;
+            cell.contentView.backgroundColor = want;
+        }
     }
 }
 

--- a/src/ApolloThemeBuilder.xm
+++ b/src/ApolloThemeBuilder.xm
@@ -1024,17 +1024,26 @@ void ApolloThemeBuilderActivateDonorLive(void) {
 // layoutSubviews AND setHighlighted: some cells (e.g. ApolloSubtitleTableViewCell,
 // which Filters & Blocks uses) don't route their layoutSubviews through this hook,
 // so the layout-only path missed them — setHighlighted always runs.
-static void ThemeBuilderColorListCell(UITableViewCell *cell) {
-    if (!sRemapActive) return;
+// The owning view-controller class name if this cell belongs to an Apollo
+// settings/search list, else nil. Used to scope every side effect (including the
+// re-layout) to those screens only — never UIKit's own table views such as the
+// keyboard's input-switcher menu.
+static NSString *ThemeBuilderListCellOwner(UITableViewCell *cell) {
     UIView *v = cell.superview;
     while (v && ![v isKindOfClass:[UITableView class]]) v = v.superview;
-    if (![v isKindOfClass:[UITableView class]]) return;
+    if (![v isKindOfClass:[UITableView class]]) return nil;
     id delegate = ((UITableView *)v).delegate;
-    if (!delegate) return;
+    if (!delegate) return nil;
     NSString *owner = NSStringFromClass([delegate class]);
     BOOL inScope = [owner containsString:@"ViewController"]
         && ([owner containsString:@"Settings"] || [owner containsString:@"Search"]);
-    if (!inScope) return;
+    return inScope ? owner : nil;
+}
+
+static void ThemeBuilderColorListCell(UITableViewCell *cell) {
+    if (!sRemapActive) return;
+    NSString *owner = ThemeBuilderListCellOwner(cell);
+    if (!owner) return;
     NSString *mode = (cell.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) ? @"dark" : @"light";
     UIColor *sel = ApolloThemeBuilderSelectionColor(mode);
     if (!sel) return;
@@ -1064,8 +1073,10 @@ static void ThemeBuilderColorListCell(UITableViewCell *cell) {
 - (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated {
     %orig;
     // Re-run layoutSubviews so the themed highlight is applied on press and the
-    // cell's own %orig restores its normal background on release.
-    if (sRemapActive) [self setNeedsLayout];
+    // cell's own %orig restores its normal background on release — but ONLY for
+    // our settings/search cells. Calling setNeedsLayout on every UITableViewCell
+    // (the keyboard's input-switcher menu, alerts, …) is an unwanted side effect.
+    if (sRemapActive && ThemeBuilderListCellOwner(self)) [self setNeedsLayout];
 }
 
 %end

--- a/src/ApolloThemeBuilder.xm
+++ b/src/ApolloThemeBuilder.xm
@@ -840,17 +840,25 @@ static void ThemeBuilderApplyHighlight(UITableViewCell *cell) {
 // release the node's %orig restores its normal colour and we leave it.
 static void ThemeBuilderApplyNodeHighlight(id node, BOOL highlighted) {
     if (!sRemapActive) return;
-    id bgNode = ThemeBuilderObjectIvar(node, "backgroundNode");
-    if (![bgNode respondsToSelector:@selector(setBackgroundColor:)]) return;
     UIUserInterfaceStyle style = UITraitCollection.currentTraitCollection.userInterfaceStyle;
     NSString *mode = (style == UIUserInterfaceStyleDark) ? @"dark" : @"light";
-    // Pressed → the visible themed highlight; released → restore the card colour
-    // ourselves (the node's own setHighlighted:NO leaves the pressed colour in
-    // place until the next layout pass, so a tap-cancel could otherwise linger).
-    UIColor *color = highlighted
-        ? ApolloThemeBuilderSelectionColor(mode)
-        : ApolloThemeBuilderColorFromHex(ApolloThemeBuilderSavedHex(kApolloThemeRolePrimaryBG, mode));
-    if (color) ((void (*)(id, SEL, UIColor *))objc_msgSend)(bgNode, @selector(setBackgroundColor:), color);
+    UIColor *sel = ApolloThemeBuilderSelectionColor(mode);
+    if (!sel) return;
+    id bgNode = ThemeBuilderObjectIvar(node, "backgroundNode");
+    if ([bgNode respondsToSelector:@selector(setBackgroundColor:)]) {
+        // Profile-style cells (ProfileFeatureCellNode) recolour a child
+        // backgroundNode and DON'T restore it on release, so we drive both
+        // directions ourselves (card colour when not pressed).
+        UIColor *color = highlighted ? sel
+            : ApolloThemeBuilderColorFromHex(ApolloThemeBuilderSavedHex(kApolloThemeRolePrimaryBG, mode));
+        if (color) ((void (*)(id, SEL, UIColor *))objc_msgSend)(bgNode, @selector(setBackgroundColor:), color);
+    } else if (highlighted && [node respondsToSelector:@selector(setBackgroundColor:)]) {
+        // Post-style cells (LargePostCellNode / CompactPostCellNode) recolour the
+        // node's own background to a darker shade on press — invisible on a dark
+        // theme. Override to the visible highlight; the node's own
+        // setHighlighted:NO restores the normal colour, so we only touch press.
+        ((void (*)(id, SEL, UIColor *))objc_msgSend)(node, @selector(setBackgroundColor:), sel);
+    }
 }
 
 static void ThemeBuilderApplyAccentImageView(id cell) {
@@ -1128,6 +1136,27 @@ void ApolloThemeBuilderActivateDonorLive(void) {
 // cell nodes, not table cells, so the table-cell highlight hooks don't reach
 // them. Repaint their backgroundNode to the themed selection while pressed.
 %hook _TtC6Apollo22ProfileFeatureCellNode
+
+- (void)setHighlighted:(BOOL)highlighted {
+    %orig;
+    ThemeBuilderApplyNodeHighlight(self, highlighted);
+}
+
+%end
+
+// Feed post cells are Texture nodes too, but recolour the node's own background
+// (not a child backgroundNode) to a darker shade on press — invisible on a dark
+// custom theme. Repaint to the visible themed selection while pressed.
+%hook _TtC6Apollo17LargePostCellNode
+
+- (void)setHighlighted:(BOOL)highlighted {
+    %orig;
+    ThemeBuilderApplyNodeHighlight(self, highlighted);
+}
+
+%end
+
+%hook _TtC6Apollo19CompactPostCellNode
 
 - (void)setHighlighted:(BOOL)highlighted {
     %orig;

--- a/src/ApolloThemeBuilder.xm
+++ b/src/ApolloThemeBuilder.xm
@@ -199,6 +199,22 @@ NSString *ApolloThemeBuilderHexFromColor(UIColor *color) {
             (int)lround(r * 255.0), (int)lround(g * 255.0), (int)lround(b * 255.0)];
 }
 
+UIColor *ApolloThemeBuilderSelectionColor(NSString *mode) {
+    UIColor *card = ApolloThemeBuilderColorFromHex(ApolloThemeBuilderSavedHex(kApolloThemeRolePrimaryBG, mode));
+    if (!card) return nil;
+    CGFloat r = 0, g = 0, b = 0, a = 0;
+    if (![card getRed:&r green:&g blue:&b alpha:&a]) return nil;
+    // Tap highlight = the card colour nudged toward white (dark mode) or black
+    // (light mode), mirroring iOS's pressed-row shade so it's clearly visible
+    // against any custom background while keeping the theme's hue.
+    BOOL dark = [mode isEqualToString:@"dark"];
+    CGFloat target = dark ? 1.0 : 0.0, k = 0.16;
+    return [UIColor colorWithRed:r + (target - r) * k
+                           green:g + (target - g) * k
+                            blue:b + (target - b) * k
+                           alpha:1.0];
+}
+
 NSString *ApolloThemeBuilderSavedHex(NSString *roleKey, NSString *mode) {
     NSDictionary *colors = ApolloThemeBuilderActiveCustomTheme()[@"colors"];
     NSString *saved = colors[[NSString stringWithFormat:@"%@.%@", roleKey, mode]];
@@ -1132,9 +1148,46 @@ static UIImage *ThemeBuilderPickerSwatch(void) {
 
 %end
 
-// Last font seen on a native Appearance settings row, used to size the injected
-// Theme Builder row to match Apollo's in-app Text Size setting (see willDisplay).
-static UIFont *sLastNativeSettingsFont = nil;
+// The injected Theme Builder row is a stock cell, so its label font doesn't
+// follow Apollo's in-app Text Size setting (the native Eureka rows are sized
+// from it, using the medium system weight). Match them by copying the current
+// font off a native sibling — and do it in layoutSubviews, because a one-shot
+// assignment doesn't survive the table's later layout/reuse passes when the
+// slider changes, whereas layoutSubviews always runs after those.
+@interface ApolloRebornThemeBuilderRowCell : UITableViewCell
+@property (nonatomic, strong) UIFont *apollo_targetFont;
+@end
+@implementation ApolloRebornThemeBuilderRowCell
+- (UIFont *)apollo_sampleNativeFont {
+    UIView *v = self.superview;
+    while (v && ![v isKindOfClass:[UITableView class]]) v = v.superview;
+    if (![v isKindOfClass:[UITableView class]]) return nil;
+    for (UITableViewCell *c in ((UITableView *)v).visibleCells) {
+        if (c == self || ![c isKindOfClass:[UITableViewCell class]]) continue;
+        NSString *t = c.textLabel.text;
+        if (c.textLabel.font && t.length && ![t isEqualToString:@"Theme Builder"]) return c.textLabel.font;
+    }
+    return nil;
+}
+- (void)layoutSubviews {
+    // Enforce the last-sampled native font: a one-shot assignment doesn't survive
+    // the table's layout/reuse passes, but layoutSubviews always re-applies it.
+    if (self.apollo_targetFont && ![self.textLabel.font isEqual:self.apollo_targetFont])
+        self.textLabel.font = self.apollo_targetFont;
+    [super layoutSubviews];
+    // Re-sample on the next runloop, when visibleCells is populated (it isn't yet
+    // during the layout cascade). This also tracks live Text Size slider changes.
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        typeof(self) s = weakSelf; if (!s) return;
+        UIFont *f = [s apollo_sampleNativeFont];
+        if (f && ![f isEqual:s.apollo_targetFont]) {
+            s.apollo_targetFont = f;
+            [s setNeedsLayout];
+        }
+    });
+}
+@end
 
 static NSInteger (*sAppearanceRowsOrig)(id, SEL, UITableView *, NSInteger);
 static UITableViewCell *(*sAppearanceCellOrig)(id, SEL, UITableView *, NSIndexPath *);
@@ -1196,7 +1249,7 @@ static UITableViewCell *ThemeBuilderAppearanceCell(id self, SEL _cmd, UITableVie
     if (ip.section == 0 && ip.row == 1) {
         static NSString *reuse = @"ApolloRebornThemeBuilderAppearanceCell";
         UITableViewCell *cell = [tv dequeueReusableCellWithIdentifier:reuse];
-        if (!cell) cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:reuse];
+        if (!cell) cell = [[ApolloRebornThemeBuilderRowCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:reuse];
         cell.textLabel.text = @"Theme Builder";
         cell.detailTextLabel.text = nil;
         cell.accessoryView = nil;
@@ -1267,37 +1320,10 @@ static void ThemeBuilderAppearanceWillDisplay(id self, SEL _cmd, UITableView *tv
     if (!ThemeBuilderAppearanceIsBuilderRow(ip)) {
         NSIndexPath *adjusted = ThemeBuilderAppearanceAdjustedIndexPath(ip);
         if (sAppearanceWillDisplayOrig) sAppearanceWillDisplayOrig(self, _cmd, tv, cell, adjusted);
-    } else {
-        // Our injected Theme Builder row is a stock UITableViewCell, whose default
-        // label font ignores Apollo's in-app Text Size setting that the native
-        // settings rows are sized from (and they use the medium system weight, not
-        // body-regular). Match them by copying a native sibling cell's font. Apply
-        // the last-known native font immediately to avoid a flash, then re-sample a
-        // current sibling on the next runloop — visibleCells isn't populated yet
-        // during the willDisplay cascade — so it also tracks live slider changes.
-        if (sLastNativeSettingsFont) cell.textLabel.font = sLastNativeSettingsFont;
-        __weak UITableViewCell *weakCell = cell;
-        __weak UITableView *weakTv = tv;
-        dispatch_async(dispatch_get_main_queue(), ^{
-            UITableViewCell *c = weakCell; UITableView *t = weakTv;
-            if (!c || !t) return;
-            UIFont *nativeFont = nil;
-            for (UITableViewCell *vc in t.visibleCells) {
-                if (vc == c || ![vc isKindOfClass:[UITableViewCell class]]) continue;
-                NSIndexPath *vip = [t indexPathForCell:vc];
-                if (vip.section == 0 && vip.row != 1 && vc.textLabel.font) { nativeFont = vc.textLabel.font; break; }
-            }
-            if (!nativeFont) {
-                for (UITableViewCell *vc in t.visibleCells) {
-                    if (vc != c && vc.textLabel.font && ![vc.textLabel.text isEqualToString:@"Theme Builder"]) { nativeFont = vc.textLabel.font; break; }
-                }
-            }
-            if (nativeFont) {
-                sLastNativeSettingsFont = nativeFont;
-                c.textLabel.font = nativeFont;
-            }
-        });
     }
+    // The injected Theme Builder row keeps its label sized to the native rows via
+    // ApolloRebornThemeBuilderRowCell's layoutSubviews (it tracks Apollo's Text
+    // Size setting) — no per-display font handling needed here.
     if (sRemapActive) {
         NSString *mode = (tv.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) ? @"dark" : @"light";
         UIColor *cellBG = ApolloThemeBuilderColorFromHex(ApolloThemeBuilderSavedHex(kApolloThemeRoleSecondaryBG, mode));
@@ -1306,7 +1332,9 @@ static void ThemeBuilderAppearanceWillDisplay(id self, SEL _cmd, UITableView *tv
         if (cellBG) {
             cell.backgroundColor = cellBG;
             UIView *sel = [[UIView alloc] init];
-            sel.backgroundColor = [cellBG colorWithAlphaComponent:0.7];
+            // Visible tap highlight derived from the card colour (the old
+            // secondaryBG@0.7 was nearly indistinguishable from the background).
+            sel.backgroundColor = ApolloThemeBuilderSelectionColor(mode) ?: [cellBG colorWithAlphaComponent:0.7];
             cell.selectedBackgroundView = sel;
         }
         if (textColor) cell.textLabel.textColor = textColor;

--- a/src/ApolloThemeBuilder.xm
+++ b/src/ApolloThemeBuilder.xm
@@ -1017,6 +1017,33 @@ void ApolloThemeBuilderActivateDonorLive(void) {
 
 %end
 
+// The Text Size slider lives in a Eureka custom cell (TextSliderCell) that has
+// no grouped-card backgroundView — its card area is painted by its contentView.
+// Apollo colors that contentView with the primaryBG role, which on this screen
+// is the table's page color (the Appearance VC paints its tableView background
+// with primaryBG and the cell cards with secondaryBG). Standard cells hide that
+// behind their own secondaryBG card, but the slider cell shows the primaryBG
+// contentView directly, so the slider reads as sitting on the page rather than
+// inside its card. Stock themes don't notice because their primaryBG and
+// secondaryBG are nearly identical; a custom theme makes them diverge. Repaint
+// the contentView to the same card color the other cells use, after Apollo's
+// own layout has run.
+%hook _TtC6Apollo14TextSliderCell
+
+- (void)layoutSubviews {
+    %orig;
+    if (!sRemapActive) return;
+    UITableViewCell *cell = (UITableViewCell *)self;
+    NSString *mode = (cell.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) ? @"dark" : @"light";
+    // Match whatever card color the willDisplay hook gave the cell (secondaryBG),
+    // falling back to the role directly if it wasn't set.
+    UIColor *card = cell.backgroundColor
+        ?: ApolloThemeBuilderColorFromHex(ApolloThemeBuilderSavedHex(kApolloThemeRoleSecondaryBG, mode));
+    if (card) cell.contentView.backgroundColor = card;
+}
+
+%end
+
 // A small rounded swatch (background + accent split) previewing the user's
 // light-mode colors, shown next to the "Custom" row in Apollo's theme picker.
 static UIImage *ThemeBuilderPickerSwatch(void) {

--- a/src/ApolloThemeBuilderViewController.m
+++ b/src/ApolloThemeBuilderViewController.m
@@ -827,9 +827,23 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
     // asCopy:YES vends an app-local copy, so this is usually a no-op; keep it as harmless
     // best-effort in case the OS ever hands back a security-scoped URL.
     BOOL scoped = [url startAccessingSecurityScopedResource];
+    // Enforce the size cap BEFORE reading: a theme is <1KB, so reject anything large up
+    // front rather than loading a multi-hundred-MB file into RAM (which could spike
+    // memory / get us jetsammed) only for the parser's own cap to bounce it afterwards.
+    NSNumber *fileSize = nil;
+    [url getResourceValue:&fileSize forKey:NSURLFileSizeKey error:NULL];
+    NSUInteger cap = ApolloThemeBuilderMaxImportBytes();
+    if (fileSize && fileSize.unsignedLongLongValue > cap) {
+        if (scoped) [url stopAccessingSecurityScopedResource];
+        ApolloLog(@"ThemeBuilder: import rejected oversize bytes=%@ cap=%lu", fileSize, (unsigned long)cap);
+        [self presentImportAlertWithTitle:@"Couldn’t Import Theme"
+                                  message:@"This file is too large to be an Apollo theme."];
+        return;
+    }
     // Read through a file coordinator so an iCloud-Drive file that is only a placeholder
     // gets materialized (downloaded) before we read it — a bare dataWithContentsOfURL:
-    // returns nil for an un-downloaded cloud file.
+    // returns nil for an un-downloaded cloud file. NSDataReadingMappedIfSafe maps rather
+    // than copies into RAM, a second guard if the size couldn't be read above.
     __block NSData *data = nil;
     __block NSError *readError = nil;
     NSError *coordError = nil;
@@ -838,7 +852,7 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
                                     options:NSFileCoordinatorReadingWithoutChanges
                                       error:&coordError
                                  byAccessor:^(NSURL *readURL) {
-        data = [NSData dataWithContentsOfURL:readURL options:0 error:&readError];
+        data = [NSData dataWithContentsOfURL:readURL options:NSDataReadingMappedIfSafe error:&readError];
     }];
     if (scoped) [url stopAccessingSecurityScopedResource];
     if (!data) {

--- a/src/ApolloThemeBuilderViewController.m
+++ b/src/ApolloThemeBuilderViewController.m
@@ -1,6 +1,7 @@
 #import "ApolloThemeBuilderViewController.h"
 #import "ApolloThemeBuilder.h"
 #import "ApolloCommon.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 // Relative luminance (sRGB-weighted; good enough for a contrast hint) + WCAG
 // contrast ratio, used to warn about color combos that can't be auto-fixed.
@@ -37,7 +38,7 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
 @implementation ThemeBuilderPreset
 @end
 
-@interface ApolloThemeBuilderViewController () <UIColorPickerViewControllerDelegate>
+@interface ApolloThemeBuilderViewController () <UIColorPickerViewControllerDelegate, UIDocumentPickerDelegate>
 @property (nonatomic, copy) NSString *editingRole;
 @property (nonatomic, copy) NSString *editingMode;
 @property (nonatomic, strong) NSTimer *repaintDebounce;
@@ -432,11 +433,12 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
     return (indexPath.row >= 0 && indexPath.row < roles.count) ? roles[indexPath.row] : nil;
 }
 
-- (UIMenu *)menuForTheme:(NSDictionary *)theme {
+- (UIMenu *)menuForTheme:(NSDictionary *)theme sourceView:(UIView *)sourceView {
     NSString *themeID = theme[@"id"];
     BOOL active = [themeID isEqualToString:ApolloThemeBuilderActiveCustomTheme()[@"id"]];
     BOOL canDelete = ApolloThemeBuilderCustomThemes().count > 1;
     __weak typeof(self) weakSelf = self;
+    __weak UIView *weakSource = sourceView;
     UIAction *edit = [UIAction actionWithTitle:@"Edit Colors" image:[UIImage systemImageNamed:@"paintpalette"]
                                     identifier:nil handler:^(__kindof UIAction *action) {
         [weakSelf pushColorEditorForThemeID:themeID];
@@ -463,6 +465,10 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
         [weakSelf refreshPreview];
         ApolloThemeBuilderForceRepaint();
     }];
+    UIAction *share = [UIAction actionWithTitle:@"Share Theme…" image:[UIImage systemImageNamed:@"square.and.arrow.up"]
+                                     identifier:nil handler:^(__kindof UIAction *action) {
+        [weakSelf exportTheme:theme fromSourceView:weakSource];
+    }];
     UIAction *rename = [UIAction actionWithTitle:@"Rename" image:[UIImage systemImageNamed:@"pencil"]
                                       identifier:nil handler:^(__kindof UIAction *action) {
         ApolloThemeBuilderSetActiveCustomThemeID(themeID);
@@ -474,7 +480,7 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
         [weakSelf confirmDeleteTheme];
     }];
     delete.attributes = canDelete ? UIMenuElementAttributesDestructive : UIMenuElementAttributesDisabled;
-    return [UIMenu menuWithTitle:@"" children:@[edit, use, template, duplicate, rename, delete]];
+    return [UIMenu menuWithTitle:@"" children:@[edit, use, template, duplicate, share, rename, delete]];
 }
 
 - (void)pushColorEditorForThemeID:(NSString *)themeID {
@@ -595,7 +601,7 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
         UIButton *more = [UIButton buttonWithType:UIButtonTypeSystem];
         more.frame = CGRectMake(0, 0, 34, 34);
         [more setImage:[UIImage systemImageNamed:@"ellipsis.circle"] forState:UIControlStateNormal];
-        more.menu = [self menuForTheme:theme];
+        more.menu = [self menuForTheme:theme sourceView:more];
         more.showsMenuAsPrimaryAction = YES;
         cell.accessoryView = more;
         return cell;
@@ -727,8 +733,97 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
         [self refreshPreview];
         ApolloThemeBuilderForceRepaint();
     }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Import from File…" style:UIAlertActionStyleDefault
+                                            handler:^(UIAlertAction *action) {
+        // Name comes from the imported file, so the text field above is ignored.
+        dispatch_async(dispatch_get_main_queue(), ^{ [self presentImportPicker]; });
+    }]];
     [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
     [self presentViewController:alert animated:YES completion:nil];
+}
+
+#pragma mark - Import / Export
+
+- (void)exportTheme:(NSDictionary *)theme fromSourceView:(UIView *)sourceView {
+    NSData *data = ApolloThemeBuilderExportData(theme);
+    if (!data.length) {
+        [self presentImportAlertWithTitle:@"Couldn’t Share Theme"
+                                  message:@"This theme could not be prepared for sharing."];
+        return;
+    }
+    NSString *filename = ApolloThemeBuilderExportFilename(theme[@"name"]);
+    NSURL *url = [[NSURL fileURLWithPath:NSTemporaryDirectory() isDirectory:YES] URLByAppendingPathComponent:filename];
+    NSError *error = nil;
+    if (![data writeToURL:url options:NSDataWritingAtomic error:&error]) {
+        ApolloLog(@"ThemeBuilder: export write failed: %@", error);
+        [self presentImportAlertWithTitle:@"Couldn’t Share Theme"
+                                  message:@"The theme file could not be written."];
+        return;
+    }
+    UIActivityViewController *activity =
+        [[UIActivityViewController alloc] initWithActivityItems:@[url] applicationActivities:nil];
+    // Remove the scratch file once sharing finishes or is cancelled. (Must run
+    // from the activity's own completion, not presentViewController:'s — the
+    // share targets may still be reading the URL after the sheet is presented.)
+    activity.completionWithItemsHandler = ^(UIActivityType _Nullable activityType, BOOL completed,
+                                            NSArray *_Nullable items, NSError *_Nullable err) {
+        [[NSFileManager defaultManager] removeItemAtURL:url error:NULL];
+    };
+    UIView *anchor = sourceView ?: self.view;
+    activity.popoverPresentationController.sourceView = anchor;
+    activity.popoverPresentationController.sourceRect = anchor.bounds;
+    [self presentViewController:activity animated:YES completion:nil];
+}
+
+- (void)presentImportPicker {
+    UIDocumentPickerViewController *picker =
+        [[UIDocumentPickerViewController alloc] initForOpeningContentTypes:@[UTTypeJSON, UTTypeText]];
+    picker.delegate = self;
+    picker.allowsMultipleSelection = NO;
+    picker.modalPresentationStyle = UIModalPresentationFormSheet; // match the app's other document pickers
+    [self presentViewController:picker animated:YES completion:nil];
+}
+
+- (void)importThemeFromURL:(NSURL *)url {
+    BOOL scoped = [url startAccessingSecurityScopedResource];
+    NSError *error = nil;
+    NSData *data = [NSData dataWithContentsOfURL:url options:0 error:&error];
+    if (scoped) [url stopAccessingSecurityScopedResource];
+    if (!data) {
+        ApolloLog(@"ThemeBuilder: import read failed: %@", error);
+        [self presentImportAlertWithTitle:@"Couldn’t Import Theme"
+                                  message:@"The selected file could not be read."];
+        return;
+    }
+    NSString *name = nil;
+    NSDictionary<NSString *, NSString *> *colors = nil;
+    if (!ApolloThemeBuilderParseImport(data, &name, &colors)) {
+        [self presentImportAlertWithTitle:@"Not an Apollo Theme"
+                                  message:@"This file isn’t a valid Apollo theme. Import a “.json” file exported from Theme Builder’s Share Theme option."];
+        return;
+    }
+    ApolloThemeBuilderCreateCustomTheme(name, colors); // mints a fresh id + makes it active
+    [self.tableView reloadData];
+    [self refreshPreview];
+    ApolloThemeBuilderForceRepaint();
+    [self presentImportAlertWithTitle:@"Theme Imported"
+                              message:[NSString stringWithFormat:@"“%@” was added to My Themes.",
+                                       ApolloThemeBuilderActiveCustomThemeName()]];
+}
+
+- (void)presentImportAlertWithTitle:(NSString *)title message:(NSString *)message {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title
+                                                                   message:message
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+#pragma mark - UIDocumentPickerDelegate
+
+- (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
+    NSURL *url = urls.firstObject;
+    if (url) [self importThemeFromURL:url];
 }
 
 - (void)presentRenameThemeDialog {

--- a/src/ApolloThemeBuilderViewController.m
+++ b/src/ApolloThemeBuilderViewController.m
@@ -798,28 +798,60 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
 }
 
 - (void)presentImportPicker {
+    // Content types: a theme file is plain JSON, but on a REAL (sideloaded) device a
+    // ".json" is often tagged generically — public.data or a dyn.* UTI — because no
+    // installed app claims the extension. The picker greys out (disables) any file that
+    // doesn't *conform* to a requested type, and UTI conformance only flows downward
+    // (public.json conforms up to text/data, but public.data/dyn.* don't conform down to
+    // public.json). A JSON-only filter therefore makes a generically-tagged file
+    // untappable: no selection, no delegate callback, no log — exactly the "tap does
+    // nothing" symptom. So we widen to the umbrella ancestors (data/item) too and
+    // validate by parsing after the pick. (The sibling Backup/Restore picker gets away
+    // with a single UTTypeZIP because .zip is universally tagged public.zip-archive.)
+    NSArray<UTType *> *types = @[ UTTypeJSON, UTTypePlainText, UTTypeText, UTTypeData, UTTypeItem ];
+    // asCopy:YES (import/copy mode) makes iOS copy the file into our own temp container
+    // and hand back a directly-readable, app-local URL — eliminating the security-scoped
+    // / FileProvider XPC round-trip that an ad-hoc-signed build can't complete (and that
+    // the Simulator silently lets slide). Mirrors Apollo's working restoreSettings picker.
     UIDocumentPickerViewController *picker =
-        [[UIDocumentPickerViewController alloc] initForOpeningContentTypes:@[UTTypeJSON, UTTypeText]];
+        [[UIDocumentPickerViewController alloc] initForOpeningContentTypes:types asCopy:YES];
     picker.delegate = self;
     picker.allowsMultipleSelection = NO;
+    picker.shouldShowFileExtensions = YES;
     picker.modalPresentationStyle = UIModalPresentationFormSheet; // match the app's other document pickers
     [self presentViewController:picker animated:YES completion:nil];
 }
 
 - (void)importThemeFromURL:(NSURL *)url {
+    ApolloLog(@"ThemeBuilder: import begin url=%@", url.path);
+    // asCopy:YES vends an app-local copy, so this is usually a no-op; keep it as harmless
+    // best-effort in case the OS ever hands back a security-scoped URL.
     BOOL scoped = [url startAccessingSecurityScopedResource];
-    NSError *error = nil;
-    NSData *data = [NSData dataWithContentsOfURL:url options:0 error:&error];
+    // Read through a file coordinator so an iCloud-Drive file that is only a placeholder
+    // gets materialized (downloaded) before we read it — a bare dataWithContentsOfURL:
+    // returns nil for an un-downloaded cloud file.
+    __block NSData *data = nil;
+    __block NSError *readError = nil;
+    NSError *coordError = nil;
+    NSFileCoordinator *coordinator = [[NSFileCoordinator alloc] initWithFilePresenter:nil];
+    [coordinator coordinateReadingItemAtURL:url
+                                    options:NSFileCoordinatorReadingWithoutChanges
+                                      error:&coordError
+                                 byAccessor:^(NSURL *readURL) {
+        data = [NSData dataWithContentsOfURL:readURL options:0 error:&readError];
+    }];
     if (scoped) [url stopAccessingSecurityScopedResource];
     if (!data) {
-        ApolloLog(@"ThemeBuilder: import read failed: %@", error);
+        ApolloLog(@"ThemeBuilder: import read failed coord=%@ read=%@", coordError, readError);
         [self presentImportAlertWithTitle:@"Couldn’t Import Theme"
                                   message:@"The selected file could not be read."];
         return;
     }
+    ApolloLog(@"ThemeBuilder: import read ok bytes=%lu", (unsigned long)data.length);
     NSString *name = nil;
     NSDictionary<NSString *, NSString *> *colors = nil;
     if (!ApolloThemeBuilderParseImport(data, &name, &colors)) {
+        ApolloLog(@"ThemeBuilder: import parse rejected bytes=%lu", (unsigned long)data.length);
         [self presentImportAlertWithTitle:@"Not an Apollo Theme"
                                   message:@"This file isn’t a valid Apollo theme. Import a “.json” file exported from Theme Builder’s Share Theme option."];
         return;
@@ -828,6 +860,7 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
     [self.tableView reloadData];
     [self refreshPreview];
     ApolloThemeBuilderForceRepaint();
+    ApolloLog(@"ThemeBuilder: import success name=%@ colors=%lu", name, (unsigned long)colors.count);
     [self presentImportAlertWithTitle:@"Theme Imported"
                               message:[NSString stringWithFormat:@"“%@” was added to My Themes.",
                                        ApolloThemeBuilderActiveCustomThemeName()]];
@@ -844,8 +877,19 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
 #pragma mark - UIDocumentPickerDelegate
 
 - (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
+    // Unconditional log BEFORE the nil check so a device trace proves the delegate fired
+    // and whether a URL was delivered (count==0 ⇒ empty/cancelled selection).
+    ApolloLog(@"ThemeBuilder: import didPickDocuments count=%lu first=%@",
+              (unsigned long)urls.count, urls.firstObject.path);
     NSURL *url = urls.firstObject;
-    if (url) [self importThemeFromURL:url];
+    if (!url) return;
+    // Defer to the next runloop so the import's result alert isn't presented while the
+    // picker is still animating its dismissal (which silently drops the alert on device).
+    dispatch_async(dispatch_get_main_queue(), ^{ [self importThemeFromURL:url]; });
+}
+
+- (void)documentPickerWasCancelled:(UIDocumentPickerViewController *)controller {
+    ApolloLog(@"ThemeBuilder: import picker cancelled");
 }
 
 - (void)presentRenameThemeDialog {

--- a/src/ApolloThemeBuilderViewController.m
+++ b/src/ApolloThemeBuilderViewController.m
@@ -663,9 +663,12 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
     UIColor *grayColor = ApolloThemeBuilderColorFromHex(ApolloThemeBuilderSavedHex(kApolloThemeRoleGray, mode));
     if (secondaryBG) {
         cell.backgroundColor = secondaryBG;
-        // Clear the default selected-background highlight so it doesn't flash white
+        // Replace the default highlight (which flashed white under a custom theme)
+        // with a visible tap highlight derived from the card colour — the old
+        // secondaryBG@0.7 was nearly indistinguishable from the background.
         cell.selectedBackgroundView = [[UIView alloc] init];
-        cell.selectedBackgroundView.backgroundColor = [secondaryBG colorWithAlphaComponent:0.7];
+        cell.selectedBackgroundView.backgroundColor =
+            ApolloThemeBuilderSelectionColor(mode) ?: [secondaryBG colorWithAlphaComponent:0.7];
     }
     if (textColor) {
         cell.textLabel.textColor = textColor;

--- a/src/ApolloThemeBuilderViewController.m
+++ b/src/ApolloThemeBuilderViewController.m
@@ -54,6 +54,9 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.title = self.colorEditorMode ? ApolloThemeBuilderActiveCustomThemeName() : @"Theme Builder";
+    // Give the table an opaque background before the push transition's first
+    // frame so the previous screen never shows through while sliding in.
+    [self applyThemeColors];
 }
 
 - (instancetype)initColorEditor {
@@ -91,7 +94,10 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
 
 - (void)applyThemeColors {
     if (!ApolloThemeBuilderIsEnabled()) {
-        self.tableView.backgroundColor = nil; // restore system default
+        // Use the opaque grouped-table default, NOT nil — nil leaves the table
+        // view transparent, which shows the previous screen straight through the
+        // push transition (and behind the cells anywhere the theme isn't active).
+        self.tableView.backgroundColor = UIColor.systemGroupedBackgroundColor;
         return;
     }
     NSString *mode = [self previewMode];

--- a/src/ApolloThemeBuilderViewController.m
+++ b/src/ApolloThemeBuilderViewController.m
@@ -107,6 +107,18 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
 
 - (UITableView *)tableViewForWillDisplay { return self.tableView; }
 
+// Tint for the builder's own controls (New Theme, the ⋯ menu, the Active label).
+// When a custom theme is active the app's accent is the theme's accent, so these
+// should match it instead of the hardcoded system blue.
+- (UIColor *)builderAccentColor {
+    if (ApolloThemeBuilderIsEnabled()) {
+        UIColor *accent = ApolloThemeBuilderColorFromHex(
+            ApolloThemeBuilderSavedHex(kApolloThemeRoleAccent, [self previewMode]));
+        if (accent) return accent;
+    }
+    return UIColor.systemBlueColor;
+}
+
 #pragma mark - Live preview
 
 // Which appearance the preview (and the live app behind us) is currently
@@ -587,7 +599,7 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
             button.frame = cell.contentView.bounds;
             button.autoresizingMask = UIViewAutoresizingFlexibleWidth;
             button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
-            button.tintColor = UIColor.systemBlueColor;
+            button.tintColor = [self builderAccentColor];
             [button setImage:[UIImage systemImageNamed:@"plus.circle.fill"] forState:UIControlStateNormal];
             [button setTitle:@" New Theme" forState:UIControlStateNormal];
             button.titleLabel.font = [UIFont systemFontOfSize:16 weight:UIFontWeightSemibold];
@@ -602,10 +614,11 @@ typedef NS_ENUM(NSInteger, ThemeBuilderSection) {
         UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:nil];
         cell.textLabel.text = [theme[@"name"] length] ? theme[@"name"] : @"Custom";
         cell.detailTextLabel.text = active ? @"Active" : @"Tap to use";
-        cell.detailTextLabel.textColor = active ? UIColor.systemBlueColor : UIColor.secondaryLabelColor;
+        cell.detailTextLabel.textColor = active ? [self builderAccentColor] : UIColor.secondaryLabelColor;
         cell.accessoryType = active ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
         UIButton *more = [UIButton buttonWithType:UIButtonTypeSystem];
         more.frame = CGRectMake(0, 0, 34, 34);
+        more.tintColor = [self builderAccentColor];
         [more setImage:[UIImage systemImageNamed:@"ellipsis.circle"] forState:UIControlStateNormal];
         more.menu = [self menuForTheme:theme sourceView:more];
         more.showsMenuAsPrimaryAction = YES;

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -232,8 +232,14 @@ typedef NS_ENUM(NSInteger, Tag) {
     if (!cell) return;
 
     UIColor *cellColor = [self apollo_themeCellBackgroundColor];
+    // Fill via the cell's own layer, NOT contentView: UIKit layers the
+    // selectedBackgroundView between the background and the contentView, so an
+    // opaque contentView would hide the tap highlight everywhere except the
+    // accessory gutter (the ">" arrow sits outside contentView). Keeping
+    // contentView clear lets the highlight show across the whole row while the
+    // layer fill keeps the unselected colour identical.
     cell.backgroundColor = cellColor;
-    cell.contentView.backgroundColor = cellColor;
+    cell.contentView.backgroundColor = [UIColor clearColor];
 
     UIView *selectedBackground = [[UIView alloc] init];
     selectedBackground.backgroundColor = [UIColor colorWithWhite:0.5 alpha:0.18];


### PR DESCRIPTION
Hey @jordanearle 👋 — this is an **add-on to your Theme Builder PR (#454)**, targeted at your `feature/theme-builder-working2` branch so you can fold it straight in if you like it. No pressure at all — take it, tweak it, or leave it.

---

Builds on #454 (Theme Builder) — a small, self-contained addition you're welcome to fold into your branch if you like it.

## What this adds

Custom themes are already pure data (a name + role→hex colors), so they're perfect to share. This adds **import and export**, so people can save, back up, and trade palettes.

| | |
|:--:|:--:|
| <img src="https://github.com/user-attachments/assets/55122f3f-4469-4c6b-875b-ba906fcf7049" width="270"><br>**Share Theme… (export)** | <img src="https://github.com/user-attachments/assets/57e472fb-eba1-4a28-ad0a-1038fee24f4b" width="270"><br>**Import from File… (import)** |
| Added to each theme's **⋯ menu**. Writes a small `<name>.json` and opens the iOS share sheet (AirDrop, Messages, Save to Files, Copy). The temp file is cleaned up after sharing. | Added to the **New Theme** dialog. Opens the document picker; the chosen `.json` is validated and added to **My Themes** (made active). |
| <img src="https://github.com/user-attachments/assets/da7ec968-6b39-4b54-a781-24a1f7f2ce1a" width="270"><br>**My Themes** | <img src="https://github.com/user-attachments/assets/9f82146e-cdb7-4a12-98e3-a96ed3e869ef" width="270"><br>**Live result** |
| Imported themes land in the list like any other — tap to use, ⋯ to manage. | A **"Synthwave"** theme imported from a file, applied live across the app. |

## Try it yourself

Download **[Synthwave-Theme.json](https://github.com/user-attachments/files/29312813/Synthwave-Theme.json)** → Theme Builder → **New Theme → Import from File…** → pick the file. That's the exact theme in the screenshots above.

## Safe to share, safe to import

- **Export** contains *only* the theme name + colors and a format marker (`{"apolloThemeBuilder": 1, …}`) — **no account data, API keys, internal ids, or timestamps.** A shared file reveals nothing about the sender.
- **Import is strict.** It accepts only known `role.mode` keys with valid 6-digit hex, drops junk keys / bad values, rejects non-JSON / oversized (>256 KB) / non-theme files, clamps the name, and **always mints a fresh id** — so an imported (or hand-edited / hostile) file can never overwrite an existing theme or inject arbitrary defaults.

## How it's built

- New engine helpers in `ApolloThemeBuilder.{h,xm}` — `ApolloThemeBuilderExportData` / `ParseImport` / `ExportFilename` — keep serialization + validation in one place.
- `ApolloThemeBuilderViewController.m` handles file IO + presentation (`UIDocumentPickerViewController`, `UIActivityViewController`). Import reuses the existing `ApolloThemeBuilderCreateCustomTheme` (which already de-dupes the name + mints the id).
- `Makefile` links `UniformTypeIdentifiers` for the document-picker content types (iOS 14+, matching the build floor). No new dependencies.

## Also included — Theme Builder fixes

**Text Size slider background.** On the Appearance screen the Text Size slider sat on the page colour instead of inside its card under a custom theme. Its Eureka cell (`TextSliderCell`) has no grouped-card background view, so Apollo paints its `contentView` with the page’s `primaryBG` role rather than the cards’ `secondaryBG`. Stock themes don’t show it because those two background roles are nearly identical; a custom theme makes them diverge. Now repainted to the card colour in a `layoutSubviews` hook, gated on a custom theme being active (stock untouched).

| Before | After |
|:--:|:--:|
| <img src="https://github.com/user-attachments/assets/a4b7ed70-dd16-4488-a65a-52a3392b2dae" width="260"> | <img src="https://github.com/user-attachments/assets/99420c5b-8af5-4ab4-ad6c-d931e0200ddb" width="260"> |

**Push-transition background.** Opening Theme Builder from Appearance slid the new screen in with a *transparent* background, so the previous screen showed straight through it while it animated. The view controller set its table `backgroundColor` to `nil` when no custom theme was active (intending the system default) — but `nil` leaves a table view transparent, not the grouped default. It now uses the opaque `systemGroupedBackgroundColor`, applied in `viewDidLoad` as well as `viewWillAppear` so it’s in place before the push transition’s first frame.

| Before — previous screen shows through the slide | After — solid background |
|:--:|:--:|
| <video src="https://github.com/user-attachments/assets/7d747613-eafe-49fa-ba67-179ab62b21c1" width="260" controls muted></video> | <video src="https://github.com/user-attachments/assets/95b6357f-02b0-4e52-9ec7-4cac692532ee" width="260" controls muted></video> |

**Text Size scaling on the Appearance row.** The “Theme Builder” entry injected into Settings → Appearance used a stock cell whose label ignored Apollo’s in-app **Text Size** setting, so it stayed one fixed size while the native rows grew and shrank with the slider (Apollo sizes its settings labels itself — medium system weight — rather than via the system Dynamic Type category, so a plain body font doesn’t match). Copying a native sibling’s font once didn’t hold: the table’s later layout/reuse passes reset it. The row now uses a small `UITableViewCell` subclass that re-applies the sampled native font in `layoutSubviews` (which always runs after a reset) and re-samples on the next runloop, when `visibleCells` is populated — so it matches the native rows on first display and tracks the slider live.

**Tap highlight (settings, search, Friends, profiles, feed, comments).** Under a custom theme, pressing a row, post or comment showed no usable highlight: Apollo highlights by darkening a cell toward its `secondaryBG`/page colour, which the remap renders nearly invisible against a dark theme (a “dark blend”). Fixed everywhere it occurs, from one themed colour — the card nudged toward white in dark mode / black in light, mirroring iOS’s pressed-row shade:

- **Settings, Search and Friends** list cells — one `UITableViewCell` hook scoped to those Apollo view controllers (UIKit’s own tables, e.g. the keyboard’s input switcher, are left completely alone). It covers both the Eureka cells those screens use (which highlight via `selectedBackgroundView`) and Apollo’s `ApolloDefault`/`RightDetail`/`Subtitle` cells (which swap `backgroundColor`); the `Subtitle` cell, used by Filters & Blocks and the Friends list, is hooked directly since its layout bypasses the base cell.
- **Profile feature rows, feed posts and comments** — these are Texture (AsyncDisplayKit) cell *nodes*, not table cells, so they need their own hook: profile rows recolour their inset `insideNode` (recolouring the full-width background node behind it bled the highlight around the card), while feed posts and comments recolour the node’s own background. Apollo restores the normal colour on release, so only the pressed state is overridden.

The Appearance/Theme Builder screens keep their own backgrounds, and stock themes are untouched.

| Not pressed | Pressed — before | Pressed — after |
|:--:|:--:|:--:|
| <img src="https://github.com/user-attachments/assets/4cd443cf-38cc-453e-9a19-f2ab778b54e2" width="200"> | <img src="https://github.com/user-attachments/assets/b1379f26-eb66-47c6-8d76-40f99a8504cb" width="200"> | <img src="https://github.com/user-attachments/assets/5c053344-ae39-4eb1-aa26-8ca8af7604a3" width="200"> |
| A settings row at rest. | The old “dark blend” — pressing collapsed the highlight onto the card colour, so the tap looked dead. | Now a clear themed highlight on the pressed row. |

**Builder controls follow the theme accent.** The Theme Builder’s own **New Theme** button, the per-theme **⋯** menu, and the **Active** label were hardcoded to system blue, so they ignored the active theme’s accent even though everything else (including the builder’s live preview) used it. They now take the active theme’s accent when a custom theme is on.

| Before | After |
|:--:|:--:|
| <img src="https://github.com/user-attachments/assets/ea83fb0b-c324-4199-9429-292d06036697" width="230"> | <img src="https://github.com/user-attachments/assets/283855a1-5640-48fe-be05-c2c62857cb5f" width="230"> |
| Hardcoded system blue. | The active theme’s accent (Synthwave magenta). |

**Reborn settings — full-row tap highlight.** A pre-existing bug, surfaced by dark custom themes: in Apollo Reborn's own settings page, pressing a row with a value + `>` (Rich Link Previews – Body/Comments/Color, Media Upload Host, etc.) lit up only the thin gutter under the disclosure arrow instead of the whole row. That page paints each cell with an opaque `contentView` background, and UIKit layers the cell's `selectedBackgroundView` *behind* its `contentView` — so the highlight was hidden everywhere except the accessory area (the `>` sits outside `contentView`). The fill now lives on the cell's own layer with `contentView` left clear: the unselected colour is byte-identical, but the tap highlight reads across the full row. (Stock themes had the same bug, just far less visible.)

## Testing

- 29 standalone unit tests of the parse/export logic (round-trip, privacy, adversarial rejection, sanitization, oversize, name handling).
- Verified end-to-end in the iOS Simulator: export produces valid JSON + share sheet; importing a crafted file with deliberate junk keys created the theme with **only** the valid colors persisted (junk dropped, fresh id), applied live.
- **Sim-tested, not yet device-tested.**

