### PR TITLE
Rich Link Previews: dedicated section + free-form custom card color

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloWebSessionLoginViewController.m \
     $(SRC_DIR)/ApolloManualSignInViewController.m \
     $(SRC_DIR)/CustomAPIViewController.m \
+    $(SRC_DIR)/ApolloLinkPreviewSettingsViewController.m \
     $(SRC_DIR)/TranslationSettingsViewController.m \
     $(SRC_DIR)/SavedCategoriesViewController.m \
     $(SRC_DIR)/TagFiltersViewController.m \

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -50,4 +50,32 @@ BOOL ApolloPresentImageChestItems(NSArray<NSDictionary *> *items, UIView *source
 // As above, but albumURL is the album's page URL when known — it enables the
 // viewer's "Share Album Link" action; pass nil otherwise.
 BOOL ApolloPresentImageChestItemsWithAlbumURL(NSArray<NSDictionary *> *items, UIView *sourceView, NSInteger initialIndex, NSURL *albumURL);
+
+// Convert between a UIColor and a 6-digit "RRGGBB" hex string. The parser
+// tolerates an optional leading '#'; it returns nil for anything that isn't
+// exactly six hex digits. The serializer emits uppercase, no '#'. Shared by
+// the link-preview card color picker and any other free-form color UI.
+UIColor *ApolloColorFromHexString(NSString *hex);
+NSString *ApolloHexStringFromColor(UIColor *color);
+
+// Returns YES when a fill color is light enough that dark (black) text reads
+// better on top of it than white. Uses Rec.601 luminance. Used to auto-contrast
+// the link-preview card text against an arbitrary user-picked card color.
+BOOL ApolloColorIsLight(UIColor *color);
+
+// Maps a legacy ApolloLinkPreviewCardColor preset enum value to its UIColor.
+// Retained only to migrate a pre-existing preset selection into the new
+// free-form hex color the first time a user runs a build with the picker.
+UIColor *ApolloLinkPreviewPresetColor(NSInteger preset);
+
+// Packs a hex color into the render-safe snapshot format used by
+// sLinkPreviewCardColorPacked: 0 for nil/invalid/empty, otherwise
+// (1<<24) | (R<<16) | (G<<8) | B.
+uint32_t ApolloPackedColorFromHexString(NSString *hex);
+
+// Canonical setter for the link-preview card color. Normalizes `hex` (nil for
+// invalid/empty = Default) and updates BOTH sLinkPreviewCardColorHex (the
+// main-thread NSString used by UI/persistence) and the render-safe packed
+// snapshot for the renderer. Call on the main thread.
+void ApolloSetLinkPreviewCardColorHex(NSString *hex);
 __END_DECLS

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -1,4 +1,5 @@
 #import "ApolloCommon.h"
+#import "ApolloState.h"
 #import <mach-o/dyld.h>
 #import <mach-o/loader.h>
 #import <objc/message.h>
@@ -528,4 +529,87 @@ BOOL ApolloIsSystemShareComposeController(UIViewController *controller) {
         if (cls && [controller isKindOfClass:cls]) return YES;
     }
     return NO;
+}
+
+#pragma mark - Color Helpers
+
+UIColor *ApolloColorFromHexString(NSString *hex) {
+    if (![hex isKindOfClass:[NSString class]]) return nil;
+    NSString *clean = [hex stringByReplacingOccurrencesOfString:@"#" withString:@""];
+    clean = [clean stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    if (clean.length != 6) return nil;
+    unsigned int value = 0;
+    NSScanner *scanner = [NSScanner scannerWithString:clean];
+    if (![scanner scanHexInt:&value] || !scanner.isAtEnd) return nil;
+    return [UIColor colorWithRed:((value >> 16) & 0xFF) / 255.0
+                           green:((value >> 8) & 0xFF) / 255.0
+                            blue:(value & 0xFF) / 255.0
+                           alpha:1.0];
+}
+
+NSString *ApolloHexStringFromColor(UIColor *color) {
+    if (![color isKindOfClass:[UIColor class]]) return nil;
+    CGFloat r = 0.0, g = 0.0, b = 0.0, a = 0.0;
+    if (![color getRed:&r green:&g blue:&b alpha:&a]) return nil;
+    r = MIN(MAX(r, 0.0), 1.0);
+    g = MIN(MAX(g, 0.0), 1.0);
+    b = MIN(MAX(b, 0.0), 1.0);
+    return [NSString stringWithFormat:@"%02X%02X%02X",
+            (int)lround(r * 255.0), (int)lround(g * 255.0), (int)lround(b * 255.0)];
+}
+
+BOOL ApolloColorIsLight(UIColor *color) {
+    CGFloat r = 0.0, g = 0.0, b = 0.0, a = 0.0;
+    if (![color isKindOfClass:[UIColor class]] || ![color getRed:&r green:&g blue:&b alpha:&a]) {
+        return YES;
+    }
+    // Rec.601 perceptual luminance. Bright fills (yellow, mint, lime) land high
+    // and want dark text; saturated blues/purples land low and want white text.
+    CGFloat luminance = 0.299 * r + 0.587 * g + 0.114 * b;
+    return luminance >= 0.6;
+}
+
+UIColor *ApolloLinkPreviewPresetColor(NSInteger preset) {
+    switch (preset) {
+        case ApolloLinkPreviewCardColorGray:     return [UIColor colorWithWhite:0.56 alpha:1.0];
+        case ApolloLinkPreviewCardColorRed:      return [UIColor colorWithRed:1.00 green:0.23 blue:0.19 alpha:1.0];
+        case ApolloLinkPreviewCardColorOrange:   return [UIColor colorWithRed:1.00 green:0.58 blue:0.00 alpha:1.0];
+        case ApolloLinkPreviewCardColorYellow:   return [UIColor colorWithRed:1.00 green:0.80 blue:0.00 alpha:1.0];
+        case ApolloLinkPreviewCardColorGreen:    return [UIColor colorWithRed:0.20 green:0.78 blue:0.35 alpha:1.0];
+        case ApolloLinkPreviewCardColorMint:     return [UIColor colorWithRed:0.00 green:0.78 blue:0.75 alpha:1.0];
+        case ApolloLinkPreviewCardColorTeal:     return [UIColor colorWithRed:0.19 green:0.69 blue:0.78 alpha:1.0];
+        case ApolloLinkPreviewCardColorCyan:     return [UIColor colorWithRed:0.20 green:0.68 blue:0.90 alpha:1.0];
+        case ApolloLinkPreviewCardColorBlue:     return [UIColor colorWithRed:0.00 green:0.48 blue:1.00 alpha:1.0];
+        case ApolloLinkPreviewCardColorIndigo:   return [UIColor colorWithRed:0.35 green:0.34 blue:0.84 alpha:1.0];
+        case ApolloLinkPreviewCardColorPurple:   return [UIColor colorWithRed:0.69 green:0.32 blue:0.87 alpha:1.0];
+        case ApolloLinkPreviewCardColorPink:     return [UIColor colorWithRed:1.00 green:0.18 blue:0.33 alpha:1.0];
+        case ApolloLinkPreviewCardColorBrown:    return [UIColor colorWithRed:0.64 green:0.52 blue:0.37 alpha:1.0];
+        case ApolloLinkPreviewCardColorCoral:    return [UIColor colorWithRed:1.00 green:0.50 blue:0.31 alpha:1.0];
+        case ApolloLinkPreviewCardColorLime:     return [UIColor colorWithRed:0.60 green:0.80 blue:0.00 alpha:1.0];
+        case ApolloLinkPreviewCardColorOlive:    return [UIColor colorWithRed:0.50 green:0.60 blue:0.20 alpha:1.0];
+        case ApolloLinkPreviewCardColorLavender: return [UIColor colorWithRed:0.56 green:0.45 blue:0.90 alpha:1.0];
+        case ApolloLinkPreviewCardColorSlate:    return [UIColor colorWithRed:0.35 green:0.43 blue:0.50 alpha:1.0];
+        case ApolloLinkPreviewCardColorNeutral:
+        default:                                 return [UIColor colorWithWhite:0.72 alpha:1.0];
+    }
+}
+
+uint32_t ApolloPackedColorFromHexString(NSString *hex) {
+    UIColor *color = ApolloColorFromHexString(hex);
+    if (!color) return 0;
+    CGFloat r = 0.0, g = 0.0, b = 0.0, a = 0.0;
+    if (![color getRed:&r green:&g blue:&b alpha:&a]) return 0;
+    uint32_t R = (uint32_t)lround(MIN(MAX(r, 0.0), 1.0) * 255.0);
+    uint32_t G = (uint32_t)lround(MIN(MAX(g, 0.0), 1.0) * 255.0);
+    uint32_t B = (uint32_t)lround(MIN(MAX(b, 0.0), 1.0) * 255.0);
+    return (1u << 24) | (R << 16) | (G << 8) | B;
+}
+
+void ApolloSetLinkPreviewCardColorHex(NSString *hex) {
+    UIColor *color = ApolloColorFromHexString(hex);
+    // Canonicalize to "RRGGBB" uppercase so persistence + UI display stay tidy.
+    sLinkPreviewCardColorHex = color ? ApolloHexStringFromColor(color) : nil;
+    // Publish the render snapshot AFTER the string, so a background reader that
+    // observes a non-zero packed value already has a consistent RGB to draw.
+    sLinkPreviewCardColorPacked = color ? ApolloPackedColorFromHexString(sLinkPreviewCardColorHex) : 0;
 }

--- a/src/ApolloInlineLinkPreviews.xm
+++ b/src/ApolloInlineLinkPreviews.xm
@@ -1090,34 +1090,60 @@ static UIColor *ApolloLPBlendColor(UIColor *foreground, UIColor *background, CGF
                            alpha:1.0];
 }
 
