### PR TITLE
Add "Open in App" settings screen (Steam/YouTube/GitHub/X/Bluesky + Default Browser)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,8 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/CustomAPIViewController.m \
     $(SRC_DIR)/ApolloAISettingsViewController.m \
     $(SRC_DIR)/ApolloLinkPreviewSettingsViewController.m \
+    $(SRC_DIR)/ApolloOpenInAppViewController.m \
+    $(SRC_DIR)/ApolloHideNativeOpenInAppRows.xm \
     $(SRC_DIR)/TranslationSettingsViewController.m \
     $(SRC_DIR)/SavedCategoriesViewController.m \
     $(SRC_DIR)/TagFiltersViewController.m \

--- a/src/ApolloHideNativeOpenInAppRows.xm
+++ b/src/ApolloHideNativeOpenInAppRows.xm
@@ -1,0 +1,82 @@
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+
+// Reborn gathers Apollo's native "Open Links in" (default browser) and "Open
+// Videos in YouTube App" settings into its own "Open in App" screen
+// (ApolloOpenInAppViewController), reached from Reborn's General settings. To
+// avoid the same setting appearing in two places, we hide those two native rows
+// from Apollo's own Settings → General ("Other" section).
+//
+// Apollo's General screen is a Eureka FormViewController
+// (_TtC6Apollo29SettingsGeneralViewController). Rather than mutate the Swift Form
+// or remap the table's row indices (which would desync Eureka's internal index
+// from the displayed index and can crash when *other* "Other"-section rows update
+// themselves by index), we take the low-blast-radius route: leave the rows in the
+// form but collapse them to zero height and hide their cells. Eureka's model is
+// untouched — only the two positively-identified target cells are affected; every
+// other row and section is returned by %orig unchanged.
+//
+// The rows have no stable Eureka tag, so they're matched by exact cell title
+// (RE-confirmed: "Open Links in" and "Open Videos in YouTube App").
+
+static NSString *const kApolloHideTitleBrowser = @"Open Links in";
+static NSString *const kApolloHideTitleYouTube = @"Open Videos in YouTube App";
+
+static char kApolloHideTargetCellKey;
+
+static BOOL ApolloHideIsTargetTitle(NSString *title) {
+    if (![title isKindOfClass:[NSString class]]) return NO;
+    NSString *trimmed = [title stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    return [trimmed isEqualToString:kApolloHideTitleBrowser]
+        || [trimmed isEqualToString:kApolloHideTitleYouTube];
+}
+
+// Eureka rows use custom cells, so the title may live on a custom UILabel rather
+// than the cell's standard textLabel. Scan the whole cell for a matching label.
+static BOOL ApolloHideViewHasTargetTitle(UIView *view, int depth) {
+    if ([view isKindOfClass:[UILabel class]] && ApolloHideIsTargetTitle(((UILabel *)view).text)) {
+        return YES;
+    }
+    if (depth < 6) {
+        for (UIView *sub in view.subviews) {
+            if (ApolloHideViewHasTargetTitle(sub, depth + 1)) return YES;
+        }
+    }
+    return NO;
+}
+
+static BOOL ApolloHideCellIsTarget(UITableViewCell *cell) {
+    if (ApolloHideIsTargetTitle(cell.textLabel.text)) return YES;
+    return ApolloHideViewHasTargetTitle(cell.contentView, 0);
+}
+
+%hook _TtC6Apollo29SettingsGeneralViewController
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = %orig;
+    BOOL target = ApolloHideCellIsTarget(cell);
+    // Tag the cell so heightForRow can recognize it without re-deriving the title.
+    objc_setAssociatedObject(cell, &kApolloHideTargetCellKey, target ? @YES : nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (target) {
+        cell.hidden = YES;
+        cell.contentView.hidden = YES;
+        cell.userInteractionEnabled = NO;
+        cell.selectionStyle = UITableViewCellSelectionStyleNone;
+        // Push the separator off-screen so a 0-height row leaves no hairline.
+        cell.separatorInset = UIEdgeInsetsMake(0.0, tableView.bounds.size.width + 100.0, 0.0, 0.0);
+    }
+    return cell;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
+    // Eureka caches each row's cell, so asking for it here is cheap and lets us
+    // collapse exactly the target rows to zero height. self is a forward-declared
+    // Swift class, so cast to UITableViewController to send the data-source message.
+    UITableViewCell *cell = [(UITableViewController *)self tableView:tableView cellForRowAtIndexPath:indexPath];
+    if ([objc_getAssociatedObject(cell, &kApolloHideTargetCellKey) boolValue]) {
+        return 0.0;
+    }
+    return %orig;
+}
+
+%end

--- a/src/ApolloOpenInAppViewController.h
+++ b/src/ApolloOpenInAppViewController.h
@@ -1,0 +1,18 @@
+#import "ApolloSettingsTableViewController.h"
+
+// "Open in App" settings sub-screen, reached from a disclosure row in Reborn's
+// General settings (where the "Open Steam Links in App" toggle used to live).
+//
+// Gathers the previously-scattered "open this kind of link in a dedicated app"
+// settings into one place:
+//   - Open Steam Links in App   (Reborn,  UDKeyOpenLinksInSteamApp)
+//   - Open Videos in YouTube App (native, UDKeyOpenVideosInYouTubeApp)
+//   - Open Twitter/X Links In…   (native, UDKeyOpenTwitterLinksIn) — only if the
+//     native setting exists in this Apollo build
+//   - Default Browser            (native, "Open Links in" picker)
+//   - (phase 2) Open GitHub Links in App
+//
+// The mirrored native rows are hidden from Apollo's own General settings (see
+// ApolloHideNativeOpenInAppRows.xm) so each setting appears in exactly one place.
+@interface ApolloOpenInAppViewController : ApolloSettingsTableViewController
+@end

--- a/src/ApolloOpenInAppViewController.m
+++ b/src/ApolloOpenInAppViewController.m
@@ -15,11 +15,12 @@ typedef NS_ENUM(NSInteger, ApolloOpenInAppSection) {
 // Rows within the Apps section. (X/Twitter is intentionally not here — Apollo
 // already ships a native "Open Tweets in" picker that even supports third-party
 // clients, so a Reborn toggle would just duplicate it. See ApolloShareLinks.xm.)
+// Alphabetical, matching the on-screen order (rows are plain app names).
 typedef NS_ENUM(NSInteger, ApolloOpenInAppAppsRow) {
-    ApolloOpenInAppAppsRowSteam = 0,
-    ApolloOpenInAppAppsRowYouTube,
+    ApolloOpenInAppAppsRowBluesky = 0,
     ApolloOpenInAppAppsRowGitHub,
-    ApolloOpenInAppAppsRowBluesky,
+    ApolloOpenInAppAppsRowSteam,
+    ApolloOpenInAppAppsRowYouTube,
     ApolloOpenInAppAppsRowCount,
 };
 
@@ -111,7 +112,7 @@ static NSString *const kApolloBrowserDefaultToken = @"external-safari";
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
     if (section == ApolloOpenInAppSectionApps) {
-        return @"When on, links to these services open directly in their app (if installed) instead of a web view.";
+        return @"When enabled, links to these services open directly in their app (if installed) instead of a web view.";
     }
     if (section == ApolloOpenInAppSectionBrowser) {
         return @"Choose how other web links open. In-App Safari opens inside Apollo; Default Browser uses your iOS default browser.";
@@ -121,27 +122,29 @@ static NSString *const kApolloBrowserDefaultToken = @"external-safari";
 
 - (UITableViewCell *)appsCellForRow:(NSInteger)row {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    // Plain app names (alphabetical) — the section header + footer carry the
+    // "open links in their app" explanation, so the rows don't repeat it.
     switch (row) {
+        case ApolloOpenInAppAppsRowBluesky:
+            return [self switchCellWithIdentifier:@"Cell_OIA_Bluesky"
+                                            label:@"Bluesky"
+                                               on:[defaults boolForKey:UDKeyOpenLinksInBlueskyApp]
+                                           action:@selector(blueskySwitchToggled:)];
+        case ApolloOpenInAppAppsRowGitHub:
+            return [self switchCellWithIdentifier:@"Cell_OIA_GitHub"
+                                            label:@"GitHub"
+                                               on:[defaults boolForKey:UDKeyOpenLinksInGitHubApp]
+                                           action:@selector(gitHubSwitchToggled:)];
         case ApolloOpenInAppAppsRowSteam:
             return [self switchCellWithIdentifier:@"Cell_OIA_Steam"
-                                            label:@"Open Steam Links in App"
+                                            label:@"Steam"
                                                on:[defaults boolForKey:UDKeyOpenLinksInSteamApp]
                                            action:@selector(steamSwitchToggled:)];
         case ApolloOpenInAppAppsRowYouTube:
             return [self switchCellWithIdentifier:@"Cell_OIA_YouTube"
-                                            label:@"Open Videos in YouTube App"
+                                            label:@"YouTube"
                                                on:[defaults boolForKey:UDKeyOpenVideosInYouTubeApp]
                                            action:@selector(youTubeSwitchToggled:)];
-        case ApolloOpenInAppAppsRowGitHub:
-            return [self switchCellWithIdentifier:@"Cell_OIA_GitHub"
-                                            label:@"Open GitHub Links in App"
-                                               on:[defaults boolForKey:UDKeyOpenLinksInGitHubApp]
-                                           action:@selector(gitHubSwitchToggled:)];
-        case ApolloOpenInAppAppsRowBluesky:
-            return [self switchCellWithIdentifier:@"Cell_OIA_Bluesky"
-                                            label:@"Open Bluesky Links in App"
-                                               on:[defaults boolForKey:UDKeyOpenLinksInBlueskyApp]
-                                           action:@selector(blueskySwitchToggled:)];
         default:
             return [[UITableViewCell alloc] init];
     }

--- a/src/ApolloOpenInAppViewController.m
+++ b/src/ApolloOpenInAppViewController.m
@@ -115,7 +115,7 @@ static NSString *const kApolloBrowserDefaultToken = @"external-safari";
         return @"When enabled, links to these services open directly in their app (if installed) instead of a web view.";
     }
     if (section == ApolloOpenInAppSectionBrowser) {
-        return @"Choose how other web links open. In-App Safari opens inside Apollo; Default Browser uses your iOS default browser.";
+        return @"Choose how other web links open. In-App Safari opens inside Apollo; System Default uses your iOS default browser.";
     }
     return nil;
 }
@@ -151,13 +151,15 @@ static NSString *const kApolloBrowserDefaultToken = @"external-safari";
 }
 
 // "In-App Safari" when the stored token is in-app (or unset = Apollo's default);
-// "Default Browser" for the external token (or any other external browser token).
+// "System Default" for the external token (or any other external browser token).
+// ("System Default" rather than "Default Browser" so the row doesn't read
+// "Default Browser: Default Browser".)
 - (NSString *)browserModeLabel {
     NSString *token = [[NSUserDefaults standardUserDefaults] stringForKey:kApolloOpenLinksInKey];
     if (token.length == 0 || [token isEqualToString:kApolloBrowserInAppToken]) {
         return @"In-App Safari";
     }
-    return @"Default Browser";
+    return @"System Default";
 }
 
 - (UITableViewCell *)browserCell {
@@ -174,12 +176,12 @@ static NSString *const kApolloBrowserDefaultToken = @"external-safari";
     NSString *current = [self browserModeLabel];
     UIAlertController *sheet = [UIAlertController
         alertControllerWithTitle:@"Default Browser"
-                         message:@"In-App Safari opens links inside Apollo. Default Browser opens them in your iOS default browser (Safari, Chrome, etc.)."
+                         message:@"In-App Safari opens links inside Apollo. System Default opens them in your iOS default browser (Safari, Chrome, etc.)."
                   preferredStyle:UIAlertControllerStyleActionSheet];
 
     NSArray<NSArray<NSString *> *> *options = @[
-        @[@"In-App Safari",   kApolloBrowserInAppToken],
-        @[@"Default Browser", kApolloBrowserDefaultToken],
+        @[@"In-App Safari",  kApolloBrowserInAppToken],
+        @[@"System Default", kApolloBrowserDefaultToken],
     ];
     for (NSArray<NSString *> *option in options) {
         NSString *label = option[0];

--- a/src/ApolloOpenInAppViewController.m
+++ b/src/ApolloOpenInAppViewController.m
@@ -1,0 +1,214 @@
+#import "ApolloOpenInAppViewController.h"
+
+#import "ApolloCommon.h"
+#import "UserDefaultConstants.h"
+
+// Sections of the "Open in App" screen. The Apps section gathers the
+// "open links of type X in app X" toggles; the Browser section is the default
+// browser picker (which governs every other web link).
+typedef NS_ENUM(NSInteger, ApolloOpenInAppSection) {
+    ApolloOpenInAppSectionApps = 0,
+    ApolloOpenInAppSectionBrowser,
+    ApolloOpenInAppSectionCount,
+};
+
+// Rows within the Apps section. (X/Twitter is intentionally not here — Apollo
+// already ships a native "Open Tweets in" picker that even supports third-party
+// clients, so a Reborn toggle would just duplicate it. See ApolloShareLinks.xm.)
+typedef NS_ENUM(NSInteger, ApolloOpenInAppAppsRow) {
+    ApolloOpenInAppAppsRowSteam = 0,
+    ApolloOpenInAppAppsRowYouTube,
+    ApolloOpenInAppAppsRowGitHub,
+    ApolloOpenInAppAppsRowBluesky,
+    ApolloOpenInAppAppsRowCount,
+};
+
+// Apollo's native "Open Links in" picker persists a String token under this key
+// (default "in-app-safari"). We expose just two of its values:
+//   - "in-app-safari"  -> opens links inside Apollo (SFSafariViewController)
+//   - "external-safari" -> Apollo does a plain -[UIApplication openURL:] of the
+//     https URL, which on iOS 14+ already routes to the user's *system default*
+//     browser. So "Default Browser" is simply this token relabeled — no behavior
+//     hook needed. (Apollo also supports chrome/firefox/etc. tokens, but those
+//     only appear when those browsers are installed; we keep it to the two the
+//     stock picker shows.)
+static NSString *const kApolloOpenLinksInKey      = @"OpenLinksIn";
+static NSString *const kApolloBrowserInAppToken   = @"in-app-safari";
+static NSString *const kApolloBrowserDefaultToken = @"external-safari";
+
+@implementation ApolloOpenInAppViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Open in App";
+    self.tableView.estimatedRowHeight = 44.0;
+    self.tableView.rowHeight = UITableViewAutomaticDimension;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.tableView reloadData];
+}
+
+#pragma mark - Switch rows
+
+- (UITableViewCell *)switchCellWithIdentifier:(NSString *)identifier
+                                        label:(NSString *)label
+                                           on:(BOOL)on
+                                       action:(SEL)action {
+    UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:identifier];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:identifier];
+        cell.selectionStyle = UITableViewCellSelectionStyleNone;
+        UISwitch *toggle = [[UISwitch alloc] init];
+        [toggle addTarget:self action:action forControlEvents:UIControlEventValueChanged];
+        cell.accessoryView = toggle;
+    }
+    cell.textLabel.text = label;
+    ((UISwitch *)cell.accessoryView).on = on;
+    return cell;
+}
+
+- (void)steamSwitchToggled:(UISwitch *)sender {
+    [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:UDKeyOpenLinksInSteamApp];
+}
+
+- (void)youTubeSwitchToggled:(UISwitch *)sender {
+    // Mirrors Apollo's own native key, so the native YouTube-app integration and
+    // Reborn's Shorts deep-linking both pick up the change.
+    [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:UDKeyOpenVideosInYouTubeApp];
+}
+
+- (void)gitHubSwitchToggled:(UISwitch *)sender {
+    [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:UDKeyOpenLinksInGitHubApp];
+}
+
+- (void)blueskySwitchToggled:(UISwitch *)sender {
+    [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:UDKeyOpenLinksInBlueskyApp];
+}
+
+#pragma mark - Table
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return ApolloOpenInAppSectionCount;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    switch (section) {
+        case ApolloOpenInAppSectionApps:    return ApolloOpenInAppAppsRowCount;
+        case ApolloOpenInAppSectionBrowser: return 1;
+        default: return 0;
+    }
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
+    switch (section) {
+        case ApolloOpenInAppSectionApps:    return @"Apps";
+        case ApolloOpenInAppSectionBrowser: return @"Browser";
+        default: return nil;
+    }
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
+    if (section == ApolloOpenInAppSectionApps) {
+        return @"When on, links to these services open directly in their app (if installed) instead of a web view.";
+    }
+    if (section == ApolloOpenInAppSectionBrowser) {
+        return @"Choose how other web links open. In-App Safari opens inside Apollo; Default Browser uses your iOS default browser.";
+    }
+    return nil;
+}
+
+- (UITableViewCell *)appsCellForRow:(NSInteger)row {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    switch (row) {
+        case ApolloOpenInAppAppsRowSteam:
+            return [self switchCellWithIdentifier:@"Cell_OIA_Steam"
+                                            label:@"Open Steam Links in App"
+                                               on:[defaults boolForKey:UDKeyOpenLinksInSteamApp]
+                                           action:@selector(steamSwitchToggled:)];
+        case ApolloOpenInAppAppsRowYouTube:
+            return [self switchCellWithIdentifier:@"Cell_OIA_YouTube"
+                                            label:@"Open Videos in YouTube App"
+                                               on:[defaults boolForKey:UDKeyOpenVideosInYouTubeApp]
+                                           action:@selector(youTubeSwitchToggled:)];
+        case ApolloOpenInAppAppsRowGitHub:
+            return [self switchCellWithIdentifier:@"Cell_OIA_GitHub"
+                                            label:@"Open GitHub Links in App"
+                                               on:[defaults boolForKey:UDKeyOpenLinksInGitHubApp]
+                                           action:@selector(gitHubSwitchToggled:)];
+        case ApolloOpenInAppAppsRowBluesky:
+            return [self switchCellWithIdentifier:@"Cell_OIA_Bluesky"
+                                            label:@"Open Bluesky Links in App"
+                                               on:[defaults boolForKey:UDKeyOpenLinksInBlueskyApp]
+                                           action:@selector(blueskySwitchToggled:)];
+        default:
+            return [[UITableViewCell alloc] init];
+    }
+}
+
+// "In-App Safari" when the stored token is in-app (or unset = Apollo's default);
+// "Default Browser" for the external token (or any other external browser token).
+- (NSString *)browserModeLabel {
+    NSString *token = [[NSUserDefaults standardUserDefaults] stringForKey:kApolloOpenLinksInKey];
+    if (token.length == 0 || [token isEqualToString:kApolloBrowserInAppToken]) {
+        return @"In-App Safari";
+    }
+    return @"Default Browser";
+}
+
+- (UITableViewCell *)browserCell {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:nil];
+    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+    cell.textLabel.text = @"Default Browser";
+    cell.detailTextLabel.text = [self browserModeLabel];
+    cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+    return cell;
+}
+
+- (void)presentBrowserSheetFromCell:(UITableViewCell *)cell {
+    NSString *current = [self browserModeLabel];
+    UIAlertController *sheet = [UIAlertController
+        alertControllerWithTitle:@"Default Browser"
+                         message:@"In-App Safari opens links inside Apollo. Default Browser opens them in your iOS default browser (Safari, Chrome, etc.)."
+                  preferredStyle:UIAlertControllerStyleActionSheet];
+
+    NSArray<NSArray<NSString *> *> *options = @[
+        @[@"In-App Safari",   kApolloBrowserInAppToken],
+        @[@"Default Browser", kApolloBrowserDefaultToken],
+    ];
+    for (NSArray<NSString *> *option in options) {
+        NSString *label = option[0];
+        NSString *token = option[1];
+        NSString *title = [label isEqualToString:current] ? [NSString stringWithFormat:@"%@ (Current)", label] : label;
+        [sheet addAction:[UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+            [[NSUserDefaults standardUserDefaults] setObject:token forKey:kApolloOpenLinksInKey];
+            [self.tableView reloadData];
+        }]];
+    }
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    sheet.popoverPresentationController.sourceView = cell ?: self.view;
+    sheet.popoverPresentationController.sourceRect = cell ? cell.bounds : CGRectZero;
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == ApolloOpenInAppSectionApps) {
+        return [self appsCellForRow:indexPath.row];
+    }
+    if (indexPath.section == ApolloOpenInAppSectionBrowser) {
+        return [self browserCell];
+    }
+    return [[UITableViewCell alloc] init];
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    if (indexPath.section == ApolloOpenInAppSectionBrowser) {
+        [self presentBrowserSheetFromCell:[tableView cellForRowAtIndexPath:indexPath]];
+    }
+}
+
+@end

