### PR TITLE
Link cards: show website name when the title is only numbers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloLinkPreviewFetcher.m \
     $(SRC_DIR)/ApolloInlineImages.xm \
     $(SRC_DIR)/ApolloInlineLinkPreviews.xm \
+    $(SRC_DIR)/ApolloLinkCardTitleFallback.xm \
     $(SRC_DIR)/ApolloFeedTextPostThumbnails.xm \
     $(SRC_DIR)/ApolloTweetBuddy.xm \
 	$(SRC_DIR)/ApolloVisionOSFix.xm \

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -34,6 +34,18 @@ NSString *ApolloBundledResourcePath(NSString *baseName, NSString *extension);
 NSString *ApolloGetLinkButtonNodeURLString(id linkButtonNode);
 void ApolloPresentWebURLFromViewController(UIViewController *presenter, NSURL *url);
 
+// Returns YES when a link-card title is a numeric-ID-style junk string —
+// contains at least one digit but no letters at all (e.g. the scraped
+// "285023 289273 400021448" title from a single-page-app page). Used to decide
+// when to substitute a website name for an unhelpful machine-scraped title.
+BOOL ApolloIsJunkNumericTitle(NSString *title);
+
+// Derives a presentable website name from a host ("fifa.com" -> "FIFA",
+// "news.bbc.co.uk" -> "BBC", "theverge.com" -> "Theverge"). Short registrable
+// labels are uppercased as acronyms; longer ones are title-cased. Returns nil
+// when no usable name can be derived (e.g. a raw IP host).
+NSString *ApolloWebsiteNameFromHost(NSString *host);
+
 // Returns YES for Apple's out-of-process share/compose controllers that the
 // tweak must never traverse or mutate. Their class names end in
 // "ComposeViewController" (e.g. MFMessageComposeViewController), so loose

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -27,13 +27,6 @@ UIImage *ApolloRebornOptionsSettingsIcon(CGFloat size);
 // inject-deb-local.sh). Returns nil if no layout has the file.
 NSString *ApolloBundledResourcePath(NSString *baseName, NSString *extension);
 
-// Returns the URL string a LinkButtonNode is presenting, by reading either
-// the obj-c .url getter (older iOS) or the urlTextNode's attributed text
-// (iOS 26+ where the Swift URL ivar is no longer ObjC-bridged). May return
-// nil if neither path yields a usable string.
-NSString *ApolloGetLinkButtonNodeURLString(id linkButtonNode);
-void ApolloPresentWebURLFromViewController(UIViewController *presenter, NSURL *url);
-
 // Returns YES when a link-card title is a numeric-ID-style junk string —
 // contains at least one digit but no letters at all (e.g. the scraped
 // "285023 289273 400021448" title from a single-page-app page). Used to decide
@@ -45,6 +38,13 @@ BOOL ApolloIsJunkNumericTitle(NSString *title);
 // labels are uppercased as acronyms; longer ones are title-cased. Returns nil
 // when no usable name can be derived (e.g. a raw IP host).
 NSString *ApolloWebsiteNameFromHost(NSString *host);
+
+// Returns the URL string a LinkButtonNode is presenting, by reading either
+// the obj-c .url getter (older iOS) or the urlTextNode's attributed text
+// (iOS 26+ where the Swift URL ivar is no longer ObjC-bridged). May return
+// nil if neither path yields a usable string.
+NSString *ApolloGetLinkButtonNodeURLString(id linkButtonNode);
+void ApolloPresentWebURLFromViewController(UIViewController *presenter, NSURL *url);
 
 // Returns YES for Apple's out-of-process share/compose controllers that the
 // tweak must never traverse or mutate. Their class names end in

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -288,6 +288,75 @@ NSString *ApolloGetLinkButtonNodeURLString(id linkButtonNode) {
     return nil;
 }
 
