### PR TITLE
Expanded Filters & Blocks: per-subreddit keyword/flair filters + subreddit-name filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,10 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/TranslationSettingsViewController.m \
     $(SRC_DIR)/SavedCategoriesViewController.m \
     $(SRC_DIR)/TagFiltersViewController.m \
+    $(SRC_DIR)/ApolloPostFilterStore.m \
+    $(SRC_DIR)/ApolloPostFilters.xm \
+    $(SRC_DIR)/ApolloFiltersBlocksInject.xm \
+    $(SRC_DIR)/ApolloSubredditFilterDetailViewController.m \
     $(SRC_DIR)/PictureInPictureViewController.m \
     $(SRC_DIR)/Defaults.m \
     $(SRC_DIR)/UIWindow+Apollo.m \

--- a/src/ApolloFiltersBlocksInject.xm
+++ b/src/ApolloFiltersBlocksInject.xm
@@ -199,10 +199,9 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (section < native) {
-        // Hide the native Blocked Users footer while collapsed (the lone summary row reads cleaner without it).
-        if (native > 0 && section == native - 1 && ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) {
-            return [[UIView alloc] init];
-        }
+        // Always the native footer — collapsed AND expanded — so it never appears/
+        // disappears during the toggle (which made its text flash to the left edge for
+        // a frame as it re-laid-out). It just slides down as the rows expand.
         return %orig;
     }
     NSString *text = (section == native)
@@ -428,11 +427,32 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 
 %new
 - (void)apollo_pfSetBlockedExpanded:(BOOL)expanded table:(UITableView *)tableView {
+    BOOL was = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
     objc_setAssociatedObject(self, kApolloPFBlockedExpandedKey, @(expanded), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     if (![tableView isKindOfClass:[UITableView class]]) return;
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (native <= 0) return;
-    [tableView reloadSections:[NSIndexSet indexSetWithIndex:native - 1] withRowAnimation:UITableViewRowAnimationAutomatic];
+    NSInteger section = native - 1;
+    NSInteger nativeCount = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
+    // Animate only Apollo's rows (indices 1..nativeCount) in/out — NOT a full
+    // reloadSections — so the section's header/footer aren't re-laid-out (that re-layout
+    // was flashing the footer text to the left edge for a frame). Row 0 (our toggle)
+    // stays put; we just reload it to flip its chevron.
+    if (was == expanded || nativeCount <= 0) {
+        [tableView reloadSections:[NSIndexSet indexSetWithIndex:section] withRowAnimation:UITableViewRowAnimationAutomatic];
+        return;
+    }
+    NSMutableArray<NSIndexPath *> *rows = [NSMutableArray arrayWithCapacity:nativeCount];
+    for (NSInteger i = 1; i <= nativeCount; i++) [rows addObject:[NSIndexPath indexPathForRow:i inSection:section]];
+    @try {
+        [tableView beginUpdates];
+        if (expanded) [tableView insertRowsAtIndexPaths:rows withRowAnimation:UITableViewRowAnimationFade];
+        else          [tableView deleteRowsAtIndexPaths:rows withRowAnimation:UITableViewRowAnimationFade];
+        [tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:0 inSection:section]] withRowAnimation:UITableViewRowAnimationNone];
+        [tableView endUpdates];
+    } @catch (__unused id e) {
+        [tableView reloadSections:[NSIndexSet indexSetWithIndex:section] withRowAnimation:UITableViewRowAnimationAutomatic];
+    }
 }
 
 // When the user taps the nav-bar Edit button while Blocked Users is collapsed, the lone

--- a/src/ApolloFiltersBlocksInject.xm
+++ b/src/ApolloFiltersBlocksInject.xm
@@ -32,9 +32,8 @@
 - (void)apollo_pfOpenDetailForSubreddit:(NSString *)sub fromTable:(UITableView *)tableView;
 - (void)apollo_pfPromptAddSubredditFromTable:(UITableView *)tableView;
 - (void)apollo_pfPromptAddNameFromTable:(UITableView *)tableView;
-- (UITableViewCell *)apollo_pfBlockedCollapsedCellForTable:(UITableView *)tableView;
-- (UIView *)apollo_pfBlockedToggleHeaderForTable:(UITableView *)tableView;
-- (void)apollo_pfToggleBlocked:(UITapGestureRecognizer *)gesture;
+- (UITableViewCell *)apollo_pfBlockedToggleCellForTable:(UITableView *)tableView showingExpanded:(BOOL)showingExpanded;
+- (void)apollo_pfRefreshBlockedToggleCount:(UITableView *)tableView;
 - (void)apollo_pfSetBlockedExpanded:(BOOL)expanded table:(UITableView *)tableView;
 @end
 
@@ -50,7 +49,20 @@ static const NSInteger kApolloPFExtraSections = 2;
 // we only add a trailing row).
 static const void *kApolloPFBlockedExpandedKey   = &kApolloPFBlockedExpandedKey;   // NSNumber BOOL on the VC
 static const void *kApolloPFBlockedNativeCountKey = &kApolloPFBlockedNativeCountKey; // NSNumber on the VC (rows incl. Add)
-static const void *kApolloPFBlockedHeaderTableKey = &kApolloPFBlockedHeaderTableKey; // UITableView on the header view
+static const void *kApolloPFBlockedTableKey       = &kApolloPFBlockedTableKey;       // UITableView (ASSIGN) on the VC
+
+// Our "Blocked Users (N)" toggle is row 0 of the blocked section and Apollo's own
+// rows follow at display index 1..nativeCount (so it all reads as ONE rounded group).
+//
+// Apollo detects its "Add User" row as `row == [tableView numberOfRowsInSection:] - 1`
+// — using the TABLE's displayed (inflated, +1) count — and otherwise indexes its
+// blockedUsers array by `row`. So we map each DISPLAY row to the index we feed Apollo:
+// the Add row (display == nativeCount, the last) keeps its index so it stays "last"
+// and Apollo's Add detection fires; every user row shifts back by 1 to line up with
+// blockedUsers[]. nativeCount is Apollo's own row count (users + Add), cached below.
+static inline NSInteger ApolloPFBlockedApolloRow(NSInteger displayRow, NSInteger nativeCount) {
+    return (displayRow >= nativeCount) ? displayRow : (displayRow - 1);
+}
 
 #pragma mark - Section header / footer views (self-sizing)
 
