### PR TITLE
AI theme generation for Theme Manager v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,8 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloThemeCompiler.m \
     $(SRC_DIR)/ApolloThemeStore.m \
     $(SRC_DIR)/ApolloThemeRuntime.xm \
+    $(SRC_DIR)/ApolloThemeAI.m \
+    $(SRC_DIR)/ApolloThemeAISheets.m \
     $(SRC_DIR)/ApolloThemeManagerViewController.m \
     $(SRC_DIR)/ApolloThemeManagerIntegration.xm \
     $(SRC_DIR)/ApolloThemeIntegrations.xm \
@@ -140,6 +142,19 @@ ApolloReborn_LIBRARIES = z iconv
 # feature simply reports unavailable in that build).
 ifneq ($(wildcard $(SYSROOT)/System/Library/Frameworks/FoundationModels.framework),)
 ApolloReborn_LDFLAGS += -weak_framework FoundationModels
+endif
+# The @Generable / @Guide macros used by ApolloFoundationModels.swift's Theme
+# Manager schema are implemented by the FoundationModelsMacros compiler plugin,
+# which ships in the iPhoneOS *platform* plugin dir — NOT the toolchain's default
+# host/plugins. Because we build against the copied SDK in $THEOS/sdks (outside
+# the .platform), swiftc doesn't auto-add that path, so the macro can't resolve
+# ("plugin for module 'FoundationModelsMacros' not found"). Point swiftc at the
+# platform plugin dir explicitly, only when it's present — older toolchains that
+# lack FoundationModels never compile the macro'd code (it's behind
+# `#if canImport(FoundationModels)`), so they don't need it.
+FM_PLUGIN_PATH := $(shell xcode-select -p)/Platforms/iPhoneOS.platform/Developer/usr/lib/swift/host/plugins
+ifneq ($(wildcard $(FM_PLUGIN_PATH)/libFoundationModelsMacros.dylib),)
+ApolloReborn_SWIFTFLAGS += -plugin-path $(FM_PLUGIN_PATH)
 endif
 # Apple's Translation framework (used by the on-device "apple" translation provider in
 # ApolloAppleTranslation.swift) only exists on iOS 18.0+. Weak-link it so the tweak still

--- a/src/ApolloFoundationModels.swift
+++ b/src/ApolloFoundationModels.swift
@@ -28,6 +28,75 @@ import FoundationModels
 // log at `.debug` (not persisted in release unless debug logging is enabled).
 private let aiLog = Logger(subsystem: "apollofix", category: "AISummary")
 
+#if canImport(FoundationModels)
+// Guided-generation schema for Theme Manager. Declaring the output with
+// `@Generable` forces the on-device model to fill a structurally valid palette
+// instead of emitting free-form JSON we then regex-parse, and the per-field
+// `@Guide` hints keep each role on-purpose. This is the core fix for the model
+// wandering off-palette (e.g. a "Superman" request drifting to green/orange):
+// the shape is now schema-guaranteed and each color's intent is described.
+//
+// Field names match the v2 Theme Manager's input keys 1:1 (ApolloThemeTokens.h
+// kApolloThemeInput*) rather than v1's role names — v1 had a confusing
+// indirection where the Swift field `background` actually meant the card/row
+// colour and `secondaryBackground` meant the page background. The model never
+// sees these Swift identifiers (only the @Guide description strings), so this
+// rename is a pure clarity fix with no effect on generation quality.
+//
+// The ObjC side (ApolloThemeAI.m) still owns local contrast repair for the
+// preview sheet, validation/scoring, and saving via ApolloThemeStore — we
+// serialize this back into a flat "key.mode" -> hex dictionary that maps
+// directly onto the v2 input schema.
+@available(iOS 26.0, *)
+@Generable
+struct ApolloGeneratedPalette {
+    @Guide(description: "Accent as #RRGGBB. The vivid signature color that carries the theme's personality — links, the selected tab, buttons.")
+    var accent: String
+    @Guide(description: "Main page/content background as #RRGGBB, behind cards and grouped sections. A calm, lower-saturation large surface that text sits on.")
+    var background: String
+    @Guide(description: "Card/row background as #RRGGBB — list rows, setting cells, post cards, grouped panels. Slightly distinct from the main background.")
+    var card: String
+    @Guide(description: "Raised/elevated surface as #RRGGBB — inset controls, elevated panels. Distinct again from the card background.")
+    var raised: String
+    @Guide(description: "Separator/hairline color as #RRGGBB. Subtle but visible against the backgrounds.")
+    var separator: String
+    @Guide(description: "Navigation and tab bar background as #RRGGBB.")
+    var bars: String
+    @Guide(description: "Secondary text as #RRGGBB — usernames, timestamps, counts. Readable, not faint.")
+    var mutedText: String
+    @Guide(description: "Primary text as #RRGGBB. Must be clearly readable on every background above.")
+    var text: String
+}
+
+@available(iOS 26.0, *)
+@Generable
+struct ApolloGeneratedTweak {
+    @Guide(description: "Short button title for a one-tap refinement, e.g. \"Make darker\".")
+    var title: String
+    @Guide(description: "One-sentence instruction describing the refinement to apply.")
+    var instruction: String
+}
+
+@available(iOS 26.0, *)
+@Generable
+struct ApolloGeneratedTheme {
+    @Guide(description: "Short, original theme name (max 32 characters). Never reuse a trademarked or official name.")
+    var name: String
+    @Guide(description: "One concise sentence describing the look.")
+    var shortDescription: String
+    @Guide(description: "Three to five short aesthetic tags.")
+    var aestheticTags: [String]
+    @Guide(description: "The light mode palette.")
+    var lightMode: ApolloGeneratedPalette
+    @Guide(description: "The dark mode palette.")
+    var darkMode: ApolloGeneratedPalette
+    @Guide(description: "Up to three short readability notes.")
+    var accessibilityNotes: [String]
+    @Guide(description: "Two suggested one-tap refinements the user could apply next.")
+    var suggestedTweaks: [ApolloGeneratedTweak]
+}
+#endif
+
 @objc(ApolloFoundationModels)
 public final class ApolloFoundationModels: NSObject {
 
@@ -232,11 +301,149 @@ public final class ApolloFoundationModels: NSObject {
         #endif
     }
 
+    /// Generate a Theme Manager palette as JSON. This is intentionally a
+    /// one-shot completion API (no streaming UI): the Objective-C theme service
+    /// owns validation, repair, saving, and presentation.
+    @objc public func generateThemeJSON(withPrompt prompt: String,
+                                        identifier: String,
+                                        currentJSON: String,
+                                        instruction: String,
+                                        maximumResponseTokens: Int,
+                                        onComplete: @escaping (String?, NSError?) -> Void) {
+        #if canImport(FoundationModels)
+        guard #available(iOS 26.0, *) else {
+            onComplete(nil, Self.makeError(code: 4, message: "Requires iOS 26 or later"))
+            return
+        }
+
+        let systemInstructions = """
+        You are Apollo Reborn's theme design assistant.
+
+        Turn a short natural-language theme idea into a polished, readable app theme for a Reddit client used for long reading sessions. Usability matters as much as personality.
+
+        Color intent — the single most important rule, and the one most often done badly:
+        - Build the WHOLE palette from the colors people associate with the request — backgrounds, bars, and separators included, not just the accent. If it names a subject with signature colors (a red-and-blue hero, an autumn forest, a Game Boy), those colors must appear across the surfaces too.
+        - background, card, raised, bars, and separator MUST be tinted toward the theme's color family. "Calm" / "low saturation" means a deep, desaturated version of the theme's hue (for example a near-navy for a blue theme) — it does NOT mean neutral grey. Do not output neutral grey or near-black surfaces unless the request is explicitly grey, monochrome, minimal, or OLED/true-black. A theme whose backgrounds are plain grey has FAILED the request.
+        - The accent is the most vivid color: the subject's boldest signature color.
+        - Only the theme NAME must be original — never reuse a trademarked or official name. The palette itself should clearly evoke the request.
+
+        Readability rules:
+        - Primary text (near-white in dark mode, near-black in light mode, optionally tinted slightly toward the theme) must be clearly readable against every background and bar.
+        - Secondary text must be clearly readable, not faint.
+        - Light and dark mode should feel related but not merely inverted: dark mode uses deep tinted surfaces, light mode uses pale tinted surfaces, both sharing the accent.
+        - Avoid muddy, chaotic, neon text, and low-contrast pastel-on-pastel palettes unless the user explicitly asks for chaos; contrast still matters.
+        - Every color is a six-digit hex with a leading # and no transparency.
+        - Do not use pure black unless the request explicitly asks for OLED, AMOLED, pure black, or true black.
+
+        Worked examples (match this approach; choose your own exact hexes):
+        - "Superman": dark mode = deep navy-blue backgrounds + a vivid red accent + near-white text; light mode = pale blue-white backgrounds + the same red accent. Recognizably red-and-blue, never grey.
+        - "Cozy autumn": warm brown/amber backgrounds + a burnt-orange accent + cream text.
+        - "Retro Game Boy": olive/pea-green surfaces + a deeper green accent, under a name like "Pocket Player".
+        """
+
+        let userPrompt: String
+        if !currentJSON.isEmpty || !instruction.isEmpty {
+            userPrompt = """
+            Improve this existing Apollo Reborn Theme Manager result.
+
+            User request:
+            "\(instruction.isEmpty ? "Refine this theme while preserving its identity." : instruction)"
+
+            Original idea:
+            "\(prompt)"
+
+            Existing theme JSON:
+            \(currentJSON)
+
+            Modify the existing theme rather than replacing it. Preserve the core identity unless the request asks for a major change. Return the full updated JSON object.
+            """
+        } else {
+            userPrompt = """
+            Create an Apollo Reborn theme from this user request:
+            "\(prompt)"
+
+            It should be usable immediately as a starting point in Theme Manager. Preserve the spirit of the request, but improve the palette where needed for readability, taste, and long-session comfort. Generate both light and dark mode palettes.
+            """
+        }
+
+        let task = Task { @MainActor in
+            // A little temperature (vs the previous .greedy) gives bolder, more
+            // colourful palettes instead of the blandest safe default — greedy
+            // tended to leave surfaces neutral grey — and makes "Regenerate"
+            // actually produce a different theme each time.
+            let options = GenerationOptions(
+                temperature: 0.7,
+                maximumResponseTokens: maximumResponseTokens > 0 ? maximumResponseTokens : nil
+            )
+            do {
+                let startedAt = ContinuousClock.now
+                let session = LanguageModelSession(model: Self.summarizationModel(), instructions: systemInstructions)
+                // Guided generation: the model fills the ApolloGeneratedTheme
+                // schema directly, so we never parse free-form text and the
+                // palette can't drift into an invalid or off-purpose shape.
+                let response = try await session.respond(to: userPrompt,
+                                                         generating: ApolloGeneratedTheme.self,
+                                                         options: options)
+                if Task.isCancelled { throw CancellationError() }
+                let json = Self.themeJSONString(from: response.content)
+                aiLog.debug("theme generation completed promptLength=\(prompt.count, privacy: .public) after \(String(describing: ContinuousClock.now - startedAt), privacy: .public)")
+                onComplete(json, nil)
+            } catch {
+                if Task.isCancelled {
+                    onComplete(nil, Self.makeError(code: 6, message: "Generation cancelled"))
+                } else {
+                    onComplete(nil, Self.classify(error))
+                }
+            }
+            activeTasks.removeValue(forKey: identifier)
+        }
+        activeTasks[identifier]?.cancel()
+        activeTasks[identifier] = task
+        #else
+        onComplete(nil, Self.makeError(code: 4, message: "FoundationModels not available in this build"))
+        #endif
+    }
+
     private static func makeError(code: Int, message: String) -> NSError {
         return NSError(domain: "ApolloFoundationModels",
                        code: code,
                        userInfo: [NSLocalizedDescriptionKey: message])
     }