-static UIColor *ApolloLPColorForCardPreset(NSInteger preset) {
-    switch (preset) {
-        case ApolloLinkPreviewCardColorGray:     return [UIColor colorWithWhite:0.56 alpha:1.0];
-        case ApolloLinkPreviewCardColorRed:      return [UIColor colorWithRed:1.00 green:0.23 blue:0.19 alpha:1.0];
-        case ApolloLinkPreviewCardColorOrange:   return [UIColor colorWithRed:1.00 green:0.58 blue:0.00 alpha:1.0];
-        case ApolloLinkPreviewCardColorYellow:   return [UIColor colorWithRed:1.00 green:0.80 blue:0.00 alpha:1.0];
-        case ApolloLinkPreviewCardColorGreen:    return [UIColor colorWithRed:0.20 green:0.78 blue:0.35 alpha:1.0];
-        case ApolloLinkPreviewCardColorMint:     return [UIColor colorWithRed:0.00 green:0.78 blue:0.75 alpha:1.0];
-        case ApolloLinkPreviewCardColorTeal:     return [UIColor colorWithRed:0.19 green:0.69 blue:0.78 alpha:1.0];
-        case ApolloLinkPreviewCardColorCyan:     return [UIColor colorWithRed:0.20 green:0.68 blue:0.90 alpha:1.0];
-        case ApolloLinkPreviewCardColorBlue:     return [UIColor colorWithRed:0.00 green:0.48 blue:1.00 alpha:1.0];
-        case ApolloLinkPreviewCardColorIndigo:   return [UIColor colorWithRed:0.35 green:0.34 blue:0.84 alpha:1.0];
-        case ApolloLinkPreviewCardColorPurple:   return [UIColor colorWithRed:0.69 green:0.32 blue:0.87 alpha:1.0];
-        case ApolloLinkPreviewCardColorPink:     return [UIColor colorWithRed:1.00 green:0.18 blue:0.33 alpha:1.0];
-        case ApolloLinkPreviewCardColorBrown:    return [UIColor colorWithRed:0.64 green:0.52 blue:0.37 alpha:1.0];
-        case ApolloLinkPreviewCardColorCoral:    return [UIColor colorWithRed:1.00 green:0.50 blue:0.31 alpha:1.0];
-        case ApolloLinkPreviewCardColorLime:     return [UIColor colorWithRed:0.60 green:0.80 blue:0.00 alpha:1.0];
-        case ApolloLinkPreviewCardColorOlive:    return [UIColor colorWithRed:0.50 green:0.60 blue:0.20 alpha:1.0];
-        case ApolloLinkPreviewCardColorLavender: return [UIColor colorWithRed:0.56 green:0.45 blue:0.90 alpha:1.0];
-        case ApolloLinkPreviewCardColorSlate:    return [UIColor colorWithRed:0.35 green:0.43 blue:0.50 alpha:1.0];
-        case ApolloLinkPreviewCardColorNeutral:
-        default:                                 return [UIColor colorWithWhite:0.72 alpha:1.0];
-    }
+// Resolves the user's free-form card color from the render-safe packed snapshot
+// (sLinkPreviewCardColorPacked). Returns nil when no custom color is set
+// ("Default"), in which case the card keeps the standard neutral background.
+// Reads the volatile uint32 (atomic aligned load on arm64) — never the NSString
+// global, which the settings UI reassigns on the main thread.
+static UIColor *ApolloLPCustomCardColor(void) {
+    uint32_t packed = sLinkPreviewCardColorPacked;
+    if ((packed & (1u << 24)) == 0) return nil;
+    CGFloat r = ((packed >> 16) & 0xFF) / 255.0;
+    CGFloat g = ((packed >> 8) & 0xFF) / 255.0;
+    CGFloat b = (packed & 0xFF) / 255.0;
+    return [UIColor colorWithRed:r green:g blue:b alpha:1.0];
+}
+
+// When a custom card color is active, fills primary/secondary text colors that
+// contrast with it (black-on-light / white-on-dark). Returns NO for the default
+// neutral card so callers keep the dynamic system label colors.
+static BOOL ApolloLPCustomCardTextColors(UIColor **primaryOut, UIColor **secondaryOut) {
+    UIColor *card = ApolloLPCustomCardColor();
+    if (!card) return NO;
+    BOOL light = ApolloColorIsLight(card);
+    UIColor *primary = light ? [UIColor colorWithWhite:0.0 alpha:1.0] : [UIColor colorWithWhite:1.0 alpha:1.0];
+    // Secondary text (site name, description) is the same ink at reduced opacity
+    // so it reads as a softer tier without introducing a clashing hue.
+    UIColor *secondary = [primary colorWithAlphaComponent:light ? 0.62 : 0.78];
+    if (primaryOut) *primaryOut = primary;
+    if (secondaryOut) *secondaryOut = secondary;
+    return YES;
+}
+
+// Rewrites just the foreground color of an existing text node's attributed text,
+// preserving its string + font. Lets a live card recolor instantly when the user
+// changes the card color, without rebuilding the whole layout from the preview.
+static void ApolloLPRecolorTextNode(ASTextNode *node, UIColor *color) {
+    if (!node || !color || ![node respondsToSelector:@selector(attributedText)]) return;
+    NSAttributedString *current = node.attributedText;
+    if (current.length == 0) return;
+    NSMutableAttributedString *mutableText = [current mutableCopy];
+    [mutableText addAttribute:NSForegroundColorAttributeName value:color range:NSMakeRange(0, mutableText.length)];
+    node.attributedText = mutableText;
 }
 
 static UIColor *ApolloLPCardBackgroundColorForNode(ASDisplayNode *hostNode, NSURL *url) {
-    UIColor *tintColor = ApolloLPColorForCardPreset(sLinkPreviewCardColor);
-    ApolloLPLogOncePerHost(ApolloLPHost(url), @"V13-card-color-preset-resolved");
+    UIColor *custom = ApolloLPCustomCardColor();
+    if (custom) {
+        // Paint the card the exact picked color, identical in light/dark, so the
+        // result matches the swatch the user chose (WYSIWYG). Text auto-contrasts.
+        ApolloLPLogOncePerHost(ApolloLPHost(url), @"V13-card-color-custom-resolved");
+        return custom;
+    }
+
+    // Default ("Neutral"): keep the original subtle, theme-aware card background.
+    UIColor *tintColor = ApolloLinkPreviewPresetColor(ApolloLinkPreviewCardColorNeutral);
+    ApolloLPLogOncePerHost(ApolloLPHost(url), @"V13-card-color-default-resolved");
 
     if (@available(iOS 13.0, *)) {
         return [UIColor colorWithDynamicProvider:^UIColor *(UITraitCollection *traitCollection) {
@@ -1165,12 +1191,13 @@ static void ApolloLPMarkNodeForColorRefresh(ASDisplayNode *node) {
 static BOOL ApolloLPApplyCardBackgroundColor(ASDisplayNode *hostNode, ASDisplayNode *backgroundNode, NSURL *url, BOOL force) {
     if (!backgroundNode || ![backgroundNode respondsToSelector:@selector(setBackgroundColor:)]) return NO;
 
-    NSNumber *lastPresetNumber = objc_getAssociatedObject(backgroundNode, &kApolloLinkPreviewBackgroundColorPresetKey);
-    BOOL presetChanged = ![lastPresetNumber isKindOfClass:[NSNumber class]] || lastPresetNumber.integerValue != sLinkPreviewCardColor;
+    NSNumber *currentToken = @((unsigned long)sLinkPreviewCardColorPacked);
+    NSNumber *lastToken = objc_getAssociatedObject(backgroundNode, &kApolloLinkPreviewBackgroundColorPresetKey);
+    BOOL presetChanged = ![lastToken isKindOfClass:[NSNumber class]] || ![lastToken isEqualToNumber:currentToken];
     if (!force && !presetChanged) return NO;
 
     backgroundNode.backgroundColor = ApolloLPCardBackgroundColorForNode(hostNode, url);
-    objc_setAssociatedObject(backgroundNode, &kApolloLinkPreviewBackgroundColorPresetKey, @(sLinkPreviewCardColor), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(backgroundNode, &kApolloLinkPreviewBackgroundColorPresetKey, currentToken, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloLPMarkNodeForColorRefresh(backgroundNode);
     ApolloLPMarkNodeForColorRefresh(hostNode);
     return YES;
@@ -1885,9 +1912,14 @@ static NSDictionary *ApolloLPPreparedNodeBundle(ASDisplayNode *hostNode, NSURL *
     avatarNode.contentMode = UIViewContentModeScaleAspectFill;
     avatarNode.clipsToBounds = YES;
     avatarNode.cornerRadius = 18.0;
-    ApolloLPSetTextNodeAttributedTextIfChanged(siteNode, ApolloLPAttributedString([siteName uppercaseString], [UIFont systemFontOfSize:11.0 weight:UIFontWeightSemibold], [UIColor secondaryLabelColor]));
-    ApolloLPSetTextNodeAttributedTextIfChanged(titleNode, ApolloLPAttributedString(ApolloLPDisplayTitleForPreview(preview), [UIFont systemFontOfSize:15.0 weight:UIFontWeightSemibold], [UIColor labelColor]));
-    ApolloLPSetTextNodeAttributedTextIfChanged(descriptionNode, ApolloLPAttributedString(ApolloLPDisplayDescriptionForPreview(preview), [UIFont systemFontOfSize:13.0 weight:UIFontWeightRegular], [UIColor secondaryLabelColor]));
+    // On a custom-colored card, swap the dynamic system label colors for ink
+    // that contrasts with the user's chosen fill; otherwise keep label colors.
+    UIColor *titleColor = [UIColor labelColor];
+    UIColor *secondaryColor = [UIColor secondaryLabelColor];
+    ApolloLPCustomCardTextColors(&titleColor, &secondaryColor);
+    ApolloLPSetTextNodeAttributedTextIfChanged(siteNode, ApolloLPAttributedString([siteName uppercaseString], [UIFont systemFontOfSize:11.0 weight:UIFontWeightSemibold], secondaryColor));
+    ApolloLPSetTextNodeAttributedTextIfChanged(titleNode, ApolloLPAttributedString(ApolloLPDisplayTitleForPreview(preview), [UIFont systemFontOfSize:15.0 weight:UIFontWeightSemibold], titleColor));
+    ApolloLPSetTextNodeAttributedTextIfChanged(descriptionNode, ApolloLPAttributedString(ApolloLPDisplayDescriptionForPreview(preview), [UIFont systemFontOfSize:13.0 weight:UIFontWeightRegular], secondaryColor));
 
     return bundle;
 }
@@ -2007,7 +2039,9 @@ static id ApolloLPBuildHeroCardSpec(ASDisplayNode *hostNode, NSURL *url, ApolloL
     NSUInteger descriptionLineCount = ApolloLPHeroDescriptionLineCount(preview);
     titleNode.maximumNumberOfLines = 2;
     descriptionNode.maximumNumberOfLines = descriptionLineCount;
-    ApolloLPSetTextNodeAttributedTextIfChanged(titleNode, ApolloLPAttributedString(ApolloLPDisplayTitleForPreview(preview), [UIFont systemFontOfSize:17.0 weight:UIFontWeightSemibold], [UIColor labelColor]));
+    UIColor *heroTitleColor = [UIColor labelColor];
+    ApolloLPCustomCardTextColors(&heroTitleColor, NULL);
+    ApolloLPSetTextNodeAttributedTextIfChanged(titleNode, ApolloLPAttributedString(ApolloLPDisplayTitleForPreview(preview), [UIFont systemFontOfSize:17.0 weight:UIFontWeightSemibold], heroTitleColor));
     ApolloLPApplyCardBackgroundColor(hostNode, backgroundNode, url, NO);
     backgroundNode.cornerRadius = 10.0;
     backgroundNode.clipsToBounds = YES;
@@ -2847,6 +2881,12 @@ static ASDisplayNode *ApolloLPNodeForViewIfPossible(UIView *view) {
 static NSUInteger ApolloLPRecolorLinkPreviewBackgroundsForNode(ASDisplayNode *node) {
     if (!node) return 0;
 
+    // Resolve the text ink that matches the (possibly just-changed) card color
+    // up front — it depends only on the global hex, not on any single bundle.
+    UIColor *titleColor = [UIColor labelColor];
+    UIColor *secondaryColor = [UIColor secondaryLabelColor];
+    ApolloLPCustomCardTextColors(&titleColor, &secondaryColor);
+
     NSUInteger recolored = 0;
     NSDictionary<NSString *, NSDictionary *> *bundles = objc_getAssociatedObject(node, &kApolloLinkPreviewNodesKey);
     if ([bundles isKindOfClass:[NSDictionary class]]) {
@@ -2856,6 +2896,11 @@ static NSUInteger ApolloLPRecolorLinkPreviewBackgroundsForNode(ASDisplayNode *no
             NSURL *url = bundle[@"url"];
             if (![url isKindOfClass:[NSURL class]]) continue;
             if (ApolloLPApplyCardBackgroundColor(node, backgroundNode, url, YES)) {
+                // Background changed — bring the text ink along so it keeps
+                // contrasting with the new fill (or reverts to label colors).
+                ApolloLPRecolorTextNode(bundle[@"site"], secondaryColor);
+                ApolloLPRecolorTextNode(bundle[@"title"], titleColor);
+                ApolloLPRecolorTextNode(bundle[@"description"], secondaryColor);
                 recolored++;
             }
         }
@@ -3253,10 +3298,10 @@ static NSString *ApolloLPVariant(ApolloLPArea area, NSInteger mode, ApolloLPCont
 
 static NSString *ApolloLPRenderSignature(NSURL *url, ApolloLinkPreview *preview, NSString *variant) {
     CGSize imageSize = preview.imageSize;
-    return [NSString stringWithFormat:@"%@|%@|%ld|%@|%@|%@|%@|%@|%@|%@|%@|%@|%.1fx%.1f|%d",
+    return [NSString stringWithFormat:@"%@|%@|%lu|%@|%@|%@|%@|%@|%@|%@|%@|%@|%.1fx%.1f|%d",
             variant ?: @"",
             url.absoluteString ?: @"",
-            (long)sLinkPreviewCardColor,
+            (unsigned long)sLinkPreviewCardColorPacked,
             ApolloLPDisplayTitleForPreview(preview) ?: @"",
             ApolloLPDisplayDescriptionForPreview(preview) ?: @"",
             ApolloLPCleanDisplayText(preview.siteName) ?: @"",
@@ -3696,5 +3741,5 @@ static id ApolloLPNativeLinkSpecWithBannedHintIfNeeded(id linkButtonNode, NSURL 
         }
     }];
 
-    ApolloLog(@"[LinkPreviews] ctor: hook installed for _TtC6Apollo14LinkButtonNode bodyMode=%ld commentsMode=%ld cardColor=%ld", (long)sLinkPreviewBodyMode, (long)sLinkPreviewCommentsMode, (long)sLinkPreviewCardColor);
+    ApolloLog(@"[LinkPreviews] ctor: hook installed for _TtC6Apollo14LinkButtonNode bodyMode=%ld commentsMode=%ld cardColorHex=%@", (long)sLinkPreviewBodyMode, (long)sLinkPreviewCommentsMode, sLinkPreviewCardColorHex ?: @"(default)");
 }

--- a/src/ApolloLinkPreviewSettingsViewController.h
+++ b/src/ApolloLinkPreviewSettingsViewController.h
@@ -1,0 +1,8 @@
+#import "ApolloSettingsTableViewController.h"
+
+@interface ApolloLinkPreviewSettingsViewController : ApolloSettingsTableViewController
+// Invoked whenever a setting on this screen changes, with the affected area
+// ("body" / "comments" / "card-color"). The presenting settings controller uses
+// it to schedule a feed/comment refresh once the whole settings stack closes.
+@property (nonatomic, copy) void (^settingsDidChange)(NSString *area);
+@end

--- a/src/ApolloLinkPreviewSettingsViewController.m
+++ b/src/ApolloLinkPreviewSettingsViewController.m
@@ -5,8 +5,9 @@
 #import "UserDefaultConstants.h"
 
 typedef NS_ENUM(NSInteger, ApolloLPSettingsSection) {
-    ApolloLPSettingsSectionModes = 0,  // Body + Comments preview modes
-    ApolloLPSettingsSectionColor,      // Card color picker + quick swatches + reset
+    ApolloLPSettingsSectionPreview = 0, // Live sample cards (full + compact)
+    ApolloLPSettingsSectionModes,       // Body + Comments preview modes
+    ApolloLPSettingsSectionColor,       // Card color picker + quick swatches + reset
     ApolloLPSettingsSectionCount,
 };
 
@@ -26,7 +27,190 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
              @"007AFF", @"5856D6", @"AF52DE", @"FF2D55"];
 }
 
+#pragma mark - Live Preview Cards
+
+// A small UIKit mock of a rich link preview card (full + compact) that recolors
+// to mirror the real renderer: a solid fill of the chosen color with title /
+// site / description text auto-contrasted to black or white. Lets the user see
+// their color on a fake card while picking, without needing a real link.
+@interface ApolloLPPreviewCardsView : UIView
+- (void)applyCardColorHex:(NSString *)hex;
+@end
+
+@implementation ApolloLPPreviewCardsView {
+    UIView *_fullCard;
+    UIImageView *_fullImage;
+    UILabel *_fullSite;
+    UILabel *_fullTitle;
+    UILabel *_fullDesc;
+    UIView *_compactCard;
+    UIImageView *_compactThumb;
+    UILabel *_compactSite;
+    UILabel *_compactTitle;
+    UILabel *_compactDesc;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        [self buildCards];
+        [self applyCardColorHex:sLinkPreviewCardColorHex];
+    }
+    return self;
+}
+
+- (UILabel *)labelSize:(CGFloat)size weight:(UIFontWeight)weight lines:(NSInteger)lines {
+    UILabel *label = [UILabel new];
+    label.font = [UIFont systemFontOfSize:size weight:weight];
+    label.numberOfLines = lines;
+    label.lineBreakMode = NSLineBreakByTruncatingTail;
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    return label;
+}
+
+- (UILabel *)caption:(NSString *)text {
+    UILabel *label = [UILabel new];
+    label.font = [UIFont systemFontOfSize:12.0 weight:UIFontWeightSemibold];
+    label.textColor = [UIColor secondaryLabelColor];
+    label.text = [text uppercaseString];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    return label;
+}
+
+- (UIImageView *)imagePlaceholder {
+    UIImageView *view = [[UIImageView alloc] init];
+    view.translatesAutoresizingMaskIntoConstraints = NO;
+    view.contentMode = UIViewContentModeCenter;
+    view.clipsToBounds = YES;
+    view.layer.cornerRadius = 8.0;
+    view.backgroundColor = [UIColor systemGray4Color];
+    if (@available(iOS 13.0, *)) {
+        view.image = [UIImage systemImageNamed:@"photo"];
+        view.tintColor = [UIColor systemGray2Color];
+    }
+    return view;
+}
+
+- (UIView *)roundedCard {
+    UIView *card = [UIView new];
+    card.translatesAutoresizingMaskIntoConstraints = NO;
+    card.layer.cornerRadius = 10.0;
+    card.clipsToBounds = YES;
+    return card;
+}
+
+- (void)buildCards {
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+
+    // ---- Full (hero) card: image on top, text below ----
+    _fullCard = [self roundedCard];
+    _fullImage = [self imagePlaceholder];
+    _fullSite = [self labelSize:11.0 weight:UIFontWeightSemibold lines:1];
+    _fullTitle = [self labelSize:15.0 weight:UIFontWeightSemibold lines:2];
+    _fullDesc = [self labelSize:13.0 weight:UIFontWeightRegular lines:1];
+    [_fullCard addSubview:_fullImage];
+    [_fullCard addSubview:_fullSite];
+    [_fullCard addSubview:_fullTitle];
+    [_fullCard addSubview:_fullDesc];
+    [NSLayoutConstraint activateConstraints:@[
+        [_fullImage.topAnchor constraintEqualToAnchor:_fullCard.topAnchor constant:10.0],
+        [_fullImage.leadingAnchor constraintEqualToAnchor:_fullCard.leadingAnchor constant:10.0],
+        [_fullImage.trailingAnchor constraintEqualToAnchor:_fullCard.trailingAnchor constant:-10.0],
+        [_fullImage.heightAnchor constraintEqualToConstant:88.0],
+        [_fullSite.topAnchor constraintEqualToAnchor:_fullImage.bottomAnchor constant:9.0],
+        [_fullSite.leadingAnchor constraintEqualToAnchor:_fullCard.leadingAnchor constant:12.0],
+        [_fullSite.trailingAnchor constraintEqualToAnchor:_fullCard.trailingAnchor constant:-12.0],
+        [_fullTitle.topAnchor constraintEqualToAnchor:_fullSite.bottomAnchor constant:3.0],
+        [_fullTitle.leadingAnchor constraintEqualToAnchor:_fullCard.leadingAnchor constant:12.0],
+        [_fullTitle.trailingAnchor constraintEqualToAnchor:_fullCard.trailingAnchor constant:-12.0],
+        [_fullDesc.topAnchor constraintEqualToAnchor:_fullTitle.bottomAnchor constant:3.0],
+        [_fullDesc.leadingAnchor constraintEqualToAnchor:_fullCard.leadingAnchor constant:12.0],
+        [_fullDesc.trailingAnchor constraintEqualToAnchor:_fullCard.trailingAnchor constant:-12.0],
+        [_fullDesc.bottomAnchor constraintEqualToAnchor:_fullCard.bottomAnchor constant:-11.0],
+    ]];
+
+    // ---- Compact card: thumbnail left, text right ----
+    _compactCard = [self roundedCard];
+    _compactThumb = [self imagePlaceholder];
+    _compactSite = [self labelSize:11.0 weight:UIFontWeightSemibold lines:1];
+    _compactTitle = [self labelSize:15.0 weight:UIFontWeightSemibold lines:1];
+    _compactDesc = [self labelSize:13.0 weight:UIFontWeightRegular lines:2];
+    [_compactCard addSubview:_compactThumb];
+    [_compactCard addSubview:_compactSite];
+    [_compactCard addSubview:_compactTitle];
+    [_compactCard addSubview:_compactDesc];
+    [NSLayoutConstraint activateConstraints:@[
+        [_compactThumb.topAnchor constraintEqualToAnchor:_compactCard.topAnchor constant:10.0],
+        [_compactThumb.leadingAnchor constraintEqualToAnchor:_compactCard.leadingAnchor constant:10.0],
+        [_compactThumb.widthAnchor constraintEqualToConstant:64.0],
+        [_compactThumb.heightAnchor constraintEqualToConstant:64.0],
+        [_compactThumb.bottomAnchor constraintLessThanOrEqualToAnchor:_compactCard.bottomAnchor constant:-10.0],
+        [_compactSite.topAnchor constraintEqualToAnchor:_compactCard.topAnchor constant:11.0],
+        [_compactSite.leadingAnchor constraintEqualToAnchor:_compactThumb.trailingAnchor constant:10.0],
+        [_compactSite.trailingAnchor constraintEqualToAnchor:_compactCard.trailingAnchor constant:-12.0],
+        [_compactTitle.topAnchor constraintEqualToAnchor:_compactSite.bottomAnchor constant:3.0],
+        [_compactTitle.leadingAnchor constraintEqualToAnchor:_compactThumb.trailingAnchor constant:10.0],
+        [_compactTitle.trailingAnchor constraintEqualToAnchor:_compactCard.trailingAnchor constant:-12.0],
+        [_compactDesc.topAnchor constraintEqualToAnchor:_compactTitle.bottomAnchor constant:3.0],
+        [_compactDesc.leadingAnchor constraintEqualToAnchor:_compactThumb.trailingAnchor constant:10.0],
+        [_compactDesc.trailingAnchor constraintEqualToAnchor:_compactCard.trailingAnchor constant:-12.0],
+        [_compactDesc.bottomAnchor constraintLessThanOrEqualToAnchor:_compactCard.bottomAnchor constant:-11.0],
+    ]];
+
+    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[
+        [self caption:@"Full"], _fullCard, [self caption:@"Compact"], _compactCard,
+    ]];
+    stack.axis = UILayoutConstraintAxisVertical;
+    stack.spacing = 6.0;
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    [stack setCustomSpacing:14.0 afterView:_fullCard];
+    [self addSubview:stack];
+    [NSLayoutConstraint activateConstraints:@[
+        [stack.topAnchor constraintEqualToAnchor:self.topAnchor],
+        [stack.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+        [stack.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+        [stack.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
+    ]];
+
+    _fullSite.text = @"WEBSITE.COM";
+    _fullTitle.text = @"Example link preview title";
+    _fullDesc.text = @"A short description of the linked page.";
+    _compactSite.text = @"WEBSITE.COM";
+    _compactTitle.text = @"Example link preview title";
+    _compactDesc.text = @"A short description of the linked page.";
+}
+
+- (void)applyCardColorHex:(NSString *)hex {
+    UIColor *custom = (hex.length > 0) ? ApolloColorFromHexString(hex) : nil;
+    UIColor *cardColor;
+    UIColor *titleColor;
+    UIColor *secondaryColor;
+    if (custom) {
+        // Mirror the real renderer: solid fill + auto-contrast ink.
+        cardColor = custom;
+        BOOL light = ApolloColorIsLight(custom);
+        titleColor = light ? [UIColor colorWithWhite:0.0 alpha:1.0] : [UIColor colorWithWhite:1.0 alpha:1.0];
+        secondaryColor = [titleColor colorWithAlphaComponent:light ? 0.62 : 0.78];
+    } else {
+        // Default ("no color"): the standard neutral card look.
+        cardColor = [UIColor secondarySystemBackgroundColor];
+        titleColor = [UIColor labelColor];
+        secondaryColor = [UIColor secondaryLabelColor];
+    }
+    _fullCard.backgroundColor = cardColor;
+    _compactCard.backgroundColor = cardColor;
+    _fullSite.textColor = secondaryColor;
+    _fullTitle.textColor = titleColor;
+    _fullDesc.textColor = secondaryColor;
+    _compactSite.textColor = secondaryColor;
+    _compactTitle.textColor = titleColor;
+    _compactDesc.textColor = secondaryColor;
+}
+
+@end
+
 @interface ApolloLinkPreviewSettingsViewController () <UIColorPickerViewControllerDelegate>
+@property (nonatomic, strong) ApolloLPPreviewCardsView *previewView;
 @end
 
 @implementation ApolloLinkPreviewSettingsViewController
@@ -34,6 +218,13 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.title = @"Rich Link Previews";
+    // The preview cell is taller than a stock row and self-sizes from its content.
+    self.tableView.estimatedRowHeight = 60.0;
+    self.tableView.rowHeight = UITableViewAutomaticDimension;
+}
+
+- (void)refreshPreview {
+    [self.previewView applyCardColorHex:sLinkPreviewCardColorHex];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -96,6 +287,7 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
 - (void)applyCardColorHex:(NSString *)hex {
     [self storeCardColorHex:hex];
     [self broadcastChangeForArea:@"card-color"];
+    [self refreshPreview];
     [self.tableView reloadData];
 }
 
@@ -158,11 +350,11 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
 #pragma mark - UIColorPickerViewControllerDelegate
 
 - (void)colorPickerViewControllerDidSelectColor:(UIColorPickerViewController *)viewController {
-    // Fires continuously while dragging — store the value and lightly refresh the
-    // Color section, but defer the heavy feed broadcast to didFinish.
+    // Fires continuously while dragging. Update the live preview (visible above
+    // the picker sheet) immediately; defer the heavier feed broadcast + full
+    // table refresh (Color row swatch + #hex) to didFinish.
     [self storeCardColorHex:ApolloHexStringFromColor(viewController.selectedColor)];
-    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:ApolloLPSettingsSectionColor]
-                  withRowAnimation:UITableViewRowAnimationNone];
+    [self refreshPreview];
 }
 
 - (void)colorPickerViewControllerDidFinish:(UIColorPickerViewController *)viewController {
@@ -177,6 +369,7 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     switch (section) {
+        case ApolloLPSettingsSectionPreview: return 1;
         case ApolloLPSettingsSectionModes: return 2;
         case ApolloLPSettingsSectionColor: return [self hasCustomColor] ? 3 : 2;
         default: return 0;
@@ -185,6 +378,7 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
     switch (section) {
+        case ApolloLPSettingsSectionPreview: return @"Card Preview";
         case ApolloLPSettingsSectionModes: return @"Previews";
         case ApolloLPSettingsSectionColor: return @"Card Color";
         default: return nil;
@@ -192,6 +386,9 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
+    if (section == ApolloLPSettingsSectionPreview) {
+        return @"Sample full and compact cards — they update live as you change the color below.";
+    }
     if (section == ApolloLPSettingsSectionModes) {
         return @"Off hides the card, Compact shows a small thumbnail row, Full shows a large hero image card.";
     }
@@ -273,7 +470,30 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
     return cell;
 }
 
+- (UITableViewCell *)previewCell {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+    if (!self.previewView) {
+        self.previewView = [[ApolloLPPreviewCardsView alloc] initWithFrame:CGRectZero];
+    }
+    // Re-host the persistent preview view so it survives reloadData and can be
+    // updated live (a view has one superview, so detach before re-adding).
+    [self.previewView removeFromSuperview];
+    [cell.contentView addSubview:self.previewView];
+    [NSLayoutConstraint activateConstraints:@[
+        [self.previewView.topAnchor constraintEqualToAnchor:cell.contentView.topAnchor constant:8.0],
+        [self.previewView.leadingAnchor constraintEqualToAnchor:cell.contentView.layoutMarginsGuide.leadingAnchor],
+        [self.previewView.trailingAnchor constraintEqualToAnchor:cell.contentView.layoutMarginsGuide.trailingAnchor],
+        [self.previewView.bottomAnchor constraintEqualToAnchor:cell.contentView.bottomAnchor constant:-10.0],
+    ]];
+    [self.previewView applyCardColorHex:sLinkPreviewCardColorHex];
+    return cell;
+}
+
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == ApolloLPSettingsSectionPreview) {
+        return [self previewCell];
+    }
     if (indexPath.section == ApolloLPSettingsSectionModes) {
         return [self modeCellForBody:(indexPath.row == 0)];
     }

--- a/src/ApolloLinkPreviewSettingsViewController.m
+++ b/src/ApolloLinkPreviewSettingsViewController.m
@@ -1,0 +1,308 @@
+#import "ApolloLinkPreviewSettingsViewController.h"
+
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+#import "UserDefaultConstants.h"
+
+typedef NS_ENUM(NSInteger, ApolloLPSettingsSection) {
+    ApolloLPSettingsSectionModes = 0,  // Body + Comments preview modes
+    ApolloLPSettingsSectionColor,      // Card color picker + quick swatches + reset
+    ApolloLPSettingsSectionCount,
+};
+
+// Rows within the Color section. The reset row only exists while a custom color
+// is set; numberOfRowsInSection reflects that.
+typedef NS_ENUM(NSInteger, ApolloLPColorRow) {
+    ApolloLPColorRowPicker = 0,
+    ApolloLPColorRowSwatches,
+    ApolloLPColorRowReset,
+};
+
+// Vivid quick-pick palette (Apple system colors). These write the same hex the
+// full picker would, so the two paths stay consistent. Kept to nine so the row
+// of fixed-size swatches fits without clipping even on the narrowest screens.
+static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
+    return @[@"FF3B30", @"FF9500", @"FFCC00", @"34C759", @"30B0C7",
+             @"007AFF", @"5856D6", @"AF52DE", @"FF2D55"];
+}
+
+@interface ApolloLinkPreviewSettingsViewController () <UIColorPickerViewControllerDelegate>
+@end
+
+@implementation ApolloLinkPreviewSettingsViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Rich Link Previews";
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.tableView reloadData];
+}
+
+#pragma mark - State helpers
+
+- (BOOL)hasCustomColor {
+    return [sLinkPreviewCardColorHex isKindOfClass:[NSString class]] && sLinkPreviewCardColorHex.length > 0;
+}
+
+- (UIColor *)currentCardColor {
+    return ApolloColorFromHexString(sLinkPreviewCardColorHex);
+}
+
+- (NSString *)modeTextForMode:(NSInteger)mode {
+    switch (mode) {
+        case ApolloLinkPreviewModeOff:     return @"Off";
+        case ApolloLinkPreviewModeCompact: return @"Compact";
+        case ApolloLinkPreviewModeFull:
+        default:                           return @"Full";
+    }
+}
+
+// A rounded color swatch for the Color row's left image. Default (no color) is a
+// neutral gray chip so the row never looks broken before a color is chosen.
+- (UIImage *)swatchImageForColor:(UIColor *)color {
+    CGSize size = CGSizeMake(26.0, 26.0);
+    UIColor *fill = color ?: [UIColor systemGray3Color];
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size];
+    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext *ctx) {
+        UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(1.0, 1.0, 24.0, 24.0) cornerRadius:6.0];
+        [fill setFill];
+        [path fill];
+        [[UIColor colorWithWhite:0.5 alpha:0.35] setStroke];
+        path.lineWidth = 1.0;
+        [path stroke];
+    }];
+    return [image imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+}
+
+#pragma mark - Mutation
+
+- (void)storeCardColorHex:(NSString *)hex {
+    // Updates the main-thread NSString + the render-safe packed snapshot together.
+    ApolloSetLinkPreviewCardColorHex(hex);
+    [[NSUserDefaults standardUserDefaults] setObject:(sLinkPreviewCardColorHex ?: @"") forKey:UDKeyLinkPreviewCardColorHex];
+}
+
+- (void)broadcastChangeForArea:(NSString *)area {
+    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloLinkPreviewModeDidChangeNotification
+                                                        object:nil
+                                                      userInfo:@{@"area": area}];
+    if (self.settingsDidChange) self.settingsDidChange(area);
+}
+
+// Commit a card color (or "" / nil to reset to Default) and refresh everything.
+- (void)applyCardColorHex:(NSString *)hex {
+    [self storeCardColorHex:hex];
+    [self broadcastChangeForArea:@"card-color"];
+    [self.tableView reloadData];
+}
+
+- (void)setLinkPreviewMode:(NSInteger)mode body:(BOOL)body {
+    if (mode < ApolloLinkPreviewModeOff || mode > ApolloLinkPreviewModeFull) mode = ApolloLinkPreviewModeFull;
+    if (body) {
+        sLinkPreviewBodyMode = mode;
+        [[NSUserDefaults standardUserDefaults] setInteger:mode forKey:UDKeyLinkPreviewBodyMode];
+    } else {
+        sLinkPreviewCommentsMode = mode;
+        [[NSUserDefaults standardUserDefaults] setInteger:mode forKey:UDKeyLinkPreviewCommentsMode];
+    }
+    [self broadcastChangeForArea:body ? @"body" : @"comments"];
+    [self.tableView reloadData];
+}
+
+#pragma mark - Actions
+
+- (void)swatchTapped:(UIButton *)sender {
+    NSArray<NSString *> *hexes = ApolloLPQuickSwatchHexes();
+    if (sender.tag < 0 || sender.tag >= (NSInteger)hexes.count) return;
+    [self applyCardColorHex:hexes[sender.tag]];
+}
+
+- (void)presentCardColorPicker {
+    UIColorPickerViewController *picker = [[UIColorPickerViewController alloc] init];
+    picker.supportsAlpha = NO;
+    picker.title = @"Preview Card Color";
+    picker.selectedColor = [self currentCardColor] ?: [UIColor systemBlueColor];
+    picker.delegate = self;
+    [self presentViewController:picker animated:YES completion:nil];
+}
+
+- (void)presentModeSheetForBody:(BOOL)body fromCell:(UITableViewCell *)cell {
+    NSInteger currentMode = body ? sLinkPreviewBodyMode : sLinkPreviewCommentsMode;
+    NSString *title = body ? @"Body Link Previews" : @"Comment Link Previews";
+    NSString *message = body
+        ? @"Choose how rich link preview cards appear in feeds and post bodies."
+        : @"Choose how rich link preview cards appear in comments.";
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:title
+                                                                   message:message
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+
+    NSArray<NSNumber *> *modes = @[@(ApolloLinkPreviewModeFull), @(ApolloLinkPreviewModeCompact), @(ApolloLinkPreviewModeOff)];
+    for (NSNumber *modeNumber in modes) {
+        NSInteger mode = modeNumber.integerValue;
+        NSString *name = [self modeTextForMode:mode];
+        NSString *actionTitle = (mode == currentMode) ? [NSString stringWithFormat:@"%@ (Current)", name] : name;
+        [sheet addAction:[UIAlertAction actionWithTitle:actionTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+            [self setLinkPreviewMode:mode body:body];
+        }]];
+    }
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    sheet.popoverPresentationController.sourceView = cell ?: self.view;
+    sheet.popoverPresentationController.sourceRect = cell ? cell.bounds : CGRectZero;
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+#pragma mark - UIColorPickerViewControllerDelegate
+
+- (void)colorPickerViewControllerDidSelectColor:(UIColorPickerViewController *)viewController {
+    // Fires continuously while dragging — store the value and lightly refresh the
+    // Color section, but defer the heavy feed broadcast to didFinish.
+    [self storeCardColorHex:ApolloHexStringFromColor(viewController.selectedColor)];
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:ApolloLPSettingsSectionColor]
+                  withRowAnimation:UITableViewRowAnimationNone];
+}
+
+- (void)colorPickerViewControllerDidFinish:(UIColorPickerViewController *)viewController {
+    [self applyCardColorHex:ApolloHexStringFromColor(viewController.selectedColor)];
+}
+
+#pragma mark - Table
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return ApolloLPSettingsSectionCount;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    switch (section) {
+        case ApolloLPSettingsSectionModes: return 2;
+        case ApolloLPSettingsSectionColor: return [self hasCustomColor] ? 3 : 2;
+        default: return 0;
+    }
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
+    switch (section) {
+        case ApolloLPSettingsSectionModes: return @"Previews";
+        case ApolloLPSettingsSectionColor: return @"Card Color";
+        default: return nil;
+    }
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
+    if (section == ApolloLPSettingsSectionModes) {
+        return @"Off hides the card, Compact shows a small thumbnail row, Full shows a large hero image card.";
+    }
+    if (section == ApolloLPSettingsSectionColor) {
+        return @"The card is painted the exact color you pick, the same in light and dark mode, with title and description text automatically set to black or white for contrast. Default keeps the standard neutral card.";
+    }
+    return nil;
+}
+
+- (UITableViewCell *)modeCellForBody:(BOOL)body {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:nil];
+    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+    cell.textLabel.text = body ? @"Body" : @"Comments";
+    cell.detailTextLabel.text = [self modeTextForMode:body ? sLinkPreviewBodyMode : sLinkPreviewCommentsMode];
+    cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+    return cell;
+}
+
+- (UITableViewCell *)colorPickerCell {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:nil];
+    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+    cell.textLabel.text = @"Color";
+    cell.imageView.image = [self swatchImageForColor:[self currentCardColor]];
+    cell.detailTextLabel.text = [self hasCustomColor]
+        ? [NSString stringWithFormat:@"#%@", [sLinkPreviewCardColorHex uppercaseString]]
+        : @"Default";
+    cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+    return cell;
+}
+
+- (UITableViewCell *)swatchPickerCell {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+
+    UIStackView *stack = [[UIStackView alloc] init];
+    stack.axis = UILayoutConstraintAxisHorizontal;
+    stack.distribution = UIStackViewDistributionEqualSpacing;
+    stack.alignment = UIStackViewAlignmentCenter;
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    [cell.contentView addSubview:stack];
+    [NSLayoutConstraint activateConstraints:@[
+        [stack.leadingAnchor constraintEqualToAnchor:cell.contentView.layoutMarginsGuide.leadingAnchor],
+        [stack.trailingAnchor constraintEqualToAnchor:cell.contentView.layoutMarginsGuide.trailingAnchor],
+        [stack.topAnchor constraintEqualToAnchor:cell.contentView.topAnchor constant:11.0],
+        [stack.bottomAnchor constraintEqualToAnchor:cell.contentView.bottomAnchor constant:-11.0],
+    ]];
+
+    NSArray<NSString *> *hexes = ApolloLPQuickSwatchHexes();
+    NSString *current = [self hasCustomColor] ? [sLinkPreviewCardColorHex uppercaseString] : nil;
+    for (NSInteger i = 0; i < (NSInteger)hexes.count; i++) {
+        NSString *hex = hexes[i];
+        UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
+        button.translatesAutoresizingMaskIntoConstraints = NO;
+        button.backgroundColor = ApolloColorFromHexString(hex);
+        button.layer.cornerRadius = 14.0;
+        button.tag = i;
+        button.accessibilityLabel = [NSString stringWithFormat:@"Card color #%@", hex];
+        [button addTarget:self action:@selector(swatchTapped:) forControlEvents:UIControlEventTouchUpInside];
+        if (current && [current isEqualToString:hex]) {
+            button.layer.borderColor = [UIColor labelColor].CGColor;
+            button.layer.borderWidth = 2.5;
+        }
+        [NSLayoutConstraint activateConstraints:@[
+            [button.widthAnchor constraintEqualToConstant:28.0],
+            [button.heightAnchor constraintEqualToConstant:28.0],
+        ]];
+        [stack addArrangedSubview:button];
+    }
+    return cell;
+}
+
+- (UITableViewCell *)resetCell {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+    cell.textLabel.text = @"Use Default (No Color)";
+    cell.textLabel.textColor = self.view.tintColor;
+    return cell;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == ApolloLPSettingsSectionModes) {
+        return [self modeCellForBody:(indexPath.row == 0)];
+    }
+    if (indexPath.section == ApolloLPSettingsSectionColor) {
+        switch (indexPath.row) {
+            case ApolloLPColorRowPicker:   return [self colorPickerCell];
+            case ApolloLPColorRowSwatches: return [self swatchPickerCell];
+            case ApolloLPColorRowReset:    return [self resetCell];
+            default: break;
+        }
+    }
+    return [[UITableViewCell alloc] init];
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+
+    if (indexPath.section == ApolloLPSettingsSectionModes) {
+        [self presentModeSheetForBody:(indexPath.row == 0) fromCell:cell];
+        return;
+    }
+    if (indexPath.section == ApolloLPSettingsSectionColor) {
+        if (indexPath.row == ApolloLPColorRowPicker) {
+            [self presentCardColorPicker];
+        } else if (indexPath.row == ApolloLPColorRowReset) {
+            [self applyCardColorHex:@""];
+        }
+    }
+}
+
+@end

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -113,7 +113,20 @@ typedef NS_ENUM(NSInteger, ApolloLinkPreviewCardColor) {
 // Rich link previews (Open Graph / oEmbed) for link cards in body/feed and comments.
 extern NSInteger sLinkPreviewBodyMode;
 extern NSInteger sLinkPreviewCommentsMode;
+// Legacy preset enum, retained only for one-time migration to the hex below.
 extern NSInteger sLinkPreviewCardColor;
+// Free-form preview card color, 6-digit "RRGGBB" hex. nil/empty = Default (no
+// custom fill). When set, the whole card is painted this exact color.
+// MAIN-THREAD ONLY: read/written by the settings UI and persistence. The card
+// renderer runs on Texture background layout threads and must NOT touch this
+// NSString* (racing a strong-pointer reassign risks a use-after-free); it reads
+// the packed snapshot below instead. Both are updated together via
+// ApolloSetLinkPreviewCardColorHex().
+extern NSString *sLinkPreviewCardColorHex;
+// Render-safe snapshot of the card color, readable from any thread (an aligned
+// 32-bit volatile load is atomic on arm64). 0 = Default; otherwise
+// (1<<24) | (R<<16) | (G<<8) | B.
+extern volatile uint32_t sLinkPreviewCardColorPacked;
 
 // Media upload host selection. Imgur is the default; Reddit uses Apollo's signed-in
 // session to upload directly to Reddit's media storage; ImgChest uploads to

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -40,6 +40,8 @@ NSInteger sAutoplayInlineGIFMode = ApolloAutoplayInlineGIFModeDefault;
 NSInteger sLinkPreviewBodyMode = ApolloLinkPreviewModeOff;
 NSInteger sLinkPreviewCommentsMode = ApolloLinkPreviewModeOff;
 NSInteger sLinkPreviewCardColor = ApolloLinkPreviewCardColorNeutral;
+NSString *sLinkPreviewCardColorHex = nil;
+volatile uint32_t sLinkPreviewCardColorPacked = 0;
 NSInteger sImageUploadProvider = ImageUploadProviderImgur;
 
 NSString *sLatestRedditBearerToken = nil;

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -2500,14 +2500,12 @@ static void ApolloReplayValetKeychainItems(NSArray<NSDictionary *> *items) {
         [defaults setInteger:sLinkPreviewCardColor forKey:UDKeyLinkPreviewCardColor];
     }
     // Free-form hex card color. A backup made by a build with the color picker
-    // carries the hex key directly; an older backup only has the legacy preset
-    // enum, so migrate it once (matches the launch-time logic in Tweak.xm).
+    // carries the hex key directly; otherwise the card starts neutral (the legacy
+    // preset enum is not promoted to a full-card fill — see Tweak.xm).
     NSString *restoredCardColorHex = [defaults stringForKey:UDKeyLinkPreviewCardColorHex];
     if (![defaults objectForKey:UDKeyLinkPreviewCardColorHex]) {
-        restoredCardColorHex = (sLinkPreviewCardColor != ApolloLinkPreviewCardColorNeutral)
-            ? ApolloHexStringFromColor(ApolloLinkPreviewPresetColor(sLinkPreviewCardColor))
-            : @"";
-        [defaults setObject:(restoredCardColorHex ?: @"") forKey:UDKeyLinkPreviewCardColorHex];
+        restoredCardColorHex = @"";
+        [defaults setObject:@"" forKey:UDKeyLinkPreviewCardColorHex];
     }
     ApolloSetLinkPreviewCardColorHex(restoredCardColorHex);
     sEnableBulkTranslation = [defaults boolForKey:UDKeyEnableBulkTranslation];

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -5,6 +5,7 @@
 #import "ApolloState.h"
 #import "ApolloUserProfileCache.h"
 #import "ApolloLinkPreviewCache.h"
+#import "ApolloLinkPreviewSettingsViewController.h"
 #import "ApolloSubredditCustomBannerCache.h"
 #import "ApolloSubredditCustomIconCache.h"
 #import "ApolloSubredditInfoCache.h"
@@ -24,6 +25,7 @@ typedef NS_ENUM(NSInteger, SectionIndex) {
     SectionBackupRestore = 0,
     SectionAPIKeys,
     SectionGeneral,
+    SectionLinkPreviews,
     SectionMedia,
     SectionSubreddits,
     SectionNotificationBackend,
@@ -398,199 +400,51 @@ typedef NS_ENUM(NSInteger, Tag) {
     }
 }
 
-- (NSString *)linkPreviewCardColorTextForColor:(NSInteger)color {
-    switch (color) {
-        case ApolloLinkPreviewCardColorGray:     return @"Gray";
-        case ApolloLinkPreviewCardColorRed:      return @"Red";
-        case ApolloLinkPreviewCardColorOrange:   return @"Orange";
-        case ApolloLinkPreviewCardColorYellow:   return @"Yellow";
-        case ApolloLinkPreviewCardColorGreen:    return @"Green";
-        case ApolloLinkPreviewCardColorMint:     return @"Mint";
-        case ApolloLinkPreviewCardColorTeal:     return @"Teal";
-        case ApolloLinkPreviewCardColorCyan:     return @"Cyan";
-        case ApolloLinkPreviewCardColorBlue:     return @"Blue";
-        case ApolloLinkPreviewCardColorIndigo:   return @"Indigo";
-        case ApolloLinkPreviewCardColorPurple:   return @"Purple";
-        case ApolloLinkPreviewCardColorPink:     return @"Pink";
-        case ApolloLinkPreviewCardColorBrown:    return @"Brown";
-        case ApolloLinkPreviewCardColorCoral:    return @"Coral";
-        case ApolloLinkPreviewCardColorLime:     return @"Lime";
-        case ApolloLinkPreviewCardColorOlive:    return @"Olive";
-        case ApolloLinkPreviewCardColorLavender: return @"Lavender";
-        case ApolloLinkPreviewCardColorSlate:    return @"Slate";
-        case ApolloLinkPreviewCardColorNeutral:
-        default:                                 return @"Neutral";
+- (UITableViewCell *)linkPreviewsCellForTableView:(UITableView *)tableView {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_LinkPreviews"];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"Cell_LinkPreviews"];
+        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+        cell.selectionStyle = UITableViewCellSelectionStyleDefault;
     }
+    cell.textLabel.text = @"Rich Link Preview Settings";
+    NSString *colorText = (sLinkPreviewCardColorHex.length > 0)
+        ? [NSString stringWithFormat:@"#%@", [sLinkPreviewCardColorHex uppercaseString]]
+        : @"Default color";
+    cell.detailTextLabel.text = [NSString stringWithFormat:@"Body %@ · Comments %@ · %@",
+                                 [self linkPreviewModeTextForMode:sLinkPreviewBodyMode],
+                                 [self linkPreviewModeTextForMode:sLinkPreviewCommentsMode],
+                                 colorText];
+    cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+    cell.detailTextLabel.numberOfLines = 0;
+    cell.detailTextLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    return cell;
 }
 
-- (UIColor *)linkPreviewCardUIColorForColor:(NSInteger)color {
-    switch (color) {
-        case ApolloLinkPreviewCardColorGray:     return [UIColor colorWithWhite:0.56 alpha:1.0];
-        case ApolloLinkPreviewCardColorRed:      return [UIColor colorWithRed:1.00 green:0.23 blue:0.19 alpha:1.0];
-        case ApolloLinkPreviewCardColorOrange:   return [UIColor colorWithRed:1.00 green:0.58 blue:0.00 alpha:1.0];
-        case ApolloLinkPreviewCardColorYellow:   return [UIColor colorWithRed:1.00 green:0.80 blue:0.00 alpha:1.0];
-        case ApolloLinkPreviewCardColorGreen:    return [UIColor colorWithRed:0.20 green:0.78 blue:0.35 alpha:1.0];
-        case ApolloLinkPreviewCardColorMint:     return [UIColor colorWithRed:0.00 green:0.78 blue:0.75 alpha:1.0];
-        case ApolloLinkPreviewCardColorTeal:     return [UIColor colorWithRed:0.19 green:0.69 blue:0.78 alpha:1.0];
-        case ApolloLinkPreviewCardColorCyan:     return [UIColor colorWithRed:0.20 green:0.68 blue:0.90 alpha:1.0];
-        case ApolloLinkPreviewCardColorBlue:     return [UIColor colorWithRed:0.00 green:0.48 blue:1.00 alpha:1.0];
-        case ApolloLinkPreviewCardColorIndigo:   return [UIColor colorWithRed:0.35 green:0.34 blue:0.84 alpha:1.0];
-        case ApolloLinkPreviewCardColorPurple:   return [UIColor colorWithRed:0.69 green:0.32 blue:0.87 alpha:1.0];
-        case ApolloLinkPreviewCardColorPink:     return [UIColor colorWithRed:1.00 green:0.18 blue:0.33 alpha:1.0];
-        case ApolloLinkPreviewCardColorBrown:    return [UIColor colorWithRed:0.64 green:0.52 blue:0.37 alpha:1.0];
-        case ApolloLinkPreviewCardColorCoral:    return [UIColor colorWithRed:1.00 green:0.50 blue:0.31 alpha:1.0];
-        case ApolloLinkPreviewCardColorLime:     return [UIColor colorWithRed:0.60 green:0.80 blue:0.00 alpha:1.0];
-        case ApolloLinkPreviewCardColorOlive:    return [UIColor colorWithRed:0.50 green:0.60 blue:0.20 alpha:1.0];
-        case ApolloLinkPreviewCardColorLavender: return [UIColor colorWithRed:0.56 green:0.45 blue:0.90 alpha:1.0];
-        case ApolloLinkPreviewCardColorSlate:    return [UIColor colorWithRed:0.35 green:0.43 blue:0.50 alpha:1.0];
-        case ApolloLinkPreviewCardColorNeutral:
-        default:                                 return [UIColor colorWithWhite:0.72 alpha:1.0];
-    }
-}
-
-- (UIImage *)linkPreviewCardColorDotImageForColor:(NSInteger)color {
-    CGSize size = CGSizeMake(18.0, 18.0);
-    CGRect dotRect = CGRectMake(3.0, 3.0, 12.0, 12.0);
-    UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    UIColor *dotColor = [self linkPreviewCardUIColorForColor:color];
-    CGContextSetFillColorWithColor(context, dotColor.CGColor);
-    CGContextFillEllipseInRect(context, dotRect);
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    return [image imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
-}
-
-- (void)setLinkPreviewMode:(NSInteger)mode body:(BOOL)body {
-    NSInteger row = ApolloMediaPhysicalRow(body ? 7 : 8);
-    NSString *key = body ? UDKeyLinkPreviewBodyMode : UDKeyLinkPreviewCommentsMode;
-    if (body) {
-        sLinkPreviewBodyMode = mode;
+- (void)openLinkPreviewSettings {
+    ApolloLinkPreviewSettingsViewController *vc =
+        [[ApolloLinkPreviewSettingsViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
+    __weak typeof(self) weakSelf = self;
+    vc.settingsDidChange = ^(NSString *area) {
+        [weakSelf noteLinkPreviewChangeForArea:area];
+    };
+    if (self.navigationController) {
+        [self.navigationController pushViewController:vc animated:YES];
     } else {
-        sLinkPreviewCommentsMode = mode;
+        UINavigationController *navigation =
+            [[UINavigationController alloc] initWithRootViewController:vc];
+        [self presentViewController:navigation animated:YES completion:nil];
     }
-    [[NSUserDefaults standardUserDefaults] setInteger:mode forKey:key];
+}
+
+// The Rich Link Preview sub-screen mutates the shared state and posts the live
+// notification itself; this just arms the deferred refresh so the feed/comments
+// rebuild once the whole settings stack is dismissed (mirrors the old in-Media
+// setters' use of these flags, consumed in viewWillDisappear).
+- (void)noteLinkPreviewChangeForArea:(NSString *)area {
     sLinkPreviewModeRefreshPending = YES;
-    sPendingLinkPreviewModeRefreshArea = body ? @"body" : @"comments";
-    sPendingLinkPreviewModeRefreshMode = mode;
-    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloLinkPreviewModeDidChangeNotification
-                                                        object:nil
-                                                      userInfo:@{
-                                                          @"area": body ? @"body" : @"comments",
-                                                          @"mode": @(mode),
-                                                      }];
-
-    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:row inSection:SectionMedia];
-    if ([[self.tableView indexPathsForVisibleRows] containsObject:indexPath]) {
-        [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
-    }
-}
-
-- (void)setLinkPreviewCardColor:(NSInteger)color {
-    if (color < ApolloLinkPreviewCardColorNeutral || color > ApolloLinkPreviewCardColorSlate) {
-        color = ApolloLinkPreviewCardColorNeutral;
-    }
-
-    sLinkPreviewCardColor = color;
-    [[NSUserDefaults standardUserDefaults] setInteger:sLinkPreviewCardColor forKey:UDKeyLinkPreviewCardColor];
-    sLinkPreviewModeRefreshPending = YES;
-    sPendingLinkPreviewModeRefreshArea = @"card-color";
-    sPendingLinkPreviewModeRefreshMode = sLinkPreviewCardColor;
-    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloLinkPreviewModeDidChangeNotification
-                                                        object:nil
-                                                      userInfo:@{
-                                                          @"area": @"card-color",
-                                                          @"cardColor": @(color),
-                                                      }];
-
-    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(9) inSection:SectionMedia];
-    if ([[self.tableView indexPathsForVisibleRows] containsObject:indexPath]) {
-        [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
-    }
-}
-
-- (void)presentLinkPreviewCardColorSheetFromSourceView:(UIView *)sourceView {
-    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Preview Card Color"
-                                                                   message:@"Choose a color."
-                                                            preferredStyle:UIAlertControllerStyleActionSheet];
-
-    NSArray<NSNumber *> *colors = @[
-        @(ApolloLinkPreviewCardColorNeutral),
-        @(ApolloLinkPreviewCardColorGray),
-        @(ApolloLinkPreviewCardColorRed),
-        @(ApolloLinkPreviewCardColorOrange),
-        @(ApolloLinkPreviewCardColorYellow),
-        @(ApolloLinkPreviewCardColorGreen),
-        @(ApolloLinkPreviewCardColorMint),
-        @(ApolloLinkPreviewCardColorTeal),
-        @(ApolloLinkPreviewCardColorCyan),
-        @(ApolloLinkPreviewCardColorBlue),
-        @(ApolloLinkPreviewCardColorIndigo),
-        @(ApolloLinkPreviewCardColorPurple),
-        @(ApolloLinkPreviewCardColorPink),
-        @(ApolloLinkPreviewCardColorBrown),
-        @(ApolloLinkPreviewCardColorCoral),
-        @(ApolloLinkPreviewCardColorLime),
-        @(ApolloLinkPreviewCardColorOlive),
-        @(ApolloLinkPreviewCardColorLavender),
-        @(ApolloLinkPreviewCardColorSlate),
-    ];
-
-    for (NSNumber *colorNumber in colors) {
-        NSInteger color = colorNumber.integerValue;
-        NSString *name = [self linkPreviewCardColorTextForColor:color];
-        NSString *title = (color == sLinkPreviewCardColor) ? [NSString stringWithFormat:@"%@ (Current)", name] : name;
-        UIAlertAction *colorAction = [UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
-            [self setLinkPreviewCardColor:color];
-        }];
-        @try {
-            [colorAction setValue:[self linkPreviewCardColorDotImageForColor:color] forKey:@"image"];
-        } @catch (__unused NSException *exception) {
-        }
-        [sheet addAction:colorAction];
-    }
-
-    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
-
-    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
-    if (popover && sourceView) {
-        popover.sourceView = sourceView;
-        popover.sourceRect = sourceView.bounds;
-    }
-
-    [self presentViewController:sheet animated:YES completion:nil];
-}
-
-- (void)presentLinkPreviewModeSheetFromSourceView:(UIView *)sourceView body:(BOOL)body {
-    NSInteger currentMode = body ? sLinkPreviewBodyMode : sLinkPreviewCommentsMode;
-    NSString *title = body ? @"Body Link Previews" : @"Comment Link Previews";
-    NSString *message = body ? @"Choose how rich link preview cards appear in feeds and post bodies." : @"Choose how rich link preview cards appear in comments.";
-    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:title
-                                                                   message:message
-                                                            preferredStyle:UIAlertControllerStyleActionSheet];
-
-    NSString *fullTitle = (currentMode == ApolloLinkPreviewModeFull) ? @"Full (Current)" : @"Full";
-    NSString *compactTitle = (currentMode == ApolloLinkPreviewModeCompact) ? @"Compact (Current)" : @"Compact";
-    NSString *offTitle = (currentMode == ApolloLinkPreviewModeOff) ? @"Off (Current)" : @"Off";
-
-    [sheet addAction:[UIAlertAction actionWithTitle:fullTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
-        [self setLinkPreviewMode:ApolloLinkPreviewModeFull body:body];
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:compactTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
-        [self setLinkPreviewMode:ApolloLinkPreviewModeCompact body:body];
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:offTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
-        [self setLinkPreviewMode:ApolloLinkPreviewModeOff body:body];
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
-
-    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
-    if (popover && sourceView) {
-        popover.sourceView = sourceView;
-        popover.sourceRect = sourceView.bounds;
-    }
-
-    [self presentViewController:sheet animated:YES completion:nil];
+    sPendingLinkPreviewModeRefreshArea = area.length > 0 ? area : @"card-color";
+    sPendingLinkPreviewModeRefreshMode = ApolloLinkPreviewModeFull;
 }
 
 #pragma mark - View Lifecycle
@@ -616,6 +470,9 @@ typedef NS_ENUM(NSInteger, Tag) {
         [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:kAPIKeyRowWebSessionLogin inSection:SectionAPIKeys]]
                               withRowAnimation:UITableViewRowAnimationNone];
     }
+    // Refresh the Rich Link Previews status subtitle after returning from its subview.
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:SectionLinkPreviews]
+                  withRowAnimation:UITableViewRowAnimationNone];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
@@ -665,7 +522,10 @@ typedef NS_ENUM(NSInteger, Tag) {
         // General base rows + the search-in-place toggle (effectiveRow 11), minus
         // the "Tap to Show Deleted Comments" row when Show Deleted Comments is off.
         case SectionGeneral: return sShowDeletedComments ? 12 : 11;
-        case SectionMedia: return 14 + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows);
+        case SectionLinkPreviews: return 1;
+        // Media base rows (the three "Rich Link Previews" rows moved out to their
+        // own SectionLinkPreviews), minus the two inline-dependent rows when off.
+        case SectionMedia: return 11 + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows);
         case SectionSubreddits: return 10 - (sSubredditListEnhancements ? 0 : 1) - (sCommunityHighlights ? 0 : 1);
         case SectionNotificationBackend: return 3; // URL + Registration Token + Test Connection
         case SectionAbout: return 5; // GitHub + Reddit + Thanks To + Export Logs + Version
