### PR TITLE
Hold for Video Speed: configurable speed + on/off toggle

### DIFF
--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -23,6 +23,27 @@ extern NSInteger sReadPostMaxCount;
 // 0 = Default (off), 1 = Remember from Full Screen, 2 = Always
 extern NSInteger sUnmuteCommentsVideos;
 
+// "Hold for Video Speed": when ON (default), press-and-hold the right side of a
+// fullscreen video to play it at sVideoHoldSpeed while held; release restores the
+// prior rate. When OFF the right side behaves like the rest of the player (normal
+// long-press menu). sVideoHoldSpeed is one of 0.25/0.5/0.75/1.25/1.5/2.0 (default
+// 2.0×). Both default via registerDefaults. See ApolloVideoHoldSpeed.xm.
+extern BOOL sVideoHoldSpeedEnabled;
+extern float sVideoHoldSpeed;
+// Snap an arbitrary stored value to the nearest supported hold speed; falls back
+// to 2.0× for an unset/corrupt/out-of-set value. Keeps the runtime, the load
+// paths, and the picker agreeing on exactly the six offered speeds. Wrapped in
+// extern "C" so the ObjC++ (.xm) callers and the ObjC (.m) definition agree on the
+// unmangled symbol name (the extern *variables* above need no guard — global
+// variable names aren't C++-mangled).
+#ifdef __cplusplus
+extern "C" {
+#endif
+float ApolloSanitizedHoldSpeed(float value);
+#ifdef __cplusplus
+}
+#endif
+
 extern BOOL sProxyImgurDDG;
 extern BOOL sShowUserAvatars;
 extern BOOL sUseProfileAvatarTabIcon;

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -22,6 +22,9 @@ NSInteger sReadPostMaxCount = 0;
 
 NSInteger sUnmuteCommentsVideos = 0; // 0=Default, 1=Remember from Full Screen, 2=Always
 
+BOOL sVideoHoldSpeedEnabled = YES;   // effective default ON via registerDefaults (UDKeyVideoHoldSpeedEnabled)
+float sVideoHoldSpeed = 2.0f;        // effective default 2.0× via registerDefaults (UDKeyVideoHoldSpeed)
+
 BOOL sProxyImgurDDG = NO;
 BOOL sShowUserAvatars = NO;
 BOOL sUseProfileAvatarTabIcon = NO;
@@ -82,3 +85,13 @@ NSDictionary<NSString *, NSDictionary *> *sTagFilterSubredditOverrides = nil;
 
 NSDictionary<NSString *, NSDictionary *> *sPostFilterSubreddits = nil;
 NSArray<NSString *> *sPostFilterNameSubstrings = nil;
+
+float ApolloSanitizedHoldSpeed(float value) {
+    // The exact speeds offered by the picker (mirrors the video player's menu,
+    // minus 1.0× — holding at normal speed would be a no-op).
+    static const float kSupported[] = { 0.25f, 0.5f, 0.75f, 1.25f, 1.5f, 2.0f };
+    for (size_t i = 0; i < sizeof(kSupported) / sizeof(kSupported[0]); i++) {
+        if (fabsf(value - kSupported[i]) < 0.001f) return kSupported[i];
+    }
+    return 2.0f;   // unset (0) / corrupt / unsupported → default boost
+}

--- a/src/ApolloVideoHoldSpeed.xm
+++ b/src/ApolloVideoHoldSpeed.xm
@@ -1,8 +1,15 @@
 // ApolloVideoHoldSpeed.xm
 //
-// "Hold for 2×" — press-and-hold the RIGHT third of the fullscreen video to
-// play it at 2× speed while held; release to restore the previous rate.
+// "Hold for Video Speed" — press-and-hold the RIGHT third of the fullscreen video
+// to play it at a chosen speed while held; release to restore the previous rate.
 // (GitHub issue #78.)