+
+    #if canImport(FoundationModels)
+    /// Serialize a guided-generation result into a flat "key.mode" -> hex JSON
+    /// object matching the v2 Theme Manager's input keys, which
+    /// ApolloThemeAI.m's `ATBResultFromJSON` parses directly — no v1-style role
+    /// indirection needed since the struct fields already match 1:1.
+    @available(iOS 26.0, *)
+    private static func themeJSONString(from theme: ApolloGeneratedTheme) -> String? {
+        func palette(_ p: ApolloGeneratedPalette) -> [String: String] {
+            return [
+                "accent": p.accent,
+                "background": p.background,
+                "card": p.card,
+                "raised": p.raised,
+                "separator": p.separator,
+                "bars": p.bars,
+                "mutedText": p.mutedText,
+                "text": p.text,
+            ]
+        }
+        let root: [String: Any] = [
+            "name": theme.name,
+            "shortDescription": theme.shortDescription,
+            "aestheticTags": theme.aestheticTags,
+            "lightMode": palette(theme.lightMode),
+            "darkMode": palette(theme.darkMode),
+            "accessibilityNotes": theme.accessibilityNotes,
+            "suggestedTweaks": theme.suggestedTweaks.map {
+                ["title": $0.title, "instruction": $0.instruction]
+            },
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: root) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+    #endif
 
     /// Map a thrown FoundationModels error to a stable integer code the ObjC
     /// side branches on (see `ApolloAIFriendlyError` / the transient-retry path

--- a/src/ApolloThemeAI.h
+++ b/src/ApolloThemeAI.h
@@ -1,0 +1,30 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^ApolloThemeAICompletion)(NSDictionary *_Nullable result, NSError *_Nullable error);
+
+// True when the Swift FoundationModels bridge is present and reports a model
+// ready to generate. UI can still call ApolloThemeAIUnavailableMessage() for
+// friendly copy when this is false.
+BOOL ApolloThemeAIIsAvailable(void);
+NSString *ApolloThemeAIUnavailableMessage(void);
+
+// Generates an app-safe theme dictionary:
+// {
+//   name, shortDescription, colors, qualityLabel, qualitySummary,
+//   notes, suggestedTweaks, validationScore, originalPrompt
+// }
+// `colors` is a flat "key.mode" -> hex dictionary keyed on the v2 Theme
+// Manager's input keys (ApolloThemeTokens.h ApolloThemeInputKeys()), e.g.
+// "accent.light", "card.dark" — directly convertible into a v2 theme's
+// nested {"light": {...}, "dark": {...}} input dict.
+void ApolloThemeAIGenerateTheme(NSString *prompt, ApolloThemeAICompletion completion);
+void ApolloThemeAIModifyTheme(NSDictionary *themeResult, NSString *instruction, ApolloThemeAICompletion completion);
+void ApolloThemeAICancel(void);
+
+// Lightweight deterministic validation used by both AI output and the manual
+// editor. Returns {score, passed, issues, warnings, summary}.
+NSDictionary *ApolloThemeAIValidateColors(NSDictionary<NSString *, NSString *> *colors, NSString *_Nullable prompt);
+
+NS_ASSUME_NONNULL_END

