### PR TITLE
Improve subreddit feed search under Liquid Glass

### DIFF
--- a/src/ApolloSearchInPlace.xm
+++ b/src/ApolloSearchInPlace.xm
@@ -260,6 +260,17 @@ static BOOL ApolloFeedSearchIsSurfaced(UIScrollView *sv) {
            (ApolloFeedSearchDesiredOffsetY(sv) > rest + 1.0);
 }
 
+// Exposed (non-static) to the Community Highlights module: YES while THIS feed table is mid-search with a
+// non-empty query — i.e. results are showing and the standalone carousel should stay scrolled off, NOT be
+// re-attached + scrolled back to the top. Excludes the dismiss window (dismissing == YES) and an empty
+// query, which are exactly when the carousel SHOULD be restored. Lets the Highlights re-attach skip its
+// scroll-to-top during active typing/scrolling so it can never yank the results.
+BOOL ApolloFeedSearchIsActiveQuery(UIScrollView *tv) {
+    return sFeedSearchActive && !sFeedSearchDismissing &&
+           (UIScrollView *)tv == sFeedSearchTable &&
+           ApolloFeedSearchQueryText().length > 0;
+}
+
 // MARK: - Round "X" cancel button
 //
 // Replaces the "Cancel" text with a neutral-gray xmark in a circle matching the search-field pill. In

