### PR TITLE
Refine and update issue templates for Apollo Reborn 3.3.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,11 +53,18 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Crash log / console output / screenshots
+      label: Crash log / console output
       description: |
-        Paste any crash backtraces, `ApolloLog` console output, or `.ips` crash reports. Drag and drop screenshots or screen recordings here.
-        Crash reports help enormously — see the README for how to grab them.
+        If you are reporting a crash, paste any crash backtraces, `ApolloLog` console output, or `.ips` crash reports. Crash reports help enormously; see the README for how to grab them.
       render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / screen recordings
+      description: Drag and drop screenshots or screen recordings here.
     validations:
       required: false
 
@@ -115,6 +122,7 @@ body:
         - Liquid Glass + No Extensions
         - Glass Icons
         - Glass Icons + No Extensions
+        - N/A (used jailbreak with .deb tweak)
     validations:
       required: true
 
@@ -134,6 +142,6 @@ body:
     id: additional
     attributes:
       label: Additional context
-      description: Anything else that might help — custom API keys in use, recently changed settings, etc.
+      description: Anything else that might help — custom API keys in use, recently changed settings, other related bug reports, etc.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,8 +72,8 @@ body:
     id: tweak-version
     attributes:
       label: Apollo Reborn version
-      description: Found in Settings → Apollo Reborn → scroll to bottom, or the IPA filename (e.g. `Apollo-Reborn-3.1.1.ipa`).
-      placeholder: "3.1.1"
+      description: Found in Settings → Apollo Reborn → scroll to bottom, or the IPA filename (e.g. `Apollo-Reborn-3.3.0.ipa`).
+      placeholder: "3.3.0"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -55,7 +55,7 @@ body:
     attributes:
       label: Crash log / console output
       description: |
-        If you are reporting a crash, paste any crash backtraces, `ApolloLog` console output, or `.ips` crash reports. Crash reports help enormously; see the README for how to grab them.
+        If you are reporting a crash, paste any crash backtraces, `ApolloLog` console output, or `.ips` crash reports. Crash reports help enormously; obtain them in iOS Settings → Privacy & Security → Analytics & Improvements → Analytics Data, then look for files starting with `Apollo-`, with the correct date and time.
       render: text
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,7 +8,7 @@ contact_links:
     about: Pre-built IPAs and AltStore/SideStore/Feather sources.
   - name: 🐞 Original Apollo Bug Tracker
     url: https://github.com/christianselig/apollo-bugs/issues
-    about: Bug tracker for the original Apollo app. Search issues here to see if a bug existed in the original app or is new to Apollo Reborn.
+    about: Bug tracker for the original Apollo app. Search issues here to see if a bug existed in the original app or is new to Apollo Reborn (don't report bugs in the original bug tracker).
   - name: 🤝 Contributing Guide
     url: https://github.com/Apollo-Reborn/Apollo-Reborn/blob/main/CONTRIBUTING.md
     about: Want to build or contribute? Start here.

--- a/.github/ISSUE_TEMPLATE/login_api_help.yml
+++ b/.github/ISSUE_TEMPLATE/login_api_help.yml
@@ -76,7 +76,7 @@ body:
     id: tweak-version
     attributes:
       label: Apollo Reborn version
-      placeholder: "3.1.1"
+      placeholder: "3.3.0"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/login_api_help.yml
+++ b/.github/ISSUE_TEMPLATE/login_api_help.yml
@@ -28,10 +28,10 @@ body:
     attributes:
       label: Which sign-in method are you using?
       options:
-        - My own Reddit API key (own app on reddit.com/prefs/apps)
         - Dystopia
         - RedReader
-        - Other custom redirect URI
+        - My own Reddit API installed app ("installed app" from reddit.com/prefs/apps)
+        - My own Reddit API web app ("web app" from reddit.com/prefs/apps)
         - API-Key-Free Mode (Experimental)
         - Not sure
     validations:
@@ -50,7 +50,7 @@ body:
     id: redirect-uri
     attributes:
       label: Redirect URI
-      description: The redirect URI you entered in Apollo Reborn settings (do NOT send any client ID or secret here).
+      description: The redirect URI you entered in Apollo Reborn settings (do NOT send any client ID or secret here). Not required if you are using API-Key-Free Mode.
       placeholder: "apollo://reddit-oauth"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/login_api_help.yml
+++ b/.github/ISSUE_TEMPLATE/login_api_help.yml
@@ -32,6 +32,7 @@ body:
         - Dystopia
         - RedReader
         - Other custom redirect URI
+        - API-Key-Free Mode (Experimental)
         - Not sure
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -38,7 +38,7 @@ body:
     id: tweak-version
     attributes:
       label: Apollo Reborn version (if applicable)
-      placeholder: "3.1.1"
+      placeholder: "3.3.0"
     validations:
       required: false
 


### PR DESCRIPTION
- Separate crash logs/console output and screenshots, as the crash logs/console output section is a text-only input, and doesn't allow uploading images/videos
- Add instructions to obtain crash logs instead of directing users to the README, which doesn't have instructions to obtain crash logs
- Refine descriptions and add new dropdown options
- Bump the Apollo Reborn version placeholders to the latest release of 3.3.0
- Add web app and API-Key-Free Mode as a sign-in method in the Login & API Key Help template