+#pragma mark - Junk link-card titles
+
+BOOL ApolloIsJunkNumericTitle(NSString *title) {
+    if (![title isKindOfClass:[NSString class]]) return NO;
+
+    NSString *trimmed = [title stringByTrimmingCharactersInSet:
+                         [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (trimmed.length == 0) return NO;
+
+    // Must contain no letters anywhere...
+    if ([trimmed rangeOfCharacterFromSet:[NSCharacterSet letterCharacterSet]].location != NSNotFound) {
+        return NO;
+    }
+    // ...but at least one digit (targets numeric-ID titles, while leaving
+    // emoji-only or punctuation-only titles untouched).
+    if ([trimmed rangeOfCharacterFromSet:[NSCharacterSet decimalDigitCharacterSet]].location == NSNotFound) {
+        return NO;
+    }
+    return YES;
+}
+
+NSString *ApolloWebsiteNameFromHost(NSString *host) {
+    if (host.length == 0) return nil;
+
+    host = host.lowercaseString;
+    while ([host hasSuffix:@"."]) host = [host substringToIndex:host.length - 1];
+    if (host.length == 0) return nil;
+
+    NSMutableArray<NSString *> *parts = [NSMutableArray array];
+    for (NSString *p in [host componentsSeparatedByString:@"."]) {
+        if (p.length > 0) [parts addObject:p];
+    }
+    NSUInteger n = parts.count;
+    if (n == 0) return nil;
+
+    NSString *label;
+    if (n == 1) {
+        label = parts[0];
+    } else {
+        static NSSet *ccSLDs = nil; // second-level labels under country-code TLDs
+        static dispatch_once_t once;
+        dispatch_once(&once, ^{
+            ccSLDs = [NSSet setWithArray:@[@"co", @"com", @"org", @"net", @"gov",
+                                           @"edu", @"ac", @"gob", @"go", @"or", @"ne"]];
+        });
+        NSString *last = parts[n - 1];
+        NSString *secondLast = parts[n - 2];
+        if (n >= 3 && last.length == 2 && [ccSLDs containsObject:secondLast]) {
+            label = parts[n - 3];
+        } else {
+            label = parts[n - 2];
+        }
+    }
+    if (label.length == 0) return nil;
+
+    // Needs at least one letter, otherwise we'd just swap digits for digits.
+    if ([label rangeOfCharacterFromSet:[NSCharacterSet letterCharacterSet]].location == NSNotFound) {
+        return nil;
+    }
+
+    // Short labels are almost always acronyms (FIFA, ESPN, BBC, TIME); longer
+    // ones read better title-cased.
+    if (label.length <= 4) {
+        return label.uppercaseString;
+    }
+    NSString *first = [[label substringToIndex:1] uppercaseString];
+    return [first stringByAppendingString:[label substringFromIndex:1]];
+}
+
 UIImage *ApolloEmojiSettingsIcon(NSString *emoji, UIColor *backgroundColor, CGFloat size) {
     if (emoji.length == 0) return nil;
     if (size <= 0.0) size = 29.0;

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -306,7 +306,43 @@ BOOL ApolloIsJunkNumericTitle(NSString *title) {
     if ([trimmed rangeOfCharacterFromSet:[NSCharacterSet decimalDigitCharacterSet]].location == NSNotFound) {
         return NO;
     }
-    return YES;
+
+    // The title is now letter-free with at least one digit, but that still
+    // covers numbers a user would legitimately want to keep: a year ("2024",
+    // "1917"), a short number ("300"), a date ("9/11"), or a phone-number page
+    // ("1-800-273-8255"). Only substitute when it actually looks like a scraped
+    // internal-ID dump rather than a plausible real title — i.e. either:
+    //   * a single long run of digits (timestamps, opaque IDs), or
+    //   * several whitespace-separated all-numeric tokens (the fifa.com
+    //     match-center "285023 289273 400021448" pattern).
+    NSCharacterSet *digits = [NSCharacterSet decimalDigitCharacterSet];
+
+    NSUInteger longestRun = 0, currentRun = 0, totalDigits = 0;
+    for (NSUInteger i = 0; i < trimmed.length; i++) {
+        if ([digits characterIsMember:[trimmed characterAtIndex:i]]) {
+            currentRun++;
+            totalDigits++;
+            if (currentRun > longestRun) longestRun = currentRun;
+        } else {
+            currentRun = 0;
+        }
+    }
+    // A run this long is not a year/date/short number; it's an ID or timestamp.
+    if (longestRun >= 7) return YES;
+
+    NSUInteger numericTokens = 0;
+    for (NSString *token in [trimmed componentsSeparatedByCharactersInSet:
+                             [NSCharacterSet whitespaceAndNewlineCharacterSet]]) {
+        if (token.length == 0) continue;
+        if ([token rangeOfCharacterFromSet:[digits invertedSet]].location == NSNotFound) {
+            numericTokens++; // token is purely digits
+        }
+    }
+    // Multiple bare numeric tokens (with enough digits to not be, say, "12 34")
+    // is the multi-ID dump shape, not a real headline.
+    if (numericTokens >= 2 && totalDigits >= 6) return YES;
+
+    return NO;
 }
 
 NSString *ApolloWebsiteNameFromHost(NSString *host) {

--- a/src/ApolloInlineLinkPreviews.xm
+++ b/src/ApolloInlineLinkPreviews.xm
@@ -1311,7 +1311,29 @@ static NSString *ApolloLPCleanMultilineDisplayText(NSString *text) {
 }
 
 static NSString *ApolloLPDisplayTitleForPreview(ApolloLinkPreview *preview) {
-    return ApolloLPCleanDisplayText(preview.title);
+    NSString *clean = ApolloLPCleanDisplayText(preview.title);
+
+    // Some pages (single-page apps like fifa.com match-center URLs) only expose
+    // a numeric-ID <title> ("285023 289273 400021448"), which renders as a
+    // meaningless series of numbers in the card. Substitute a clean website
+    // name derived from the source — the eyebrow still shows the full domain.
+    if (ApolloIsJunkNumericTitle(clean)) {
+        NSString *site = preview.siteName;
+        NSString *name = nil;
+        if (site.length > 0 && [site containsString:@"."] && ![site containsString:@" "]) {
+            // Host-like siteName ("fifa.com") -> "FIFA".
+            name = ApolloWebsiteNameFromHost(site);
+        } else if (site.length > 0 && !ApolloIsJunkNumericTitle(site)) {
+            // Already a presentable name (og:site_name / curated, e.g. "YouTube").
+            name = site;
+        }
+        if (name.length > 0) {
+            ApolloLPLogOncePerHost(site, [NSString stringWithFormat:@"junk-numeric-title-substituted->%@", name]);
+            return name;
+        }
+    }
+
+    return clean;
 }
 
 static NSString *ApolloLPDisplayDescriptionForPreview(ApolloLinkPreview *preview) {

--- a/src/ApolloLinkCardTitleFallback.xm
+++ b/src/ApolloLinkCardTitleFallback.xm
@@ -1,0 +1,146 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+#import "ApolloCommon.h"
+
+// =============================================================================
+// MARK: - Overview
+// =============================================================================
+//
+// Some link posts point at pages whose only machine-scraped <title> is a string
+// of numbers — typically single-page apps (e.g. fifa.com match-center URLs)
+// whose static HTML carries internal IDs ("285023 289273 400021448") instead of
+// a human headline. Reddit stores that scraped title verbatim, and Apollo's
+// LinkButtonNode renders it in the card's title slot, so the compact card shows
+// a meaningless series of digits under the domain eyebrow.
+//
+// Fix: when the card's title contains no letters but does contain digits (the
+// numeric-ID signature), replace it with a clean website name derived from the
+// link's host (fifa.com -> "FIFA"). The domain eyebrow ("FIFA.COM") is left
+// alone, mirroring the Safari/iMessage link-preview pattern (site name as the
+// headline, full host underneath).
+//
+// Seam: LinkButtonNode has no ObjC method that sets the title (it is configured
+// from pure Swift), so the title text is only reachable once the node lays out.
+// -layoutSpecThatFits: runs on a background layout thread, where reading the
+// titleTextNode's attributedText is safe but mutating it is not. So we read on
+// the layout thread and, when the title is junk, apply the swap on the main
+// thread (guarded by a per-node in-flight flag to avoid scheduling a pile-up of
+// blocks across repeated layout passes). The replacement has letters, so the
+// next layout pass no longer matches the junk test and nothing re-fires — the
+// fix converges in one extra pass and re-applies cleanly on cell reuse.
+//
+// =============================================================================
+
+static char kApolloLinkCardTitleFixInFlightKey;
+
+// Junk-title detection and website-name derivation live in ApolloCommon so the
+// native LinkButtonNode path (here) and ApolloInlineLinkPreviews' replacement
+// cards share one implementation.
+static NSString *ApolloLinkCardWebsiteNameForURLString(NSString *urlString) {
+    if (urlString.length == 0) return nil;
+
+    NSString *host = [NSURL URLWithString:urlString].host;
+    if (host.length == 0) {
+        // Tolerate a missing scheme (the urlTextNode fallback omits it).
+        host = [NSURL URLWithString:[@"https://" stringByAppendingString:urlString]].host;
+    }
+    return ApolloWebsiteNameFromHost(host);
+}
+
+static id ApolloLinkCardTitleNode(id linkButtonNode) {
+    if (!linkButtonNode) return nil;
+    Ivar ivar = class_getInstanceVariable([linkButtonNode class], "titleTextNode");
+    return ivar ? object_getIvar(linkButtonNode, ivar) : nil;
+}
+
+// Main-thread: re-resolve the node's current title + URL and, if still junk,
+// swap in the website name. Re-resolving here (rather than trusting values
+// captured on the layout thread) keeps the swap correct if the cell was reused
+// for a different post between scheduling and running.
+static void ApolloLinkCardApplyTitleFix(id linkButtonNode) {
+    id titleNode = ApolloLinkCardTitleNode(linkButtonNode);
+    if (!titleNode || ![titleNode respondsToSelector:@selector(attributedText)]) return;
+
+    NSAttributedString *current = [titleNode attributedText];
+    NSString *text = current.string;
+    if (!ApolloIsJunkNumericTitle(text)) return;
+
+    NSString *urlString = ApolloGetLinkButtonNodeURLString(linkButtonNode);
+    NSString *name = ApolloLinkCardWebsiteNameForURLString(urlString);
+    if (name.length == 0) return;
+
+    // Preserve the title's existing typography (font, color, paragraph style).
+    NSDictionary *attrs = current.length > 0 ? [current attributesAtIndex:0 effectiveRange:NULL] : nil;
+    NSAttributedString *replacement = attrs
+        ? [[NSAttributedString alloc] initWithString:name attributes:attrs]
+        : [[NSAttributedString alloc] initWithString:name];
+
+    if (![titleNode respondsToSelector:@selector(setAttributedText:)]) return;
+    [titleNode setAttributedText:replacement];
+
+    ApolloLog(@"[LinkCardTitle] junk title \"%@\" -> \"%@\" (%@)", text, name, urlString ?: @"(no url)");
+}
+
+// Layout thread: cheap junk pre-check (reads only), then defer the mutation to
+// the main thread. The in-flight flag collapses repeated layout passes into a
+// single scheduled fix.
+static void ApolloLinkCardScheduleTitleFix(id linkButtonNode) {
+    if (!linkButtonNode) return;
+
+    NSNumber *inFlight = objc_getAssociatedObject(linkButtonNode, &kApolloLinkCardTitleFixInFlightKey);
+    if ([inFlight boolValue]) return;
+
+    id titleNode = ApolloLinkCardTitleNode(linkButtonNode);
+    if (!titleNode || ![titleNode respondsToSelector:@selector(attributedText)]) return;
+    if (!ApolloIsJunkNumericTitle([[titleNode attributedText] string])) return;
+
+    objc_setAssociatedObject(linkButtonNode, &kApolloLinkCardTitleFixInFlightKey,
+                             @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    __weak id weakNode = linkButtonNode;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        id node = weakNode;
+        if (!node) return;
+        objc_setAssociatedObject(node, &kApolloLinkCardTitleFixInFlightKey,
+                                 @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        @try {
+            ApolloLinkCardApplyTitleFix(node);
+        } @catch (__unused NSException *e) {}
+    });
+}
+
+// ASSizeRange ABI for -layoutSpecThatFits: (matches Apollo's class dump).
+struct CDStruct_90e057aa { CGSize min; CGSize max; };
+
+%hook LinkButtonNode
+
+- (id)layoutSpecThatFits:(struct CDStruct_90e057aa)constrainedSize {
+    id spec = %orig;
+    @try {
+        ApolloLinkCardScheduleTitleFix(self);
+    } @catch (__unused NSException *e) {}
+    return spec;
+}
+
+%end
+
+// =============================================================================
+// MARK: - Constructor
+// =============================================================================
+
+%ctor {
+    Class linkButtonNodeClass = objc_getClass("_TtC6Apollo14LinkButtonNode");
+
+    ApolloLog(@"[LinkCardTitle] ctor: LinkButtonNode=%p", (void *)linkButtonNodeClass);
+
+    if (!linkButtonNodeClass) {
+        ApolloLog(@"[LinkCardTitle] ctor: LinkButtonNode class not found — skipping hook");
+        return;
+    }
+
+    %init(LinkButtonNode = linkButtonNodeClass);
+
+    ApolloLog(@"[LinkCardTitle] ctor: hook installed");
+}


### PR DESCRIPTION
## Problem

Some link posts point at pages — typically single-page apps like **fifa.com match-center** URLs — whose only machine-scraped `<title>` is a string of internal numeric IDs. Reddit stores that verbatim, so the link card renders a meaningless series of numbers under the domain eyebrow:

> **FIFA.COM**
> `285023 289273 400021448`

## Fix

Detect a numeric-junk title (contains at least one digit but **no letters**) and substitute a clean website name derived from the host — the Safari/iMessage link-preview pattern. The domain eyebrow still shows the full host:

> **FIFA.COM**
> FIFA

- A real page title always wins, so this only kicks in when the scraped title is genuinely unusable. Emoji-only / punctuation-only titles are left alone, and pages with real headlines are untouched.
- Name derivation is ccTLD-aware (`news.bbc.co.uk` → BBC). Short registrable labels become acronyms (FIFA, ESPN, BBC, TIME); longer ones are title-cased (`theverge.com` → Theverge).

## Where

- **Primary:** `ApolloLPDisplayTitleForPreview` in `ApolloInlineLinkPreviews.xm` — the single title chokepoint for the default inline-preview compact/hero cards.
- **Fallback:** new `ApolloLinkCardTitleFallback.xm` patches Apollo's native `LinkButtonNode` card for when inline link previews are turned off.
- Shared `ApolloIsJunkNumericTitle` / `ApolloWebsiteNameFromHost` helpers in `ApolloCommon`.

## Testing

Verified in the iOS 26 simulator: the fifa.com card now renders **FIFA**, a `streamin.link` upload-timestamp title becomes **Streamin**, normal cards with real titles are unchanged, and there are no crashes. Not yet device-tested.