@@ -109,17 +121,12 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (section < native) {
-        // Blocked Users = last native section: collapse to a single summary row
-        // unless expanded (then show Apollo's own rows, unchanged).
         if (native > 0 && section == native - 1) {
-            NSInteger n = %orig; // native row count (blocked users + "Add User")
+            NSInteger n = %orig; // Apollo's own count (blocked users + "Add User")
             objc_setAssociatedObject(self, kApolloPFBlockedNativeCountKey, @(n), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            // Collapsed: a single summary row (our toggle). Expanded: EXACTLY Apollo's
-            // own rows, unchanged — the toggle becomes a section HEADER instead of a
-            // row. Apollo identifies its "Add User" row as `row == numberOfRows - 1`,
-            // so we must NEVER inflate this count or that detection (and Add User)
-            // breaks.
-            return [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue] ? n : 1;
+            objc_setAssociatedObject(self, kApolloPFBlockedTableKey, tableView, OBJC_ASSOCIATION_ASSIGN);
+            // Collapsed: just our toggle (1). Expanded: toggle + Apollo's n rows.
+            return [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue] ? (n + 1) : 1;
         }
         return %orig;
     }
@@ -130,11 +137,13 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (indexPath.section < native) {
-        if (native > 0 && indexPath.section == native - 1 &&
-            ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) {
-            // Collapsed: a single "Blocked Users (N) ›" summary row (tap to expand).
-            // Expanded: fall through to %orig — Apollo's own rows, untouched.
-            return [self apollo_pfBlockedCollapsedCellForTable:tableView];
+        if (native > 0 && indexPath.section == native - 1) {
+            BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
+            // Row 0 is always our "Blocked Users (N)" toggle cell (collapsed: only row).
+            if (indexPath.row == 0) return [self apollo_pfBlockedToggleCellForTable:tableView showingExpanded:expanded];
+            // Apollo's cellForRow indexes its model by row (Add = last DATA index), so
+            // every native row just shifts back by 1 past our toggle.
+            return %orig(tableView, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
         }
         return %orig;
     }
@@ -177,11 +186,9 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (section < native) {
         if (native > 0 && section == native - 1) {
-            // Collapsed: no header (the summary row stands alone). Expanded: a tappable
-            // "Blocked Users (N) ⌄" header sits at the TOP and the rows expand below it;
-            // tap it to collapse again.
-            if (![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) return [[UIView alloc] init];
-            return [self apollo_pfBlockedToggleHeaderForTable:tableView];
+            // No header — our "Blocked Users (N)" toggle is row 0 of the section, so the
+            // toggle + its users read as one continuous rounded group.
+            return [[UIView alloc] init];
         }
         return %orig;
     }
@@ -207,14 +214,21 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (indexPath.section < native) {
-        // Tapping the collapsed Blocked Users summary row expands the section.
-        if (native > 0 && indexPath.section == native - 1 &&
-            ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) {
-            [tableView deselectRowAtIndexPath:indexPath animated:YES];
-            [self apollo_pfSetBlockedExpanded:YES table:tableView];
+        if (native > 0 && indexPath.section == native - 1) {
+            // Row 0 = our toggle: flip expanded/collapsed.
+            if (indexPath.row == 0) {
+                [tableView deselectRowAtIndexPath:indexPath animated:YES];
+                BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
+                [self apollo_pfSetBlockedExpanded:!expanded table:tableView];
+                return;
+            }
+            // Apollo's own row (incl. Add User) — mapped so Apollo handles it correctly.
+            NSInteger nativeCount = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
+            NSInteger apolloRow = ApolloPFBlockedApolloRow(indexPath.row, nativeCount);
+            %orig(tableView, [NSIndexPath indexPathForRow:apolloRow inSection:indexPath.section]);
             return;
         }
-        %orig; return; // native row (incl. Add User) — Apollo handles it
+        %orig; return;
     }
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 
@@ -237,10 +251,12 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (indexPath.section < native) {
-        // Collapsed Blocked Users summary row isn't swipe-deletable (expand to manage);
-        // expanded native rows route to %orig.
-        if (native > 0 && indexPath.section == native - 1 &&
-            ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) return NO;
+        if (native > 0 && indexPath.section == native - 1) {
+            if (indexPath.row == 0) return NO; // our toggle row
+            NSInteger nativeCount = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
+            if (indexPath.row >= nativeCount) return NO; // Apollo's "Add User" row (last)
+            return %orig(tableView, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
+        }
         return %orig;
     }
     NSArray<NSString *> *items = (indexPath.section == native) ? [ApolloPostFilterStore allSubreddits]
@@ -251,9 +267,12 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (BOOL)tableView:(UITableView *)tableView canMoveRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (indexPath.section < native) {
-        // Collapsed summary row can't be reordered; expanded native rows route to %orig.
-        if (native > 0 && indexPath.section == native - 1 &&
-            ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) return NO;
+        if (native > 0 && indexPath.section == native - 1) {
+            if (indexPath.row == 0) return NO; // our toggle row
+            NSInteger nativeCount = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
+            if (indexPath.row >= nativeCount) return NO; // Apollo's "Add User" row (last)
+            return %orig(tableView, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
+        }
         return %orig;
     }
     return NO;
@@ -261,7 +280,19 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 
 - (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
-    if (indexPath.section < native) { %orig; return; }
+    if (indexPath.section < native) {
+        if (native > 0 && indexPath.section == native - 1 && indexPath.row >= 1) {
+            // Only a user row reaches here (the Add row is non-editable); it maps to
+            // Apollo's blockedUsers[] index = display row - 1.
+            %orig(tableView, editingStyle, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
+            // Refresh our toggle row's "(N)" count after Apollo settles the delete.
+            __weak UITableView *wt = tableView;
+            __weak typeof(self) ws = self;
+            dispatch_async(dispatch_get_main_queue(), ^{ [ws apollo_pfRefreshBlockedToggleCount:wt]; });
+            return;
+        }
+        %orig; return;
+    }
     if (editingStyle != UITableViewCellEditingStyleDelete) return;
     BOOL isSubSection = (indexPath.section == native);
     NSArray<NSString *> *items = isSubSection ? [ApolloPostFilterStore allSubreddits]
@@ -275,7 +306,12 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 
 - (NSString *)tableView:(UITableView *)tableView titleForDeleteConfirmationButtonForRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
-    if (indexPath.section < native) return %orig;
+    if (indexPath.section < native) {
+        if (native > 0 && indexPath.section == native - 1 && indexPath.row >= 1) {
+            return %orig(tableView, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
+        }
+        return %orig;
+    }
     return @"Delete";
 }
 
@@ -339,11 +375,13 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 
 #pragma mark - Collapsible Blocked Users toggle
 
-// Collapsed summary row: a single themed "Blocked Users (N) ›" disclosure row. It is
-// OUR OWN cell (dedicated reuse id) so its accessory never leaks onto Apollo's
-// recycled cells. Samples a native cell's background to match Apollo's theme.
+// Row 0 of the Blocked Users section: our themed "Blocked Users (N)" toggle cell, so
+// the toggle and the users below it read as ONE continuous rounded group. It is OUR
+// OWN cell (dedicated reuse id) so its chevron never leaks onto Apollo's recycled
+// cells. Collapsed shows a disclosure chevron (tap to expand); expanded shows a down
+// chevron (tap to collapse). The count is read LIVE from Apollo's native row count.
 %new
-- (UITableViewCell *)apollo_pfBlockedCollapsedCellForTable:(UITableView *)tableView {
+- (UITableViewCell *)apollo_pfBlockedToggleCellForTable:(UITableView *)tableView showingExpanded:(BOOL)showingExpanded {
     NSInteger nativeRows = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
     NSInteger count = MAX((NSInteger)0, nativeRows - 1); // exclude the "Add User" row
 
@@ -360,57 +398,32 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
     cell.textLabel.text = [NSString stringWithFormat:@"Blocked Users (%ld)", (long)count];
     cell.textLabel.textColor = [UIColor labelColor];
     cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-    cell.accessoryView = nil;
-    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    // Set BOTH accessory slots explicitly so a recycled instance never carries the
+    // other state's accessory.
+    if (showingExpanded) {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        UIImageView *chevron = [[UIImageView alloc] initWithImage:[[UIImage systemImageNamed:@"chevron.down"] imageWithConfiguration:[UIImageSymbolConfiguration configurationWithPointSize:13.0 weight:UIImageSymbolWeightSemibold]]];
+        chevron.tintColor = [UIColor secondaryLabelColor];
+        [chevron sizeToFit];
+        cell.accessoryView = chevron;
+    } else {
+        cell.accessoryView = nil;
+        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    }
     return cell;
 }
 
-// Expanded header: a tappable "Blocked Users (N) ⌄" title that sits at the TOP of the
-// section, with Apollo's own rows expanding directly below it. Deliberately a PLAIN
-// header (label + chevron on the table background) — NOT a floating rounded bar —
-// so it reads as the section's title, not a second box. Tapping it collapses.
+// Re-render just the toggle row so its "(N)" count tracks Apollo's blocked list after
+// an unblock (Apollo's delete is async; this catches the count up without disturbing
+// the rest of the section).
 %new
-- (UIView *)apollo_pfBlockedToggleHeaderForTable:(UITableView *)tableView {
-    NSInteger nativeRows = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
-    NSInteger count = MAX((NSInteger)0, nativeRows - 1); // exclude the "Add User" row
-
-    UIView *container = [[UIView alloc] init];
-    container.userInteractionEnabled = YES;
-
-    UILabel *label = [[UILabel alloc] init];
-    label.translatesAutoresizingMaskIntoConstraints = NO;
-    label.text = [NSString stringWithFormat:@"Blocked Users (%ld)", (long)count];
-    label.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
-    label.textColor = [UIColor labelColor];
-    [container addSubview:label];
-
-    UIImageView *chevron = [[UIImageView alloc] initWithImage:[[UIImage systemImageNamed:@"chevron.down"] imageWithConfiguration:[UIImageSymbolConfiguration configurationWithPointSize:14.0 weight:UIImageSymbolWeightSemibold]]];
-    chevron.translatesAutoresizingMaskIntoConstraints = NO;
-    chevron.tintColor = [UIColor secondaryLabelColor];
-    chevron.contentMode = UIViewContentModeScaleAspectFit;
-    [container addSubview:chevron];
-
-    [NSLayoutConstraint activateConstraints:@[
-        [label.leadingAnchor constraintEqualToAnchor:container.leadingAnchor constant:20.0],
-        [label.topAnchor constraintEqualToAnchor:container.topAnchor constant:16.0],
-        [label.bottomAnchor constraintEqualToAnchor:container.bottomAnchor constant:-8.0],
-        [chevron.centerYAnchor constraintEqualToAnchor:label.centerYAnchor],
-        [chevron.trailingAnchor constraintEqualToAnchor:container.trailingAnchor constant:-20.0],
-        [chevron.leadingAnchor constraintGreaterThanOrEqualToAnchor:label.trailingAnchor constant:8.0],
-    ]];
-
-    // Weakly remember the table so the tap handler can reload just this section.
-    objc_setAssociatedObject(container, kApolloPFBlockedHeaderTableKey, tableView, OBJC_ASSOCIATION_ASSIGN);
-    [container addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(apollo_pfToggleBlocked:)]];
-    return container;
-}
-
-// Tapping the expanded "Blocked Users (N) ⌄" header collapses the section again.
-%new
-- (void)apollo_pfToggleBlocked:(UITapGestureRecognizer *)gesture {
-    UITableView *tableView = objc_getAssociatedObject(gesture.view, kApolloPFBlockedHeaderTableKey);
-    BOOL expanded = ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
-    [self apollo_pfSetBlockedExpanded:expanded table:tableView];
+- (void)apollo_pfRefreshBlockedToggleCount:(UITableView *)tableView {
+    if (![tableView isKindOfClass:[UITableView class]]) return;
+    if (![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) return;
+    NSInteger native = [self apollo_pfNativeSectionCount:tableView];
+    if (native <= 0) return;
+    NSIndexPath *toggle = [NSIndexPath indexPathForRow:0 inSection:native - 1];
+    @try { [tableView reloadRowsAtIndexPaths:@[toggle] withRowAnimation:UITableViewRowAnimationNone]; } @catch (__unused id e) {}
 }
 
 %new
@@ -420,6 +433,18 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (native <= 0) return;
     [tableView reloadSections:[NSIndexSet indexSetWithIndex:native - 1] withRowAnimation:UITableViewRowAnimationAutomatic];
+}
+
+// When the user taps the nav-bar Edit button while Blocked Users is collapsed, the lone
+// toggle row isn't editable and (selection-during-edit being off) can't be tapped to
+// expand — a dead end. Auto-expand on entering edit mode so the blocked rows are
+// present and deletable. (Review finding.)
+- (void)setEditing:(BOOL)editing animated:(BOOL)animated {
+    %orig;
+    if (editing && ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) {
+        UITableView *t = objc_getAssociatedObject(self, kApolloPFBlockedTableKey);
+        if ([t isKindOfClass:[UITableView class]]) [self apollo_pfSetBlockedExpanded:YES table:t];
+    }
 }
 
 %end

--- a/src/ApolloFiltersBlocksInject.xm
+++ b/src/ApolloFiltersBlocksInject.xm
@@ -38,6 +38,11 @@
 // Number of Reborn sections appended after the native ones.
 static const NSInteger kApolloPFExtraSections = 2;
 
+// Reuse identifier for the Blocked Users toggle row. It has its OWN identifier so
+// it never enters Apollo's cell-reuse pool — otherwise its chevron / accessoryType
+// would leak onto recycled username / "Add User" cells.
+static NSString *const kApolloPFBlockedToggleReuse = @"ApolloPFBlockedUsersToggle";
+
 // Collapsible native Blocked Users section (the last native section): collapsed by
 // default to a single tappable header so a long block list doesn't bloat the page.
 // Expanding restores Apollo's own rows (Add User + swipe-delete) unchanged — we only
@@ -126,19 +131,25 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
                 BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
                 NSInteger n = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
                 NSInteger count = MAX((NSInteger)0, n - 1); // exclude the "Add User" row
-                NSInteger nativeRows0 = [self tableView:tableView numberOfRowsInSection:0];
-                UITableViewCell *cell = %orig(tableView, [NSIndexPath indexPathForRow:MAX((NSInteger)0, nativeRows0 - 1) inSection:0]);
-                cell.imageView.image = nil;
-                cell.textLabel.textColor = [UIColor labelColor];
+                // Our OWN cell (separate reuse pool) so nothing leaks onto Apollo's rows.
+                UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kApolloPFBlockedToggleReuse];
+                if (!cell) cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:kApolloPFBlockedToggleReuse];
+                // Match Apollo's themed cell background by sampling a native cell.
+                @try {
+                    UITableViewCell *probe = %orig(tableView, [NSIndexPath indexPathForRow:0 inSection:0]);
+                    UIColor *bg = probe.backgroundColor ?: probe.contentView.backgroundColor;
+                    if (bg && CGColorGetAlpha(bg.CGColor) > 0.01) cell.backgroundColor = bg;
+                } @catch (__unused id e) {}
                 cell.textLabel.text = [NSString stringWithFormat:@"Blocked Users (%ld)", (long)count];
+                cell.textLabel.textColor = [UIColor labelColor];
                 cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-                cell.accessoryType = UITableViewCellAccessoryNone;
                 UIImageView *chevron = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:(expanded ? @"chevron.down" : @"chevron.right")]];
                 chevron.tintColor = [UIColor tertiaryLabelColor];
                 [chevron sizeToFit];
                 cell.accessoryView = chevron;
                 return cell;
             }
+            // Apollo's own rows — returned untouched (their native disclosures etc. intact).
             return %orig(tableView, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
         }
         return %orig;

--- a/src/ApolloFiltersBlocksInject.xm
+++ b/src/ApolloFiltersBlocksInject.xm
@@ -32,10 +32,21 @@
 - (void)apollo_pfOpenDetailForSubreddit:(NSString *)sub fromTable:(UITableView *)tableView;
 - (void)apollo_pfPromptAddSubredditFromTable:(UITableView *)tableView;
 - (void)apollo_pfPromptAddNameFromTable:(UITableView *)tableView;
+- (UIView *)apollo_pfBlockedToggleHeaderForTable:(UITableView *)tableView;
+- (void)apollo_pfToggleBlocked:(UITapGestureRecognizer *)gesture;
+- (void)apollo_pfSetBlockedExpanded:(BOOL)expanded table:(UITableView *)tableView;
 @end
 
 // Number of Reborn sections appended after the native ones.
 static const NSInteger kApolloPFExtraSections = 2;
+
+// Collapsible native Blocked Users section (the last native section): collapsed by
+// default to a single tappable header so a long block list doesn't bloat the page.
+// Expanding restores Apollo's own rows (Add User + swipe-delete) unchanged — we only
+// vary the row COUNT (0 vs %orig), never re-map indices, so native editing is intact.
+static const void *kApolloPFBlockedExpandedKey   = &kApolloPFBlockedExpandedKey;   // NSNumber BOOL on the VC
+static const void *kApolloPFBlockedNativeCountKey = &kApolloPFBlockedNativeCountKey; // NSNumber on the VC (rows incl. Add)
+static const void *kApolloPFBlockedHeaderTableKey = &kApolloPFBlockedHeaderTableKey; // UITableView on the header view
 
 #pragma mark - Section header / footer views (self-sizing)
 
@@ -93,14 +104,40 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
-    if (section < native) return %orig;
+    if (section < native) {
+        // Blocked Users = last native section: collapse to a single summary row
+        // unless expanded (then show Apollo's own rows, unchanged).
+        if (native > 0 && section == native - 1) {
+            NSInteger n = %orig; // native row count (blocked users + "Add User")
+            objc_setAssociatedObject(self, kApolloPFBlockedNativeCountKey, @(n), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            return [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue] ? n : 1;
+        }
+        return %orig;
+    }
     if (section == native) return (NSInteger)[ApolloPostFilterStore allSubreddits].count + 1; // + Add
     return (NSInteger)[ApolloPostFilterStore nameSubstrings].count + 1;                        // + Add
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
-    if (indexPath.section < native) return %orig;
+    if (indexPath.section < native) {
+        // Collapsed Blocked Users: a single themed "Blocked Users (N)" disclosure row.
+        if (native > 0 && indexPath.section == native - 1 &&
+            ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) {
+            NSInteger n = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
+            NSInteger count = MAX((NSInteger)0, n - 1); // exclude the "Add User" row
+            NSInteger nativeRows0 = [self tableView:tableView numberOfRowsInSection:0];
+            UITableViewCell *cell = %orig(tableView, [NSIndexPath indexPathForRow:MAX((NSInteger)0, nativeRows0 - 1) inSection:0]);
+            cell.imageView.image = nil;
+            cell.accessoryView = nil;
+            cell.textLabel.textColor = [UIColor labelColor];
+            cell.textLabel.text = [NSString stringWithFormat:@"Blocked Users (%ld)", (long)count];
+            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+            cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+            return cell;
+        }
+        return %orig;
+    }
 
     BOOL isSubSection = (indexPath.section == native);
     NSArray<NSString *> *items = isSubSection ? [ApolloPostFilterStore allSubreddits]
@@ -138,14 +175,28 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
-    if (section < native) return %orig;
+    if (section < native) {
+        if (native > 0 && section == native - 1) {
+            // Collapsed: no header (the summary row stands alone). Expanded: a tappable
+            // "BLOCKED USERS ▾" header to collapse again.
+            if (![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) return [[UIView alloc] init];
+            return [self apollo_pfBlockedToggleHeaderForTable:tableView];
+        }
+        return %orig;
+    }
     NSString *title = (section == native) ? @"Subreddit-Specific Filters" : @"Filter Subreddits by Name";
     return ApolloPFSectionHeaderView(title);
 }
 
 - (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
-    if (section < native) return %orig;
+    if (section < native) {
+        // Hide the native Blocked Users footer while collapsed (the lone summary row reads cleaner without it).
+        if (native > 0 && section == native - 1 && ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) {
+            return [[UIView alloc] init];
+        }
+        return %orig;
+    }
     NSString *text = (section == native)
         ? @"Hide posts in a specific subreddit by title keyword or post flair. Tap a subreddit to configure. Applies on this device."
         : @"Hide any subreddit whose name contains one of these words, in feeds and in search (e.g. 'circlejerk' hides r/carscirclejerk). Applies on this device.";
@@ -154,7 +205,16 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
-    if (indexPath.section < native) { %orig; return; }
+    if (indexPath.section < native) {
+        // Tapping the collapsed Blocked Users summary row expands the section.
+        if (native > 0 && indexPath.section == native - 1 &&
+            ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) {
+            [tableView deselectRowAtIndexPath:indexPath animated:YES];
+            [self apollo_pfSetBlockedExpanded:YES table:tableView];
+            return;
+        }
+        %orig; return;
+    }
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 
     if (indexPath.section == native) {
@@ -175,7 +235,12 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
-    if (indexPath.section < native) return %orig;
+    if (indexPath.section < native) {
+        // Collapsed Blocked Users summary row isn't swipe-deletable (expand to manage).
+        if (native > 0 && indexPath.section == native - 1 &&
+            ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) return NO;
+        return %orig;
+    }
     NSArray<NSString *> *items = (indexPath.section == native) ? [ApolloPostFilterStore allSubreddits]
                                                               : [ApolloPostFilterStore nameSubstrings];
     return (NSUInteger)indexPath.row < items.count; // item rows deletable; Add row not
@@ -263,6 +328,67 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
         [tableView reloadData];
     }]];
     [(UIViewController *)self presentViewController:alert animated:YES completion:nil];
+}
+
+#pragma mark - Collapsible Blocked Users header
+
+// Tappable header that replaces the native "BLOCKED USERS" header: shows the count
+// and a chevron, and toggles the section open/closed.
+%new
+- (UIView *)apollo_pfBlockedToggleHeaderForTable:(UITableView *)tableView {
+    BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
+    NSInteger nativeRows = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
+    NSInteger count = MAX((NSInteger)0, nativeRows - 1); // exclude the "Add User" row
+
+    UIView *container = [[UIView alloc] init];
+    container.userInteractionEnabled = YES;
+
+    UILabel *label = [[UILabel alloc] init];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.text = [NSString stringWithFormat:@"BLOCKED USERS (%ld)", (long)count];
+    label.font = [UIFont preferredFontForTextStyle:UIFontTextStyleFootnote];
+    label.textColor = [UIColor secondaryLabelColor];
+    label.numberOfLines = 1;
+    [container addSubview:label];
+
+    UIImageView *chevron = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:(expanded ? @"chevron.down" : @"chevron.right")]];
+    chevron.translatesAutoresizingMaskIntoConstraints = NO;
+    chevron.tintColor = [UIColor secondaryLabelColor];
+    chevron.contentMode = UIViewContentModeScaleAspectFit;
+    [container addSubview:chevron];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [label.leadingAnchor constraintEqualToAnchor:container.leadingAnchor constant:20.0],
+        [label.topAnchor constraintEqualToAnchor:container.topAnchor constant:18.0],
+        [label.bottomAnchor constraintEqualToAnchor:container.bottomAnchor constant:-6.0],
+        [chevron.centerYAnchor constraintEqualToAnchor:label.centerYAnchor],
+        [chevron.trailingAnchor constraintEqualToAnchor:container.trailingAnchor constant:-20.0],
+        [chevron.leadingAnchor constraintGreaterThanOrEqualToAnchor:label.trailingAnchor constant:8.0],
+        [chevron.widthAnchor constraintEqualToConstant:12.0],
+        [chevron.heightAnchor constraintEqualToConstant:12.0],
+    ]];
+
+    // Weakly remember the table so the tap handler can reload just this section.
+    objc_setAssociatedObject(container, kApolloPFBlockedHeaderTableKey, tableView, OBJC_ASSOCIATION_ASSIGN);
+    [container addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(apollo_pfToggleBlocked:)]];
+    return container;
+}
+
+%new
+- (void)apollo_pfSetBlockedExpanded:(BOOL)expanded table:(UITableView *)tableView {
+    objc_setAssociatedObject(self, kApolloPFBlockedExpandedKey, @(expanded), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (![tableView isKindOfClass:[UITableView class]]) return;
+    NSInteger native = [self apollo_pfNativeSectionCount:tableView];
+    if (native <= 0) return;
+    [tableView reloadSections:[NSIndexSet indexSetWithIndex:native - 1] withRowAnimation:UITableViewRowAnimationAutomatic];
+}
+
+// Tapping the expanded "BLOCKED USERS" header collapses the section again.
+%new
+- (void)apollo_pfToggleBlocked:(UITapGestureRecognizer *)gesture {
+    UITableView *tableView = objc_getAssociatedObject(gesture.view, kApolloPFBlockedHeaderTableKey);
+    BOOL expanded = ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
+    [self apollo_pfSetBlockedExpanded:expanded table:tableView];
 }
 
 %end

--- a/src/ApolloFiltersBlocksInject.xm
+++ b/src/ApolloFiltersBlocksInject.xm
@@ -32,8 +32,6 @@
 - (void)apollo_pfOpenDetailForSubreddit:(NSString *)sub fromTable:(UITableView *)tableView;
 - (void)apollo_pfPromptAddSubredditFromTable:(UITableView *)tableView;
 - (void)apollo_pfPromptAddNameFromTable:(UITableView *)tableView;
-- (UIView *)apollo_pfBlockedToggleHeaderForTable:(UITableView *)tableView;
-- (void)apollo_pfToggleBlocked:(UITapGestureRecognizer *)gesture;
 - (void)apollo_pfSetBlockedExpanded:(BOOL)expanded table:(UITableView *)tableView;
 @end
 
@@ -46,7 +44,6 @@ static const NSInteger kApolloPFExtraSections = 2;
 // vary the row COUNT (0 vs %orig), never re-map indices, so native editing is intact.
 static const void *kApolloPFBlockedExpandedKey   = &kApolloPFBlockedExpandedKey;   // NSNumber BOOL on the VC
 static const void *kApolloPFBlockedNativeCountKey = &kApolloPFBlockedNativeCountKey; // NSNumber on the VC (rows incl. Add)
-static const void *kApolloPFBlockedHeaderTableKey = &kApolloPFBlockedHeaderTableKey; // UITableView on the header view
 
 #pragma mark - Section header / footer views (self-sizing)
 
@@ -105,12 +102,13 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (section < native) {
-        // Blocked Users = last native section: collapse to a single summary row
-        // unless expanded (then show Apollo's own rows, unchanged).
+        // Blocked Users = last native section. Row 0 is always our "Blocked Users (N)"
+        // toggle; when expanded, Apollo's own rows follow (offset by 1) in the SAME
+        // group, so it reads as one continuous list rather than a floating header.
         if (native > 0 && section == native - 1) {
             NSInteger n = %orig; // native row count (blocked users + "Add User")
             objc_setAssociatedObject(self, kApolloPFBlockedNativeCountKey, @(n), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            return [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue] ? n : 1;
+            return [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue] ? (n + 1) : 1;
         }
         return %orig;
     }
@@ -121,20 +119,27 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (indexPath.section < native) {
-        // Collapsed Blocked Users: a single themed "Blocked Users (N)" disclosure row.
-        if (native > 0 && indexPath.section == native - 1 &&
-            ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) {
-            NSInteger n = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
-            NSInteger count = MAX((NSInteger)0, n - 1); // exclude the "Add User" row
-            NSInteger nativeRows0 = [self tableView:tableView numberOfRowsInSection:0];
-            UITableViewCell *cell = %orig(tableView, [NSIndexPath indexPathForRow:MAX((NSInteger)0, nativeRows0 - 1) inSection:0]);
-            cell.imageView.image = nil;
-            cell.accessoryView = nil;
-            cell.textLabel.textColor = [UIColor labelColor];
-            cell.textLabel.text = [NSString stringWithFormat:@"Blocked Users (%ld)", (long)count];
-            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-            cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-            return cell;
+        if (native > 0 && indexPath.section == native - 1) {
+            // Row 0 = the "Blocked Users (N)" toggle (chevron points right collapsed,
+            // down expanded). Rows >0 are Apollo's own rows, offset by 1.
+            if (indexPath.row == 0) {
+                BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
+                NSInteger n = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
+                NSInteger count = MAX((NSInteger)0, n - 1); // exclude the "Add User" row
+                NSInteger nativeRows0 = [self tableView:tableView numberOfRowsInSection:0];
+                UITableViewCell *cell = %orig(tableView, [NSIndexPath indexPathForRow:MAX((NSInteger)0, nativeRows0 - 1) inSection:0]);
+                cell.imageView.image = nil;
+                cell.textLabel.textColor = [UIColor labelColor];
+                cell.textLabel.text = [NSString stringWithFormat:@"Blocked Users (%ld)", (long)count];
+                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+                cell.accessoryType = UITableViewCellAccessoryNone;
+                UIImageView *chevron = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:(expanded ? @"chevron.down" : @"chevron.right")]];
+                chevron.tintColor = [UIColor tertiaryLabelColor];
+                [chevron sizeToFit];
+                cell.accessoryView = chevron;
+                return cell;
+            }
+            return %orig(tableView, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
         }
         return %orig;
     }
@@ -176,12 +181,8 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (section < native) {
-        if (native > 0 && section == native - 1) {
-            // Collapsed: no header (the summary row stands alone). Expanded: a tappable
-            // "BLOCKED USERS ▾" header to collapse again.
-            if (![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) return [[UIView alloc] init];
-            return [self apollo_pfBlockedToggleHeaderForTable:tableView];
-        }
+        // No header for Blocked Users — the toggle row leads the group in both states.
+        if (native > 0 && section == native - 1) return [[UIView alloc] init];
         return %orig;
     }
     NSString *title = (section == native) ? @"Subreddit-Specific Filters" : @"Filter Subreddits by Name";
@@ -206,11 +207,15 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (indexPath.section < native) {
-        // Tapping the collapsed Blocked Users summary row expands the section.
-        if (native > 0 && indexPath.section == native - 1 &&
-            ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) {
-            [tableView deselectRowAtIndexPath:indexPath animated:YES];
-            [self apollo_pfSetBlockedExpanded:YES table:tableView];
+        if (native > 0 && indexPath.section == native - 1) {
+            // Row 0 toggles; deeper rows are Apollo's own (offset by 1).
+            if (indexPath.row == 0) {
+                [tableView deselectRowAtIndexPath:indexPath animated:YES];
+                BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
+                [self apollo_pfSetBlockedExpanded:!expanded table:tableView];
+                return;
+            }
+            %orig(tableView, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
             return;
         }
         %orig; return;
@@ -236,9 +241,13 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (indexPath.section < native) {
-        // Collapsed Blocked Users summary row isn't swipe-deletable (expand to manage).
-        if (native > 0 && indexPath.section == native - 1 &&
-            ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) return NO;
+        if (native > 0 && indexPath.section == native - 1) {
+            // Row 0 = toggle, last row = Apollo's "Add User" — neither is swipe-deletable;
+            // the blocked-user rows in between map to Apollo's rows (offset by 1).
+            NSInteger nativeCount = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
+            if (indexPath.row == 0 || (nativeCount > 0 && indexPath.row >= nativeCount)) return NO;
+            return %orig(tableView, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
+        }
         return %orig;
     }
     NSArray<NSString *> *items = (indexPath.section == native) ? [ApolloPostFilterStore allSubreddits]
@@ -248,13 +257,30 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 
 - (BOOL)tableView:(UITableView *)tableView canMoveRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
-    if (indexPath.section < native) return %orig;
+    if (indexPath.section < native) {
+        if (native > 0 && indexPath.section == native - 1) {
+            if (indexPath.row == 0) return NO;
+            return %orig(tableView, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
+        }
+        return %orig;
+    }
     return NO;
 }
 
 - (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
-    if (indexPath.section < native) { %orig; return; }
+    if (indexPath.section < native) {
+        // Expanded Blocked Users: deletions act on Apollo's own row (offset by 1).
+        // Re-render afterward so the row list AND the "(N)" count in the toggle row
+        // stay correct no matter how Apollo animates its own deletion.
+        if (native > 0 && indexPath.section == native - 1 && indexPath.row >= 1) {
+            %orig(tableView, editingStyle, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
+            __weak UITableView *weakTable = tableView;
+            dispatch_async(dispatch_get_main_queue(), ^{ [weakTable reloadData]; });
+            return;
+        }
+        %orig; return;
+    }
     if (editingStyle != UITableViewCellEditingStyleDelete) return;
     BOOL isSubSection = (indexPath.section == native);
     NSArray<NSString *> *items = isSubSection ? [ApolloPostFilterStore allSubreddits]
@@ -268,7 +294,12 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 
 - (NSString *)tableView:(UITableView *)tableView titleForDeleteConfirmationButtonForRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
-    if (indexPath.section < native) return %orig;
+    if (indexPath.section < native) {
+        if (native > 0 && indexPath.section == native - 1 && indexPath.row >= 1) {
+            return %orig(tableView, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
+        }
+        return %orig;
+    }
     return @"Delete";
 }
 
@@ -330,68 +361,7 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
     [(UIViewController *)self presentViewController:alert animated:YES completion:nil];
 }
 
-#pragma mark - Collapsible Blocked Users header
-
-// Tappable header shown ONLY while the section is expanded — styled to mirror the
-// collapsed "Blocked Users (N)" row (same themed rounded bar + chevron) so it's
-// obviously the same control, now pointing down to collapse. Tapping it collapses.
-%new
-- (UIView *)apollo_pfBlockedToggleHeaderForTable:(UITableView *)tableView {
-    NSInteger nativeRows = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
-    NSInteger count = MAX((NSInteger)0, nativeRows - 1); // exclude the "Add User" row
-
-    // Sample the themed cell background from a real native cell so the bar matches
-    // Apollo's current theme (synthwave, etc.), falling back to the system colour.
-    UIColor *cellBG = [UIColor secondarySystemGroupedBackgroundColor];
-    @try {
-        UITableViewCell *probe = [self tableView:tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
-        UIColor *c = probe.backgroundColor ?: probe.contentView.backgroundColor;
-        if (c && CGColorGetAlpha(c.CGColor) > 0.01) cellBG = c;
-    } @catch (__unused id e) {}
-
-    UIView *container = [[UIView alloc] init];
-    container.userInteractionEnabled = YES;
-
-    UIView *bar = [[UIView alloc] init];
-    bar.translatesAutoresizingMaskIntoConstraints = NO;
-    bar.backgroundColor = cellBG;
-    bar.layer.cornerRadius = 10.0;
-    bar.layer.cornerCurve = kCACornerCurveContinuous;
-    [container addSubview:bar];
-
-    UILabel *label = [[UILabel alloc] init];
-    label.translatesAutoresizingMaskIntoConstraints = NO;
-    label.text = [NSString stringWithFormat:@"Blocked Users (%ld)", (long)count];
-    label.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
-    label.textColor = [UIColor labelColor];
-    [bar addSubview:label];
-
-    UIImageView *chevron = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"chevron.down"]];
-    chevron.translatesAutoresizingMaskIntoConstraints = NO;
-    chevron.tintColor = [UIColor tertiaryLabelColor];
-    chevron.contentMode = UIViewContentModeScaleAspectFit;
-    [bar addSubview:chevron];
-
-    [NSLayoutConstraint activateConstraints:@[
-        [bar.leadingAnchor constraintEqualToAnchor:container.leadingAnchor constant:16.0],
-        [bar.trailingAnchor constraintEqualToAnchor:container.trailingAnchor constant:-16.0],
-        [bar.topAnchor constraintEqualToAnchor:container.topAnchor constant:6.0],
-        [bar.bottomAnchor constraintEqualToAnchor:container.bottomAnchor constant:-6.0],
-        [label.leadingAnchor constraintEqualToAnchor:bar.leadingAnchor constant:16.0],
-        [label.topAnchor constraintEqualToAnchor:bar.topAnchor constant:11.0],
-        [label.bottomAnchor constraintEqualToAnchor:bar.bottomAnchor constant:-11.0],
-        [chevron.centerYAnchor constraintEqualToAnchor:label.centerYAnchor],
-        [chevron.trailingAnchor constraintEqualToAnchor:bar.trailingAnchor constant:-16.0],
-        [chevron.leadingAnchor constraintGreaterThanOrEqualToAnchor:label.trailingAnchor constant:8.0],
-        [chevron.widthAnchor constraintEqualToConstant:13.0],
-        [chevron.heightAnchor constraintEqualToConstant:13.0],
-    ]];
-
-    // Weakly remember the table so the tap handler can reload just this section.
-    objc_setAssociatedObject(container, kApolloPFBlockedHeaderTableKey, tableView, OBJC_ASSOCIATION_ASSIGN);
-    [container addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(apollo_pfToggleBlocked:)]];
-    return container;
-}
+#pragma mark - Collapsible Blocked Users toggle
 
 %new
 - (void)apollo_pfSetBlockedExpanded:(BOOL)expanded table:(UITableView *)tableView {
@@ -400,14 +370,6 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (native <= 0) return;
     [tableView reloadSections:[NSIndexSet indexSetWithIndex:native - 1] withRowAnimation:UITableViewRowAnimationAutomatic];
-}
-
-// Tapping the expanded "BLOCKED USERS" header collapses the section again.
-%new
-- (void)apollo_pfToggleBlocked:(UITapGestureRecognizer *)gesture {
-    UITableView *tableView = objc_getAssociatedObject(gesture.view, kApolloPFBlockedHeaderTableKey);
-    BOOL expanded = ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
-    [self apollo_pfSetBlockedExpanded:expanded table:tableView];
 }
 
 %end

--- a/src/ApolloFiltersBlocksInject.xm
+++ b/src/ApolloFiltersBlocksInject.xm
@@ -32,21 +32,20 @@
 - (void)apollo_pfOpenDetailForSubreddit:(NSString *)sub fromTable:(UITableView *)tableView;
 - (void)apollo_pfPromptAddSubredditFromTable:(UITableView *)tableView;
 - (void)apollo_pfPromptAddNameFromTable:(UITableView *)tableView;
+- (UITableViewCell *)apollo_pfBlockedToggleCellForTable:(UITableView *)tableView showingExpanded:(BOOL)showingExpanded;
 - (void)apollo_pfSetBlockedExpanded:(BOOL)expanded table:(UITableView *)tableView;
 @end
 
 // Number of Reborn sections appended after the native ones.
 static const NSInteger kApolloPFExtraSections = 2;
 
-// Reuse identifier for the Blocked Users toggle row. It has its OWN identifier so
-// it never enters Apollo's cell-reuse pool — otherwise its chevron / accessoryType
-// would leak onto recycled username / "Add User" cells.
-static NSString *const kApolloPFBlockedToggleReuse = @"ApolloPFBlockedUsersToggle";
-
 // Collapsible native Blocked Users section (the last native section): collapsed by
-// default to a single tappable header so a long block list doesn't bloat the page.
-// Expanding restores Apollo's own rows (Add User + swipe-delete) unchanged — we only
-// vary the row COUNT (0 vs %orig), never re-map indices, so native editing is intact.
+// default to a single tappable "Blocked Users (N)" row so a long block list doesn't
+// bloat the page. Expanding shows Apollo's own rows (Add User + swipe-delete) FIRST,
+// unchanged at their native indices, then appends our own "Blocked Users (N)" row at
+// the BOTTOM as a "tap to collapse" control — so the whole thing reads as one
+// continuous group and native editing stays intact (we never re-map native indices,
+// we only add a trailing row).
 static const void *kApolloPFBlockedExpandedKey   = &kApolloPFBlockedExpandedKey;   // NSNumber BOOL on the VC
 static const void *kApolloPFBlockedNativeCountKey = &kApolloPFBlockedNativeCountKey; // NSNumber on the VC (rows incl. Add)
 
@@ -107,12 +106,13 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (section < native) {
-        // Blocked Users = last native section. Row 0 is always our "Blocked Users (N)"
-        // toggle; when expanded, Apollo's own rows follow (offset by 1) in the SAME
-        // group, so it reads as one continuous list rather than a floating header.
+        // Blocked Users = last native section: collapse to a single summary row
+        // unless expanded (then show Apollo's own rows, unchanged).
         if (native > 0 && section == native - 1) {
             NSInteger n = %orig; // native row count (blocked users + "Add User")
             objc_setAssociatedObject(self, kApolloPFBlockedNativeCountKey, @(n), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            // Collapsed: a single summary row. Expanded: all of Apollo's own rows
+            // (0..n-1, untouched) plus our trailing "tap to collapse" row at index n.
             return [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue] ? (n + 1) : 1;
         }
         return %orig;
@@ -125,32 +125,13 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (indexPath.section < native) {
         if (native > 0 && indexPath.section == native - 1) {
-            // Row 0 = the "Blocked Users (N)" toggle (chevron points right collapsed,
-            // down expanded). Rows >0 are Apollo's own rows, offset by 1.
-            if (indexPath.row == 0) {
-                BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
-                NSInteger n = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
-                NSInteger count = MAX((NSInteger)0, n - 1); // exclude the "Add User" row
-                // Our OWN cell (separate reuse pool) so nothing leaks onto Apollo's rows.
-                UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kApolloPFBlockedToggleReuse];
-                if (!cell) cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:kApolloPFBlockedToggleReuse];
-                // Match Apollo's themed cell background by sampling a native cell.
-                @try {
-                    UITableViewCell *probe = %orig(tableView, [NSIndexPath indexPathForRow:0 inSection:0]);
-                    UIColor *bg = probe.backgroundColor ?: probe.contentView.backgroundColor;
-                    if (bg && CGColorGetAlpha(bg.CGColor) > 0.01) cell.backgroundColor = bg;
-                } @catch (__unused id e) {}
-                cell.textLabel.text = [NSString stringWithFormat:@"Blocked Users (%ld)", (long)count];
-                cell.textLabel.textColor = [UIColor labelColor];
-                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-                UIImageView *chevron = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:(expanded ? @"chevron.down" : @"chevron.right")]];
-                chevron.tintColor = [UIColor tertiaryLabelColor];
-                [chevron sizeToFit];
-                cell.accessoryView = chevron;
-                return cell;
-            }
-            // Apollo's own rows — returned untouched (their native disclosures etc. intact).
-            return %orig(tableView, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
+            BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
+            // Collapsed: a single "Blocked Users (N) ⌄" summary row (tap to expand).
+            if (!expanded) return [self apollo_pfBlockedToggleCellForTable:tableView showingExpanded:NO];
+            // Expanded: our trailing "Blocked Users (N) ⌃" row (tap to collapse) sits
+            // after Apollo's own rows. Everything below it is native, untouched.
+            NSInteger n = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
+            if (indexPath.row >= n) return [self apollo_pfBlockedToggleCellForTable:tableView showingExpanded:YES];
         }
         return %orig;
     }
@@ -192,8 +173,11 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (section < native) {
-        // No header for Blocked Users — the toggle row leads the group in both states.
-        if (native > 0 && section == native - 1) return [[UIView alloc] init];
+        if (native > 0 && section == native - 1) {
+            // No header in either state — our "Blocked Users (N)" toggle row is the
+            // label (collapsed it stands alone; expanded it trails the group).
+            return [[UIView alloc] init];
+        }
         return %orig;
     }
     NSString *title = (section == native) ? @"Subreddit-Specific Filters" : @"Filter Subreddits by Name";
@@ -219,17 +203,22 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (indexPath.section < native) {
         if (native > 0 && indexPath.section == native - 1) {
-            // Row 0 toggles; deeper rows are Apollo's own (offset by 1).
-            if (indexPath.row == 0) {
+            BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
+            // Collapsed summary row → expand.
+            if (!expanded) {
                 [tableView deselectRowAtIndexPath:indexPath animated:YES];
-                BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
-                [self apollo_pfSetBlockedExpanded:!expanded table:tableView];
+                [self apollo_pfSetBlockedExpanded:YES table:tableView];
                 return;
             }
-            %orig(tableView, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
-            return;
+            // Trailing "tap to collapse" row → collapse.
+            NSInteger n = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
+            if (indexPath.row >= n) {
+                [tableView deselectRowAtIndexPath:indexPath animated:YES];
+                [self apollo_pfSetBlockedExpanded:NO table:tableView];
+                return;
+            }
         }
-        %orig; return;
+        %orig; return; // native row (incl. Add User) — Apollo handles it
     }
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 
@@ -252,12 +241,13 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (indexPath.section < native) {
+        // Neither of our own toggle rows (collapsed summary / trailing collapse) is
+        // swipe-deletable; Apollo's own rows below route to %orig.
         if (native > 0 && indexPath.section == native - 1) {
-            // Row 0 = toggle, last row = Apollo's "Add User" — neither is swipe-deletable;
-            // the blocked-user rows in between map to Apollo's rows (offset by 1).
-            NSInteger nativeCount = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
-            if (indexPath.row == 0 || (nativeCount > 0 && indexPath.row >= nativeCount)) return NO;
-            return %orig(tableView, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
+            BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
+            if (!expanded) return NO;
+            NSInteger n = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
+            if (indexPath.row >= n) return NO;
         }
         return %orig;
     }
@@ -269,9 +259,12 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (BOOL)tableView:(UITableView *)tableView canMoveRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (indexPath.section < native) {
+        // Our own toggle rows can't be reordered; native rows route to %orig.
         if (native > 0 && indexPath.section == native - 1) {
-            if (indexPath.row == 0) return NO;
-            return %orig(tableView, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
+            BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
+            if (!expanded) return NO;
+            NSInteger n = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
+            if (indexPath.row >= n) return NO;
         }
         return %orig;
     }
@@ -280,18 +273,7 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 
 - (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
-    if (indexPath.section < native) {
-        // Expanded Blocked Users: deletions act on Apollo's own row (offset by 1).
-        // Re-render afterward so the row list AND the "(N)" count in the toggle row
-        // stay correct no matter how Apollo animates its own deletion.
-        if (native > 0 && indexPath.section == native - 1 && indexPath.row >= 1) {
-            %orig(tableView, editingStyle, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
-            __weak UITableView *weakTable = tableView;
-            dispatch_async(dispatch_get_main_queue(), ^{ [weakTable reloadData]; });
-            return;
-        }
-        %orig; return;
-    }
+    if (indexPath.section < native) { %orig; return; }
     if (editingStyle != UITableViewCellEditingStyleDelete) return;
     BOOL isSubSection = (indexPath.section == native);
     NSArray<NSString *> *items = isSubSection ? [ApolloPostFilterStore allSubreddits]
@@ -305,12 +287,7 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 
 - (NSString *)tableView:(UITableView *)tableView titleForDeleteConfirmationButtonForRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
-    if (indexPath.section < native) {
-        if (native > 0 && indexPath.section == native - 1 && indexPath.row >= 1) {
-            return %orig(tableView, [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:indexPath.section]);
-        }
-        return %orig;
-    }
+    if (indexPath.section < native) return %orig;
     return @"Delete";
 }
 
@@ -372,7 +349,47 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
     [(UIViewController *)self presentViewController:alert animated:YES completion:nil];
 }
 
-#pragma mark - Collapsible Blocked Users toggle
+#pragma mark - Collapsible Blocked Users toggle row
+
+// The "Blocked Users (N)" toggle row. It is OUR OWN cell (a dedicated reuse
+// identifier), so its chevron never leaks onto Apollo's recycled username / "Add
+// User" cells. showingExpanded == NO renders the collapsed summary row (chevron
+// down = tap to expand); YES renders the trailing collapse row (chevron up = tap to
+// collapse). It samples a native cell's background so it matches Apollo's theme.
+%new
+- (UITableViewCell *)apollo_pfBlockedToggleCellForTable:(UITableView *)tableView showingExpanded:(BOOL)showingExpanded {
+    NSInteger nativeRows = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
+    NSInteger count = MAX((NSInteger)0, nativeRows - 1); // exclude the "Add User" row
+
+    static NSString *const kReuse = @"ApolloPFBlockedUsersToggle";
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kReuse];
+    if (!cell) cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:kReuse];
+
+    // Match Apollo's themed cell background by sampling a native cell.
+    @try {
+        UITableViewCell *probe = [self tableView:tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
+        UIColor *c = probe.backgroundColor ?: probe.contentView.backgroundColor;
+        if (c && CGColorGetAlpha(c.CGColor) > 0.01) cell.backgroundColor = c;
+    } @catch (__unused id e) {}
+
+    cell.textLabel.text = [NSString stringWithFormat:@"Blocked Users (%ld)", (long)count];
+    cell.textLabel.textColor = [UIColor labelColor];
+    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+    // Collapsed: the standard disclosure chevron (tap to expand). Expanded: our own
+    // up-chevron on the trailing row (tap to collapse). Set both accessory slots
+    // explicitly so a recycled instance never carries the other state's accessory.
+    if (showingExpanded) {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        UIImageView *chevron = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"chevron.up"]];
+        chevron.tintColor = [UIColor tertiaryLabelColor];
+        [chevron sizeToFit];
+        cell.accessoryView = chevron;
+    } else {
+        cell.accessoryView = nil;
+        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    }
+    return cell;
+}
 
 %new
 - (void)apollo_pfSetBlockedExpanded:(BOOL)expanded table:(UITableView *)tableView {

--- a/src/ApolloFiltersBlocksInject.xm
+++ b/src/ApolloFiltersBlocksInject.xm
@@ -332,40 +332,59 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 
 #pragma mark - Collapsible Blocked Users header
 
-// Tappable header that replaces the native "BLOCKED USERS" header: shows the count
-// and a chevron, and toggles the section open/closed.
+// Tappable header shown ONLY while the section is expanded — styled to mirror the
+// collapsed "Blocked Users (N)" row (same themed rounded bar + chevron) so it's
+// obviously the same control, now pointing down to collapse. Tapping it collapses.
 %new
 - (UIView *)apollo_pfBlockedToggleHeaderForTable:(UITableView *)tableView {
-    BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
     NSInteger nativeRows = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
     NSInteger count = MAX((NSInteger)0, nativeRows - 1); // exclude the "Add User" row
+
+    // Sample the themed cell background from a real native cell so the bar matches
+    // Apollo's current theme (synthwave, etc.), falling back to the system colour.
+    UIColor *cellBG = [UIColor secondarySystemGroupedBackgroundColor];
+    @try {
+        UITableViewCell *probe = [self tableView:tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
+        UIColor *c = probe.backgroundColor ?: probe.contentView.backgroundColor;
+        if (c && CGColorGetAlpha(c.CGColor) > 0.01) cellBG = c;
+    } @catch (__unused id e) {}
 
     UIView *container = [[UIView alloc] init];
     container.userInteractionEnabled = YES;
 
+    UIView *bar = [[UIView alloc] init];
+    bar.translatesAutoresizingMaskIntoConstraints = NO;
+    bar.backgroundColor = cellBG;
+    bar.layer.cornerRadius = 10.0;
+    bar.layer.cornerCurve = kCACornerCurveContinuous;
+    [container addSubview:bar];
+
     UILabel *label = [[UILabel alloc] init];
     label.translatesAutoresizingMaskIntoConstraints = NO;
-    label.text = [NSString stringWithFormat:@"BLOCKED USERS (%ld)", (long)count];
-    label.font = [UIFont preferredFontForTextStyle:UIFontTextStyleFootnote];
-    label.textColor = [UIColor secondaryLabelColor];
-    label.numberOfLines = 1;
-    [container addSubview:label];
+    label.text = [NSString stringWithFormat:@"Blocked Users (%ld)", (long)count];
+    label.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    label.textColor = [UIColor labelColor];
+    [bar addSubview:label];
 
-    UIImageView *chevron = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:(expanded ? @"chevron.down" : @"chevron.right")]];
+    UIImageView *chevron = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"chevron.down"]];
     chevron.translatesAutoresizingMaskIntoConstraints = NO;
-    chevron.tintColor = [UIColor secondaryLabelColor];
+    chevron.tintColor = [UIColor tertiaryLabelColor];
     chevron.contentMode = UIViewContentModeScaleAspectFit;
-    [container addSubview:chevron];
+    [bar addSubview:chevron];
 
     [NSLayoutConstraint activateConstraints:@[
-        [label.leadingAnchor constraintEqualToAnchor:container.leadingAnchor constant:20.0],
-        [label.topAnchor constraintEqualToAnchor:container.topAnchor constant:18.0],
-        [label.bottomAnchor constraintEqualToAnchor:container.bottomAnchor constant:-6.0],
+        [bar.leadingAnchor constraintEqualToAnchor:container.leadingAnchor constant:16.0],
+        [bar.trailingAnchor constraintEqualToAnchor:container.trailingAnchor constant:-16.0],
+        [bar.topAnchor constraintEqualToAnchor:container.topAnchor constant:6.0],
+        [bar.bottomAnchor constraintEqualToAnchor:container.bottomAnchor constant:-6.0],
+        [label.leadingAnchor constraintEqualToAnchor:bar.leadingAnchor constant:16.0],
+        [label.topAnchor constraintEqualToAnchor:bar.topAnchor constant:11.0],
+        [label.bottomAnchor constraintEqualToAnchor:bar.bottomAnchor constant:-11.0],
         [chevron.centerYAnchor constraintEqualToAnchor:label.centerYAnchor],
-        [chevron.trailingAnchor constraintEqualToAnchor:container.trailingAnchor constant:-20.0],
+        [chevron.trailingAnchor constraintEqualToAnchor:bar.trailingAnchor constant:-16.0],
         [chevron.leadingAnchor constraintGreaterThanOrEqualToAnchor:label.trailingAnchor constant:8.0],
-        [chevron.widthAnchor constraintEqualToConstant:12.0],
-        [chevron.heightAnchor constraintEqualToConstant:12.0],
+        [chevron.widthAnchor constraintEqualToConstant:13.0],
+        [chevron.heightAnchor constraintEqualToConstant:13.0],
     ]];
 
     // Weakly remember the table so the tap handler can reload just this section.

--- a/src/ApolloFiltersBlocksInject.xm
+++ b/src/ApolloFiltersBlocksInject.xm
@@ -32,7 +32,9 @@
 - (void)apollo_pfOpenDetailForSubreddit:(NSString *)sub fromTable:(UITableView *)tableView;
 - (void)apollo_pfPromptAddSubredditFromTable:(UITableView *)tableView;
 - (void)apollo_pfPromptAddNameFromTable:(UITableView *)tableView;
-- (UITableViewCell *)apollo_pfBlockedToggleCellForTable:(UITableView *)tableView showingExpanded:(BOOL)showingExpanded;
+- (UITableViewCell *)apollo_pfBlockedCollapsedCellForTable:(UITableView *)tableView;
+- (UIView *)apollo_pfBlockedToggleHeaderForTable:(UITableView *)tableView;
+- (void)apollo_pfToggleBlocked:(UITapGestureRecognizer *)gesture;
 - (void)apollo_pfSetBlockedExpanded:(BOOL)expanded table:(UITableView *)tableView;
 @end
 
@@ -48,6 +50,7 @@ static const NSInteger kApolloPFExtraSections = 2;
 // we only add a trailing row).
 static const void *kApolloPFBlockedExpandedKey   = &kApolloPFBlockedExpandedKey;   // NSNumber BOOL on the VC
 static const void *kApolloPFBlockedNativeCountKey = &kApolloPFBlockedNativeCountKey; // NSNumber on the VC (rows incl. Add)
+static const void *kApolloPFBlockedHeaderTableKey = &kApolloPFBlockedHeaderTableKey; // UITableView on the header view
 
 #pragma mark - Section header / footer views (self-sizing)
 
@@ -111,9 +114,12 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
         if (native > 0 && section == native - 1) {
             NSInteger n = %orig; // native row count (blocked users + "Add User")
             objc_setAssociatedObject(self, kApolloPFBlockedNativeCountKey, @(n), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            // Collapsed: a single summary row. Expanded: all of Apollo's own rows
-            // (0..n-1, untouched) plus our trailing "tap to collapse" row at index n.
-            return [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue] ? (n + 1) : 1;
+            // Collapsed: a single summary row (our toggle). Expanded: EXACTLY Apollo's
+            // own rows, unchanged — the toggle becomes a section HEADER instead of a
+            // row. Apollo identifies its "Add User" row as `row == numberOfRows - 1`,
+            // so we must NEVER inflate this count or that detection (and Add User)
+            // breaks.
+            return [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue] ? n : 1;
         }
         return %orig;
     }
@@ -124,14 +130,11 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (indexPath.section < native) {
-        if (native > 0 && indexPath.section == native - 1) {
-            BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
-            // Collapsed: a single "Blocked Users (N) ⌄" summary row (tap to expand).
-            if (!expanded) return [self apollo_pfBlockedToggleCellForTable:tableView showingExpanded:NO];
-            // Expanded: our trailing "Blocked Users (N) ⌃" row (tap to collapse) sits
-            // after Apollo's own rows. Everything below it is native, untouched.
-            NSInteger n = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
-            if (indexPath.row >= n) return [self apollo_pfBlockedToggleCellForTable:tableView showingExpanded:YES];
+        if (native > 0 && indexPath.section == native - 1 &&
+            ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) {
+            // Collapsed: a single "Blocked Users (N) ›" summary row (tap to expand).
+            // Expanded: fall through to %orig — Apollo's own rows, untouched.
+            return [self apollo_pfBlockedCollapsedCellForTable:tableView];
         }
         return %orig;
     }
@@ -174,9 +177,11 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (section < native) {
         if (native > 0 && section == native - 1) {
-            // No header in either state — our "Blocked Users (N)" toggle row is the
-            // label (collapsed it stands alone; expanded it trails the group).
-            return [[UIView alloc] init];
+            // Collapsed: no header (the summary row stands alone). Expanded: a tappable
+            // "Blocked Users (N) ⌄" header sits at the TOP and the rows expand below it;
+            // tap it to collapse again.
+            if (![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) return [[UIView alloc] init];
+            return [self apollo_pfBlockedToggleHeaderForTable:tableView];
         }
         return %orig;
     }
@@ -202,21 +207,12 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (indexPath.section < native) {
-        if (native > 0 && indexPath.section == native - 1) {
-            BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
-            // Collapsed summary row → expand.
-            if (!expanded) {
-                [tableView deselectRowAtIndexPath:indexPath animated:YES];
-                [self apollo_pfSetBlockedExpanded:YES table:tableView];
-                return;
-            }
-            // Trailing "tap to collapse" row → collapse.
-            NSInteger n = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
-            if (indexPath.row >= n) {
-                [tableView deselectRowAtIndexPath:indexPath animated:YES];
-                [self apollo_pfSetBlockedExpanded:NO table:tableView];
-                return;
-            }
+        // Tapping the collapsed Blocked Users summary row expands the section.
+        if (native > 0 && indexPath.section == native - 1 &&
+            ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) {
+            [tableView deselectRowAtIndexPath:indexPath animated:YES];
+            [self apollo_pfSetBlockedExpanded:YES table:tableView];
+            return;
         }
         %orig; return; // native row (incl. Add User) — Apollo handles it
     }
@@ -241,14 +237,10 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (indexPath.section < native) {
-        // Neither of our own toggle rows (collapsed summary / trailing collapse) is
-        // swipe-deletable; Apollo's own rows below route to %orig.
-        if (native > 0 && indexPath.section == native - 1) {
-            BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
-            if (!expanded) return NO;
-            NSInteger n = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
-            if (indexPath.row >= n) return NO;
-        }
+        // Collapsed Blocked Users summary row isn't swipe-deletable (expand to manage);
+        // expanded native rows route to %orig.
+        if (native > 0 && indexPath.section == native - 1 &&
+            ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) return NO;
         return %orig;
     }
     NSArray<NSString *> *items = (indexPath.section == native) ? [ApolloPostFilterStore allSubreddits]
@@ -259,13 +251,9 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (BOOL)tableView:(UITableView *)tableView canMoveRowAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger native = [self apollo_pfNativeSectionCount:tableView];
     if (indexPath.section < native) {
-        // Our own toggle rows can't be reordered; native rows route to %orig.
-        if (native > 0 && indexPath.section == native - 1) {
-            BOOL expanded = [objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
-            if (!expanded) return NO;
-            NSInteger n = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
-            if (indexPath.row >= n) return NO;
-        }
+        // Collapsed summary row can't be reordered; expanded native rows route to %orig.
+        if (native > 0 && indexPath.section == native - 1 &&
+            ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) return NO;
         return %orig;
     }
     return NO;
@@ -349,15 +337,13 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
     [(UIViewController *)self presentViewController:alert animated:YES completion:nil];
 }
 
-#pragma mark - Collapsible Blocked Users toggle row
+#pragma mark - Collapsible Blocked Users toggle
 
-// The "Blocked Users (N)" toggle row. It is OUR OWN cell (a dedicated reuse
-// identifier), so its chevron never leaks onto Apollo's recycled username / "Add
-// User" cells. showingExpanded == NO renders the collapsed summary row (chevron
-// down = tap to expand); YES renders the trailing collapse row (chevron up = tap to
-// collapse). It samples a native cell's background so it matches Apollo's theme.
+// Collapsed summary row: a single themed "Blocked Users (N) ›" disclosure row. It is
+// OUR OWN cell (dedicated reuse id) so its accessory never leaks onto Apollo's
+// recycled cells. Samples a native cell's background to match Apollo's theme.
 %new
-- (UITableViewCell *)apollo_pfBlockedToggleCellForTable:(UITableView *)tableView showingExpanded:(BOOL)showingExpanded {
+- (UITableViewCell *)apollo_pfBlockedCollapsedCellForTable:(UITableView *)tableView {
     NSInteger nativeRows = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
     NSInteger count = MAX((NSInteger)0, nativeRows - 1); // exclude the "Add User" row
 
@@ -365,7 +351,6 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:kReuse];
     if (!cell) cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:kReuse];
 
-    // Match Apollo's themed cell background by sampling a native cell.
     @try {
         UITableViewCell *probe = [self tableView:tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
         UIColor *c = probe.backgroundColor ?: probe.contentView.backgroundColor;
@@ -375,20 +360,57 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
     cell.textLabel.text = [NSString stringWithFormat:@"Blocked Users (%ld)", (long)count];
     cell.textLabel.textColor = [UIColor labelColor];
     cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-    // Collapsed: the standard disclosure chevron (tap to expand). Expanded: our own
-    // up-chevron on the trailing row (tap to collapse). Set both accessory slots
-    // explicitly so a recycled instance never carries the other state's accessory.
-    if (showingExpanded) {
-        cell.accessoryType = UITableViewCellAccessoryNone;
-        UIImageView *chevron = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"chevron.up"]];
-        chevron.tintColor = [UIColor tertiaryLabelColor];
-        [chevron sizeToFit];
-        cell.accessoryView = chevron;
-    } else {
-        cell.accessoryView = nil;
-        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-    }
+    cell.accessoryView = nil;
+    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     return cell;
+}
+
+// Expanded header: a tappable "Blocked Users (N) ⌄" title that sits at the TOP of the
+// section, with Apollo's own rows expanding directly below it. Deliberately a PLAIN
+// header (label + chevron on the table background) — NOT a floating rounded bar —
+// so it reads as the section's title, not a second box. Tapping it collapses.
+%new
+- (UIView *)apollo_pfBlockedToggleHeaderForTable:(UITableView *)tableView {
+    NSInteger nativeRows = [objc_getAssociatedObject(self, kApolloPFBlockedNativeCountKey) integerValue];
+    NSInteger count = MAX((NSInteger)0, nativeRows - 1); // exclude the "Add User" row
+
+    UIView *container = [[UIView alloc] init];
+    container.userInteractionEnabled = YES;
+
+    UILabel *label = [[UILabel alloc] init];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.text = [NSString stringWithFormat:@"Blocked Users (%ld)", (long)count];
+    label.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    label.textColor = [UIColor labelColor];
+    [container addSubview:label];
+
+    UIImageView *chevron = [[UIImageView alloc] initWithImage:[[UIImage systemImageNamed:@"chevron.down"] imageWithConfiguration:[UIImageSymbolConfiguration configurationWithPointSize:14.0 weight:UIImageSymbolWeightSemibold]]];
+    chevron.translatesAutoresizingMaskIntoConstraints = NO;
+    chevron.tintColor = [UIColor secondaryLabelColor];
+    chevron.contentMode = UIViewContentModeScaleAspectFit;
+    [container addSubview:chevron];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [label.leadingAnchor constraintEqualToAnchor:container.leadingAnchor constant:20.0],
+        [label.topAnchor constraintEqualToAnchor:container.topAnchor constant:16.0],
+        [label.bottomAnchor constraintEqualToAnchor:container.bottomAnchor constant:-8.0],
+        [chevron.centerYAnchor constraintEqualToAnchor:label.centerYAnchor],
+        [chevron.trailingAnchor constraintEqualToAnchor:container.trailingAnchor constant:-20.0],
+        [chevron.leadingAnchor constraintGreaterThanOrEqualToAnchor:label.trailingAnchor constant:8.0],
+    ]];
+
+    // Weakly remember the table so the tap handler can reload just this section.
+    objc_setAssociatedObject(container, kApolloPFBlockedHeaderTableKey, tableView, OBJC_ASSOCIATION_ASSIGN);
+    [container addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(apollo_pfToggleBlocked:)]];
+    return container;
+}
+
+// Tapping the expanded "Blocked Users (N) ⌄" header collapses the section again.
+%new
+- (void)apollo_pfToggleBlocked:(UITapGestureRecognizer *)gesture {
+    UITableView *tableView = objc_getAssociatedObject(gesture.view, kApolloPFBlockedHeaderTableKey);
+    BOOL expanded = ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue];
+    [self apollo_pfSetBlockedExpanded:expanded table:tableView];
 }
 
 %new

--- a/src/ApolloFiltersBlocksInject.xm
+++ b/src/ApolloFiltersBlocksInject.xm
@@ -1,0 +1,272 @@
+// ApolloFiltersBlocksInject
+//
+// Beefs out Apollo's native Filters & Blocks screen
+// (_TtC6Apollo29SettingsFiltersViewController) by APPENDING two Reborn sections
+// below the native Keywords / Subreddits / Users sections:
+//
+//   • SUBREDDIT-SPECIFIC FILTERS — a list of configured subreddits; tap one to
+//     open ApolloSubredditFilterDetailViewController and manage its keyword/flair
+//     lists, plus an "Add Subreddit..." row.
+//   • FILTER SUBREDDITS BY NAME — a list of name substrings (hide any subreddit
+//     whose name contains the word), plus an "Add Word..." row.
+//
+// Native sections are left fully intact (we append, so their indices never shift;
+// every native section/row routes straight to %orig). Cells are borrowed from a
+// native row so they inherit Apollo's exact theme; our section headers/footers are
+// self-sizing label views. Enforcement lives in ApolloPostFilters.xm; storage in
+// ApolloPostFilterStore.
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+
+#import "ApolloCommon.h"
+#import "ApolloPostFilterStore.h"
+#import "ApolloSubredditFilterDetailViewController.h"
+
+// Native Filters & Blocks screen (Apollo.SettingsFiltersViewController). Declared
+// for the compiler so our self-calls (the dataSource method + the %new helpers
+// below) type-check; the real class is hooked/resolved at runtime.
+@interface _TtC6Apollo29SettingsFiltersViewController : UIViewController <UITableViewDataSource, UITableViewDelegate>
+- (NSInteger)apollo_pfNativeSectionCount:(UITableView *)tableView;
+- (void)apollo_pfOpenDetailForSubreddit:(NSString *)sub fromTable:(UITableView *)tableView;
+- (void)apollo_pfPromptAddSubredditFromTable:(UITableView *)tableView;
+- (void)apollo_pfPromptAddNameFromTable:(UITableView *)tableView;
+@end
+
+// Number of Reborn sections appended after the native ones.
+static const NSInteger kApolloPFExtraSections = 2;
+
+#pragma mark - Section header / footer views (self-sizing)
+
+static UIView *ApolloPFSectionHeaderView(NSString *title) {
+    UIView *container = [[UIView alloc] init];
+    UILabel *label = [[UILabel alloc] init];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.text = title.uppercaseString;
+    label.font = [UIFont preferredFontForTextStyle:UIFontTextStyleFootnote];
+    label.textColor = [UIColor secondaryLabelColor];
+    label.numberOfLines = 0;
+    [container addSubview:label];
+    [NSLayoutConstraint activateConstraints:@[
+        [label.leadingAnchor constraintEqualToAnchor:container.leadingAnchor constant:20.0],
+        [label.trailingAnchor constraintLessThanOrEqualToAnchor:container.trailingAnchor constant:-20.0],
+        [label.topAnchor constraintEqualToAnchor:container.topAnchor constant:18.0],
+        [label.bottomAnchor constraintEqualToAnchor:container.bottomAnchor constant:-6.0],
+    ]];
+    return container;
+}
+
+static UIView *ApolloPFSectionFooterView(NSString *text) {
+    UIView *container = [[UIView alloc] init];
+    UILabel *label = [[UILabel alloc] init];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.text = text;
+    label.font = [UIFont preferredFontForTextStyle:UIFontTextStyleFootnote];
+    label.textColor = [UIColor secondaryLabelColor];
+    label.numberOfLines = 0;
+    [container addSubview:label];
+    [NSLayoutConstraint activateConstraints:@[
+        [label.leadingAnchor constraintEqualToAnchor:container.leadingAnchor constant:20.0],
+        [label.trailingAnchor constraintEqualToAnchor:container.trailingAnchor constant:-20.0],
+        [label.topAnchor constraintEqualToAnchor:container.topAnchor constant:6.0],
+        [label.bottomAnchor constraintEqualToAnchor:container.bottomAnchor constant:-6.0],
+    ]];
+    return container;
+}
+
+#pragma mark - Hook
+
+%hook _TtC6Apollo29SettingsFiltersViewController
+
+// origCount: our numberOfSectionsInTableView: returns native + kApolloPFExtraSections,
+// so subtracting it back yields the native count without needing %orig outside the
+// numberOfSections hook.
+%new
+- (NSInteger)apollo_pfNativeSectionCount:(UITableView *)tableView {
+    return [self numberOfSectionsInTableView:tableView] - kApolloPFExtraSections;
+}
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return %orig + kApolloPFExtraSections;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    NSInteger native = [self apollo_pfNativeSectionCount:tableView];
+    if (section < native) return %orig;
+    if (section == native) return (NSInteger)[ApolloPostFilterStore allSubreddits].count + 1; // + Add
+    return (NSInteger)[ApolloPostFilterStore nameSubstrings].count + 1;                        // + Add
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSInteger native = [self apollo_pfNativeSectionCount:tableView];
+    if (indexPath.section < native) return %orig;
+
+    BOOL isSubSection = (indexPath.section == native);
+    NSArray<NSString *> *items = isSubSection ? [ApolloPostFilterStore allSubreddits]
+                                              : [ApolloPostFilterStore nameSubstrings];
+    BOOL isAddRow = ((NSUInteger)indexPath.row >= items.count);
+
+    // Borrow a native cell (the "Add" row of section 0) so we inherit Apollo's
+    // exact theme — background, fonts, and the accent text color used for Add rows.
+    NSInteger nativeRows0 = [self tableView:tableView numberOfRowsInSection:0];
+    NSIndexPath *borrow = [NSIndexPath indexPathForRow:MAX((NSInteger)0, nativeRows0 - 1) inSection:0];
+    UITableViewCell *cell = %orig(tableView, borrow);
+    cell.imageView.image = nil;
+    cell.accessoryView = nil;
+
+    if (isAddRow) {
+        cell.textLabel.text = isSubSection ? @"Add Subreddit..." : @"Add Word...";
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+        // Keep the borrowed accent text color (this IS a native Add cell).
+    } else {
+        NSString *item = items[indexPath.row];
+        cell.textLabel.textColor = [UIColor labelColor]; // override accent → normal item text
+        if (isSubSection) {
+            cell.textLabel.text = [NSString stringWithFormat:@"r/%@", item];
+            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+            cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+        } else {
+            cell.textLabel.text = item;
+            cell.accessoryType = UITableViewCellAccessoryNone;
+            cell.selectionStyle = UITableViewCellSelectionStyleNone;
+        }
+    }
+    return cell;
+}
+
+- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {
+    NSInteger native = [self apollo_pfNativeSectionCount:tableView];
+    if (section < native) return %orig;
+    NSString *title = (section == native) ? @"Subreddit-Specific Filters" : @"Filter Subreddits by Name";
+    return ApolloPFSectionHeaderView(title);
+}
+
+- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section {
+    NSInteger native = [self apollo_pfNativeSectionCount:tableView];
+    if (section < native) return %orig;
+    NSString *text = (section == native)
+        ? @"Hide posts in a specific subreddit by title keyword or post flair. Tap a subreddit to configure. Applies on this device."
+        : @"Hide any subreddit whose name contains one of these words, in feeds and in search (e.g. 'circlejerk' hides r/carscirclejerk). Applies on this device.";
+    return ApolloPFSectionFooterView(text);
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSInteger native = [self apollo_pfNativeSectionCount:tableView];
+    if (indexPath.section < native) { %orig; return; }
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+
+    if (indexPath.section == native) {
+        NSArray<NSString *> *subs = [ApolloPostFilterStore allSubreddits];
+        if ((NSUInteger)indexPath.row < subs.count) {
+            [self apollo_pfOpenDetailForSubreddit:subs[indexPath.row] fromTable:tableView];
+        } else {
+            [self apollo_pfPromptAddSubredditFromTable:tableView];
+        }
+    } else {
+        NSArray<NSString *> *names = [ApolloPostFilterStore nameSubstrings];
+        if ((NSUInteger)indexPath.row >= names.count) {
+            [self apollo_pfPromptAddNameFromTable:tableView];
+        }
+        // Existing name rows: no detail; remove via swipe / Edit.
+    }
+}
+
+- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSInteger native = [self apollo_pfNativeSectionCount:tableView];
+    if (indexPath.section < native) return %orig;
+    NSArray<NSString *> *items = (indexPath.section == native) ? [ApolloPostFilterStore allSubreddits]
+                                                              : [ApolloPostFilterStore nameSubstrings];
+    return (NSUInteger)indexPath.row < items.count; // item rows deletable; Add row not
+}
+
+- (BOOL)tableView:(UITableView *)tableView canMoveRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSInteger native = [self apollo_pfNativeSectionCount:tableView];
+    if (indexPath.section < native) return %orig;
+    return NO;
+}
+
+- (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSInteger native = [self apollo_pfNativeSectionCount:tableView];
+    if (indexPath.section < native) { %orig; return; }
+    if (editingStyle != UITableViewCellEditingStyleDelete) return;
+    BOOL isSubSection = (indexPath.section == native);
+    NSArray<NSString *> *items = isSubSection ? [ApolloPostFilterStore allSubreddits]
+                                              : [ApolloPostFilterStore nameSubstrings];
+    if ((NSUInteger)indexPath.row >= items.count) return;
+    NSString *item = items[indexPath.row];
+    if (isSubSection) [ApolloPostFilterStore removeSubreddit:item];
+    else [ApolloPostFilterStore removeNameSubstring:item];
+    [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForDeleteConfirmationButtonForRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSInteger native = [self apollo_pfNativeSectionCount:tableView];
+    if (indexPath.section < native) return %orig;
+    return @"Delete";
+}
+
+#pragma mark - Added actions
+
+%new
+- (void)apollo_pfOpenDetailForSubreddit:(NSString *)sub fromTable:(UITableView *)tableView {
+    ApolloSubredditFilterDetailViewController *detail = [[ApolloSubredditFilterDetailViewController alloc] initWithSubreddit:sub];
+    __weak UITableView *weakTable = tableView;
+    detail.onChange = ^{ [weakTable reloadData]; };
+    UIViewController *selfVC = (UIViewController *)self;
+    if (selfVC.navigationController) {
+        [selfVC.navigationController pushViewController:detail animated:YES];
+    } else {
+        [selfVC presentViewController:[[UINavigationController alloc] initWithRootViewController:detail] animated:YES completion:nil];
+    }
+}
+
+%new
+- (void)apollo_pfPromptAddSubredditFromTable:(UITableView *)tableView {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Filter a Subreddit"
+                                                                  message:@"Enter the subreddit to configure (without r/). You'll then add keywords or flairs to hide in it."
+                                                           preferredStyle:UIAlertControllerStyleAlert];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField *tf) {
+        tf.placeholder = @"funny";
+        tf.autocapitalizationType = UITextAutocapitalizationTypeNone;
+        tf.autocorrectionType = UITextAutocorrectionTypeNo;
+    }];
+    __weak UIAlertController *weakAlert = alert;
+    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Add" style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) {
+        NSString *sub = [ApolloPostFilterStore normalizeSubreddit:weakAlert.textFields.firstObject.text];
+        if (sub.length == 0) return;
+        [ApolloPostFilterStore ensureSubreddit:sub];
+        [tableView reloadData];
+        [self apollo_pfOpenDetailForSubreddit:sub fromTable:tableView];
+    }]];
+    [(UIViewController *)self presentViewController:alert animated:YES completion:nil];
+}
+
+%new
+- (void)apollo_pfPromptAddNameFromTable:(UITableView *)tableView {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Filter Subreddits by Name"
+                                                                  message:@"Enter a word. Any subreddit whose name contains it is hidden from feeds and search (e.g. 'circlejerk' hides r/carscirclejerk)."
+                                                           preferredStyle:UIAlertControllerStyleAlert];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField *tf) {
+        tf.placeholder = @"circlejerk";
+        tf.autocapitalizationType = UITextAutocapitalizationTypeNone;
+        tf.autocorrectionType = UITextAutocorrectionTypeNo;
+    }];
+    __weak UIAlertController *weakAlert = alert;
+    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Add" style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) {
+        NSString *term = [ApolloPostFilterStore normalizeTerm:weakAlert.textFields.firstObject.text];
+        if (term.length == 0) return;
+        [ApolloPostFilterStore addNameSubstring:term];
+        [tableView reloadData];
+    }]];
+    [(UIViewController *)self presentViewController:alert animated:YES completion:nil];
+}
+
+%end
+
+%ctor {
+    %init(_TtC6Apollo29SettingsFiltersViewController = objc_getClass("_TtC6Apollo29SettingsFiltersViewController"));
+}

