### PR TITLE
Fix Highlight subreddit-list rows on tap in classic / non-modern-divider modes (#452)

### DIFF
--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -19,6 +19,9 @@ static char kApolloSubredditOriginalSelectedBackgroundKey;
 static char kApolloSubredditOriginalMultipleSelectedBackgroundKey;
 static char kApolloSubredditModernSelectionChromeAppliedKey;
 static char kApolloSubredditModernPressOverlayKey;
+// Flag-independent "this is the subreddit list" marker used only by the tap/selection highlight fix
+// (#452). Distinct from kApolloSubredditIndexTableKey, which gates the enhancement styling suite.
+static char kApolloSubredditSelectionTableKey;
 static char kApolloSubredditHeaderSeparatorKey;
 static char kApolloSubredditHeaderGradientLayerKey;
 static char kApolloSubredditHeaderLoggedKey;
@@ -1214,6 +1217,37 @@ static BOOL ApolloSubredditIndexEnsureSubredditTable(UITableView *tableView) {
     return YES;
 }
 
+// Identifies the subreddit list purely by structure (owning title + a large A–Z section index),
+// independent of sSubredditListEnhancements / sModernSubredditDividers. This lets the tap/selection
+// highlight (#452) run in every mode — including "classic" (enhancements off) — while the rest of the
+// enhancement styling stays gated on kApolloSubredditIndexTableKey. Deliberately does NOT set that
+// enhancement key; it only caches its own kApolloSubredditSelectionTableKey.
+static BOOL ApolloSubredditIndexEnsureSelectionTable(UITableView *tableView) {
+    if (!tableView) return NO;
+    if ([objc_getAssociatedObject(tableView, &kApolloSubredditSelectionTableKey) boolValue]) return YES;
+    // If the enhancement suite already recognised this table, inherit that verdict.
+    if ([objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue]) {
+        objc_setAssociatedObject(tableView, &kApolloSubredditSelectionTableKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return YES;
+    }
+    if (!ApolloSubredditIndexShouldInspectTable(tableView)) return NO;
+    NSArray<NSString *> *titles = ApolloSubredditIndexTitlesForTable(tableView);
+    if (!ApolloSubredditIndexLooksLikeSubredditsTable(tableView, titles)) return NO;
+    objc_setAssociatedObject(tableView, &kApolloSubredditSelectionTableKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return YES;
+}
+
+// Cheap O(1) gate for the app-wide -[UITableViewCell setHighlighted:]/setSelected: hooks: only act on
+// tables we've ALREADY recognised as the subreddit list. The recognition (and the one-time structural
+// detection it needs) happens in the scoped willDisplayCell / layoutSubviews passes, which always run
+// before a row can be tapped — so by press time a subreddit table already carries one of these keys.
+// This keeps every cell tap elsewhere in the app from triggering a responder-chain walk + title compare.
+static BOOL ApolloSubredditIndexTableAlreadyRecognised(UITableView *tableView) {
+    if (!tableView) return NO;
+    return [objc_getAssociatedObject(tableView, &kApolloSubredditSelectionTableKey) boolValue] ||
+           [objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue];
+}
+
 static UIView *ApolloSubredditIndexModernSelectionBackground(UITableView *tableView, UITableViewCell *cell) {
     UIView *view = [[UIView alloc] initWithFrame:CGRectZero];
     view.userInteractionEnabled = NO;
@@ -1262,7 +1296,7 @@ static UIView *ApolloSubredditIndexModernPressOverlay(UITableView *tableView, UI
 
 static void ApolloSubredditIndexSetModernPressOverlayVisible(UITableViewCell *cell, UITableView *tableView, BOOL visible, BOOL animated) {
     if (!cell) return;
-    if (!sModernSubredditDividers || !tableView || !ApolloSubredditIndexEnsureSubredditTable(tableView)) {
+    if (!tableView || !ApolloSubredditIndexEnsureSelectionTable(tableView)) {
         ApolloSubredditIndexRemoveModernPressOverlay(cell);
         return;
     }
@@ -1303,40 +1337,43 @@ static void ApolloSubredditIndexRestoreCellSelectionChrome(UITableViewCell *cell
 }
 
 static void ApolloSubredditIndexApplyCellSelectionChrome(UITableViewCell *cell, UITableView *tableView) {
-    if (!cell || !tableView || !ApolloSubredditIndexEnsureSubredditTable(tableView)) return;
+    if (!cell || !tableView || !ApolloSubredditIndexEnsureSelectionTable(tableView)) return;
 
-    BOOL hideSeparators = sModernSubredditDividers;
-    UITableViewCellSeparatorStyle separatorStyle = hideSeparators ? UITableViewCellSeparatorStyleNone : UITableViewCellSeparatorStyleSingleLine;
-    if (tableView.separatorStyle != separatorStyle) {
-        tableView.separatorStyle = separatorStyle;
-    }
-
-    BOOL appliedModernChrome = [objc_getAssociatedObject(cell, &kApolloSubredditModernSelectionChromeAppliedKey) boolValue];
-    if (sModernSubredditDividers) {
-        if (!appliedModernChrome) {
-            objc_setAssociatedObject(cell, &kApolloSubredditOriginalSelectionStyleKey, @(cell.selectionStyle), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            objc_setAssociatedObject(cell, &kApolloSubredditOriginalSelectedBackgroundKey, cell.selectedBackgroundView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            objc_setAssociatedObject(cell, &kApolloSubredditOriginalMultipleSelectedBackgroundKey, cell.multipleSelectionBackgroundView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            objc_setAssociatedObject(cell, &kApolloSubredditModernSelectionChromeAppliedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    // Separator style belongs to the enhancement/divider suite — only touch it when that suite owns
+    // this table. In classic mode we leave Apollo's native separators untouched.
+    if (ApolloSubredditIndexEnsureSubredditTable(tableView)) {
+        UITableViewCellSeparatorStyle separatorStyle = sModernSubredditDividers ? UITableViewCellSeparatorStyleNone : UITableViewCellSeparatorStyleSingleLine;
+        if (tableView.separatorStyle != separatorStyle) {
+            tableView.separatorStyle = separatorStyle;
         }
-
-        cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-        cell.selectedBackgroundView = ApolloSubredditIndexModernSelectionBackground(tableView, cell);
-        cell.multipleSelectionBackgroundView = ApolloSubredditIndexModernSelectionBackground(tableView, cell);
-        cell.backgroundView.layer.borderWidth = 0.0;
-        cell.selectedBackgroundView.layer.borderWidth = 0.0;
-        cell.multipleSelectionBackgroundView.layer.borderWidth = 0.0;
-        ApolloSubredditIndexSetModernPressOverlayVisible(cell, tableView, cell.highlighted || cell.selected, NO);
-        return;
     }
 
-    if (appliedModernChrome) ApolloSubredditIndexRestoreCellSelectionChrome(cell);
+    // Tap/selection highlight (#452). Apollo's native subreddit rows don't paint a visible selected
+    // background under Liquid Glass — their opaque cell background covers it — so we install our own
+    // selected background plus an in-contentView press overlay. This is a bug fix, so it runs in every
+    // mode, not just when Modern Subreddit Dividers is on. The enhancement toggles only govern the
+    // surrounding styling (separators, headers, custom index), handled elsewhere.
+    BOOL appliedModernChrome = [objc_getAssociatedObject(cell, &kApolloSubredditModernSelectionChromeAppliedKey) boolValue];
+    if (!appliedModernChrome) {
+        objc_setAssociatedObject(cell, &kApolloSubredditOriginalSelectionStyleKey, @(cell.selectionStyle), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(cell, &kApolloSubredditOriginalSelectedBackgroundKey, cell.selectedBackgroundView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(cell, &kApolloSubredditOriginalMultipleSelectedBackgroundKey, cell.multipleSelectionBackgroundView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(cell, &kApolloSubredditModernSelectionChromeAppliedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+    cell.selectedBackgroundView = ApolloSubredditIndexModernSelectionBackground(tableView, cell);
+    cell.multipleSelectionBackgroundView = ApolloSubredditIndexModernSelectionBackground(tableView, cell);
+    cell.backgroundView.layer.borderWidth = 0.0;
+    cell.selectedBackgroundView.layer.borderWidth = 0.0;
+    cell.multipleSelectionBackgroundView.layer.borderWidth = 0.0;
+    ApolloSubredditIndexSetModernPressOverlayVisible(cell, tableView, cell.highlighted || cell.selected, NO);
 }
 
 static void ApolloSubredditIndexApplyModernPressedCellSelectionChrome(UITableViewCell *cell) {
-    if (!sModernSubredditDividers || !cell) return;
+    if (!cell) return;
     UITableView *tableView = ApolloSubredditIndexTableForCell(cell);
-    if (!ApolloSubredditIndexEnsureSubredditTable(tableView)) return;
+    if (!ApolloSubredditIndexEnsureSelectionTable(tableView)) return;
 
     ApolloSubredditIndexApplyCellSelectionChrome(cell, tableView);
     ApolloSubredditIndexSetModernPressOverlayVisible(cell, tableView, cell.highlighted || cell.selected, NO);
@@ -1732,8 +1769,12 @@ static void ApolloSubredditIndexInstallHeaderLayoutHook(void) {
     if (!redditListCellClass || ![(UITableViewCell *)self isKindOfClass:redditListCellClass]) return;
 
     UITableView *tableView = ApolloSubredditIndexTableForCell((UITableViewCell *)self);
-    if ([objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue]) {
+    // Selection highlight is a bug fix that applies on the subreddit list in every mode (#452).
+    if (ApolloSubredditIndexEnsureSelectionTable(tableView)) {
         ApolloSubredditIndexApplyCellSelectionChrome((UITableViewCell *)self, tableView);
+    }
+    // Star proxy + multireddit child styling are enhancement-only.
+    if ([objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue]) {
         ApolloSubredditIndexInstallStarProxyForCell((UITableViewCell *)self, tableView);
         ApolloSubredditIndexApplyMultiredditChildStyleIfNeeded(tableView, (UITableViewCell *)self, [tableView indexPathForCell:(UITableViewCell *)self]);
     }
@@ -1742,6 +1783,7 @@ static void ApolloSubredditIndexInstallHeaderLayoutHook(void) {
 - (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated {
     %orig;
     UITableView *tableView = ApolloSubredditIndexTableForCell((UITableViewCell *)self);
+    if (!ApolloSubredditIndexTableAlreadyRecognised(tableView)) return;
     ApolloSubredditIndexApplyModernPressedCellSelectionChrome((UITableViewCell *)self);
     ApolloSubredditIndexSetModernPressOverlayVisible((UITableViewCell *)self, tableView, highlighted || ((UITableViewCell *)self).selected, animated);
     if (highlighted) {
@@ -1757,6 +1799,7 @@ static void ApolloSubredditIndexInstallHeaderLayoutHook(void) {
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {
     %orig;
     UITableView *tableView = ApolloSubredditIndexTableForCell((UITableViewCell *)self);
+    if (!ApolloSubredditIndexTableAlreadyRecognised(tableView)) return;
     ApolloSubredditIndexApplyModernPressedCellSelectionChrome((UITableViewCell *)self);
     ApolloSubredditIndexSetModernPressOverlayVisible((UITableViewCell *)self, tableView, selected || ((UITableViewCell *)self).highlighted, animated);
     if (selected) {
@@ -1775,8 +1818,10 @@ static void ApolloSubredditIndexInstallHeaderLayoutHook(void) {
     if (!redditListCellClass || ![(UITableViewCell *)self isKindOfClass:redditListCellClass]) return;
 
     UITableView *tableView = ApolloSubredditIndexTableForCell((UITableViewCell *)self);
-    if ([objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue]) {
+    if (ApolloSubredditIndexEnsureSelectionTable(tableView)) {
         ApolloSubredditIndexApplyCellSelectionChrome((UITableViewCell *)self, tableView);
+    }
+    if ([objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue]) {
         ApolloSubredditIndexInstallStarProxyForCell((UITableViewCell *)self, tableView);
     }
 }


### PR DESCRIPTION
Fixes #452.

## Problem
Tapping a subreddit in the subreddit list didn't show a cell selection highlight unless **Modern Subreddit Dividers** was enabled — only the native alphabet index on the right highlighted. Home/Popular/All always highlighted correctly. Reported on the Liquid Glass build, iOS 26.

## Root cause
Under Liquid Glass, Apollo's native subreddit-list rows have an opaque cell background that covers the standard `selectedBackgroundView`, so they never paint a native selection highlight. The tweak's own selection chrome (a themed `selectedBackgroundView` + an in-`contentView` press overlay) masked this — but **every** selection path was gated behind `sModernSubredditDividers`, and the module short-circuits entirely when **Subreddit List Enhancements** is off (`ApolloSubredditIndexEnsureSubredditTable` returns early when the master toggle is off). So in classic mode, or with modern dividers off, the tweak was inert on those cells and the native no-highlight showed through. The alphabet index still highlighted because it's a separate native control.

## Fix
Decouple the tap/selection highlight from both toggles:

- New flag-independent detector `ApolloSubredditIndexEnsureSelectionTable` recognises the subreddit list purely by structure (owning title + a large A–Z section index), cached under its own key. It deliberately does **not** set the enhancement key, so it can only drive the highlight — not the rest of the enhancement styling.
- The selection highlight (`selectedBackgroundView` + press overlay) now runs in **every** mode. Divider/header/custom-index styling stays gated on the existing flags, so classic mode keeps Apollo's native separators.
- Added a cheap O(1) recognition guard to the app-wide `-[UITableViewCell setHighlighted:]`/`setSelected:` hooks so cell taps elsewhere in the app don't trigger the structural detection (which also removes a small cost the previous modern-mode path already paid app-wide).

## Testing
- Verified in the iOS 26 Simulator (Liquid Glass) with **Subreddit List Enhancements OFF**: subreddit rows now highlight on press where they previously showed nothing. Modern-dividers mode is unchanged.
- Not yet device-tested.