### PR TITLE
Fix multi-image ImgChest album posting (#552)

### DIFF
--- a/src/ApolloImageUploadHost.xm
+++ b/src/ApolloImageUploadHost.xm
@@ -1195,6 +1195,53 @@ static NSURLRequest *ApolloRedditGallerySubmitRequestFromForm(NSURLRequest *requ
 
 // MARK: - Request rewriting (submit)
 
+// ImgChest album submit fix (issue #552). Our album responder combines the member
+// uploads into one ImgChest post and hands Apollo a synthetic Imgur album response
+// whose id is the ImgChest post id. Apollo's createAlbum then rebuilds the post link
+// as https://imgur.com/a/<id> — keeping our ImgChest post id but swapping the host to
+// imgur.com, so the submitted link is a dead Imgur album. Rewrite the submit's `url`
+// field back to the real imgchest.com/p/<id> post (and inject composer body text if
+// supplied, mirroring the Imgur path). Single-image ImgChest posts submit the CDN link
+// directly, so ApolloImgurAlbumIDFromURLString returns nil for them and they pass
+// through untouched. Returns nil when nothing applied.
+static NSURLRequest *ApolloImgChestRewriteSubmitRequest(NSURLRequest *request, NSArray<NSString *> *pairs, NSString *bodyTextToInject) {
+    NSMutableArray<NSString *> *rewrittenPairs = [NSMutableArray arrayWithCapacity:pairs.count + 1];
+    BOOL changed = NO;
+    BOOL wroteText = NO;
+    NSString *rewrittenURL = nil;
+    for (NSString *pair in pairs) {
+        NSRange equals = [pair rangeOfString:@"="];
+        NSString *key = ApolloFormDecodeComponent(equals.location == NSNotFound ? pair : [pair substringToIndex:equals.location]);
+        NSString *value = ApolloFormDecodeComponent(equals.location == NSNotFound ? @"" : [pair substringFromIndex:equals.location + 1]);
+        if ([key isEqualToString:@"url"]) {
+            NSString *albumID = ApolloImgurAlbumIDFromURLString(value);
+            NSURL *imgChestURL = albumID.length > 0 ? ApolloImgChestPostURLForAlbumID(albumID) : nil;
+            if (imgChestURL.absoluteString.length > 0 && ![imgChestURL.absoluteString isEqualToString:value]) {
+                value = imgChestURL.absoluteString;
+                rewrittenURL = value;
+                changed = YES;
+            }
+        } else if ([key isEqualToString:@"text"] && bodyTextToInject.length > 0 && ApolloTrimmedString(value).length == 0) {
+            value = bodyTextToInject;
+            wroteText = YES;
+            changed = YES;
+        }
+        [rewrittenPairs addObject:[NSString stringWithFormat:@"%@=%@", ApolloFormEncodeComponent(key), ApolloFormEncodeComponent(value)]];
+    }
+    if (bodyTextToInject.length > 0 && !wroteText) {
+        [rewrittenPairs addObject:[NSString stringWithFormat:@"%@=%@", ApolloFormEncodeComponent(@"text"), ApolloFormEncodeComponent(bodyTextToInject)]];
+        changed = YES;
+    }
+    if (!changed) return nil;
+
+    NSMutableURLRequest *modified = [request mutableCopy];
+    NSData *newBody = [[rewrittenPairs componentsJoinedByString:@"&"] dataUsingEncoding:NSUTF8StringEncoding];
+    modified.HTTPBody = newBody;
+    [modified setValue:[NSString stringWithFormat:@"%lu", (unsigned long)newBody.length] forHTTPHeaderField:@"Content-Length"];
+    if (rewrittenURL.length > 0) ApolloLog(@"[ImgChestUpload] Rewrote multi-image submit url to ImgChest album %@", rewrittenURL);
+    return modified;
+}
+
 NSURLRequest *ApolloRedditMaybeRewriteSubmitRequest(NSURLRequest *request) {
     if (!ApolloIsRedditLegacySubmitRequest(request)) return nil;
 
@@ -1224,6 +1271,16 @@ NSURLRequest *ApolloRedditMaybeRewriteSubmitRequest(NSURLRequest *request) {
     else if (hasExistingRichTextJSON) preflightSkipReason = @"existing-richtext";
     else if (!hostedMediaForm) preflightSkipReason = @"not-hosted-media-form";
     ApolloMediaPostBodyLogSubmitDecision(@"preflight", formValues, composerBodyText, hostedMediaForm, preflightSkipReason);
+
+    if (sImageUploadProvider == ImageUploadProviderImgChest) {
+        // #552: fix the imgur.com/a/<id> -> imgchest.com/p/<id> album link, and
+        // inject composer body text in the same rebuild if applicable.
+        NSURLRequest *imgChestRequest = ApolloImgChestRewriteSubmitRequest(request, pairs, shouldInjectComposerBodyText ? composerBodyText : nil);
+        if (imgChestRequest) {
+            ApolloLog(@"[MediaPostBody] Rewrote ImgChest submit (album url fix + body=%@)", shouldInjectComposerBodyText ? @"yes" : @"no");
+        }
+        return imgChestRequest;
+    }
 
     if (sImageUploadProvider != ImageUploadProviderReddit) {
         if (!shouldInjectComposerBodyText) return nil;

--- a/src/ApolloImgChestUpload.h
+++ b/src/ApolloImgChestUpload.h
@@ -24,6 +24,13 @@ void ApolloImgChestUploadData(NSData *data,
 /// Used by the chat send path to send the short post link instead of the long CDN file URL.
 NSURL *_Nullable ApolloImgChestPostURLForUploadedLink(NSURL *cdnLink);
 
+/// When `albumID` is the id of a multi-image ImgChest album post this tweak created (issue #552),
+/// returns its real post URL (imgchest.com/p/<id>); nil otherwise. The synthetic Imgur album
+/// response we hand Apollo carries this id, and Apollo's createAlbum then rebuilds the submit link
+/// as imgur.com/a/<id> — keeping our ImgChest post id but swapping the host to imgur.com, which
+/// posts a dead Imgur album. The submit path uses this to rewrite that url back to ImgChest.
+NSURL *_Nullable ApolloImgChestPostURLForAlbumID(NSString *albumID);
+
 /// When `request` is an Imgur album-creation request whose member tokens are
 /// all cached ImgChest uploads, returns a block that asynchronously creates
 /// the combined ImgChest post and replies with a synthetic Imgur album

--- a/src/ApolloImgChestUpload.m
+++ b/src/ApolloImgChestUpload.m
@@ -77,6 +77,17 @@ NSURL *ApolloImgChestPostURLForUploadedLink(NSURL *cdnLink) {
     return [NSURL URLWithString:[@"https://imgchest.com/p/" stringByAppendingString:postID]];
 }
 
+NSURL *ApolloImgChestPostURLForAlbumID(NSString *albumID) {
+    if (![albumID isKindOfClass:[NSString class]] || albumID.length == 0) return nil;
+    NSDictionary *entry = ApolloUploadRegistryEntry(albumID);
+    NSString *provider = [entry[@"provider"] isKindOfClass:[NSString class]] ? entry[@"provider"] : nil;
+    if (![provider isEqualToString:kProviderImgChest]) return nil;
+    NSString *link = [entry[@"link"] isKindOfClass:[NSString class]] ? entry[@"link"] : nil;
+    if (link.length > 0) return [NSURL URLWithString:link];
+    NSString *postID = [entry[@"post"] isKindOfClass:[NSString class]] ? entry[@"post"] : nil;
+    return postID.length > 0 ? [NSURL URLWithString:[@"https://imgchest.com/p/" stringByAppendingString:postID]] : nil;
+}
+
 void ApolloUploadRegistryRecordRedditUpload(NSURL *mediaURL) {
     NSString *token = mediaURL.lastPathComponent;
     if (token.length == 0) return;

--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -3685,6 +3685,31 @@ static BOOL ApolloLinkButtonHasInlineHost(ASDisplayNode *linkButtonNode) {
     if (!urlString) return %orig;
 
     NSURL *url = [NSURL URLWithString:urlString];
+
+    // #552: an ImgChest album LINK POST (imgchest.com/p/<id>) has no MarkdownNode
+    // body to carry an inline replacement, so previously nothing rendered the
+    // album here and the LinkPreviews card was suppressed → blank. Render the
+    // album cover inline (tap → the same swipeable viewer as in-text links),
+    // reusing the resolver + per-host node cache. If the same album was already
+    // inlined in a text body, hide this card to avoid a duplicate cover.
+    if (ApolloImageChestIsPostURL(url)) {
+        BOOL alreadyInlined = ApolloLinkButtonHasInlineHost((ASDisplayNode *)self)
+                           || ApolloInlineSuppressionContainsURL(url);
+        if (alreadyInlined) {
+            Class layoutSpecCls = NSClassFromString(@"ASLayoutSpec");
+            if (layoutSpecCls) {
+                ASLayoutSpec *empty = [[layoutSpecCls alloc] init];
+                [[empty style] setValue:[NSValue valueWithCGSize:CGSizeZero] forKey:@"preferredSize"];
+                return empty;
+            }
+            return %orig;
+        }
+        ASNetworkImageNode *coverNode = ApolloImageNodeForURL(url, (ASDisplayNode *)self);
+        ASLayoutSpec *wrapped = coverNode ? ApolloWrapImageNodeForLayout(coverNode, constrainedSize.max.width) : nil;
+        if (wrapped) return wrapped;   // resolved → album cover shown inline
+        return %orig;                  // still resolving → native card as placeholder
+    }
+
     if (!ApolloIsInlineRenderableImageURL(url) && !ApolloIsInlineRenderableVideoURL(url)) return %orig;
 
     // Album inline rendering depends on async resolution. Until that succeeds,

--- a/src/ApolloInlineLinkPreviews.xm
+++ b/src/ApolloInlineLinkPreviews.xm
@@ -3400,15 +3400,6 @@ static ApolloLinkPreview *ApolloLPPreviewByApplyingTranslation(ASDisplayNode *ho
     return displayPreview;
 }
 
-static ASLayoutSpec *ApolloLPEmptyLayoutSpec(void) {
-    Class layoutSpecCls = ApolloLPClass(@"ASLayoutSpec");
-    if (!layoutSpecCls) return nil;
-
-    ASLayoutSpec *empty = [[layoutSpecCls alloc] init];
-    ApolloLPApplyStyleSize([empty style], CGSizeZero);
-    return empty;
-}
-
 static id ApolloLPNativeLinkSpecWithBannedHintIfNeeded(id linkButtonNode, NSURL *url, id nativeSpec) {
     NSString *redditUsername = ApolloLPRedditUsernameFromProfileURL(url);
     if (redditUsername.length == 0 || !ApolloBannedProfileCachedIsSuspended(redditUsername)) {
@@ -3458,10 +3449,15 @@ static id ApolloLPNativeLinkSpecWithBannedHintIfNeeded(id linkButtonNode, NSURL 
         }
     }
     if (ApolloLPIsImageChestAlbumURL(url)) {
-        ApolloLPLogOncePerHost(host, @"suppress-imagechest-card");
+        // #552: defer to the inline-image album renderer (ApolloInlineImages'
+        // LinkButtonNode hook) instead of suppressing to empty. Suppressing left
+        // ImgChest album LINK POSTS blank — the inline-image album only rendered
+        // for in-text links, never a bare link post, so nothing filled the space.
+        // Deferring lets the album cover render (or the native card show as a
+        // placeholder / failure fallback) regardless of hook load order.
+        ApolloLPLogOncePerHost(host, @"defer-imagechest-album");
         ApolloLPRestoreHostShell((ASDisplayNode *)self);
-        ASLayoutSpec *empty = ApolloLPEmptyLayoutSpec();
-        return empty ?: %orig;
+        return %orig;
     }
 
     NSInteger selectedMode = ApolloLPModeForArea(area);


### PR DESCRIPTION
Fixes #552.

### The bug
With **ImgChest** as the Media Upload Host, posting **multiple** images produced a dead `imgur.com/a/...` album link instead of an ImgChest album — Apollo showed "Imgur error :(" and the images never loaded. Single-image posts were fine.

### Root cause (two parts)
1. **Wrong submit URL.** The images *do* upload to ImgChest and get combined into one ImgChest post correctly. But Apollo's `createAlbum` reconstructs the post link as `https://imgur.com/a/<id>` from the synthetic Imgur-album `id` we return — keeping our ImgChest post id but swapping the host to `imgur.com`. So the link Apollo submits to Reddit is a nonexistent Imgur album. (Single images submit the returned CDN link directly, which is why they worked.)
2. **No inline preview.** Even once the URL is correct, an ImgChest album **link post** (no selftext) never rendered inline: the inline-image album is only built from links inside post/comment *text* (`MarkdownNode`), while the ImgChest link card was unconditionally suppressed — leaving a blank.

### The fix
1. In the `/api/submit` rewrite path, when the provider is ImgChest, rewrite the `url` field `imgur.com/a/<id>` → `imgchest.com/p/<id>` using the upload registry (`ApolloImgChestPostURLForAlbumID`). Composer body-text injection is preserved.
2. Render the ImgChest album cover inline for link posts in the `LinkButtonNode` hook (reusing the existing resolver + per-host node cache + swipeable album viewer), and change the link-card suppression to **defer** (`%orig`) instead of blanking, so the two `LinkButtonNode` hooks cooperate regardless of load order. If the album was already inlined in body text, the card is hidden to avoid a duplicate; if resolution is pending/fails, the native link card shows as a placeholder rather than a blank.

Single-image ImgChest posts are unaffected.

### Screenshots
A 5-image ImgChest post, after the fix:

| Feed | Opened post | Fullscreen album |
|:---:|:---:|:---:|
| <img width="250" src="https://github.com/user-attachments/assets/03eac0d5-fd98-40ed-ad2e-407a77cfb115" /> | <img width="250" src="https://github.com/user-attachments/assets/0d7cdc9c-fc3f-42fb-a780-b5c717414785" /> | <img width="250" src="https://github.com/user-attachments/assets/e44c5ecb-88dd-4328-8d03-48205a833455" /> |
| The album cover now renders inline in the feed — previously blank / an "Imgur error" card. | Same inline album cover when the post is opened (no more dead Imgur link). | Tapping the cover opens Apollo's swipeable viewer: one ImgChest album, all 5 images (3 / 5 shown). |

### Testing
Reproduced and verified in the iOS 26 Simulator (Liquid Glass, Apollo-Reborn 3.3.0): a 5-image ImgChest post now creates one ImgChest album and renders it inline (swipeable), with no Imgur error. Not yet device-tested.
