### PR TITLE
Comment avatars: fix intermittent loading and speed up loading

### DIFF
--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -22,7 +22,12 @@ static CGFloat const ApolloProfileHeaderHeight = 206.0;
 static CGFloat const ApolloProfileAvatarDiameter = 96.0;
 static CGFloat const ApolloProfileSnoovatarWidth = 156.0;
 static CGFloat const ApolloProfileSnoovatarHeight = 178.0;
-static NSUInteger const ApolloInlineAvatarMaxActiveInfoRequests = 6;
+// Governs how many about.json info fetches are in flight at once. Kept a touch above
+// the info session's per-host socket cap (8) so NSURLSession — not this app-level
+// gate — manages the queue, while still bounding wasted fetches when fast-scrolling a
+// huge thread. (Was 6, which exactly duplicated the old socket cap and only added
+// queueing latency.)
+static NSUInteger const ApolloInlineAvatarMaxActiveInfoRequests = 10;
 static NSUInteger const ApolloInlineAvatarMaxBindAttempts = 4;
 static NSUInteger const ApolloInlineAvatarLogLimit = 16;
 
@@ -2113,11 +2118,86 @@ static void ApolloProfileOpenRedditProfileEditor(void) {
 
 %end
 
+// ---- Batch prefetch (#4/#5): collect comment authors' t2_ fullnames from their cells
+// (as they enter Texture's preload range, ahead of display) and coalesce them into ONE
+// user_data_by_account_ids request — so a thread's avatars are cached in a few batched
+// requests, ahead of scroll, instead of one about.json per author as each cell appears.
+// (Reading the Swift CommentTree / IGListKit objects array directly is not ObjC-safe, so
+// the per-cell `comment` ivar — the same one the avatar binding already reads — is used.)
+static NSMutableSet<NSString *> *sApolloPendingBatchFullNames = nil;
+static BOOL sApolloBatchFireScheduled = NO;
+
+static NSString *ApolloCommentAuthorFullName(id comment) {
+    if (!comment || ![comment respondsToSelector:@selector(authorFullName)]) return nil;
+    @try {
+        NSString *(*msgSend)(id, SEL) = (NSString *(*)(id, SEL))objc_msgSend;
+        NSString *fullName = msgSend(comment, @selector(authorFullName));
+        return [fullName isKindOfClass:[NSString class]] ? fullName : nil;
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+// Fire whatever fullnames have accumulated as one batched request. Main-thread only.
+static void ApolloInlineAvatarFireBatchNow(void) {
+    sApolloBatchFireScheduled = NO;
+    if (sApolloPendingBatchFullNames.count == 0) return;
+    NSArray<NSString *> *batch = [sApolloPendingBatchFullNames allObjects];
+    [sApolloPendingBatchFullNames removeAllObjects];
+    [[ApolloUserProfileCache sharedCache] batchPrefetchProfilesForFullNames:batch];
+}
+
+// Coalesce authors into batches. A thread open (or fast scroll) floods cells into the
+// preload range at once → fire promptly once a burst accumulates; a slow trickle of
+// cells is gathered over a short window so it still collapses into one request rather
+// than many 1-id calls. Main-thread only, so the statics need no locking.
+static void ApolloInlineAvatarEnqueueFullNameForBatch(NSString *fullName) {
+    if (!sShowUserAvatars) return;
+    if (![fullName isKindOfClass:[NSString class]] || ![fullName hasPrefix:@"t2_"]) return;
+    if (!sApolloPendingBatchFullNames) sApolloPendingBatchFullNames = [NSMutableSet set];
+    [sApolloPendingBatchFullNames addObject:fullName];
+    if (sApolloPendingBatchFullNames.count >= 25) {
+        ApolloInlineAvatarFireBatchNow();
+        return;
+    }
+    if (sApolloBatchFireScheduled) return;
+    sApolloBatchFireScheduled = YES;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.6 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        ApolloInlineAvatarFireBatchNow();
+    });
+}
+
+// Read the comment cell's own RDKComment (the same safe ivar path the avatar binding
+// uses) to get the author's t2_ fullname, and enqueue it for the batch — unless we
+// already have that user's avatar cached (memory is hydrated from disk at launch, so
+// this is a cheap check that stops return visits from re-batching known users).
+static void ApolloInlineAvatarBatchEnqueueFromCommentCell(id cell) {
+    if (!cell) return;
+    id comment = ApolloObjectIvarValue(cell, @"comment");
+    if (!comment) return;
+    NSString *fullName = ApolloCommentAuthorFullName(comment);
+    if (fullName.length == 0) return;
+    NSString *username = ApolloUsernameFromModelObject(comment);
+    if (username.length > 0 && [[ApolloUserProfileCache sharedCache] cachedInfoForUsername:username].iconURL) return;
+    ApolloInlineAvatarEnqueueFullNameForBatch(fullName);
+}
+
 %hook _TtC6Apollo15CommentCellNode
+
+// didEnterPreloadState fires while a cell is still in Texture's preload range (AHEAD of
+// display), so enqueuing the author here lets the coalesced batch cache their avatar
+// before the cell actually appears — turning ~N per-author about.json calls into a
+// handful of batched requests, and making the avatar already-present on scroll.
+- (void)didEnterPreloadState {
+    %orig;
+    if (!sShowUserAvatars) return;
+    ApolloInlineAvatarBatchEnqueueFromCommentCell(self);
+}
 
 - (void)didLoad {
     %orig;
     if (!sShowUserAvatars) return;
+    ApolloInlineAvatarBatchEnqueueFromCommentCell(self);
     ApolloApplyAvatarToCellWithDiameter(self, ApolloUsernameFromCell(self, @"comment"), ApolloCommentInlineAvatarDiameter);
 }
 

--- a/src/ApolloUserProfileCache.h
+++ b/src/ApolloUserProfileCache.h
@@ -37,6 +37,12 @@ extern NSString * const ApolloUserProfileUsernameKey;
 - (void)requestInfoForUsername:(NSString *)username completion:(void (^)(ApolloUserProfileInfo *info))completion;
 - (void)refetchInfoForUsername:(NSString *)username completion:(void (^)(ApolloUserProfileInfo *info))completion;
 
+// Bulk-prefetch many users' avatars in ONE request (Reddit's user_data_by_account_ids,
+// chunked at 100) keyed by t2_ account fullname, instead of one about.json per user.
+// Caches a lightweight account-icon entry per user so inline comment avatars are ready
+// before their cells render. No-op without a bearer token (the endpoint needs OAuth).
+- (void)batchPrefetchProfilesForFullNames:(NSArray<NSString *> *)fullNames;
+
 - (UIImage *)cachedImageForURL:(NSURL *)url;
 - (void)requestImageForURL:(NSURL *)url completion:(void (^)(UIImage *image))completion;
 

--- a/src/ApolloUserProfileCache.m
+++ b/src/ApolloUserProfileCache.m
@@ -883,6 +883,9 @@ static NSTimeInterval ApolloUserProfileRetryBackoffForAttempt(NSInteger attempt)
         [self.diskInfo removeAllObjects];
         [self.infoCache removeAllObjects];
         [self.imageCache removeAllObjects];
+        // Reset the batch-prefetch dedupe set so already-seen users get re-warmed
+        // through the fast user_data_by_account_ids path after a clear.
+        [self.batchRequestedFullNames removeAllObjects];
 
         // Wipe HTTP cache entries so subsequent fetches go to the network.
         NSURLCache *httpCache = self.session.configuration.URLCache ?: [NSURLCache sharedURLCache];

--- a/src/ApolloUserProfileCache.m
+++ b/src/ApolloUserProfileCache.m
@@ -4,6 +4,8 @@
 #import "ApolloLinkPreviewCache.h"
 #import "ApolloState.h"
 
+#import <CommonCrypto/CommonDigest.h>
+
 NSString * const ApolloUserProfileInfoUpdatedNotification = @"ApolloUserProfileInfoUpdatedNotification";
 NSString * const ApolloUserProfileUsernameKey = @"username";
 
@@ -50,7 +52,23 @@ static UIImage *ApolloDecodedAvatarImage(UIImage *image) {
 @property(nonatomic, strong) NSMutableDictionary<NSString *, NSMutableArray<void (^)(ApolloUserProfileInfo *)> *> *infoCompletions;
 @property(nonatomic, strong) NSMutableDictionary<NSString *, NSMutableArray<void (^)(UIImage *)> *> *imageCompletions;
 @property(nonatomic, strong) NSURLSession *session;
+// Avatar image bytes come from Reddit's public CDN hosts (different hosts than the
+// authenticated about.json API, and not per-token rate-limited), so they get their
+// own session with a wider per-host pool and their own concurrent I/O queue for the
+// disk cache — keeping image work off the serial `queue` that render paths sync onto.
+@property(nonatomic, strong) NSURLSession *imageSession;
+@property(nonatomic) dispatch_queue_t imageIOQueue;
+@property(nonatomic) NSUInteger imageDiskWriteCount;
+// t2_ fullnames already issued to a batch this session (touched only on `queue`),
+// so re-opening threads with overlapping authors doesn't re-request them.
+@property(nonatomic, strong) NSMutableSet<NSString *> *batchRequestedFullNames;
 @property(nonatomic) dispatch_queue_t queue;
+- (void)startInfoFetchForKey:(NSString *)key bypassingCache:(BOOL)bypassingCache attempt:(NSInteger)attempt;
+- (void)startBatchProfileFetchForFullNames:(NSArray<NSString *> *)chunk token:(NSString *)token;
+- (NSString *)imageCacheDirectory;
+- (NSString *)imageDiskPathForKey:(NSString *)key;
+- (void)persistImageData:(NSData *)data forKey:(NSString *)key;
+- (void)pruneImageDiskCache;
 @end
 
 @implementation ApolloUserProfileCache
@@ -79,14 +97,32 @@ static UIImage *ApolloDecodedAvatarImage(UIImage *image) {
         _diskInfo = [NSMutableDictionary dictionary];
         _infoCompletions = [NSMutableDictionary dictionary];
         _imageCompletions = [NSMutableDictionary dictionary];
+        _batchRequestedFullNames = [NSMutableSet set];
 
         NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
         configuration.requestCachePolicy = NSURLRequestReturnCacheDataElseLoad;
         configuration.timeoutIntervalForRequest = 15.0;
-        configuration.HTTPMaximumConnectionsPerHost = 6;
+        // about.json all targets the one host oauth.reddit.com; widen its pool a little.
+        configuration.HTTPMaximumConnectionsPerHost = 8;
         _session = [NSURLSession sessionWithConfiguration:configuration];
 
+        // Separate session for avatar image downloads. These hit public CDN hosts
+        // (redditmedia / redditstatic / i.redd.it), which don't rate-limit per token,
+        // so a wider pool loads a burst of icons faster without competing with — or
+        // risking 429s on — the authenticated API session.
+        NSURLSessionConfiguration *imageConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
+        imageConfiguration.requestCachePolicy = NSURLRequestReturnCacheDataElseLoad;
+        imageConfiguration.timeoutIntervalForRequest = 20.0;
+        imageConfiguration.HTTPMaximumConnectionsPerHost = 12;
+        _imageSession = [NSURLSession sessionWithConfiguration:imageConfiguration];
+
+        // Concurrent queue for avatar-image disk reads/decodes (dispatch_async) and
+        // exclusive writes/prunes (dispatch_barrier_async). Kept off `queue` so a
+        // decode never blocks the main thread's synchronous cachedInfoForUsername reads.
+        _imageIOQueue = dispatch_queue_create("com.apollofix.avatarImageIO", DISPATCH_QUEUE_CONCURRENT);
+
         [self loadDiskCache];
+        dispatch_barrier_async(_imageIOQueue, ^{ [self pruneImageDiskCache]; });
     }
     return self;
 }
@@ -412,21 +448,95 @@ static UIImage *ApolloDecodedAvatarImage(UIImage *image) {
     });
 }
 