@@ -678,6 +538,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionBackupRestore: return @"Data";
         case SectionAPIKeys: return @"API Keys";
         case SectionGeneral: return @"General";
+        case SectionLinkPreviews: return @"Rich Link Previews";
         case SectionMedia: return @"Media";
         case SectionSubreddits: return @"Subreddits";
         case SectionNotificationBackend: return @"Notification Backend";
@@ -692,6 +553,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionBackupRestore: cell = [self backupRestoreCellForRow:indexPath.row tableView:tableView]; break;
         case SectionAPIKeys: cell = [self apiKeyCellForRow:indexPath.row tableView:tableView]; break;
         case SectionGeneral: cell = [self generalCellForRow:indexPath.row tableView:tableView]; break;
+        case SectionLinkPreviews: cell = [self linkPreviewsCellForTableView:tableView]; break;
         case SectionMedia: cell = [self mediaCellForRow:indexPath.row tableView:tableView]; break;
         case SectionSubreddits: cell = [self subredditCellForRow:indexPath.row tableView:tableView]; break;
         case SectionNotificationBackend: cell = [self notificationBackendCellForRow:indexPath.row tableView:tableView]; break;
@@ -1193,58 +1055,22 @@ typedef NS_ENUM(NSInteger, Tag) {
             cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
             return cell;
         }
