### PR TITLE
Add "Show Detailed Profiles" toggle

### DIFF
--- a/src/ApolloProfileSocialLinks.h
+++ b/src/ApolloProfileSocialLinks.h
@@ -44,7 +44,8 @@
 - (void)refresh;
 @end
 
-// YES when the "Social Links in Profile" toggle is on (reads sSocialLinksInProfile).
+// YES when "Show Detailed Profiles" is on (reads sShowDetailedProfiles) — the Social
+// Links band is part of the detailed profile, so it shares that toggle.
 FOUNDATION_EXPORT BOOL ApolloProfileSocialLinksEnabled(void);
 
 // Posted by Settings when the toggle flips; the band observes it to reload.

--- a/src/ApolloProfileSocialLinks.m
+++ b/src/ApolloProfileSocialLinks.m
@@ -12,7 +12,9 @@
 NSString *const ApolloSocialLinksToggleChangedNotification = @"ApolloSocialLinksToggleChangedNotification";
 
 BOOL ApolloProfileSocialLinksEnabled(void) {
-    return sSocialLinksInProfile;
+    // The Social Links band is part of the detailed profile (it lives inside the
+    // custom header), so it's gated on the single "Show Detailed Profiles" toggle.
+    return sShowDetailedProfiles;
 }
 
 #pragma mark - Model

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -26,12 +26,14 @@ extern NSInteger sUnmuteCommentsVideos;
 extern BOOL sProxyImgurDDG;
 extern BOOL sShowUserAvatars;
 extern BOOL sUseProfileAvatarTabIcon;
-// When ON, a redditor's profile social links (Buy Me a Coffee, Instagram, X, …) are
-// shown in the profile header between the username and bio: a tappable pill for a
-// single link, or a row of brand badges that opens a slide-up sheet for several.
-// Rendered inside the tweak's custom profile header, so it needs sShowUserAvatars ON.
-// See ApolloProfileSocialLinks.{h,m}.
-extern BOOL sSocialLinksInProfile;
+// When ON (default), profile pages show Reborn's detailed profile — the banner,
+// large avatar/snoovatar, display name, bio, and the Social Links band (Buy Me a
+// Coffee, Instagram, X, …). When OFF, profiles revert to Apollo's compact stock
+// layout — the detailed header is not installed and any existing one is torn down.
+// Independent of sShowUserAvatars (inline avatars). The Social Links band lives
+// inside this header, so it is gated on this same flag. Default ON via
+// registerDefaults. See ApolloUserAvatars.xm and ApolloProfileSocialLinks.{h,m}.
+extern BOOL sShowDetailedProfiles;
 extern BOOL sShowSubredditHeaders;
 // When ON, a horizontally-scrolling "Community Highlights" carousel of the
 // subreddit's pinned/stickied posts is shown at the top of the feed (mirrors

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -25,7 +25,7 @@ NSInteger sUnmuteCommentsVideos = 0; // 0=Default, 1=Remember from Full Screen, 
 BOOL sProxyImgurDDG = NO;
 BOOL sShowUserAvatars = NO;
 BOOL sUseProfileAvatarTabIcon = NO;
-BOOL sSocialLinksInProfile = YES;
+BOOL sShowDetailedProfiles = YES;   // effective default ON via registerDefaults (UDKeyShowDetailedProfiles)
 BOOL sShowSubredditHeaders = NO;
 BOOL sCommunityHighlights = NO;
 BOOL sCommunityHighlightsWeb = NO;

--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -70,6 +70,12 @@ static const void *kApolloProfileTabAvatarImageMarkerKey = &kApolloProfileTabAva
 @property(nonatomic, strong) ApolloProfileSocialLinksView *socialLinksView;
 @property(nonatomic, weak) UIViewController *hostViewController;
 @property(nonatomic, copy) NSString *username;
+// The avatar/snoovatar and banner URLs the most recent profile info applied to this
+// header wanted. The header view is reused across usernames (and re-fetched for the
+// same user), so async image completions compare against these to detect that a newer
+// load has superseded the URL they were fetching before stamping a stale image.
+@property(nonatomic, copy) NSURL *currentProfileImageURL;
+@property(nonatomic, copy) NSURL *currentBannerURL;
 @property(nonatomic, copy) void (^heightInvalidationBlock)(void);
 - (void)applyProfileInfo:(ApolloUserProfileInfo *)info fallbackUsername:(NSString *)username;
 - (CGFloat)preferredHeightForWidth:(CGFloat)width;