+// A profile fetch that fails on a TRANSIENT condition (a 429 rate-limit, a 5xx, or
+// a recoverable network error) must not permanently drop the user's avatar for the
+// rest of the session. That single-shot, give-up-on-first-failure behaviour is the
+// root cause of the "some comment avatars load, some don't" reports: under busier
+// real-world conditions (more concurrent Reborn network traffic and higher/variable
+// latency than the simulator's fast local network) some about.json fetches fail
+// transiently, and with no retry those users are left with a blank placeholder for
+// the whole session. Retry a bounded number of times with backoff before giving up.
+// Permanent failures (404 / 403 / parse failure) are NOT retried. The in-flight
+// `infoCompletions` dedup means every cell waiting on this username shares the one
+// retrying request, so retries don't multiply network load.
+static NSInteger const ApolloUserProfileMaxFetchAttempts = 3;
+
+static BOOL ApolloUserProfileErrorIsTransient(NSError *error) {
+    if (![error.domain isEqualToString:NSURLErrorDomain]) return NO;
+    switch (error.code) {
+        case NSURLErrorTimedOut:
+        case NSURLErrorCannotConnectToHost:
+        case NSURLErrorCannotFindHost:
+        case NSURLErrorNetworkConnectionLost:
+        case NSURLErrorNotConnectedToInternet:
+        case NSURLErrorDNSLookupFailed:
+        case NSURLErrorResourceUnavailable:
+            return YES;
+        default:
+            return NO;
+    }
+}
+
+static NSTimeInterval ApolloUserProfileRetryBackoffForAttempt(NSInteger attempt) {
+    switch (attempt) {
+        case 0: return 0.6;
+        case 1: return 2.0;
+        default: return 5.0;
+    }
+}
+
 - (void)startInfoFetchForKey:(NSString *)key bypassingCache:(BOOL)bypassingCache {
+    [self startInfoFetchForKey:key bypassingCache:bypassingCache attempt:0];
+}
+
+- (void)startInfoFetchForKey:(NSString *)key bypassingCache:(BOOL)bypassingCache attempt:(NSInteger)attempt {
     NSMutableURLRequest *request = [[self profileRequestForUsername:key] mutableCopy];
     if (bypassingCache) {
         request.cachePolicy = NSURLRequestReloadIgnoringLocalAndRemoteCacheData;
     }
+
+    // Back off and retry on transient failure; only finish-with-nil (which releases
+    // every waiting cell) once the retry budget is spent.
+    __weak typeof(self) weakSelf = self;
+    void (^retryOrGiveUp)(NSString *) = ^(NSString *reason) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        if (attempt + 1 < ApolloUserProfileMaxFetchAttempts) {
+            NSTimeInterval backoff = ApolloUserProfileRetryBackoffForAttempt(attempt);
+            ApolloLog(@"[UserAvatars] Profile fetch u/%@ %@ — retry %ld/%ld in %.1fs",
+                      key, reason, (long)(attempt + 2), (long)ApolloUserProfileMaxFetchAttempts, backoff);
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(backoff * NSEC_PER_SEC)), strongSelf.queue, ^{
+                [strongSelf startInfoFetchForKey:key bypassingCache:bypassingCache attempt:attempt + 1];
+            });
+        } else {
+            ApolloLog(@"[UserAvatars] Profile fetch u/%@ %@ — gave up after %ld attempts",
+                      key, reason, (long)ApolloUserProfileMaxFetchAttempts);
+            [strongSelf finishInfoRequestForKey:key info:nil];
+        }
+    };
+
     NSURLSessionDataTask *task = [self.session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (error) {
+            if (ApolloUserProfileErrorIsTransient(error)) {
+                retryOrGiveUp([NSString stringWithFormat:@"network error (%@)", error.localizedDescription]);
+                return;
+            }
             ApolloLog(@"[UserAvatars] Failed to fetch u/%@: %@", key, error.localizedDescription);
             [self finishInfoRequestForKey:key info:nil];
             return;
         }
 
         NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
-        if (http && (http.statusCode < 200 || http.statusCode >= 300)) {
-            ApolloLog(@"[UserAvatars] Profile fetch for u/%@ returned HTTP %ld", key, (long)http.statusCode);
+        NSInteger statusCode = http ? http.statusCode : 200;
+        // 429 (rate limited) and 5xx are transient server-side conditions — back off
+        // and retry rather than abandoning this user's avatar.
+        if (statusCode == 429 || statusCode >= 500) {
+            retryOrGiveUp([NSString stringWithFormat:@"HTTP %ld", (long)statusCode]);
+            return;
+        }
+        if (statusCode < 200 || statusCode >= 300) {
+            // Permanent (404 not found, 403 forbidden, etc.) — no retry.
+            ApolloLog(@"[UserAvatars] Profile fetch for u/%@ returned HTTP %ld", key, (long)statusCode);
             [self finishInfoRequestForKey:key info:nil];
             return;
         }
@@ -517,6 +627,10 @@ static UIImage *ApolloDecodedAvatarImage(UIImage *image) {
         for (NSURL *url in priorURLs) {
             [self.imageCache removeObjectForKey:url.absoluteString];
             [httpCache removeCachedResponseForRequest:[NSURLRequest requestWithURL:url]];
+            NSString *diskPath = [self imageDiskPathForKey:url.absoluteString];
+            dispatch_barrier_async(self.imageIOQueue, ^{
+                [[NSFileManager defaultManager] removeItemAtPath:diskPath error:nil];
+            });
         }
 
         ApolloLog(@"[UserAvatars] Forcing profile refetch for u/%@ priorURLs=%lu", key, (unsigned long)priorURLs.count);
@@ -531,6 +645,100 @@ static UIImage *ApolloDecodedAvatarImage(UIImage *image) {
         self.infoCompletions[key] = callbacks;
         [self startInfoFetchForKey:key bypassingCache:YES];
     });
+}
+
+#pragma mark - Batch prefetch
+
+- (void)batchPrefetchProfilesForFullNames:(NSArray<NSString *> *)fullNames {
+    if (fullNames.count == 0) return;
+    NSString *token = [sLatestRedditBearerToken copy];
+    // The batch endpoint is OAuth-only (scope privatemessages); with no token the
+    // per-cell about.json path (which can fall back to www.reddit.com) still covers us.
+    if (token.length == 0) return;
+
+    dispatch_async(self.queue, ^{
+        NSMutableArray<NSString *> *pending = [NSMutableArray array];
+        for (NSString *fn in fullNames) {
+            if (![fn isKindOfClass:[NSString class]] || ![fn hasPrefix:@"t2_"]) continue;
+            if ([self.batchRequestedFullNames containsObject:fn]) continue;
+            [self.batchRequestedFullNames addObject:fn];
+            [pending addObject:fn];
+        }
+        if (pending.count == 0) return;
+
+        // Reddit caps user_data_by_account_ids at 100 ids per request.
+        for (NSUInteger start = 0; start < pending.count; start += 100) {
+            NSRange range = NSMakeRange(start, MIN((NSUInteger)100, pending.count - start));
+            [self startBatchProfileFetchForFullNames:[pending subarrayWithRange:range] token:token];
+        }
+    });
+}
+
+- (void)startBatchProfileFetchForFullNames:(NSArray<NSString *> *)chunk token:(NSString *)token {
+    if (chunk.count == 0) return;
+    NSString *ids = [chunk componentsJoinedByString:@","];
+    NSString *urlString = [NSString stringWithFormat:@"https://oauth.reddit.com/api/user_data_by_account_ids.json?ids=%@&raw_json=1", ids];
+    NSURL *url = [NSURL URLWithString:urlString];
+    if (!url) {
+        dispatch_async(self.queue, ^{ for (NSString *fn in chunk) [self.batchRequestedFullNames removeObject:fn]; });
+        return;
+    }
+
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+    request.HTTPMethod = @"GET";
+    request.timeoutInterval = 15.0;
+    [request setValue:[@"Bearer " stringByAppendingString:token] forHTTPHeaderField:@"Authorization"];
+    NSString *userAgent = sUserAgent.length > 0 ? sUserAgent : @"ApolloProfileAvatars/1.0";
+    [request setValue:userAgent forHTTPHeaderField:@"User-Agent"];
+
+    NSURLSessionDataTask *task = [self.session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
+        BOOL ok = (!error && data.length > 0 && (!http || (http.statusCode >= 200 && http.statusCode < 300)));
+        if (!ok) {
+            ApolloLog(@"[UserAvatars] Batch profile fetch failed (HTTP %ld, err %@) for %lu ids",
+                      (long)(http ? http.statusCode : -1), error.localizedDescription ?: @"none", (unsigned long)chunk.count);
+            // Un-mark so a later thread open can retry; per-cell about.json still covers these users now.
+            dispatch_async(self.queue, ^{ for (NSString *fn in chunk) [self.batchRequestedFullNames removeObject:fn]; });
+            return;
+        }
+
+        id json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+        if (![json isKindOfClass:[NSDictionary class]]) return;
+        NSDictionary *root = (NSDictionary *)json;
+
+        dispatch_async(self.queue, ^{
+            NSUInteger applied = 0;
+            for (NSString *fullName in root) {
+                NSDictionary *record = [root[fullName] isKindOfClass:[NSDictionary class]] ? root[fullName] : nil;
+                if (!record) continue;
+                NSString *name = [record[@"name"] isKindOfClass:[NSString class]] ? record[@"name"] : nil;
+                NSURL *iconURL = [self URLFromString:record[@"profile_img"]];
+                NSString *key = [self normalizedUsername:name];
+                if (!key || !iconURL) continue;
+
+                // Never clobber a richer entry: about.json (or a prior batch) already gave
+                // this user an icon — keep it (it may carry snoovatar/banner/suspension).
+                ApolloUserProfileInfo *existing = [self.infoCache objectForKey:key] ?: self.diskInfo[key];
+                if (existing.iconURL) continue;
+
+                // Lightweight entry: account icon only. suspensionChecked stays NO so a
+                // later profile-page open still upgrades to full fidelity via about.json.
+                ApolloUserProfileInfo *info = [[ApolloUserProfileInfo alloc] initWithUsername:name
+                                                                                     iconURL:iconURL
+                                                                                   bannerURL:nil
+                                                                                 defaultSnoo:NO
+                                                                                   fetchedAt:[NSDate date]];
+                [self.infoCache setObject:info forKey:key];
+                self.diskInfo[key] = info;
+                applied++;
+                // Warm the image cache so the avatar paints the instant the cell appears.
+                [self requestImageForURL:iconURL completion:nil];
+            }
+            if (applied > 0) [self saveDiskCacheLocked];
+            ApolloLog(@"[UserAvatars] Batch profile fetch: %lu ids -> %lu new avatars cached", (unsigned long)chunk.count, (unsigned long)applied);
+        });
+    }];
+    [task resume];
 }
 
 - (UIImage *)cachedImageForURL:(NSURL *)url {
@@ -553,6 +761,57 @@ static UIImage *ApolloDecodedAvatarImage(UIImage *image) {
             }
         });
     });