+//
+// Configurable via Settings → Media → "Hold for Video Speed":
+//   • A master toggle (default ON — preserves the original always-on behaviour).
+//     When OFF, the right side behaves like the rest of the player (normal menu).
+//   • A "Hold Speed" picker — one of 0.25×/0.5×/0.75×/1.25×/1.5×/2× (default 2×),
+//     so the gesture can speed video up OR slow it down (slow-motion review).
+//   Both live in sVideoHoldSpeedEnabled / sVideoHoldSpeed (read live at touch).
 //
 // The fullscreen player is `MediaViewerController` (ObjC name
 // `_TtC6Apollo21MediaViewerController`). A long-press anywhere on it normally
@@ -11,10 +18,10 @@
 //
 // We must coexist with that menu, not replace it:
 //
-//     ┌──────────────────────────┬──────────┐
-//     │     left + center 2/3    │  right ⅓ │
-//     │   normal long-press menu │  2× hold │
-//     └──────────────────────────┴──────────┘
+//     ┌──────────────────────────┬────────────┐
+//     │     left + center 2/3    │   right ⅓   │
+//     │   normal long-press menu │  speed hold │
+//     └──────────────────────────┴────────────┘
 //
 // Why a custom passive recognizer (not a UILongPressGestureRecognizer):
 //   A second long-press recognizer competing with Apollo's loses UIKit's gesture
@@ -25,14 +32,15 @@
 //   arbitration can't kill it and it never blocks Apollo's own tap/pan handling.
 //
 // Mechanics:
-//   • On touch-DOWN we check, against the video's live on-screen geometry, whether
-//     the touch is in the right third. If so we immediately DISABLE every other
-//     long-press recognizer in the tree — so the menu simply can't appear for this
-//     touch — and re-enable them on release. (No timing race with the menu.)
+//   • On touch-DOWN, if the feature is on, we check (against the video's live
+//     on-screen geometry) whether the touch is in the right third. If so we
+//     immediately DISABLE every other long-press recognizer in the tree — so the
+//     menu simply can't appear for this touch — and re-enable them on release.
+//     (No timing race with the menu.)
 //   • If the press is still held after a short delay, we capture the live rate,
-//     force 2×, and show a "2× ⏵⏵" overlay. On release we restore the captured
-//     rate and hide the overlay. A quick tap in the right zone just toggles the
-//     menu recognizers off/on with no speed change.
+//     force the chosen speed, and show a "<speed>× ⏵⏵" overlay reflecting it. On
+//     release we restore the captured rate and hide the overlay. A quick tap in
+//     the right zone just toggles the menu recognizers off/on with no speed change.
 //   • Left/center touches are left entirely alone, so the normal menu still works.
 //   • We never touch `videoPlaybackSpeed` (Apollo's persistent menu choice), so
 //     the speed menu's checkmark stays correct.
@@ -42,6 +50,7 @@
 // to landscape on the portrait-locked screen, and under pinch-zoom.
 
 #import "ApolloCommon.h"
+#import "ApolloState.h"   // sVideoHoldSpeedEnabled, sVideoHoldSpeed, ApolloSanitizedHoldSpeed
 
 #import <UIKit/UIKit.h>
 #import <UIKit/UIGestureRecognizerSubclass.h>
@@ -49,13 +58,14 @@
 #import <objc/runtime.h>
 #import <objc/message.h>
 
-// Rightmost fraction of the video that activates hold-to-2×.
+// Rightmost fraction of the video that activates hold-to-speed.
 static const CGFloat kRightZoneFraction = 1.0 / 3.0;
 
-// The speed applied while held.
-static const float kHoldSpeed = 2.0f;
+// The speed applied while held comes from the in-app "Hold for Video Speed" picker
+// (sVideoHoldSpeed), read live at engage. ApolloSanitizedHoldSpeed() guards it to
+// the six supported values, falling back to 2.0× for any unset/invalid value.
 
-// How long the press must be held before 2× engages. Short enough to feel
+// How long the press must be held before the speed engages. Short enough to feel
 // instant, long enough that a quick tap never trips it. (This only gates the
 // speed change — the menu is suppressed at touch-down, so there's no race.)
 static const NSTimeInterval kHoldActivationDelay = 0.18;
@@ -64,10 +74,33 @@ static const NSTimeInterval kHoldActivationDelay = 0.18;
 // scrub / swipe-to-dismiss instead of a speed-up.
 static const CGFloat kHoldMoveTolerance = 12.0;
 