--- a/src/ApolloPostFilterStore.h
+++ b/src/ApolloPostFilterStore.h
@@ -1,0 +1,49 @@
+// ApolloPostFilterStore
+//
+// Single read/write surface for the Reborn "Post Filters" feature — the
+// device-wide content filters layered onto Apollo's native Filters & Blocks
+// screen. Bridges the persisted NSUserDefaults representation and the in-memory
+// ApolloState snapshots (sPostFilterSubreddits / sPostFilterNameSubstrings) that
+// the feed matcher reads off-main, and broadcasts ApolloPostFiltersChangedNotification
+// on every mutation so visible feeds refresh.
+//
+// Both the native-screen injection hook (ApolloPostFilters.xm) and the
+// per-subreddit detail VC mutate through here so the trim+lowercase normalization
+// stays identical on every write (and matches Tweak.xm's hydration on read).
+
+#import <Foundation/Foundation.h>
+
+extern NSString *const ApolloPostFiltersChangedNotification;
+
+@interface ApolloPostFilterStore : NSObject
+
+// Normalization — write side must match read side (Tweak.xm hydration AND the
+// feed matcher). Subreddit: trim, strip a leading r/ or /, lowercase. Term
+// (keyword): trim, lowercase. Flair: additionally strip ":emoji:" snoomoji tokens
+// and collapse interior whitespace, so a typed label matches the post's raw
+// linkFlairText (e.g. ":n_media: Media" → "media").
++ (NSString *)normalizeSubreddit:(NSString *)raw;
++ (NSString *)normalizeTerm:(NSString *)raw;
++ (NSString *)normalizeFlair:(NSString *)raw;
+
+// Per-subreddit rules ------------------------------------------------------
++ (NSArray<NSString *> *)allSubreddits;                     // lowercased, sorted
++ (NSArray<NSString *> *)keywordsForSubreddit:(NSString *)sub;
++ (NSArray<NSString *> *)flairsForSubreddit:(NSString *)sub;
++ (NSInteger)ruleCountForSubreddit:(NSString *)sub;         // keywords + flairs
++ (void)setKeywords:(NSArray<NSString *> *)keywords
+             flairs:(NSArray<NSString *> *)flairs
+       forSubreddit:(NSString *)sub;
++ (void)addKeyword:(NSString *)keyword forSubreddit:(NSString *)sub;
++ (void)removeKeyword:(NSString *)keyword forSubreddit:(NSString *)sub;
++ (void)addFlair:(NSString *)flair forSubreddit:(NSString *)sub;
++ (void)removeFlair:(NSString *)flair forSubreddit:(NSString *)sub;
++ (void)ensureSubreddit:(NSString *)sub;                    // create empty entry if absent
++ (void)removeSubreddit:(NSString *)sub;
+
+// Subreddit-name substrings ------------------------------------------------
++ (NSArray<NSString *> *)nameSubstrings;                    // lowercased, sorted
++ (void)addNameSubstring:(NSString *)term;
++ (void)removeNameSubstring:(NSString *)term;
+
+@end