--- a/src/ApolloSearchInPlace.xm
+++ b/src/ApolloSearchInPlace.xm
@@ -638,8 +638,8 @@ static void recenterCancelButton(void) {
 
 - (void)setContentOffset:(CGPoint)offset {
     // Only when a FULL subreddit header is present (the managed case). Without it — Home, or just the small
-    // Community Highlights carousel (Subreddit Headers off) — leave the feed's geometry stock, so dismissing
-    // a search can't strand the rebuilt carousel header behind the chrome (blank space).
+    // Community Highlights carousel (Subreddit Headers off) — leave the feed's geometry stock; Apollo
+    // surfaces results there natively, and the Highlights module re-attaches its carousel on dismiss.
     if ((UIScrollView *)self == sFeedSearchTable &&
         (sFeedSearchActive || sFeedSearchDismissing) &&
         ApolloFeedSearchManagedHeader((UIScrollView *)self)) {
@@ -665,13 +665,9 @@ static void recenterCancelButton(void) {
             }
         }
 
-        // While holding the surfaced position, hide the header so the scrolled-up chrome doesn't bleed
-        // through the translucent field/nav; otherwise (empty query, dismissing, or the user scrolling to
-        // browse) keep it visible.
         BOOL surfaced = hasQuery && sFeedSearchActive && !sFeedSearchDismissing &&
                         !sFeedSearchScrolledByUser && (target > rest + 1.0);
         ApolloFeedSearchSetHeaderHidden(sv, surfaced);
-
         %orig(offset);
         return;
     }

--- a/src/ApolloSearchInPlace.xm
+++ b/src/ApolloSearchInPlace.xm
@@ -193,6 +193,59 @@ static CGFloat ApolloFeedSearchActiveRestTop(void) {
                                                       : ApolloFeedSearchRestTop();
 }
 
+// The current feed query text, or nil/empty when not searching.
+static NSString *ApolloFeedSearchQueryText(void) {
+    UIView *f = sFeedSearchField;
+    return [f isKindOfClass:[UITextField class]] ? [(UITextField *)f text] : nil;
+}
+
+// MARK: - "Search on top" — surface results above the subreddit chrome
+//
+// Apollo pins the feed so its top (the tableHeaderView: banner + description + Community Highlights) sits
+// just under the docked field, leaving the "Search r/X for query" row + matching posts buried ~400pt down.
+// When there's a query we instead want the feed scrolled so that header is off the top and the first
+// results row sits directly under the field. Returns the desired content-offset.y: rest when empty / no
+// header (e.g. Home), or (headerHeight - insetTop) when there's a query.
+//
+// Scoped to "Keep Search Bar In Place" mode: with the toggle off, the feed keeps its original
+// rest-pinned behavior (results below the chrome), so that mode is unchanged from stock Apollo.
+static CGFloat ApolloFeedSearchDesiredOffsetY(UIScrollView *sv) {
+    CGFloat rest = -ApolloFeedSearchActiveRestTop();
+    if (!sKeepSearchBarInPlace) return rest;          // OFF mode: original, no surfacing
+    if (ApolloFeedSearchQueryText().length == 0) return rest;
+    UIView *hdr = [sv respondsToSelector:@selector(tableHeaderView)] ? [(UITableView *)sv tableHeaderView] : nil;
+    CGFloat H = hdr ? CGRectGetHeight(hdr.frame) : 0.0;
+    if (H <= 1.0) return rest;
+    CGFloat surfaced = H - sv.contentInset.top; // first results row just under the docked field
+    return surfaced > rest ? surfaced : rest;
+}
+
+// When the chrome is surfaced off the top, its tail still sits in the band behind the translucent
+// field/nav and bleeds through the Liquid Glass. Hide the header view while surfaced so the glass blurs
+// the plain feed background instead of the scrolled-up Community Highlights; show it again otherwise.
+// Alpha-only (no layout/offset change). `surfaced` callers MUST pair every hide with a restore — the
+// teardown / disappear paths below force it back to visible so the banner can never get stuck hidden.
+static void ApolloFeedSearchSetHeaderHidden(UIScrollView *sv, BOOL hidden) {
+    UIView *hdr = [sv respondsToSelector:@selector(tableHeaderView)] ? [(UITableView *)sv tableHeaderView] : nil;
+    if (hdr && hdr.alpha != (hidden ? 0.0 : 1.0)) hdr.alpha = hidden ? 0.0 : 1.0;
+}
+
+// Force the captured feed's header back to visible (teardown / leaving — belt-and-suspenders against a
+// header left transparent).
+static void ApolloFeedSearchRestoreHeader(void) {
+    if (sFeedSearchTable) ApolloFeedSearchSetHeaderHidden(sFeedSearchTable, NO);
+}
+
+// YES while the feed is holding the surfaced position (query non-empty, chrome scrolled off, not being
+// dismissed or user-browsed). The single source of truth for "should the header be hidden right now".
+static BOOL ApolloFeedSearchIsSurfaced(UIScrollView *sv) {
+    if (!sv) return NO;
+    CGFloat rest = -ApolloFeedSearchActiveRestTop();
+    return sFeedSearchActive && !sFeedSearchDismissing && !sFeedSearchScrolledByUser &&
+           ApolloFeedSearchQueryText().length > 0 &&
+           (ApolloFeedSearchDesiredOffsetY(sv) > rest + 1.0);
+}
+
 // MARK: - Round "X" cancel button
 //
 // Replaces the "Cancel" text with a neutral-gray xmark in a circle matching the search-field pill. In
@@ -434,6 +487,14 @@ static void recenterCancelButton(void) {
     id field = ApolloObjectIvar(self, "searchTextField");
     if ([field isKindOfClass:[UIView class]]) sFeedSearchField = (UIView *)field;
 
+    // Re-assert the surfaced-header visibility after every relayout (runs regardless of Liquid Glass).
+    // setContentOffset: alone isn't enough on return: a reload there can recreate the header at full
+    // alpha (and Apollo may re-park via setBounds: instead of setContentOffset:), so the scrolled-up
+    // chrome bleeds back through the glass. Recompute it here so it stays hidden while surfaced.
+    if (sFeedSearchTable) {
+        ApolloFeedSearchSetHeaderHidden(sFeedSearchTable, ApolloFeedSearchIsSurfaced(sFeedSearchTable));
+    }
+
     // Liquid Glass only: keep the round-X styled and run its slide-in.
     if (!IsLiquidGlass()) return;
     id cancel = ApolloObjectIvar(self, "dismissSearchBarButton");
@@ -451,6 +512,7 @@ static void recenterCancelButton(void) {
     // and release on a timer guarded by a generation counter against a re-focus.
     if (IsLiquidGlass() && sKeepSearchBarInPlace) {
         sFeedSearchDismissing = YES;                  // pins stay armed via (active || dismissing)
+        ApolloFeedSearchRestoreHeader();              // bring the chrome back as the search closes
         NSUInteger gen = ++sFeedSearchDismissGen;     // a newer dismiss / re-focus invalidates this timer
         %orig;
         animateCancelOut();                           // fade the round-X out
@@ -471,6 +533,7 @@ static void recenterCancelButton(void) {
 
     // OFF (nav-hide): release the capture up front so Apollo's restore passes through, then run a short
     // dismissing window.
+    ApolloFeedSearchRestoreHeader();                 // bring the chrome back as the search closes
     sFeedSearchNavBar = nil;
     sFeedSearchActive = NO;
     sFeedSearchDismissing = YES;
@@ -478,6 +541,49 @@ static void recenterCancelButton(void) {
     animateCancelOut(); // slide the round-X out
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.4 * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{ sFeedSearchDismissing = NO; });
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    %orig;
+    if (!IsLiquidGlass() || MSHookIvar<BOOL>(self, "searchBarShouldStickToKeyboard")) return;
+    id field = ApolloObjectIvar(self, "searchTextField");
+    NSString *txt = [field isKindOfClass:[UITextField class]] ? [(UITextField *)field text] : nil;
+
+    // Issue 2 (in-place): returning to a feed whose search is being restored, Apollo re-runs its search
+    // takeover — it hides the nav bar AND docks the search toolbar to the very top (it assumes the nav is
+    // gone). In-place mode keeps the nav visible with the toolbar pinned just below it, but those pins only
+    // engage once the search is "active", and the takeover fires during the restoring field's
+    // becomeFirstResponder — BEFORE textFieldDidBeginEditing arms them. So without this the nav re-hides
+    // (or the toolbar lands on top of it). Arm the whole in-place pin set here (capture refs + the active
+    // flag) before the appear / re-focus, so the nav stays put and the toolbar docks below it from the
+    // first pass. textFieldDidBeginEditing re-arms idempotently if/when the field actually focuses.
+    if (sKeepSearchBarInPlace && txt.length > 0) {
+        sFeedSearchNavBar = [(UIViewController *)self navigationController].navigationBar;
+        if ([field isKindOfClass:[UIView class]]) sFeedSearchField = (UIView *)field;
+        id upper = ApolloObjectIvar(self, "upperToolbar");
+        if ([upper isKindOfClass:[UIView class]]) sFeedSearchToolbar = (UIView *)upper;
+        sFeedSearchActive = YES;
+        sFeedSearchDismissing = NO;
+        sFeedSearchScrolledByUser = NO;
+    }
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    if (!IsLiquidGlass() || MSHookIvar<BOOL>(self, "searchBarShouldStickToKeyboard")) return;
+    UINavigationBar *nb = [(UIViewController *)self navigationController].navigationBar;
+
+    // Issue 2 safety net: if the nav bar slipped into the hidden state before our block armed, restore
+    // it (in-place mode keeps it visible), and re-assert the toolbar so it sits below the nav instead of
+    // docked on top of it. Only touch the bar/toolbar we captured for this feed.
+    if (sKeepSearchBarInPlace && nb && nb == sFeedSearchNavBar) {
+        if (nb.transform.ty < -1.0) nb.transform = CGAffineTransformIdentity;
+        if (nb.alpha < 1.0) nb.alpha = 1.0;
+        // Route the toolbar back through the setFrame pin (now that the flags are armed) so it re-docks
+        // below the still-visible nav rather than at the top.
+        UIView *tb = sFeedSearchToolbar;
+        if (tb && sFeedSearchActive && !sFeedSearchScrolledByUser) [tb setFrame:tb.frame];
+    }
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
@@ -521,18 +627,81 @@ static void recenterCancelButton(void) {
         UIScrollView *sv = (UIScrollView *)self;
         CGFloat rest = -ApolloFeedSearchActiveRestTop();
         BOOL userScrolling = sv.isDragging || sv.isDecelerating;
+        BOOL hasQuery = (ApolloFeedSearchQueryText().length > 0);
+        CGFloat target = ApolloFeedSearchDesiredOffsetY(sv); // rest (empty) or surfaced (query)
 
-        // Once the user drags, stop clamping; re-arm when they settle back at rest.
+        // Once the user drags, stop pinning so they can browse; re-arm when they settle back at/above
+        // the target (scrolling up toward the chrome snaps back; scrolling down through results is free).
         if (sv.isDragging) sFeedSearchScrolledByUser = YES;
-        else if (offset.y <= rest + 1.0) sFeedSearchScrolledByUser = NO;
+        else if (offset.y <= target + 1.0) sFeedSearchScrolledByUser = NO;
 
         if (sFeedSearchDismissing && !userScrolling) {
-            if (offset.y > rest) offset.y = rest; // teardown: only pull DOWN to rest, don't fight restore
+            if (offset.y > rest) offset.y = rest; // teardown: restore the chrome as the search dismisses
         } else if (sFeedSearchActive && !sFeedSearchDismissing && !userScrolling &&
-                   !sFeedSearchScrolledByUser && offset.y > rest) {
-            offset.y = rest; // kill Apollo's programmatic re-park (focus / keystroke / banner)
+                   !sFeedSearchScrolledByUser) {
+            if (hasQuery && target > rest + 1.0) {
+                offset.y = target;            // surfaced (in-place + query): hold the chrome scrolled off
+            } else if (offset.y > rest) {
+                offset.y = rest;              // otherwise: clamp down to rest only; keep pull-to-refresh
+            }
         }
+
+        // While holding the surfaced position, hide the header so the scrolled-up chrome doesn't bleed
+        // through the translucent field/nav; otherwise (empty query, dismissing, or the user scrolling to
+        // browse) keep it visible.
+        BOOL surfaced = hasQuery && sFeedSearchActive && !sFeedSearchDismissing &&
+                        !sFeedSearchScrolledByUser && (target > rest + 1.0);
+        ApolloFeedSearchSetHeaderHidden(sv, surfaced);
+
         %orig(offset);
+        return;
+    }
+    %orig;
+}
+
+// A scroll view's bounds.origin IS its contentOffset; Texture/Apollo re-park the feed via setBounds:
+// too, which setContentOffset: alone doesn't catch. Mirror the same pin here so the surfaced position
+// actually holds (otherwise a setBounds: re-park to rest renders before our next setContentOffset:).
+- (void)setBounds:(CGRect)bounds {
+    if ((UIScrollView *)self == sFeedSearchTable) {
+        UIScrollView *sv = (UIScrollView *)self;
+        // Only while surfacing (in-place + query); OFF mode never enters here, so its bounds pass through.
+        if (!sv.isDragging && !sv.isDecelerating && ApolloFeedSearchIsSurfaced(sv)) {
+            CGFloat want = ApolloFeedSearchDesiredOffsetY(sv);
+            if (fabs(bounds.origin.y - want) > 0.5) bounds.origin.y = want;
+            // Hide the header here too: the surface often lands via setBounds: (not setContentOffset:),
+            // and viewDidLayoutSubviews may not run again until the next keystroke — so without this the
+            // chrome bleeds through the glass until the 2nd letter. Pair with the surface, atomically.
+            ApolloFeedSearchSetHeaderHidden(sv, YES);
+        }
+    }
+    %orig(bounds);
+}
+
+// The header gets re-installed on reloads; hide the freshly-installed one immediately if we're surfaced.
+- (void)setTableHeaderView:(UIView *)header {
+    %orig;
+    if ((UIScrollView *)self == sFeedSearchTable && header && ApolloFeedSearchIsSurfaced((UIScrollView *)self)) {
+        header.alpha = 0.0;
+    }
+}
+
+%end
+
+// The subreddit header wrapper force-restores its own alpha to 1 in -layoutSubviews (anti-flash). While
+// the feed search is surfaced, that re-shows the scrolled-up chrome behind the glass every layout pass
+// (and wins the final frame on the first keystroke). Intercept its setAlpha: and hold it at 0 while
+// surfaced, for the captured feed's header only; otherwise pass through so it shows normally.
+@interface ApolloSubredditHeaderWrapperView : UIView
+@end
+
+%hook ApolloSubredditHeaderWrapperView
+
+- (void)setAlpha:(CGFloat)alpha {
+    if (alpha > 0.0 && sFeedSearchTable &&
+        (UIView *)self == [(UITableView *)sFeedSearchTable tableHeaderView] &&
+        ApolloFeedSearchIsSurfaced(sFeedSearchTable)) {
+        %orig(0.0);
         return;
     }
     %orig;

--- a/src/ApolloSearchInPlace.xm
+++ b/src/ApolloSearchInPlace.xm
@@ -158,6 +158,7 @@ static BOOL sFeedSearchDismissing     = NO;  // YES briefly during dismiss (rela
 static BOOL sFeedSearchScrolledByUser = NO;  // armed once the user drags → stop clamping so they can browse
 static NSUInteger sFeedSearchDismissGen = 0; // bumps each dismiss / focus / disappear; the release timer ignores stale gens
 static __weak UIView *sFeedSearchField    = nil; // captured searchTextField
+static CGFloat sFeedSearchStandaloneRestInset = 0.0; // feed's resting top inset (Headers OFF), captured while NOT searching
 
 // Stable content-top rest for the feed search table: the docked toolbar's window-space bottom (where the
 // first results row sits). Falls back to window safe-area top + 45 until the toolbar is docked.
@@ -637,17 +638,48 @@ static void recenterCancelButton(void) {
 %hook ASTableView
 
 - (void)setContentInset:(UIEdgeInsets)inset {
-    if (sFeedSearchActive && (UIScrollView *)self == sFeedSearchTable &&
-        ApolloFeedSearchManagedHeader((UIScrollView *)self)) {
-        CGFloat want = ApolloFeedSearchActiveRestTop();
-        if (inset.top < want) inset.top = want; // FLOOR only — never lower (allow pull-to-refresh growth)
-        %orig(inset);
-        return;
+    if ((UIScrollView *)self == sFeedSearchTable) {
+        BOOL managed = ApolloFeedSearchManagedHeader((UIScrollView *)self);
+        if (!sFeedSearchActive && !sFeedSearchDismissing) {
+            // Remember the feed's resting top inset (standalone / Headers OFF) so we can hold the chrome in
+            // place when the field is focused with no query yet.
+            if (!managed && inset.top > 1.0) sFeedSearchStandaloneRestInset = inset.top;
+        } else if (sFeedSearchActive && managed) {
+            CGFloat want = ApolloFeedSearchActiveRestTop();
+            if (inset.top < want) inset.top = want; // FLOOR only — never lower (allow pull-to-refresh growth)
+        } else if (sFeedSearchActive && !sFeedSearchDismissing && !managed &&
+                   sFeedSearchStandaloneRestInset > 1.0) {
+            // Standalone (Subreddit Headers OFF), focused: Apollo shrinks the top inset (~161->99) for the
+            // docked-field layout, which pulls the small Community Highlights carousel up behind the field.
+            // The carousel is short enough that it doesn't bury the results, so we keep it in place for the
+            // WHOLE search (empty AND while typing) — Apollo's native per-query surfacing is inconsistent
+            // (some letters push it up, some don't); the user wants it to always stay, results below it.
+            // Hold the resting inset; releases only on dismiss (which has its own restore).
+            if (inset.top < sFeedSearchStandaloneRestInset) inset.top = sFeedSearchStandaloneRestInset;
+        }
     }
-    %orig;
+    %orig(inset);
 }
 
 - (void)setContentOffset:(CGPoint)offset {
+    // Standalone (Headers OFF) + focused: pair with the inset hold above to keep the small Community
+    // Highlights carousel at its resting position throughout the search (tap AND while typing) so it stays
+    // in place with results below it, instead of Apollo inconsistently pushing it up behind the field on
+    // some queries. NOT during dismiss (which has its own restore). Released the instant the user drags
+    // (so they can scroll down through the results), and re-armed when they settle back at the top.
+    if ((UIScrollView *)self == sFeedSearchTable && sFeedSearchActive && !sFeedSearchDismissing &&
+        sFeedSearchStandaloneRestInset > 1.0 &&
+        !ApolloFeedSearchManagedHeader((UIScrollView *)self)) {
+        UIScrollView *sv2 = (UIScrollView *)self;
+        CGFloat rest = -sFeedSearchStandaloneRestInset;
+        if (sv2.isDragging) sFeedSearchScrolledByUser = YES;
+        else if (offset.y <= rest + 1.0) sFeedSearchScrolledByUser = NO;
+        if (!sv2.isDragging && !sv2.isDecelerating && !sFeedSearchScrolledByUser) {
+            if (offset.y > rest) offset.y = rest; // hold the carousel at rest
+        }
+        %orig(offset);
+        return;
+    }
     // Only when a FULL subreddit header is present (the managed case). Without it — Home, or just the small
     // Community Highlights carousel (Subreddit Headers off) — leave the feed's geometry stock; Apollo
     // surfaces results there natively, and the Highlights module re-attaches its carousel on dismiss.

--- a/src/ApolloSearchInPlace.xm
+++ b/src/ApolloSearchInPlace.xm
@@ -209,12 +209,24 @@ static NSString *ApolloFeedSearchQueryText(void) {
 //
 // Scoped to "Keep Search Bar In Place" mode: with the toggle off, the feed keeps its original
 // rest-pinned behavior (results below the chrome), so that mode is unchanged from stock Apollo.
+// The surfacing only engages when the feed has a FULL subreddit header — Reborn's
+// ApolloSubredditHeaderWrapperView (Subreddit Headers ON: banner + description + Community Highlights,
+// ~400pt of chrome that genuinely buries the search row). When that's off, the header is either nothing
+// (Home) or just the small Community Highlights carousel, which the highlights module rebuilds + re-nests
+// across reloads; surfacing it both isn't worth it (little chrome to clear) and mis-positions / strands
+// that rebuilt header. So those cases keep stock behavior (results below the chrome).
+static BOOL ApolloFeedSearchManagedHeader(UIScrollView *sv) {
+    UIView *hdr = [sv respondsToSelector:@selector(tableHeaderView)] ? [(UITableView *)sv tableHeaderView] : nil;
+    return hdr && [hdr isKindOfClass:objc_getClass("ApolloSubredditHeaderWrapperView")];
+}
+
 static CGFloat ApolloFeedSearchDesiredOffsetY(UIScrollView *sv) {
     CGFloat rest = -ApolloFeedSearchActiveRestTop();
     if (!sKeepSearchBarInPlace) return rest;          // OFF mode: original, no surfacing
+    if (!ApolloFeedSearchManagedHeader(sv)) return rest; // no full header to clear → stock
     if (ApolloFeedSearchQueryText().length == 0) return rest;
-    UIView *hdr = [sv respondsToSelector:@selector(tableHeaderView)] ? [(UITableView *)sv tableHeaderView] : nil;
-    CGFloat H = hdr ? CGRectGetHeight(hdr.frame) : 0.0;
+    UIView *hdr = [(UITableView *)sv tableHeaderView];
+    CGFloat H = CGRectGetHeight(hdr.frame);
     if (H <= 1.0) return rest;
     CGFloat surfaced = H - sv.contentInset.top; // first results row just under the docked field
     return surfaced > rest ? surfaced : rest;
@@ -223,11 +235,13 @@ static CGFloat ApolloFeedSearchDesiredOffsetY(UIScrollView *sv) {
 // When the chrome is surfaced off the top, its tail still sits in the band behind the translucent
 // field/nav and bleeds through the Liquid Glass. Hide the header view while surfaced so the glass blurs
 // the plain feed background instead of the scrolled-up Community Highlights; show it again otherwise.
-// Alpha-only (no layout/offset change). `surfaced` callers MUST pair every hide with a restore — the
-// teardown / disappear paths below force it back to visible so the banner can never get stuck hidden.
+// Alpha-only (no layout/offset change). Only ever runs for the managed wrapper (the only thing that
+// surfaces); its setAlpha: is hooked below so the wrapper's per-pass anti-flash can't re-show it.
 static void ApolloFeedSearchSetHeaderHidden(UIScrollView *sv, BOOL hidden) {
-    UIView *hdr = [sv respondsToSelector:@selector(tableHeaderView)] ? [(UITableView *)sv tableHeaderView] : nil;
-    if (hdr && hdr.alpha != (hidden ? 0.0 : 1.0)) hdr.alpha = hidden ? 0.0 : 1.0;
+    if (!ApolloFeedSearchManagedHeader(sv)) return;
+    UIView *hdr = [(UITableView *)sv tableHeaderView];
+    CGFloat a = hidden ? 0.0 : 1.0;
+    if (hdr.alpha != a) hdr.alpha = a;
 }
 
 // Force the captured feed's header back to visible (teardown / leaving — belt-and-suspenders against a
@@ -612,7 +626,8 @@ static void recenterCancelButton(void) {
 %hook ASTableView
 
 - (void)setContentInset:(UIEdgeInsets)inset {
-    if (sFeedSearchActive && (UIScrollView *)self == sFeedSearchTable) {
+    if (sFeedSearchActive && (UIScrollView *)self == sFeedSearchTable &&
+        ApolloFeedSearchManagedHeader((UIScrollView *)self)) {
         CGFloat want = ApolloFeedSearchActiveRestTop();
         if (inset.top < want) inset.top = want; // FLOOR only — never lower (allow pull-to-refresh growth)
         %orig(inset);
@@ -622,8 +637,12 @@ static void recenterCancelButton(void) {
 }
 
 - (void)setContentOffset:(CGPoint)offset {
+    // Only when a FULL subreddit header is present (the managed case). Without it — Home, or just the small
+    // Community Highlights carousel (Subreddit Headers off) — leave the feed's geometry stock, so dismissing
+    // a search can't strand the rebuilt carousel header behind the chrome (blank space).
     if ((UIScrollView *)self == sFeedSearchTable &&
-        (sFeedSearchActive || sFeedSearchDismissing)) {
+        (sFeedSearchActive || sFeedSearchDismissing) &&
+        ApolloFeedSearchManagedHeader((UIScrollView *)self)) {
         UIScrollView *sv = (UIScrollView *)self;
         CGFloat rest = -ApolloFeedSearchActiveRestTop();
         BOOL userScrolling = sv.isDragging || sv.isDecelerating;
@@ -682,7 +701,7 @@ static void recenterCancelButton(void) {
 - (void)setTableHeaderView:(UIView *)header {
     %orig;
     if ((UIScrollView *)self == sFeedSearchTable && header && ApolloFeedSearchIsSurfaced((UIScrollView *)self)) {
-        header.alpha = 0.0;
+        ApolloFeedSearchSetHeaderHidden((UIScrollView *)self, YES);
     }
 }
 

--- a/src/ApolloSubredditHighlights.xm
+++ b/src/ApolloSubredditHighlights.xm
@@ -1257,7 +1257,38 @@ static void ApolloHLInstallCarousel(UIViewController *vc, UITableView *tableView
 
     BOOL sameContent = [storedSubreddit isEqualToString:subreddit] && [storedSignature isEqualToString:signature];
     if (sameContent && wrapper && tableView.tableHeaderView == wrapper) {
-        return; // already installed and current
+        // Already installed and current — UNLESS the wrapper has been detached from the window while the
+        // table is on-screen. Apollo's in-place feed search removes the tableHeaderView from the view
+        // hierarchy to show results, but leaves the `tableHeaderView` PROPERTY pointing at our wrapper, so
+        // on dismiss every re-install short-circuits here and the carousel never comes back (it's set but
+        // unrendered → a blank gap). Detect that and force a re-attach: nil then re-set under the rewrap
+        // guard so the table re-adds + lays out the header. STANDALONE carousel only (Subreddit Headers
+        // off): when headers are on, the carousel is hosted inside the headers wrapper and the search
+        // module owns that chrome, so re-seating + scrolling here would scroll the banner off.
+        if (sShowSubredditHeaders || !(tableView.window && !wrapper.window)) {
+            return; // headers-hosted, or attached / off-screen → nothing to do
+        }
+        objc_setAssociatedObject(tableView, kApolloHLRewrapInProgressKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        tableView.tableHeaderView = nil;
+        tableView.tableHeaderView = wrapper;
+        objc_setAssociatedObject(tableView, kApolloHLRewrapInProgressKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        // The feed is still scrolled where the search results were, so the just-re-attached carousel sits
+        // above the viewport (behind the field). Scroll back to the top so it's visible again — but defer
+        // it: the search-dismiss is still animating the content inset back to its resting value, so reading
+        // it now would over-scroll (hiding the field). Re-read on the next runloop turns until it settles.
+        __weak UITableView *weakTV = tableView;
+        for (int i = 1; i <= 3; i++) {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(i * 0.15 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                UITableView *tv = weakTV;
+                if (!tv || tv.tracking || tv.dragging) return;
+                CGFloat top = -tv.adjustedContentInset.top;
+                if (tv.contentOffset.y > top + 0.5) {
+                    [tv setContentOffset:CGPointMake(tv.contentOffset.x, top) animated:(i == 3)];
+                }
+            });
+        }
+        ApolloLog(@"[Highlights] re-attached detached carousel r/%@", subreddit);
+        return;
     }
 
     CGFloat width = tableView.bounds.size.width > 0 ? tableView.bounds.size.width : UIScreen.mainScreen.bounds.size.width;

--- a/src/ApolloSubredditHighlights.xm
+++ b/src/ApolloSubredditHighlights.xm
@@ -1244,6 +1244,33 @@ static void ApolloHLTeardown(UIViewController *vc, BOOL restoreNativeHeader) {
     ApolloHLRestoreStandaloneHeader(vc);
 }
 
+// Mid-search predicate from ApolloSearchInPlace.xm (same dylib): YES while this feed table is showing
+// search results for a non-empty query, so we must not re-attach/scroll its carousel back to the top.
+extern BOOL ApolloFeedSearchIsActiveQuery(UIScrollView *tv);
+
+// Keep a just-re-attached standalone carousel pinned to the feed top while the search dismiss finishes.
+// The dismiss animates BOTH the content inset (the search field restoring) and the offset back over a
+// device-dependent duration (the sim is much faster than a real device — see the memory's issues 2/2b),
+// so a single scroll mis-lands: read too early (before the field's inset grows back) and we over-scroll
+// the carousel up behind the nav, hiding the field. Instead re-pin to the CURRENT -inset.top every ~0.1s
+// for up to ~0.8s, so the carousel tracks the field as its inset grows and ends just below it. Aborts
+// permanently the moment the user takes over the scroll (tracking/dragging/decelerating) or a search
+// re-activates. Non-animated (instant) so the per-tick re-pin reads as one smooth settle, and re-reads the
+// table weakly so it never retains it across the delays.
+static void ApolloHLPinCarouselToTop(UITableView *tv, int attempt) {
+    if (!tv || attempt > 8) return;
+    if (tv.tracking || tv.dragging || tv.decelerating) return;     // user took over → stop
+    if (ApolloFeedSearchIsActiveQuery((UIScrollView *)tv)) return;  // search re-activated → leave results up
+    CGFloat top = -tv.adjustedContentInset.top;
+    if (tv.contentOffset.y > top + 0.5) {
+        [tv setContentOffset:CGPointMake(tv.contentOffset.x, top) animated:NO];
+    }
+    __weak UITableView *weakTV = tv;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        ApolloHLPinCarouselToTop(weakTV, attempt + 1);
+    });
+}
+
 static void ApolloHLInstallCarousel(UIViewController *vc, UITableView *tableView, NSArray<ApolloHLItem *> *items, NSString *subreddit) {
     if (items.count == 0) {
         // Nothing pinned — make sure we aren't leaving a stale carousel up.
@@ -1264,29 +1291,22 @@ static void ApolloHLInstallCarousel(UIViewController *vc, UITableView *tableView
         // unrendered → a blank gap). Detect that and force a re-attach: nil then re-set under the rewrap
         // guard so the table re-adds + lays out the header. STANDALONE carousel only (Subreddit Headers
         // off): when headers are on, the carousel is hosted inside the headers wrapper and the search
-        // module owns that chrome, so re-seating + scrolling here would scroll the banner off.
-        if (sShowSubredditHeaders || !(tableView.window && !wrapper.window)) {
-            return; // headers-hosted, or attached / off-screen → nothing to do
+        // module owns that chrome, so re-seating + scrolling here would scroll the banner off. And skip
+        // entirely while a search is ACTIVE with a query (results are showing) — re-attaching + scrolling
+        // to the top then would yank the user's results away; the carousel should only come back once the
+        // search ends (dismiss) or the query is cleared to empty.
+        if (sShowSubredditHeaders || !(tableView.window && !wrapper.window) ||
+            ApolloFeedSearchIsActiveQuery((UIScrollView *)tableView)) {
+            return; // headers-hosted, attached/off-screen, or mid-search → nothing to do
         }
         objc_setAssociatedObject(tableView, kApolloHLRewrapInProgressKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         tableView.tableHeaderView = nil;
         tableView.tableHeaderView = wrapper;
         objc_setAssociatedObject(tableView, kApolloHLRewrapInProgressKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         // The feed is still scrolled where the search results were, so the just-re-attached carousel sits
-        // above the viewport (behind the field). Scroll back to the top so it's visible again — but defer
-        // it: the search-dismiss is still animating the content inset back to its resting value, so reading
-        // it now would over-scroll (hiding the field). Re-read on the next runloop turns until it settles.
-        __weak UITableView *weakTV = tableView;
-        for (int i = 1; i <= 3; i++) {
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(i * 0.15 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                UITableView *tv = weakTV;
-                if (!tv || tv.tracking || tv.dragging) return;
-                CGFloat top = -tv.adjustedContentInset.top;
-                if (tv.contentOffset.y > top + 0.5) {
-                    [tv setContentOffset:CGPointMake(tv.contentOffset.x, top) animated:(i == 3)];
-                }
-            });
-        }
+        // above the viewport (behind the field). Pin it back to the top so it's visible again — tracking the
+        // still-restoring inset so it lands just below the field instead of over-scrolling behind the nav.
+        ApolloHLPinCarouselToTop(tableView, 0);
         ApolloLog(@"[Highlights] re-attached detached carousel r/%@", subreddit);
         return;
     }


### PR DESCRIPTION
Refines the feed/subreddit search behavior, **scoped entirely to the existing "Keep Search Bar In Place" toggle** (Settings → Apollo Reborn → General). With the toggle **off, feed search is unchanged from stock Apollo**. With it **on**:

### 1. Results surface on top while typing
In a subreddit, the chrome (banner, description, Community Highlights — all the feed table's `tableHeaderView`, ~400pt) sat *between* the search field and the "Search r/X for query" row + matching posts, so the search affordances were buried far down the feed. When there's a query, the feed now scrolls that header off the top so the search row + results sit directly under the field. An empty query, or Home (no header), collapses to the previous resting position.

### 2. Nav bar + toolbar stay correct after returning from a result
Type a query → open a result → back: Apollo re-runs its search takeover during the restoring field's `becomeFirstResponder`, which fires *before* `textFieldDidBeginEditing` armed the in-place pins — so the nav bar got hidden and the search toolbar docked on top of where it should be. The in-place pin set is now armed early (in `viewWillAppear`, with a `viewDidAppear` backstop), so the nav stays visible and the toolbar sits below it.

### 3. No chrome bleed-through behind the glass
The surfaced header still occupies the band behind the translucent field/nav, so the Community Highlights bled through the Liquid Glass. The header is now hidden (alpha) while surfaced and restored on empty query / dismiss / while the user scrolls. The subreddit header wrapper force-restores its own alpha each layout pass (anti-flash), so its `setAlpha:` is intercepted to hold it hidden while surfaced — for the captured feed header only, so it can never get stuck hidden.

## Video In action

https://github.com/user-attachments/assets/2e73551e-b6cf-4d17-9ac9-484bd5775d64

### Notes
- One file (`src/ApolloSearchInPlace.xm`).
- `setContentOffset:` alone isn't enough — Apollo re-parks the feed via `setBounds:` too (a scroll view's `bounds.origin` is its `contentOffset`), so the pins/header-hide are mirrored there.
- Empty query / Home / no-header subreddits are a no-op.
- **Toggle off = original Apollo** (results below the chrome, stock nav-hide takeover) — nothing changed.

Built and **device-tested** (iOS 26 / Liquid Glass) across r/apple, r/anime, r/pics and Home, both toggle states: ON surfaces results on top with the nav/toolbar staying put after navigating to a result and back, and dismissing/clearing restores the banner + highlights; OFF behaves exactly like stock.