-// Haptic tap fired the instant 2× engages, mirroring the press-and-hold speed
+// Haptic tap fired the instant the hold speed engages, mirroring the press-and-hold
 // cue in YouTube/Instagram — a clear-but-gentle "it's on" tick. Medium impact;
 // the Taptic Engine is pre-warmed on touch-down so the tap lands with no lag.
 static const UIImpactFeedbackStyle kHoldHapticStyle = UIImpactFeedbackStyleMedium;
+
+// Top-center overlay text for the engaged speed, e.g. "2× ⏵⏵" or "0.5×". The
+// fast-forward chevrons (U+23F5 ×2) read as "faster", so they're shown only when
+// speeding up; for slow-motion speeds (<1×) the bare multiplier is clearer and the
+// arrows would actively mislead. Mirrors whatever the user picked in settings.
+static NSAttributedString *HoldOverlayText(float speed) {
+    NSString *num;
+    if (fabsf(speed - 0.25f) < 0.001f)      num = @"0.25";
+    else if (fabsf(speed - 0.5f)  < 0.001f) num = @"0.5";
+    else if (fabsf(speed - 0.75f) < 0.001f) num = @"0.75";
+    else if (fabsf(speed - 1.25f) < 0.001f) num = @"1.25";
+    else if (fabsf(speed - 1.5f)  < 0.001f) num = @"1.5";
+    else if (fabsf(speed - 2.0f)  < 0.001f) num = @"2";
+    else                                    num = [NSString stringWithFormat:@"%g", speed];
+    // U+00D7 multiplication sign; chevrons only when boosting.
+    NSString *s = (speed > 1.0f)
+        ? [NSString stringWithFormat:@"%@%C ⏵⏵", num, (unichar)0x00D7]
+        : [NSString stringWithFormat:@"%@%C", num, (unichar)0x00D7];
+    return [[NSAttributedString alloc] initWithString:s attributes:@{
+        NSFontAttributeName: [UIFont systemFontOfSize:17.0 weight:UIFontWeightSemibold],
+        NSForegroundColorAttributeName: [UIColor whiteColor],
+    }];
+}
 
 #pragma mark - Player access (mirrors ApolloVideoPlaybackSpeed.xm)
 