-        case 7: {
-            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_LinkPreviewBodyMode"];
-            if (!cell) {
-                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_LinkPreviewBodyMode"];
-                cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-            }
-            cell.textLabel.text = @"Rich Link Previews - Body";
-            cell.detailTextLabel.text = [self linkPreviewModeTextForMode:sLinkPreviewBodyMode];
-            cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
-            return cell;
-        }
-        case 8: {
-            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_LinkPreviewCommentsMode"];
-            if (!cell) {
-                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_LinkPreviewCommentsMode"];
-                cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-            }
-            cell.textLabel.text = @"Rich Link Previews - Comments";
-            cell.detailTextLabel.text = [self linkPreviewModeTextForMode:sLinkPreviewCommentsMode];
-            cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
-            return cell;
-        }
-        case 9: {
-            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_LinkPreviewCardColor"];
-            if (!cell) {
-                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_LinkPreviewCardColor"];
-                cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-            }
-            cell.textLabel.text = @"Rich Link Previews - Color";
-            cell.detailTextLabel.text = [self linkPreviewCardColorTextForColor:sLinkPreviewCardColor];
-            cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
-            return cell;
-        }
-        case 10:
+        case 7:
             return [self switchCellWithIdentifier:@"Cell_Media_TextPostThumbnails"
                                             label:@"Text Post Thumbnails"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyFeedTextPostThumbnails]
                                            action:@selector(textPostThumbnailsSwitchToggled:)];
