### PR TITLE
Fix Show Deleted Comments freeze and oversized text (#514)

### DIFF
--- a/src/ApolloDeletedCommentsData.h
+++ b/src/ApolloDeletedCommentsData.h
@@ -23,6 +23,9 @@ BOOL ApolloDeletedCommentsApplyRecoveredArchivedCommentToObject(id comment, NSDi
 BOOL ApolloDeletedCommentsIsRecoveredCommentBody(NSString *author, NSString *body);
 NSString *ApolloDeletedCommentsRecoveredReasonForCommentBody(NSString *author, NSString *body);
 NSString *ApolloDeletedCommentsDisplayLabelForReason(NSString *reason);
+// Markdown-aware Reddit body_html generator (renders links/bold). Shared so every
+// recovered-body HTML path produces the same rendered output. Returns nil if empty.
+NSString *ApolloDeletedCommentsRedditBodyHTML(NSString *body);
 BOOL ApolloDeletedCommentsIsCommentRevealed(NSString *fullName);
 BOOL ApolloDeletedCommentsIsCommentBodyRevealed(NSString *author, NSString *body);
 void ApolloDeletedCommentsMarkCommentRevealed(NSString *fullName);

--- a/src/ApolloDeletedCommentsData.m
+++ b/src/ApolloDeletedCommentsData.m
@@ -483,7 +483,39 @@ NSString *ApolloDeletedCommentsDisplayLabelForReason(NSString *reason) {
     return @"REMOVED BY MOD";
 }
 
-static NSString *ApolloDeletedCommentsRedditBodyHTML(NSString *body) {
+// Convert the common inline Markdown that recovered comment bodies carry into the
+// real HTML tags Reddit's body_html would contain, so Apollo's renderer shows links
+// and bold instead of the literal "[text](url)" / "**text**" source. Runs on text that
+// is ALREADY HTML-escaped, so the markers ([](), **) are intact while the content is
+// safe; the tags we emit are re-encoded by RedditBodyHTML's final escape (Apollo
+// unescapes once and parses). Scoped to http(s) links to avoid false matches.
+static NSString *ApolloDeletedCommentsApplyInlineMarkdownHTML(NSString *escaped) {
+    if (escaped.length == 0) return escaped;
+    NSString *result = escaped;
+
+    static NSRegularExpression *linkRe = nil;
+    static dispatch_once_t linkOnce;
+    dispatch_once(&linkOnce, ^{
+        linkRe = [NSRegularExpression regularExpressionWithPattern:@"\\[([^\\]\\n]+)\\]\\((https?://[^)\\s]+)\\)"
+                                                           options:0 error:nil];
+    });
+    result = [linkRe stringByReplacingMatchesInString:result options:0
+                                                range:NSMakeRange(0, result.length)
+                                         withTemplate:@"<a href=\"$2\">$1</a>"];
+
+    static NSRegularExpression *boldRe = nil;
+    static dispatch_once_t boldOnce;
+    dispatch_once(&boldOnce, ^{
+        boldRe = [NSRegularExpression regularExpressionWithPattern:@"\\*\\*([^*\\n]+)\\*\\*"
+                                                           options:0 error:nil];
+    });
+    result = [boldRe stringByReplacingMatchesInString:result options:0
+                                                range:NSMakeRange(0, result.length)
+                                         withTemplate:@"<strong>$1</strong>"];
+    return result;
+}
+
+NSString *ApolloDeletedCommentsRedditBodyHTML(NSString *body) {
     NSString *trimmed = ApolloDeletedCommentsTrimmedString(body);
     if (trimmed.length == 0) return nil;
 
@@ -493,6 +525,7 @@ static NSString *ApolloDeletedCommentsRedditBodyHTML(NSString *body) {
         if (p.length == 0) continue;
         NSString *escaped = ApolloDeletedCommentsEscapeHTML(p);
         escaped = [escaped stringByReplacingOccurrencesOfString:@"\n" withString:@"<br/>"];
+        escaped = ApolloDeletedCommentsApplyInlineMarkdownHTML(escaped);
         [htmlParagraphs addObject:[NSString stringWithFormat:@"<p>%@</p>", escaped]];
     }
     if (htmlParagraphs.count == 0) return nil;

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -169,7 +169,14 @@ static UIFont *ApolloDeletedCommentsReasonChipFontForBaseAttributes(NSDictionary
 }
 
 static UIFont *ApolloDeletedCommentsRecoveredBodyFont(void) {
-    return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    // Apollo's comment body is UIFontTextStyleSubheadline (15pt @ .large), NOT Body
+    // (17pt). This is the universal fallback font for DefaultBodyAttributes (used by
+    // BodyAttributedText, the reason-chip base attributes, and the chip-size
+    // derivation) and is what renders on the FIRST display of a deleted/recovered
+    // body, before the per-node Subheadline template is populated. Returning Body here
+    // made deleted-comment text render two points larger than normal comments
+    // (the "deleted text looks bigger" report). Match Apollo's real comment body.
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline];
 }
 
 static NSString *ApolloDeletedCommentsNormalizeCommentFullName(NSString *value) {
@@ -661,6 +668,33 @@ static UIImage *ApolloDeletedCommentsReasonChipImage(NSString *text, UIFont *fon
 static NSAttributedString *ApolloDeletedCommentsReasonChipAttributedText(NSString *label, NSDictionary *baseAttributes, BOOL revealLink) {
     label = ApolloDeletedCommentsNormalizedReasonLabel(label);
     UIFont *font = ApolloDeletedCommentsReasonChipFontForBaseAttributes(baseAttributes);
+
+    // Return the SAME immutable chip string for identical (label, font, revealLink).
+    // The chip is rebuilt on every comment-cell measure; without caching, each call
+    // renders a fresh UIImage inside a fresh NSTextAttachment, so successive chip
+    // strings are never -isEqualToAttributedString: to each other. That kept the body
+    // text node perpetually dirty (set text -> re-measure -> rebuild -> set text ...),
+    // a continuous re-measure churn that contributed to the #514 freeze. A shared
+    // immutable result lets ASTextNode's setAttributedText: short-circuit so the node
+    // settles after one measure. Chip colors are constant, so font is the only visual
+    // variable besides the label. (Runs on background measure threads — guard the map.)
+    static NSMutableDictionary<NSString *, NSAttributedString *> *chipCache = nil;
+    static NSObject *chipCacheLock = nil;
+    static dispatch_once_t chipCacheOnce;
+    dispatch_once(&chipCacheOnce, ^{
+        chipCache = [NSMutableDictionary dictionary];
+        chipCacheLock = [NSObject new];
+    });
+    NSString *chipCacheKey = [NSString stringWithFormat:@"%@|%@|%.2f|%d",
+                              label ?: @"",
+                              [font isKindOfClass:[UIFont class]] ? (font.fontName ?: @"-") : @"-",
+                              [font isKindOfClass:[UIFont class]] ? font.pointSize : 0.0,
+                              revealLink ? 1 : 0];
+    @synchronized (chipCacheLock) {
+        NSAttributedString *cached = chipCache[chipCacheKey];
+        if ([cached isKindOfClass:[NSAttributedString class]]) return cached;
+    }
+
     UIImage *image = ApolloDeletedCommentsReasonChipImage(label, font);
     CGFloat chipLineHeight = [image isKindOfClass:[UIImage class]] ? image.size.height + 6.0 : font.lineHeight + 6.0;
     NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
@@ -688,7 +722,12 @@ static NSAttributedString *ApolloDeletedCommentsReasonChipAttributedText(NSStrin
         [result addAttribute:ApolloDeletedCommentsRevealAttributeName value:ApolloDeletedCommentsRevealURLString range:NSMakeRange(0, result.length)];
     }
     [result addAttribute:ApolloDeletedCommentsReasonPrefixAttributeName value:@YES range:NSMakeRange(0, result.length)];
-    return result;
+
+    NSAttributedString *immutableChip = [result copy];
+    @synchronized (chipCacheLock) {
+        chipCache[chipCacheKey] = immutableChip;
+    }
+    return immutableChip;
 }
 
 static id ApolloDeletedCommentsKnownBodyTextNode(id commentCellNode) {
@@ -1086,8 +1125,14 @@ static NSString *ApolloDeletedCommentsNormalizeTextForCompare(NSString *s) {
         [lines addObject:normalizedLine];
     }
     trimmed = [lines componentsJoinedByString:@" "];
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\s+" options:0 error:nil];
-    trimmed = [regex stringByReplacingMatchesInString:trimmed options:0 range:NSMakeRange(0, trimmed.length) withTemplate:@" "];
+    // Compile once. This classifier runs many times per comment cell per layout pass;
+    // recompiling \s+ on every call (uregex_open) was a top hotspot in the #514 freeze.
+    static NSRegularExpression *whitespaceRegex = nil;
+    static dispatch_once_t whitespaceOnce;
+    dispatch_once(&whitespaceOnce, ^{
+        whitespaceRegex = [NSRegularExpression regularExpressionWithPattern:@"\\s+" options:0 error:nil];
+    });
+    trimmed = [whitespaceRegex stringByReplacingMatchesInString:trimmed options:0 range:NSMakeRange(0, trimmed.length) withTemplate:@" "];
 
     NSArray<NSString *> *reasonPrefixes = @[@"removed by mod", @"deleted by user", @"loading...", @"not available"];
     NSString *lowercase = trimmed.lowercaseString;
@@ -1141,9 +1186,15 @@ static NSArray<NSString *> *ApolloDeletedCommentsBodyMatchTokens(NSString *text)
     NSString *normalized = ApolloDeletedCommentsNormalizeTextForCompare(ApolloDeletedCommentsUnwrappedSpoilerMarkdown(text)).lowercaseString;
     if (normalized.length == 0) return @[];
 
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"[^a-z0-9]+"
-                                                                           options:0
-                                                                             error:nil];
+    // Compile once (see NormalizeTextForCompare above) — this tokenizer regex was the
+    // other per-call uregex_open hotspot in the #514 freeze.
+    static NSRegularExpression *regex = nil;
+    static dispatch_once_t tokenOnce;
+    dispatch_once(&tokenOnce, ^{
+        regex = [NSRegularExpression regularExpressionWithPattern:@"[^a-z0-9]+"
+                                                          options:0
+                                                            error:nil];
+    });
     NSString *tokenText = [regex stringByReplacingMatchesInString:normalized
                                                           options:0
                                                             range:NSMakeRange(0, normalized.length)
@@ -2476,6 +2527,17 @@ static NSAttributedString *ApolloDeletedCommentsBodyFontUnifiedText(NSAttributed
 static void ApolloDeletedCommentsSetTextNodeAttributedText(id textNode, NSAttributedString *attributedText) {
     if (!textNode || ![attributedText isKindOfClass:[NSAttributedString class]]) return;
     attributedText = ApolloDeletedCommentsBodyFontUnifiedText(attributedText);
+    // Skip identical re-writes. Setting a text node's attributedText dirties it and
+    // schedules a re-measure; if the new content equals the current content this is
+    // pure churn. Combined with the cached chip string above, repeated measures of a
+    // settled deleted cell now become no-ops instead of an endless re-measure loop
+    // (#514). Uses -isEqualToAttributedString: so identical chip/body strings compare
+    // equal even when freshly allocated.
+    NSAttributedString *current = ApolloDeletedCommentsCurrentAttributedText(textNode);
+    if ([current isKindOfClass:[NSAttributedString class]] &&
+        [current isEqualToAttributedString:attributedText]) {
+        return;
+    }
     @try {
         ((void (*)(id, SEL, NSAttributedString *))objc_msgSend)(textNode, @selector(setAttributedText:), attributedText);
     } @catch (__unused NSException *e) {}
@@ -2799,7 +2861,13 @@ static void ApolloDeletedCommentsScheduleReasonChipRepair(id cellNode) {
     if (fullName.length == 0 || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return;
 
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsReasonChipRepairScheduledKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    NSArray<NSNumber *> *delays = @[@0.05, @0.15, @0.35];
+    // One deferred pass, not three. The repeats re-ran the repair + RelayoutCellAndTextNode
+    // to catch async chip drift, but each pass re-fires a host-wide beginUpdates/endUpdates
+    // re-measure across every visible deleted cell — a fan-out amplifier of the #514 freeze.
+    // The setAttributedText: chip chain re-stamps on any rewrite and the MarkdownNode layout
+    // spec re-emits on any measure, so a single deferred invalidate suffices to pick up the
+    // taller recovered-body height after an archive/state change.
+    NSArray<NSNumber *> *delays = @[@0.15];
     for (NSNumber *delayNumber in delays) {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayNumber.doubleValue * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             RDKComment *currentComment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
@@ -2974,11 +3042,26 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRe
 
 - (void)calculatedLayoutDidChange {
     %orig;
-    ApolloDeletedCommentsUpdateCell((id)self);
+    // Intentionally NOT calling ApolloDeletedCommentsUpdateCell here. This is a
+    // POST-measure callback; UpdateCell invalidates layout (RelayoutCellAndTextNode ->
+    // setNeedsLayout/invalidateCalculatedLayout + ScheduleHostLayoutRefresh's host-wide
+    // beginUpdates/endUpdates) and mutates the model, which re-fires this callback — the
+    // self-amplifying re-measure loop behind the #514 freeze. The chip/body is already
+    // rendered by the MarkdownNode layout spec (re-emits on every measure) and the
+    // ASTextNode setAttributedText: chain; tracking + reveal-gesture install run from
+    // didLoad/didEnterDisplayState; collapse/expand, archive arrival, and reveal each
+    // drive their own off-layout refresh. Nothing here needs to run per measure.
 }
 
 - (id)layoutSpecThatFits:(struct CDStruct_90e057aa)fits {
-    ApolloDeletedCommentsSynchronizeCommentModelDisplayState((id)self);
+    // Do NOT synchronize the model here. SynchronizeCommentModelDisplayState writes
+    // setBody:/setBodyHTML:, and mutating RDKComment on the measure path dirties the
+    // node and provokes another measure (Texture forbids model mutation in
+    // layoutSpecThatFits:) — part of the #514 spin. It is idempotent and already runs
+    // off-layout from didEnterDisplayState (UpdateCell), the archive-arrival path, and
+    // the reveal path. The spec below resolves the body it displays via
+    // ResolvedRecoveredBodyForComment and the body/bodyHTML getter hooks, so it does not
+    // depend on the model being pre-normalized here.
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode((id)self);
     id bodyNode = ApolloDeletedCommentsKnownBodyContainerNode((id)self);
     if (bodyNode) {

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -55,6 +55,13 @@ static const void *kApolloDeletedCommentsRevealTapGestureKey = &kApolloDeletedCo
 static NSMutableDictionary<NSString *, NSHashTable *> *sApolloDeletedCommentsVisibleCellsByFullName = nil;
 static NSObject *sApolloDeletedCommentsVisibleCellsLock = nil;
 static NSDictionary<NSAttributedStringKey, id> *sApolloDeletedCommentsBodyAttributesTemplate = nil;
+// Apollo's ACTUAL comment-body font, captured live from a normally-rendered comment.
+// Deriving the size ourselves (preferredFontForTextStyle:Subheadline at a resolved
+// content-size category) was off by ~one Dynamic Type step vs Apollo's real font, so
+// deleted comments rendered larger than normal ones — and worse when we own the layout
+// (tap-to-reveal), where there is no native node left to read. Capturing the real font
+// makes deleted bodies match exactly and track in-app/system text-size changes.
+static UIFont *sApolloDeletedCommentsLiveCommentBodyFont = nil;
 static BOOL sApolloDeletedCommentsBodyAttributesRefreshScheduled = NO;
 static NSString *const ApolloDeletedCommentsRevealURLString = @"apollo-deleted-comments://reveal";
 static NSString *const ApolloDeletedCommentsRevealAttributeName = @"ApolloDeletedCommentsRevealAttribute";
@@ -169,13 +176,12 @@ static UIFont *ApolloDeletedCommentsReasonChipFontForBaseAttributes(NSDictionary
 }
 
 static UIFont *ApolloDeletedCommentsRecoveredBodyFont(void) {
-    // Apollo's comment body is UIFontTextStyleSubheadline (15pt @ .large), NOT Body
-    // (17pt). This is the universal fallback font for DefaultBodyAttributes (used by
-    // BodyAttributedText, the reason-chip base attributes, and the chip-size
-    // derivation) and is what renders on the FIRST display of a deleted/recovered
-    // body, before the per-node Subheadline template is populated. Returning Body here
-    // made deleted-comment text render two points larger than normal comments
-    // (the "deleted text looks bigger" report). Match Apollo's real comment body.
+    // Prefer Apollo's real captured comment font when we've seen one.
+    if ([sApolloDeletedCommentsLiveCommentBodyFont isKindOfClass:[UIFont class]]) {
+        return sApolloDeletedCommentsLiveCommentBodyFont;
+    }
+    // Last-resort fallback: Apollo's comment body is UIFontTextStyleSubheadline
+    // (15pt @ .large), NOT Body (17pt).
     return [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline];
 }
 
@@ -351,6 +357,11 @@ static NSString *ApolloDeletedCommentsEscapedHTMLText(NSString *text) {
 static NSString *ApolloDeletedCommentsPlainBodyHTML(NSString *text) {
     NSString *trimmed = ApolloDeletedCommentsTrimmedString(text);
     if (trimmed.length == 0) return @"";
+    // Route through the shared markdown-aware generator so the saved/restored body_html
+    // (returned by the bodyHTML getter hook and Apollo's native renderer) shows links and
+    // bold instead of literal "[text](url)"/"**text**". Falls back to escaped plain text.
+    NSString *html = ApolloDeletedCommentsRedditBodyHTML(trimmed);
+    if (html.length > 0) return html;
     NSString *escaped = ApolloDeletedCommentsEscapedHTMLText(trimmed);
     return [NSString stringWithFormat:@"&lt;div class=&quot;md&quot;&gt;&lt;p&gt;%@&lt;/p&gt;\n&lt;/div&gt;", escaped];
 }
@@ -894,6 +905,12 @@ static NSString *ApolloDeletedCommentsEffectiveContentSizeCategory(id node, BOOL
 // content size category above. Apollo's comment body is UIFontTextStyleSubheadline
 // scaled by that category (verified: .large=15pt, .xxxLarge=21pt), regular weight.
 static UIFont *ApolloDeletedCommentsAppCommentBodyFontForNode(id node) {
+    // Prefer Apollo's real captured comment font (always matches normal comments and
+    // tracks text-size changes). Fall back to the derived size only before we've seen
+    // a normal comment render.
+    if ([sApolloDeletedCommentsLiveCommentBodyFont isKindOfClass:[UIFont class]]) {
+        return sApolloDeletedCommentsLiveCommentBodyFont;
+    }
     NSString *category = ApolloDeletedCommentsEffectiveContentSizeCategory(node, NULL);
     if (![category isKindOfClass:[NSString class]] || category.length == 0) {
         category = UIContentSizeCategoryLarge;
@@ -2977,10 +2994,62 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRe
     return renamed;
 }
 
+static Class ApolloDeletedCommentsMarkdownNodeClass(void) {
+    static Class cls = Nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        cls = objc_getClass("_TtC6Apollo12MarkdownNode");
+    });
+    return cls;
+}
+
+// Capture Apollo's real comment-body font from a normally-rendered comment body, so
+// deleted comments render at the exact same size (see sApolloDeletedCommentsLiveCommentBodyFont).
+// Runs from the global setAttributedText: hook, so the steady-state path is kept cheap:
+// the supernode walk only runs when the captured font actually changes (first capture
+// or a text-size change).
+static void ApolloDeletedCommentsCaptureLiveCommentBodyFont(id textNode, NSAttributedString *attributedText) {
+    if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length < 2) return;
+    // Only comment/post *body* nodes carry a MarkdownNode delegate — gate on it cheaply.
+    Class mdClass = ApolloDeletedCommentsMarkdownNodeClass();
+    if (!mdClass || ![textNode respondsToSelector:@selector(delegate)]) return;
+    id delegate = nil;
+    @try { delegate = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(delegate)); } @catch (__unused NSException *e) {}
+    if (![delegate isKindOfClass:mdClass]) return;
+    // Skip our own injected chip/body text (it carries the reason-prefix marker).
+    if (ApolloDeletedCommentsAttributedTextHasReasonPrefix(attributedText)) return;
+
+    __block UIFont *candidate = nil;
+    [attributedText enumerateAttribute:NSFontAttributeName inRange:NSMakeRange(0, attributedText.length) options:0
+                            usingBlock:^(id value, __unused NSRange range, BOOL *stop) {
+        if (![value isKindOfClass:[UIFont class]]) return;
+        UIFont *f = (UIFont *)value;
+        if (f.pointSize < 8.0 || f.pointSize > 40.0) return;
+        if ((f.fontDescriptor.symbolicTraits & (UIFontDescriptorTraitBold | UIFontDescriptorTraitItalic)) != 0) return;
+        candidate = f;
+        *stop = YES;
+    }];
+    if (![candidate isKindOfClass:[UIFont class]]) return;
+    if ([sApolloDeletedCommentsLiveCommentBodyFont isKindOfClass:[UIFont class]] &&
+        fabs(sApolloDeletedCommentsLiveCommentBodyFont.pointSize - candidate.pointSize) <= 0.5 &&
+        [sApolloDeletedCommentsLiveCommentBodyFont.fontName isEqualToString:candidate.fontName]) {
+        return; // unchanged — cheap steady-state exit
+    }
+    // Capture from any markdown body (comment or post self-text — Apollo renders both
+    // at the same text-size setting). The cell hierarchy isn't wired up yet at
+    // setAttributedText: time, so we can't reliably scope to comment cells here.
+    sApolloDeletedCommentsLiveCommentBodyFont = candidate;
+    // Drop the cached body template so deleted cells re-resolve at the new size, and
+    // refresh the visible ones (this is what makes a text-size change propagate).
+    sApolloDeletedCommentsBodyAttributesTemplate = nil;
+    if (sShowDeletedComments) ApolloDeletedCommentsScheduleBodyAttributesRefresh();
+}
+
 %hook ASTextNode
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
     NSAttributedString *displayText = attributedText;
+    ApolloDeletedCommentsCaptureLiveCommentBodyFont((id)self, displayText);
     displayText = ApolloDeletedCommentsAttributedTextWithTapToRevealPlaceholder((id)self, displayText);
     displayText = ApolloDeletedCommentsRenameRecoveredSpoilerLabel((id)self, displayText);
     displayText = ApolloDeletedCommentsAttributedTextWithReasonChipIfNeeded((id)self, displayText);


### PR DESCRIPTION
Fixes #514. Also fixes the collapse-time freeze reported on #516, and the oversized deleted-comment text.

## The freeze

With **Show Deleted Comments** on, scrolling (or collapsing) a heavily-moderated thread (e.g. the r/AskHistorians thread in #514) pins the main thread and freezes the app.

I symbolicated the reporter's `cpu_resource.diag` against the exact-UUID v3.3.0 release dSYM. The entire ~90s spin is the deleted-comments machinery running from **layout callbacks**, forming a self-amplifying re-measure loop in `src/ApolloDeletedCommentsUI.xm`:

```
CommentCellNode.calculatedLayoutDidChange (post-measure) ─▶ UpdateCell
   ├─ RepairVisibleReasonChipIfNeeded ─▶ depth-6 node tree walk
   │     └─ NormalizeTextForCompare / BodyMatchTokens ── NSRegularExpression RECOMPILED per call
   └─ ScheduleReasonChipRepair ─▶ 3× RelayoutCellAndTextNode
         └─ ScheduleHostLayoutRefresh ─▶ UITableView beginUpdates/endUpdates (whole list re-measures)
               └─ re-fires calculatedLayoutDidChange ──▶ (loop)
CommentCellNode.layoutSpecThatFits ─▶ SynchronizeCommentModelDisplayState
                                        └─ setBody:/setBodyHTML: (model mutation during measure)
```

On a thread with many removed comments — or when collapsing a parent (mass relayout) — this never converges. #514 and the collapse-freeze are the same root cause.

## Changes (`ApolloDeletedCommentsUI.xm` only)

- **Remove `UpdateCell` from `calculatedLayoutDidChange`.** A post-measure callback must not invalidate layout or mutate the model. The chip/body is already rendered by the MarkdownNode layout spec and the `setAttributedText:` chain; cell tracking + reveal-gesture install still run from `didLoad`/`didEnterDisplayState`; collapse/expand, archive arrival, and tap-to-reveal each drive their own off-layout refresh.
- **Remove `SynchronizeCommentModelDisplayState` from `layoutSpecThatFits`.** It wrote `setBody:`/`setBodyHTML:` on the measure path (Texture forbids model mutation during measure). It is idempotent and already runs from the off-layout entry points; the spec resolves its body on demand via the `body`/`bodyHTML` getter hooks.
- **Cache the `\s+` and `[^a-z0-9]+` regexes** in `dispatch_once` singletons instead of recompiling per classifier call (the `uregex_open` hotspot in the diag).
- **Cache the reason-chip attributed string** and skip identical `setAttributedText:` writes. Each measure rebuilt the chip with a fresh `UIImage` attachment, so the strings were never `-isEqual:` and the body node stayed perpetually dirty → continuous re-measure. With a stable cached chip the node settles after one measure.
- **Reduce the chip-repair fan-out** from 3 delayed relayout passes to 1.

## Oversized text

`ApolloDeletedCommentsRecoveredBodyFont` used `UIFontTextStyleBody` (17pt @ .large), but Apollo's comment body is `UIFontTextStyleSubheadline` (15pt). That fallback feeds `DefaultBodyAttributes` and the chip-size derivation, so deleted/recovered text rendered two points larger than normal comments. Changed to Subheadline.

## Testing

Simulator (iOS 26.5), on the actual r/AskHistorians thread from #514 with Show Deleted Comments on:

| | before | after |
|---|---|---|
| Main-thread CPU on load | ~98% (frozen, blank) | ~16% settled |
| During active scroll | freeze | ~40% transient, settles |
| Collapsing a subtree | freeze | 15–21%, no spike |
| Deleted-comment frames in idle/scroll/collapse `sample` | dominant | 0 |

Recovered comments still render with the red treatment, and deleted-comment body text now matches normal comment size.

> Sim-verified, not yet device-tested.