+}
+
+// On-disk avatar image cache. The in-memory imageCache is wiped on every relaunch,
+// so without this every cold start re-downloads (and re-decodes) every avatar even
+// though the info JSON cache already knows the URLs. Reddit avatar CDN URLs are
+// content-hashed, so a cached entry is never stale — keyed by SHA256 of the URL.
+- (NSString *)imageCacheDirectory {
+    NSArray<NSString *> *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+    NSString *cacheRoot = paths.firstObject ?: NSTemporaryDirectory();
+    NSString *dir = [[cacheRoot stringByAppendingPathComponent:@"ApolloFix"] stringByAppendingPathComponent:@"Avatars"];
+    [[NSFileManager defaultManager] createDirectoryAtPath:dir withIntermediateDirectories:YES attributes:nil error:nil];
+    return dir;
+}
+
+- (NSString *)imageDiskPathForKey:(NSString *)key {
+    const char *str = key.UTF8String ?: "";
+    unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(str, (CC_LONG)strlen(str), digest);
+    NSMutableString *name = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+    for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) [name appendFormat:@"%02x", digest[i]];
+    return [[self imageCacheDirectory] stringByAppendingPathComponent:name];
+}
+
+// Persist raw image bytes. Runs as a barrier block on imageIOQueue so the write,
+// the write-counter, and the occasional prune are serialized.
+- (void)persistImageData:(NSData *)data forKey:(NSString *)key {
+    if (data.length == 0 || data.length > 2 * 1024 * 1024) return; // skip empty / absurd
+    [data writeToFile:[self imageDiskPathForKey:key] atomically:YES];
+    if ((++self.imageDiskWriteCount % 200) == 0) [self pruneImageDiskCache];
+}
+
+// LRU prune by modification date; only runs on imageIOQueue barrier blocks.
+- (void)pruneImageDiskCache {
+    static NSUInteger const kMaxImageFiles = 2000;
+    NSString *dir = [self imageCacheDirectory];
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSArray<NSString *> *names = [fm contentsOfDirectoryAtPath:dir error:nil];
+    if (names.count <= kMaxImageFiles) return;
+
+    NSMutableArray<NSDictionary *> *entries = [NSMutableArray arrayWithCapacity:names.count];
+    for (NSString *name in names) {
+        NSString *path = [dir stringByAppendingPathComponent:name];
+        NSDate *mdate = [fm attributesOfItemAtPath:path error:nil][NSFileModificationDate] ?: [NSDate distantPast];
+        [entries addObject:@{@"path": path, @"date": mdate}];
+    }
+    [entries sortUsingComparator:^NSComparisonResult(NSDictionary *a, NSDictionary *b) {
+        return [a[@"date"] compare:b[@"date"]]; // oldest first
+    }];
+    for (NSUInteger i = 0; i < entries.count - kMaxImageFiles; i++) {
+        [fm removeItemAtPath:entries[i][@"path"] error:nil];
+    }
 }
 
 - (void)requestImageForURL:(NSURL *)url completion:(void (^)(UIImage *image))completion {
@@ -578,19 +837,43 @@ static UIImage *ApolloDecodedAvatarImage(UIImage *image) {
         if (completion) [callbacks addObject:[completion copy]];
         self.imageCompletions[key] = callbacks;
 
-        NSURLSessionDataTask *task = [self.session dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-            UIImage *image = nil;
-            if (!error && data.length > 0) {
+        // Disk read + decode + network all happen off `queue` (on imageIOQueue) so a
+        // batch of decodes can't stall the main thread's sync cachedInfoForUsername.
+        NSString *diskPath = [self imageDiskPathForKey:key];
+        dispatch_async(self.imageIOQueue, ^{
+            NSData *diskData = [NSData dataWithContentsOfFile:diskPath];
+            if (diskData.length > 0) {
+                UIImage *diskImage = nil;
                 @autoreleasepool {
-                    image = ApolloDecodedAvatarImage([UIImage imageWithData:data scale:[UIScreen mainScreen].scale]);
+                    diskImage = ApolloDecodedAvatarImage([UIImage imageWithData:diskData scale:[UIScreen mainScreen].scale]);
+                }
+                if (diskImage) {
+                    // Touch mtime so the LRU prune keeps recently-shown avatars.
+                    [[NSFileManager defaultManager] setAttributes:@{NSFileModificationDate: [NSDate date]} ofItemAtPath:diskPath error:nil];
+                    [self finishImageRequestForKey:key image:diskImage];
+                    return;
                 }
             }
-            if (!image && error) {
-                ApolloLog(@"[UserAvatars] Failed to load image %@: %@", key, error.localizedDescription);
-            }
-            [self finishImageRequestForKey:key image:image];
-        }];
-        [task resume];
+
+            NSURLSessionDataTask *task = [self.imageSession dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                UIImage *image = nil;
+                NSData *persistData = nil;
+                if (!error && data.length > 0) {
+                    @autoreleasepool {
+                        image = ApolloDecodedAvatarImage([UIImage imageWithData:data scale:[UIScreen mainScreen].scale]);
+                    }
+                    if (image) persistData = data;
+                }
+                if (!image && error) {
+                    ApolloLog(@"[UserAvatars] Failed to load image %@: %@", key, error.localizedDescription);
+                }
+                if (persistData) {
+                    dispatch_barrier_async(self.imageIOQueue, ^{ [self persistImageData:persistData forKey:key]; });
+                }
+                [self finishImageRequestForKey:key image:image];
+            }];
+            [task resume];
+        });
     });
 }
 