-        case 11:
+        case 8:
             return [self switchCellWithIdentifier:@"Cell_Media_UserAvatars"
                                             label:@"Show User Profile Pictures"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars]
                                            action:@selector(userAvatarsSwitchToggled:)];
-        case 12:
+        case 9:
             return [self switchCellWithIdentifier:@"Cell_Media_ProfileTabAvatar"
                                             label:@"Profile Picture Tab Icon"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon]
                                            action:@selector(profileTabAvatarSwitchToggled:)];
-        case 13:
+        case 10:
             return [self switchCellWithIdentifier:@"Cell_Media_SocialLinks"
                                             label:@"Social Links in Profile"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeySocialLinksInProfile]
@@ -1625,6 +1451,11 @@ typedef NS_ENUM(NSInteger, Tag) {
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 
+    if (indexPath.section == SectionLinkPreviews) {
+        [self openLinkPreviewSettings];
+        return;
+    }
+
     if (indexPath.section == SectionBackupRestore) {
         UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
         if (indexPath.row == 0) {
@@ -1677,12 +1508,6 @@ typedef NS_ENUM(NSInteger, Tag) {
             [self presentInlineImageAlignmentSheetFromSourceView:cell];
         } else if (row == 6) {
             [self presentAutoplayInlineGIFModeSheetFromSourceView:cell];
-        } else if (row == 7) {
-            [self presentLinkPreviewModeSheetFromSourceView:cell body:YES];
-        } else if (row == 8) {
-            [self presentLinkPreviewModeSheetFromSourceView:cell body:NO];
-        } else if (row == 9) {
-            [self presentLinkPreviewCardColorSheetFromSourceView:cell];
         }
     } else if (indexPath.section == SectionNotificationBackend && indexPath.row == 2) {
         [self testNotificationBackendConnection];
@@ -1754,9 +1579,10 @@ typedef NS_ENUM(NSInteger, Tag) {
         if (row == kAPIKeyRowTroubleshooting || row == kAPIKeyRowSetupGuide ||
             row == kAPIKeyRowWebSessionLogin || row == kAPIKeyRowWidgetSetupCode) return YES;
     }
+    if (indexPath.section == SectionLinkPreviews) return YES;
     if (indexPath.section == SectionMedia) {
         NSInteger row = ApolloMediaLogicalRow(indexPath.row);
-        return (row == 0 || row == 1 || row == 2 || row == 5 || row == 6 || row == 7 || row == 8 || row == 9);
+        return (row == 0 || row == 1 || row == 2 || row == 5 || row == 6);
     }
     if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 || indexPath.row == 3)) return YES;
     if (indexPath.section == SectionNotificationBackend && indexPath.row == 2) return YES;
@@ -2673,6 +2499,17 @@ static void ApolloReplayValetKeychainItems(NSArray<NSDictionary *> *items) {
         sLinkPreviewCardColor = ApolloLinkPreviewCardColorNeutral;
         [defaults setInteger:sLinkPreviewCardColor forKey:UDKeyLinkPreviewCardColor];
     }
+    // Free-form hex card color. A backup made by a build with the color picker
+    // carries the hex key directly; an older backup only has the legacy preset
+    // enum, so migrate it once (matches the launch-time logic in Tweak.xm).
+    NSString *restoredCardColorHex = [defaults stringForKey:UDKeyLinkPreviewCardColorHex];
+    if (![defaults objectForKey:UDKeyLinkPreviewCardColorHex]) {
+        restoredCardColorHex = (sLinkPreviewCardColor != ApolloLinkPreviewCardColorNeutral)
+            ? ApolloHexStringFromColor(ApolloLinkPreviewPresetColor(sLinkPreviewCardColor))
+            : @"";
+        [defaults setObject:(restoredCardColorHex ?: @"") forKey:UDKeyLinkPreviewCardColorHex];
+    }
+    ApolloSetLinkPreviewCardColorHex(restoredCardColorHex);
     sEnableBulkTranslation = [defaults boolForKey:UDKeyEnableBulkTranslation];
     sAutoTranslateOnAppear = [defaults boolForKey:UDKeyAutoTranslateOnAppear];
 

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1355,7 +1355,20 @@ static void initializeRandomSources() {
         sLinkPreviewCardColor = ApolloLinkPreviewCardColorNeutral;
         [standardDefaults setInteger:sLinkPreviewCardColor forKey:UDKeyLinkPreviewCardColor];
     }
-    ApolloLog(@"[LinkPreviews] settings loaded bodyMode=%ld commentsMode=%ld cardColor=%ld", (long)sLinkPreviewBodyMode, (long)sLinkPreviewCommentsMode, (long)sLinkPreviewCardColor);
+    // Free-form hex card color supersedes the legacy preset enum. The hex key is
+    // intentionally NOT in registerDefaults so its absence reliably marks a
+    // first launch on a build with the color picker: migrate a non-Neutral
+    // preset selection into hex once, so the user's chosen hue carries over
+    // (now an accurate full-card fill rather than the old faint tint).
+    NSString *cardColorHex = [standardDefaults stringForKey:UDKeyLinkPreviewCardColorHex];
+    if (![standardDefaults objectForKey:UDKeyLinkPreviewCardColorHex]) {
+        cardColorHex = (sLinkPreviewCardColor != ApolloLinkPreviewCardColorNeutral)
+            ? ApolloHexStringFromColor(ApolloLinkPreviewPresetColor(sLinkPreviewCardColor))
+            : @"";
+        [standardDefaults setObject:(cardColorHex ?: @"") forKey:UDKeyLinkPreviewCardColorHex];
+    }
+    ApolloSetLinkPreviewCardColorHex(cardColorHex);
+    ApolloLog(@"[LinkPreviews] settings loaded bodyMode=%ld commentsMode=%ld cardColor=%ld cardColorHex=%@", (long)sLinkPreviewBodyMode, (long)sLinkPreviewCommentsMode, (long)sLinkPreviewCardColor, sLinkPreviewCardColorHex ?: @"(default)");
     sImageUploadProvider = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyImageUploadProvider];
     sShowUserAvatars = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars];
     sUseProfileAvatarTabIcon = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon];

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1355,17 +1355,15 @@ static void initializeRandomSources() {
         sLinkPreviewCardColor = ApolloLinkPreviewCardColorNeutral;
         [standardDefaults setInteger:sLinkPreviewCardColor forKey:UDKeyLinkPreviewCardColor];
     }