@@ -262,19 +295,21 @@ static void CollectContextMenuInteractions(UIView *view,
 @property (nonatomic, weak) UIViewController *mediaViewer;
 @property (nonatomic, strong) ApolloHoldTouchRecognizer *recognizer;
 @property (nonatomic, strong) UIView *overlayView;
+@property (nonatomic, strong) UILabel *overlayLabel;   // updated per-engage to the chosen speed
+@property (nonatomic, assign) float engagedHoldSpeed;  // the speed currently applied (for the overlay)
 // Apollo's context-menu interaction(s), removed while a right-zone touch is down
 // and re-added on release. Parallel arrays (interaction + the view it belongs to).
 @property (nonatomic, strong) NSArray<UIContextMenuInteraction *> *suppressedInteractions;
 @property (nonatomic, strong) NSArray<UIView *> *suppressedInteractionViews;
 @property (nonatomic, assign) BOOL inZone;     // current touch began in the right third
-@property (nonatomic, assign) BOOL active;     // 2× currently engaged
+@property (nonatomic, assign) BOOL active;     // hold speed currently engaged
 @property (nonatomic, assign) float preHoldRate;
-// Fires a single confirmation tap when 2× engages. Pre-warmed on touch-down.
+// Fires a single confirmation tap when the hold speed engages. Pre-warmed on touch-down.
 @property (nonatomic, strong) UIImpactFeedbackGenerator *hapticGenerator;
 // The exact AVPlayer we sped up, held strongly so we restore *that* instance on
 // release — not one re-resolved from the (possibly torn-down) media viewer. For
 // shared v.redd.it players, re-resolving could miss the restore and leave the
-// feed/comments copy stuck at 2×.
+// feed/comments copy stuck at the hold speed.
 @property (nonatomic, strong) AVPlayer *engagedPlayer;
 - (void)installOnView:(UIView *)view;
 @end
@@ -354,6 +389,10 @@ static void CollectContextMenuInteractions(UIView *view,
 #pragma mark Touch lifecycle
 
 - (void)touchDownAt:(CGPoint)windowPoint {
+    // Feature off → the right side behaves like the rest of the player: no zone
+    // capture, no menu suppression, no haptic, so Apollo's normal long-press menu
+    // appears everywhere. Read live so a settings change applies immediately.
+    if (!sVideoHoldSpeedEnabled) { self.inZone = NO; return; }
     self.inZone = [self pointInActivationZone:windowPoint];
     // Remove the context-menu interaction the instant a right-zone touch lands, so
     // the menu can never appear for this press. Left/center is left alone → normal
@@ -374,21 +413,23 @@ static void CollectContextMenuInteractions(UIView *view,
     AVPlayer *player = MediaViewerPlayer(self.mediaViewer);
     if (!player) { ApolloLog(@"VideoHoldSpeed: holdElapsed — no player"); return; }
 
+    float holdSpeed = ApolloSanitizedHoldSpeed(sVideoHoldSpeed);   // user's "Hold Speed" choice
+    self.engagedHoldSpeed = holdSpeed;
     self.engagedPlayer = player;      // restore THIS exact instance on release
     self.preHoldRate = player.rate;   // 0 if paused, 1.0, or a custom menu speed
     self.active = YES;
-    [player setRate:kHoldSpeed];
+    [player setRate:holdSpeed];
     [self showOverlay];
 
-    // A single confirmation tap the moment 2× kicks in — the tactile equivalent
-    // of the "2× ⏵⏵" overlay, like YouTube/Instagram. No-op on devices without a
+    // A single confirmation tap the moment the speed kicks in — the tactile
+    // equivalent of the overlay, like YouTube/Instagram. No-op on devices without a
     // Taptic Engine. (Created/prepared on touch-down; create defensively in case.)
     if (!self.hapticGenerator) {
         self.hapticGenerator = [[UIImpactFeedbackGenerator alloc] initWithStyle:kHoldHapticStyle];
     }
     [self.hapticGenerator impactOccurred];
 
-    ApolloLog(@"VideoHoldSpeed: engaged 2x (prevRate=%.2f)", self.preHoldRate);
+    ApolloLog(@"VideoHoldSpeed: engaged %.2fx (prevRate=%.2f)", holdSpeed, self.preHoldRate);
 }
 
 - (void)touchUp {
@@ -400,7 +441,7 @@ static void CollectContextMenuInteractions(UIView *view,
     // viewer, which may be a different instance (compact posts spin up a fresh
     // comments player) or nil (a swipe-to-dismiss while holding can tear down the
     // weak mediaViewer before the finger lifts). Missing the restore on a shared
-    // v.redd.it player would leave the feed/comments copy stuck at 2×.
+    // v.redd.it player would leave the feed/comments copy stuck at the hold speed.
     [self.engagedPlayer setRate:self.preHoldRate];
     self.engagedPlayer = nil;
     [self hideOverlay];
@@ -431,14 +472,6 @@ static void CollectContextMenuInteractions(UIView *view,
         blur.userInteractionEnabled = NO;
 
         UILabel *label = [[UILabel alloc] init];
-        // "2× ⏵⏵" — U+00D7 multiplication sign, U+23F5 double right-pointing.
-        label.attributedText = ({
-            NSString *s = [NSString stringWithFormat:@"2%C ⏵⏵", (unichar)0x00D7];
-            [[NSAttributedString alloc] initWithString:s attributes:@{
-                NSFontAttributeName: [UIFont systemFontOfSize:17.0 weight:UIFontWeightSemibold],
-                NSForegroundColorAttributeName: [UIColor whiteColor],
-            }];
-        });
         label.translatesAutoresizingMaskIntoConstraints = NO;
         [blur.contentView addSubview:label];
         [NSLayoutConstraint activateConstraints:@[
@@ -447,8 +480,12 @@ static void CollectContextMenuInteractions(UIView *view,
             [label.topAnchor constraintEqualToAnchor:blur.contentView.topAnchor constant:8.0],
             [label.bottomAnchor constraintEqualToAnchor:blur.contentView.bottomAnchor constant:-8.0],
         ]];
+        self.overlayLabel = label;
         self.overlayView = blur;
     }
+
+    // Refresh the text each engage — the chosen speed can change between holds.
+    self.overlayLabel.attributedText = HoldOverlayText(self.engagedHoldSpeed);
 
     UIView *overlay = self.overlayView;
     if (overlay.superview != host) {
@@ -509,5 +546,5 @@ static void InstallHoldSpeed(UIViewController *mvc) {
 %end
 
 %ctor {
-    ApolloLog(@"ApolloVideoHoldSpeed: module loaded (hold right third for 2x)");
+    ApolloLog(@"ApolloVideoHoldSpeed: module loaded (hold right third for chosen speed)");
 }

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -59,6 +59,24 @@ static NSInteger ApolloMediaPhysicalRow(NSInteger logicalRow) {
     return logicalRow;
 }
 
+// The six speeds the "Hold for Video Speed" picker offers, in display order. They
+// mirror the video player's own speed menu minus 1.0× (holding at normal speed
+// would be a no-op). ApolloSanitizedHoldSpeed() guards the stored value to this set.
+static const float kVideoHoldSpeeds[] = { 0.25f, 0.5f, 0.75f, 1.25f, 1.5f, 2.0f };
+
+// "0.25×" / "0.5×" / … / "2×", using the U+00D7 multiplication sign Apollo uses.
+static NSString *ApolloVideoHoldSpeedTitle(float speed) {
+    NSString *num;
+    if (fabsf(speed - 0.25f) < 0.001f)      num = @"0.25";
+    else if (fabsf(speed - 0.5f)  < 0.001f) num = @"0.5";
+    else if (fabsf(speed - 0.75f) < 0.001f) num = @"0.75";
+    else if (fabsf(speed - 1.25f) < 0.001f) num = @"1.25";
+    else if (fabsf(speed - 1.5f)  < 0.001f) num = @"1.5";
+    else if (fabsf(speed - 2.0f)  < 0.001f) num = @"2";
+    else                                    num = [NSString stringWithFormat:@"%g", speed];
+    return [num stringByAppendingFormat:@"%C", (unichar)0x00D7];
+}
+
 // Canonical (mode-on) row indices within SectionAPIKeys. The Web Session Login
 // row only exists while API-Key-Free Mode is on; with it off, that row is absent
 // and every row at or below it slides up one slot. Mirrors the Media-section
@@ -540,9 +558,10 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionApolloAI: return 1;
         case SectionLinkPreviews: return 1;
         // Media base rows (the three "Rich Link Previews" rows moved out to their
-        // own SectionLinkPreviews) plus the chat inline-media toggle, minus the two
-        // inline-dependent rows when off.
-        case SectionMedia: return 12 + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows);
+        // own SectionLinkPreviews) plus the chat inline-media toggle and the
+        // "Hold for Video Speed" toggle, minus the two inline-dependent rows when
+        // off, plus the hold-speed picker (logical row 13) when that toggle is on.
+        case SectionMedia: return 13 + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows) + (sVideoHoldSpeedEnabled ? 1 : 0);
         case SectionSubreddits: return 10 - (sSubredditListEnhancements ? 0 : 1) - (sCommunityHighlights ? 0 : 1);
         case SectionNotificationBackend: return 3; // URL + Registration Token + Test Connection
         case SectionAbout: return 5; // GitHub + Reddit + Thanks To + Export Logs + Version
@@ -1133,6 +1152,28 @@ typedef NS_ENUM(NSInteger, Tag) {
                                             label:@"Inline Media in Chat"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableChatMedia]
                                            action:@selector(chatMediaSwitchToggled:)];
+        case 12:
+            // Master toggle for "Hold for Video Speed". When on, the hold-speed
+            // picker (logical row 13) is shown below; when off, the right side of a
+            // fullscreen video keeps Apollo's normal long-press menu. The gesture is
+            // explained in the section footer, matching the sibling Media toggles
+            // (which are plain switches with no inline subtitle).
+            return [self switchCellWithIdentifier:@"Cell_Media_HoldSpeed"
+                                            label:@"Hold for Video Speed"
+                                               on:sVideoHoldSpeedEnabled
+                                           action:@selector(videoHoldSpeedSwitchToggled:)];
+        case 13: {
+            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_HoldSpeedValue"];
+            if (!cell) {
+                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_HoldSpeedValue"];
+                cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+            }
+            cell.textLabel.text = @"Hold Speed";
+            cell.detailTextLabel.text = [self videoHoldSpeedText];
+            cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+            return cell;
+        }
         default: return [[UITableViewCell alloc] init];
     }
 }
@@ -1585,6 +1626,8 @@ typedef NS_ENUM(NSInteger, Tag) {
             [self presentInlineImageAlignmentSheetFromSourceView:cell];
         } else if (row == 6) {
             [self presentAutoplayInlineGIFModeSheetFromSourceView:cell];
+        } else if (row == 13) {
+            [self presentVideoHoldSpeedSheetFromSourceView:cell];
         }
     } else if (indexPath.section == SectionNotificationBackend && indexPath.row == 2) {
         [self testNotificationBackendConnection];
@@ -1660,7 +1703,7 @@ typedef NS_ENUM(NSInteger, Tag) {
     if (indexPath.section == SectionLinkPreviews) return YES;
     if (indexPath.section == SectionMedia) {
         NSInteger row = ApolloMediaLogicalRow(indexPath.row);
-        return (row == 0 || row == 1 || row == 2 || row == 5 || row == 6);
+        return (row == 0 || row == 1 || row == 2 || row == 5 || row == 6 || row == 13);
     }
     if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 || indexPath.row == 3)) return YES;
     if (indexPath.section == SectionNotificationBackend && indexPath.row == 2) return YES;
@@ -2330,6 +2373,62 @@ typedef NS_ENUM(NSInteger, Tag) {
     [self.tableView reloadRowsAtIndexPaths:@[autoplayRow] withRowAnimation:UITableViewRowAnimationNone];
 }
 
+#pragma mark - Hold for Video Speed
+
+- (void)videoHoldSpeedSwitchToggled:(UISwitch *)sender {
+    BOOL wasOn = sVideoHoldSpeedEnabled;
+    sVideoHoldSpeedEnabled = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sVideoHoldSpeedEnabled forKey:UDKeyVideoHoldSpeedEnabled];
+    if (sVideoHoldSpeedEnabled == wasOn) return;
+    // The "Hold Speed" picker (logical row 13) is the last Media row and is shown
+    // only while this toggle is on. Insert/delete it so the row counts stay
+    // consistent. ApolloMediaPhysicalRow(13) accounts for the inline-dependent gap.
+    NSIndexPath *pickerPath = [NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(13) inSection:SectionMedia];
+    if (sVideoHoldSpeedEnabled) {
+        [self.tableView insertRowsAtIndexPaths:@[pickerPath] withRowAnimation:UITableViewRowAnimationFade];
+    } else {
+        [self.tableView deleteRowsAtIndexPaths:@[pickerPath] withRowAnimation:UITableViewRowAnimationFade];
+    }
+}
+
+- (NSString *)videoHoldSpeedText {
+    return ApolloVideoHoldSpeedTitle(sVideoHoldSpeed);
+}
+
+- (void)setVideoHoldSpeed:(float)speed {
+    sVideoHoldSpeed = ApolloSanitizedHoldSpeed(speed);
+    [[NSUserDefaults standardUserDefaults] setFloat:sVideoHoldSpeed forKey:UDKeyVideoHoldSpeed];
+    NSIndexPath *pickerPath = [NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(13) inSection:SectionMedia];
+    if ([[self.tableView indexPathsForVisibleRows] containsObject:pickerPath]) {
+        [self.tableView reloadRowsAtIndexPaths:@[pickerPath] withRowAnimation:UITableViewRowAnimationNone];
+    }
+}
+
+- (void)presentVideoHoldSpeedSheetFromSourceView:(UIView *)sourceView {
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Hold Speed"
+                                                                   message:@"Speed applied while you hold the right side of a fullscreen video."
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+
+    for (size_t i = 0; i < sizeof(kVideoHoldSpeeds) / sizeof(kVideoHoldSpeeds[0]); i++) {
+        float speed = kVideoHoldSpeeds[i];
+        BOOL isCurrent = fabsf(sVideoHoldSpeed - speed) < 0.001f;
+        NSString *title = isCurrent ? [ApolloVideoHoldSpeedTitle(speed) stringByAppendingString:@" (Current)"]
+                                    : ApolloVideoHoldSpeedTitle(speed);
+        [sheet addAction:[UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+            [self setVideoHoldSpeed:speed];
+        }]];
+    }
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    if (popover && sourceView) {
+        popover.sourceView = sourceView;
+        popover.sourceRect = sourceView.bounds;
+    }
+
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
 - (void)promptClearCustomSubredditBannersFromSourceView:(__unused UIView *)sourceView {
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Clear Custom Banners & Icons?"
                                                                    message:@"Locally saved custom subreddit banner and icon images will be removed. Official Reddit art will show again where available."
@@ -2622,6 +2721,8 @@ static void ApolloReplayValetKeychainItems(NSArray<NSDictionary *> *items) {
     sEnableFlairColors = [defaults boolForKey:UDKeyEnableFlairColors];
     sPreferredGIFFallbackFormat = ([defaults integerForKey:UDKeyPreferredGIFFallbackFormat] == 0) ? 0 : 1;
     sUnmuteCommentsVideos = [defaults integerForKey:UDKeyUnmuteCommentsVideos];
+    sVideoHoldSpeedEnabled = [defaults boolForKey:UDKeyVideoHoldSpeedEnabled];
+    sVideoHoldSpeed = ApolloSanitizedHoldSpeed([defaults floatForKey:UDKeyVideoHoldSpeed]);
     sImageUploadProvider = [defaults integerForKey:UDKeyImageUploadProvider];
     sLinkPreviewCardColor = [defaults integerForKey:UDKeyLinkPreviewCardColor];
     if (sLinkPreviewCardColor < ApolloLinkPreviewCardColorNeutral || sLinkPreviewCardColor > ApolloLinkPreviewCardColorSlate) {

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1460,6 +1460,8 @@ static void initializeRandomSources() {
                                     UDKeyFeedTextPostThumbnails: @YES,
                                     UDKeyPreferredGIFFallbackFormat: @1,
                                     UDKeyUnmuteCommentsVideos: @0,
+                                    UDKeyVideoHoldSpeedEnabled: @YES,
+                                    UDKeyVideoHoldSpeed: @2.0,
                                     UDKeyProxyImgurDDG: @NO,
                                     UDKeyImageChestAPIToken: @"",
                                     UDKeyGiphyAPIKey: @"",
@@ -1531,6 +1533,8 @@ static void initializeRandomSources() {
     sPreferredGIFFallbackFormat = ([[NSUserDefaults standardUserDefaults] integerForKey:UDKeyPreferredGIFFallbackFormat] == 0) ? 0 : 1;
     sReadPostMaxCount = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyReadPostMaxCount];
     sUnmuteCommentsVideos = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyUnmuteCommentsVideos];
+    sVideoHoldSpeedEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyVideoHoldSpeedEnabled];
+    sVideoHoldSpeed = ApolloSanitizedHoldSpeed([[NSUserDefaults standardUserDefaults] floatForKey:UDKeyVideoHoldSpeed]);
     sProxyImgurDDG = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyProxyImgurDDG];
     sEnableInlineImages = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableInlineImages];
     sEnableChatMedia = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableChatMedia];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -38,6 +38,13 @@ static NSString *const UDKeyReadPostMaxCount = @"ReadPostMaxCount";
 static NSString *const UDKeyShowRecentlyReadThumbnails = @"ShowRecentlyReadThumbnails";
 static NSString *const UDKeyPreferredGIFFallbackFormat = @"PreferredGIFFallbackFormat";
 static NSString *const UDKeyUnmuteCommentsVideos = @"UnmuteCommentsVideos";