--- a/src/ApolloPostFilterStore.m
+++ b/src/ApolloPostFilterStore.m
@@ -1,0 +1,202 @@
+#import "ApolloPostFilterStore.h"
+
+#import "ApolloState.h"
+#import "UserDefaultConstants.h"
+
+NSString *const ApolloPostFiltersChangedNotification = @"ApolloPostFiltersChangedNotification";
+
+@implementation ApolloPostFilterStore
+
+#pragma mark - Normalization
+
++ (NSString *)normalizeTerm:(NSString *)raw {
+    if (![raw isKindOfClass:[NSString class]]) return @"";
+    return [raw stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].lowercaseString;
+}
+
++ (NSString *)normalizeSubreddit:(NSString *)raw {
+    if (![raw isKindOfClass:[NSString class]]) return @"";
+    NSString *s = [raw stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if ([s hasPrefix:@"r/"] || [s hasPrefix:@"R/"]) s = [s substringFromIndex:2];
+    if ([s hasPrefix:@"/"]) s = [s substringFromIndex:1];
+    return s.lowercaseString;
+}
+
+// Strip ":emoji:" snoomoji tokens (e.g. ":n_media:") and collapse interior runs of
+// whitespace, then trim + lowercase. Used on BOTH the typed-filter side and the
+// post's raw linkFlairText so an exact match lines up regardless of flair emoji.
++ (NSString *)normalizeFlair:(NSString *)raw {
+    if (![raw isKindOfClass:[NSString class]] || raw.length == 0) return @"";
+    static NSRegularExpression *re = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        re = [NSRegularExpression regularExpressionWithPattern:@":[^:\\s]+:" options:0 error:NULL];
+    });
+    NSString *out = re ? [re stringByReplacingMatchesInString:raw options:0 range:NSMakeRange(0, raw.length) withTemplate:@""] : raw;
+    NSArray<NSString *> *parts = [out componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    NSMutableArray<NSString *> *kept = [NSMutableArray array];
+    for (NSString *p in parts) if (p.length) [kept addObject:p];
+    return [[kept componentsJoinedByString:@" "] lowercaseString];
+}
+
+#pragma mark - Persistence helpers
+
+// Update the in-memory snapshot (read by the feed matcher), persist, and
+// broadcast. The snapshot is always swapped as an immutable [copy] so off-main
+// readers see a consistent container.
++ (void)persistSubreddits:(NSDictionary<NSString *, NSDictionary *> *)dict {
+    sPostFilterSubreddits = [dict copy] ?: @{};
+    [[NSUserDefaults standardUserDefaults] setObject:sPostFilterSubreddits forKey:UDKeyPostFilterSubreddits];
+    [self broadcast];
+}
+
++ (void)persistNameSubstrings:(NSArray<NSString *> *)list {
+    sPostFilterNameSubstrings = [list copy] ?: @[];
+    [[NSUserDefaults standardUserDefaults] setObject:sPostFilterNameSubstrings forKey:UDKeyPostFilterNameSubstrings];
+    [self broadcast];
+}
+
++ (void)broadcast {
+    if ([NSThread isMainThread]) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:ApolloPostFiltersChangedNotification object:nil];
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:ApolloPostFiltersChangedNotification object:nil];
+        });
+    }
+}
+
+// Sanitize an arbitrary array into a deduped list of normalized terms. Flairs use
+// the flair normalizer (emoji-strip + whitespace-collapse); keywords use the plain
+// term normalizer.
++ (NSArray<NSString *> *)cleanArray:(NSArray *)arr flairs:(BOOL)flairs {
+    NSMutableArray<NSString *> *out = [NSMutableArray array];
+    if ([arr isKindOfClass:[NSArray class]]) {
+        for (id t in arr) {
+            NSString *s = flairs ? [self normalizeFlair:t] : [self normalizeTerm:t];
+            if (s.length > 0 && ![out containsObject:s]) [out addObject:s];
+        }
+    }
+    return [out copy];
+}
+
+#pragma mark - Per-subreddit rules
+
++ (NSArray<NSString *> *)allSubreddits {
+    NSDictionary *all = sPostFilterSubreddits ?: @{};
+    return [[all allKeys] sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
+}
+
++ (NSDictionary *)rulesForSubreddit:(NSString *)sub {
+    NSString *key = [self normalizeSubreddit:sub];
+    NSDictionary *o = (key.length > 0) ? (sPostFilterSubreddits ?: @{})[key] : nil;
+    return [o isKindOfClass:[NSDictionary class]] ? o : @{};
+}
+
++ (NSArray<NSString *> *)keywordsForSubreddit:(NSString *)sub {
+    id kw = [self rulesForSubreddit:sub][@"keywords"];
+    return [kw isKindOfClass:[NSArray class]] ? (NSArray *)kw : @[];
+}
+
++ (NSArray<NSString *> *)flairsForSubreddit:(NSString *)sub {
+    id fl = [self rulesForSubreddit:sub][@"flairs"];
+    return [fl isKindOfClass:[NSArray class]] ? (NSArray *)fl : @[];
+}
+
++ (NSInteger)ruleCountForSubreddit:(NSString *)sub {
+    return (NSInteger)[self keywordsForSubreddit:sub].count + (NSInteger)[self flairsForSubreddit:sub].count;
+}
+
++ (void)setKeywords:(NSArray<NSString *> *)keywords
+             flairs:(NSArray<NSString *> *)flairs
+       forSubreddit:(NSString *)sub {
+    NSString *key = [self normalizeSubreddit:sub];
+    if (key.length == 0) return;
+    NSMutableDictionary *all = [(sPostFilterSubreddits ?: @{}) mutableCopy];
+    NSMutableDictionary *rules = [NSMutableDictionary dictionary];
+    NSArray<NSString *> *kw = [self cleanArray:keywords flairs:NO];
+    NSArray<NSString *> *fl = [self cleanArray:flairs flairs:YES];
+    if (kw.count > 0) rules[@"keywords"] = kw;
+    if (fl.count > 0) rules[@"flairs"] = fl;
+    all[key] = [rules copy]; // keep the entry even when empty (until explicitly removed)
+    [self persistSubreddits:all];
+}
+
++ (void)addKeyword:(NSString *)keyword forSubreddit:(NSString *)sub {
+    NSString *t = [self normalizeTerm:keyword];
+    if (t.length == 0) return;
+    NSArray<NSString *> *kw = [self keywordsForSubreddit:sub];
+    if ([kw containsObject:t]) return;
+    [self setKeywords:[kw arrayByAddingObject:t] flairs:[self flairsForSubreddit:sub] forSubreddit:sub];
+}
+
++ (void)removeKeyword:(NSString *)keyword forSubreddit:(NSString *)sub {
+    NSString *t = [self normalizeTerm:keyword];
+    if (t.length == 0) return;
+    NSMutableArray<NSString *> *kw = [[self keywordsForSubreddit:sub] mutableCopy];
+    if (![kw containsObject:t]) return;
+    [kw removeObject:t];
+    [self setKeywords:kw flairs:[self flairsForSubreddit:sub] forSubreddit:sub];
+}
+
++ (void)addFlair:(NSString *)flair forSubreddit:(NSString *)sub {
+    NSString *t = [self normalizeFlair:flair];
+    if (t.length == 0) return;
+    NSArray<NSString *> *fl = [self flairsForSubreddit:sub];
+    if ([fl containsObject:t]) return;
+    [self setKeywords:[self keywordsForSubreddit:sub] flairs:[fl arrayByAddingObject:t] forSubreddit:sub];
+}
+
++ (void)removeFlair:(NSString *)flair forSubreddit:(NSString *)sub {
+    NSString *t = [self normalizeFlair:flair];
+    if (t.length == 0) return;
+    NSMutableArray<NSString *> *fl = [[self flairsForSubreddit:sub] mutableCopy];
+    if (![fl containsObject:t]) return;
+    [fl removeObject:t];
+    [self setKeywords:[self keywordsForSubreddit:sub] flairs:fl forSubreddit:sub];
+}
+
++ (void)ensureSubreddit:(NSString *)sub {
+    NSString *key = [self normalizeSubreddit:sub];
+    if (key.length == 0) return;
+    if ((sPostFilterSubreddits ?: @{})[key]) return;
+    NSMutableDictionary *all = [(sPostFilterSubreddits ?: @{}) mutableCopy];
+    all[key] = @{};
+    [self persistSubreddits:all];
+}
+
++ (void)removeSubreddit:(NSString *)sub {
+    NSString *key = [self normalizeSubreddit:sub];
+    if (key.length == 0) return;
+    if (!(sPostFilterSubreddits ?: @{})[key]) return;
+    NSMutableDictionary *all = [(sPostFilterSubreddits ?: @{}) mutableCopy];
+    [all removeObjectForKey:key];
+    [self persistSubreddits:all];
+}
+
+#pragma mark - Name substrings
+
++ (NSArray<NSString *> *)nameSubstrings {
+    NSArray *all = sPostFilterNameSubstrings ?: @[];
+    return [all sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
+}
+
++ (void)addNameSubstring:(NSString *)term {
+    NSString *t = [self normalizeTerm:term];
+    if (t.length == 0) return;
+    NSArray *current = sPostFilterNameSubstrings ?: @[];
+    if ([current containsObject:t]) return;
+    [self persistNameSubstrings:[current arrayByAddingObject:t]];
+}
+
++ (void)removeNameSubstring:(NSString *)term {
+    NSString *t = [self normalizeTerm:term];
+    if (t.length == 0) return;
+    NSArray *current = sPostFilterNameSubstrings ?: @[];
+    if (![current containsObject:t]) return;
+    NSMutableArray *m = [current mutableCopy];
+    [m removeObject:t];
+    [self persistNameSubstrings:m];
+}
+
+@end

--- a/src/ApolloPostFilters.xm
+++ b/src/ApolloPostFilters.xm
@@ -1,0 +1,573 @@
+// ApolloPostFilters
+//
+// Reborn "Post Filters" — device-wide content filters that beef out Apollo's
+// native Filters & Blocks screen. Three filter kinds (all configured on the
+// native screen via ApolloFiltersBlocksInject.xm):
+//
+//   1. Per-subreddit KEYWORDS — hide posts in r/<sub> whose title/link contains
+//      any configured word.
+//   2. Per-subreddit FLAIRS — hide posts in r/<sub> whose flair label matches.
+//   3. Subreddit-NAME substrings — hide any post whose subreddit name contains a
+//      configured word (e.g. "circlejerk" hides r/carscirclejerk). The same names
+//      are also filtered out of the search screen's subreddit suggestions (see the
+//      _TtC6Apollo20SearchViewController hook below).
+//
+// Matching keys on the POST's own `link.subreddit`, so per-sub rules apply
+// wherever that sub's posts appear (Home / All / the sub itself), mirroring how
+// Apollo's native subreddit filters behave.
+//
+// Enforcement reuses the Community Highlights hide mechanism: hook the post cell
+// nodes' -layoutSpecThatFits: and return a zero-size ASStackLayoutSpec to collapse
+// the row to 0pt (keeps Apollo's `links` array + pagination intact — no IGListKit
+// desync), and collapse the trailing ThickSeparatorCellNode so hidden posts don't
+// leave stacked 8pt breaker gaps.
+//
+// Threading: the matcher reads the immutable ApolloState snapshots
+// (sPostFilterSubreddits / sPostFilterNameSubstrings) off-main during Texture
+// layout. Writes always swap in a fresh [copy] (see ApolloPostFilterStore), so a
+// reader either sees the old or the new immutable container — never a mutating one.
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+#import "ApolloPostFilterStore.h"
+#import "Tweak.h"
+#import "UserDefaultConstants.h"
+
+// RDKLink fields not declared on the shared interface in Tweak.h.
+@interface RDKLink (ApolloPostFilters)
+@property (copy, nonatomic) NSString *linkFlairText;
+@property (retain, nonatomic) RDKLink *crosspostParent;
+@end
+
+// ASSizeRange ABI: { CGSize min; CGSize max; } — matches the arg of
+// -layoutSpecThatFits: / -calculateLayoutThatFits:.
+struct ApolloPFSizeRange { CGSize min; CGSize max; };
+
+// Dummy interface so the ASStackLayoutSpec factory selector is known to the
+// compiler (the real class is resolved at runtime via objc_getClass).
+@interface ApolloPFStackSpec : NSObject
++ (instancetype)stackLayoutSpecWithDirection:(NSInteger)direction
+                                     spacing:(CGFloat)spacing
+                              justifyContent:(NSUInteger)justifyContent
+                                  alignItems:(NSUInteger)alignItems
+                                    children:(NSArray *)children;
+@end
+
+#pragma mark - Matcher
+
+static BOOL ApolloPFContainsAnyTerm(NSString *haystackLower, NSArray<NSString *> *needlesLower) {
+    if (haystackLower.length == 0 || needlesLower.count == 0) return NO;
+    for (NSString *n in needlesLower) {
+        if (n.length == 0) continue;
+        if ([haystackLower rangeOfString:n].location != NSNotFound) return YES;
+    }
+    return NO;
+}
+
+// YES if a subreddit name contains any configured name-substring (the same test
+// used for feed posts and search suggestions). Case-insensitive.
+static BOOL ApolloPFSubredditNameBlocked(NSString *name) {
+    if (![name isKindOfClass:[NSString class]]) return NO;
+    NSArray<NSString *> *names = sPostFilterNameSubstrings;
+    if (names.count == 0) return NO;
+    NSString *lower = name.lowercaseString;
+    for (NSString *frag in names) {
+        if (frag.length > 0 && [lower rangeOfString:frag].location != NSNotFound) return YES;
+    }
+    return NO;
+}
+
+// The post's visible flair label, normalized via the SAME transform the store
+// applies to typed flair filters (ApolloPostFilterStore normalizeFlair: — strips
+// ":emoji:" snoomoji tokens, collapses whitespace, trims, lowercases) so an exact
+// match lines up. Reddit post flairs frequently embed emoji tokens in the raw
+// linkFlairText (e.g. r/soccer's ":n_media: Media"); only the trailing words
+// render as the visible label. Falls back to linkFlairRichText text segments when
+// linkFlairText is empty.
+static NSString *ApolloPFNormalizedFlairLabel(id linkObj) {
+    NSString *flair = nil;
+    @try { flair = ((RDKLink *)linkObj).linkFlairText; } @catch (__unused id e) {}
+    if (![flair isKindOfClass:[NSString class]] || flair.length == 0) {
+        @try {
+            id rich = [(NSObject *)linkObj valueForKey:@"linkFlairRichText"];
+            if ([rich isKindOfClass:[NSArray class]]) {
+                NSMutableString *acc = [NSMutableString string];
+                for (id seg in (NSArray *)rich) {
+                    if ([seg isKindOfClass:[NSDictionary class]]) {
+                        id t = ((NSDictionary *)seg)[@"t"];
+                        if ([t isKindOfClass:[NSString class]]) [acc appendString:(NSString *)t];
+                    }
+                }
+                flair = acc;
+            }
+        } @catch (__unused id e) {}
+    }
+    return [ApolloPostFilterStore normalizeFlair:flair];
+}
+
+// Tests a single link object (top-level post or a crosspost parent) against the
+// configured rules. Returns YES if it should be hidden.
+static BOOL ApolloPFLinkMatchesRules(id linkObj) {
+    Class linkCls = objc_getClass("RDKLink");
+    if (!linkCls || ![linkObj isKindOfClass:linkCls]) return NO;
+    RDKLink *link = (RDKLink *)linkObj;
+
+    NSString *sub = nil;
+    @try { sub = link.subreddit; } @catch (__unused id e) {}
+    if (![sub isKindOfClass:[NSString class]] || sub.length == 0) return NO;
+    NSString *subKey = sub.lowercaseString;
+
+    // 1) Subreddit-name substring match (applies to any subreddit).
+    if (ApolloPFSubredditNameBlocked(subKey)) return YES;
+
+    // 2) Per-subreddit keyword / flair rules.
+    NSDictionary *rules = sPostFilterSubreddits[subKey];
+    if (![rules isKindOfClass:[NSDictionary class]]) return NO;
+
+    NSArray<NSString *> *keywords = rules[@"keywords"];
+    if ([keywords isKindOfClass:[NSArray class]] && keywords.count > 0) {
+        NSString *title = nil; @try { title = link.title; } @catch (__unused id e) {}
+        NSString *titleLower = [title isKindOfClass:[NSString class]] ? title.lowercaseString : @"";
+        if (ApolloPFContainsAnyTerm(titleLower, keywords)) return YES;
+        // Also test the link URL, mirroring Apollo's native "title, link, or flair".
+        NSString *urlLower = @"";
+        @try {
+            NSURL *u = link.URL;
+            if ([u isKindOfClass:[NSURL class]]) urlLower = u.absoluteString.lowercaseString ?: @"";
+        } @catch (__unused id e) {}
+        if (ApolloPFContainsAnyTerm(urlLower, keywords)) return YES;
+    }
+
+    NSArray<NSString *> *flairs = rules[@"flairs"];
+    if ([flairs isKindOfClass:[NSArray class]] && flairs.count > 0) {
+        NSString *flairLower = ApolloPFNormalizedFlairLabel(link);
+        if (flairLower.length > 0) {
+            for (NSString *f in flairs) {
+                if (f.length > 0 && [f isEqualToString:flairLower]) return YES; // exact (visible) label match
+            }
+        }
+    }
+    return NO;
+}
+
+static BOOL ApolloPFShouldHideLink(id link) {
+    if (!link) return NO;
+    // Fast out: nothing configured (the common case).
+    if (sPostFilterSubreddits.count == 0 && sPostFilterNameSubstrings.count == 0) return NO;
+    if (ApolloPFLinkMatchesRules(link)) return YES;
+    // Crosspost: also test the original post so a crosspost FROM a filtered sub
+    // (or carrying the parent's title/flair) is filtered too.
+    @try {
+        RDKLink *parent = ((RDKLink *)link).crosspostParent;
+        if (parent && ApolloPFLinkMatchesRules(parent)) return YES;
+    } @catch (__unused id e) {}
+    return NO;
+}
+
+#pragma mark - Cell / node helpers
+
+static id ApolloPFIvarValueByName(id obj, const char *name) {
+    if (!obj || !name) return nil;
+    Class cls = object_getClass(obj);
+    while (cls) {
+        Ivar ivar = class_getInstanceVariable(cls, name);
+        if (ivar) return object_getIvar(obj, ivar);
+        cls = class_getSuperclass(cls);
+    }
+    return nil;
+}
+
+static BOOL ApolloPFCellShouldHide(id cell) {
+    id link = ApolloPFIvarValueByName(cell, "link");
+    return ApolloPFShouldHideLink(link);
+}
+
+// Zero-size layout spec used to collapse a hidden cell.
+static id ApolloPFEmptySpec(void) {
+    Class stackClass = objc_getClass("ASStackLayoutSpec");
+    if (!stackClass) return nil;
+    return [stackClass stackLayoutSpecWithDirection:0 spacing:0 justifyContent:0 alignItems:0 children:@[]];
+}
+
+// Zero a node's fixed style heights so an empty spec actually collapses it (the
+// ThickSeparator bakes in an 8pt height). ASDimension = { NSInteger unit; CGFloat value }.
+static void ApolloPFZeroNodeHeight(id node) {
+    id style = [node respondsToSelector:@selector(style)] ? ((id (*)(id, SEL))objc_msgSend)(node, @selector(style)) : nil;
+    if (!style) return;
+    typedef struct { NSInteger unit; CGFloat value; } ApolloPFDim;
+    ApolloPFDim zero = {1, 0.0}; // {ASDimensionUnitPoints, 0}
+    if ([style respondsToSelector:@selector(setHeight:)])    ((void (*)(id, SEL, ApolloPFDim))objc_msgSend)(style, @selector(setHeight:), zero);
+    if ([style respondsToSelector:@selector(setMinHeight:)]) ((void (*)(id, SEL, ApolloPFDim))objc_msgSend)(style, @selector(setMinHeight:), zero);
+    if ([style respondsToSelector:@selector(setMaxHeight:)]) ((void (*)(id, SEL, ApolloPFDim))objc_msgSend)(style, @selector(setMaxHeight:), zero);
+}
+
+#pragma mark - Trailing-separator collapse
+//
+// Each post cell is followed by a ThickSeparatorCellNode. When we collapse a
+// post to 0pt its separator stays (8pt), so a run of hidden posts would stack
+// breaker gaps. We record each post's hide decision per owning table node (keyed
+// by row), and the separator at row r collapses when the post at row r-1 is
+// hidden. Records are updated both ways on every post layout so a row that stops
+// being hidden (after a data reload) clears correctly.
+
+static char kApolloPFHiddenRowsKey;
+// Set on a table node when a post's hidden state actually changes, so a deferred
+// main-thread pass can reconcile a trailing separator that measured before the post
+// recorded its hidden row (Texture measures nodes concurrently, so order isn't
+// guaranteed). Cleared by the reconcile pass.
+static char kApolloPFSepDirtyKey;
+
+static id ApolloPFOwningTableNode(id cellNode) {
+    return [cellNode respondsToSelector:@selector(owningNode)] ? ((id (*)(id, SEL))objc_msgSend)(cellNode, @selector(owningNode)) : nil;
+}
+static NSInteger ApolloPFNodeRow(id cellNode) {
+    if (![cellNode respondsToSelector:@selector(indexPath)]) return -1;
+    NSIndexPath *ip = ((NSIndexPath *(*)(id, SEL))objc_msgSend)(cellNode, @selector(indexPath));
+    return ip ? ip.row : -1;
+}
+// Caller holds @synchronized(owningTable). The set is associated with the stable
+// owning table node and only mutated/emptied (never niled), so it can't be freed
+// while an off-main layout reads it.
+static NSMutableSet *ApolloPFHiddenRowsSet(id owningTable, BOOL create) {
+    if (!owningTable) return nil;
+    NSMutableSet *set = objc_getAssociatedObject(owningTable, &kApolloPFHiddenRowsKey);
+    if (!set && create) {
+        set = [NSMutableSet set];
+        objc_setAssociatedObject(owningTable, &kApolloPFHiddenRowsKey, set, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    return set;
+}
+static void ApolloPFUpdateHiddenRow(id postNode, BOOL hidden) {
+    id owning = ApolloPFOwningTableNode(postNode);
+    NSInteger row = ApolloPFNodeRow(postNode);
+    if (!owning || row < 0) return;
+    BOOL changed = NO;
+    @synchronized(owning) {
+        NSMutableSet *set = ApolloPFHiddenRowsSet(owning, YES);
+        BOOL had = [set containsObject:@(row)];
+        if (hidden && !had) { [set addObject:@(row)]; changed = YES; }
+        else if (!hidden && had) { [set removeObject:@(row)]; changed = YES; }
+    }
+    // Flag for separator reconciliation only when the row's state actually flipped,
+    // so the deferred pass runs at most once per real change (not every layout).
+    if (changed) objc_setAssociatedObject(owning, &kApolloPFSepDirtyKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+static BOOL ApolloPFSeparatorShouldCollapse(id sepNode) {
+    if (sPostFilterSubreddits.count == 0 && sPostFilterNameSubstrings.count == 0) return NO;
+    NSInteger r = ApolloPFNodeRow(sepNode);
+    if (r < 1) return NO;
+    id owning = ApolloPFOwningTableNode(sepNode);
+    if (!owning) return NO;
+    @synchronized(owning) {
+        NSMutableSet *set = ApolloPFHiddenRowsSet(owning, NO);
+        return [set containsObject:@(r - 1)];
+    }
+}
+
+#pragma mark - Live refresh
+
+// Re-measure visible feeds after a settings change so the new rules take effect
+// without requiring a scroll. relayoutItems on the ASTableNode forces a fresh
+// layoutSpecThatFits: pass; reloadData on the table view is a belt-and-suspenders
+// fallback for any plain UITableView.
+static void ApolloPFReloadTableNode(id tableNode); // defined below
+
+static void ApolloPFRefreshVisibleFeeds(void) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        void (^__block walk)(UIView *) = nil;
+        void (^localWalk)(UIView *) = ^(UIView *root) {
+            if ([root isKindOfClass:[UITableView class]]) {
+                UITableView *tv = (UITableView *)root;
+                id node = nil;
+                if ([tv respondsToSelector:@selector(tableNode)]) {
+                    @try { node = ((id (*)(id, SEL))objc_msgSend)(tv, @selector(tableNode)); } @catch (__unused id e) {}
+                }
+                if (node) ApolloPFReloadTableNode(node);   // Texture feed: re-measure cells
+                else @try { [tv reloadData]; } @catch (__unused id e) {} // plain UITableView fallback
+            }
+            for (UIView *sub in root.subviews) walk(sub);
+        };
+        walk = localWalk;
+        // Union UIApplication.windows with the active scenes' windows — on iOS 26 a
+        // scene app's visible window can be absent from UIApplication.windows, so the
+        // immediate refresh would otherwise miss the currently-visible feed.
+        NSMutableArray<UIWindow *> *windows = [NSMutableArray array];
+        @try { for (UIWindow *w in [UIApplication sharedApplication].windows) if (w) [windows addObject:w]; } @catch (__unused id e) {}
+        @try {
+            for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+                if (![scene isKindOfClass:[UIWindowScene class]]) continue;
+                for (UIWindow *w in ((UIWindowScene *)scene).windows) {
+                    if (w && ![windows containsObject:w]) [windows addObject:w];
+                }
+            }
+        } @catch (__unused id e) {}
+        for (UIWindow *window in windows) walk(window);
+        walk = nil;
+    });
+}
+
+// Cross-tab live apply. A generation counter is bumped on every filter change.
+// A feed that last laid out under an older generation re-measures on its next
+// appearance — so adding a filter in Settings takes effect when you return to the
+// feed tab, even though Texture caches layouts and a plain tab switch would
+// otherwise keep stale cells. (The currently-visible feed is handled directly by
+// ApolloPFRefreshVisibleFeeds above.)
+static int sApolloPFGeneration = 0;
+static const void *kApolloPFAppliedGenKey = &kApolloPFAppliedGenKey;
+
+// Force a full re-measure of an ASTableNode's cells. reloadData re-runs every
+// cell's layoutSpecThatFits: (where the matcher decides to collapse), which
+// relayoutItems alone does not for already-measured/cached nodes. This is the
+// reliable way to apply a filter change to an existing feed.
+static void ApolloPFReloadTableNode(id tableNode) {
+    if (tableNode && [tableNode respondsToSelector:@selector(reloadData)]) {
+        @try { ((void (*)(id, SEL))objc_msgSend)(tableNode, @selector(reloadData)); } @catch (__unused id e) {}
+    }
+}
+
+static void ApolloPFReloadTableNodeOfVC(id vc) {
+    ApolloPFReloadTableNode(ApolloPFIvarValueByName(vc, "tableNode"));
+}
+
+#pragma mark - Separator reconciliation
+
+// YES if any visible ThickSeparatorCellNode is still full-height even though its
+// preceding row is hidden — i.e. the separator measured before the post recorded
+// its hidden row and kept its 8pt height (the race). Main thread only.
+static BOOL ApolloPFTableHasOrphanSeparator(id tableNode, UITableView *tv) {
+    NSSet *hidden = nil;
+    @synchronized(tableNode) {
+        NSMutableSet *s = ApolloPFHiddenRowsSet(tableNode, NO);
+        hidden = s ? [s copy] : nil;
+    }
+    if (hidden.count == 0) return NO;
+    for (UITableViewCell *cell in tv.visibleCells) {
+        id node = [cell respondsToSelector:@selector(node)] ? ((id (*)(id, SEL))objc_msgSend)(cell, @selector(node)) : nil;
+        if (!node || ![NSStringFromClass([node class]) isEqualToString:@"Apollo.ThickSeparatorCellNode"]) continue;
+        NSIndexPath *ip = [tv indexPathForCell:cell];
+        if (!ip || ip.row < 1) continue;
+        if (![hidden containsObject:@(ip.row - 1)]) continue;
+        if (cell.bounds.size.height > 0.5) return YES; // should be collapsed but isn't
+    }
+    return NO;
+}
+
+// Deferred, idempotent: after a hidden-state change, re-measure the table ONCE — but
+// only if an orphan separator actually exists. In the common (no-race) case nothing
+// is re-measured, so there is no scroll jank; only when the race actually bit do we
+// pay a single relayoutItems to collapse the stray 8pt gap.
+static void ApolloPFReconcileSeparators(id vc) {
+    if (sPostFilterSubreddits.count == 0 && sPostFilterNameSubstrings.count == 0) return;
+    id tableNode = ApolloPFIvarValueByName(vc, "tableNode");
+    if (!tableNode) return;
+    if (![objc_getAssociatedObject(tableNode, &kApolloPFSepDirtyKey) boolValue]) return;
+    UITableView *tv = nil;
+    @try { if ([tableNode respondsToSelector:@selector(view)]) tv = (UITableView *)((id (*)(id, SEL))objc_msgSend)(tableNode, @selector(view)); } @catch (__unused id e) {}
+    if (![tv isKindOfClass:[UITableView class]]) return;
+    // Clear first; any further transition will re-set it and re-trigger us.
+    objc_setAssociatedObject(tableNode, &kApolloPFSepDirtyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (ApolloPFTableHasOrphanSeparator(tableNode, tv)) {
+        @try { if ([tableNode respondsToSelector:@selector(relayoutItems)]) ((void (*)(id, SEL))objc_msgSend)(tableNode, @selector(relayoutItems)); } @catch (__unused id e) {}
+    }
+}
+
+#pragma mark - Cell hooks
+
+%hook _TtC6Apollo17LargePostCellNode
+- (id)layoutSpecThatFits:(struct ApolloPFSizeRange)constrainedSize {
+    BOOL hide = ApolloPFCellShouldHide(self);
+    ApolloPFUpdateHiddenRow(self, hide);
+    if (hide) {
+        id empty = ApolloPFEmptySpec();
+        if (empty) return empty;
+    }
+    return %orig;
+}
+%end
+
+%hook _TtC6Apollo19CompactPostCellNode
+- (id)layoutSpecThatFits:(struct ApolloPFSizeRange)constrainedSize {
+    BOOL hide = ApolloPFCellShouldHide(self);
+    ApolloPFUpdateHiddenRow(self, hide);
+    if (hide) {
+        id empty = ApolloPFEmptySpec();
+        if (empty) return empty;
+    }
+    return %orig;
+}
+%end
+
+// Collapse the separator trailing a hidden post. calculateLayoutThatFits: is
+// where ThickSeparatorCellNode bakes its 8pt height, so override the measured
+// size there; layoutSpecThatFits: is a backup. (Composes with Community
+// Highlights' hooks on the same class — both call %orig, and either wanting to
+// collapse wins.)
+%hook _TtC6Apollo22ThickSeparatorCellNode
+- (id)calculateLayoutThatFits:(struct ApolloPFSizeRange)constrainedSize {
+    if (!ApolloPFSeparatorShouldCollapse(self)) return %orig;
+    ApolloPFZeroNodeHeight(self);
+    id layout = %orig;
+    if (layout) {
+        CGSize s = ((CGSize (*)(id, SEL))objc_msgSend)(layout, @selector(size));
+        if (s.height > 0.0) {
+            Class ASLayoutCls = objc_getClass("ASLayout");
+            if (ASLayoutCls) {
+                id zero = ((id (*)(id, SEL, id, CGSize))objc_msgSend)(ASLayoutCls, @selector(layoutWithLayoutElement:size:), self, CGSizeMake(s.width, 0.0));
+                if (zero) return zero;
+            }
+        }
+    }
+    return layout;
+}
+- (id)layoutSpecThatFits:(struct ApolloPFSizeRange)constrainedSize {
+    if (ApolloPFSeparatorShouldCollapse(self)) {
+        ApolloPFZeroNodeHeight(self);
+        id empty = ApolloPFEmptySpec();
+        if (empty) return empty;
+    }
+    return %orig;
+}
+%end
+
+// Re-measure a feed on appearance if filters changed since it last laid out.
+%hook _TtC6Apollo19PostsViewController
+- (void)viewWillAppear:(BOOL)animated {
+    %orig;
+    if (sPostFilterSubreddits.count == 0 && sPostFilterNameSubstrings.count == 0) return;
+    NSNumber *applied = objc_getAssociatedObject(self, kApolloPFAppliedGenKey);
+    objc_setAssociatedObject(self, kApolloPFAppliedGenKey, @(sApolloPFGeneration), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    // First appearance under the current generation already measured with the live
+    // rules; only force a re-measure when the generation actually advanced.
+    if (applied && applied.intValue != sApolloPFGeneration) {
+        ApolloPFReloadTableNodeOfVC(self);
+    }
+}
+- (void)viewDidLayoutSubviews {
+    %orig;
+    ApolloPFReconcileSeparators(self);
+}
+%end
+
+#pragma mark - Search filtering
+//
+// The name-substring filter should hide matching subreddits in search too. Two
+// screens show subreddits:
+//   • _TtC6Apollo20SearchViewController — the as-you-type suggestion list. Rows are
+//     bare ApolloDefaultTableViewCell whose textLabel is the subreddit name (the
+//     "Posts with …"/"Go to User …" action rows always contain spaces). Self-sizing
+//     table, no heightForRow.
+//   • _TtC6Apollo36SubredditSearchResultsViewController — the full "Subreddits with
+//     X" results page. Rows are SubredditSearchResultTableViewCell backed by a Swift
+//     [RDKSubreddit] array; it implements heightForRowAtIndexPath:.
+//
+// We must NOT change row COUNTS: this screen performs animated row insert/delete as
+// you type, and a filtered numberOfRows desyncs UITableView's batch-update invariant
+// (→ "invalid number of rows" exception). Instead we collapse a blocked row to 0pt
+// height, leaving counts/indices identical to Apollo's. Gated on having name filters,
+// so there is zero overhead otherwise.
+
+// A fresh, invisible, 0-height cell used to collapse a blocked row in a self-sizing
+// table without touching row counts.
+static UITableViewCell *ApolloPFMakeCollapsedCell(void) {
+    UITableViewCell *c = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    c.backgroundColor = [UIColor clearColor];
+    c.contentView.backgroundColor = [UIColor clearColor];
+    c.selectionStyle = UITableViewCellSelectionStyleNone;
+    c.userInteractionEnabled = NO;
+    c.separatorInset = UIEdgeInsetsMake(0, 100000, 0, 0); // push the separator off-screen
+    NSLayoutConstraint *h = [c.contentView.heightAnchor constraintEqualToConstant:0.0];
+    h.priority = UILayoutPriorityRequired - 1;
+    h.active = YES;
+    return c;
+}
+
+// The bare subreddit name shown by a search cell (subredditLabel for results cells,
+// textLabel for suggestion cells), or nil if the row isn't a hide-able subreddit
+// (e.g. a "Posts with …" action row — those contain whitespace; names never do).
+static NSString *ApolloPFSubredditNameFromSearchCell(UITableViewCell *cell) {
+    NSString *name = nil;
+    SEL sel = @selector(subredditLabel);
+    if ([cell respondsToSelector:sel]) {
+        id l = ((id (*)(id, SEL))objc_msgSend)(cell, sel);
+        if ([l isKindOfClass:[UILabel class]]) name = [(UILabel *)l text];
+    }
+    if (![name isKindOfClass:[NSString class]] || name.length == 0) name = cell.textLabel.text;
+    if (![name isKindOfClass:[NSString class]]) return nil;
+    NSString *t = [name stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (t.length == 0) return nil;
+    if ([t rangeOfCharacterFromSet:[NSCharacterSet whitespaceCharacterSet]].location != NSNotFound) return nil; // action row
+    if ([t hasPrefix:@"r/"] || [t hasPrefix:@"R/"]) t = [t substringFromIndex:2];
+    return t;
+}
+
+// Suggestion list: collapse a blocked suggestion's cell (self-sizing → 0pt). Counts
+// untouched.
+%hook _TtC6Apollo20SearchViewController
+- (UITableViewCell *)tableView:(UITableView *)tv cellForRowAtIndexPath:(NSIndexPath *)ip {
+    UITableViewCell *cell = %orig;
+    if (sPostFilterNameSubstrings.count == 0) return cell;
+    NSString *name = ApolloPFSubredditNameFromSearchCell(cell);
+    if (name && ApolloPFSubredditNameBlocked(name)) return ApolloPFMakeCollapsedCell();
+    return cell;
+}
+%end
+
+// Full "Subreddits with X" results page: data is a Swift [RDKSubreddit] (ObjC
+// objects, safely readable) and the VC sets explicit row heights, so collapse via
+// heightForRow (which runs before cellForRow) and hide the cell content too.
+static BOOL ApolloPFResultsRowBlocked(id vc, NSIndexPath *ip) {
+    if (!ip || ip.section != 0) return NO;
+    @try {
+        id arr = ApolloPFIvarValueByName(vc, "subreddits");
+        if (![arr isKindOfClass:[NSArray class]]) return NO;
+        NSArray *subs = (NSArray *)arr;
+        if (ip.row < 0 || ip.row >= (NSInteger)subs.count) return NO;
+        id sub = subs[(NSUInteger)ip.row];
+        Class subCls = objc_getClass("RDKSubreddit");
+        if (!subCls || ![sub isKindOfClass:subCls] || ![sub respondsToSelector:@selector(name)]) return NO;
+        NSString *name = ((NSString *(*)(id, SEL))objc_msgSend)(sub, @selector(name));
+        return ApolloPFSubredditNameBlocked(name);
+    } @catch (__unused id e) {
+        return NO;
+    }
+}
+
+%hook _TtC6Apollo36SubredditSearchResultsViewController
+- (double)tableView:(UITableView *)tv heightForRowAtIndexPath:(NSIndexPath *)ip {
+    if (sPostFilterNameSubstrings.count > 0 && ApolloPFResultsRowBlocked(self, ip)) return 0.0;
+    return %orig;
+}
+- (UITableViewCell *)tableView:(UITableView *)tv cellForRowAtIndexPath:(NSIndexPath *)ip {
+    UITableViewCell *cell = %orig;
+    if (sPostFilterNameSubstrings.count > 0) {
+        BOOL blocked = ApolloPFResultsRowBlocked(self, ip);
+        cell.hidden = blocked;          // explicit both ways so reused cells reset
+        cell.contentView.hidden = blocked;
+    }
+    return cell;
+}
+%end
+
+#pragma mark - Constructor
+
+%ctor {
+    %init(_TtC6Apollo17LargePostCellNode = objc_getClass("_TtC6Apollo17LargePostCellNode"),
+          _TtC6Apollo19CompactPostCellNode = objc_getClass("_TtC6Apollo19CompactPostCellNode"),
+          _TtC6Apollo22ThickSeparatorCellNode = objc_getClass("_TtC6Apollo22ThickSeparatorCellNode"),
+          _TtC6Apollo19PostsViewController = objc_getClass("_TtC6Apollo19PostsViewController"),
+          _TtC6Apollo20SearchViewController = objc_getClass("_TtC6Apollo20SearchViewController"),
+          _TtC6Apollo36SubredditSearchResultsViewController = objc_getClass("_TtC6Apollo36SubredditSearchResultsViewController"));
+
+    [[NSNotificationCenter defaultCenter] addObserverForName:ApolloPostFiltersChangedNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(__unused NSNotification *note) {
+        sApolloPFGeneration++;
+        ApolloPFRefreshVisibleFeeds();
+    }];
+}

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -226,3 +226,9 @@ extern BOOL sTagFilterSpoiler;
 // Lowercased subreddit name -> dictionary with optional keys:
 //   nsfw (NSNumber BOOL), spoiler (NSNumber BOOL), mode (NSString).
 extern NSDictionary<NSString *, NSDictionary *> *sTagFilterSubredditOverrides;
+
+// Post filters (Reborn) feature — see UserDefaultConstants.h.
+// Lowercased subreddit -> @{ @"keywords": NSArray<NSString*>, @"flairs": NSArray<NSString*> }.
+extern NSDictionary<NSString *, NSDictionary *> *sPostFilterSubreddits;
+// Lowercased subreddit-name substrings (hide any subreddit whose name contains one).
+extern NSArray<NSString *> *sPostFilterNameSubstrings;

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -74,3 +74,6 @@ NSString *sTagFilterMode = @"blur";
 BOOL sTagFilterNSFW = YES;
 BOOL sTagFilterSpoiler = YES;
 NSDictionary<NSString *, NSDictionary *> *sTagFilterSubredditOverrides = nil;
+
+NSDictionary<NSString *, NSDictionary *> *sPostFilterSubreddits = nil;
+NSArray<NSString *> *sPostFilterNameSubstrings = nil;

--- a/src/ApolloSubredditFilterDetailViewController.h
+++ b/src/ApolloSubredditFilterDetailViewController.h
@@ -1,0 +1,17 @@
+// ApolloSubredditFilterDetailViewController
+//
+// Per-subreddit detail screen for the Reborn "Post Filters" feature, pushed when
+// the user taps a subreddit row in the SUBREDDIT-SPECIFIC FILTERS section injected
+// onto Apollo's native Filters & Blocks screen. Edits the keyword list and flair
+// list for one subreddit via ApolloPostFilterStore.
+
+#import "ApolloSettingsTableViewController.h"
+
+@interface ApolloSubredditFilterDetailViewController : ApolloSettingsTableViewController
+
+- (instancetype)initWithSubreddit:(NSString *)subreddit;
+
+// Invoked after any change so the presenting screen can refresh its summary rows.
+@property (nonatomic, copy) void (^onChange)(void);
+
+@end

--- a/src/ApolloSubredditFilterDetailViewController.m
+++ b/src/ApolloSubredditFilterDetailViewController.m
@@ -1,0 +1,207 @@
+#import "ApolloSubredditFilterDetailViewController.h"
+#import "ApolloPostFilterStore.h"
+
+typedef NS_ENUM(NSInteger, ApolloPFDetailSection) {
+    ApolloPFDetailSectionKeywords = 0,
+    ApolloPFDetailSectionFlairs,
+    ApolloPFDetailSectionRemove,
+    ApolloPFDetailSectionCount,
+};
+
+@interface ApolloSubredditFilterDetailViewController ()
+@property (nonatomic, copy) NSString *subredditName; // lowercased, normalized
+@end
+
+@implementation ApolloSubredditFilterDetailViewController
+
+- (instancetype)initWithSubreddit:(NSString *)subreddit {
+    self = [super initWithStyle:UITableViewStyleInsetGrouped];
+    if (self) {
+        _subredditName = [ApolloPostFilterStore normalizeSubreddit:subreddit];
+    }
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = [NSString stringWithFormat:@"r/%@", self.subredditName];
+    [self updateEditButtonAnimated:NO];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.tableView reloadData];
+    [self updateEditButtonAnimated:NO];
+}
+
+// Show the standard Edit button (toggles delete controls on the keyword/flair
+// rows) whenever there's something to remove — mirrors the native Filters &
+// Blocks screen. Swipe-to-delete keeps working too.
+- (void)updateEditButtonAnimated:(BOOL)animated {
+    BOOL hasItems = ([self keywords].count + [self flairs].count) > 0;
+    if (hasItems) {
+        if (self.navigationItem.rightBarButtonItem != self.editButtonItem) {
+            [self.navigationItem setRightBarButtonItem:self.editButtonItem animated:animated];
+        }
+    } else {
+        if (self.isEditing) [self setEditing:NO animated:animated];
+        if (self.navigationItem.rightBarButtonItem != nil) {
+            [self.navigationItem setRightBarButtonItem:nil animated:animated];
+        }
+    }
+}
+
+#pragma mark - Data
+
+- (NSArray<NSString *> *)keywords { return [ApolloPostFilterStore keywordsForSubreddit:self.subredditName]; }
+- (NSArray<NSString *> *)flairs   { return [ApolloPostFilterStore flairsForSubreddit:self.subredditName]; }
+
+- (void)didChange {
+    [self.tableView reloadData];
+    [self updateEditButtonAnimated:YES];
+    if (self.onChange) self.onChange();
+}
+
+#pragma mark - Table structure
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView { return ApolloPFDetailSectionCount; }
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    if (section == ApolloPFDetailSectionKeywords) return (NSInteger)[self keywords].count + 1; // + "Add"
+    if (section == ApolloPFDetailSectionFlairs)   return (NSInteger)[self flairs].count + 1;   // + "Add"
+    return 1; // Remove
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
+    if (section == ApolloPFDetailSectionKeywords) return @"Keywords";
+    if (section == ApolloPFDetailSectionFlairs) return @"Flairs";
+    return nil;
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
+    if (section == ApolloPFDetailSectionKeywords)
+        return [NSString stringWithFormat:@"Hide posts in r/%@ whose title or link contains any of these words (case-insensitive).", self.subredditName];
+    if (section == ApolloPFDetailSectionFlairs)
+        return [NSString stringWithFormat:@"Hide posts in r/%@ with any of these post flairs. Type the flair label exactly as it appears on posts (case-insensitive).", self.subredditName];
+    return @"Stops filtering this subreddit and clears its keywords and flairs.";
+}
+
+#pragma mark - Cells
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSInteger section = indexPath.section;
+
+    if (section == ApolloPFDetailSectionRemove) {
+        UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+        cell.textLabel.text = @"Remove This Subreddit";
+        cell.textLabel.textColor = [UIColor systemRedColor];
+        cell.textLabel.textAlignment = NSTextAlignmentCenter;
+        return cell;
+    }
+
+    NSArray<NSString *> *items = (section == ApolloPFDetailSectionKeywords) ? [self keywords] : [self flairs];
+    if ((NSUInteger)indexPath.row < items.count) {
+        UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+        cell.textLabel.text = items[indexPath.row];
+        cell.selectionStyle = UITableViewCellSelectionStyleNone;
+        return cell;
+    }
+
+    // "Add ..." row.
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    cell.textLabel.text = (section == ApolloPFDetailSectionKeywords) ? @"Add Keyword..." : @"Add Flair...";
+    [self apollo_applyAccentActionTextColorToCell:cell];
+    return cell;
+}
+
+#pragma mark - Selection
+
+- (BOOL)isAddRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == ApolloPFDetailSectionKeywords) return (NSUInteger)indexPath.row == [self keywords].count;
+    if (indexPath.section == ApolloPFDetailSectionFlairs)   return (NSUInteger)indexPath.row == [self flairs].count;
+    return NO;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+
+    if (indexPath.section == ApolloPFDetailSectionRemove) {
+        [ApolloPostFilterStore removeSubreddit:self.subredditName];
+        if (self.onChange) self.onChange();
+        [self.navigationController popViewControllerAnimated:YES];
+        return;
+    }
+
+    if (![self isAddRowAtIndexPath:indexPath]) return;
+
+    BOOL isKeyword = (indexPath.section == ApolloPFDetailSectionKeywords);
+    NSString *title = isKeyword ? @"Add Keyword" : @"Add Flair";
+    NSString *message = isKeyword
+        ? @"Posts in this subreddit whose title or link contains this word are hidden."
+        : @"Posts in this subreddit with this flair label are hidden.";
+    NSString *placeholder = isKeyword ? @"giveaway" : @"Fanart";
+    [self presentAddPromptWithTitle:title message:message placeholder:placeholder onAdd:^(NSString *text) {
+        if (isKeyword) {
+            [ApolloPostFilterStore addKeyword:text forSubreddit:self.subredditName];
+        } else {
+            [ApolloPostFilterStore addFlair:text forSubreddit:self.subredditName];
+        }
+        [self didChange];
+    }];
+}
+
+#pragma mark - Editing (swipe to delete)
+
+- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == ApolloPFDetailSectionKeywords) return (NSUInteger)indexPath.row < [self keywords].count;
+    if (indexPath.section == ApolloPFDetailSectionFlairs)   return (NSUInteger)indexPath.row < [self flairs].count;
+    return NO;
+}
+
+- (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (editingStyle != UITableViewCellEditingStyleDelete) return;
+    if (indexPath.section == ApolloPFDetailSectionKeywords) {
+        NSArray<NSString *> *kw = [self keywords];
+        if ((NSUInteger)indexPath.row >= kw.count) return;
+        [ApolloPostFilterStore removeKeyword:kw[indexPath.row] forSubreddit:self.subredditName];
+    } else if (indexPath.section == ApolloPFDetailSectionFlairs) {
+        NSArray<NSString *> *fl = [self flairs];
+        if ((NSUInteger)indexPath.row >= fl.count) return;
+        [ApolloPostFilterStore removeFlair:fl[indexPath.row] forSubreddit:self.subredditName];
+    } else {
+        return;
+    }
+    [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+    // Defer the edit-button refresh (which may toggle setEditing:NO when the last
+    // item is gone) so it doesn't fight the in-flight delete animation.
+    __weak typeof(self) wself = self;
+    dispatch_async(dispatch_get_main_queue(), ^{ [wself updateEditButtonAnimated:YES]; });
+    if (self.onChange) self.onChange();
+}
+
+#pragma mark - Add prompt
+
+- (void)presentAddPromptWithTitle:(NSString *)title
+                          message:(NSString *)message
+                      placeholder:(NSString *)placeholder
+                            onAdd:(void (^)(NSString *text))onAdd {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title
+                                                                  message:message
+                                                           preferredStyle:UIAlertControllerStyleAlert];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField *tf) {
+        tf.placeholder = placeholder;
+        tf.autocapitalizationType = UITextAutocapitalizationTypeNone;
+        tf.autocorrectionType = UITextAutocorrectionTypeNo;
+    }];
+    __weak UIAlertController *weakAlert = alert;
+    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Add" style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) {
+        UITextField *tf = weakAlert.textFields.firstObject;
+        NSString *text = tf.text ?: @"";
+        if ([text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length == 0) return;
+        if (onAdd) onAdd(text);
+    }]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+@end

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -19,6 +19,7 @@
 #import "Tweak.h"
 #import "CustomAPIViewController.h"
 #import "UserDefaultConstants.h"