-    // Free-form hex card color supersedes the legacy preset enum. The hex key is
-    // intentionally NOT in registerDefaults so its absence reliably marks a
-    // first launch on a build with the color picker: migrate a non-Neutral
-    // preset selection into hex once, so the user's chosen hue carries over
-    // (now an accurate full-card fill rather than the old faint tint).
+    // Free-form hex card color. Default is "" — the neutral card — so a bright
+    // full-fill is fully opt-in via the picker. The legacy preset enum is
+    // deliberately NOT promoted into a color: those presets only ever rendered as
+    // a faint 8-14% tint, so turning them into a bold full-card fill on update
+    // would be jarring. Existing pickers re-choose a color if they want one.
     NSString *cardColorHex = [standardDefaults stringForKey:UDKeyLinkPreviewCardColorHex];
     if (![standardDefaults objectForKey:UDKeyLinkPreviewCardColorHex]) {
-        cardColorHex = (sLinkPreviewCardColor != ApolloLinkPreviewCardColorNeutral)
-            ? ApolloHexStringFromColor(ApolloLinkPreviewPresetColor(sLinkPreviewCardColor))
-            : @"";
-        [standardDefaults setObject:(cardColorHex ?: @"") forKey:UDKeyLinkPreviewCardColorHex];
+        cardColorHex = @"";
+        [standardDefaults setObject:@"" forKey:UDKeyLinkPreviewCardColorHex];
     }
     ApolloSetLinkPreviewCardColorHex(cardColorHex);
     ApolloLog(@"[LinkPreviews] settings loaded bodyMode=%ld commentsMode=%ld cardColor=%ld cardColorHex=%@", (long)sLinkPreviewBodyMode, (long)sLinkPreviewCommentsMode, (long)sLinkPreviewCardColor, sLinkPreviewCardColorHex ?: @"(default)");

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -120,5 +120,11 @@ static NSString *const UDKeyFeedTextPostThumbnails = @"FeedTextPostThumbnails";
 // Rich link preview cards: 0 = Off, 1 = Compact, 2 = Full.
 static NSString *const UDKeyLinkPreviewBodyMode = @"LinkPreviewBodyMode";
 static NSString *const UDKeyLinkPreviewCommentsMode = @"LinkPreviewCommentsMode";
