### PR TITLE
Pixel Pals: don't open the menu over media/web/modals (fixes #305)

### DIFF
--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1104,6 +1104,51 @@ static NSURLRequest *ApolloLocalFastFailRequest(NSString *path) {
 // On devices with different safe area insets, compute the correct DI Y position.
 // The gap between DI bottom and safe area scales proportionally with safeTop.
 // Y is floored to the nearest half-pixel to match the baseline's sub-pixel alignment.
+//
+// --- Pixel Pals freeze guard (issue #305) ---
+// Tapping the Dynamic Island Pixel Pals area (pixelPalTappedWithTapGestureRecognizer:)
+// or a pal barking for attention (dogBarkedWithNotification:) both present the
+// PixelPalOverlayViewController on the *topmost* currently-presented view
+// controller — Apollo's presenter (sub_1002cd660) walks rootViewController's
+// presentedViewController chain to the end and presents there. When a fullscreen
+// media viewer or the in-app web browser is open — especially mid-interactive
+// swipe-dismiss — that races the in-flight transition: the overlay is presented
+// onto a controller that is being torn down, leaving an orphaned fullscreen
+// transition view that swallows every touch. The app looks frozen (the video's
+// audio keeps playing underneath) and has to be force-quit.
+//
+// Fix: refuse to open the Pixel Pals menu whenever any non-Pixel-Pals modal is
+// presented, or any present/dismiss transition is in flight, anywhere in the
+// window's view-controller chain. This matches the reporters' own diagnosis
+// ("preventing the pixel pal menu from opening with any media or website open
+// should fix everything") and is a strict superset of Apollo's intended
+// behaviour (the menu is already meant to be unreachable while media is open).
+static BOOL ApolloPixelPalsBlockedByModal(UIWindow *window) {
+    Class overlayCls = objc_getClass("_TtC6Apollo29PixelPalOverlayViewController");
+    UIViewController *vc = window.rootViewController;
+    while (vc) {
+        UIViewController *presented = vc.presentedViewController;
+        if (!presented) break;  // nothing modally presented here — safe to open
+        // A modal present/dismiss is animating at this level — the mid-swipe media
+        // dismiss in the repro. We only consult the coordinator once we know a modal
+        // is actually presented: on iOS 26 the transitionCoordinator getter recurses
+        // into child view controllers, so the root tab controller reports a live
+        // coordinator during ordinary feed push/pop too, and checking it
+        // unconditionally would wrongly swallow taps during normal navigation.
+        if (vc.transitionCoordinator) return YES;
+        // The overlay already being up is harmless — Apollo no-ops a re-tap; descend
+        // past it and keep checking the rest of the chain.
+        if (overlayCls && [presented isKindOfClass:overlayCls]) {
+            vc = presented;
+            continue;
+        }
+        // Some other modal (media viewer, in-app web browser, share/settings sheet)
+        // is on top — presenting the menu over it is exactly what wedges UIKit.
+        return YES;
+    }
+    return NO;
+}
+
 %hook _TtC6Apollo15ThemeableWindow
 
 - (void)layoutSubviews {
@@ -1180,6 +1225,25 @@ static NSURLRequest *ApolloLocalFastFailRequest(NSString *path) {
     ApolloLog(@"[PixelPals] Tap overlay y: %.1f → %.3f", f.origin.y, f.origin.y + shift);
     f.origin.y += shift;
     view.frame = f;
+}
+
+// Suppress the Pixel Pals menu while media / a website / any modal is open or
+// mid-transition — opening it then races UIKit and freezes the app (issue #305).
+- (void)pixelPalTappedWithTapGestureRecognizer:(id)recognizer {
+    if (ApolloPixelPalsBlockedByModal((UIWindow *)self)) {
+        ApolloLog(@"[PixelPals] Tap ignored — a modal is open/transitioning (issue #305 freeze guard)");
+        return;
+    }
+    %orig;
+}
+
+// Same guard for the auto-open path when a pal barks for attention.
+- (void)dogBarkedWithNotification:(id)notification {
+    if (ApolloPixelPalsBlockedByModal((UIWindow *)self)) {
+        ApolloLog(@"[PixelPals] Bark menu suppressed — a modal is open/transitioning (issue #305 freeze guard)");
+        return;
+    }
+    %orig;
 }
 
 %end


### PR DESCRIPTION
Closes #305.

## The bug

Opening the Pixel Pals menu while media (or the in-app web browser) is open freezes the app. Repro from the issue:

1. Open any media fullscreen
2. Slowly swipe partway to dismiss it until the status bar reappears (finger still down)
3. Tap the Dynamic Island Pixel Pals area
4. Let go of the image
5. Close the Pixel Pals menu → **app is frozen, ignores all input** (and on macOS the video's audio keeps playing underneath)

## Root cause (RE)

Both ways of opening the menu — `pixelPalTappedWithTapGestureRecognizer:` (the tap) and `dogBarkedWithNotification:` (a pal barking for attention) — funnel into Apollo's presenter, which **walks `rootViewController`'s `presentedViewController` chain to the topmost presented controller and presents the `PixelPalOverlayViewController` there.**

When a fullscreen media viewer (`MediaPageViewController`) or the web browser is up — *especially* mid-interactive swipe-dismiss — the overlay gets presented onto a controller that is being torn down. The two transitions race and leave an orphaned fullscreen transition view that swallows every touch, so the app looks frozen while the media keeps running underneath. Normally the menu is unreachable over fullscreen media (the status bar is hidden); the slow partial swipe re-reveals the tappable area without actually dismissing the media, which is what circumvents the normal block.

## The fix

Guard both open paths on `_TtC6Apollo15ThemeableWindow`: refuse to open the menu while any non-Pixel-Pals modal is presented, or a present/dismiss transition is in flight, in the window's view-controller chain. This matches the reporters' own diagnosis ("preventing the pixel pal menu from opening with any media or website open should fix everything").

One subtlety handled: on iOS 26 the `transitionCoordinator` getter recurses into child view controllers, so the root tab controller reports a live coordinator during *ordinary* feed push/pop too. The transition check is therefore scoped to chain levels that actually have a presented modal, so normal feed navigation never wrongly swallows a pal tap.

## Verification (iOS 26 simulator)

The simulator can't instantiate Apollo's Pixel Pal UI (its device mapper reads `uname().machine`, which is `arm64` in the sim), so the guard's decision function was exercised directly against real Apollo states:

| State | Guard |
|---|---|
| Plain feed | open ✅ |
| Feed push/pop navigation | open ✅ (no false block) |
| Fullscreen media viewer (`MediaPageViewController`) | **blocked** ✅ |
| Action sheet / any modal | **blocked** ✅ |
| Modal dismissed | open again ✅ |

It was also put through a multi-lens adversarial review (UIKit-correctness, completeness, regression, ObjC/Logos correctness).

## Notes

- **Not yet device-tested** — opening for review; the end-to-end pal-tap-over-media can only be exercised on a Dynamic Island device.
- Known minor residual: a third, internal caller of the presenter exists — the first-run onboarding announcement ("Just tap the Pixel Pal up top…"), a Swift closure that doesn't route through either hooked method, so it isn't guarded. It's first-run only and won't coincide with a mid-swipe media dismiss, so the reported repro is fully closed; left out to keep this a minimal freeze fix.
