### PR TITLE
Theme Builder: fix #000000 rendering gray (#7A7A7A) under custom themes

### DIFF
--- a/src/ApolloThemeBuilder.xm
+++ b/src/ApolloThemeBuilder.xm
@@ -25,6 +25,7 @@
 #import <UIKit/UIKit.h>
 #import <math.h>
 #import <mach-o/dyld.h>
+#import <mach-o/loader.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
 #import <os/lock.h>
@@ -135,8 +136,33 @@ static void FindApolloImage(void) {
         if (!name) continue;
         size_t len = strlen(name);
         if (len >= 7 && strcmp(name + len - 7, "/Apollo") == 0) {
-            sApolloStart = (uintptr_t)_dyld_get_image_header(i);
-            sApolloEnd = sApolloStart + 0x8000000;
+            const struct mach_header *mh = _dyld_get_image_header(i);
+            intptr_t slide = _dyld_get_image_vmaddr_slide(i);
+            sApolloStart = (uintptr_t)mh;
+            // Bound Apollo by its ACTUAL mapped extent (max segment vmaddr+vmsize),
+            // not a fixed 128MB window. The old `start + 0x8000000` guess could,
+            // depending on dyld's layout, swallow the separately-loaded tweak dylib
+            // (or a system framework) — misclassifying their colours as Apollo's and
+            // remapping the tweak's own #000000 swatch/picker into an auto-contrast
+            // gray (#7A7A7A). The real image extent can't overlap another image, so
+            // it precisely excludes the tweak.
+            uintptr_t maxEnd = sApolloStart;
+            const uint8_t *p = (const uint8_t *)mh + sizeof(struct mach_header_64);
+            for (uint32_t c = 0; c < mh->ncmds; c++) {
+                const struct load_command *lc = (const struct load_command *)p;
+                if (lc->cmd == LC_SEGMENT_64) {
+                    const struct segment_command_64 *seg = (const struct segment_command_64 *)lc;
+                    if (strcmp(seg->segname, SEG_PAGEZERO) != 0) {
+                        uintptr_t end = (uintptr_t)((intptr_t)seg->vmaddr + slide) + (uintptr_t)seg->vmsize;
+                        if (end > maxEnd) maxEnd = end;
+                    }
+                }
+                p += lc->cmdsize;
+            }
+            // Fallback: if no segments were parsed (unexpected for a normal arm64
+            // image), keep the old coarse window so the remap still functions rather
+            // than ending up with an empty range that disables the theme entirely.
+            sApolloEnd = (maxEnd > sApolloStart) ? maxEnd : (sApolloStart + 0x8000000);
             return;
         }
     }


### PR DESCRIPTION
Hey @jordanearle 👋 — small fix targeted at your `feature/theme-builder-working2` branch so you can fold it straight into the Theme Builder PR (#454).

## The bug

Reported by @deltandy:

> I'm noticing if I use #000000 for any of the colors, it turns gray, and tapping on the color shows #7A7A7A in the color picker instead of #000000.

## Root cause

The donor remap decides whether a colour is "Apollo's own" (and therefore eligible for recolouring / the near-black auto-contrast pass) by checking whether the **caller's return address** falls inside Apollo's image — so it leaves the tweak's own UI and the system frameworks alone.

That range was estimated as `image_header + 0x8000000` (**128 MB**). Apollo's actual image is only ~**13 MB**, so the window extended ~115 MB past the end of Apollo — and depending on how dyld lays out memory, the separately-loaded tweak dylib (and parts of UIKit) can land *inside* that window.

When they do, two things get misclassified as "Apollo colours" and pushed through the near-black → auto-contrast path, which returns a mid-gray (~`#7A7A7A`):

- the tweak's own `ColorFromHex(#000000)` used to paint a role's **swatch** and seed the **colour picker**, and
- UIKit's colour for the system colour picker.

So a role set to `#000000` displays gray, and re-opening the picker shows `#7A7A7A`. It's address-layout-dependent, which is why it reproduces for some people and not others.

## The fix

Bound Apollo by its **real mapped extent** — the max `vmaddr + vmsize` across its load-command segments — instead of a fixed 128 MB guess. An image's real extent can't overlap another loaded image, so the tweak and system frameworks are now reliably excluded. Apollo's own near-black auto-contrast (e.g. black text staying visible on a dark custom theme) is unchanged. A fallback keeps the old window only if segment parsing ever fails, so the remap can never end up with an empty range.

## Verification (iOS Simulator, on the latest #454 + this fix)

Instrumented the image-range computation and a self-test:

```
Apollo image [0x10022c000,0x100fe4000) size=13MB  old128End=0x10822c000
tweakFn=0x101a5206c  inOld=1  inNew=0
self-test ColorFromHex(000000) remapActive=1 -> (0,0,0)
```

- Apollo's real image is **13 MB**; the old window was **128 MB**.
- The tweak's own code sat **inside the old window (`inOld=1`)** but **outside Apollo's real extent (`inNew=0`)** — i.e. the old code misclassified it, the fix doesn't.
- With the remap active, `ColorFromHex("#000000")` now returns **(0,0,0)** (true black) instead of a gray. A role set to `#000000` renders black, and the picker reads back `#000000`.

Sim-verified, not yet device-tested.