+// "Hold for Video Speed": press-and-hold the right side of a fullscreen video to
+// play at a chosen speed while held. Master toggle (default YES via
+// registerDefaults — preserves the original always-on behaviour) and the speed
+// applied while held (one of 0.25/0.5/0.75/1.25/1.5/2.0; default 2.0×). See
+// ApolloVideoHoldSpeed.xm.
+static NSString *const UDKeyVideoHoldSpeedEnabled = @"VideoHoldSpeedEnabled";
+static NSString *const UDKeyVideoHoldSpeed = @"VideoHoldSpeed";
 static NSString *const UDKeyOpenLinksInSteamApp = @"OpenLinksInSteamApp";
 static NSString *const UDKeyCollapsePinnedComments = @"CollapsePinnedComments";
 static NSString *const UDKeyShowDeletedComments = @"ShowDeletedComments";


### PR DESCRIPTION
Makes the "Hold for 2×" gesture ([#78](https://github.com/Apollo-Reborn/Apollo-Reborn/issues/78), shipped in #479) configurable — you can now choose any speed to hold at, or turn the gesture off entirely.

## Demo

| 1️⃣ Enable it | 2️⃣ Pick a speed |
|:---:|:---:|
| <img alt="Hold for Video Speed toggle" src="https://github.com/user-attachments/assets/6ec888c0-e07e-4747-8254-e6ff53fe8e34" width="300"> | <img alt="Hold Speed action sheet" src="https://github.com/user-attachments/assets/06ecb606-91bc-44a0-a4fc-c2e119449915" width="300"> |
| Turn on **Hold for Video Speed** in Settings → Media. A **Hold Speed** row appears right below it. | Tap **Hold Speed** and choose any speed from the action sheet — **0.25× → 2×**. |

**3️⃣ Hold to use it** — press &amp; hold the **right side** of a fullscreen video → it plays at your chosen speed, with the matching overlay:

https://github.com/user-attachments/assets/5bd196b4-8732-4edc-8029-bbad91b288d2

## What's new (Settings → Media)
- **"Hold for Video Speed"** master toggle — **default ON**, so existing behaviour is unchanged. When **OFF**, the right side of a fullscreen video just gets Apollo's normal long-press menu (no zone capture, no menu suppression, no haptic).
- **"Hold Speed"** picker (shown only while the toggle is on) — an action sheet offering **0.25× / 0.5× / 0.75× / 1.25× / 1.5× / 2×** (default **2×**). `1×` is intentionally omitted since holding at normal speed does nothing. So the gesture can now **speed up _or_ slow down** — handy for skimming ahead at 2× or watching something in slow motion at 0.5×.

## Behaviour
- The held speed is read live from the picker at engage; release restores the prior rate exactly as before (direction-agnostic — slow speeds and paused/custom-rate videos restore correctly).
- The top-center overlay now reflects the **chosen** speed instead of a fixed "2×" — `2× ⏵⏵` when boosting, a bare `0.5×` for slow-motion (the fast-forward chevrons would mislead below 1×).
- Never touches `videoPlaybackSpeed` (Apollo's persistent menu choice), so the speed menu's checkmark stays correct.

## Implementation
- `ApolloVideoHoldSpeed.xm`: per-touch gate on the toggle, live speed read, speed-aware overlay.
- Settings (`CustomAPIViewController.m`): the toggle + dependent picker row + action sheet, with the picker as the last Media row so the existing inline-images row math is untouched.
- Data layer (`ApolloState.{h,m}`, `Tweak.xm`, `UserDefaultConstants.h`): two new keys (default toggle YES, speed 2.0) registered + loaded at startup; `ApolloSanitizedHoldSpeed()` snaps any stored/legacy value to the six supported speeds.

## Testing
- Builds + links clean for the simulator.
- Adversarial multi-agent review: no functional findings — the runtime logic, the table-row math (all four toggle/inline-images combinations), and the persistence layer were each independently verified.
- Sim-verified that the new rows render and the module loads. **Not yet device-tested** — the press-and-hold gesture itself can't be driven in the simulator (needs a real finger), so a device check of the hold/engage/release at a non-2× speed would be appreciated.