--- a/src/ApolloThemeAI.m
+++ b/src/ApolloThemeAI.m
@@ -1,0 +1,354 @@
+#import "ApolloThemeAI.h"
+#import "ApolloThemeTokens.h"
+#import "ApolloCommon.h"
+#import <UIKit/UIKit.h>
+#import <math.h>
+
+@interface ApolloFoundationModels : NSObject
++ (instancetype)shared;
+- (NSInteger)availabilityStatus;
+- (void)cancelRequest:(NSString *)identifier;
+- (void)generateThemeJSONWithPrompt:(NSString *)prompt
+                          identifier:(NSString *)identifier
+                         currentJSON:(NSString *)currentJSON
+                         instruction:(NSString *)instruction
+               maximumResponseTokens:(NSInteger)maximumResponseTokens
+                          onComplete:(void (^)(NSString *_Nullable json, NSError *_Nullable error))onComplete;
+@end
+
+typedef struct { CGFloat r, g, b; } ATBColor;
+static NSString * const kATBRequestID = @"theme-ai-generation";
+
+static ApolloFoundationModels *ATBBridge(void) {
+    Class cls = NSClassFromString(@"ApolloFoundationModels");
+    return [cls respondsToSelector:@selector(shared)] ? [cls shared] : nil;
+}
+
+BOOL ApolloThemeAIIsAvailable(void) {
+    ApolloFoundationModels *bridge = ATBBridge();
+    return bridge && [bridge respondsToSelector:@selector(availabilityStatus)] && [bridge availabilityStatus] == 0;
+}
+
+NSString *ApolloThemeAIUnavailableMessage(void) {
+    ApolloFoundationModels *bridge = ATBBridge();
+    NSInteger status = bridge ? [bridge availabilityStatus] : 4;
+    switch (status) {
+        case 1: return @"AI theme generation requires Apple Intelligence to be enabled. You can still create themes manually.";
+        case 2: return @"AI theme generation is still preparing on this device. You can still create themes manually.";
+        case 3: return @"AI theme generation requires Apple Intelligence support on this device. You can still create themes manually.";
+        case 4: return @"AI theme generation requires iOS 26 and the Foundation Models framework. You can still create themes manually.";
+        default: return @"AI theme generation is unavailable right now. You can still create themes manually.";
+    }
+}
+
+// --- colour helpers built on the v2 shared primitives (ApolloThemeTokens.h) ---
+
+static BOOL ATBParseHex(NSString *hex, ATBColor *out) {
+    uint32_t rgb = 0;
+    if (![hex isKindOfClass:[NSString class]] || !ApolloThemeParseHex(hex, &rgb)) return NO;
+    if (out) *out = (ATBColor){ ((rgb >> 16) & 0xFF) / 255.0, ((rgb >> 8) & 0xFF) / 255.0, (rgb & 0xFF) / 255.0 };
+    return YES;
+}
+
+static NSString *ATBHexFromColor(ATBColor c) {
+    CGFloat r = MAX(0, MIN(1, c.r)), g = MAX(0, MIN(1, c.g)), b = MAX(0, MIN(1, c.b));
+    return ApolloThemeHexFromRGB(ApolloThemeRGBKeyFromComponents(r, g, b));
+}
+
+static CGFloat ATBContrastColors(ATBColor a, ATBColor b) {
+    return ApolloThemeContrastRatio(ApolloThemeRGBKeyFromComponents(a.r, a.g, a.b),
+                                     ApolloThemeRGBKeyFromComponents(b.r, b.g, b.b));
+}
+
+static CGFloat ATBDistance(ATBColor a, ATBColor b) {
+    CGFloat dr = a.r - b.r, dg = a.g - b.g, db = a.b - b.b;
+    return sqrt(dr * dr + dg * dg + db * db);
+}
+
+static CGFloat ATBSaturation(ATBColor c) {
+    CGFloat maxv = MAX(c.r, MAX(c.g, c.b));
+    CGFloat minv = MIN(c.r, MIN(c.g, c.b));
+    return maxv <= 0.001 ? 0 : (maxv - minv) / maxv;
+}
+
+// Perceptual "intensity" for large surfaces: HSV saturation weighted by
+// brightness. A deep navy (high HSV saturation, low brightness) reads as calm,
+// so it scores low here; only colors that are both saturated AND bright — the
+// ones that actually fatigue the eye on big reading surfaces — score high. This
+// is what lets the AI tint backgrounds toward the theme (deep navy, warm brown)
+// without tripping the "may feel intense" warning that raw saturation did.
+static CGFloat ATBSurfaceIntensity(ATBColor c) {
+    return ATBSaturation(c) * MAX(c.r, MAX(c.g, c.b));
+}
+
+static ATBColor ATBBlend(ATBColor a, ATBColor b, CGFloat amount) {
+    amount = MAX(0, MIN(1, amount));
+    return (ATBColor){ a.r + (b.r - a.r) * amount, a.g + (b.g - a.g) * amount, a.b + (b.b - a.b) * amount };
+}
+
+// Worst (lowest) WCAG contrast of a candidate text colour across every surface
+// it has to sit on. The text repair targets this minimum so it's readable on the
+// hardest surface, not just one.
+static CGFloat ATBMinContrastVsSurfaces(ATBColor c, NSArray<NSString *> *surfaceHexes) {
+    CGFloat minC = INFINITY;
+    for (NSString *hex in surfaceHexes) {
+        ATBColor s;
+        if (!ATBParseHex(hex, &s)) continue;
+        minC = MIN(minC, ATBContrastColors(c, s));
+    }
+    return isinf(minC) ? 1.0 : minC;
+}
+
+// Deterministic readability guarantee. Returns a text colour that meets `minimum`
+// WCAG contrast against EVERY surface if achievable, preserving as much of the
+// model's chosen tint as possible. It tries blending the model's colour toward
+// both white and black and picks the direction that passes against all surfaces
+// with the least change (so theme tint survives where it can). If neither
+// direction can clear every surface — e.g. a palette that mixes very light and
+// very dark surfaces — it returns the pure black/white endpoint with the highest
+// minimum contrast, i.e. the most readable option available. Mode-agnostic: it
+// can never leave near-white text stranded on a light surface.
+static NSString *ATBReadableTextHex(NSString *textHex, NSArray<NSString *> *surfaceHexes, CGFloat minimum) {
+    ATBColor text;
+    if (!ATBParseHex(textHex, &text)) text = (ATBColor){0.5, 0.5, 0.5};
+    ATBColor targets[2] = {(ATBColor){1, 1, 1}, (ATBColor){0, 0, 0}};
+    BOOL passed[2] = {NO, NO};
+    ATBColor best[2];
+    CGFloat bestMin[2] = {0, 0};
+    NSInteger bestStep[2] = {21, 21};
+    for (int t = 0; t < 2; t++) {
+        // Smallest blend toward this endpoint that clears `minimum` everywhere.
+        for (NSInteger i = 0; i <= 20; i++) {
+            ATBColor cand = ATBBlend(text, targets[t], i / 20.0);
+            CGFloat m = ATBMinContrastVsSurfaces(cand, surfaceHexes);
+            if (m >= minimum) { passed[t] = YES; best[t] = cand; bestMin[t] = m; bestStep[t] = i; break; }
+        }
+        if (!passed[t]) { best[t] = targets[t]; bestMin[t] = ATBMinContrastVsSurfaces(targets[t], surfaceHexes); }
+    }
+    if (passed[0] && passed[1]) {
+        // Both endpoints work — keep whichever changed the model colour least.
+        return ATBHexFromColor(bestStep[0] <= bestStep[1] ? best[0] : best[1]);
+    }
+    if (passed[0]) return ATBHexFromColor(best[0]);
+    if (passed[1]) return ATBHexFromColor(best[1]);
+    return ATBHexFromColor(bestMin[0] >= bestMin[1] ? best[0] : best[1]);
+}
+
+// `colors` is a flat "key.mode" -> hex dict keyed on ApolloThemeInputKeys().
+NSDictionary *ApolloThemeAIValidateColors(NSDictionary<NSString *, NSString *> *colors, NSString *prompt) {
+    NSMutableArray *issues = [NSMutableArray array];
+    NSMutableArray *warnings = [NSMutableArray array];
+    NSArray *keys = ApolloThemeInputKeys();
+    for (NSString *mode in @[@"light", @"dark"]) {
+        for (NSString *key in keys) {
+            NSString *k = [NSString stringWithFormat:@"%@.%@", key, mode];
+            uint32_t rgb;
+            if (!ApolloThemeParseHex(colors[k], &rgb)) {
+                [issues addObject:[NSString stringWithFormat:@"%@ has an invalid color.", ApolloThemeInputDisplayName(key)]];
+            }
+        }
+        ATBColor background, card, raised, bars, text, mutedText, accent, separator;
+        if (!ATBParseHex(colors[[@"background." stringByAppendingString:mode]], &background) ||
+            !ATBParseHex(colors[[@"card." stringByAppendingString:mode]], &card) ||
+            !ATBParseHex(colors[[@"raised." stringByAppendingString:mode]], &raised) ||
+            !ATBParseHex(colors[[@"bars." stringByAppendingString:mode]], &bars) ||
+            !ATBParseHex(colors[[@"text." stringByAppendingString:mode]], &text) ||
+            !ATBParseHex(colors[[@"mutedText." stringByAppendingString:mode]], &mutedText) ||
+            !ATBParseHex(colors[[@"accent." stringByAppendingString:mode]], &accent) ||
+            !ATBParseHex(colors[[@"separator." stringByAppendingString:mode]], &separator)) {
+            continue;
+        }
+        NSDictionary *surfaces = @{@"background": [NSValue valueWithBytes:&background objCType:@encode(ATBColor)],
+                                   @"card background": [NSValue valueWithBytes:&card objCType:@encode(ATBColor)],
+                                   @"raised background": [NSValue valueWithBytes:&raised objCType:@encode(ATBColor)],
+                                   @"bars and chrome": [NSValue valueWithBytes:&bars objCType:@encode(ATBColor)]};
+        for (NSString *name in surfaces) {
+            ATBColor surface;
+            [surfaces[name] getValue:&surface];
+            if (ATBContrastColors(text, surface) < 4.5) {
+                [issues addObject:[NSString stringWithFormat:@"%@ mode text may be hard to read on %@.", mode.capitalizedString, name]];
+            }
+            CGFloat mutedContrast = ATBContrastColors(mutedText, surface);
+            if (mutedContrast < 2.5) {
+                [issues addObject:[NSString stringWithFormat:@"%@ mode secondary text is too faint on %@.", mode.capitalizedString, name]];
+            } else if (mutedContrast < 3.0) {
+                [warnings addObject:[NSString stringWithFormat:@"%@ mode secondary text is slightly faint.", mode.capitalizedString]];
+            }
+        }
+        CGFloat accentContrast = MIN(ATBContrastColors(accent, background), ATBContrastColors(accent, card));
+        if (accentContrast < 2.0) [warnings addObject:[NSString stringWithFormat:@"%@ mode accent may be faint on selected controls.", mode.capitalizedString]];
+        if (ATBDistance(background, card) < 0.035 || ATBDistance(card, raised) < 0.035) {
+            [warnings addObject:[NSString stringWithFormat:@"%@ mode surfaces are very similar.", mode.capitalizedString]];
+        }
+        if (ATBSurfaceIntensity(background) > 0.30 || ATBSurfaceIntensity(card) > 0.30 || ATBSurfaceIntensity(raised) > 0.30) {
+            [warnings addObject:[NSString stringWithFormat:@"%@ mode backgrounds may feel intense during long reading sessions.", mode.capitalizedString]];
+        }
+        NSString *lowerPrompt = prompt.lowercaseString ?: @"";
+        BOOL oledAllowed = [lowerPrompt containsString:@"oled"] || [lowerPrompt containsString:@"amoled"] ||
+                           [lowerPrompt containsString:@"pure black"] || [lowerPrompt containsString:@"true black"];
+        if (!oledAllowed && [colors[[@"background." stringByAppendingString:mode]] isEqualToString:@"000000"]) {
+            [warnings addObject:[NSString stringWithFormat:@"%@ mode uses pure black as the main background.", mode.capitalizedString]];
+        }
+        CGFloat sepDistance = MIN(ATBDistance(separator, background), ATBDistance(separator, card));
+        if (sepDistance < 0.018) [warnings addObject:[NSString stringWithFormat:@"%@ mode separators may be too subtle.", mode.capitalizedString]];
+    }
+    NSInteger score = MAX(0, MIN(100, 100 - ((NSInteger)issues.count * 30) - ((NSInteger)warnings.count * 10)));
+    NSString *label = score >= 90 ? @"Excellent" : (score >= 75 ? @"Good" : (score >= 60 ? @"Needs tweaks" : @"Hard to read"));
+    NSString *summary = issues.count ? @"This theme needed readability fixes." :
+        (warnings.count ? @"Readable, with a few suggested tweaks." : @"Readable and well balanced.");
+    return @{@"score": @(score), @"passed": @(issues.count == 0), @"issues": issues, @"warnings": warnings,
+             @"qualityLabel": label, @"summary": summary};
+}
+
+// Fallback for a key the model omitted or returned an unparsable hex for.
+// Genuinely rare (every field is a required, guided-generation property), so a
+// plain neutral is enough — this is a last-resort safety net, not a design
+// choice, unlike v1's per-role "donor" defaults.
+static NSString *const kATBFallbackHex = @"808080";
+
+static NSDictionary<NSString *, NSString *> *ATBLocallyRepairedColors(NSDictionary<NSString *, NSString *> *input, NSString *prompt) {
+    NSMutableDictionary *colors = [NSMutableDictionary dictionary];
+    for (NSString *mode in @[@"light", @"dark"]) {
+        for (NSString *key in ApolloThemeInputKeys()) {
+            NSString *k = [NSString stringWithFormat:@"%@.%@", key, mode];
+            uint32_t rgb;
+            colors[k] = ApolloThemeParseHex(input[k], &rgb) ? ApolloThemeHexFromRGB(rgb) : kATBFallbackHex;
+        }
+        BOOL dark = [mode isEqualToString:@"dark"];
+        NSString *backgroundKey = [@"background." stringByAppendingString:mode];
+        NSString *cardKey = [@"card." stringByAppendingString:mode];
+        NSString *raisedKey = [@"raised." stringByAppendingString:mode];
+        if ([colors[cardKey] isEqualToString:colors[backgroundKey]]) {
+            ATBColor bg; ATBParseHex(colors[backgroundKey], &bg);
+            colors[cardKey] = ATBHexFromColor(ATBBlend(bg, dark ? (ATBColor){1,1,1} : (ATBColor){0,0,0}, 0.06));
+        }
+        if ([colors[raisedKey] isEqualToString:colors[cardKey]]) {
+            ATBColor card; ATBParseHex(colors[cardKey], &card);
+            colors[raisedKey] = ATBHexFromColor(ATBBlend(card, dark ? (ATBColor){1,1,1} : (ATBColor){0,0,0}, 0.07));
+        }
+        // Force primary and secondary text to clear WCAG contrast against ALL
+        // four surfaces at once (not one at a time), trying both lighten/darken
+        // directions — guarantees readable text whatever the model returned.
+        NSArray<NSString *> *surfaceHexes = @[colors[backgroundKey], colors[cardKey], colors[raisedKey],
+                                              colors[[@"bars." stringByAppendingString:mode]]];
+        colors[[@"text." stringByAppendingString:mode]] =
+            ATBReadableTextHex(colors[[@"text." stringByAppendingString:mode]], surfaceHexes, 4.5);
+        colors[[@"mutedText." stringByAppendingString:mode]] =
+            ATBReadableTextHex(colors[[@"mutedText." stringByAppendingString:mode]], surfaceHexes, 3.0);
+    }
+    return colors;
+}
+
+static NSDictionary *ATBJSONObjectFromData(NSData *data) {
+    id obj = data ? [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL] : nil;
+    return [obj isKindOfClass:NSDictionary.class] ? obj : nil;
+}
+
+static NSString *ATBJSONString(NSDictionary *dict) {
+    NSData *data = dict ? [NSJSONSerialization dataWithJSONObject:dict options:NSJSONWritingSortedKeys error:NULL] : nil;
+    return data ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] : @"";
+}
+
+// The Swift bridge's guided-generation struct fields already match the v2
+// input keys 1:1 (ApolloFoundationModels.swift ApolloGeneratedPalette), so
+// this is a direct copy rather than a role-name translation.
+static NSDictionary<NSString *, NSString *> *ATBColorsFromGeneratedTheme(NSDictionary *root) {
+    NSMutableDictionary *colors = [NSMutableDictionary dictionary];
+    NSDictionary *modeMap = @{@"light": @"lightMode", @"dark": @"darkMode"};
+    for (NSString *mode in modeMap) {
+        NSDictionary *palette = [root[modeMap[mode]] isKindOfClass:NSDictionary.class] ? root[modeMap[mode]] : @{};
+        for (NSString *key in ApolloThemeInputKeys()) {
+            uint32_t rgb;
+            if (ApolloThemeParseHex(palette[key], &rgb)) {
+                colors[[NSString stringWithFormat:@"%@.%@", key, mode]] = ApolloThemeHexFromRGB(rgb);
+            }
+        }
+    }
+    return colors;
+}
+
+static NSString *ATBClampedPrompt(NSString *prompt) {
+    NSString *trimmed = [prompt stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet] ?: @"";
+    if (trimmed.length <= 300) return trimmed;
+    return [trimmed substringToIndex:[trimmed rangeOfComposedCharacterSequencesForRange:NSMakeRange(0, 300)].length];
+}
+
+static NSDictionary *ATBResultFromJSON(NSString *json, NSString *prompt, NSError **outError) {
+    NSRange start = [json rangeOfString:@"{"];
+    NSRange end = [json rangeOfString:@"}" options:NSBackwardsSearch];
+    if (start.location == NSNotFound || end.location == NSNotFound || end.location <= start.location) {
+        if (outError) *outError = [NSError errorWithDomain:@"ApolloThemeAI" code:2 userInfo:@{NSLocalizedDescriptionKey: @"Model output was not JSON."}];
+        return nil;
+    }
+    NSString *clean = [json substringWithRange:NSMakeRange(start.location, end.location - start.location + 1)];
+    NSDictionary *root = ATBJSONObjectFromData([clean dataUsingEncoding:NSUTF8StringEncoding]);
+    if (!root) {
+        if (outError) *outError = [NSError errorWithDomain:@"ApolloThemeAI" code:2 userInfo:@{NSLocalizedDescriptionKey: @"Model output could not be parsed."}];
+        return nil;
+    }
+    NSDictionary *repaired = ATBLocallyRepairedColors(ATBColorsFromGeneratedTheme(root), prompt);
+    NSDictionary *validation = ApolloThemeAIValidateColors(repaired, prompt);
+    NSString *name = [root[@"name"] isKindOfClass:NSString.class] && [root[@"name"] length] ? root[@"name"] : @"Generated Theme";
+    if (name.length > 32) name = [name substringToIndex:[name rangeOfComposedCharacterSequencesForRange:NSMakeRange(0, 32)].length];
+    NSArray *notes = [root[@"accessibilityNotes"] isKindOfClass:NSArray.class] ? root[@"accessibilityNotes"] : @[];
+    NSArray *warnings = validation[@"warnings"];
+    if (!notes.count && [warnings count]) notes = [warnings subarrayWithRange:NSMakeRange(0, MIN((NSUInteger)3, [warnings count]))];
+    return @{
+        @"name": name,
+        @"shortDescription": [root[@"shortDescription"] isKindOfClass:NSString.class] ? root[@"shortDescription"] : @"Generated from your prompt.",
+        @"colors": repaired,
+        @"notes": notes,
+        @"suggestedTweaks": [root[@"suggestedTweaks"] isKindOfClass:NSArray.class] ? root[@"suggestedTweaks"] : @[],
+        @"validation": validation,
+        @"validationScore": validation[@"score"] ?: @0,
+        @"qualityLabel": validation[@"qualityLabel"] ?: @"Good",
+        @"qualitySummary": validation[@"summary"] ?: @"Readable and ready to tweak.",
+        @"originalPrompt": prompt ?: @"",
+    };
+}
+
+static void ATBGenerate(NSString *prompt, NSDictionary *current, NSString *instruction, ApolloThemeAICompletion completion) {
+    NSString *cleanPrompt = ATBClampedPrompt(prompt);
+    if (!cleanPrompt.length) {
+        if (completion) completion(nil, [NSError errorWithDomain:@"ApolloThemeAI" code:1 userInfo:@{NSLocalizedDescriptionKey: @"Describe the kind of theme you want first."}]);
+        return;
+    }
+    if (!ApolloThemeAIIsAvailable()) {
+        if (completion) completion(nil, [NSError errorWithDomain:@"ApolloThemeAI" code:4 userInfo:@{NSLocalizedDescriptionKey: ApolloThemeAIUnavailableMessage()}]);
+        return;
+    }
+    NSString *currentJSON = current ? ATBJSONString(current) : @"";
+    ApolloLog(@"ThemeAI: starting generation promptLength=%lu modify=%d", (unsigned long)cleanPrompt.length, instruction.length > 0);
+    [ATBBridge() generateThemeJSONWithPrompt:cleanPrompt
+                                  identifier:kATBRequestID
+                                 currentJSON:currentJSON
+                                 instruction:instruction ?: @""
+                       maximumResponseTokens:1600
+                                  onComplete:^(NSString *json, NSError *error) {
+        if (error || !json.length) {
+            if (completion) completion(nil, error ?: [NSError errorWithDomain:@"ApolloThemeAI" code:5 userInfo:@{NSLocalizedDescriptionKey: @"Couldn’t generate a usable theme from that prompt."}]);
+            return;
+        }
+        NSError *parseError = nil;
+        NSDictionary *result = ATBResultFromJSON(json, cleanPrompt, &parseError);
+        if (!result) {
+            if (completion) completion(nil, parseError);
+            return;
+        }
+        ApolloLog(@"ThemeAI: generation succeeded score=%@", result[@"validationScore"]);
+        if (completion) completion(result, nil);
+    }];
+}
+
+void ApolloThemeAIGenerateTheme(NSString *prompt, ApolloThemeAICompletion completion) {
+    ATBGenerate(prompt, nil, nil, completion);
+}
+
+void ApolloThemeAIModifyTheme(NSDictionary *themeResult, NSString *instruction, ApolloThemeAICompletion completion) {
+    NSString *prompt = themeResult[@"originalPrompt"] ?: themeResult[@"name"] ?: @"custom theme";
+    ATBGenerate(prompt, themeResult, instruction, completion);
+}
+
+void ApolloThemeAICancel(void) {
+    [ATBBridge() cancelRequest:kATBRequestID];
+}