@@ -1399,13 +1405,35 @@ static ApolloProfileHeaderView *ApolloProfileCreateHeader(CGFloat width) {
     return header;
 }
 
+static BOOL ApolloProfileURLsMatch(NSURL *left, NSURL *right) {
+    if (left == right) return YES;
+    if (!left || !right) return NO;
+    return [left.absoluteString isEqualToString:right.absoluteString];
+}
+
 static void ApolloProfileLoadImages(ApolloProfileHeaderView *header, NSString *username, BOOL forceRefresh) {
     if (!header || username.length == 0) return;
     ApolloUserProfileCache *cache = [ApolloUserProfileCache sharedCache];
     ApolloUserProfileInfo *cachedInfo = [cache cachedInfoForUsername:username];
 
+    // The header view is cached on the profile/account-manager VC and repointed to a
+    // new username by ApolloProfileInstallOrUpdateHeader (account switch, reused
+    // persistent ProfileViewController, etc.). These info/image fetches are async and
+    // land on the main queue, so by the time a completion fires the header may already
+    // belong to a different user — stamping a late result would bleed user A's
+    // avatar/snoovatar/banner/name/bio onto user B and never self-heal. Capture the
+    // target identity up front and bail from every completion whose header no longer
+    // matches it (mirrors the social-links band's `username == want` guard).
+    NSString *targetUsername = ApolloAvatarNormalizedUsername(username);
+    if (targetUsername.length == 0) return;
+
     void (^applyInfo)(ApolloUserProfileInfo *) = ^(ApolloUserProfileInfo *info) {
         if (!info) return;
+        // Dropped if the header was repointed to another user while this was in flight.
+        if (!ApolloAvatarUsernameMatches(header.username, targetUsername)) {
+            ApolloLog(@"[UserAvatars] Dropping stale profile info for u/%@ (header now u/%@)", targetUsername, header.username ?: @"nil");
+            return;
+        }
         [header applyProfileInfo:info fallbackUsername:username];
 
         if (header.hostViewController) {
@@ -1416,6 +1444,10 @@ static void ApolloProfileLoadImages(ApolloProfileHeaderView *header, NSString *u
         ApolloProfileSetSnoovatarMode(header, showSnoovatar);
 
         NSURL *profileImageURL = showSnoovatar ? info.snoovatarURL : info.iconURL;
+        // Record what this (now-current) info wants so a later async image completion
+        // can tell whether it has been superseded by a newer load for the same user.
+        header.currentProfileImageURL = profileImageURL;
+        header.currentBannerURL = info.bannerURL;
         if (profileImageURL) {
             UIImage *image = [cache cachedImageForURL:profileImageURL];
             if (image) {
@@ -1424,6 +1456,10 @@ static void ApolloProfileLoadImages(ApolloProfileHeaderView *header, NSString *u
             } else {
                 [cache requestImageForURL:profileImageURL completion:^(UIImage *loadedImage) {
                     if (!loadedImage) return;
+                    // Re-validate: the header may have switched users, or a newer fetch
+                    // for this same user may have chosen a different avatar/snoovatar URL.
+                    if (!ApolloAvatarUsernameMatches(header.username, targetUsername)) return;
+                    if (!ApolloProfileURLsMatch(header.currentProfileImageURL, profileImageURL)) return;
                     if (showSnoovatar) header.snoovatarImageView.image = loadedImage;
                     else header.avatarImageView.image = loadedImage;
                 }];
@@ -1434,8 +1470,12 @@ static void ApolloProfileLoadImages(ApolloProfileHeaderView *header, NSString *u
             if (banner) {
                 header.bannerImageView.image = banner;
             } else {
-                [cache requestImageForURL:info.bannerURL completion:^(UIImage *loadedImage) {
-                    if (loadedImage) header.bannerImageView.image = loadedImage;
+                NSURL *bannerURL = info.bannerURL;
+                [cache requestImageForURL:bannerURL completion:^(UIImage *loadedImage) {
+                    if (!loadedImage) return;
+                    if (!ApolloAvatarUsernameMatches(header.username, targetUsername)) return;
+                    if (!ApolloProfileURLsMatch(header.currentBannerURL, bannerURL)) return;
+                    header.bannerImageView.image = loadedImage;
                 }];
             }
         }
@@ -1713,6 +1753,10 @@ static void ApolloProfileInstallOrUpdateHeader(id viewControllerObject) {
         header.avatarImageView.image = ApolloProfilePlaceholderAvatar();
         header.snoovatarImageView.image = nil;
         header.bannerImageView.image = nil;
+        // Forget the previous user's expected image URLs so an in-flight completion
+        // from that user can't match and stamp onto the freshly-repointed header.
+        header.currentProfileImageURL = nil;
+        header.currentBannerURL = nil;
         [header applyProfileInfo:nil fallbackUsername:username];
         ApolloProfileSetSnoovatarMode(header, NO);
         ApolloProfileLoadImages(header, username, NO);

--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -83,6 +83,7 @@ static BOOL ApolloProfileUsernameIsLoggedInAccount(NSString *username);
 static void ApolloProfileOpenRedditProfileEditor(void);
 static void ApolloProfileSetSnoovatarMode(ApolloProfileHeaderView *header, BOOL showSnoovatar);
 static void ApolloProfileLoadImages(ApolloProfileHeaderView *header, NSString *username, BOOL forceRefresh);
+static void ApolloProfileRemoveHeader(id viewControllerObject, UITableView *tableView);
 static void ApolloProfileRefreshControllersForUsername(NSString *username);
 static void ApolloProfileApplyTabAvatarForController(UITabBarController *tabBarController);
 static void ApolloProfileApplyTabAvatarForVisibleWindows(void);
@@ -1569,6 +1570,46 @@ static void ApolloProfileInstallUsernameCopyInteraction(UIViewController *viewCo
     }
 }
 
+// Tear down the custom profile header and restore Apollo's native table header.
+// Used when "Show Detailed Profiles" is OFF (either toggled off live, or already
+// off when a profile page appears) so the page falls back to Apollo's stock layout.
+// Safe to call repeatedly: once the wrapper is removed and the per-VC state cleared,
+// subsequent calls are a cheap no-op.
+static void ApolloProfileRemoveHeader(id viewControllerObject, UITableView *tableView) {
+    if (!viewControllerObject) return;
+
+    UIView *wrappedHeader = objc_getAssociatedObject(viewControllerObject, kApolloProfileWrappedHeaderKey);
+    UIView *originalHeader = objc_getAssociatedObject(viewControllerObject, kApolloProfileOriginalHeaderKey);
+
+    // The table may currently host our wrapper even if our per-VC refs went stale
+    // (fresh controller, reused VC, etc.) — detect it via the wrapper marker.
+    UIView *currentTableHeader = tableView.tableHeaderView;
+    if (currentTableHeader && objc_getAssociatedObject(currentTableHeader, kApolloProfileWrapperMarkerKey)) {
+        wrappedHeader = currentTableHeader;
+        originalHeader = objc_getAssociatedObject(currentTableHeader, kApolloProfileOriginalHeaderKey) ?: originalHeader;
+    }
+
+    if (wrappedHeader && tableView.tableHeaderView == wrappedHeader) {
+        // Pull Apollo's native header back out of our wrapper, reset its frame to the
+        // origin, and reinstate it as the table header (nil if Apollo had none — that
+        // is the stock look for AsyncDisplayKit profiles whose stats live in cells).
+        if (originalHeader) {
+            CGFloat width = tableView.bounds.size.width > 0 ? tableView.bounds.size.width : originalHeader.frame.size.width;
+            [originalHeader removeFromSuperview];
+            originalHeader.frame = CGRectMake(0.0, 0.0, width, originalHeader.frame.size.height);
+        }
+        tableView.tableHeaderView = originalHeader;  // nil is valid — clears the header
+        NSString *className = NSStringFromClass([(UIViewController *)viewControllerObject class]);
+        ApolloLog(@"[UserAvatars] Removed profile header (toggle off) class=%@ vc=%p native=%@", className, viewControllerObject, originalHeader ? NSStringFromClass([originalHeader class]) : @"nil");
+    }
+
+    // Clear all per-VC state so a later re-enable installs a fresh header cleanly.
+    objc_setAssociatedObject(viewControllerObject, kApolloProfileHeaderViewKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(viewControllerObject, kApolloProfileWrappedHeaderKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(viewControllerObject, kApolloProfileOriginalHeaderKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(viewControllerObject, kApolloProfileUsernameKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
 static void ApolloProfileInstallOrUpdateHeader(id viewControllerObject) {
     if (![viewControllerObject isKindOfClass:[UIViewController class]]) return;
     UIViewController *viewController = (UIViewController *)viewControllerObject;
@@ -1578,6 +1619,14 @@ static void ApolloProfileInstallOrUpdateHeader(id viewControllerObject) {
         if (ApolloViewControllerLooksProfileRelated(viewController)) {
             ApolloLog(@"[UserAvatars] Profile header skipped class=%@ vc=%p reason=no-table", className, viewControllerObject);
         }
+        return;
+    }
+
+    // "Show Detailed Profiles" OFF → revert to Apollo's stock profile layout. Tear
+    // down anything we previously installed and bail before building/refreshing it.
+    // (Independent of sShowUserAvatars, which only governs the inline username avatars.)
+    if (!sShowDetailedProfiles) {
+        ApolloProfileRemoveHeader(viewControllerObject, tableView);
         return;
     }
 

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -1121,10 +1121,13 @@ typedef NS_ENUM(NSInteger, Tag) {
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon]
                                            action:@selector(profileTabAvatarSwitchToggled:)];
         case 10:
-            return [self switchCellWithIdentifier:@"Cell_Media_SocialLinks"
-                                            label:@"Social Links in Profile"
-                                               on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeySocialLinksInProfile]
-                                           action:@selector(socialLinksInProfileSwitchToggled:)];
+            // Single toggle for Reborn's detailed profile page: banner, large
+            // avatar/snoovatar, display name, bio, and the Social Links band (all of
+            // which live in the custom header). Off → Apollo's compact stock profile.
+            return [self switchCellWithIdentifier:@"Cell_Media_DetailedProfiles"
+                                            label:@"Show Detailed Profiles"
+                                               on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowDetailedProfiles]
+                                           action:@selector(showDetailedProfilesSwitchToggled:)];
         case 11:
             return [self switchCellWithIdentifier:@"Cell_Media_ChatMedia"
                                             label:@"Inline Media in Chat"
@@ -2171,9 +2174,15 @@ typedef NS_ENUM(NSInteger, Tag) {
     [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloProfileTabAvatarIconChangedNotification" object:nil];
 }
 
-- (void)socialLinksInProfileSwitchToggled:(UISwitch *)sender {
-    sSocialLinksInProfile = sender.isOn;
-    [[NSUserDefaults standardUserDefaults] setBool:sSocialLinksInProfile forKey:UDKeySocialLinksInProfile];
+- (void)showDetailedProfilesSwitchToggled:(UISwitch *)sender {
+    // One toggle for the whole detailed profile (header + banner + avatar + bio +
+    // social links). The avatars-toggle notification is observed in ApolloUserAvatars.xm
+    // and re-walks visible profile controllers, installing or tearing down the header
+    // per the new value; the social-links notification refreshes the band (gated on the
+    // same flag). Both apply live, no relaunch.
+    sShowDetailedProfiles = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sShowDetailedProfiles forKey:UDKeyShowDetailedProfiles];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloUserAvatarsToggleChangedNotification" object:nil];
     [[NSNotificationCenter defaultCenter] postNotificationName:ApolloSocialLinksToggleChangedNotification object:nil];
 }
 

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1474,7 +1474,7 @@ static void initializeRandomSources() {
                                     UDKeyImageUploadProvider: @(ImageUploadProviderImgur),
                                     UDKeyShowUserAvatars: @NO,
                                     UDKeyUseProfileAvatarTabIcon: @NO,
-                                    UDKeySocialLinksInProfile: @YES,
+                                    UDKeyShowDetailedProfiles: @YES,
                                     UDKeyShowSubredditHeaders: @NO,
                                     UDKeyCommunityHighlights: @NO,
                                     UDKeyCommunityHighlightsWeb: @NO,
@@ -1578,7 +1578,7 @@ static void initializeRandomSources() {
     sImageUploadProvider = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyImageUploadProvider];
     sShowUserAvatars = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars];
     sUseProfileAvatarTabIcon = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon];
-    sSocialLinksInProfile = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeySocialLinksInProfile];
+    sShowDetailedProfiles = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowDetailedProfiles];
     sShowSubredditHeaders = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowSubredditHeaders];
     sCommunityHighlights = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyCommunityHighlights];
     sCommunityHighlightsWeb = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyCommunityHighlightsWeb];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -48,7 +48,14 @@ static NSString *const UDKeyProxyImgurDDG = @"ProxyImgurDDG";
 static NSString *const UDKeyImageUploadProvider = @"ImageUploadProvider";
 static NSString *const UDKeyShowUserAvatars = @"ShowUserAvatars";
 static NSString *const UDKeyUseProfileAvatarTabIcon = @"UseProfileAvatarTabIcon";
-static NSString *const UDKeySocialLinksInProfile = @"SocialLinksInProfile";
+// When ON (default), profile pages show Reborn's detailed profile — the banner,
+// large avatar/snoovatar, display name, bio, and the Social Links band. When OFF,
+// the profile page reverts to Apollo's compact stock layout: the detailed header is
+// not installed, and any header already on screen is torn down (restoring Apollo's
+// native table header). Independent of "Show User Profile Pictures"
+// (UDKeyShowUserAvatars), which governs the inline avatars next to usernames.
+// See ApolloUserAvatars.xm and ApolloProfileSocialLinks.m. Default YES.
+static NSString *const UDKeyShowDetailedProfiles = @"ShowDetailedProfiles";
 static NSString *const UDKeyShowSubredditHeaders = @"ShowSubredditHeaders";
 static NSString *const UDKeyCommunityHighlights = @"CommunityHighlights";
 static NSString *const UDKeyCommunityHighlightsWeb = @"CommunityHighlightsWeb";


### PR DESCRIPTION
## What

Adds a single **"Show Detailed Profiles"** toggle in Settings → Apollo Reborn → Media (default **ON**, so nothing changes for existing users unless they opt out).

- **ON** (default): profile pages show Reborn's detailed profile — banner, large avatar/snoovatar, display name, bio, and the Social Links band.
- **OFF**: profile pages revert to Apollo's **compact stock** layout. The detailed header is not installed, and if one is already on screen it is torn down (Apollo's native table header is restored).

This is **independent of "Show User Profile Pictures"**, which only governs the inline avatars shown next to usernames in comments/feeds. That separation is the point: users have reported that a profile's big banner/avatar still appears even with *"Show User Profile Pictures"* turned **off**, pushing the karma stats and Posts/Comments rows down. They can now get the compact stock profile back without losing inline avatars.

The Social Links band lives *inside* this header, so it shares this one toggle — the previously separate "Social Links in Profile" switch is folded in.

## Profile page

<img width="850" alt="Profile page — ON (detailed) vs OFF (Apollo default)" src="https://github.com/user-attachments/assets/b975da44-e085-4229-89f4-ba25ea1de20b" />

## Settings

A single switch — no extra sub-rows:

<img width="413" alt="Show Detailed Profiles toggle in Settings" src="https://github.com/user-attachments/assets/eb66ee2d-db92-4a17-b4e0-0d36e6a410b4" />

## Implementation

- New `UDKeyShowDetailedProfiles` / `sShowDetailedProfiles` (default **YES** via `registerDefaults`), replacing the now-folded-in `SocialLinksInProfile` toggle.
- `ApolloProfileInstallOrUpdateHeader` bails early and tears down via a new `ApolloProfileRemoveHeader` when off — restoring Apollo's native `tableHeaderView` (or `nil` for ASDK profiles whose stats live in cells).
- `ApolloProfileSocialLinksEnabled()` now reads the same flag, so the Social Links band follows the toggle.
- The toggle posts the existing avatars-changed + social-links-changed notifications, whose observers re-walk visible profile controllers, so the change **applies live** (no relaunch).

## Second commit: avatar/name bleed race fix

While reviewing this work a **pre-existing** bug surfaced in `ApolloProfileLoadImages` (unrelated to the toggle): because the profile header view is reused across usernames, a slow avatar/info request for one user landing after the header was repointed to another could stamp the wrong user's avatar/name/bio onto the visible profile (e.g. after an account switch). The second commit adds a freshness guard so stale completions are dropped. It's a small, self-contained fix in the same file; kept as a **separate commit** so it can be reviewed (or dropped) independently.

## Testing

Sim-tested on iOS 26 (Liquid Glass) with a signed-in account:

- ON → detailed profile (header + banner + avatar + bio + social links); OFF → Apollo's stock profile, no crash.
- **Live toggle both directions** — header + social links torn down / re-installed on the visible profile VC (verified via logs + screenshots + accessibility tree).
- Fresh launch with the pref OFF → stock profile; persists across relaunch.
- The race-fix commit builds + loads + happy path correct; the interactive multi-account repro is **not** exercised (sim has one account).

**Not device-tested yet.**