+#import "ApolloPostFilterStore.h"
 #import "Defaults.h"
 #import "ApolloMarkdownToolbarGif.h"
 #import "ApolloWebAuthViewController.h"
@@ -1448,6 +1449,8 @@ static void initializeRandomSources() {
                                     UDKeyTagFilterNSFW: @YES,
                                     UDKeyTagFilterSpoiler: @YES,
                                     UDKeyTagFilterSubredditOverrides: @{},
+                                    UDKeyPostFilterSubreddits: @{},
+                                    UDKeyPostFilterNameSubstrings: @[],
                                     UDKeyWebJSONEnabled: @NO,
                                     UDKeyNotificationBackendURL: @"",
                                     UDKeyNotificationBackendRegistrationToken: @"",
@@ -1635,6 +1638,55 @@ static void initializeRandomSources() {
             }
         }
         sTagFilterSubredditOverrides = [clean copy];
+    }
+
+    // Post filters (Reborn) hydration — defensive isKindOfClass-guarded rebuild
+    // (defaults can carry user-imported / backup-restored junk). Normalize keys and
+    // terms through ApolloPostFilterStore — the SAME single source of truth the
+    // write side uses — so runtime lookups match even for externally-edited plists
+    // (sub keys get the r/ strip; flairs get emoji-strip + whitespace-collapse).
+    // Keep sub keys even when their rule lists are empty (an added but unconfigured
+    // subreddit stays in the list until explicitly removed).
+    {
+        id raw = [[NSUserDefaults standardUserDefaults] objectForKey:UDKeyPostFilterSubreddits];
+        NSMutableDictionary<NSString *, NSDictionary *> *clean = [NSMutableDictionary dictionary];
+        if ([raw isKindOfClass:[NSDictionary class]]) {
+            for (id key in (NSDictionary *)raw) {
+                if (![key isKindOfClass:[NSString class]]) continue;
+                NSString *sub = [ApolloPostFilterStore normalizeSubreddit:(NSString *)key];
+                if (sub.length == 0) continue;
+                id v = ((NSDictionary *)raw)[key];
+                if (![v isKindOfClass:[NSDictionary class]]) continue;
+                NSMutableDictionary *rules = [NSMutableDictionary dictionary];
+                for (NSString *field in @[@"keywords", @"flairs"]) {
+                    id arr = ((NSDictionary *)v)[field];
+                    if (![arr isKindOfClass:[NSArray class]]) continue;
+                    BOOL isFlairs = [field isEqualToString:@"flairs"];
+                    NSMutableArray<NSString *> *terms = [NSMutableArray array];
+                    for (id t in (NSArray *)arr) {
+                        if (![t isKindOfClass:[NSString class]]) continue;
+                        NSString *s = isFlairs ? [ApolloPostFilterStore normalizeFlair:(NSString *)t]
+                                               : [ApolloPostFilterStore normalizeTerm:(NSString *)t];
+                        if (s.length > 0 && ![terms containsObject:s]) [terms addObject:s];
+                    }
+                    if (terms.count > 0) rules[field] = [terms copy];
+                }
+                clean[sub] = [rules copy];
+            }
+        }
+        sPostFilterSubreddits = [clean copy];
+    }
+    {
+        id raw = [[NSUserDefaults standardUserDefaults] objectForKey:UDKeyPostFilterNameSubstrings];
+        NSMutableArray<NSString *> *clean = [NSMutableArray array];
+        if ([raw isKindOfClass:[NSArray class]]) {
+            for (id v in (NSArray *)raw) {
+                if (![v isKindOfClass:[NSString class]]) continue;
+                NSString *s = [ApolloPostFilterStore normalizeTerm:(NSString *)v];
+                if (s.length > 0 && ![clean containsObject:s]) [clean addObject:s];
+            }
+        }
+        sPostFilterNameSubstrings = [clean copy];
     }
 
     // Trim ReadPostIDs if over configured max

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -123,6 +123,19 @@ static NSString *const UDKeyTagFilterSpoiler = @"TagFilterSpoiler";        // gl
 // Missing keys fall back to global settings.
 static NSString *const UDKeyTagFilterSubredditOverrides = @"TagFilterSubredditOverrides";
 