+// Legacy preset color (ApolloLinkPreviewCardColor enum). Superseded by the
+// free-form hex below; still read once at launch to migrate an old selection.
 static NSString *const UDKeyLinkPreviewCardColor = @"LinkPreviewCardColor";
+// Free-form preview card color as a 6-digit "RRGGBB" hex string. Empty string
+// means "Default" (no custom fill — the standard neutral card). A non-empty
+// hex paints the whole card that exact color, with auto-contrasted text.
+static NSString *const UDKeyLinkPreviewCardColorHex = @"LinkPreviewCardColorHex";
 static NSString *const ApolloLinkPreviewModeDidChangeNotification = @"ApolloLinkPreviewModeDidChangeNotification";


### PR DESCRIPTION
## What

Reworks the Rich Link Previews settings and card color:

- **Its own section + sub-screen.** The three `Rich Link Previews - Body / Comments / Color` rows move out of *Media* into a dedicated **Rich Link Previews** section. Its single row opens a sub-screen with **Body**, **Comments** and **Color** together — less clutter in Media, one place for everything.
- **Full color picker.** The Color control is now Apple's native `UIColorPickerViewController` (grid / spectrum / sliders / eyedropper / hex), plus a row of quick swatches and a **Use Default (No Color)** reset — instead of a fixed list of presets.
- **Accurate card color.** The card is now painted the **exact** color you pick (full fill), with the title/description text automatically set to black or white for contrast. Previously the color was blended into the system background at only 8–14% opacity, so even vivid choices looked muddy (Pink rendered as a dark maroon).
- **Live preview.** The sub-screen has a **Card Preview** area showing sample *full* and *compact* cards that recolor live as you pick (swatch, picker drag, or Default reset), so you can see the exact color and the auto-contrast text before applying it.

