### PR TITLE
Fix modmail conversation layout under Liquid Glass (#525)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloInboxCommentScroll.xm \
     $(SRC_DIR)/ApolloLiquidGlass.xm \
     $(SRC_DIR)/ApolloLiquidGlassIconPicker.xm \
+    $(SRC_DIR)/ApolloModmailLayout.xm \
     $(SRC_DIR)/ApolloAutoHideTabBar.xm \
     $(SRC_DIR)/ApolloSettings.xm \
     $(SRC_DIR)/ApolloRecentlyRead.xm \

--- a/src/ApolloLiquidGlass.xm
+++ b/src/ApolloLiquidGlass.xm
@@ -578,6 +578,13 @@ static char kASTableViewHasSearchToolbarKey;
 @end
 
 static void FixScrollEdgeEffectInversion(UIScrollView *scrollView) {
+    // Only counter-invert when the collection ITSELF is inverted (scaleY=-1). When
+    // it isn't (e.g. modmail / DM conversations in Apollo 3.3.0, where the collection
+    // is upright), flipping the effect host pushes the *top* scroll-edge blur down to
+    // the bottom, leaving the nav-bar edge unmasked — chat content then bleeds up
+    // through the (image-less, Liquid Glass) nav bar background. See issue #525.
+    BOOL collectionInverted = scrollView.transform.d < 0;
+
     for (UIView *subview in scrollView.subviews) {
         if (![NSStringFromClass([subview class]) containsString:@"TouchPassthroughView"]) continue;
 
@@ -590,12 +597,19 @@ static void FixScrollEdgeEffectInversion(UIScrollView *scrollView) {
         }
         if (!hasEffectChild) continue;
 
-        // The collection view has transform scaleY=-1 (inverted for chat UI).
-        // Counter-invert the effect container so the blur gradient renders correctly.
         CGAffineTransform current = subview.transform;
-        if (current.d > 0) {
-            // Not yet counter-inverted — apply scaleY=-1
-            subview.transform = CGAffineTransformMakeScale(1, -1);
+        if (collectionInverted) {
+            // Inverted collection: counter-invert the effect container so the blur
+            // gradient renders the right way up at the nav-bar edge.
+            if (current.d > 0) {
+                subview.transform = CGAffineTransformMakeScale(1, -1);
+            }
+        } else {
+            // Upright collection: the effect host must stay upright. Undo any flip a
+            // prior pass applied so the top scroll-edge blur masks content correctly.
+            if (current.d < 0) {
+                subview.transform = CGAffineTransformIdentity;
+            }
         }
     }
 }

--- a/src/ApolloModmailLayout.xm
+++ b/src/ApolloModmailLayout.xm
@@ -1,0 +1,81 @@
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import "ApolloCommon.h"
+
+// MARK: - Modmail conversation layout fixes for Liquid Glass (issue #525)
+//
+// Apollo's chat conversation screen is `PrivateMessageViewController`
+// (a MessageKit `MessagesViewController` subclass). The SAME class backs both
+// regular DMs and modmail conversations — modmail mode is identified by a
+// non-nil `newModmailConversationID`.
+//
+// In modmail mode `viewWillAppear:` reaches up to the enclosing
+// `ApolloTabBarController` and sets `themeAsModerator = YES`, deliberately
+// KEEPING the (now green) tab bar on screen — unlike a DM, which hides the
+// bottom bar. Pre-Liquid-Glass that opaque green tab bar sat cleanly below the
+// compose bar. On iOS 26 Liquid Glass both the tab bar and the MessageKit input
+// bar float as translucent pills, so they collide: the compose field overlaps
+// the tab bar and the conversation gets translucent bleed at top and bottom.
+//
+// Fix (this file): for a modmail conversation under Liquid Glass, hide the
+// bottom bar so the screen behaves like every other chat window — exactly what
+// the issue asks for. We do this by overriding `hidesBottomBarWhenPushed` to
+// return YES; UINavigationController reads it at push time, hides the tab bar
+// for the conversation, and restores it automatically on pop back to the
+// modmail inbox.
+//
+// Gated to Liquid Glass: the non-LG opaque tab bar has coexisted with modmail
+// for years (the issue reports this as new in the LG build), so we leave that
+// long-standing behavior untouched.
+//
+// Companion fix (in ApolloLiquidGlass.xm): the issue's second half — a too-tall,
+// text-bleeding top band — was the chat's nav-bar scroll-edge blur landing at the
+// bottom instead of the top. `FixScrollEdgeEffectInversion` was counter-inverting
+// the effect host unconditionally, but Apollo 3.3.0's chat collection is upright
+// (not scaleY=-1), so the flip pushed the top blur off-screen and conversation
+// text bled up through the image-less Liquid Glass nav bar. That hook is now gated
+// on the collection actually being inverted. See the note there for details.
+
+@interface _TtC6Apollo28PrivateMessageViewController : UIViewController
+@end
+
+// Cached ivar offset of `newModmailConversationID` (a Swift `String?`). We do
+// NOT try to materialize the Swift String — we only replicate Apollo's own
+// runtime nil-check, which tests the second 8-byte word of the inline String
+// struct (`*(self + offset + 8) != 0`; see -[PrivateMessageViewController
+// viewWillAppear:] in the binary). That word is the String's owner/discriminator
+// slot — zero only when the optional is `.none`. This mirrors the app's exact
+// gate and avoids the Swift-struct-ivar pitfalls (see AGENTS.md).
+static BOOL ApolloPMVCIsModmailConversation(UIViewController *vc) {
+    if (!vc) return NO;
+    static dispatch_once_t onceToken;
+    static ptrdiff_t sConvIDOffset = -1;
+    dispatch_once(&onceToken, ^{
+        Class cls = objc_getClass("_TtC6Apollo28PrivateMessageViewController");
+        if (cls) {
+            Ivar iv = class_getInstanceVariable(cls, "newModmailConversationID");
+            if (iv) sConvIDOffset = ivar_getOffset(iv);
+        }
+    });
+    if (sConvIDOffset < 0) return NO;
+
+    uintptr_t discriminator = *(uintptr_t *)((char *)(__bridge void *)vc + sConvIDOffset + sizeof(void *));
+    return discriminator != 0;
+}
+
+%hook _TtC6Apollo28PrivateMessageViewController
+
+// UINavigationController queries this during the push transition to decide
+// whether to slide the tab bar away. Force YES for modmail under Liquid Glass.
+- (BOOL)hidesBottomBarWhenPushed {
+    if (IsLiquidGlass() && ApolloPMVCIsModmailConversation(self)) {
+        return YES;
+    }
+    return %orig;
+}
+
+%end
+
+%ctor {
+    %init;
+}


### PR DESCRIPTION
Fixes #525 — modmail conversations were visually broken under iOS 26 Liquid Glass.

Apollo's chat conversation screen is `PrivateMessageViewController` (a MessageKit `MessagesViewController` subclass, shared by DMs and modmail; modmail mode = non‑nil `newModmailConversationID`). Two independent Liquid Glass regressions:

### 1. Tall top band with text bleeding behind the status bar / title
The collection's insets are actually correct (`adjustedContentInset.top = 116` = status bar + nav bar) and the chat collection is **not** inverted in 3.3.0 (`transform.d = 1.0`). The existing `FixScrollEdgeEffectInversion` hook, however, was **unconditionally** counter‑flipping the `_UITouchPassthroughView` that hosts the `ScrollEdgeEffectView`. On an upright collection that flip moves the *top* nav‑bar blur down to the bottom — and since the nav bar's background image view is hidden (intended Liquid Glass behavior), conversation text bled straight up behind the status bar and title.

**Fix:** gate the counter‑inversion on the collection actually being inverted (`transform.d < 0`), and restore identity if a prior layout pass already flipped it. The hook only runs on `MessagesCollectionView`, so feeds/comments are untouched; DMs benefit from the same correction.

### 2. Tab bar overlapping the compose bar
In modmail mode `viewWillAppear:` themes and keeps the (moderator‑green) tab bar. Under Liquid Glass that floating tab bar collides with the floating MessageKit compose bar.

**Fix:** override `hidesBottomBarWhenPushed` to return `YES` for modmail conversations under Liquid Glass, so the screen behaves like every other chat window. Gated to Liquid Glass — the long‑standing non‑LG behavior is untouched, and where the bar is already hidden it's a safe no‑op.

### Screenshots

| Before | After |
|:---:|:---:|
| <img width="280" alt="Before — tab bar overlapping the compose bar, cramped top with text bleeding under the status bar" src="https://github.com/user-attachments/assets/eb2ac911-26f1-41ea-ae2b-b12ba52443e3" /><br>**Before** — the main tab bar (Posts / Inbox / …) shows through and collides with the compose bar at the bottom, and the header band is cramped with conversation text bleeding up under the status bar. | <img width="280" alt="After — clean title at top, no tab bar, just the compose bar" src="https://github.com/user-attachments/assets/2c97acdb-4c1b-4ce1-b458-ada485c7f9bd" /><br>**After** — no tab bar (just the compose bar, like every other chat window), and the title sits clean with content blurring correctly under the nav bar. |

### Files
- `src/ApolloModmailLayout.xm` (new) — the `hidesBottomBarWhenPushed` override.
- `src/ApolloLiquidGlass.xm` — gate `FixScrollEdgeEffectInversion` on real inversion.
- `Makefile` — register the new file.

### Testing
- **Top‑band fix: verified before/after in the iOS 26 Simulator (Liquid Glass).** Reproduced the bleed, confirmed it's gone, content under the nav bar now blurs correctly; regular DMs unchanged.
- **Tab‑bar fix:** RE‑justified and standard, but reached via the unified‑inbox path the conversation already hides the bar, so the overlap reproduces on the subreddit‑moderator entry path (matching the report) — that path is worth a quick **device** check. Not device‑tested yet.