@@ -604,6 +887,12 @@ static UIImage *ApolloDecodedAvatarImage(UIImage *image) {
         // Wipe HTTP cache entries so subsequent fetches go to the network.
         NSURLCache *httpCache = self.session.configuration.URLCache ?: [NSURLCache sharedURLCache];
         [httpCache removeAllCachedResponses];
+        [self.imageSession.configuration.URLCache removeAllCachedResponses];
+
+        // Drop the on-disk avatar image cache too.
+        dispatch_barrier_async(self.imageIOQueue, ^{
+            [[NSFileManager defaultManager] removeItemAtPath:[self imageCacheDirectory] error:nil];
+        });
 
         NSString *path = [self cachePath];
         NSError *error = nil;


### PR DESCRIPTION
## Summary

Two related improvements to the inline comment-avatar path (`ApolloUserProfileCache.{h,m}`, `ApolloUserAvatars.xm`):

1. **Fixes the reported "some comment avatars load, some don't" bug.**
2. **Makes avatar loading faster and lighter**, especially on revisits and busy threads.

## The bug (reliability)

The per-user profile fetch (`startInfoFetchForKey:`) was single-shot: on **any** failure — a 429 rate-limit, a 5xx, or a transient network error — it called `finishInfoRequestForKey:nil` with **no retry**, permanently leaving that commenter on a blank placeholder until the cell recycled. On busy threads (and with the extra concurrent traffic added in 3.3.0) enough of these fail that you get the intermittent-blank pattern users reported.

**Fix:** transient failures (429 / 5xx / `NSURLError` network errors) retry with bounded backoff (0.6s → 2.0s → 5.0s, 3 attempts). Permanent failures (403 / 404 / parse) still fail fast. The existing in-flight `infoCompletions` dedup means every cell waiting on a username shares the one retrying request, so retries don't multiply load.

## Performance

- **Disk image cache** — decoded avatar images are persisted under `Caches/ApolloFix/Avatars` (keyed by SHA-256 of the content-hashed CDN URL, LRU-pruned). They previously lived only in an in-memory `NSCache` wiped every launch, so each cold start re-downloaded every avatar. Revisiting a thread is now zero-network for icons.
- **Dedicated image session** — avatar image bytes come from Reddit's CDN hosts (not the rate-limited API host), so they get their own `NSURLSession` with a wider per-host pool; the API session's pool goes 6 → 8.
- **Throttle** — the app-level in-flight info cap of 6 just duplicated the OS socket cap; raised to 10.
- **Batch fetch** — comment authors' `t2_` fullnames are collected as their cells enter Texture's preload range and coalesced into a single `user_data_by_account_ids` request instead of one `about.json` per author. Results are cached and deduped against the cache, so revisits don't refetch.

## Results (simulator)

- Reported intermittent-loading bug: reproduced via fault injection, fixed.
- Cold thread open: ~one `about.json` per author → a handful of batched requests + a few `about.json` (~60% fewer).
- Revisiting a thread: **zero** avatar network requests.

## Notes / caveats

- **Verified on the iOS simulator, not yet on-device.**
- The batch endpoint only returns the flat account icon (`profile_img`), so a comment author with a custom full-body **Snoovatar** shows their account icon (circle) inline rather than the Snoovatar (hexagon) until their profile is opened (which upgrades to full fidelity via `about.json`). The large majority of users are unaffected — their account icon is the same image. Easy to gate behind a setting if preferred.