## Screenshots

The sub-screen, with the live **Card Preview** at the top — it recolors as you pick (here: the starting color → after choosing a new one):

| Live preview — before | Live preview — after |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/f0b3584c-fc50-4d9e-afd5-531a4eeb6211" width="280"> | <img src="https://github.com/user-attachments/assets/bb42f0e2-4ea3-446f-a0db-f6ecdbae21f5" width="280"> |

The full color picker, and the card rendered with the exact color (text auto-contrasted to stay readable):

| Color picker | Light fill → dark text | Dark fill → white text |
| --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/4273af3d-21d8-4f6e-8c85-2a187897fa88" width="250"> | <img src="https://github.com/user-attachments/assets/4c7d7137-a2c7-48c4-ab83-e2aaac8f8b58" width="250"> | <img src="https://github.com/user-attachments/assets/d2347f40-5e3a-4665-9c69-d16ce9d22b27" width="250"> |

## Notes

- The color is stored as a free-form hex (`LinkPreviewCardColorHex`); the default is the **neutral card**, so a colored card is fully opt-in. The old preset colors are intentionally *not* auto-promoted to a full-card fill on update — they only ever rendered as a faint 8–14% tint, so a sudden bold fill would look jarring. (A backup that already carries a chosen color still restores it.)
- The renderer runs on Texture's background layout threads, so it reads a render-safe packed-`uint32` snapshot rather than the main-thread `NSString`, avoiding a data race on the strong pointer.

## Testing

- Verified in the iOS 26 Simulator: the new section + sub-screen, the color picker, quick swatches, Default reset, and card rendering in both compact and full layouts — confirming the exact fill color and auto-contrast for light (yellow) and dark (blue) picks.
- Builds clean for the shipping device target (`iphone:clang:26.0:14.0`).
- Not yet tested on a physical device.