+// Post filters (Reborn) — device-wide content filters layered onto Apollo's
+// native Filters & Blocks screen. Independent of Apollo's account-synced filter
+// prefs (filteredSubreddits / blockedUsers) and of the Tag Filters feature above.
+// Per-subreddit rules: dictionary keyed by lowercased subreddit name. Each value
+// is a dictionary with optional keys:
+//   "keywords" -> NSArray<NSString *>  (lowercased; hide posts whose title/link contains any)
+//   "flairs"   -> NSArray<NSString *>  (lowercased; hide posts whose flair label equals any)
+static NSString *const UDKeyPostFilterSubreddits = @"PostFilterSubreddits";
+// Subreddit-name substrings: NSArray<NSString *> (lowercased). Hide any subreddit
+// whose name CONTAINS one of these substrings — both posts in feeds and the
+// subreddit's own search suggestions (e.g. "circlejerk" hides r/carscirclejerk).
+static NSString *const UDKeyPostFilterNameSubstrings = @"PostFilterNameSubstrings";
+
 // Web JSON spike (see ApolloWebJSON.m). Master switch for re-pointing
 // whitelisted listing reads at cookie-authenticated www.reddit.com JSON.
 static NSString *const UDKeyWebJSONEnabled = @"WebJSONEnabled";


