### PR TITLE
Fix Share as Image on short phones: Share button off-screen + gallery collage with Include Post Details (#551)

### DIFF
--- a/src/ApolloShareAsImageGallery.xm
+++ b/src/ApolloShareAsImageGallery.xm
@@ -625,8 +625,18 @@ static void ApolloShareGalleryPrepare(id previewNode) {
         // the collage would be lost and the compact card would show. Re-assert the
         // cached collage when we detect the reset. Comment / non-gallery shares
         // never cache a collage, so they no-op here.
+        //
+        // But only while the post media is actually being shown: if the user has
+        // since turned "Include Post Details" (and "Include Post Text, Poll, or
+        // Image") back OFF on a comment share, the preview is meant to be the bare
+        // comment, so re-injecting would leak the post collage back in. Re-using the
+        // same condition as the bail check below keeps the two in lock-step.
+        BOOL postMediaShown = (ApolloShareIvarObject(previewNode, "comment") == nil) ||
+                              ApolloShareIvarBool(previewNode, "includePostDetails") ||
+                              ApolloShareIvarBool(previewNode, "includePostTextPollOrImage");
         UIImage *cached = objc_getAssociatedObject(previewNode, &kApolloShareGalleryCollageKey);
-        if ([cached isKindOfClass:[UIImage class]] &&
+        if (postMediaShown &&
+            [cached isKindOfClass:[UIImage class]] &&
             ApolloShareIvarObject(previewNode, "imageForImagePost") == nil) {
             ApolloLog(@"[ShareGallery] collage reset by a toggle, re-injecting cached image");
             ApolloShareGalleryInstallImageOnMain(previewNode, cached, YES);
@@ -640,19 +650,33 @@ static void ApolloShareGalleryPrepare(id previewNode) {
     // media — injecting imageForImagePost there is what made the post's gallery
     // image leak into a plain comment share.
     //
-    // EXCEPTION: when the user enables "Include Post Text, Poll, or Image" (the
-    // includePostTextPollOrImage toggle, which only appears in comment mode), Apollo
-    // ALSO renders the underlying post's media region above the comment — and for a
-    // gallery/video/spoiler post that region falls back to Apollo's compact link
-    // card (imageForImagePost stays nil), exactly as it does for a post share. In
-    // that case we DO want to inject the collage/poster into the post media region;
-    // the comment itself (baseCommentNode) is laid out separately and is left
-    // untouched. So only bail here when the post media is NOT being shown.
+    // EXCEPTION: when the user shows the underlying post above the comment, Apollo
+    // ALSO renders the post's media region — and for a gallery/video/spoiler post
+    // that region falls back to Apollo's compact link card (imageForImagePost stays
+    // nil), exactly as it does for a post share. In that case we DO want to inject
+    // the collage/poster into the post media region; the comment itself
+    // (baseCommentNode) is laid out separately and is left untouched.
+    //
+    // Two distinct node flags can request the post media in comment mode, and they
+    // map to two different sheet toggles: "Include Post Details" (includePostDetails)
+    // and "Include Post Text, Poll, or Image" (includePostTextPollOrImage). The sheet
+    // surfaces one or the other depending on context, so we must honour BOTH —
+    // checking only includePostTextPollOrImage left "Include Post Details" gallery
+    // shares falling back to the compact link card (#551 follow-up). Only bail when
+    // the post media is NOT being shown by either flag.
+    //
+    // CRUCIAL: do NOT mark the node Applied on this bail. The sheet opens with post
+    // details OFF, so this gate is the FIRST thing that fires for every comment
+    // share — caching "Applied" here would lock the node, and because Apollo reuses
+    // the same preview node when the user later toggles "Include Post Details" ON,
+    // we'd never re-examine it and the compact link card would stay stuck (the
+    // collage only appeared before when Apollo happened to rebuild the node — racy).
+    // Leaving the state untouched (None) makes each layout pass re-check, so the
+    // collage is injected the moment post media is turned on. The check is cheap
+    // (ivar reads) and no network fetch starts until a gallery is actually detected.
     if (ApolloShareIvarObject(previewNode, "comment") != nil &&
-        !ApolloShareIvarBool(previewNode, "includePostTextPollOrImage")) {
-        objc_setAssociatedObject(previewNode, &kApolloShareGalleryStateKey,
-                                 @(ApolloShareGalleryStateApplied),
-                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        !ApolloShareIvarBool(previewNode, "includePostTextPollOrImage") &&
+        !ApolloShareIvarBool(previewNode, "includePostDetails")) {
         return;
     }
 

--- a/src/ApolloShareAsImagePreviewFix.xm
+++ b/src/ApolloShareAsImagePreviewFix.xm
@@ -41,6 +41,24 @@
 //       actually COMPLETED (cancelling the activity sheet leaves the preview up so
 //       you can tweak options and try again).
 //
+//   #5  SHARE BUTTON OFF-SCREEN ON SHORT PHONES (#551). The view controller lays its
+//       whole UI out with absolute frames directly on its (non-scrolling) view: title,
+//       a preview snapshot, the option rows, then the Share button at the bottom — the
+//       button's Y is `maxY(lastRow) + spacing` and the preview's height is whatever
+//       the preview node measures with NO cap, and the view's own height is never
+//       consulted (confirmed by RE: there's no UIScrollView and no clamp in this VC).
+//       So when "Include Post Details" pulls a tall post (image/gallery) into the
+//       preview, the button's Y grows past the bottom edge and is clipped — with no
+//       scroll view to reach it. It only bites on short screens (e.g. iPhone SE 3,
+//       667pt): taller phones have the room, which is why it slipped through. Fix:
+//       after Apollo's native layout, if the Share button's bottom falls below the
+//       visible area, shrink the on-screen preview (proportionally, preserving aspect)
+//       by the overflow and slide the rows + button back up by the same amount, so the
+//       button is always reachable. A no-op when everything already fits (so taller
+//       devices are untouched). The EXPORTED image is unaffected: the share path reads
+//       `previewSnapshotImageView.image` (the full-resolution snapshot), and we only
+//       resize the image view's display frame, never its `image`.
+//
 // Pure ObjC-runtime access + public UIKit; no hardcoded binary addresses.
 //
 // MODULE ORDERING (Makefile ApolloReborn_FILES): this module is listed LAST of the
@@ -141,10 +159,86 @@ static void ApolloSIPFPollSnapshot(UIViewController *vc, int attempt, CGFloat pr
     });
 }
 
+// #5: keep the Share button on-screen on short phones. Runs after Apollo's native
+// layout (which positions everything top-down with absolute frames and never clamps to
+// the view height). If the button's bottom has been pushed below the visible area,
+// shrink the preview snapshot (proportionally, so the image's aspect is preserved) by
+// exactly the overflow and slide every element below the preview — the option rows,
+// separators, and the Share button — up by that same delta. Idempotent and self-
+// correcting: each native layout pass restores the full-height preview and we re-clamp
+// from scratch, and because we only move existing subviews' frames (never the VC view's
+// bounds/margins) this can't drive another layout pass, so there's no loop. A no-op
+// whenever the button already fits, leaving taller devices untouched.
+static void ApolloSIPFClampShareButtonOnScreen(UIViewController *vc) {
+    if (![vc isViewLoaded]) return;
+    UIView *root = vc.viewIfLoaded;
+    if (!root) return;
+
+    UIView *previewIV = (UIView *)ApolloSIPFIvarObject(vc, "previewSnapshotImageView");
+    UIView *shareBtn  = (UIView *)ApolloSIPFIvarObject(vc, "shareButton");
+    if (![previewIV isKindOfClass:[UIView class]] || ![shareBtn isKindOfClass:[UIView class]]) return;
+
+    // All content (preview, rows, button) is parented to the same container — the
+    // preview's superview (rootView.contentView). Operate within that coordinate space.
+    UIView *container = previewIV.superview;
+    if (!container) return;
+    UIView *dropShadow = (UIView *)ApolloSIPFIvarObject(vc, "previewDropShadowView");
+
+    CGRect pf = previewIV.frame;
+    if (pf.size.height < 1.0 || pf.size.width < 1.0) return;
+    CGFloat previewBottom = CGRectGetMaxY(pf);
+
+    // Measure against the WINDOW's visible bottom, NOT the sheet view's own bounds:
+    // Apollo's Sourdough sheet sizes the presented view to its content, so on a short
+    // screen that view is itself TALLER than the window (its lower edge sits off-screen)
+    // — clamping to root.bounds would leave the button below the visible area. Convert
+    // the button into window space and compare against the window's safe bottom instead.
+    // root↔window is a pure translation (no scaling), so a delta computed here applies
+    // 1:1 to the subview frames we move below.
+    UIWindow *win = root.window;
+    if (![win isKindOfClass:[UIWindow class]]) return;
+    CGFloat bottomGap = MAX(win.safeAreaInsets.bottom, 8.0) + 12.0; // breathing room below the button
+    CGFloat visibleBottom = win.bounds.size.height - bottomGap;
+    CGFloat buttonBottom = CGRectGetMaxY([shareBtn convertRect:shareBtn.bounds toView:win]);
+    if (buttonBottom <= visibleBottom + 0.5) return; // already fits — no-op
+
+    CGFloat overflow = buttonBottom - visibleBottom;
+    static const CGFloat kMinPreviewHeight = 60.0; // don't shrink the preview to nothing
+    CGFloat newHeight = MAX(pf.size.height - overflow, kMinPreviewHeight);
+    CGFloat delta = pf.size.height - newHeight; // actual reduction we can apply (>= 0)
+    if (delta < 1.0) return; // preview already at its floor — nothing more we can do
+
+    // Shrink the preview proportionally (aspect preserved) and re-center horizontally.
+    CGFloat scale = newHeight / pf.size.height;
+    CGFloat newWidth = pf.size.width * scale;
+    CGRect newPF = CGRectMake(pf.origin.x + (pf.size.width - newWidth) / 2.0,
+                              pf.origin.y, newWidth, newHeight);
+    previewIV.frame = newPF;
+    if ([dropShadow isKindOfClass:[UIView class]]) dropShadow.frame = newPF; // shadow tracks the card
+
+    // Slide everything that sits below the preview up by the reclaimed delta.
+    for (UIView *v in container.subviews) {
+        if (v == previewIV || v == dropShadow) continue;
+        CGRect f = v.frame;
+        if (f.origin.y >= previewBottom - 1.0) {
+            f.origin.y -= delta;
+            v.frame = f;
+        }
+    }
+
+    ApolloLog(@"[SharePreviewFix] clamped: preview %.0f->%.0f (delta %.0f), button bottom %.0f -> visible %.0fpt window",
+              pf.size.height, newHeight, delta, buttonBottom, win.bounds.size.height);
+}
+
 %hook _TtC6Apollo26ShareAsImageViewController
 
 - (void)viewDidLayoutSubviews {
     %orig;
+
+    // #5: every pass, after the native absolute-frame layout, keep the Share button
+    // on-screen on short phones (no-op when it already fits). Must run each pass since
+    // toggling options (Include Post Details, parent count) re-runs the native layout.
+    ApolloSIPFClampShareButtonOnScreen((UIViewController *)self);
 
     // Arm the snapshot poll once, on the first layout after present. It observes the
     // preview node's size and refreshes the snapshot as soon as any async comment/post


### PR DESCRIPTION
Fixes #551.

Two "Share as Image" fixes surfaced by the iPhone SE 3 report in #551, both verified in the iOS 26 Simulator on an **iPhone SE 3 (375×667pt)**.

## 1. Share button pushed off-screen (the reported bug)
`ShareAsImageViewController` lays its whole UI out with absolute frames on a **non-scrolling** view: title → preview → option rows → Share button. The button sits at `maxY(lastRow) + spacing` and the preview height is uncapped — the view's own height is never consulted (no scroll view, no clamp). So when **Include Post Details** pulls a tall post (image/gallery) into the preview, the Share button grows past the bottom edge and is clipped, with no way to scroll to it. Taller phones have the room, which is why it only reproduces on short screens.

**Fix** (`ApolloShareAsImagePreviewFix.xm`): after Apollo's native layout, if the Share button's bottom falls below the visible window, shrink the on-screen preview snapshot (proportionally, preserving aspect) by the overflow and slide the rows + button up by the same delta. A no-op when everything already fits, so taller devices are untouched. The **exported image is unaffected** — the share path reads `previewSnapshotImageView.image` (the full-res snapshot); only the display frame is resized.

## 2. Gallery shown as a compact link card instead of the collage
When sharing a comment with **Include Post Details** on, a gallery post's media region fell back to Apollo's compact "Gallery …" link card instead of the image collage shown elsewhere.

**Fix** (`ApolloShareAsImageGallery.xm`): the module only treated the post media as "shown" when `includePostTextPollOrImage` was set, but the comment-mode toggle is **Include Post Details** → the separate `includePostDetails` flag; it now honours both. It also no longer marks the node `Applied` when bailing a comment share — the sheet opens with post details OFF (so that gate fires first), and since Apollo reuses the preview node when the toggle is later turned on, caching `Applied` left the compact card stuck (the collage only appeared when Apollo happened to rebuild the node — racy). Leaving the state re-checkable injects the collage as soon as post media is shown; the re-assert path uses the same condition so turning the toggle back off doesn't leak the collage into the bare comment.

## Screenshots
_iPhone SE 3, Liquid Glass — Share as Image with Include Post Details on._

<table>
<tr>
<td><img width="300" src="https://github.com/user-attachments/assets/41d0b124-9d6e-4efd-819c-54c533acba25" /></td>
<td><img width="300" src="https://github.com/user-attachments/assets/db878ac0-f5cd-4c2a-951f-3557bbf56bcc" /></td>
</tr>
</table>

## Testing
Sim-verified on iPhone SE 3 (iOS 26, Liquid Glass): Share button reachable with post details + parent comments; the gallery shows the 2×2 collage on **Include Post Details** and reverts cleanly when turned off; exported JPEG is full content/resolution. Not yet device-tested.