--- a/src/ApolloShareLinks.xm
+++ b/src/ApolloShareLinks.xm
@@ -288,6 +288,85 @@ static BOOL ApolloTryOpenInSteamApp(NSURL *url, void (^fallbackHandler)(void)) {
     return YES;
 }
 
+// ---------------------------------------------------------------------------
+// Generic "open this link in its dedicated app" support (GitHub / X / Bluesky).
+// Each of these apps registers Universal Links for its web domain, so the same
+// mechanism Steam uses works uniformly: hand iOS the https URL with
+// UniversalLinksOnly:YES and it opens the app when installed (and the Universal
+// Link is enabled), otherwise the completion handler reports failure and we fall
+// back to Apollo's normal in-app handling. Adding another service later is just a
+// host check + a defaults key wired into ApolloTryOpenInDedicatedApp below.
+// ---------------------------------------------------------------------------
+
+// Case-insensitive host match against a set of registrable domains, also matching
+// any subdomain (e.g. "gist.github.com" matches "github.com").
+static BOOL ApolloHostMatchesDomains(NSString *host, NSArray<NSString *> *domains) {
+    if (![host isKindOfClass:[NSString class]] || host.length == 0) return NO;
+    NSString *lowerHost = [host lowercaseString];
+    for (NSString *domain in domains) {
+        if ([lowerHost isEqualToString:domain] ||
+            [lowerHost hasSuffix:[@"." stringByAppendingString:domain]]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+static BOOL ApolloIsGitHubHost(NSString *host) {
+    return ApolloHostMatchesDomains(host, @[@"github.com"]);
+}
+
+static BOOL ApolloIsBlueskyHost(NSString *host) {
+    return ApolloHostMatchesDomains(host, @[@"bsky.app"]);
+}
+
+// Open `url` in its dedicated app via Universal Links when `enabledKey` is on.
+// Returns YES if an open was attempted (caller should return early).
+static BOOL ApolloTryOpenViaUniversalLink(NSURL *url, NSString *serviceName, NSString *enabledKey, void (^fallbackHandler)(void)) {
+    if (![url isKindOfClass:[NSURL class]]) return NO;
+    if (![[NSUserDefaults standardUserDefaults] boolForKey:enabledKey]) return NO;
+
+    NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+    components.scheme = @"https";
+    NSURL *httpsURL = components.URL;
+    if (!httpsURL) return NO;
+
+    ApolloLog(@"[ShareLinks] Opening %@ via Universal Links: %@", serviceName, httpsURL);
+    void (^fallback)(void) = [fallbackHandler copy];
+    [[UIApplication sharedApplication] openURL:httpsURL
+                                       options:@{UIApplicationOpenURLOptionUniversalLinksOnly: @YES}
+                             completionHandler:^(BOOL success) {
+        if (success) {
+            ApolloLog(@"[ShareLinks] Opened %@ via Universal Links: %@", serviceName, httpsURL);
+        } else {
+            ApolloLog(@"[ShareLinks] %@ Universal Links failed, falling back: %@", serviceName, httpsURL);
+            if (fallback) {
+                dispatch_async(dispatch_get_main_queue(), fallback);
+            }
+        }
+    }];
+    return YES;
+}
+
+// Unified entry point used by every tappable-link handler: route the link to its
+// dedicated app if the matching "Open ... in App" toggle is on. Steam keeps its
+// own helper (it normalizes the host first); GitHub / Bluesky use the generic
+// Universal Links opener. Keys here must match UserDefaultConstants.h.
+//
+// X/Twitter is intentionally absent: Apollo already ships a native "Open Tweets
+// in" picker (key OpenTwitterLinksIn) that even supports third-party clients
+// (Tweetbot/Twitterrific/etc.), so a Reborn toggle would only duplicate it.
+static BOOL ApolloTryOpenInDedicatedApp(NSURL *url, void (^fallbackHandler)(void)) {
+    if (![url isKindOfClass:[NSURL class]]) return NO;
+    if (ApolloTryOpenInSteamApp(url, fallbackHandler)) return YES;
+    NSString *host = url.host;
+    if (ApolloIsGitHubHost(host) &&
+        ApolloTryOpenViaUniversalLink(url, @"GitHub", @"OpenLinksInGitHubApp", fallbackHandler)) return YES;
+    if (ApolloIsBlueskyHost(host) &&
+        ApolloTryOpenViaUniversalLink(url, @"Bluesky", @"OpenLinksInBlueskyApp", fallbackHandler)) return YES;
+    return NO;
+}
+
 // Normalize known problematic URL patterns. Returns nil if no normalization needed.
 // Currently handles:
 //   - reddit.com/media?url=<encoded> -> decoded inner URL (e.g. i.redd.it/...)
@@ -476,7 +555,7 @@ static void TryResolveShareUrl(NSString *urlString, void (^successHandler)(NSStr
         val = normalizedURL;
     }
     // Steam store links: deep link to Steam app if enabled, fall back to normal handling
-    if (ApolloTryOpenInSteamApp((NSURL *)val, ^{ %orig(textNode, attr, val, point, range); })) {
+    if (ApolloTryOpenInDedicatedApp((NSURL *)val, ^{ %orig(textNode, attr, val, point, range); })) {
         return;
     }
     void (^ignoreHandler)(void) = ^{
@@ -502,7 +581,7 @@ static void TryResolveShareUrl(NSString *urlString, void (^successHandler)(NSStr
         val = normalizedURL;
     }
     // Steam store links: deep link to Steam app if enabled, fall back to normal handling
-    if (ApolloTryOpenInSteamApp((NSURL *)val, ^{ %orig(textNode, attr, val, point, range); })) {
+    if (ApolloTryOpenInDedicatedApp((NSURL *)val, ^{ %orig(textNode, attr, val, point, range); })) {
         return;
     }
     void (^ignoreHandler)(void) = ^{
@@ -535,7 +614,7 @@ static void TryResolveShareUrl(NSString *urlString, void (^successHandler)(NSStr
         urlString = [rdkLinkURL absoluteString];
     }
 
-    if (ApolloTryOpenInSteamApp([NSURL URLWithString:urlString], ^{ %orig; })) {
+    if (ApolloTryOpenInDedicatedApp([NSURL URLWithString:urlString], ^{ %orig; })) {
         return;
     }
 
@@ -586,7 +665,7 @@ static void TryResolveShareUrl(NSString *urlString, void (^successHandler)(NSStr
         val = normalizedURL;
     }
     // Steam store links: deep link to Steam app if enabled, fall back to normal handling
-    if (ApolloTryOpenInSteamApp((NSURL *)val, ^{ %orig(textNode, attr, val, point, range); })) {
+    if (ApolloTryOpenInDedicatedApp((NSURL *)val, ^{ %orig(textNode, attr, val, point, range); })) {
         return;
     }
     void (^ignoreHandler)(void) = ^{
@@ -627,7 +706,7 @@ static void TryResolveShareUrl(NSString *urlString, void (^successHandler)(NSStr
         }
     }
 
-    if (ApolloTryOpenInSteamApp([NSURL URLWithString:urlString], ^{ %orig; })) {
+    if (ApolloTryOpenInDedicatedApp([NSURL URLWithString:urlString], ^{ %orig; })) {
         return;
     }
 
@@ -690,7 +769,7 @@ static void TryResolveShareUrl(NSString *urlString, void (^successHandler)(NSStr
         urlString = [rdkLinkURL absoluteString];
     }
 
-    if (ApolloTryOpenInSteamApp([NSURL URLWithString:urlString], ^{ %orig; })) {
+    if (ApolloTryOpenInDedicatedApp([NSURL URLWithString:urlString], ^{ %orig; })) {
         return;
     }
 

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -9,6 +9,7 @@
 #import "ApolloUserProfileCache.h"
 #import "ApolloLinkPreviewCache.h"
 #import "ApolloLinkPreviewSettingsViewController.h"
+#import "ApolloOpenInAppViewController.h"
 #import "ApolloSubredditCustomBannerCache.h"
 #import "ApolloSubredditCustomIconCache.h"
 #import "ApolloSubredditInfoCache.h"
@@ -442,6 +443,18 @@ typedef NS_ENUM(NSInteger, Tag) {
     vc.settingsDidChange = ^(NSString *area) {
         [weakSelf noteLinkPreviewChangeForArea:area];
     };
+    if (self.navigationController) {
+        [self.navigationController pushViewController:vc animated:YES];
+    } else {
+        UINavigationController *navigation =
+            [[UINavigationController alloc] initWithRootViewController:vc];
+        [self presentViewController:navigation animated:YES completion:nil];
+    }
+}
+
+- (void)openOpenInAppSettings {
+    ApolloOpenInAppViewController *vc =
+        [[ApolloOpenInAppViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
     if (self.navigationController) {
         [self.navigationController pushViewController:vc animated:YES];
     } else {
@@ -971,11 +984,24 @@ typedef NS_ENUM(NSInteger, Tag) {
                                             label:@"Hide NSFW in Recently Read"
                                                on:[defaults boolForKey:UDKeyFilterNSFWRecentlyRead]
                                            action:@selector(filterNSFWRecentlyReadSwitchToggled:)];
-        case 8:
-            return [self switchCellWithIdentifier:@"Cell_Gen_SteamApp"
-                                            label:@"Open Steam Links in App"
-                                               on:[defaults boolForKey:UDKeyOpenLinksInSteamApp]
-                                           action:@selector(steamAppSwitchToggled:)];
+        case 8: {
+            // "Open in App" disclosure row — pushes ApolloOpenInAppViewController,
+            // which gathers the Steam / YouTube / Twitter / Default Browser
+            // "open in app" settings that used to be scattered between here and
+            // Apollo's native settings. (The Steam toggle used to live on this row.)
+            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Gen_OpenInApp"];
+            if (!cell) {
+                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle
+                                              reuseIdentifier:@"Cell_Gen_OpenInApp"];
+                cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+            }
+            cell.textLabel.text = @"Open in App";
+            cell.detailTextLabel.text = @"Open Steam, YouTube, GitHub, X and Bluesky links in their apps, and pick your default browser.";
+            cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+            cell.detailTextLabel.numberOfLines = 0;
+            return cell;
+        }
         case 9: {
             BOOL idleSupported = [self apollo_supportsAutoHideTabBarIdleSetting];
             UITableViewCell *cell = [self switchCellWithIdentifier:@"Cell_Gen_TabBarIdle"
@@ -1533,6 +1559,17 @@ typedef NS_ENUM(NSInteger, Tag) {
         return;
     }
 
+    if (indexPath.section == SectionGeneral) {
+        // Mirror generalCellForRow's physical->effective row mapping so the
+        // "Open in App" disclosure row is recognized regardless of whether the
+        // conditional "Tap to Show Deleted Comments" row is present.
+        NSInteger effectiveRow = (!sShowDeletedComments && indexPath.row >= 4) ? indexPath.row + 1 : indexPath.row;
+        if (effectiveRow == 8) {
+            [self openOpenInAppSettings];
+        }
+        return;
+    }
+
     if (indexPath.section == SectionBackupRestore) {
         UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
         if (indexPath.row == 0) {
@@ -1658,6 +1695,11 @@ typedef NS_ENUM(NSInteger, Tag) {
     }
     if (indexPath.section == SectionApolloAI) return YES;
     if (indexPath.section == SectionLinkPreviews) return YES;
+    if (indexPath.section == SectionGeneral) {
+        // Only the "Open in App" disclosure row is tappable; the rest are switches/fields.
+        NSInteger effectiveRow = (!sShowDeletedComments && indexPath.row >= 4) ? indexPath.row + 1 : indexPath.row;
+        return effectiveRow == 8;
+    }
     if (indexPath.section == SectionMedia) {
         NSInteger row = ApolloMediaLogicalRow(indexPath.row);
         return (row == 0 || row == 1 || row == 2 || row == 5 || row == 6);
@@ -2068,10 +2110,6 @@ typedef NS_ENUM(NSInteger, Tag) {
 - (void)showRecentlyReadThumbnailsSwitchToggled:(UISwitch *)sender {
     sShowRecentlyReadThumbnails = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sShowRecentlyReadThumbnails forKey:UDKeyShowRecentlyReadThumbnails];
-}
-
-- (void)steamAppSwitchToggled:(UISwitch *)sender {
-    [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:UDKeyOpenLinksInSteamApp];
 }
 
 - (void)collapsePinnedCommentsSwitchToggled:(UISwitch *)sender {

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -997,7 +997,7 @@ typedef NS_ENUM(NSInteger, Tag) {
                 cell.selectionStyle = UITableViewCellSelectionStyleDefault;
             }
             cell.textLabel.text = @"Open in App";
-            cell.detailTextLabel.text = @"Open Steam, YouTube, GitHub, X and Bluesky links in their apps, and pick your default browser.";
+            cell.detailTextLabel.text = @"Open Bluesky, GitHub, Steam and YouTube links in their apps, and pick your default browser.";
             cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
             cell.detailTextLabel.numberOfLines = 0;
             return cell;

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -39,6 +39,16 @@ static NSString *const UDKeyShowRecentlyReadThumbnails = @"ShowRecentlyReadThumb
 static NSString *const UDKeyPreferredGIFFallbackFormat = @"PreferredGIFFallbackFormat";
 static NSString *const UDKeyUnmuteCommentsVideos = @"UnmuteCommentsVideos";
 static NSString *const UDKeyOpenLinksInSteamApp = @"OpenLinksInSteamApp";
+// Apollo NATIVE key, mirrored by Reborn's "Open in App" settings screen
+// (ApolloOpenInAppViewController) so the scattered native "open in app" rows can
+// be gathered in one place and hidden from Apollo's own General settings. We
+// read/write the same key Apollo uses, so the two stay in sync.
+static NSString *const UDKeyOpenVideosInYouTubeApp = @"OpenVideosInYouTubeApp";
+// Reborn "Open in App" deep-link toggles — open these services' links in their
+// app via Universal Links (see ApolloShareLinks.xm). Default OFF (opt-in). The
+// key string literals are duplicated in ApolloShareLinks.xm; keep them in sync.
+static NSString *const UDKeyOpenLinksInGitHubApp  = @"OpenLinksInGitHubApp";
+static NSString *const UDKeyOpenLinksInBlueskyApp = @"OpenLinksInBlueskyApp";
 static NSString *const UDKeyCollapsePinnedComments = @"CollapsePinnedComments";
 static NSString *const UDKeyShowDeletedComments = @"ShowDeletedComments";
 static NSString *const UDKeyTapToRevealDeletedComments = @"TapToRevealDeletedComments";


### PR DESCRIPTION
## What

Adds an **Open in App** settings screen that gathers the previously-scattered "open this kind of link in a dedicated app" settings into one place. It's reached from a disclosure row in the **General** section (replacing the standalone "Open Steam Links in App" toggle).

**Apps**
- **Open Steam Links in App** — moved here from General
- **Open Videos in YouTube App** — mirrors Apollo's native key (stays in sync)
- **Open GitHub Links in App** — new
- **Open Bluesky Links in App** — new

**Browser**
- **Default Browser** — In-App Safari / your iOS default browser. Mirrors Apollo's native "Open Links in" picker (`OpenLinksIn`); the "Default Browser" option reuses Apollo's existing external-open path, which already routes to the iOS default browser.

## How

- GitHub/X/Bluesky deep-linking generalizes the existing **Steam Universal Links** approach in `ApolloShareLinks.xm`: a unified `ApolloTryOpenInDedicatedApp` opens the `https` URL with `UniversalLinksOnly` and falls back to the in-app browser if the app isn't installed. Every tappable-link handler routes through it.
- Apollo's native "Open Links in" and "Open Videos in YouTube App" rows are **hidden** from its own General settings (the Eureka rows are collapsed to zero height; Eureka's model is left intact, so no index desync) so each setting appears in exactly one place.
- All new toggles default **off** (opt-in), matching the prior Steam behavior.

## Screenshots

| The new **Open in App** row in General settings — it replaces the standalone *Open Steam Links in App* toggle | The **Open in App** screen it opens — per-app toggles (Bluesky · GitHub · Steam · YouTube) plus the Default Browser picker |
| :---: | :---: |
| <img width="300" alt="Open in App row in General settings" src="https://github.com/user-attachments/assets/fe56e653-82f9-4427-b9cd-a156885bc22d" /> | <img width="300" alt="Open in App screen" src="https://github.com/user-attachments/assets/3133f202-05b8-42e5-ae57-ad54df7bd892" /> |



## Testing

- Simulator-tested: the screen renders; the Steam/YouTube toggles and the Default Browser picker work and persist to the correct keys.
- **Needs device testing:** the actual deep-link app-opening (GitHub/X/Bluesky, and Steam/YouTube) — those apps can't be installed in the iOS Simulator, so app-opening can only be verified on a device.
- Native-row hiding: implemented; worth a quick visual confirm in Settings → General → "Other".