### PR DESCRIPTION
Beefs out the native **Filters & Blocks** screen with device-wide content filters, for finer-grained control than site-wide keywords / whole-subreddit blocks. Two new sections are appended below the native Filtered Keywords / Filtered Subreddits / Blocked Users (all left completely untouched).

### Subreddit-specific filters
Tap a subreddit to hide its posts by **title/link keyword** or by **post flair** — for when you don't want a sub's "fluff" (videos, fanart, media clips…) but the titles aren't uniform enough for a useful site-wide keyword. Flair matching strips emoji/snoomoji tokens from the raw flair (e.g. `:n_media: Media` → `Media`) so you type the label you actually see, with a richtext-flair fallback.

### Filter subreddits by name
Hide **any** subreddit whose name contains a word — e.g. `circlejerk` hides r/carscirclejerk, r/teslacirclejerk, … without blocking each clone individually. Applies in **feeds** and in **search** (autocomplete suggestions and the "Subreddits with X" results page).

| Filters &amp; Blocks (two new sections) | Per-subreddit keywords + flairs |
|:--:|:--:|
| <img src="https://github.com/user-attachments/assets/c7dc5a89-88b4-4038-b837-4d6597128c50" width="300"> | <img src="https://github.com/user-attachments/assets/2b60cfb2-ecdb-4d40-8235-ef2dd3adb04a" width="300"> |

