### PR TITLE
Fix spurious "REMOVED BY MOD" chips on non-removed content (sidebar stats + bylines, #522)

### DIFF
--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -1616,7 +1616,17 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsAttribut
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
     if (ApolloDeletedCommentsAttributedTextHasVisibleReasonChip(attributedText)) return attributedText;
 
-    NSString *text = ApolloDeletedCommentsNormalizedReasonLabel(ApolloDeletedCommentsTrimmedString(attributedText.string));
+    // A node that trims to empty has no text to classify, so it can never be a
+    // deleted-comment reason label. Bail before normalizing: this hook fires for
+    // EVERY ASTextNode in the app, and NormalizedReasonLabel() defaults an empty
+    // string to "REMOVED BY MOD". Without this guard, unrelated blank placeholder
+    // labels get stamped with the chip — e.g. the subreddit sidebar's VISITORS /
+    // CONTRIBUTIONS stat values, which are momentarily blank while their counts
+    // load and briefly flashed "REMOVED BY MOD" before the real numbers arrived.
+    NSString *trimmedSource = ApolloDeletedCommentsTrimmedString(attributedText.string);
+    if (trimmedSource.length == 0) return attributedText;
+
+    NSString *text = ApolloDeletedCommentsNormalizedReasonLabel(trimmedSource);
     BOOL exactReasonLabel = ApolloDeletedCommentsStringIsReasonLabel(text);
     if (!exactReasonLabel) return attributedText;
 

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -1632,13 +1632,17 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsAttribut
 
     id cellNode = ApolloDeletedCommentsCommentCellNodeForTextNode(textNode);
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
+    // Only a node that belongs to a comment cell whose comment is ACTUALLY
+    // recovered/removed/deleted may receive a chip. A node that merely reads a
+    // reason-label string — or normalizes to one because it is blank — with no
+    // removed comment behind it (feed-post bylines, empty author-flair slots on
+    // flair-enabled subreddits, transient UI labels) is NOT a deleted comment and
+    // must be left untouched. This mirrors the sibling reason-prefix injector, which
+    // bails on the identical condition. Previously this branch STAMPED a chip, which
+    // is what made every non-removed post and comment on subs like r/personalfinance
+    // show "REMOVED BY MOD" in the byline (#522).
     if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) {
-        NSDictionary *baseAttributes = ApolloDeletedCommentsReasonChipBaseAttributes(attributedText, cellNode);
-        NSAttributedString *chip = ApolloDeletedCommentsReasonChipAttributedText(text,
-                                                                                 baseAttributes,
-                                                                                 sTapToRevealDeletedComments);
-        if (sTapToRevealDeletedComments) ApolloDeletedCommentsEnsureRevealAttributeIsTappable(textNode);
-        return chip;
+        return attributedText;
     }
 
     NSString *label = ApolloDeletedCommentsReasonLabelForComment(comment);


### PR DESCRIPTION
## Summary

Two related symptoms of the same root cause — the **Show Deleted Comments** feature stamping a **"REMOVED BY MOD"** chip onto things that are *not* removed comments:

1. **Subreddit sidebar stats** — VISITORS / CONTRIBUTIONS briefly flash "REMOVED BY MOD" while their counts load (and stay that way on subs whose counts aren't exposed).
2. **r/personalfinance bylines (#522)** — *every* non-removed post and comment on flair-enabled subs shows "REMOVED BY MOD" right after the author name.

Fixes #522.

### Symptom 1 — sidebar stat labels

| Before (on load) | After (on load) | After (settled) |
|---|---|---|
| ![before](https://github.com/user-attachments/assets/2360d8c1-3fd5-4109-b6f0-d38d905c8932) | ![after loading](https://github.com/user-attachments/assets/01d2b435-f7a0-41fa-ad6f-d2075257a25e) | ![after settled](https://github.com/user-attachments/assets/dc787471-09e2-47cc-9ccd-3e5931147090) |

### Symptom 2 — r/personalfinance bylines (#522)

|  | Before (3.3.0) | After (this PR) |
|---|---|---|
| **Feed** | ![feed before](https://github.com/user-attachments/assets/686e5d90-eeec-4a26-901f-22b88df9fd16) | ![feed after](https://github.com/user-attachments/assets/31faee2f-d332-4cd5-8e2f-e3e1db03b4b5) |
| **Comments** | ![comments before](https://github.com/user-attachments/assets/94039b62-52d0-4dd8-8a3d-1528aea9c911) | ![comments after](https://github.com/user-attachments/assets/586f4f3f-7f47-45d1-88ca-a439cf9d8cd4) |

## Root cause

The reason-chip injector (`ApolloDeletedCommentsAttributedTextWithReasonChipIfNeeded`) is wired into the **global** `-[ASTextNode setAttributedText:]` hook, so it inspects *every* text node in the app — not just comment bodies. A chip is produced when a node's trimmed text normalizes to one of four labels (`REMOVED BY MOD` / `DELETED BY USER` / `LOADING...` / `NOT AVAILABLE`), and `NormalizedReasonLabel()` **defaults an empty string to "REMOVED BY MOD"**:

```objc
static NSString *ApolloDeletedCommentsNormalizedReasonLabel(NSString *label) {
    if (![label isKindOfClass:[NSString class]] || label.length == 0) return @"REMOVED BY MOD";
    ...
}
```

The injector then had a fallback branch that **stamped the chip even when there was no removed comment behind the node**:

```objc
if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) {
    ... return chip;   // <-- stamps a chip on ANY reason-label-looking node
}
```

Two kinds of innocent nodes hit this:

- **Sidebar stat values** are momentarily **blank** while loading → trim to empty → normalize to "REMOVED BY MOD" → chip.
- **Bylines on flair-enabled subs** (r/personalfinance) carry an empty author-flair slot rendered as a single **U+200B zero-width space** → trims to empty → same path. Confirmed via instrumentation: every triggering byline node was `rawLen=1 trimLen=0 codes=[200B]`, with no comment behind it. (Apollo's own removed-post text is "Removed by moderator", a different string — so the all-caps chip is unambiguously ours.)

## The fix

Two guards in the injector:

1. **Bail on blank nodes** (kept from the sidebar-stats fix): a node that trims to empty has no text to classify.
2. **Bail when there is no real removed comment** (new, fixes #522): only stamp a chip for a node whose backing `RDKComment` is actually removed/deleted. Previously this branch stamped a chip; now it returns the original text — mirroring the sibling `…WithReasonPrefix` injector, which already bails on the identical condition.

```objc
if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) {
    return attributedText;   // was: stamp a chip
}
```

## Why genuine removed comments are unaffected

A removed comment's body only ever reads one of the four recognized labels because **our own cell machinery put it there**, and that machinery requires a resolved `RDKComment`. So a real removed comment always has resolvable context and is chipped by the verified branch (or the placeholder / reason-prefix paths) — never the fallback. The fallback only ever fired on false positives (blank/zero-width nodes with no comment), so removing it removes only the false positives.

## Testing

- Reproduced and fixed in the iOS 26.5 Simulator (Liquid Glass), Show Deleted Comments enabled.
- **#522:** r/personalfinance feed posts and comment bylines are clean on cold load (see After shots); with the feature toggled off the chip also disappears, confirming it was ours.
- **Sidebar stats:** VISITORS/CONTRIBUTIONS are blank during load and resolve to the real counts, with no "REMOVED BY MOD" flash.
- Not device-tested.