--- a/src/ApolloThemeAISheets.h
+++ b/src/ApolloThemeAISheets.h
@@ -1,0 +1,31 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Lean, hand-built UIKit sheets for creating a theme, prompting the AI, and
+// previewing the result. Presented modally from ApolloThemeManagerViewController
+// and call back into its flows via blocks — no theme logic is duplicated here.
+// They are deliberately plain (system grouped backgrounds, an accent tint
+// passed in by the presenter); no gradients.
+
+// AI prompt sheet: multi-line prompt field, suggestion chips that FILL the
+// field (not auto-submit), a guardrails note, and Cancel / Generate.
+@interface ApolloThemeGenerateSheetViewController : UIViewController
+@property (nonatomic, strong, nullable) UIColor *accentColor;
+@property (nonatomic, copy, nullable) NSString *initialPrompt;
+@property (nonatomic, copy, nullable) void (^onGenerate)(NSString *prompt);
+@end
+
+// Lean result preview: name, description, swatch row, quality summary, and
+// Use / Edit Manually / Regenerate plus up to three suggested-tweak buttons.
+@interface ApolloThemeResultSheetViewController : UIViewController
+@property (nonatomic, strong, nullable) UIColor *accentColor;
+@property (nonatomic, copy) NSDictionary *result; // ApolloThemeAI result dict
+@property (nonatomic, copy) NSString *mode;        // "light" / "dark"
+@property (nonatomic, copy, nullable) void (^onUse)(void);
+@property (nonatomic, copy, nullable) void (^onEdit)(void);
+@property (nonatomic, copy, nullable) void (^onRegenerate)(void);
+@property (nonatomic, copy, nullable) void (^onTweak)(NSString *instruction);
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ApolloThemeAISheets.m
+++ b/src/ApolloThemeAISheets.m
@@ -1,0 +1,470 @@
+#import "ApolloThemeAISheets.h"
+#import "ApolloThemeTokens.h"
+
+#pragma mark - Shared helpers
+
+// Configure a presented VC's sheet (detents, grabber, rounded corners). Guarded
+// for iOS 15+ (UISheetPresentationController); on iOS 14 the VC just presents as
+// a normal page sheet, which is acceptable for this dev-facing flow.
+static void ATBConfigureSheet(UIViewController *vc, BOOL large) {
+    if (@available(iOS 15.0, *)) {
+        UISheetPresentationController *sheet = vc.sheetPresentationController;
+        if (sheet) {
+            sheet.detents = large ? @[UISheetPresentationControllerDetent.mediumDetent,
+                                      UISheetPresentationControllerDetent.largeDetent]
+                                  : @[UISheetPresentationControllerDetent.mediumDetent];
+            sheet.prefersGrabberVisible = YES;
+            sheet.preferredCornerRadius = 22.0;
+        }
+    }
+}
+
+// A pill-shaped suggestion/tweak chip.
+static UIButton *ATBChipButton(NSString *title, UIColor *accent) {
+    UIButton *chip = [UIButton buttonWithType:UIButtonTypeSystem];
+    [chip setTitle:title forState:UIControlStateNormal];
+    chip.titleLabel.font = [UIFont systemFontOfSize:15 weight:UIFontWeightMedium];
+    [chip setTitleColor:UIColor.labelColor forState:UIControlStateNormal];
+    chip.backgroundColor = UIColor.tertiarySystemFillColor;
+    chip.contentEdgeInsets = UIEdgeInsetsMake(8, 14, 8, 14);
+    chip.layer.cornerRadius = 16.0;
+    chip.layer.cornerCurve = kCACornerCurveContinuous;
+    chip.tintColor = accent;
+    return chip;
+}
+
+#pragma mark - Wrapping chip container
+
+// Lays out its chip subviews left-to-right, wrapping to new rows, and reports an
+// intrinsic height so it sizes correctly inside a vertical stack.
+@interface ApolloChipsView : UIView
+@property (nonatomic, copy) NSArray<NSString *> *titles;
+@property (nonatomic, strong) UIColor *accent;
+@property (nonatomic, copy) void (^onSelect)(NSString *title);
+@end
+
+@implementation ApolloChipsView {
+    NSMutableArray<UIButton *> *_chips;
+    CGFloat _contentHeight;
+    CGFloat _lastLayoutWidth;
+}
+
+- (void)setTitles:(NSArray<NSString *> *)titles {
+    _titles = [titles copy];
+    for (UIButton *chip in _chips) [chip removeFromSuperview];
+    _chips = [NSMutableArray array];
+    for (NSString *title in titles) {
+        UIButton *chip = ATBChipButton(title, self.accent ?: UIColor.systemBlueColor);
+        [chip addTarget:self action:@selector(chipTapped:) forControlEvents:UIControlEventTouchUpInside];
+        [self addSubview:chip];
+        [_chips addObject:chip];
+    }
+    _lastLayoutWidth = -1;
+    [self setNeedsLayout];
+}
+
+- (void)chipTapped:(UIButton *)sender {
+    NSString *title = [sender titleForState:UIControlStateNormal];
+    if (self.onSelect && title) self.onSelect(title);
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGFloat maxWidth = self.bounds.size.width;
+    if (maxWidth <= 0) return;
+    CGFloat spacing = 8.0, x = 0, y = 0, rowHeight = 0;
+    for (UIButton *chip in _chips) {
+        CGSize size = [chip sizeThatFits:CGSizeMake(maxWidth, CGFLOAT_MAX)];
+        if (x > 0 && x + size.width > maxWidth) { // wrap
+            x = 0;
+            y += rowHeight + spacing;
+            rowHeight = 0;
+        }
+        chip.frame = CGRectMake(x, y, size.width, size.height);
+        x += size.width + spacing;
+        rowHeight = MAX(rowHeight, size.height);
+    }
+    CGFloat newHeight = y + rowHeight;
+    if (fabs(newHeight - _contentHeight) > 0.5 || fabs(maxWidth - _lastLayoutWidth) > 0.5) {
+        _contentHeight = newHeight;
+        _lastLayoutWidth = maxWidth;
+        [self invalidateIntrinsicContentSize];
+    }
+}
+
+- (CGSize)intrinsicContentSize {
+    return CGSizeMake(UIViewNoIntrinsicMetric, _contentHeight);
+}
+
+@end
+
+#pragma mark - Generate sheet
+
+@interface ApolloThemeGenerateSheetViewController () <UITextViewDelegate>
+@end
+
+@implementation ApolloThemeGenerateSheetViewController {
+    UITextView *_promptView;
+    UILabel *_placeholder;
+    UIButton *_generateButton;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.backgroundColor = UIColor.systemGroupedBackgroundColor;
+    UIColor *accent = self.accentColor ?: UIColor.systemBlueColor;
+    self.view.tintColor = accent;
+    ATBConfigureSheet(self, YES);
+    // Open expanded — the prompt field opens the keyboard immediately, so the
+    // medium detent would be cramped.
+    if (@available(iOS 15.0, *)) {
+        self.sheetPresentationController.selectedDetentIdentifier = UISheetPresentationControllerDetentIdentifierLarge;
+    }
+
+    UILabel *title = [UILabel new];
+    title.text = @"Generate Theme";
+    title.font = [UIFont systemFontOfSize:24 weight:UIFontWeightBold];
+    title.textColor = UIColor.labelColor;
+
+    UILabel *desc = [UILabel new];
+    desc.text = @"Describe a vibe, colour palette, game, season, place, or style. Apollo AI creates a readable theme you can tweak.";
+    desc.font = [UIFont systemFontOfSize:15];
+    desc.textColor = UIColor.secondaryLabelColor;
+    desc.numberOfLines = 0;
+
+    // Prompt input (UITextView styled as a rounded field with a placeholder).
+    UIView *inputWell = [UIView new];
+    inputWell.backgroundColor = UIColor.secondarySystemGroupedBackgroundColor;
+    inputWell.layer.cornerRadius = 14.0;
+    inputWell.layer.cornerCurve = kCACornerCurveContinuous;
+
+    _promptView = [UITextView new];
+    _promptView.backgroundColor = UIColor.clearColor;
+    _promptView.font = [UIFont systemFontOfSize:17];
+    _promptView.textColor = UIColor.labelColor;
+    _promptView.delegate = self;
+    _promptView.scrollEnabled = YES;
+    _promptView.textContainerInset = UIEdgeInsetsMake(12, 10, 12, 10);
+    _promptView.text = self.initialPrompt ?: @"";
+    _promptView.returnKeyType = UIReturnKeyDefault;
+    _promptView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    _placeholder = [UILabel new];
+    _placeholder.text = @"Super Mario inspired theme with a playful dark mode";
+    _placeholder.font = [UIFont systemFontOfSize:17];
+    _placeholder.textColor = UIColor.placeholderTextColor;
+    _placeholder.numberOfLines = 0;
+    _placeholder.hidden = _promptView.text.length > 0;
+    _placeholder.translatesAutoresizingMaskIntoConstraints = NO;
+
+    [inputWell addSubview:_promptView];
+    [inputWell addSubview:_placeholder];
+    inputWell.translatesAutoresizingMaskIntoConstraints = NO;
+
+    ApolloChipsView *chips = [ApolloChipsView new];
+    chips.accent = accent;
+    chips.titles = @[@"Cozy autumn", @"OLED purple", @"Game Boy green",
+                     @"Dark synthwave", @"Rainy forest", @"Soft pastel"];
+    __weak typeof(self) weakSelf = self;
+    chips.onSelect = ^(NSString *t) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        strongSelf->_promptView.text = t;
+        strongSelf->_placeholder.hidden = YES;
+        [strongSelf->_promptView becomeFirstResponder];
+    };
+    chips.translatesAutoresizingMaskIntoConstraints = NO;
+
+    // Guardrails note (plain row, no card / gradient).
+    UIImageView *check = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"checkmark.seal.fill"]];
+    check.tintColor = UIColor.systemGreenColor;
+    check.contentMode = UIViewContentModeScaleAspectFit;
+    [check setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+    UILabel *guard = [UILabel new];
+    guard.text = @"Built-in guardrails check generated colours for contrast and long-reading comfort.";
+    guard.font = [UIFont systemFontOfSize:13];
+    guard.textColor = UIColor.secondaryLabelColor;
+    guard.numberOfLines = 0;
+    UIStackView *guardRow = [[UIStackView alloc] initWithArrangedSubviews:@[check, guard]];
+    guardRow.axis = UILayoutConstraintAxisHorizontal;
+    guardRow.spacing = 8.0;
+    guardRow.alignment = UIStackViewAlignmentTop;
+
+    UIStackView *content = [[UIStackView alloc] initWithArrangedSubviews:@[title, desc, inputWell, chips, guardRow]];
+    content.axis = UILayoutConstraintAxisVertical;
+    content.spacing = 16.0;
+    [content setCustomSpacing:10 afterView:title];
+    content.translatesAutoresizingMaskIntoConstraints = NO;
+
+    // Bottom action bar: Cancel + Generate.
+    UIButton *cancel = [UIButton buttonWithType:UIButtonTypeSystem];
+    [cancel setTitle:@"Cancel" forState:UIControlStateNormal];
+    cancel.titleLabel.font = [UIFont systemFontOfSize:17 weight:UIFontWeightSemibold];
+    cancel.backgroundColor = UIColor.secondarySystemGroupedBackgroundColor;
+    [cancel setTitleColor:UIColor.labelColor forState:UIControlStateNormal];
+    cancel.layer.cornerRadius = 14.0;
+    cancel.layer.cornerCurve = kCACornerCurveContinuous;
+    [cancel addTarget:self action:@selector(cancelTapped) forControlEvents:UIControlEventTouchUpInside];
+
+    _generateButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [_generateButton setTitle:@"Generate" forState:UIControlStateNormal];
+    _generateButton.titleLabel.font = [UIFont systemFontOfSize:17 weight:UIFontWeightSemibold];
+    _generateButton.backgroundColor = accent;
+    [_generateButton setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
+    _generateButton.layer.cornerRadius = 14.0;
+    _generateButton.layer.cornerCurve = kCACornerCurveContinuous;
+    [_generateButton addTarget:self action:@selector(generateTapped) forControlEvents:UIControlEventTouchUpInside];
+
+    UIStackView *buttons = [[UIStackView alloc] initWithArrangedSubviews:@[cancel, _generateButton]];
+    buttons.axis = UILayoutConstraintAxisHorizontal;
+    buttons.spacing = 12.0;
+    buttons.distribution = UIStackViewDistributionFill;
+    buttons.translatesAutoresizingMaskIntoConstraints = NO;
+    [cancel.widthAnchor constraintEqualToAnchor:_generateButton.widthAnchor multiplier:0.5].active = YES;
+
+    // Scroll the content so a tall prompt + chips never get trapped behind the
+    // keyboard or the bottom action bar on small devices.
+    UIScrollView *scroll = [UIScrollView new];
+    scroll.translatesAutoresizingMaskIntoConstraints = NO;
+    scroll.showsVerticalScrollIndicator = NO;
+    scroll.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
+    [self.view addSubview:scroll];
+    [scroll addSubview:content];
+    [self.view addSubview:buttons];
+
+    UILayoutGuide *guide = self.view.safeAreaLayoutGuide;
+    UILayoutGuide *contentGuide = scroll.contentLayoutGuide;
+    [NSLayoutConstraint activateConstraints:@[
+        [scroll.topAnchor constraintEqualToAnchor:guide.topAnchor],
+        [scroll.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [scroll.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+
+        // Vertical follows the scroll content; horizontal is pinned to the safe
+        // area so width is fixed (vertical-only scrolling).
+        [content.topAnchor constraintEqualToAnchor:contentGuide.topAnchor constant:24],
+        [content.bottomAnchor constraintEqualToAnchor:contentGuide.bottomAnchor constant:-16],
+        [content.leadingAnchor constraintEqualToAnchor:guide.leadingAnchor constant:20],
+        [content.trailingAnchor constraintEqualToAnchor:guide.trailingAnchor constant:-20],
+
+        [_promptView.topAnchor constraintEqualToAnchor:inputWell.topAnchor],
+        [_promptView.leadingAnchor constraintEqualToAnchor:inputWell.leadingAnchor],
+        [_promptView.trailingAnchor constraintEqualToAnchor:inputWell.trailingAnchor],
+        [_promptView.bottomAnchor constraintEqualToAnchor:inputWell.bottomAnchor],
+        [inputWell.heightAnchor constraintEqualToConstant:96],
+        [_placeholder.topAnchor constraintEqualToAnchor:inputWell.topAnchor constant:14],
+        [_placeholder.leadingAnchor constraintEqualToAnchor:inputWell.leadingAnchor constant:14],
+        [_placeholder.trailingAnchor constraintEqualToAnchor:inputWell.trailingAnchor constant:-14],
+
+        [buttons.leadingAnchor constraintEqualToAnchor:guide.leadingAnchor constant:20],
+        [buttons.trailingAnchor constraintEqualToAnchor:guide.trailingAnchor constant:-20],
+        [scroll.bottomAnchor constraintEqualToAnchor:buttons.topAnchor constant:-12],
+        [buttons.heightAnchor constraintEqualToConstant:50],
+        [cancel.heightAnchor constraintEqualToConstant:50],
+    ]];
+    // Keep the action bar above the keyboard (the prompt field opens it on
+    // appear). keyboardLayoutGuide tracks the safe-area bottom when hidden, so
+    // this works in both states; fall back to the safe area below iOS 15.
+    if (@available(iOS 15.0, *)) {
+        [buttons.bottomAnchor constraintEqualToAnchor:self.view.keyboardLayoutGuide.topAnchor constant:-12].active = YES;
+    } else {
+        [buttons.bottomAnchor constraintEqualToAnchor:guide.bottomAnchor constant:-12].active = YES;
+    }
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    [_promptView becomeFirstResponder];
+}
+
+- (void)textViewDidChange:(UITextView *)textView {
+    _placeholder.hidden = textView.text.length > 0;
+}
+
+- (void)cancelTapped {
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)generateTapped {
+    NSString *prompt = [_promptView.text stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    void (^cb)(NSString *) = self.onGenerate;
+    [self dismissViewControllerAnimated:YES completion:^{ if (cb) cb(prompt ?: @""); }];
+}
+
+@end
+
+#pragma mark - Result sheet
+
+@implementation ApolloThemeResultSheetViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.backgroundColor = UIColor.systemGroupedBackgroundColor;
+    UIColor *accent = self.accentColor ?: UIColor.systemBlueColor;
+    self.view.tintColor = accent;
+    ATBConfigureSheet(self, YES);
+
+    NSDictionary *result = self.result ?: @{};
+    NSString *mode = self.mode.length ? self.mode : @"dark";
+
+    UILabel *title = [UILabel new];
+    title.text = [result[@"name"] length] ? result[@"name"] : @"Generated Theme";
+    title.font = [UIFont systemFontOfSize:24 weight:UIFontWeightBold];
+    title.textColor = UIColor.labelColor;
+    title.numberOfLines = 2;
+
+    UILabel *desc = [UILabel new];
+    desc.text = [result[@"shortDescription"] isKindOfClass:NSString.class] ? result[@"shortDescription"] : @"Generated from your prompt.";
+    desc.font = [UIFont systemFontOfSize:15];
+    desc.textColor = UIColor.secondaryLabelColor;
+    desc.numberOfLines = 0;
+
+    UIStackView *content = [[UIStackView alloc] init];
+    content.axis = UILayoutConstraintAxisVertical;
+    content.spacing = 16.0;
+    content.translatesAutoresizingMaskIntoConstraints = NO;
+    [content addArrangedSubview:title];
+    [content setCustomSpacing:8 afterView:title];
+    [content addArrangedSubview:desc];
+
+    // Swatch row, in role order.
+    NSDictionary *colors = [result[@"colors"] isKindOfClass:NSDictionary.class] ? result[@"colors"] : @{};
+    NSArray *roleOrder = @[kApolloThemeInputAccent, kApolloThemeInputCard, kApolloThemeInputBackground,
+                           kApolloThemeInputRaised, kApolloThemeInputBars, kApolloThemeInputSeparator, kApolloThemeInputText];
+    UIStackView *swatches = [[UIStackView alloc] init];
+    swatches.axis = UILayoutConstraintAxisHorizontal;
+    swatches.spacing = 8.0;
+    swatches.distribution = UIStackViewDistributionFillEqually;
+    for (NSString *role in roleOrder) {
+        NSString *hex = colors[[NSString stringWithFormat:@"%@.%@", role, mode]];
+        UIView *swatch = [UIView new];
+        uint32_t rgb;
+        swatch.backgroundColor = ApolloThemeParseHex(hex, &rgb) ? ApolloThemeUIColorFromRGB(rgb) : UIColor.tertiarySystemFillColor;
+        swatch.layer.cornerRadius = 8.0;
+        swatch.layer.cornerCurve = kCACornerCurveContinuous;
+        swatch.layer.borderWidth = 1.0;
+        swatch.layer.borderColor = [UIColor.separatorColor colorWithAlphaComponent:0.5].CGColor;
+        [swatch.heightAnchor constraintEqualToConstant:36].active = YES;
+        [swatches addArrangedSubview:swatch];
+    }
+    [content addArrangedSubview:swatches];
+
+    // Quality line.
+    NSDictionary *validation = [result[@"validation"] isKindOfClass:NSDictionary.class] ? result[@"validation"] : @{};
+    BOOL passed = [validation[@"passed"] boolValue];
+    NSString *qualityLabel = [result[@"qualityLabel"] isKindOfClass:NSString.class] ? result[@"qualityLabel"] : @"Good";
+    NSString *qualitySummary = [result[@"qualitySummary"] isKindOfClass:NSString.class] ? result[@"qualitySummary"] : @"Readable and ready to tweak.";
+    UIImageView *qIcon = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:(passed ? @"checkmark.seal.fill" : @"exclamationmark.triangle.fill")]];
+    qIcon.tintColor = passed ? UIColor.systemGreenColor : UIColor.systemOrangeColor;
+    qIcon.contentMode = UIViewContentModeScaleAspectFit;
+    [qIcon setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+    UILabel *qLabel = [UILabel new];
+    qLabel.numberOfLines = 0;
+    NSMutableAttributedString *q = [[NSMutableAttributedString alloc]
+        initWithString:[NSString stringWithFormat:@"%@ — ", qualityLabel]
+            attributes:@{NSFontAttributeName: [UIFont systemFontOfSize:14 weight:UIFontWeightSemibold],
+                         NSForegroundColorAttributeName: UIColor.labelColor}];
+    [q appendAttributedString:[[NSAttributedString alloc] initWithString:qualitySummary
+        attributes:@{NSFontAttributeName: [UIFont systemFontOfSize:14],
+                     NSForegroundColorAttributeName: UIColor.secondaryLabelColor}]];
+    qLabel.attributedText = q;
+    UIStackView *qRow = [[UIStackView alloc] initWithArrangedSubviews:@[qIcon, qLabel]];
+    qRow.axis = UILayoutConstraintAxisHorizontal;
+    qRow.spacing = 8.0;
+    qRow.alignment = UIStackViewAlignmentTop;
+    [content addArrangedSubview:qRow];
+
+    // Up to three suggested-tweak chips.
+    NSArray *tweaks = [result[@"suggestedTweaks"] isKindOfClass:NSArray.class] ? result[@"suggestedTweaks"] : @[];
+    NSMutableArray<NSString *> *tweakTitles = [NSMutableArray array];
+    NSMutableArray<NSString *> *tweakInstructions = [NSMutableArray array];
+    for (NSDictionary *tweak in tweaks) {
+        if (![tweak isKindOfClass:NSDictionary.class]) continue;
+        NSString *t = [tweak[@"title"] isKindOfClass:NSString.class] ? tweak[@"title"] : nil;
+        NSString *ins = [tweak[@"instruction"] isKindOfClass:NSString.class] ? tweak[@"instruction"] : nil;
+        if (!t.length || !ins.length) continue;
+        [tweakTitles addObject:t];
+        [tweakInstructions addObject:ins];
+        if (tweakTitles.count >= 3) break;
+    }
+    if (tweakTitles.count) {
+        ApolloChipsView *tweakChips = [ApolloChipsView new];
+        tweakChips.accent = accent;
+        tweakChips.titles = tweakTitles;
+        __weak typeof(self) weakSelf = self;
+        tweakChips.onSelect = ^(NSString *t) {
+            NSUInteger idx = [tweakTitles indexOfObject:t];
+            if (idx == NSNotFound) return;
+            NSString *ins = tweakInstructions[idx];
+            void (^cb)(NSString *) = weakSelf.onTweak;
+            [weakSelf dismissViewControllerAnimated:YES completion:^{ if (cb) cb(ins); }];
+        };
+        UILabel *tweakHeader = [UILabel new];
+        tweakHeader.text = @"Quick refinements";
+        tweakHeader.font = [UIFont systemFontOfSize:13 weight:UIFontWeightSemibold];
+        tweakHeader.textColor = UIColor.secondaryLabelColor;
+        [content addArrangedSubview:tweakHeader];
+        [content setCustomSpacing:8 afterView:tweakHeader];
+        [content addArrangedSubview:tweakChips];
+    }
+
+    // Primary / secondary actions.
+    UIButton *use = [self filledButton:@"Use Theme" accent:accent action:@selector(useTapped)];
+    UIStackView *secondary = [[UIStackView alloc] initWithArrangedSubviews:@[
+        [self tintedButton:@"Edit Manually" accent:accent action:@selector(editTapped)],
+        [self tintedButton:@"Regenerate" accent:accent action:@selector(regenerateTapped)],
+    ]];
+    secondary.axis = UILayoutConstraintAxisHorizontal;
+    secondary.spacing = 12.0;
+    secondary.distribution = UIStackViewDistributionFillEqually;
+
+    UIStackView *actions = [[UIStackView alloc] initWithArrangedSubviews:@[use, secondary]];
+    actions.axis = UILayoutConstraintAxisVertical;
+    actions.spacing = 12.0;
+    actions.translatesAutoresizingMaskIntoConstraints = NO;
+
+    [self.view addSubview:content];
+    [self.view addSubview:actions];
+    UILayoutGuide *guide = self.view.safeAreaLayoutGuide;
+    [NSLayoutConstraint activateConstraints:@[
+        [content.topAnchor constraintEqualToAnchor:guide.topAnchor constant:24],
+        [content.leadingAnchor constraintEqualToAnchor:guide.leadingAnchor constant:20],
+        [content.trailingAnchor constraintEqualToAnchor:guide.trailingAnchor constant:-20],
+
+        [actions.leadingAnchor constraintEqualToAnchor:guide.leadingAnchor constant:20],
+        [actions.trailingAnchor constraintEqualToAnchor:guide.trailingAnchor constant:-20],
+        [actions.bottomAnchor constraintEqualToAnchor:guide.bottomAnchor constant:-12],
+        [actions.topAnchor constraintGreaterThanOrEqualToAnchor:content.bottomAnchor constant:16],
+        [use.heightAnchor constraintEqualToConstant:50],
+    ]];
+}
+
+- (UIButton *)filledButton:(NSString *)t accent:(UIColor *)accent action:(SEL)action {
+    UIButton *b = [UIButton buttonWithType:UIButtonTypeSystem];
+    [b setTitle:t forState:UIControlStateNormal];
+    b.titleLabel.font = [UIFont systemFontOfSize:17 weight:UIFontWeightSemibold];
+    b.backgroundColor = accent;
+    [b setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
+    b.layer.cornerRadius = 14.0;
+    b.layer.cornerCurve = kCACornerCurveContinuous;
+    [b addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
+    return b;
+}
+
+- (UIButton *)tintedButton:(NSString *)t accent:(UIColor *)accent action:(SEL)action {
+    UIButton *b = [UIButton buttonWithType:UIButtonTypeSystem];
+    [b setTitle:t forState:UIControlStateNormal];
+    b.titleLabel.font = [UIFont systemFontOfSize:16 weight:UIFontWeightSemibold];
+    b.backgroundColor = UIColor.secondarySystemGroupedBackgroundColor;
+    [b setTitleColor:accent forState:UIControlStateNormal];
+    b.layer.cornerRadius = 14.0;
+    b.layer.cornerCurve = kCACornerCurveContinuous;
+    [b.heightAnchor constraintEqualToConstant:48].active = YES;
+    [b addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
+    return b;
+}
+
+- (void)useTapped { void (^cb)(void) = self.onUse; [self dismissViewControllerAnimated:YES completion:^{ if (cb) cb(); }]; }
+- (void)editTapped { void (^cb)(void) = self.onEdit; [self dismissViewControllerAnimated:YES completion:^{ if (cb) cb(); }]; }
+- (void)regenerateTapped { void (^cb)(void) = self.onRegenerate; [self dismissViewControllerAnimated:YES completion:^{ if (cb) cb(); }]; }
+
+@end

--- a/src/ApolloThemeManagerViewController.m
+++ b/src/ApolloThemeManagerViewController.m
@@ -3,6 +3,8 @@
 #import "ApolloThemeStore.h"
 #import "ApolloThemeCompiler.h"
 #import "ApolloThemeRuntime.h"
+#import "ApolloThemeAI.h"
+#import "ApolloThemeAISheets.h"
 #import "ApolloCommon.h"
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
@@ -241,10 +243,15 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESGenerate, ESPreview, ESApply, 
     switch (section) {
         case LSEnable:  return 1;
         case LSThemes:  return MAX((NSInteger)[[self store] allThemes].count, 0);
-        case LSActions: return 2; // New, Import
+        case LSActions: return (self.aiRowVisible ? 3 : 2); // [Generate with AI], New, Import
     }
     return 0;
 }
+
+// Row 0 of LSActions is "Generate with AI", shown only when the on-device
+// model is actually available — mirrors v1's ApolloNewThemeSheetViewController
+// hiding its AI card rather than showing a row that always errors on tap.
+- (BOOL)aiRowVisible { return ApolloThemeAIIsAvailable(); }
 
 - (NSString *)tableView:(UITableView *)tv titleForHeaderInSection:(NSInteger)section {
     if (self.editingThemeID) {
@@ -331,9 +338,19 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESGenerate, ESPreview, ESApply, 
         cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
         return cell;
     }
-    // Actions
+    // Actions: [Generate with AI], New Theme, Import Theme…
     UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
-    if (ip.row == 0) {
+    NSInteger row = ip.row;
+    if (self.aiRowVisible) {
+        if (row == 0) {
+            cell.textLabel.text = @"Generate with AI…";
+            cell.imageView.image = [UIImage systemImageNamed:@"sparkles"];
+            cell.textLabel.textColor = self.view.tintColor;
+            return cell;
+        }
+        row -= 1;
+    }
+    if (row == 0) {
         cell.textLabel.text = @"New Theme";
         cell.imageView.image = [UIImage systemImageNamed:@"plus.circle"];
     } else {
@@ -485,7 +502,12 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESGenerate, ESPreview, ESApply, 
         return;
     }
     if (ip.section == LSActions) {
-        if (ip.row == 0) [self newThemeTapped];
+        NSInteger row = ip.row;
+        if (self.aiRowVisible) {
+            if (row == 0) { [self presentAIThemePromptSheetWithInitialPrompt:nil]; return; }
+            row -= 1;
+        }
+        if (row == 0) [self newThemeTapped];
         else [self importTapped];
     }
 }
@@ -772,6 +794,139 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESGenerate, ESPreview, ESApply, 
                                                       preferredStyle:UIAlertControllerStyleAlert];
     [a addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
     [self presentViewController:a animated:YES completion:nil];
+}
+
+- (void)presentAlertWithTitle:(NSString *)title message:(NSString *)message {
+    UIAlertController *a = [UIAlertController alertControllerWithTitle:title
+                                                                 message:message
+                                                          preferredStyle:UIAlertControllerStyleAlert];
+    [a addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+    [self presentViewController:a animated:YES completion:nil];
+}
+
+// ===========================================================================
+// AI theme generation
+// ===========================================================================
+
+// ApolloThemeAI's result `colors` is a flat "key.mode" -> hex dict keyed on
+// ApolloThemeInputKeys() — the same shape the v2 Store persists, just nested
+// differently. Converts directly, no role-name translation needed.
+- (NSDictionary *)v2InputFromAIColors:(NSDictionary<NSString *, NSString *> *)colors {
+    NSMutableDictionary *input = [NSMutableDictionary dictionary];
+    for (NSString *mode in @[@"light", @"dark"]) {
+        NSMutableDictionary *modeInput = [NSMutableDictionary dictionary];
+        for (NSString *key in ApolloThemeInputKeys()) {
+            NSString *hex = colors[[NSString stringWithFormat:@"%@.%@", key, mode]];
+            if (hex.length) modeInput[key] = hex;
+        }
+        input[mode] = modeInput;
+    }
+    return input;
+}
+
+- (void)presentAIThemePromptSheetWithInitialPrompt:(NSString *)initialPrompt {
+    if (!ApolloThemeAIIsAvailable()) {
+        [self presentAlertWithTitle:@"AI Theme Generation Unavailable"
+                             message:ApolloThemeAIUnavailableMessage()];
+        return;
+    }
+    ApolloThemeGenerateSheetViewController *sheet = [[ApolloThemeGenerateSheetViewController alloc] init];
+    sheet.accentColor = [self themeAccentColor];
+    sheet.initialPrompt = initialPrompt;
+    __weak typeof(self) weakSelf = self;
+    sheet.onGenerate = ^(NSString *prompt) { [weakSelf generateAIThemeFromPrompt:prompt]; };
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+- (void)generateAIThemeFromPrompt:(NSString *)prompt {
+    NSString *trimmed = [prompt stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    if (!trimmed.length) {
+        [self presentAlertWithTitle:@"Describe a Theme"
+                             message:@"Describe the kind of theme you want first."];
+        return;
+    }
+    UIAlertController *loading =
+        [UIAlertController alertControllerWithTitle:@"Creating Theme…"
+                                            message:@"Choosing readable colours and checking contrast."
+                                     preferredStyle:UIAlertControllerStyleAlert];
+    [loading addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel
+                                              handler:^(UIAlertAction *action) {
+        ApolloThemeAICancel();
+    }]];
+    [self presentViewController:loading animated:YES completion:nil];
+    ApolloThemeAIGenerateTheme(trimmed, ^(NSDictionary *result, NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [loading dismissViewControllerAnimated:YES completion:^{
+                if (error || !result) {
+                    [self presentAlertWithTitle:@"Couldn’t Generate Theme"
+                                         message:error.localizedDescription ?: @"Try a different description, or start from scratch."];
+                    return;
+                }
+                [self presentGeneratedThemeResult:result];
+            }];
+        });
+    });
+}
+
+- (void)presentGeneratedThemeResult:(NSDictionary *)result {
+    ApolloThemeResultSheetViewController *sheet = [[ApolloThemeResultSheetViewController alloc] init];
+    sheet.accentColor = [self themeAccentColor];
+    sheet.result = result;
+    sheet.mode = ApolloThemeModeKey(CurrentAppearanceMode(self.traitCollection));
+    __weak typeof(self) weakSelf = self;
+    sheet.onUse = ^{ [weakSelf saveGeneratedThemeResult:result apply:YES edit:NO]; };
+    sheet.onEdit = ^{ [weakSelf saveGeneratedThemeResult:result apply:NO edit:YES]; };
+    sheet.onRegenerate = ^{ [weakSelf generateAIThemeFromPrompt:result[@"originalPrompt"] ?: @""]; };
+    sheet.onTweak = ^(NSString *instruction) { [weakSelf modifyGeneratedThemeResult:result instruction:instruction]; };
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+- (void)modifyGeneratedThemeResult:(NSDictionary *)result instruction:(NSString *)instruction {
+    UIAlertController *loading =
+        [UIAlertController alertControllerWithTitle:@"Updating Theme…"
+                                            message:@"Applying the tweak and checking contrast."
+                                     preferredStyle:UIAlertControllerStyleAlert];
+    [loading addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel
+                                              handler:^(UIAlertAction *action) {
+        ApolloThemeAICancel();
+    }]];
+    [self presentViewController:loading animated:YES completion:nil];
+    ApolloThemeAIModifyTheme(result, instruction, ^(NSDictionary *updated, NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [loading dismissViewControllerAnimated:YES completion:^{
+                if (error || !updated) {
+                    [self presentAlertWithTitle:@"Couldn’t Update Theme"
+                                         message:error.localizedDescription ?: @"Try a different tweak, or edit manually."];
+                    return;
+                }
+                [self presentGeneratedThemeResult:updated];
+            }];
+        });
+    });
+}
+
+- (void)saveGeneratedThemeResult:(NSDictionary *)result apply:(BOOL)apply edit:(BOOL)edit {
+    ApolloLog(@"ThemeUI: saving AI-generated theme '%@' apply=%d edit=%d", result[@"name"], apply, edit);
+    ApolloThemeStore *store = [self store];
+    NSDictionary *input = [self v2InputFromAIColors:result[@"colors"] ?: @{}];
+    // The AI always produces text/mutedText/separator (they're required fields
+    // in the guided-generation schema), so Advanced is on by default — these are
+    // deliberately art-directed, not auto-derived, values.
+    NSString *themeID = [store createThemeNamed:result[@"name"]
+                                          input:input
+                                        variant:ApolloThemeVariantBalanced
+                         advancedOptionsEnabled:YES
+                                    generation:@{ @"source": @"ai",
+                                                  @"prompt": result[@"originalPrompt"] ?: @"",
+                                                  @"qualityLabel": result[@"qualityLabel"] ?: @"",
+                                                  @"validationScore": result[@"validationScore"] ?: @0 }];
+    if (apply) {
+        store.activeThemeID = themeID;
+        if ([store runtimeDisabledDueToCrash]) [store clearCrashDisable];
+        ApolloThemeRuntimeEnable();
+    }
+    [self.tableView reloadData];
+    if (edit) [self openEditorForThemeID:themeID];
 }
 
 @end


### PR DESCRIPTION
## Summary

Stacked on #558. Brings back AI-assisted theme generation (guided on-device model palettes, originally added on this branch's history and reverted out of #558 to keep that PR focused) — reintegrated onto the v2 architecture rather than ported as-is.

## What changed vs. the original v1 implementation

- **`ApolloFoundationModels.swift`**: the `@Generable` palette schema's field names now match v2's input keys 1:1 (`accent`/`background`/`card`/`raised`/`bars`/`separator`/`mutedText`/`text`). v1 had a confusing indirection where the Swift field `background` actually meant the card/row colour and `secondaryBackground` meant the page background (a leftover of v1's own role-naming). The model never sees Swift identifiers, only the `@Guide` description strings, so this rename is a pure clarity fix with zero effect on generation quality.
- **`ApolloThemeAI.m`**: ported off `ApolloThemeBuilder`'s v1 role-key system onto `ApolloThemeTokens`' v2 input keys throughout. Reuses v2's shared hex/contrast primitives (`ApolloThemeParseHex`/`HexFromRGB`/`ContrastRatio`) instead of duplicating them — only the genuinely AI-specific logic remains local: the worst-case-across-all-surfaces text repair search and the quality-scoring heuristic, neither of which has a v2 equivalent yet.
- **`ApolloThemeAISheets.m`**: kept almost unchanged — it was already presenter-agnostic, driven entirely by block callbacks, per its own header comment. Only the swatch role order and the hex→color helper needed retargeting to v2 keys/primitives. Dropped the unused `ApolloNewThemeSheetViewController` (the old 3-choice "New Theme" entry sheet): v2's list screen already has working New Theme / Import Theme rows covering two of its three destinations, so restoring a whole replacement entry sheet wasn't worth the risk — a single new row was enough.
- **`ApolloThemeManagerViewController.m`**: new "Generate with AI…" row in the list screen's Actions section, hidden when `ApolloThemeAIIsAvailable()` is `NO` (matching v1's precedent of hiding the option rather than showing one that always errors). Drives the prompt → result → Use/Edit/Regenerate/Tweak flow. A generated theme's colours convert directly into a v2 input dict (same key names now, so this is a straight copy, not a translation) and save via `ApolloThemeStore.createThemeNamed:...`, with `advancedOptionsEnabled` always `YES` since the AI always produces deliberately art-directed text/separator colours rather than auto-derived ones. Provenance is recorded in the schema's existing `generation` field (`{"source": "ai", "prompt": ..., "qualityLabel": ..., "validationScore": ...}`) — that field already existed in v2's schema for exactly this purpose but nothing populated it until now.
- **`Makefile`**: re-adds `ApolloThemeAI.m`/`ApolloThemeAISheets.m` to the build and restores the `FoundationModelsMacros` plugin-path flag the `@Generable`/`@Guide` macros need when building Swift against the copied `$THEOS/sdks` SDK (outside the platform dir where swiftc looks for it by default).

## Test plan

- [x] Clean simulator build
- [x] Launched in Device Hub (iOS 27 sim), tweak hooks confirmed via `apollofix` log, no crashes
- [ ] Manual click-through: Generate with AI → prompt → result sheet → Use/Edit/Regenerate/Tweak, on a device/sim with Apple Intelligence actually available (this dev simulator doesn't have it, so the row correctly hides rather than erroring — verified via the availability gate, not visually)
- [ ] Confirm a generated theme's colours look correct end-to-end (advanced text/separator overrides actually applied) and its `generation` provenance is visible/inspectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)