**Search** — blocking the word `circlejerk` also removes matching subreddits from search suggestions:

| Before | After |
|:--:|:--:|
| <img src="https://github.com/user-attachments/assets/ed673497-73ac-43db-92a7-45848f58f552" width="300"> | <img src="https://github.com/user-attachments/assets/64fbb0ea-65a8-4098-a006-59b41c6f0779" width="300"> |

### How it works
- Filtering keys on each post's own `link.subreddit`, so per-sub rules apply wherever that sub's posts appear (Home / All / the subreddit itself); crosspost parents are matched too.
- Feed enforcement collapses matching post cells to zero height via the Texture layout hooks (`-layoutSpecThatFits:`) — the same mechanism Community Highlights uses — with trailing-separator reconciliation so hidden posts don't leave gaps. It does **not** mutate Apollo's `links` array (no pagination / IGListKit desync).
- Search filtering collapses matching rows **without changing row counts**, so Apollo's animated search updates stay consistent (changing the count here triggers a `UITableView` "invalid number of rows" crash).
- Storage mirrors the existing Tag Filters feature: two `NSUserDefaults` keys, sanitized hydration through one shared normalizer, and a change-notification that live-refreshes visible feeds. Survives Backup/Restore automatically.

New files: `ApolloPostFilters.xm`, `ApolloPostFilterStore.{h,m}`, `ApolloSubredditFilterDetailViewController.{h,m}`, `ApolloFiltersBlocksInject.xm`.

### Testing
Verified in the iOS Simulator (iOS 26 / Liquid Glass): all three filter types hide the right posts in real feeds with clean separators; search suggestions + results filter correctly; native filters / Blocked Users / Tag Filters / Community Highlights are unaffected; Edit mode and long-press on the injected rows don't crash; the device target compiles clean. **Not yet tested on a physical device** — feedback welcome.
