### PR TITLE
Share as Video: support Streamable and Redgifs posts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloUserFlair.xm \
     $(SRC_DIR)/ApolloFlairColors.xm \
     $(SRC_DIR)/ApolloNativeActionMenus.xm \
+    $(SRC_DIR)/ApolloHostedVideo.m \
     $(SRC_DIR)/ApolloShareAsImageGallery.xm \
     $(SRC_DIR)/ApolloShareAsImageLink.xm \
     $(SRC_DIR)/ApolloShareAsVideo.xm \

--- a/src/ApolloHostedVideo.h
+++ b/src/ApolloHostedVideo.h
@@ -1,0 +1,49 @@
+// ApolloHostedVideo.h
+//
+// Shared resolver for external video hosts (Streamable, Redgifs) that Apollo
+// plays inline but exposes to the share sheet only as a link-preview card — they
+// carry no RDKVideo, so the playable mp4 AND the poster still must be resolved
+// from the host's public API.
+//
+// Two consumers:
+//   * ApolloShareAsVideo  — needs the progressive mp4 (+ audio) to export.
+//   * ApolloShareAsImageGallery — needs the poster + true pixel size to replace
+//     the compact link card with a full-width still (so the share card looks like
+//     the post, not a junk-titled link box).
+//
+// Both come from the SAME single API response, so one resolver serves both. The
+// completion always fires on the main queue; any field is nil/zero on failure.
+
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+typedef NS_ENUM(NSInteger, ApolloHostedVideoKind) {
+    ApolloHostedVideoNone = 0,
+    ApolloHostedVideoStreamable,
+    ApolloHostedVideoRedgifs,
+};
+
+// This file is plain Objective-C (.m, C linkage) but its callers are Logos .xm
+// files compiled as Objective-C++, so without extern "C" they'd reference C++
+// name-mangled symbols the .m never exports (link error). Keep these in C linkage.
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Classifies a post's external page URL (RDKLink.URL) into a hosted-video kind.
+ApolloHostedVideoKind ApolloHostedVideoKindForURL(NSURL *url);
+
+// Resolves a hosted video from its page URL. Streamable/Redgifs serve a single
+// progressive mp4 with embedded audio, so there is never a separate audio track.
+//   mp4URL    — progressive, AVFoundation-exportable mp4 (nil on failure)
+//   posterURL — full-aspect poster still for the card (nil if none)
+//   pixelSize — source pixel dimensions for aspect (CGSizeZero if unknown)
+//   hasAudio  — whether the mp4 carries an audio track
+// completion is invoked on the main queue exactly once.
+void ApolloHostedVideoResolve(NSURL *pageURL,
+                              void (^completion)(NSURL *mp4URL, NSURL *posterURL,
+                                                 CGSize pixelSize, BOOL hasAudio));
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ApolloHostedVideo.m
+++ b/src/ApolloHostedVideo.m
@@ -1,0 +1,207 @@
+// ApolloHostedVideo.m — see ApolloHostedVideo.h.
+//
+// Recipes (both verified live):
+//   Streamable: GET https://api.streamable.com/videos/<shortcode> (no auth) ->
+//     files.mp4.url (signed, time-limited progressive mp4 w/ embedded audio),
+//     thumbnail_url (poster), files.mp4.width/height (size).
+//   Redgifs: GET /v2/auth/temporary (GET, not POST) -> token, then
+//     GET /v2/gifs/<id-lowercased> with Bearer token + the SAME User-Agent ->
+//     gif.urls.hd (progressive mp4), gif.urls.poster, gif.width/height,
+//     gif.hasAudio. The token is bound to the exact UA that minted it.
+
+#import "ApolloHostedVideo.h"
+#import "ApolloCommon.h"
+
+#pragma mark - Host classification + id extraction
+
+ApolloHostedVideoKind ApolloHostedVideoKindForURL(NSURL *url) {
+    if (![url isKindOfClass:[NSURL class]]) return ApolloHostedVideoNone;
+    NSString *host = (url.host ?: @"").lowercaseString;
+    if ([host isEqualToString:@"streamable.com"] || [host hasSuffix:@".streamable.com"])
+        return ApolloHostedVideoStreamable;
+    if ([host isEqualToString:@"redgifs.com"] || [host hasSuffix:@".redgifs.com"])
+        return ApolloHostedVideoRedgifs;
+    return ApolloHostedVideoNone;
+}
+
+// Path components of `url` minus the "/" separator, in order.
+static NSArray<NSString *> *AHVPathParts(NSURL *url) {
+    NSMutableArray<NSString *> *parts = [NSMutableArray array];
+    for (NSString *c in url.pathComponents) {
+        if (c.length && ![c isEqualToString:@"/"]) [parts addObject:c];
+    }
+    return parts;
+}
+
+// Streamable shortcode = first path component, skipping a leading e/ o/ s/ embed
+// segment. Case-SENSITIVE.
+static NSString *AHVStreamableShortcode(NSURL *url) {
+    NSArray<NSString *> *parts = AHVPathParts(url);
+    if (parts.count == 0) return nil;
+    NSString *first = parts.firstObject;
+    if (parts.count >= 2 && ([first isEqualToString:@"e"] || [first isEqualToString:@"o"] || [first isEqualToString:@"s"]))
+        return parts[1];
+    return first;
+}
+
+// Redgifs id = path component after watch/ifr/i, LOWERCASED for the v2 API path.
+static NSString *AHVRedgifsID(NSURL *url) {
+    NSArray<NSString *> *parts = AHVPathParts(url);
+    if (parts.count == 0) return nil;
+    NSString *first = parts.firstObject.lowercaseString;
+    NSString *picked = (parts.count >= 2 &&
+                        ([first isEqualToString:@"watch"] || [first isEqualToString:@"ifr"] || [first isEqualToString:@"i"]))
+                       ? parts[1] : parts.firstObject;
+    return [picked stringByDeletingPathExtension].lowercaseString;
+}
+
+#pragma mark - Helpers
+
+// Redgifs binds its temp token to the exact User-Agent that minted it, so both
+// Redgifs calls reuse this. Also a harmless browser-like default for Streamable.
+static NSString *AHVUserAgent(void) {
+    return @"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+}
+
+// NSURL from a string, normalizing a protocol-relative ("//cdn…") form to https.
+static NSURL *AHVURLFromString(NSString *s) {
+    if (![s isKindOfClass:[NSString class]] || s.length == 0) return nil;
+    if ([s hasPrefix:@"//"]) s = [@"https:" stringByAppendingString:s];
+    return [NSURL URLWithString:s];
+}
+
+static double AHVNumber(id v) {
+    return [v isKindOfClass:[NSNumber class]] ? [v doubleValue] : 0.0;
+}
+
+// Reads a Streamable "files.<rendition>" entry's url, honouring its readiness
+// status (2 == ready) when present.
+static NSString *AHVStreamableRenditionURL(id entry) {
+    if (![entry isKindOfClass:[NSDictionary class]]) return nil;
+    NSDictionary *d = (NSDictionary *)entry;
+    id status = d[@"status"];
+    if ([status isKindOfClass:[NSNumber class]] && [status integerValue] != 2) return nil;
+    id url = d[@"url"];
+    return [url isKindOfClass:[NSString class]] ? (NSString *)url : nil;
+}
+
+#pragma mark - Per-host resolvers
+
+static void AHVResolveStreamable(NSString *shortcode,
+                                 void (^cb)(NSURL *mp4, NSURL *poster, CGSize size, BOOL hasAudio)) {
+    if (shortcode.length == 0) { cb(nil, nil, CGSizeZero, NO); return; }
+    NSURL *api = [NSURL URLWithString:[NSString stringWithFormat:@"https://api.streamable.com/videos/%@", shortcode]];
+    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:api
+                                                      cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
+                                                  timeoutInterval:12.0];
+    [req setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+    [req setValue:AHVUserAgent() forHTTPHeaderField:@"User-Agent"];
+    ApolloLog(@"[HostedVideo] streamable resolving shortcode=%@", shortcode);
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:req
+        completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        NSInteger status = [response isKindOfClass:[NSHTTPURLResponse class]]
+            ? ((NSHTTPURLResponse *)response).statusCode : 0;
+        NSURL *mp4 = nil, *poster = nil; CGSize size = CGSizeZero; BOOL hasAudio = YES;
+        if (!error && status >= 200 && status < 300 && data.length) {
+            NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+            if ([json isKindOfClass:[NSDictionary class]]) {
+                NSDictionary *files = json[@"files"];
+                NSDictionary *mp4Entry = [files isKindOfClass:[NSDictionary class]] && [files[@"mp4"] isKindOfClass:[NSDictionary class]]
+                    ? files[@"mp4"] : nil;
+                if ([files isKindOfClass:[NSDictionary class]]) {
+                    NSString *u = AHVStreamableRenditionURL(files[@"mp4"]);
+                    if (!u) u = AHVStreamableRenditionURL(files[@"mp4-mobile"]);
+                    mp4 = AHVURLFromString(u);
+                }
+                poster = AHVURLFromString([json[@"thumbnail_url"] isKindOfClass:[NSString class]] ? json[@"thumbnail_url"] : nil);
+                double w = AHVNumber(mp4Entry[@"width"]),  h = AHVNumber(mp4Entry[@"height"]);
+                if (w <= 0 || h <= 0) { w = AHVNumber(json[@"width"]); h = AHVNumber(json[@"height"]); }
+                if (w > 0 && h > 0) size = CGSizeMake(w, h);
+                id ch = json[@"audio_channels"];
+                if ([ch isKindOfClass:[NSNumber class]]) hasAudio = [ch integerValue] > 0;
+            }
+        }
+        ApolloLog(@"[HostedVideo] streamable mp4=%@ poster=%@ size=%@ (http %ld)",
+                  mp4 ? @"yes" : @"no", poster ? @"yes" : @"no", NSStringFromCGSize(size), (long)status);
+        cb(mp4, poster, size, hasAudio);
+    }];
+    [task resume];
+}
+
+static void AHVResolveRedgifs(NSString *gifID,
+                              void (^cb)(NSURL *mp4, NSURL *poster, CGSize size, BOOL hasAudio)) {
+    if (gifID.length == 0) { cb(nil, nil, CGSizeZero, NO); return; }
+    NSString *ua = AHVUserAgent();
+
+    NSURL *authURL = [NSURL URLWithString:@"https://api.redgifs.com/v2/auth/temporary"];
+    NSMutableURLRequest *authReq = [NSMutableURLRequest requestWithURL:authURL
+                                                          cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
+                                                      timeoutInterval:12.0];
+    [authReq setValue:ua forHTTPHeaderField:@"User-Agent"];
+    [authReq setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+    ApolloLog(@"[HostedVideo] redgifs minting token for id=%@", gifID);
+
+    NSURLSessionDataTask *authTask = [[NSURLSession sharedSession] dataTaskWithRequest:authReq
+        completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        NSString *token = nil;
+        if (!error && data.length) {
+            NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+            if ([json isKindOfClass:[NSDictionary class]] && [json[@"token"] isKindOfClass:[NSString class]])
+                token = json[@"token"];
+        }
+        if (token.length == 0) { ApolloLog(@"[HostedVideo] redgifs token mint FAILED"); cb(nil, nil, CGSizeZero, NO); return; }
+
+        NSURL *gifURL = [NSURL URLWithString:[NSString stringWithFormat:@"https://api.redgifs.com/v2/gifs/%@", gifID]];
+        NSMutableURLRequest *gifReq = [NSMutableURLRequest requestWithURL:gifURL
+                                                             cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
+                                                         timeoutInterval:12.0];
+        [gifReq setValue:[NSString stringWithFormat:@"Bearer %@", token] forHTTPHeaderField:@"Authorization"];
+        [gifReq setValue:ua forHTTPHeaderField:@"User-Agent"];
+        [gifReq setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+        [gifReq setValue:@"https://www.redgifs.com/" forHTTPHeaderField:@"Referer"];
+
+        NSURLSessionDataTask *gifTask = [[NSURLSession sharedSession] dataTaskWithRequest:gifReq
+            completionHandler:^(NSData *gdata, NSURLResponse *gresp, NSError *gerror) {
+            NSInteger status = [gresp isKindOfClass:[NSHTTPURLResponse class]]
+                ? ((NSHTTPURLResponse *)gresp).statusCode : 0;
+            NSURL *mp4 = nil, *poster = nil; CGSize size = CGSizeZero; BOOL hasAudio = NO;
+            if (!gerror && status >= 200 && status < 300 && gdata.length) {
+                NSDictionary *json = [NSJSONSerialization JSONObjectWithData:gdata options:0 error:nil];
+                NSDictionary *gif = [json isKindOfClass:[NSDictionary class]] ? json[@"gif"] : nil;
+                if ([gif isKindOfClass:[NSDictionary class]]) {
+                    hasAudio = [gif[@"hasAudio"] isKindOfClass:[NSNumber class]] ? [gif[@"hasAudio"] boolValue] : NO;
+                    NSDictionary *urls = gif[@"urls"];
+                    if ([urls isKindOfClass:[NSDictionary class]]) {
+                        NSString *u = [urls[@"hd"] isKindOfClass:[NSString class]] ? urls[@"hd"] : nil;
+                        if (!u) u = [urls[@"sd"] isKindOfClass:[NSString class]] ? urls[@"sd"] : nil;
+                        mp4 = AHVURLFromString(u);
+                        poster = AHVURLFromString([urls[@"poster"] isKindOfClass:[NSString class]] ? urls[@"poster"] : nil);
+                    }
+                    double w = AHVNumber(gif[@"width"]), h = AHVNumber(gif[@"height"]);
+                    if (w > 0 && h > 0) size = CGSizeMake(w, h);
+                }
+            }
+            ApolloLog(@"[HostedVideo] redgifs mp4=%@ poster=%@ size=%@ hasAudio=%d (http %ld)",
+                      mp4 ? @"yes" : @"no", poster ? @"yes" : @"no", NSStringFromCGSize(size), (int)hasAudio, (long)status);
+            cb(mp4, poster, size, hasAudio);
+        }];
+        [gifTask resume];
+    }];
+    [authTask resume];
+}
+
+#pragma mark - Public entry
+
+void ApolloHostedVideoResolve(NSURL *pageURL,
+                              void (^completion)(NSURL *mp4URL, NSURL *posterURL,
+                                                 CGSize pixelSize, BOOL hasAudio)) {
+    void (^done)(NSURL *, NSURL *, CGSize, BOOL) = ^(NSURL *m, NSURL *p, CGSize s, BOOL a) {
+        dispatch_async(dispatch_get_main_queue(), ^{ if (completion) completion(m, p, s, a); });
+    };
+    switch (ApolloHostedVideoKindForURL(pageURL)) {
+        case ApolloHostedVideoStreamable: AHVResolveStreamable(AHVStreamableShortcode(pageURL), done); return;
+        case ApolloHostedVideoRedgifs:    AHVResolveRedgifs(AHVRedgifsID(pageURL), done);              return;
+        case ApolloHostedVideoNone:
+        default:                          done(nil, nil, CGSizeZero, NO);                              return;
+    }
+}

--- a/src/ApolloShareAsImageGallery.xm
+++ b/src/ApolloShareAsImageGallery.xm
@@ -22,6 +22,7 @@
 #import <objc/runtime.h>
 #import <objc/message.h>
 #import "ApolloCommon.h"
+#import "ApolloHostedVideo.h"
 
 // ASSizeRange is { CGSize min; CGSize max; }. The rest of the repo matches the
 // -layoutSpecThatFits: selector ABI with `struct CDStruct_90e057aa` from the
@@ -550,6 +551,68 @@ static void ApolloShareGalleryPrepareSingle(id previewNode, id link) {
         objc_setAssociatedObject(previewNode, &kApolloShareGalleryStateKey,
                                  @(ApolloShareGalleryStateApplied),
                                  OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return;
+    }
+
+    // External hosted video (Streamable / Redgifs): these carry no RDKVideo, so
+    // ApolloShareLinkHasVideo is NO and Apollo shows its compact link card with the
+    // host's scraped title (e.g. "Watch ssstwitter…"). Resolve the poster + true
+    // size from the host API and install it full-width — dropping the link card —
+    // so the share card matches the post. ApolloShareAsVideo then composites the
+    // clip over this correctly-sized still (no crop). Resolution is async (an API
+    // call), unlike the native poster path below, so it has its own flow.
+    NSURL *linkURL = (NSURL *)ApolloShareCall(link, @selector(URL));
+    if (ApolloHostedVideoKindForURL(linkURL) != ApolloHostedVideoNone) {
+        // Re-entrancy guard: flip to Placeholder synchronously before async work, so
+        // repeated background layout passes don't launch duplicate resolves.
+        objc_setAssociatedObject(previewNode, &kApolloShareGalleryStateKey,
+                                 @(ApolloShareGalleryStatePlaceholder),
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+        // Smooth the first frame: drop the compact link card IMMEDIATELY with a
+        // neutral placeholder, BEFORE the async host-API poster resolve, so the
+        // junk-titled link card never flashes. Size it from Reddit's own scraped
+        // preview aspect when available (previewMedia/thumbnail) so there's no
+        // reflow; the host API then confirms the exact aspect + supplies the still.
+        CGSize syncAspect = ApolloShareResolvePosterAspect(link);
+        UIImage *immediate = ApolloShareGalleryRenderSingle(nil, syncAspect);
+        if (immediate) ApolloShareGalleryInstallImageOnMain(previewNode, immediate, NO);
+        ApolloLog(@"[ShareGallery] hosted video node=%p url=%@ syncAspect=%@ — placeholder + resolve",
+                  previewNode, linkURL.absoluteString, NSStringFromCGSize(syncAspect));
+        __weak id weakNode = previewNode;
+        ApolloHostedVideoResolve(linkURL, ^(__unused NSURL *mp4, NSURL *posterURL,
+                                            CGSize pixelSize, __unused BOOL hasAudio) {
+            id strongNode = weakNode;
+            if (!strongNode) return;
+            if (!posterURL) {
+                // No poster resolvable — leave Apollo's native card untouched.
+                objc_setAssociatedObject(strongNode, &kApolloShareGalleryStateKey,
+                                         @(ApolloShareGalleryStateApplied),
+                                         OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                return;
+            }
+            CGSize aspect = (pixelSize.width > 0 && pixelSize.height > 0) ? pixelSize : CGSizeZero;
+            // Placeholder immediately (correct aspect) so the link card doesn't linger.
+            UIImage *placeholder = ApolloShareGalleryRenderSingle(nil, aspect);
+            if (placeholder) ApolloShareGalleryInstallImageOnMain(strongNode, placeholder, NO);
+            ApolloShareGalleryFetchImages(@[posterURL], ^(NSArray *images) {
+                id n2 = weakNode;
+                if (!n2) return;
+                UIImage *fetched = nil;
+                for (id img in images) {
+                    if ([img isKindOfClass:[UIImage class]]) { fetched = (UIImage *)img; break; }
+                }
+                UIImage *single = fetched ? ApolloShareGalleryRenderSingle(fetched, aspect) : nil;
+                ApolloLog(@"[ShareGallery] hosted poster fetch node=%p ok=%d", n2, fetched != nil);
+                if (single) {
+                    ApolloShareGalleryInstallImageOnMain(n2, single, YES);
+                } else {
+                    objc_setAssociatedObject(n2, &kApolloShareGalleryStateKey,
+                                             @(ApolloShareGalleryStateApplied),
+                                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                }
+            });
+        });
         return;
     }
 

--- a/src/ApolloShareAsVideo.xm
+++ b/src/ApolloShareAsVideo.xm
@@ -301,78 +301,80 @@ static void ApolloSVResolveSources(id link, void (^completion)(NSURL *videoURL, 
         dispatch_async(dispatch_get_main_queue(), ^{ completion(v, a, s); });
     };
 
-    // Hosted-source fallback (Streamable / Redgifs) from the link's external page
-    // URL. Used when there's no exportable RDKVideo — captured here so both the
-    // "no RDKVideo" and "RDKVideo but nothing exportable" paths can reach it.
     NSURL *pageURL = (NSURL *)ApolloSVCall(link, @selector(URL));
-    void (^tryHosted)(CGSize) = ^(CGSize natural) {
-        if (ApolloHostedVideoKindForURL(pageURL) != ApolloHostedVideoNone) {
-            ApolloHostedVideoResolve(pageURL, ^(NSURL *mp4, __unused NSURL *poster,
-                                                CGSize pixelSize, __unused BOOL hasAudio) {
-                // Single combined mp4 (audio embedded) -> audioURL nil. Use the
-                // API's true pixel size for natural when the link gave us none.
-                CGSize sz = (natural.width > 0 && natural.height > 0) ? natural : pixelSize;
-                done(mp4, nil, sz);
-            });
-        } else {
-            done(nil, nil, natural);
-        }
-    };
-
     id video = ApolloSVBestVideo(link);
-    if (!video) { tryHosted(CGSizeZero); return; }
-
-    NSURL *url   = (NSURL *)ApolloSVCall(video, @selector(URL));
-    NSURL *fb    = (NSURL *)ApolloSVCall(video, @selector(fallbackURL));
-    NSURL *small = (NSURL *)ApolloSVCall(video, @selector(smallerURL));
-
-    double w = ApolloSVCallDouble(video, @selector(width));
-    double h = ApolloSVCallDouble(video, @selector(height));
+    NSURL *url   = video ? (NSURL *)ApolloSVCall(video, @selector(URL)) : nil;
+    NSURL *fb    = video ? (NSURL *)ApolloSVCall(video, @selector(fallbackURL)) : nil;
+    NSURL *small = video ? (NSURL *)ApolloSVCall(video, @selector(smallerURL)) : nil;
+    double w = video ? ApolloSVCallDouble(video, @selector(width))  : 0.0;
+    double h = video ? ApolloSVCallDouble(video, @selector(height)) : 0.0;
     CGSize natural = (w > 0 && h > 0) ? CGSizeMake(w, h) : CGSizeZero;
 
-    NSString *assetID = ApolloSVRedditAssetID(url) ?: ApolloSVRedditAssetID(fb);
-    if (assetID.length > 0) {
-        NSURL *mpd = [NSURL URLWithString:[NSString stringWithFormat:@"https://v.redd.it/%@/DASHPlaylist.mpd", assetID]];
-        NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:mpd
-                                                          cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                      timeoutInterval:10.0];
-        ApolloLog(@"[ShareVideo] resolving v.redd.it asset=%@", assetID);
-        NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:req
-            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-            NSInteger status = [response isKindOfClass:[NSHTTPURLResponse class]]
-                ? ((NSHTTPURLResponse *)response).statusCode : 0;
-            NSURL *videoURL = nil, *audioURL = nil;
-            if (!error && status >= 200 && status < 300 && data.length) {
-                videoURL = ApolloSVLowestDashURL(data, mpd, @"video");
-                audioURL = ApolloSVLowestDashURL(data, mpd, @"audio");
+    // Resolves from the post's RDKVideo: a v.redd.it DASH stream (split video+audio)
+    // or a direct progressive .mp4. Used for native videos, and as the fallback when
+    // a hosted-source resolve fails.
+    void (^resolveFromRDKVideo)(void) = ^{
+        if (!video) { done(nil, nil, natural); return; }
+        NSString *assetID = ApolloSVRedditAssetID(url) ?: ApolloSVRedditAssetID(fb);
+        if (assetID.length > 0) {
+            NSURL *mpd = [NSURL URLWithString:[NSString stringWithFormat:@"https://v.redd.it/%@/DASHPlaylist.mpd", assetID]];
+            NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:mpd
+                                                              cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                          timeoutInterval:10.0];
+            ApolloLog(@"[ShareVideo] resolving v.redd.it asset=%@", assetID);
+            NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:req
+                completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                NSInteger status = [response isKindOfClass:[NSHTTPURLResponse class]]
+                    ? ((NSHTTPURLResponse *)response).statusCode : 0;
+                NSURL *videoURL = nil, *audioURL = nil;
+                if (!error && status >= 200 && status < 300 && data.length) {
+                    videoURL = ApolloSVLowestDashURL(data, mpd, @"video");
+                    audioURL = ApolloSVLowestDashURL(data, mpd, @"audio");
+                }
+                if (!videoURL) {
+                    // Manifest unavailable/unparseable: fall back to the API's
+                    // progressive fallback MP4 (video-only, no audio).
+                    videoURL = ApolloSVIsMP4(fb) ? fb : (ApolloSVIsMP4(url) ? url : nil);
+                    audioURL = nil;
+                }
+                ApolloLog(@"[ShareVideo] v.redd.it resolved video=%@ audio=%@",
+                          videoURL ? @"yes" : @"no", audioURL ? @"yes" : @"no");
+                done(videoURL, audioURL, natural);
+            }];
+            [task resume];
+            return;
+        }
+        // Direct progressive MP4 (e.g. imgur). No separate audio track to fetch; if
+        // the file itself carries audio the composition picks it up from this asset.
+        NSURL *direct = ApolloSVIsMP4(url) ? url : (ApolloSVIsMP4(fb) ? fb : (ApolloSVIsMP4(small) ? small : nil));
+        if (direct) {
+            ApolloLog(@"[ShareVideo] direct mp4 resolved=yes");
+            done(direct, nil, natural);
+            return;
+        }
+        ApolloLog(@"[ShareVideo] no exportable RDKVideo source");
+        done(nil, nil, natural);
+    };
+
+    // Prefer the host's own mp4 for Streamable/Redgifs posts: it carries the
+    // original audio + full quality, whereas Reddit's reddit_video_preview (which
+    // ApolloSVBestVideo picks for these external links) is SILENT and re-encoded.
+    // Fall back to the RDKVideo path if the host resolve fails.
+    if (ApolloHostedVideoKindForURL(pageURL) != ApolloHostedVideoNone) {
+        ApolloLog(@"[ShareVideo] hosted post — preferring host mp4 over reddit preview");
+        ApolloHostedVideoResolve(pageURL, ^(NSURL *mp4, __unused NSURL *poster,
+                                            CGSize pixelSize, __unused BOOL hasAudio) {
+            if (mp4) {
+                CGSize sz = (natural.width > 0 && natural.height > 0) ? natural : pixelSize;
+                done(mp4, nil, sz);
+            } else {
+                ApolloLog(@"[ShareVideo] host resolve failed — falling back to RDKVideo");
+                resolveFromRDKVideo();
             }
-            if (!videoURL) {
-                // Manifest unavailable/unparseable: fall back to the API's
-                // progressive fallback MP4 (video-only, no audio).
-                videoURL = ApolloSVIsMP4(fb) ? fb : (ApolloSVIsMP4(url) ? url : nil);
-                audioURL = nil;
-            }
-            ApolloLog(@"[ShareVideo] v.redd.it resolved video=%@ audio=%@",
-                      videoURL ? @"yes" : @"no", audioURL ? @"yes" : @"no");
-            done(videoURL, audioURL, natural);
-        }];
-        [task resume];
+        });
         return;
     }
-
-    // Direct progressive MP4 (e.g. imgur). No separate audio track to fetch; if
-    // the file itself carries audio the composition picks it up from this asset.
-    NSURL *direct = ApolloSVIsMP4(url) ? url : (ApolloSVIsMP4(fb) ? fb : (ApolloSVIsMP4(small) ? small : nil));
-    if (direct) {
-        ApolloLog(@"[ShareVideo] direct mp4 resolved=yes");
-        done(direct, nil, natural);
-        return;
-    }
-
-    // RDKVideo present but nothing AVFoundation can export (e.g. an HLS-only
-    // smallerURL): fall back to the hosted page URL (Streamable / Redgifs).
-    ApolloLog(@"[ShareVideo] no exportable RDKVideo url — trying hosted page url");
-    tryHosted(natural);
+    resolveFromRDKVideo();
 }
 
 #pragma mark - Card image + media rect
@@ -649,11 +651,19 @@ static CGFloat ApolloSVEven(CGFloat v) { long n = lround(v); if (n & 1) n += 1; 
 // during export and completion(outURL,error) on the main queue when finished.
 // Keeps strong refs to its CALayers/session on `vc` so nothing is reclaimed
 // mid-export.
-static void ApolloSVExport(id vc, UIImage *card, CGRect mediaNorm,
-                           NSURL *videoURL, NSURL *audioURL,
-                           void (^progress)(float p),
-                           void (^completion)(NSURL *outURL, NSError *error)) {
+// Composites the live video over the card and exports an mp4. `videoURL` should be
+// a LOCAL file (materialized by ApolloSVExport) so AVFoundation reads the full
+// track list. `tempVideoFile`, if non-nil, is that downloaded temp file and is
+// deleted once the export finishes or fails.
+static void ApolloSVComposeAndExport(id vc, UIImage *card, CGRect mediaNorm,
+                                     NSURL *videoURL, NSURL *audioURL, NSURL *tempVideoFile,
+                                     void (^progress)(float p),
+                                     void (^completion)(NSURL *outURL, NSError *error)) {
+    void (^cleanupTemp)(void) = ^{
+        if (tempVideoFile) [[NSFileManager defaultManager] removeItemAtURL:tempVideoFile error:nil];
+    };
     void (^fail)(NSString *) = ^(NSString *why) {
+        cleanupTemp();
         ApolloLog(@"[ShareVideo] export FAIL: %@", why);
         dispatch_async(dispatch_get_main_queue(), ^{
             completion(nil, [NSError errorWithDomain:@"ApolloShareVideo" code:1
@@ -805,6 +815,7 @@ static void ApolloSVExport(id vc, UIImage *card, CGRect mediaNorm,
             // retained card image) is released with the composition after export.
             dispatch_async(dispatch_get_main_queue(), ^{
                 objc_setAssociatedObject(vc, &kApolloShareVideoSessionKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                cleanupTemp(); // the downloaded source is no longer needed
                 if (st == AVAssetExportSessionStatusCompleted) {
                     ApolloLog(@"[ShareVideo] export OK -> %@", outPath);
                     completion(outURL, nil);
@@ -815,6 +826,78 @@ static void ApolloSVExport(id vc, UIImage *card, CGRect mediaNorm,
                 }
             });
         }];
+    });
+}
+
+#pragma mark - Source materialization + export entry
+
+// Downloads a remote http(s) URL to a local temp .mp4, returning its file URL (nil
+// on failure). AVFoundation needs a LOCAL file to reliably enumerate every track:
+// streaming a non-fast-start mp4 (e.g. Redgifs' CDN files) can leave the embedded
+// audio track undiscovered, exporting a silent clip. A local copy also dodges
+// signed-URL expiry mid-export. A browser User-Agent is sent so CDN-gating hosts
+// (Redgifs) still serve it. cb runs on the URLSession queue.
+static void ApolloSVDownloadToTemp(NSURL *url, void (^cb)(NSURL *localURL)) {
+    if (![url isKindOfClass:[NSURL class]]) { cb(nil); return; }
+    NSString *scheme = url.scheme.lowercaseString;
+    if (![scheme isEqualToString:@"http"] && ![scheme isEqualToString:@"https"]) { cb(nil); return; }
+
+    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url
+                                                      cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
+                                                  timeoutInterval:60.0];
+    [req setValue:@"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+        forHTTPHeaderField:@"User-Agent"];
+    ApolloLog(@"[ShareVideo] materializing source to temp…");
+    NSURLSessionDownloadTask *task = [[NSURLSession sharedSession] downloadTaskWithRequest:req
+        completionHandler:^(NSURL *tmp, NSURLResponse *response, NSError *error) {
+        NSInteger status = [response isKindOfClass:[NSHTTPURLResponse class]]
+            ? ((NSHTTPURLResponse *)response).statusCode : 0;
+        if (error || !tmp || (status && (status < 200 || status >= 300))) {
+            ApolloLog(@"[ShareVideo] source download failed (http %ld: %@) — falling back to streaming",
+                      (long)status, error.localizedDescription);
+            cb(nil); return;
+        }
+        NSURL *dest = [[NSURL fileURLWithPath:NSTemporaryDirectory()]
+            URLByAppendingPathComponent:[NSString stringWithFormat:@"ApolloShareVideoSrc-%@.mp4",
+                                         [[NSUUID UUID] UUIDString]]];
+        [[NSFileManager defaultManager] removeItemAtURL:dest error:nil];
+        NSError *moveErr = nil;
+        if (![[NSFileManager defaultManager] moveItemAtURL:tmp toURL:dest error:&moveErr]) {
+            ApolloLog(@"[ShareVideo] temp move failed: %@ — falling back to streaming", moveErr.localizedDescription);
+            cb(nil); return;
+        }
+        cb(dest);
+    }];
+    [task resume];
+}
+
+// Export entry. For the COMBINED-mp4 case (audioURL == nil: Streamable / Redgifs /
+// direct mp4) the embedded audio lives in the video file itself, so the file is
+// first materialized to local temp — otherwise non-fast-start sources export
+// silent. v.redd.it (separate audio track, audioURL != nil) is the common path and
+// already streams reliably, so it is left untouched. Falls back to streaming if the
+// download fails.
+static void ApolloSVExport(id vc, UIImage *card, CGRect mediaNorm,
+                           NSURL *videoURL, NSURL *audioURL,
+                           void (^progress)(float p),
+                           void (^completion)(NSURL *outURL, NSError *error)) {
+    if (![card isKindOfClass:[UIImage class]] || !videoURL) {
+        ApolloLog(@"[ShareVideo] export FAIL: missing card or video url");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion(nil, [NSError errorWithDomain:@"ApolloShareVideo" code:1
+                                            userInfo:@{NSLocalizedDescriptionKey: @"missing card or video url"}]);
+        });
+        return;
+    }
+    ApolloLog(@"[ShareVideo] export entry: audioURL=%@", audioURL ? @"present" : @"nil");
+    if (audioURL != nil) { // v.redd.it: separate audio track streams fine
+        ApolloSVComposeAndExport(vc, card, mediaNorm, videoURL, audioURL, nil, progress, completion);
+        return;
+    }
+    ApolloSVDownloadToTemp(videoURL, ^(NSURL *localVideoURL) {
+        NSURL *useVideoURL = localVideoURL ?: videoURL;
+        NSURL *tempVideoFile = (localVideoURL && localVideoURL.isFileURL) ? localVideoURL : nil;
+        ApolloSVComposeAndExport(vc, card, mediaNorm, useVideoURL, audioURL, tempVideoFile, progress, completion);
     });
 }
 

--- a/src/ApolloShareAsVideo.xm
+++ b/src/ApolloShareAsVideo.xm
@@ -64,6 +64,7 @@
 #import <objc/runtime.h>
 #import <objc/message.h>
 #import "ApolloCommon.h"
+#import "ApolloHostedVideo.h"
 
 #pragma mark - Tunables
 
@@ -179,22 +180,40 @@ static NSURL *ApolloSVToExportableMP4(NSURL *url) {
     return nil;
 }
 
+#pragma mark - External hosted video (Streamable / Redgifs)
+
+// Some external video posts (Streamable, Redgifs) carry NO RDKVideo — Apollo plays
+// them inline by resolving the host's own API at runtime, but exposes them to the
+// share sheet only as a link card whose external page URL sits on -[RDKLink URL].
+// Apollo's resolved URL is never written back to the link and its resolvers are
+// pure-Swift (no @objc entry point), so we resolve the progressive mp4 ourselves
+// from the host's public API at export time. Host classification + resolution live
+// in the shared ApolloHostedVideo helper (also used by ApolloShareAsImageGallery to
+// replace the link card with the video poster). Both hosts serve a single combined
+// mp4 with embedded audio, so no separate audio track is needed.
+
 // SYNCHRONOUS feasibility check (decides whether the toggle is shown). True when
 // the post has a video we can produce a progressive, exportable file for:
 //   * a v.redd.it video (we'll resolve its DASH MP4 + audio at export time), or
-//   * a direct .mp4 URL.
-// HLS-only sources (Streamable / redgifs with no progressive form) return NO, so
-// the toggle simply never appears for them.
+//   * a direct .mp4 URL, or
+//   * a Streamable / Redgifs link post (resolved via the host API at export time).
 static BOOL ApolloSVPostIsExportableVideo(id link) {
+    // Preferred fast paths: a real RDKVideo we can export with no extra network —
+    // v.redd.it (DASH) or a direct .mp4. Reddit also synthesizes a v.redd.it
+    // previewVideo for some external link posts, which is covered here too.
     id video = ApolloSVBestVideo(link);
-    if (!video) return NO;
-
-    NSURL *url   = (NSURL *)ApolloSVCall(video, @selector(URL));
-    NSURL *fb    = (NSURL *)ApolloSVCall(video, @selector(fallbackURL));
-    NSURL *small = (NSURL *)ApolloSVCall(video, @selector(smallerURL));
-
-    if (ApolloSVHostContains(url, @"v.redd.it") || ApolloSVHostContains(fb, @"v.redd.it")) return YES;
-    if (ApolloSVIsMP4(url) || ApolloSVIsMP4(fb) || ApolloSVIsMP4(small)) return YES;
+    if (video) {
+        NSURL *url   = (NSURL *)ApolloSVCall(video, @selector(URL));
+        NSURL *fb    = (NSURL *)ApolloSVCall(video, @selector(fallbackURL));
+        NSURL *small = (NSURL *)ApolloSVCall(video, @selector(smallerURL));
+        if (ApolloSVHostContains(url, @"v.redd.it") || ApolloSVHostContains(fb, @"v.redd.it")) return YES;
+        if (ApolloSVIsMP4(url) || ApolloSVIsMP4(fb) || ApolloSVIsMP4(small)) return YES;
+    }
+    // External hosts Apollo plays inline but exposes only as a link card (no
+    // RDKVideo): Streamable / Redgifs. Their progressive mp4 is resolved from the
+    // link's page URL at export time, so offer the toggle here.
+    NSURL *pageURL = (NSURL *)ApolloSVCall(link, @selector(URL));
+    if (ApolloHostedVideoKindForURL(pageURL) != ApolloHostedVideoNone) return YES;
     return NO;
 }
 
@@ -282,8 +301,26 @@ static void ApolloSVResolveSources(id link, void (^completion)(NSURL *videoURL, 
         dispatch_async(dispatch_get_main_queue(), ^{ completion(v, a, s); });
     };
 
+    // Hosted-source fallback (Streamable / Redgifs) from the link's external page
+    // URL. Used when there's no exportable RDKVideo — captured here so both the
+    // "no RDKVideo" and "RDKVideo but nothing exportable" paths can reach it.
+    NSURL *pageURL = (NSURL *)ApolloSVCall(link, @selector(URL));
+    void (^tryHosted)(CGSize) = ^(CGSize natural) {
+        if (ApolloHostedVideoKindForURL(pageURL) != ApolloHostedVideoNone) {
+            ApolloHostedVideoResolve(pageURL, ^(NSURL *mp4, __unused NSURL *poster,
+                                                CGSize pixelSize, __unused BOOL hasAudio) {
+                // Single combined mp4 (audio embedded) -> audioURL nil. Use the
+                // API's true pixel size for natural when the link gave us none.
+                CGSize sz = (natural.width > 0 && natural.height > 0) ? natural : pixelSize;
+                done(mp4, nil, sz);
+            });
+        } else {
+            done(nil, nil, natural);
+        }
+    };
+
     id video = ApolloSVBestVideo(link);
-    if (!video) { done(nil, nil, CGSizeZero); return; }
+    if (!video) { tryHosted(CGSizeZero); return; }
 
     NSURL *url   = (NSURL *)ApolloSVCall(video, @selector(URL));
     NSURL *fb    = (NSURL *)ApolloSVCall(video, @selector(fallbackURL));
@@ -326,8 +363,16 @@ static void ApolloSVResolveSources(id link, void (^completion)(NSURL *videoURL, 
     // Direct progressive MP4 (e.g. imgur). No separate audio track to fetch; if
     // the file itself carries audio the composition picks it up from this asset.
     NSURL *direct = ApolloSVIsMP4(url) ? url : (ApolloSVIsMP4(fb) ? fb : (ApolloSVIsMP4(small) ? small : nil));
-    ApolloLog(@"[ShareVideo] direct mp4 resolved=%@", direct ? @"yes" : @"no");
-    done(direct, nil, natural);
+    if (direct) {
+        ApolloLog(@"[ShareVideo] direct mp4 resolved=yes");
+        done(direct, nil, natural);
+        return;
+    }
+
+    // RDKVideo present but nothing AVFoundation can export (e.g. an HLS-only
+    // smallerURL): fall back to the hosted page URL (Streamable / Redgifs).
+    ApolloLog(@"[ShareVideo] no exportable RDKVideo url — trying hosted page url");
+    tryHosted(natural);
 }
 
 #pragma mark - Card image + media rect
@@ -397,7 +442,18 @@ static BOOL ApolloSVMediaRectNormalized(id vc, CGRect *outNorm) {
         id baseCommentNode = ApolloSVIvarObject(previewNode, "baseCommentNode");
         mediaNode = ApolloSVLargestMediaNode(baseCommentNode ?: previewNode);
     } else {
-        mediaNode = ApolloSVIvarObject(previewNode, "imageNode");
+        // Native media posts expose the preview's imageNode directly. External
+        // video link posts (Streamable / Redgifs) render a link-preview card whose
+        // thumbnail isn't `imageNode`, so target the largest image/video node in
+        // the card — that thumbnail is what we composite the video over. Each path
+        // cross-falls-back to the other for robustness.
+        NSURL *pageURL = (NSURL *)ApolloSVCall(ApolloSVIvarObject(vc, "link"), @selector(URL));
+        if (ApolloHostedVideoKindForURL(pageURL) != ApolloHostedVideoNone) {
+            mediaNode = ApolloSVLargestMediaNode(previewNode) ?: ApolloSVIvarObject(previewNode, "imageNode");
+            ApolloLog(@"[ShareVideo] hosted-link post media node=%@", mediaNode ? @"largest" : @"none");
+        } else {
+            mediaNode = ApolloSVIvarObject(previewNode, "imageNode") ?: ApolloSVLargestMediaNode(previewNode);
+        }
     }
     if (!mediaNode) return NO;
 


### PR DESCRIPTION
## What

Extends **Share as Video** (#380, shipped in #484) to **Streamable** and **Redgifs** posts.

These are external video link posts: Apollo plays them inline, but since they carry no `RDKVideo` it renders them in the share sheet as a compact link card with the host's scraped title (e.g. *"Watch ssstwitter…"*). As a result the **Share as Video** toggle never appeared for them, and the share-as-image card showed the link box with that junk title.

## Changes

- **`src/ApolloHostedVideo.{h,m}`** (new) — shared helper that classifies a post's external URL (Streamable / Redgifs) and, in a single API call, resolves the progressive mp4, poster still, pixel dimensions and audio flag.
  - **Streamable:** `GET api.streamable.com/videos/{shortcode}` → `files.mp4.url` + `thumbnail_url` (no auth).
  - **Redgifs:** `GET /v2/auth/temporary` (temporary token) → `GET /v2/gifs/{id}` → `gif.urls.hd` + `gif.urls.poster` (token bound to a fixed User-Agent, sent on both calls).
- **`src/ApolloShareAsImageGallery.xm`** — the single-still handler, which already converts native video posts into a clean full-width poster (dropping the compact link card), now covers these hosts: it resolves the poster via the host API and installs it at the video's **true aspect ratio**. An immediate placeholder, sized from the post's own preview aspect, drops the link card on open so its scraped title never flashes.
- **`src/ApolloShareAsVideo.xm`** — the share path now goes through the shared helper, and keeps audio for these hosts:
  - **Prefers the host's own mp4** over Reddit's `reddit_video_preview` (a silent, re-encoded v.redd.it copy Reddit synthesizes for some external links), so the export uses the file that actually has audio + full quality.
  - **Materializes the combined mp4 to a local temp** before compositing, so AVFoundation reads the embedded audio track — streaming a non-fast-start mp4 (Redgifs' CDN) otherwise dropped it. v.redd.it (separate audio track) still streams; falls back to streaming if the download fails.

## Result

The share card matches the post — full-width video at the correct aspect, post title, no link box / junk title — and the exported clip composites over the full poster **with audio** and no cropping. The toggle appears for these posts in both image and video share.

## Testing

Simulator-verified end-to-end (iOS 26, Liquid Glass):
- **Streamable** (r/nba post): toggle appears → clean poster card → resolve `HTTP 200` → exported `720×1528 H.264 + AAC`, frame matches the post.
- **Redgifs** (post with a silent reddit_video_preview): card renders cleanly at true aspect; export prefers the host mp4, materializes it, and produces `H.264 + AAC stereo` (previously video-only).

Both host-API recipes were verified against the live APIs. Not yet device-tested.
