### PR TITLE
Web JSON keyless mode: session reliability, keyless uploads, composer + chat fixes

### DIFF
--- a/src/ApolloChatsFilter.xm
+++ b/src/ApolloChatsFilter.xm
@@ -17,6 +17,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloState.h"
+#import "ApolloWebJSON.h" // ApolloWebJSONHasUsableSession — Direct Chat row hidden in keyless mode
 #import "ApolloUserProfileCache.h"
 #import "ApolloSubredditInfoCache.h"
 #import "ApolloSubredditCustomIconCache.h"
@@ -34,6 +35,17 @@ static NSInteger sMessagesRow = -1;         // detected row index of "Messages" 
 static const BOOL sDirectChatRowEnabled = YES;
 static BOOL sNextInboxIsChatFilter = NO;    // armed when the Direct Chat row is tapped
 static char kChatFilterKey;                 // on InboxViewController: this list is chat-filtered
+
+// Whether the Direct Chat row should exist for the ACTIVE account right now.
+// Reddit's web JSON API omits the chat-bridge t4 messages entirely under
+// cookie auth (verified live: /message/messages.json returns zero children on
+// a session whose OAuth counterpart has chats), so in API-Key-Free mode the
+// row would only ever open an empty list. Hide it for cookie accounts; OAuth
+// accounts keep it. Re-evaluated per table callback, so it tracks account
+// switches whenever the Boxes list reloads.
+static BOOL ApolloDirectChatRowActive(void) {
+    return sDirectChatRowEnabled && !ApolloWebJSONHasUsableSession();
+}
 
 #pragma mark - helpers
 
@@ -115,9 +127,9 @@ static void ApolloWarnIfUnhandledRowDelegates(id vc) {
 %hook _TtC6Apollo23InboxListViewController
 
 - (long long)tableView:(UITableView *)tableView numberOfRowsInSection:(long long)section {
-    if (sDirectChatRowEnabled) ApolloWarnIfUnhandledRowDelegates(self);   // one-shot future-proofing canary
+    if (ApolloDirectChatRowActive()) ApolloWarnIfUnhandledRowDelegates(self);   // one-shot future-proofing canary
     long long n = %orig;
-    if (sDirectChatRowEnabled && sMessagesSection >= 0 && section == sMessagesSection) {
+    if (ApolloDirectChatRowActive() && sMessagesSection >= 0 && section == sMessagesSection) {
         n += 1;   // + our Direct Chat row
     }
     return n;
@@ -133,7 +145,7 @@ static NSInteger ApolloRealMessagesRow(NSInteger displayedRow) {
 }
 
 - (id)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (!sDirectChatRowEnabled) return %orig;   // Direct Chat row disabled — leave Boxes untouched
+    if (!ApolloDirectChatRowActive()) return %orig;   // Direct Chat row disabled / keyless — leave Boxes untouched
     // Detection pass: until we know which section/row holds "Messages", just observe.
     if (sMessagesSection < 0) {
         UITableViewCell *cell = %orig;
@@ -169,7 +181,7 @@ static NSInteger ApolloRealMessagesRow(NSInteger displayedRow) {
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (sDirectChatRowEnabled && sMessagesSection >= 0 && indexPath.section == sMessagesSection) {
+    if (ApolloDirectChatRowActive() && sMessagesSection >= 0 && indexPath.section == sMessagesSection) {
         NSInteger realRow = ApolloRealMessagesRow(indexPath.row);
         if (realRow < 0) {
             ChatsFilterLog(@"Direct Chat tapped -> opening filtered messages list");
@@ -197,7 +209,7 @@ static NSInteger ApolloRealMessagesRow(NSInteger displayedRow) {
 // one. Map our displayed index path back to Apollo's real row; the Direct Chat row borrows the
 // Messages row's height. (Raised by @nickclyde in review.)
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (sDirectChatRowEnabled && sMessagesSection >= 0 && indexPath.section == sMessagesSection) {
+    if (ApolloDirectChatRowActive() && sMessagesSection >= 0 && indexPath.section == sMessagesSection) {
         NSInteger realRow = ApolloRealMessagesRow(indexPath.row);
         if (realRow < 0) realRow = sMessagesRow;   // Direct Chat row -> same height as the Messages row
         return %orig(tableView, [NSIndexPath indexPathForRow:realRow inSection:sMessagesSection]);

--- a/src/ApolloImageUploadHost.xm
+++ b/src/ApolloImageUploadHost.xm
@@ -28,6 +28,7 @@ void ApolloChatClearImageUpload(void);
 }
 #endif
 #import "ApolloWebJSON.h"
+#import "ApolloWebSessionStore.h"
 #import "Defaults.h"
 #import "fishhook.h"
 
@@ -2717,7 +2718,9 @@ static BOOL ApolloShouldUseCookieRedditUpload(NSURLRequest *request) {
     if (!ApolloIsImgurImageUploadRequest(request)) return NO;
     if (![ApolloRedditUploadBearerToken() isEqualToString:ApolloWebJSONSyntheticBearerToken]) return NO;
     if (!ApolloWebJSONHasUsableSession()) return NO;
-    if (sWebSessionModhash.length == 0) return NO;
+    // Per-account session (#505) — the legacy sWebSessionModhash global is
+    // migration scratch and stays empty for post-refactor logins.
+    if (ApolloActiveWebSession().modhash.length == 0) return NO;
     NSString *mimeType = ApolloMediaMIMETypeForFilename(nil, [request valueForHTTPHeaderField:@"Content-Type"]);
     if (ApolloMediaMIMETypeIsVideo(mimeType)) return NO;
     if (ApolloMediaComposerRecentlyHadSelectedVideoContextForUpload()) return NO;
@@ -2831,13 +2834,24 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
         if (videoContext) ApolloMediaComposerCompleteVideoUploadContext(videoContext, YES, @"media-upload-success");
         completeSyntheticUpload();
     };
+    // Resolve the active account's per-account session once so the cookie and
+    // modhash can't come from two different accounts if a switch races the
+    // upload. A nil entry (account switched away mid-flight) fails fast rather
+    // than making a doomed request with the synthetic bearer.
+    ApolloWebSessionEntry *webSession = cookieMode ? ApolloActiveWebSession() : nil;
+    if (cookieMode && webSession.cookieHeader.length == 0) {
+        ApolloLog(@"[RedditUpload] Cookie mode requested but no active web session — aborting upload");
+        completionHandler(nil, nil, [NSError errorWithDomain:@"ApolloRedditMediaUpload" code:54
+            userInfo:@{NSLocalizedDescriptionKey: @"No active web session for the posting account — try again after switching back to it"}]);
+        return;
+    }
     if (mediaFileURL) {
         attempt.mediaOperation = cookieMode
-            ? ApolloUploadMediaFileToRedditViaCookieCancellable(mediaFileURL, filename, mimeType, sWebSessionCookieHeader, sWebSessionModhash, userAgent, progressHandler, mediaCompletion)
+            ? ApolloUploadMediaFileToRedditViaCookieCancellable(mediaFileURL, filename, mimeType, webSession.cookieHeader, webSession.modhash, userAgent, progressHandler, mediaCompletion)
             : ApolloUploadMediaFileToRedditCancellable(mediaFileURL, filename, mimeType, token, userAgent, progressHandler, mediaCompletion);
     } else {
         attempt.mediaOperation = cookieMode
-            ? ApolloUploadMediaDataToRedditViaCookieCancellable(mediaData, filename, mimeType, sWebSessionCookieHeader, sWebSessionModhash, userAgent, progressHandler, mediaCompletion)
+            ? ApolloUploadMediaDataToRedditViaCookieCancellable(mediaData, filename, mimeType, webSession.cookieHeader, webSession.modhash, userAgent, progressHandler, mediaCompletion)
             : ApolloUploadMediaDataToRedditCancellable(mediaData, filename, mimeType, token, userAgent, progressHandler, mediaCompletion);
     }
 }

--- a/src/ApolloImageUploadHost.xm
+++ b/src/ApolloImageUploadHost.xm
@@ -290,7 +290,7 @@ void ApolloRedditCaptureBearerTokenFromAuthorization(NSString *authorization, NS
     // requests without real keys; it's a placeholder, not a usable oauth token,
     // so don't let it overwrite a real captured token (the chokepoint replaces
     // it with the cookie before it reaches Reddit anyway).
-    if ([token isEqualToString:ApolloWebJSONSyntheticBearerToken]) return;
+    if (ApolloWebJSONBearerIsSynthetic(token)) return;
 
     sLatestRedditBearerToken = [token copy];
     ApolloLog(@"[RedditUpload] Captured Reddit bearer token from %@", source ?: @"unknown source");
@@ -2702,7 +2702,7 @@ static NSString *ApolloRedditUploadBearerToken(void) {
     NSString *composeToken = ApolloMediaComposerActivePostingBearerToken();
     if (composeToken.length > 0) return composeToken;
     if (sLatestRedditBearerToken.length > 0) return [sLatestRedditBearerToken copy];
-    if (ApolloWebJSONHasUsableSession()) return ApolloWebJSONSyntheticBearerToken;
+    if (ApolloWebJSONHasUsableSession()) return ApolloWebJSONSyntheticBearerTokenForUsername(ApolloActiveWebSessionUsername());
     return nil;
 }
 
@@ -2716,7 +2716,7 @@ static NSString *ApolloRedditUploadBearerToken(void) {
 // when a video upload context is/was in flight. Videos keep falling back to Imgur.
 static BOOL ApolloShouldUseCookieRedditUpload(NSURLRequest *request) {
     if (!ApolloIsImgurImageUploadRequest(request)) return NO;
-    if (![ApolloRedditUploadBearerToken() isEqualToString:ApolloWebJSONSyntheticBearerToken]) return NO;
+    if (!ApolloWebJSONBearerIsSynthetic(ApolloRedditUploadBearerToken())) return NO;
     if (!ApolloWebJSONHasUsableSession()) return NO;
     // Per-account session (#505) — the legacy sWebSessionModhash global is
     // migration scratch and stays empty for post-refactor logins.
@@ -2741,10 +2741,10 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
     NSString *token = ApolloRedditUploadBearerToken();
     // Keyless Web JSON: no real bearer (just the synthetic placeholder), so the
     // lease goes to the old-reddit web endpoint with cookie + modhash instead.
-    BOOL cookieMode = [token isEqualToString:ApolloWebJSONSyntheticBearerToken];
+    BOOL cookieMode = ApolloWebJSONBearerIsSynthetic(token);
     if (composeToken.length > 0 && ![composeToken isEqualToString:sLatestRedditBearerToken]) {
         ApolloLog(@"[RedditUpload] Using temporary posting account token for upload (differs from last captured Reddit token)");
-    } else if ([token isEqualToString:ApolloWebJSONSyntheticBearerToken]) {
+    } else if (ApolloWebJSONBearerIsSynthetic(token)) {
         ApolloLog(@"[RedditUpload] No real bearer token; routing media lease through the Web JSON cookie session");
     }
     NSString *userAgent = sUserAgent.length > 0 ? sUserAgent : defaultUserAgent;
@@ -2929,7 +2929,7 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
     // back to Apollo's Imgur path and warn once if no Imgur key is set either.
     BOOL cookieUpload = ApolloShouldUseCookieRedditUpload(request);
     if (ApolloIsImgurImageUploadRequest(request)
-        && [ApolloRedditUploadBearerToken() isEqualToString:ApolloWebJSONSyntheticBearerToken]
+        && ApolloWebJSONBearerIsSynthetic(ApolloRedditUploadBearerToken())
         && !cookieUpload) {
         if (sImgurClientId.length == 0) ApolloWarnKeylessUploadUnavailableOnce();
         return %orig;
@@ -3057,7 +3057,7 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
     // Imgur key). ImgChest with its own key already returned above.
     BOOL cookieUpload = ApolloShouldUseCookieRedditUpload(request);
     if (ApolloIsImgurImageUploadRequest(request)
-        && [ApolloRedditUploadBearerToken() isEqualToString:ApolloWebJSONSyntheticBearerToken]
+        && ApolloWebJSONBearerIsSynthetic(ApolloRedditUploadBearerToken())
         && !cookieUpload) {
         if (sImgurClientId.length == 0) ApolloWarnKeylessUploadUnavailableOnce();
         return %orig;

--- a/src/ApolloWebJSON.h
+++ b/src/ApolloWebJSON.h
@@ -66,6 +66,15 @@ id ApolloWebJSONFixupModeratorsResponseObject(NSURLResponse *response, id respon
 // OAuth path is untouched). Called from the RDKResponseSerializer hook.
 BOOL ApolloWebJSONShouldStubInvitedModerators(NSURLResponse *response);
 
+// YES if `response` is a cookie-routed GET /r/<sub>/api/link_flair(_v2) or
+// user_flair(_v2) — OAuth-only endpoints that 404 on www.reddit.com — and a
+// cookie session is active. The caller should override the parsed result to an
+// empty array (and clear the parse/status error) so the post composer's Submit
+// drawer loads with no flair options instead of hanging/erroring. NO for any
+// other endpoint or when the active account is OAuth. Called from the
+// RDKResponseSerializer hook.
+BOOL ApolloWebJSONShouldStubFlairList(NSURLResponse *response);
+
 // Hydrates the legacy single-session globals from the keychain, migrating any
 // legacy NSUserDefaults cookie value, then any legacy single-global session,
 // into the per-account ApolloWebSessionStore (see that file's harvest path for
@@ -91,6 +100,14 @@ BOOL ApolloWebJSONHasUsableSession(void);
 // account on disk. Implemented in ApolloWebJSONIdentity.xm. The caller should
 // prompt a relaunch: AccountManager loads accounts once per launch.
 BOOL ApolloWebJSONSynthesizeSignedInAccount(NSString *username);
+
+// Re-arms expiry detection for `username` after a fresh harvest replaced its
+// stored session: clears the "already announced" latch, the block-page streak,
+// and any probe backoff, so the NEW session's health is tracked from scratch.
+// Called from the harvest path (login VC + silent re-harvester); without it a
+// re-authenticated account could never be detected as expired again until the
+// next app launch.
+void ApolloWebJSONNoteSessionReauthenticated(NSString *username);
 
 // Posted (on the main thread) the first time a harvested session is observed to
 // have expired/been revoked, with userInfo[@"username"] set to the (lowercased)

--- a/src/ApolloWebJSON.h
+++ b/src/ApolloWebJSON.h
@@ -121,7 +121,53 @@ extern NSString *const ApolloWebJSONSessionExpiredNotification;
 // without real API keys. It's never sent to Reddit (the chokepoint strips
 // Authorization), but it rides outgoing Authorization headers — so the bearer
 // capture path must ignore it to avoid poisoning sLatestRedditBearerToken.
+// Synthetic tokens are now minted per-account ("<sentinel>:<username>", see
+// ApolloWebJSONSyntheticBearerTokenForUsername) so the chokepoint can tell
+// WHICH web-session account a request belongs to; this constant remains the
+// bare prefix, and every "is this synthetic?" check must go through
+// ApolloWebJSONBearerIsSynthetic (prefix match) rather than string equality,
+// so persisted bare-sentinel credentials from older installs keep matching.
 extern NSString *const ApolloWebJSONSyntheticBearerToken;
+
+// YES if `token` is a synthetic placeholder bearer (bare legacy sentinel or a
+// per-account "<sentinel>:<username>" variant). Never YES for a real OAuth token.
+BOOL ApolloWebJSONBearerIsSynthetic(NSString *token);
+
+// The per-account synthetic bearer for `username` ("<sentinel>:<lowercased
+// username>"), or the bare sentinel when `username` is empty/nil.
+NSString *ApolloWebJSONSyntheticBearerTokenForUsername(NSString *username);
+
+// The lowercased username embedded in a per-account synthetic bearer, or nil
+// for the bare legacy sentinel / a non-synthetic token.
+NSString *ApolloWebJSONUsernameFromSyntheticBearer(NSString *token);
+
+// Bearer-ownership registry: maps REAL OAuth access tokens to the (lowercased)
+// account that owns them, so the transport chokepoint can tell whose request
+// it is looking at instead of assuming everything belongs to the active
+// account. Registration ignores empty and synthetic tokens. Seeded at launch
+// from the on-disk account blobs (ApolloWebJSONSeedBearerRegistryFromDisk) and
+// kept fresh by the identity hooks whenever a client's credential is observed.
+void ApolloWebJSONRegisterAccountBearer(NSString *username, NSString *token);
+NSString *ApolloWebJSONUsernameForRegisteredBearer(NSString *token);
+
+// Seeds the bearer registry from the persisted RedditAccounts2 / Valet account
+// blobs (each index's username + real access token). Call once from %ctor
+// after the SecItem fishhooks are installed (the Valet read needs them in the
+// simulator). Implemented in ApolloWebJSONIdentity.xm.
+void ApolloWebJSONSeedBearerRegistryFromDisk(void);
+
+// One-shot launch repair for installs poisoned by the pre-fix cross-account
+// identity leak: a cookie-rewritten /api/v1/me answered with the WEB-SESSION
+// user's identity while an OAuth account issued it, Apollo installed that as
+// the OAuth account's currentUser, and persistInformationToDisk wrote it out —
+// leaving two RedditAccounts2 indexes claiming the same (web-session) username,
+// so the OAuth account resolves as keyless forever. Detects the duplicate-
+// username signature, identifies the true web-session account by its synthetic
+// Valet token, and clears the poisoned duplicates' currentUser so Apollo
+// re-fetches their real identity on next selection. No-op on healthy blobs.
+// Implemented in ApolloWebJSONIdentity.xm; call from %ctor before account
+// synthesis.
+void ApolloWebJSONRepairPoisonedAccountBlobs(void);
 
 // Returns a copy of `url` with the internal probe fragment applied. The
 // fragment is stripped by NSURLSession before transmission so it never reaches

--- a/src/ApolloWebJSON.m
+++ b/src/ApolloWebJSON.m
@@ -4,6 +4,7 @@
 #import "UserDefaultConstants.h"
 #import "Defaults.h"
 #import "ApolloWebSessionStore.h"
+#import "ApolloWebSessionLoginViewController.h" // silent re-harvest before the expiry prompt
 
 #import <Security/Security.h>
 
@@ -175,6 +176,15 @@ static ApolloWebJSONPathKind ApolloWebJSONClassifyReadPath(NSString *path) {
         if ([what isEqualToString:@"about"]) return ApolloWebJSONPathListing;    // /r/<sub>/about[/...]
         if ([what isEqualToString:@"wiki"]) return ApolloWebJSONPathListing;     // /r/<sub>/wiki/...
         if ([what isEqualToString:@"duplicates"]) return ApolloWebJSONPathListing;
+        // Subreddit-scoped /r/<sub>/api/* GETs (link_flair, user_flair, …).
+        // Some are OAuth-only and 404 on www (the flair-list stub covers the
+        // ones the composer needs), but they MUST be routed regardless: left
+        // on oauth they 401 against the synthetic bearer, and the identity
+        // layer's instant-success token refresh turns that into an infinite
+        // 401→refresh→retry loop (~8 req/s, observed live hanging the Submit
+        // drawer on /r/<sub>/api/link_flair). A definitive www response —
+        // even a 404 — ends the cycle.
+        if ([what isEqualToString:@"api"]) return ApolloWebJSONPathAPI;
         return ApolloWebJSONPathUnsupported;
     }
 
@@ -363,6 +373,19 @@ NSURLRequest *ApolloWebJSONRewriteRequest(NSURLRequest *request) {
     if (isWrite && session.modhash.length > 0) {
         [mutable setValue:session.modhash forHTTPHeaderField:@"X-Modhash"];
     }
+    // Shape cookie-authed writes like the browser requests Reddit's anti-bot
+    // expects: a same-origin fetch from www.reddit.com carries these on every
+    // real browser write, and a bare non-browser-shaped POST is the likely
+    // trigger for the "breaks right after I change a setting / edit my
+    // subscriptions" block-page reports. Reads pass without them today, so
+    // they're added on the write path only (smallest change that can help).
+    if (isWrite) {
+        [mutable setValue:@"https://www.reddit.com" forHTTPHeaderField:@"Origin"];
+        [mutable setValue:@"https://www.reddit.com/" forHTTPHeaderField:@"Referer"];
+        [mutable setValue:@"same-origin" forHTTPHeaderField:@"Sec-Fetch-Site"];
+        [mutable setValue:@"cors" forHTTPHeaderField:@"Sec-Fetch-Mode"];
+        [mutable setValue:@"empty" forHTTPHeaderField:@"Sec-Fetch-Dest"];
+    }
 
     [mutable setValue:([sUserAgent length] > 0 ? sUserAgent : defaultUserAgent) forHTTPHeaderField:@"User-Agent"];
 
@@ -390,9 +413,28 @@ static NSMutableSet<NSString *> *sSessionExpiredAnnouncedUsers;
 static NSMutableSet<NSString *> *sSessionProbeInFlightUsers;
 static const NSUInteger kSessionExpiredBlockThreshold = 3;
 
+// Backoff state for inconclusive probes (rate limit / server error / network
+// blip): probe again later instead of declaring the session dead on a signal
+// that says nothing about the cookie. Keyed by lowercased username.
+static NSMutableDictionary<NSString *, NSNumber *> *sProbeBackoffAttemptsByUser;
+static const NSTimeInterval kProbeBackoffDelays[] = {30.0, 120.0, 480.0, 900.0};
+static const NSUInteger kProbeBackoffDelayCount = sizeof(kProbeBackoffDelays) / sizeof(kProbeBackoffDelays[0]);
+
+static void ApolloWebJSONMergeSetCookiesFromResponse(NSString *username, NSHTTPURLResponse *http);
+
 static void ApolloWebJSONResetBlockStreak(NSString *username) {
     @synchronized (ApolloWebJSONExpiryLock()) {
         [sConsecutiveBlockResponsesByUser removeObjectForKey:username];
+    }
+}
+
+void ApolloWebJSONNoteSessionReauthenticated(NSString *username) {
+    NSString *key = [[username ?: @"" stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+    if (key.length == 0) return;
+    @synchronized (ApolloWebJSONExpiryLock()) {
+        [sConsecutiveBlockResponsesByUser removeObjectForKey:key];
+        [sSessionExpiredAnnouncedUsers removeObject:key];
+        [sProbeBackoffAttemptsByUser removeObjectForKey:key];
     }
 }
 
@@ -429,31 +471,175 @@ static void ApolloWebJSONVerifySessionThenAnnounce(NSString *username) {
     NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
     NSURLSessionDataTask *task = [session dataTaskWithRequest:req completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
-        BOOL alive = NO;
+        // Three-way verdict. "Inconclusive" (rate limit, server error, network
+        // blip, challenge page served as 200) says nothing about the cookie:
+        // announcing on it kills a healthy session and trains the user to
+        // re-login pointlessly, so those back off and probe again instead.
+        typedef NS_ENUM(NSInteger, ProbeVerdict) { ProbeInconclusive, ProbeAlive, ProbeDead };
+        ProbeVerdict verdict = ProbeInconclusive;
+        NSString *contentType = [http.allHeaderFields[@"Content-Type"] lowercaseString] ?: @"";
         if (http.statusCode == 200 && data.length > 0) {
             id json = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
             NSDictionary *d = [json isKindOfClass:[NSDictionary class]] ? json[@"data"] : nil;
             NSString *name = [d isKindOfClass:[NSDictionary class]] ? d[@"name"] : nil;
-            alive = [name isKindOfClass:[NSString class]] && name.length > 0;
+            if ([name isKindOfClass:[NSString class]] && name.length > 0) {
+                verdict = ProbeAlive;
+            } else if ([json isKindOfClass:[NSDictionary class]]) {
+                // A logged-out /api/me.json is HTTP 200 with an empty JSON
+                // object — the definitive "this cookie no longer signs in".
+                verdict = ProbeDead;
+            }
+            // 200 with a non-JSON body (challenge page) stays inconclusive.
+        } else if (http.statusCode == 403 && [contentType containsString:@"text/html"]) {
+            // The anonymous block page on a direct probe: the cookie itself no
+            // longer authenticates. (A sustained IP rate limit can also look
+            // like this — the silent re-harvest gate downstream of the expiry
+            // notification is what disambiguates those.)
+            verdict = ProbeDead;
         }
 
-        if (alive) {
+        if (verdict == ProbeAlive) {
             ApolloWebJSONResetBlockStreak(username);
+            @synchronized (ApolloWebJSONExpiryLock()) { [sProbeBackoffAttemptsByUser removeObjectForKey:username]; }
+            // A successful probe is the perfect moment to fold in any rotated
+            // auth cookies the response carried.
+            ApolloWebJSONMergeSetCookiesFromResponse(username, http);
             ApolloLog(@"[WebJSON] Session probe for u/%@ still authenticates — suppressing false expiry prompt", username);
+        } else if (verdict == ProbeDead) {
+            // The stored snapshot no longer signs in — but the persistent
+            // WKWebView jar usually still holds a LIVE login for this user
+            // (Reddit rotates its cookies there, while our frozen header went
+            // stale). Try a silent re-harvest first; only the visible prompt
+            // when that also fails. Success re-arms all expiry state via
+            // ApolloWebJSONNoteSessionReauthenticated inside the harvest.
+            ApolloLog(@"[WebJSON] Session probe for u/%@ came back logged-out (HTTP %ld) — attempting silent re-harvest before prompting",
+                      username, (long)http.statusCode);
+            [ApolloWebSessionLoginViewController attemptSilentReharvestForUsername:username completion:^(BOOL success) {
+                if (success) return; // recovered without UI; nothing to announce
+                @synchronized (ApolloWebJSONExpiryLock()) {
+                    [sSessionExpiredAnnouncedUsers addObject:username];
+                    [sProbeBackoffAttemptsByUser removeObjectForKey:username];
+                }
+                ApolloLog(@"[WebJSON] Silent re-harvest for u/%@ failed — session expired, prompting re-login", username);
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloWebJSONSessionExpiredNotification
+                                                                          object:nil
+                                                                        userInfo:@{@"username": username}];
+                });
+            }];
         } else {
-            @synchronized (ApolloWebJSONExpiryLock()) { [sSessionExpiredAnnouncedUsers addObject:username]; }
-            ApolloLog(@"[WebJSON] Session probe for u/%@ failed (HTTP %ld%@) — session expired, prompting re-login",
-                      username, (long)http.statusCode, error ? [@", " stringByAppendingString:error.localizedDescription] : @"");
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [[NSNotificationCenter defaultCenter] postNotificationName:ApolloWebJSONSessionExpiredNotification
-                                                                      object:nil
-                                                                    userInfo:@{@"username": username}];
+            // Inconclusive: schedule a backoff re-probe. Honor Retry-After when
+            // the server sent one; otherwise walk the exponential table.
+            NSUInteger attempt;
+            @synchronized (ApolloWebJSONExpiryLock()) {
+                if (!sProbeBackoffAttemptsByUser) sProbeBackoffAttemptsByUser = [NSMutableDictionary dictionary];
+                attempt = sProbeBackoffAttemptsByUser[username].unsignedIntegerValue;
+                sProbeBackoffAttemptsByUser[username] = @(attempt + 1);
+            }
+            NSTimeInterval delay = kProbeBackoffDelays[MIN(attempt, kProbeBackoffDelayCount - 1)];
+            NSTimeInterval retryAfter = [http.allHeaderFields[@"Retry-After"] doubleValue];
+            if (retryAfter > delay) delay = MIN(retryAfter, 900.0);
+            ApolloLog(@"[WebJSON] Session probe for u/%@ inconclusive (HTTP %ld%@) — not treating as expiry, re-probing in %.0fs",
+                      username, (long)http.statusCode, error ? [@", " stringByAppendingString:error.localizedDescription] : @"", delay);
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                BOOL stillBlocked;
+                @synchronized (ApolloWebJSONExpiryLock()) {
+                    stillBlocked = sConsecutiveBlockResponsesByUser[username].unsignedIntegerValue >= kSessionExpiredBlockThreshold;
+                }
+                if (stillBlocked) {
+                    ApolloWebJSONVerifySessionThenAnnounce(username);
+                } else {
+                    // A good response came through while we were waiting — the
+                    // burst was transient, forget the backoff.
+                    @synchronized (ApolloWebJSONExpiryLock()) { [sProbeBackoffAttemptsByUser removeObjectForKey:username]; }
+                }
             });
         }
         @synchronized (ApolloWebJSONExpiryLock()) { [sSessionProbeInFlightUsers removeObject:username]; }
         [session finishTasksAndInvalidate];
     }];
     [task resume];
+}
+
+#pragma mark - Set-Cookie rotation capture
+
+// Auth-relevant cookie names worth persisting when Reddit rotates them via
+// Set-Cookie. Deliberately NOT every cookie: session_tracker (analytics)
+// rotates on nearly every response and would churn a keychain write each
+// time, while these rotate rarely (token_v2 is a ~24h JWT) but are exactly
+// the ones whose staleness kills the stored session.
+static NSSet<NSString *> *ApolloWebJSONMergeableCookieNames(void) {
+    static NSSet *names;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        names = [NSSet setWithArray:@[@"reddit_session", @"token_v2", @"loid", @"csrf_token", @"edgebucket"]];
+    });
+    return names;
+}
+
+// Merge server-rotated auth cookies from a cookie-authed www.reddit.com
+// response back into the stored per-account session header. The stored header
+// is a frozen snapshot from harvest time; without this, Reddit's token_v2
+// rotation (~24h) silently invalidates the snapshot while the server-side
+// session stays perfectly alive — the root cause of the "stops working a few
+// times a day, but the login browser says I'm already signed in" reports.
+// Serialized behind a lock: two concurrent responses doing read-modify-write
+// against the same keychain item must not interleave.
+static void ApolloWebJSONMergeSetCookiesFromResponse(NSString *username, NSHTTPURLResponse *http) {
+    if (username.length == 0 || !http) return;
+    if ([http valueForHTTPHeaderField:@"Set-Cookie"].length == 0) return;
+    NSArray<NSHTTPCookie *> *cookies = [NSHTTPCookie cookiesWithResponseHeaderFields:http.allHeaderFields
+                                                                              forURL:[NSURL URLWithString:@"https://www.reddit.com/"]];
+    if (cookies.count == 0) return;
+
+    static NSObject *mergeLock;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ mergeLock = [NSObject new]; });
+
+    @synchronized (mergeLock) {
+        ApolloWebSessionEntry *entry = ApolloWebSessionFor(username);
+        if (entry.cookieHeader.length == 0) return;
+
+        // Parse the stored "name=value; name2=value2" header into ordered pairs
+        // so the re-serialized header keeps a stable shape.
+        NSMutableArray<NSString *> *order = [NSMutableArray array];
+        NSMutableDictionary<NSString *, NSString *> *values = [NSMutableDictionary dictionary];
+        for (NSString *pair in [entry.cookieHeader componentsSeparatedByString:@"; "]) {
+            NSRange eq = [pair rangeOfString:@"="];
+            if (eq.location == NSNotFound || eq.location == 0) continue;
+            NSString *name = [pair substringToIndex:eq.location];
+            if (!values[name]) [order addObject:name];
+            values[name] = [pair substringFromIndex:eq.location + 1];
+        }
+
+        BOOL changed = NO;
+        for (NSHTTPCookie *c in cookies) {
+            if (![ApolloWebJSONMergeableCookieNames() containsObject:c.name]) continue;
+            // A past expiry (or empty value) is the server deleting the cookie.
+            BOOL deletion = c.value.length == 0 || (c.expiresDate && c.expiresDate.timeIntervalSinceNow < 0);
+            if (deletion) {
+                if (values[c.name]) {
+                    [order removeObject:c.name];
+                    [values removeObjectForKey:c.name];
+                    changed = YES;
+                    ApolloLog(@"[WebJSON] Server expired cookie %@ for u/%@ — dropping it from the stored session", c.name, username);
+                }
+                continue;
+            }
+            if ([values[c.name] isEqualToString:c.value]) continue;
+            if (!values[c.name]) [order addObject:c.name];
+            values[c.name] = c.value;
+            changed = YES;
+            ApolloLog(@"[WebJSON] Server rotated cookie %@ for u/%@ — refreshing the stored session", c.name, username);
+        }
+        if (!changed) return;
+
+        NSMutableArray<NSString *> *pairs = [NSMutableArray arrayWithCapacity:order.count];
+        for (NSString *name in order) {
+            [pairs addObject:[NSString stringWithFormat:@"%@=%@", name, values[name]]];
+        }
+        ApolloWebSessionSet(username, [pairs componentsJoinedByString:@"; "], entry.modhash);
+    }
 }
 
 void ApolloWebJSONNoteResponse(NSURLRequest *request, NSURLResponse *response) {
@@ -478,11 +664,27 @@ void ApolloWebJSONNoteResponse(NSURLRequest *request, NSURLResponse *response) {
     NSString *username = ApolloWebJSONAccountFromURL(url);
     if (username.length == 0) return;
 
+    // Persist server-rotated auth cookies before the expiry accounting.
+    // Successful responses only: a 403 block/challenge page never carries a
+    // fresh token_v2, and merging challenge cookies could poison the header.
+    NSHTTPURLResponse *earlyHTTP = (NSHTTPURLResponse *)response;
+    if (earlyHTTP.statusCode >= 200 && earlyHTTP.statusCode < 400) {
+        ApolloWebJSONMergeSetCookiesFromResponse(username, earlyHTTP);
+    }
+
     BOOL alreadyAnnounced;
     @synchronized (ApolloWebJSONExpiryLock()) {
         alreadyAnnounced = [sSessionExpiredAnnouncedUsers containsObject:username];
     }
     if (alreadyAnnounced) return;
+
+    // New-modmail endpoints (/api/mod/conversations…) are OAuth2-only: they
+    // return the 403 HTML block page for ANY cookie-authed request, healthy
+    // session or not (verified live — mod.reddit.com refuses the bare cookie
+    // too). For a moderator account they fire on every inbox refresh, so
+    // counting them would poison the expiry streak with permanent false
+    // evidence. They say nothing about the session either way — ignore them.
+    if ([url.path hasPrefix:@"/api/mod/"]) return;
 
     NSHTTPURLResponse *http = (NSHTTPURLResponse *)response;
     // Reddit's anonymous block page is HTTP 403 with a ~190 KB text/html body.
@@ -493,11 +695,16 @@ void ApolloWebJSONNoteResponse(NSURLRequest *request, NSURLResponse *response) {
     BOOL isBlockPage = (http.statusCode == 403) && [contentType containsString:@"text/html"];
 
     if (!isBlockPage) {
-        // Any non-block response on a cookie-authed request means the session is
-        // still answering us, so clear the streak. This is what keeps a transient
-        // Cloudflare/rate-limit/captcha block page from accumulating toward a
-        // false expiry: a 200 (or even a 403 JSON content error) in between resets
-        // the count.
+        // A 429 or 5xx says nothing about the session either way — hold the
+        // streak where it is (it's neither evidence of death nor of life), so a
+        // rate-limit burst mixed into a block-page streak can't fake or mask a
+        // real expiry.
+        if (http.statusCode == 429 || http.statusCode >= 500) return;
+        // Any other non-block response on a cookie-authed request means the
+        // session is still answering us, so clear the streak. This is what keeps
+        // a transient Cloudflare/rate-limit/captcha block page from accumulating
+        // toward a false expiry: a 200 (or even a 403 JSON content error) in
+        // between resets the count.
         ApolloWebJSONResetBlockStreak(username);
         return;
     }
@@ -772,6 +979,29 @@ BOOL ApolloWebJSONShouldStubInvitedModerators(NSURLResponse *response) {
     static dispatch_once_t once;
     dispatch_once(&once, ^{
         re = [NSRegularExpression regularExpressionWithPattern:@"^/api/v1/[^/]+/moderators_invited/?$"
+                                                         options:0 error:NULL];
+    });
+    return [re firstMatchInString:path options:0 range:NSMakeRange(0, path.length)] != nil;
+}
+
+// GET /r/<sub>/api/link_flair(_v2) — the post composer's flair-template list —
+// is OAuth-only: the www mirror 404s for cookie auth (verified live; old
+// reddit picks flair via a different POST flow the app can't use). The rewrite
+// still routes it to www so it draws a definitive 404 instead of the oauth
+// 401→refresh→retry loop (see the classifier note), and this override turns
+// that 404 into an empty flair list so the Submit drawer loads normally — no
+// flair choices, a missing feature rather than a hang. user_flair(_v2) gets
+// the same treatment for symmetry. OAuth accounts untouched (session gate).
+BOOL ApolloWebJSONShouldStubFlairList(NSURLResponse *response) {
+    if (!ApolloWebJSONHasUsableSession()) return NO;
+    if (![response isKindOfClass:[NSHTTPURLResponse class]]) return NO;
+    NSString *host = [((NSHTTPURLResponse *)response).URL.host lowercaseString] ?: @"";
+    if (![host isEqualToString:@"www.reddit.com"]) return NO;
+    NSString *path = [((NSHTTPURLResponse *)response).URL.path lowercaseString] ?: @"";
+    static NSRegularExpression *re;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        re = [NSRegularExpression regularExpressionWithPattern:@"^/r/[^/]+/api/(link_flair|user_flair)(_v2)?/?$"
                                                          options:0 error:NULL];
     });
     return [re firstMatchInString:path options:0 range:NSMakeRange(0, path.length)] != nil;

--- a/src/ApolloWebJSON.m
+++ b/src/ApolloWebJSON.m
@@ -11,6 +11,57 @@
 NSString *const ApolloWebJSONSessionExpiredNotification = @"ApolloWebJSONSessionExpiredNotification";
 NSString *const ApolloWebJSONSyntheticBearerToken = @"apollo-webjson-cookie-session";
 
+#pragma mark - Synthetic bearer helpers + bearer-ownership registry
+
+BOOL ApolloWebJSONBearerIsSynthetic(NSString *token) {
+    return [token isKindOfClass:[NSString class]] && [token hasPrefix:ApolloWebJSONSyntheticBearerToken];
+}
+
+NSString *ApolloWebJSONSyntheticBearerTokenForUsername(NSString *username) {
+    NSString *lower = [[username stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+    if (lower.length == 0) return ApolloWebJSONSyntheticBearerToken;
+    return [NSString stringWithFormat:@"%@:%@", ApolloWebJSONSyntheticBearerToken, lower];
+}
+
+NSString *ApolloWebJSONUsernameFromSyntheticBearer(NSString *token) {
+    if (!ApolloWebJSONBearerIsSynthetic(token)) return nil;
+    if (token.length <= ApolloWebJSONSyntheticBearerToken.length + 1) return nil; // bare legacy sentinel
+    if ([token characterAtIndex:ApolloWebJSONSyntheticBearerToken.length] != ':') return nil;
+    NSString *username = [token substringFromIndex:ApolloWebJSONSyntheticBearerToken.length + 1];
+    return username.length > 0 ? username.lowercaseString : nil;
+}
+
+// token -> lowercased owning username. Real OAuth tokens only — the chokepoint
+// uses this to recognize a request issued by an account OTHER than the one the
+// cookie transport would otherwise hijack it for.
+static NSMutableDictionary<NSString *, NSString *> *sBearerOwnerByToken;
+
+static NSObject *ApolloWebJSONBearerRegistryLock(void) {
+    static NSObject *lock;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ lock = [NSObject new]; });
+    return lock;
+}
+
+void ApolloWebJSONRegisterAccountBearer(NSString *username, NSString *token) {
+    NSString *lower = [[username stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+    if (lower.length == 0 || token.length == 0 || ApolloWebJSONBearerIsSynthetic(token)) return;
+    @synchronized (ApolloWebJSONBearerRegistryLock()) {
+        if (!sBearerOwnerByToken) sBearerOwnerByToken = [NSMutableDictionary new];
+        if ([sBearerOwnerByToken[token] isEqualToString:lower]) return;
+        sBearerOwnerByToken[token] = lower;
+        ApolloLog(@"[WebJSON] Registered bearer (%lu chars) -> u/%@ (%lu known)",
+                  (unsigned long)token.length, lower, (unsigned long)sBearerOwnerByToken.count);
+    }
+}
+
+NSString *ApolloWebJSONUsernameForRegisteredBearer(NSString *token) {
+    if (token.length == 0) return nil;
+    @synchronized (ApolloWebJSONBearerRegistryLock()) {
+        return sBearerOwnerByToken[token];
+    }
+}
+
 // Both markers below ride on the request's URL fragment ("#..."), which is
 // stripped by NSURLSession before ever forming the actual request line, so
 // it is never transmitted over the wire.
@@ -273,19 +324,62 @@ NSURLRequest *ApolloWebJSONRewriteRequest(NSURLRequest *request) {
     // cookie set; leave it untouched so we don't recurse through the rewrite.
     if (ApolloWebJSONURLIsProbe(request.URL)) return nil;
 
-    // Resolve by the ACTIVE account, not a single global cookie. This is what
-    // lets a cookie account and a real OAuth account coexist: when the active
-    // account is OAuth, ApolloActiveWebSession() is nil, this function returns
-    // nil, and the request proceeds on the untouched oauth path with its real
-    // bearer. Only when the active account itself is a web-session account does
-    // the cookie transport kick in.
-    NSString *activeUsername = ApolloActiveWebSessionUsername();
-    ApolloWebSessionEntry *session = activeUsername.length > 0 ? ApolloWebSessionFor(activeUsername) : nil;
-    if (session.cookieHeader.length == 0) return nil;
-
     NSURL *url = request.URL;
     NSString *host = url.host.lowercaseString;
     if (![host isEqualToString:@"oauth.reddit.com"] && ![host isEqualToString:@"www.reddit.com"]) return nil;
+
+    // Resolve the owning account PER REQUEST from the Authorization bearer, not
+    // just from whichever account is globally active. Apollo runs background
+    // polls (inbox, /api/v1/me) for EVERY signed-in account concurrently;
+    // keying the transport purely off the active account hijacked those — an
+    // OAuth account's identity refresh went out with the web-session account's
+    // cookie, came back as the WRONG user, got installed as that account's
+    // currentUser, and persistInformationToDisk wrote the poison to disk
+    // (user-visible as "switched back to my API-key account but it's still
+    // running keyless"). The bearer tells us whose request this really is:
+    //   • synthetic bearer            -> a web-session client; the embedded
+    //     username (per-account mint) picks the session, bare legacy sentinel
+    //     falls back to the active account;
+    //   • real bearer, registered to a web-session user -> that user (the
+    //     restored "Reddit killed our keys" account, whose stale-but-real
+    //     token never rotates because its refresh is short-circuited);
+    //   • any other real bearer       -> an OAuth account's request; leave it
+    //     on the oauth path untouched;
+    //   • no bearer                   -> not account-scoped; use the active
+    //     account, matching the old behavior.
+    NSString *authorization = [request valueForHTTPHeaderField:@"Authorization"];
+    NSString *bearer = nil;
+    if ([authorization isKindOfClass:[NSString class]]) {
+        NSRange r = [authorization rangeOfString:@"Bearer " options:NSCaseInsensitiveSearch | NSAnchoredSearch];
+        if (r.location != NSNotFound) {
+            bearer = [[authorization substringFromIndex:NSMaxRange(r)]
+                      stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        }
+    }
+    NSString *sessionUsername = nil;
+    if (bearer.length == 0) {
+        sessionUsername = ApolloActiveWebSessionUsername();
+    } else if (ApolloWebJSONBearerIsSynthetic(bearer)) {
+        sessionUsername = ApolloWebJSONUsernameFromSyntheticBearer(bearer) ?: ApolloActiveWebSessionUsername();
+    } else {
+        NSString *owner = ApolloWebJSONUsernameForRegisteredBearer(bearer);
+        if (owner.length > 0 && ApolloWebSessionFor(owner) != nil) {
+            sessionUsername = owner;
+        } else {
+            // A real OAuth bearer that doesn't belong to a web-session account:
+            // this request must stay on the oauth path with its own credential.
+            // Only log when the cookie transport would previously have hijacked
+            // it (an active web session exists) — otherwise this is just the
+            // normal OAuth path and logging would fire for every request.
+            if (ApolloActiveWebSession() != nil) {
+                ApolloLog(@"[WebJSON] Foreign real bearer (u/%@) on %@ %@ — leaving on oauth path",
+                          owner ?: @"unknown", request.HTTPMethod ?: @"GET", url.path);
+            }
+            return nil;
+        }
+    }
+    ApolloWebSessionEntry *session = sessionUsername.length > 0 ? ApolloWebSessionFor(sessionUsername) : nil;
+    if (session.cookieHeader.length == 0) return nil;
 
     NSString *method = request.HTTPMethod.uppercaseString ?: @"GET";
     NSString *path = url.path ?: @"/";
@@ -303,7 +397,7 @@ NSURLRequest *ApolloWebJSONRewriteRequest(NSURLRequest *request) {
         NSURL *modURL = modComponents.URL;
         if (!modURL) return nil;
         modURL = ApolloWebJSONURLWithFragment(modURL, [kApolloWebJSONAccountMarkerPrefix stringByAppendingString:
-            [activeUsername stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLFragmentAllowedCharacterSet]] ?: @""]);
+            [sessionUsername stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLFragmentAllowedCharacterSet]] ?: @""]);
 
         NSMutableURLRequest *modMutable = [request mutableCopy];
         modMutable.URL = modURL;
@@ -311,7 +405,7 @@ NSURLRequest *ApolloWebJSONRewriteRequest(NSURLRequest *request) {
         [modMutable setValue:session.cookieHeader forHTTPHeaderField:@"Cookie"];
         modMutable.HTTPShouldHandleCookies = NO;
         [modMutable setValue:([sUserAgent length] > 0 ? sUserAgent : defaultUserAgent) forHTTPHeaderField:@"User-Agent"];
-        ApolloLog(@"[WebJSON] Rewrote moderators GET %@ -> %@ for u/%@", url.absoluteString, modURL.absoluteString, activeUsername);
+        ApolloLog(@"[WebJSON] Rewrote moderators GET %@ -> %@ for u/%@", url.absoluteString, modURL.absoluteString, sessionUsername);
         return modMutable;
     }
 
@@ -352,7 +446,7 @@ NSURLRequest *ApolloWebJSONRewriteRequest(NSURLRequest *request) {
     if (!rewrittenURL) return nil;
     // Account marker goes on the URL fragment
     NSString *accountFragment = [kApolloWebJSONAccountMarkerPrefix stringByAppendingString:
-        [activeUsername stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLFragmentAllowedCharacterSet]] ?: @""];
+        [sessionUsername stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLFragmentAllowedCharacterSet]] ?: @""];
     rewrittenURL = ApolloWebJSONURLWithFragment(rewrittenURL, accountFragment);
 
     NSMutableURLRequest *mutable = [request mutableCopy];
@@ -390,7 +484,7 @@ NSURLRequest *ApolloWebJSONRewriteRequest(NSURLRequest *request) {
     [mutable setValue:([sUserAgent length] > 0 ? sUserAgent : defaultUserAgent) forHTTPHeaderField:@"User-Agent"];
 
     ApolloLog(@"[WebJSON] Rewrote %@ %@ -> %@ for u/%@ (%@%@)",
-              method, url.absoluteString, rewrittenURL.absoluteString, activeUsername,
+              method, url.absoluteString, rewrittenURL.absoluteString, sessionUsername,
               isWrite ? @"write" : @"read",
               (isWrite && session.modhash.length > 0) ? @", modhash" : @"");
     return mutable;
@@ -785,24 +879,119 @@ static NSDictionary *ApolloWebJSONFetchModernThingData(NSString *fullname) {
     return result;
 }
 
+// Extracts the permalink, subreddit, and link id36 from an old-reddit content
+// blob's data-permalink attribute ("/r/<sub>/comments/<id36>/slug/[<cid36>/]").
+static BOOL ApolloWebJSONPermalinkPartsFromLegacyContent(NSString *html, NSString **outPermalink,
+                                                         NSString **outSubreddit, NSString **outLinkId36) {
+    if (html.length == 0) return NO;
+    static NSRegularExpression *re;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        re = [NSRegularExpression regularExpressionWithPattern:@"data-permalink=\"(/r/([^/\"]+)/comments/([0-9a-z]+)/[^\"]*)\""
+                                                       options:NSRegularExpressionCaseInsensitive error:NULL];
+    });
+    NSTextCheckingResult *m = [re firstMatchInString:html options:0 range:NSMakeRange(0, html.length)];
+    if (!m || m.numberOfRanges < 4) return NO;
+    if (outPermalink) *outPermalink = [html substringWithRange:[m rangeAtIndex:1]];
+    if (outSubreddit) *outSubreddit = [html substringWithRange:[m rangeAtIndex:2]];
+    if (outLinkId36) *outLinkId36 = [html substringWithRange:[m rangeAtIndex:3]];
+    return YES;
+}
+
+// Minimal HTML-escape for synthesizing a body_html when the legacy response
+// carries no contentHTML. Reddit's own body_html wraps in <div class="md">.
+static NSString *ApolloWebJSONEscapedBodyHTML(NSString *body) {
+    NSMutableString *escaped = [body mutableCopy] ?: [NSMutableString string];
+    [escaped replaceOccurrencesOfString:@"&" withString:@"&amp;" options:0 range:NSMakeRange(0, escaped.length)];
+    [escaped replaceOccurrencesOfString:@"<" withString:@"&lt;" options:0 range:NSMakeRange(0, escaped.length)];
+    [escaped replaceOccurrencesOfString:@">" withString:@"&gt;" options:0 range:NSMakeRange(0, escaped.length)];
+    return [NSString stringWithFormat:@"<div class=\"md\"><p>%@</p></div>", escaped];
+}
+
+// Builds a modern comment `data` dict directly from the legacy old-reddit
+// response thing — no network, so it works when the serializer runs on the
+// main thread (where the sync refetch is forbidden) and when info.json hasn't
+// caught up with a seconds-old comment yet. The legacy dict carries the
+// submitted markdown (contentText), the rendered body (contentHTML), the
+// parent fullname (parent), and the link fullname (link); the author is the
+// web-session account that issued the write (comment posting always happens
+// as the foreground account). Optimistic fields (score 1, fresh timestamp)
+// self-correct on the next thread refresh.
+static NSDictionary *ApolloWebJSONSynthesizeModernThingData(NSString *fullname, NSDictionary *legacy, BOOL isEdit) {
+    if (fullname.length == 0 || ![fullname hasPrefix:@"t1_"]) return nil;
+
+    NSString *content = [legacy[@"content"] isKindOfClass:[NSString class]] ? legacy[@"content"] : nil;
+    NSString *body = [legacy[@"contentText"] isKindOfClass:[NSString class]] ? legacy[@"contentText"] : nil;
+    NSString *bodyHTML = [legacy[@"contentHTML"] isKindOfClass:[NSString class]] ? legacy[@"contentHTML"] : nil;
+    if (body.length == 0 && bodyHTML.length == 0) return nil; // nothing renderable to show
+
+    // ApolloActiveWebSessionUsername() preserves the stored capitalization,
+    // which matters because Apollo gates the Edit affordance on
+    // comment.author == currentUser.username.
+    NSString *author = ApolloActiveWebSessionUsername();
+    if (author.length == 0) return nil;
+
+    NSMutableDictionary *modern = [NSMutableDictionary dictionary];
+    modern[@"id"] = [fullname substringFromIndex:3];
+    modern[@"name"] = fullname;
+    modern[@"author"] = author;
+    modern[@"body"] = body.length > 0 ? body : @"";
+    modern[@"body_html"] = bodyHTML.length > 0 ? bodyHTML : ApolloWebJSONEscapedBodyHTML(body ?: @"");
+    if ([legacy[@"parent"] isKindOfClass:[NSString class]]) modern[@"parent_id"] = legacy[@"parent"];
+    if ([legacy[@"link"] isKindOfClass:[NSString class]]) modern[@"link_id"] = legacy[@"link"];
+
+    NSString *permalink = nil, *subreddit = nil, *linkId36 = nil;
+    ApolloWebJSONPermalinkPartsFromLegacyContent(content, &permalink, &subreddit, &linkId36);
+    if (permalink.length > 0) modern[@"permalink"] = permalink;
+    if (subreddit.length > 0) modern[@"subreddit"] = subreddit;
+    if (!modern[@"link_id"] && linkId36.length > 0) modern[@"link_id"] = [@"t3_" stringByAppendingString:linkId36];
+
+    NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
+    modern[@"created"] = @(now);
+    modern[@"created_utc"] = @(now);
+    modern[@"edited"] = isEdit ? @(now) : @NO;
+    modern[@"score"] = @1;
+    modern[@"ups"] = @1;
+    modern[@"downs"] = @0;
+    modern[@"likes"] = @YES;
+    modern[@"score_hidden"] = @NO;
+    modern[@"replies"] = @"";
+    modern[@"gilded"] = @0;
+    modern[@"all_awardings"] = @[];
+    modern[@"total_awards_received"] = @0;
+    modern[@"saved"] = @NO;
+    modern[@"archived"] = @NO;
+    modern[@"stickied"] = @NO;
+    modern[@"locked"] = @NO;
+    modern[@"collapsed"] = @NO;
+    modern[@"controversiality"] = @0;
+    modern[@"send_replies"] = @YES;
+    return modern;
+}
+
 // www.reddit.com's old-reddit /api/editusertext and /api/comment responses return
 // each thing's `data` in the legacy shape {parent, content:"<html>"} instead of
 // the modern comment JSON ({body, body_html, score, author, …}) that
 // oauth.reddit.com returns. Apollo parses things[0].data into an RDKComment, finds
-// no body/score, and re-renders the just-edited/posted comment empty with 0
-// upvotes (the write itself succeeded; only the display object is wrong). We
-// detect the legacy shape and swap in the modern object, re-fetched via info.json,
-// so the in-place re-render is correct. No-op outside Web JSON mode, on errors, on
-// the modern shape, or if the refetch fails (degrades to today's behavior).
+// no body/score, and re-renders the just-edited comment empty — or, for a fresh
+// /api/comment post, inserts nothing at all (the new comment only appears after a
+// manual refresh). We detect the legacy shape and swap in the modern object:
+// primary source is an info.json refetch (authoritative fields); when that isn't
+// possible (serializer on the main thread — no sync network allowed) or comes up
+// empty (info.json can lag a seconds-old comment), we synthesize the modern dict
+// locally from the legacy fields, which always carry the submitted text. No-op
+// outside Web JSON mode, on API errors, or on the modern shape.
 id ApolloWebJSONFixupWriteResponseObject(NSURLResponse *response, id responseObject) {
     if (!ApolloWebJSONHasUsableSession()) return responseObject;
     if (![response isKindOfClass:[NSHTTPURLResponse class]]) return responseObject;
-    // Synchronous refetch below — never block the main thread (the serializer
-    // normally runs on a background processing queue, so this is rarely hit).
-    if ([NSThread isMainThread]) return responseObject;
 
     NSString *path = [((NSHTTPURLResponse *)response).URL.path lowercaseString] ?: @"";
     if (!([path hasSuffix:@"/api/editusertext"] || [path hasSuffix:@"/api/comment"])) return responseObject;
+    BOOL isEdit = [path hasSuffix:@"/api/editusertext"];
+
+    // The synchronous info.json refetch must never block the main thread; the
+    // synthesis fallback below is network-free, so the repair itself still runs.
+    BOOL allowNetwork = ![NSThread isMainThread];
 
     // The serializer may hand us the parsed dict or the raw JSON data; handle both
     // and return the same form so we never change the contract for the modern path.
@@ -817,12 +1006,19 @@ id ApolloWebJSONFixupWriteResponseObject(NSURLResponse *response, id responseObj
     }
 
     NSDictionary *json = root[@"json"];
-    if (![json isKindOfClass:[NSDictionary class]]) return responseObject;
+    if (![json isKindOfClass:[NSDictionary class]]) {
+        ApolloLog(@"[WebJSON] %@ response has no json envelope (top-level keys: %@) — skipping write fixup",
+                  path, [[(NSDictionary *)root allKeys] componentsJoinedByString:@","]);
+        return responseObject;
+    }
     NSArray *errors = json[@"errors"];
     if ([errors isKindOfClass:[NSArray class]] && errors.count > 0) return responseObject; // surface the error
     NSDictionary *dataDict = json[@"data"];
     NSArray *things = [dataDict isKindOfClass:[NSDictionary class]] ? dataDict[@"things"] : nil;
-    if (![things isKindOfClass:[NSArray class]] || things.count == 0) return responseObject;
+    if (![things isKindOfClass:[NSArray class]] || things.count == 0) {
+        ApolloLog(@"[WebJSON] %@ response json.data.things missing/empty — skipping write fixup", path);
+        return responseObject;
+    }
 
     NSMutableArray *newThings = [things mutableCopy];
     BOOL changed = NO;
@@ -834,14 +1030,48 @@ id ApolloWebJSONFixupWriteResponseObject(NSURLResponse *response, id responseObj
         if (td[@"body"] != nil || ![td[@"content"] isKindOfClass:[NSString class]]) continue; // already modern
 
         NSString *fullname = ApolloWebJSONFullnameFromLegacyContent(td[@"content"]);
-        NSDictionary *modern = ApolloWebJSONFetchModernThingData(fullname);
-        if (![modern isKindOfClass:[NSDictionary class]]) continue;
+        // The legacy dict's own "id" field is the fullname too — use it when the
+        // content HTML doesn't carry a data-fullname attribute.
+        if (fullname.length == 0 && [td[@"id"] isKindOfClass:[NSString class]]
+            && [(NSString *)td[@"id"] hasPrefix:@"t"]
+            && [(NSString *)td[@"id"] rangeOfString:@"_"].location != NSNotFound) {
+            fullname = td[@"id"];
+        }
+        if (fullname.length == 0) {
+            ApolloLog(@"[WebJSON] %@ legacy thing %lu has no extractable fullname — cannot repair", path, (unsigned long)i);
+            continue;
+        }
+
+        // Fresh /api/comment: synthesize first — we know everything about a
+        // comment the user just wrote, it's instant (the sync info.json refetch
+        // can block the insert for many seconds when Reddit lags a brand-new
+        // fullname), and the optimistic fields are exact for a new comment.
+        // /api/editusertext: refetch first — the comment already exists with a
+        // real score/flair that synthesis would clobber with placeholders.
+        NSDictionary *modern = nil;
+        NSString *source = nil;
+        if (!isEdit) {
+            modern = ApolloWebJSONSynthesizeModernThingData(fullname, td, isEdit);
+            source = @"local synthesis";
+        }
+        if (![modern isKindOfClass:[NSDictionary class]] && allowNetwork) {
+            modern = ApolloWebJSONFetchModernThingData(fullname);
+            source = @"info.json";
+        }
+        if (![modern isKindOfClass:[NSDictionary class]] && isEdit) {
+            modern = ApolloWebJSONSynthesizeModernThingData(fullname, td, isEdit);
+            source = allowNetwork ? @"local synthesis (refetch failed)" : @"local synthesis (main thread)";
+        }
+        if (![modern isKindOfClass:[NSDictionary class]]) {
+            ApolloLog(@"[WebJSON] %@ thing %@ unrepairable (refetch and synthesis both failed)", path, fullname);
+            continue;
+        }
 
         NSString *kind = [thing[@"kind"] isKindOfClass:[NSString class]] ? thing[@"kind"]
                        : ([fullname hasPrefix:@"t1_"] ? @"t1" : @"t3");
         newThings[i] = @{ @"kind": kind, @"data": modern };
         changed = YES;
-        ApolloLog(@"[WebJSON] Rebuilt %@ response thing %@ from info.json for correct in-place render", path, fullname);
+        ApolloLog(@"[WebJSON] Rebuilt %@ response thing %@ via %@ for correct in-place render", path, fullname, source);
     }
     if (!changed) return responseObject;
 

--- a/src/ApolloWebJSONIdentity.xm
+++ b/src/ApolloWebJSONIdentity.xm
@@ -547,6 +547,16 @@ BOOL ApolloWebJSONSynthesizeSignedInAccount(NSString *username) {
                 ApolloLog(@"[WebJSON] Stubbed empty invited-moderators list (no cookie-compatible endpoint)");
             }
         } @catch (NSException *e) { ApolloLog(@"[WebJSON] invited-moderators stub failed: %@", e); }
+        // Flair-template lists are OAuth-only (www 404s for cookie auth) — see
+        // ApolloWebJSONShouldStubFlairList. Empty list = no flair options in
+        // the composer, instead of a hung Submit drawer.
+        @try {
+            if (ApolloWebJSONShouldStubFlairList(response)) {
+                obj = @[];
+                if (error) *error = nil;
+                ApolloLog(@"[WebJSON] Stubbed empty flair list for %@ (OAuth-only endpoint)", ((NSHTTPURLResponse *)response).URL.path);
+            }
+        } @catch (NSException *e) { ApolloLog(@"[WebJSON] flair-list stub failed: %@", e); }
     }
     return obj;
 }

--- a/src/ApolloWebJSONIdentity.xm
+++ b/src/ApolloWebJSONIdentity.xm
@@ -46,13 +46,16 @@
 //      web-session username (before AccountManager loads, so it takes effect
 //      same-launch).
 //
-// Per-account resolution (ApolloWebJSONHasUsableSession() / ApolloActiveWebSession()
-// in ApolloWebSessionStore.h) is what lets a web-session account and a real OAuth
-// account coexist: everything here is gated on the ACTIVE account specifically
-// being a web-session account, so an OAuth account's own request/auth path is
-// untouched even while a different account in the switcher uses cookies. The mint
-// short-circuit additionally requires the client to have no live credential (or
-// our own synthetic one), so a real, working OAuth credential is never bypassed.
+// Per-CLIENT resolution (ApolloWebJSONShouldActForClient, below) is what lets a
+// web-session account and a real OAuth account coexist: every hook here acts
+// only on the client whose own currentUser.username has a stored web session
+// (plus the anonymous app-only bootstrap client, which stays on the global
+// active-account gate). A named OAuth account's request/auth path is untouched
+// in every foreground/background combination — the earlier active-account-only
+// gate suppressed background OAuth clients' real token refreshes and let the
+// transport hijack their requests, which is how switch-back poisoning happened.
+// A real (even stale) credential is never clobbered, so a working OAuth
+// credential is never bypassed and disabling Web JSON Mode restores it.
 //
 // Verified end-to-end in the iOS 26 simulator with a harvested u/<user> cookie:
 // account tab shows the user, personalized reads (subscriptions/profile/inbox/
@@ -92,11 +95,6 @@
 - (id)refreshAccessTokenWithCompletion:(id)completion;
 @end
 
-// Sentinel access-token string (shared so the bearer-capture path can ignore
-// it). Never sent to Reddit — the chokepoint strips Authorization and
-// substitutes the cookie — it only has to be non-empty for Apollo's "do I have a
-// token?" checks to pass.
-#define kApolloWebJSONSyntheticToken ApolloWebJSONSyntheticBearerToken
 // ~100 years, so Apollo never considers the token expired and never tries to
 // refresh it.
 static const unsigned long long kApolloWebJSONSyntheticDuration = 100ULL * 365 * 24 * 60 * 60;
@@ -111,16 +109,12 @@ static NSString *ApolloWebJSONCredentialTokenString(id credential) {
     return [tokenString isKindOfClass:[NSString class]] ? (NSString *)tokenString : nil;
 }
 
-// Returns YES if `credential` already carries a non-empty access token. Used
-// only to decide whether to install the synthetic credential (we never clobber
-// an existing one, real or stale, so it survives turning Web JSON Mode off).
-static BOOL ApolloWebJSONCredentialIsLive(id credential) {
-    return ApolloWebJSONCredentialTokenString(credential).length > 0;
-}
-
 // Builds an RDKOAuthCredential wrapping a synthetic RDKAccessToken via KVC, so
-// no link-time dependency on the private classes is needed.
-static id ApolloWebJSONMakeSyntheticCredential(void) {
+// no link-time dependency on the private classes is needed. The token embeds
+// `username` (per-account variant) so the transport chokepoint can tell WHICH
+// web-session account's cookie a request needs; an empty username mints the
+// bare sentinel, which the chokepoint resolves as "the active account".
+static id ApolloWebJSONMakeSyntheticCredential(NSString *username) {
     Class accessTokenClass = objc_getClass("RDKAccessToken");
     Class credentialClass = objc_getClass("RDKOAuthCredential");
     if (!accessTokenClass || !credentialClass) {
@@ -128,13 +122,14 @@ static id ApolloWebJSONMakeSyntheticCredential(void) {
         return nil;
     }
 
+    NSString *token = ApolloWebJSONSyntheticBearerTokenForUsername(username);
     id accessToken = [[accessTokenClass alloc] init];
     @try {
-        [accessToken setValue:kApolloWebJSONSyntheticToken forKey:@"accessToken"];
+        [accessToken setValue:token forKey:@"accessToken"];
         [accessToken setValue:@"bearer" forKey:@"tokenType"];
         [accessToken setValue:@(kApolloWebJSONSyntheticDuration) forKey:@"duration"];
         // A non-nil refresh token keeps any "can this be refreshed?" branch happy.
-        [accessToken setValue:kApolloWebJSONSyntheticToken forKey:@"refreshToken"];
+        [accessToken setValue:token forKey:@"refreshToken"];
     } @catch (NSException *e) {
         ApolloLog(@"[WebJSON][identity] Failed to populate synthetic access token: %@", e);
         return nil;
@@ -150,19 +145,111 @@ static id ApolloWebJSONMakeSyntheticCredential(void) {
     return credential;
 }
 
+// The client's own identity (currentUser.username), lowercased — nil/empty for
+// an anonymous client (app-only bootstrap, or an account whose identity never
+// resolved). KVC + @try so an unexpected object shape degrades to anonymous.
+static NSString *ApolloWebJSONClientUsername(RDKClient *client) {
+    if (!client) return nil;
+    id user = nil;
+    @try { user = [(id)client valueForKey:@"currentUser"]; }
+    @catch (__unused NSException *e) { return nil; }
+    if (!user) return nil;
+    NSString *username = nil;
+    @try { username = [user valueForKey:@"username"]; }
+    @catch (__unused NSException *e) { return nil; }
+    return [username isKindOfClass:[NSString class]] && username.length > 0 ? username.lowercaseString : nil;
+}
+
+static BOOL ApolloWebJSONClientIsAppOnly(RDKClient *client) {
+    if (!client) return NO;
+    @try { return [[(id)client valueForKey:@"usesApplicationOnlyOAuth"] boolValue]; }
+    @catch (__unused NSException *e) { return NO; }
+}
+
 // Backfills a missing username onto a live currentUser (defined below).
 static void ApolloWebJSONBackfillUsernameOnUser(id user);
 
-// Installs a synthetic credential on `client` if Web JSON has a usable session
-// and the client has no live credential. Idempotent and cheap; safe to call from
-// several entry points.
+// YES when the identity layer should act on THIS client — fake its auth state,
+// short-circuit its token mints/refreshes, install a synthetic credential.
+//
+// The old gate was purely global ("a usable cookie session exists"), but the
+// RDKClient hooks fire on EVERY client instance, including other signed-in
+// accounts' clients running background polls. Acting on those suppressed a
+// real OAuth account's token refreshes whenever a web-session account was
+// merely foreground — one half of the "switched back to my API-key account but
+// it's still keyless" report. The gate is now per-client:
+//   • named client (currentUser.username resolved): act iff THAT username has
+//     a stored web session — a named OAuth account is never touched, in any
+//     foreground/background combination. This also keeps the primary "Reddit
+//     killed our keys" restored account working: its username has a session,
+//     so its doomed stale-token refresh is still short-circuited.
+//   • anonymous app-only client: old global gate. This is the logged-out
+//     bootstrap client; substituting its mint is what lets a keyless cold
+//     start proceed to the cookie-authed reads.
+//   • anonymous NON-app-only client: never act. It's some account whose
+//     identity hasn't resolved — if it were a web-session account it would
+//     have been synthesized/backfilled with a username; assuming it's ours and
+//     suppressing its refresh is exactly the cross-account damage we're fixing.
+// When the flag is off this is NO everywhere and the real OAuth path is
+// byte-for-byte untouched.
+static BOOL ApolloWebJSONShouldActForClient(RDKClient *client) {
+    if (!client || !sWebJSONEnabled) return NO;
+    NSString *username = ApolloWebJSONClientUsername(client);
+    if (username.length > 0) return ApolloWebSessionFor(username) != nil;
+    if (ApolloWebJSONClientIsAppOnly(client)) return ApolloWebJSONHasUsableSession();
+    return NO;
+}
+
+// Feeds the bearer-ownership registry (ApolloWebJSON.m) so the transport
+// chokepoint can attribute requests to accounts. A named client's REAL token
+// registers under its own username; an app-only client's real token registers
+// under the ACTIVE web-session username, preserving the old behavior where
+// app-only reads ride the active account's cookie in the dead-keys case (the
+// app-only account lives outside RedditAccounts2, so this cannot poison an
+// account blob). Anonymous user-account clients are never registered — guessing
+// their owner is how cross-account contamination started.
+static void ApolloWebJSONRegisterClientBearer(RDKClient *client) {
+    if (!client || !sWebJSONEnabled) return;
+    id credential = [client respondsToSelector:@selector(authorizationCredential)] ? [client authorizationCredential] : nil;
+    NSString *token = ApolloWebJSONCredentialTokenString(credential);
+    if (token.length == 0 || ApolloWebJSONBearerIsSynthetic(token)) return;
+    NSString *username = ApolloWebJSONClientUsername(client);
+    if (username.length == 0 && ApolloWebJSONClientIsAppOnly(client)) {
+        username = ApolloWebSessionFor(ApolloActiveWebSessionUsername()) != nil ? ApolloActiveWebSessionUsername() : nil;
+    }
+    if (username.length > 0) ApolloWebJSONRegisterAccountBearer(username, token);
+}
+
+// Installs a synthetic credential on `client` when the identity layer is
+// acting for it and the client has no REAL credential. Idempotent and cheap;
+// safe to call from several entry points. A real (even stale) credential is
+// never clobbered — it's what lets the restored dead-keys account go back to
+// OAuth if Web JSON Mode is turned off — but an older synthetic credential IS
+// upgraded in place when the desired per-account variant differs (bare legacy
+// sentinel -> per-account token once the username is known).
 static void ApolloWebJSONInstallSyntheticCredentialIfNeeded(RDKClient *client) {
-    if (!client || !ApolloWebJSONHasUsableSession()) return;
+    if (!client || !ApolloWebJSONShouldActForClient(client)) return;
+
+    // Named web-session client mints its own per-account token; the anonymous
+    // app-only bootstrap client mints the bare sentinel, which the chokepoint
+    // resolves as "the active account" (correct across account switches).
+    NSString *clientUsername = ApolloWebJSONClientUsername(client);
+    NSString *desiredToken = ApolloWebJSONSyntheticBearerTokenForUsername(clientUsername);
 
     id existing = [client respondsToSelector:@selector(authorizationCredential)] ? [client authorizationCredential] : nil;
-    if (ApolloWebJSONCredentialIsLive(existing)) return; // real OAuth (or already synthetic) — leave it
+    NSString *existingToken = ApolloWebJSONCredentialTokenString(existing);
+    if (existingToken.length > 0) {
+        if (!ApolloWebJSONBearerIsSynthetic(existingToken)) {
+            // Real (possibly stale) credential — leave it, but make sure the
+            // chokepoint knows whose it is so its requests get THIS account's
+            // cookie instead of falling through to oauth with a dead token.
+            ApolloWebJSONRegisterClientBearer(client);
+            return;
+        }
+        if ([existingToken isEqualToString:desiredToken]) return; // already correct
+    }
 
-    id synthetic = ApolloWebJSONMakeSyntheticCredential();
+    id synthetic = ApolloWebJSONMakeSyntheticCredential(clientUsername);
     if (!synthetic) return;
 
     if ([client respondsToSelector:@selector(setAuthorizationCredential:)]) {
@@ -178,21 +265,8 @@ static void ApolloWebJSONInstallSyntheticCredentialIfNeeded(RDKClient *client) {
     if ([client respondsToSelector:@selector(currentUser)]) {
         ApolloWebJSONBackfillUsernameOnUser([client currentUser]);
     }
-    ApolloLog(@"[WebJSON][identity] Installed synthetic credential for cookie session (user %@)",
-              ApolloActiveWebSessionUsername() ?: @"(unknown)");
-}
-
-// YES when a token mint/refresh should be replaced by an instant synthetic
-// success. The gate is simply "a usable cookie session exists": enabling Web
-// JSON Mode + harvesting a cookie is an explicit opt-in to cookie transport, so
-// the OAuth token path is moot. Crucially this must NOT depend on whether a
-// credential looks "live" — the primary "Reddit killed our keys" case restores
-// an account whose access token is present but stale/unrefreshable, and letting
-// that doomed refresh run is exactly the cold-start stall we're removing. When
-// the flag is off (or no cookie), this is NO and the real OAuth path is
-// byte-for-byte untouched.
-static BOOL ApolloWebJSONShouldSubstituteTokenMint(RDKClient *client) {
-    return client != nil && ApolloWebJSONHasUsableSession();
+    ApolloLog(@"[WebJSON][identity] Installed synthetic credential (%@) for cookie session",
+              clientUsername.length > 0 ? [@"u/" stringByAppendingString:clientUsername] : @"app-only/bootstrap");
 }
 
 // Invokes a token-method completion as success. Signature verified in Hopper:
@@ -395,7 +469,7 @@ BOOL ApolloWebJSONSynthesizeSignedInAccount(NSString *username) {
             [user setValue:username forKey:@"username"];
             [client setValue:user forKey:@"currentUser"];
         }
-        id cred = ApolloWebJSONMakeSyntheticCredential();
+        id cred = ApolloWebJSONMakeSyntheticCredential(username);
         if (cred) [client setValue:cred forKey:@"authorizationCredential"];
     } @catch (NSException *ex) {
         ApolloLog(@"[WebJSON][identity] account configuration failed: %@", ex);
@@ -416,9 +490,12 @@ BOOL ApolloWebJSONSynthesizeSignedInAccount(NSString *username) {
     }
 
     // Sensitive dict mirrors the app-only format ({accessToken, clientIdentifier});
-    // a dummy token is fine — the cookie authenticates at the chokepoint.
+    // a dummy token is fine — the cookie authenticates at the chokepoint. The
+    // per-account synthetic variant marks WHICH username this synthesized
+    // account belongs to, which the poisoned-blob repair uses to tell the true
+    // web-session account apart from a poisoned OAuth duplicate.
     NSDictionary *sensitive = @{
-        @"accessToken":      ApolloWebJSONSyntheticBearerToken,
+        @"accessToken":      ApolloWebJSONSyntheticBearerTokenForUsername(username),
         @"refreshToken":     @"",
         @"clientIdentifier": @"",
         @"authorizationCode": @"",
@@ -452,6 +529,137 @@ BOOL ApolloWebJSONSynthesizeSignedInAccount(NSString *username) {
     return YES;
 }
 
+#pragma mark - Bearer-registry disk seed + poisoned-blob repair (launch)
+
+// Seeds the transport's bearer-ownership registry from the persisted account
+// blobs: each RedditAccounts2 index's username paired with the Valet sensitive
+// dict's real accessToken at the same index. This is what guarantees the
+// chokepoint can attribute every persisted account's requests from the very
+// first one — before any RDKClient hook has observed a live credential. The
+// restored "Reddit killed our keys" account depends on this: its stale-but-real
+// token never rotates (its refresh is short-circuited), so the disk value IS
+// its live bearer.
+void ApolloWebJSONSeedBearerRegistryFromDisk(void) {
+    if (!sWebJSONEnabled) return;
+    NSUserDefaults *group = [[NSUserDefaults alloc] initWithSuiteName:kApolloGroupSuite];
+    id accountsObj = ApolloWebJSONUnarchive([group objectForKey:@"RedditAccounts2"]);
+    NSArray *accounts = [accountsObj isKindOfClass:[NSArray class]] ? accountsObj : @[];
+    if (accounts.count == 0) return;
+    NSArray<NSDictionary *> *valet = ApolloWebJSONReadValetAccountsArray(NULL) ?: @[];
+
+    NSUInteger seeded = 0;
+    for (NSUInteger i = 0; i < accounts.count && i < valet.count; i++) {
+        NSString *username = ApolloWebJSONUsernameAtIndex(accounts, i);
+        NSDictionary *sensitive = [valet[i] isKindOfClass:[NSDictionary class]] ? valet[i] : nil;
+        NSString *token = [sensitive[@"accessToken"] isKindOfClass:[NSString class]] ? sensitive[@"accessToken"] : nil;
+        if (username.length == 0 || token.length == 0 || ApolloWebJSONBearerIsSynthetic(token)) continue;
+        ApolloWebJSONRegisterAccountBearer(username, token);
+        seeded++;
+    }
+    if (seeded > 0) ApolloLog(@"[WebJSON][identity] Seeded bearer registry from disk (%lu account(s))", (unsigned long)seeded);
+}
+
+// One-shot launch repair for installs poisoned by the pre-fix cross-account
+// identity leak (see ApolloWebJSONRewriteRequest's bearer-attribution comment):
+// a cookie-rewritten /api/v1/me answered an OAuth account's identity refresh
+// with the WEB-SESSION user's identity, Apollo installed it as that account's
+// currentUser, and persistInformationToDisk archived it — so two (or more)
+// RedditAccounts2 indexes now claim the same web-session username, and the
+// OAuth account resolves as keyless forever (ApolloActiveAccountUsername ->
+// ApolloWebSessionFor match at ITS index).
+//
+// Poison signature: one lowercased username with a stored web session
+// appearing at MORE THAN ONE index. Legitimate blobs never duplicate a
+// username (ApolloWebJSONSynthesizeSignedInAccount skips existing usernames).
+// The true web-session account is the index whose Valet accessToken is our
+// synthetic sentinel (per-account variant or legacy bare); every OTHER
+// duplicate is a poisoned victim whose currentUser we clear. A cleared
+// currentUser makes ApolloActiveAccountUsername() return nil at that index, so
+// keyless mode disengages and Apollo's own post-selection /api/v1/me — now
+// carrying the account's real bearer thanks to the per-request transport
+// attribution — restores the real identity and persists the healed blob.
+//
+// If NO duplicate carries a synthetic token (a restored real-token web-session
+// account was itself duplicated) the victim can't be told apart safely; log
+// loudly and leave the blob alone rather than risk damaging the restored
+// account. currentUser is only ever CLEARED, never rewritten — RDKMe's MTLModel
+// re-archive drops a re-set username (verified; see the backfill notes above),
+// but nil-ing survives archiving fine.
+void ApolloWebJSONRepairPoisonedAccountBlobs(void) {
+    if (!sWebJSONEnabled) return;
+    NSUserDefaults *group = [[NSUserDefaults alloc] initWithSuiteName:kApolloGroupSuite];
+    id accountsObj = ApolloWebJSONUnarchive([group objectForKey:@"RedditAccounts2"]);
+    NSArray *accounts = [accountsObj isKindOfClass:[NSArray class]] ? accountsObj : @[];
+    if (accounts.count < 2) return;
+
+    // Group indexes by username; only web-session usernames can be poison.
+    NSMutableDictionary<NSString *, NSMutableArray<NSNumber *> *> *indexesByUsername = [NSMutableDictionary dictionary];
+    for (NSUInteger i = 0; i < accounts.count; i++) {
+        NSString *username = ApolloWebJSONUsernameAtIndex(accounts, i);
+        if (username.length == 0) continue;
+        NSMutableArray *list = indexesByUsername[username] ?: (indexesByUsername[username] = [NSMutableArray array]);
+        [list addObject:@(i)];
+    }
+
+    BOOL valetReadFailed = NO;
+    NSArray<NSDictionary *> *valet = nil; // read lazily — only needed when a duplicate exists
+    NSMutableIndexSet *victims = [NSMutableIndexSet indexSet];
+    for (NSString *username in indexesByUsername) {
+        NSArray<NSNumber *> *indexes = indexesByUsername[username];
+        if (indexes.count < 2) continue;
+        if (ApolloWebSessionFor(username) == nil) continue; // duplicate but not keyless-related; not ours to touch
+
+        if (!valet && !valetReadFailed) valet = ApolloWebJSONReadValetAccountsArray(&valetReadFailed);
+        if (valetReadFailed) {
+            ApolloLog(@"[WebJSON][repair] Valet read failed — skipping poisoned-blob repair this launch");
+            return;
+        }
+
+        NSMutableArray<NSNumber *> *syntheticIndexes = [NSMutableArray array];
+        for (NSNumber *idx in indexes) {
+            NSUInteger i = idx.unsignedIntegerValue;
+            NSDictionary *sensitive = (i < valet.count && [valet[i] isKindOfClass:[NSDictionary class]]) ? valet[i] : nil;
+            NSString *token = [sensitive[@"accessToken"] isKindOfClass:[NSString class]] ? sensitive[@"accessToken"] : nil;
+            if (ApolloWebJSONBearerIsSynthetic(token)) [syntheticIndexes addObject:idx];
+        }
+        if (syntheticIndexes.count == 0) {
+            ApolloLog(@"[WebJSON][repair] u/%@ appears at %lu account indexes but none is our synthesized account — "
+                      @"cannot identify the poisoned one safely; leaving as-is (removing and re-adding the API-key "
+                      @"account clears this)", username, (unsigned long)indexes.count);
+            continue;
+        }
+        // Keep the first synthetic index (the real synthesized web-session
+        // account); every other duplicate — real-token victim or stray extra
+        // synthetic — gets its currentUser cleared.
+        NSNumber *keeper = syntheticIndexes.firstObject;
+        for (NSNumber *idx in indexes) {
+            if ([idx isEqualToNumber:keeper]) continue;
+            [victims addIndex:idx.unsignedIntegerValue];
+        }
+        ApolloLog(@"[WebJSON][repair] u/%@ duplicated at indexes %@ — keeping synthesized index %@, clearing the other(s)",
+                  username, [indexes componentsJoinedByString:@","], keeper);
+    }
+    if (victims.count == 0) return;
+
+    NSUInteger repaired = 0;
+    [victims enumerateIndexesUsingBlock:^(NSUInteger i, BOOL *stop __unused) {
+        @try { [accounts[i] setValue:nil forKey:@"currentUser"]; }
+        @catch (NSException *e) { ApolloLog(@"[WebJSON][repair] clearing currentUser at index %lu failed: %@", (unsigned long)i, e); }
+    }];
+    for (NSUInteger i = 0; i < accounts.count; i++) repaired += [victims containsIndex:i] ? 1 : 0;
+
+    NSError *err = nil;
+    NSData *accountsData = [NSKeyedArchiver archivedDataWithRootObject:accounts requiringSecureCoding:NO error:&err];
+    if (![accountsData isKindOfClass:[NSData class]]) {
+        ApolloLog(@"[WebJSON][repair] failed to re-archive repaired accounts array: %@ — leaving blob unchanged", err);
+        return;
+    }
+    [group setObject:accountsData forKey:@"RedditAccounts2"];
+    [group synchronize];
+    ApolloLog(@"[WebJSON][repair] Cleared poisoned currentUser on %lu account(s); their real identity reloads on next selection",
+              (unsigned long)repaired);
+}
+
 %hook RDKClient
 
 // When the loaded account installs its currentUser (RDKMe) without a username,
@@ -464,20 +672,27 @@ BOOL ApolloWebJSONSynthesizeSignedInAccount(NSString *username) {
     %orig;
 }
 
-// Make the rest of the app treat a cookie-only session as authenticated.
+// Make the rest of the app treat a cookie-only session as authenticated —
+// but only for the client that actually IS a web-session account (or the
+// app-only bootstrap); an OAuth account's client answers with its real state.
+// The %orig path doubles as the bearer-registry capture point: it observes
+// every OAuth client's current token so the transport chokepoint can
+// attribute that client's requests and leave them on the oauth path.
 - (BOOL)isAuthenticated {
-    if (ApolloWebJSONHasUsableSession()) {
+    if (ApolloWebJSONShouldActForClient(self)) {
         ApolloWebJSONInstallSyntheticCredentialIfNeeded(self);
         return YES;
     }
+    ApolloWebJSONRegisterClientBearer(self);
     return %orig;
 }
 
 - (BOOL)isAuthenticatedWithOAuth {
-    if (ApolloWebJSONHasUsableSession()) {
+    if (ApolloWebJSONShouldActForClient(self)) {
         ApolloWebJSONInstallSyntheticCredentialIfNeeded(self);
         return YES;
     }
+    ApolloWebJSONRegisterClientBearer(self);
     return %orig;
 }
 
@@ -492,7 +707,7 @@ BOOL ApolloWebJSONSynthesizeSignedInAccount(NSString *username) {
 // is inert and the real OAuth token path runs untouched. (We never clobber an
 // existing credential, so disabling Web JSON Mode restores normal OAuth.)
 - (id)retrieveAccessTokenForApplicationOnlyWithCompletion:(id)completion {
-    if (ApolloWebJSONShouldSubstituteTokenMint(self)) {
+    if (ApolloWebJSONShouldActForClient(self)) {
         ApolloWebJSONInstallSyntheticCredentialIfNeeded(self);
         ApolloLog(@"[WebJSON][identity] Short-circuited app-only token mint (cookie session)");
         ApolloWebJSONFulfillTokenCompletion(completion);
@@ -502,9 +717,10 @@ BOOL ApolloWebJSONSynthesizeSignedInAccount(NSString *username) {
 }
 
 - (id)retrieveAccessTokenWithCompletion:(id)completion {
-    if (ApolloWebJSONShouldSubstituteTokenMint(self)) {
+    if (ApolloWebJSONShouldActForClient(self)) {
         ApolloWebJSONInstallSyntheticCredentialIfNeeded(self);
-        ApolloLog(@"[WebJSON][identity] Short-circuited token retrieval (cookie session)");
+        ApolloLog(@"[WebJSON][identity] Short-circuited token retrieval (cookie session) for u/%@",
+                  ApolloWebJSONClientUsername(self) ?: @"(anonymous)");
         ApolloWebJSONFulfillTokenCompletion(completion);
         return nil;
     }
@@ -512,9 +728,10 @@ BOOL ApolloWebJSONSynthesizeSignedInAccount(NSString *username) {
 }
 
 - (id)refreshAccessTokenWithCompletion:(id)completion {
-    if (ApolloWebJSONShouldSubstituteTokenMint(self)) {
+    if (ApolloWebJSONShouldActForClient(self)) {
         ApolloWebJSONInstallSyntheticCredentialIfNeeded(self);
-        ApolloLog(@"[WebJSON][identity] Short-circuited token refresh (cookie session)");
+        ApolloLog(@"[WebJSON][identity] Short-circuited token refresh (cookie session) for u/%@",
+                  ApolloWebJSONClientUsername(self) ?: @"(anonymous)");
         ApolloWebJSONFulfillTokenCompletion(completion);
         return nil;
     }

--- a/src/ApolloWebSessionLoginViewController.h
+++ b/src/ApolloWebSessionLoginViewController.h
@@ -38,6 +38,21 @@ NS_ASSUME_NONNULL_BEGIN
 // with older notification posts, but every current poster supplies it.
 + (void)presentExpiredSessionPromptForUsername:(nullable NSString *)username;
 
+// Attempts to refresh `username`'s stored session WITHOUT any UI, by loading
+// reddit.com in an off-screen WKWebView on the same persistent data store the
+// login flow uses. Reddit rotates its session cookies (token_v2 is a ~24h JWT)
+// server-side, so the webview's jar usually still holds a LIVE login long after
+// our frozen harvested snapshot has gone stale — in that case this re-harvests
+// silently and the "session expired" prompt never needs to show. `completion`
+// is called on the main thread with YES when a matching logged-in session was
+// re-harvested. It reports NO when the webview session is genuinely logged out,
+// belongs to a different user (shared jar, multi-account), times out, or a
+// recent silent success evidently didn't stick (10-minute cooldown — repeated
+// expiry verdicts right after a "successful" re-harvest mean the problem isn't
+// snapshot staleness). Concurrent attempts for the same username are coalesced:
+// later callers' completions are dropped and the first attempt's outcome stands.
++ (void)attemptSilentReharvestForUsername:(NSString *)username completion:(void (^)(BOOL success))completion;
+
 @end
 
 #ifdef __cplusplus

--- a/src/ApolloWebSessionLoginViewController.m
+++ b/src/ApolloWebSessionLoginViewController.m
@@ -39,7 +39,39 @@ static const NSTimeInterval kFarFutureCookieInterval = 10000.0 * 24 * 60 * 60;
 // and for re-authenticating a known-expired session (already dead, so there's
 // nothing worth preserving).
 @property (nonatomic) BOOL clearsExistingSessionBeforeLoad;
+// Consecutive harvest attempts that found an incomplete session (see the
+// completeness gate in _harvestAndFinishForUser:).
+@property (nonatomic) NSUInteger harvestAttempts;
 @end
+
+// How many times the harvest may defer back to the 2s auth poll while waiting
+// for a complete session (missing token_v2/reddit_session/modhash) before
+// proceeding with whatever is there — ~10s total, bounded so flows that never
+// produce a given cookie (e.g. old.reddit logins on iOS < 16, or sessions
+// whose /api/me.json omits the modhash) still finish.
+static const NSUInteger kMaxIncompleteHarvestAttempts = 5;
+
+// Off-screen WKWebView that refreshes a stale stored session from the shared
+// persistent data store. See +attemptSilentReharvestForUsername:completion:.
+// Implementation at the bottom of this file (it reuses the shared probe/harvest
+// helpers defined alongside the login VC's own auth-state machinery).
+@interface ApolloWebSessionSilentReharvester : NSObject <WKNavigationDelegate>
+@property (nonatomic, strong) WKWebView *webView;
+@property (nonatomic, copy) NSString *username;      // lowercased target
+@property (nonatomic, copy) void (^completion)(BOOL);
+@property (nonatomic) BOOL done;
+- (void)_finish:(BOOL)success;
+@end
+
+// In-flight attempts, keyed by lowercased username. Retains the reharvester
+// (and thereby its WKWebView) for the duration of the attempt. Main-thread only.
+static NSMutableDictionary<NSString *, ApolloWebSessionSilentReharvester *> *sReharvestsInFlight;
+// Last time a silent re-harvest reported success, per lowercased username —
+// the cooldown that stops a silent hot loop when re-harvests "succeed" but the
+// transport keeps getting blocked anyway (e.g. an IP-level block).
+static NSMutableDictionary<NSString *, NSDate *> *sLastReharvestSuccess;
+static const NSTimeInterval kReharvestSuccessCooldown = 600.0;
+static const NSTimeInterval kReharvestTimeout = 25.0;
 
 @implementation ApolloWebSessionLoginViewController
 
@@ -180,26 +212,64 @@ static const NSTimeInterval kFarFutureCookieInterval = 10000.0 * 24 * 60 * 60;
     self.authPollTimer = nil;
 }
 
-#pragma mark - Auth state (source of truth: /api/me.json)
+#pragma mark - Shared probe/harvest helpers (login VC + silent re-harvester)
 
-// Asks Reddit, from the page's own origin (so httpOnly cookies are sent), who
-// is logged in. Returns the username, or @"" if anonymous / the request fails.
-- (void)_probeLoggedInUserWithCompletion:(void (^)(NSString *username))completion {
-    if (!self.pageLoaded) { completion(@""); return; }
-    NSString *js =
+// Fetches a field of /api/me.json from the page's own origin (so httpOnly
+// cookies are sent) in `webView`. Returns @"" if anonymous / the request fails.
+static void ApolloWebSessionProbeMeField(WKWebView *webView, NSString *field, void (^completion)(NSString *value)) {
+    NSString *js = [NSString stringWithFormat:
         @"try {"
         @"  const r = await fetch('/api/me.json', {credentials: 'include'});"
         @"  if (!r.ok) return '';"
         @"  const j = await r.json();"
-        @"  return (j && j.data && j.data.name) ? j.data.name : '';"
-        @"} catch (e) { return ''; }";
-    [self.webView callAsyncJavaScript:js
-                            arguments:nil
-                              inFrame:nil
-                       inContentWorld:WKContentWorld.pageWorld
-                    completionHandler:^(id result, NSError *error) {
+        @"  return (j && j.data && j.data.%@) ? j.data.%@ : '';"
+        @"} catch (e) { return ''; }", field, field];
+    [webView callAsyncJavaScript:js
+                       arguments:nil
+                         inFrame:nil
+                  inContentWorld:WKContentWorld.pageWorld
+               completionHandler:^(id result, NSError *error) {
         completion([result isKindOfClass:[NSString class]] ? (NSString *)result : @"");
     }];
+}
+
+// Sweeps every .reddit.com cookie in `cookieStore` into a "name=value; …"
+// header, rewrites session-only cookies to a far-future expiry so the
+// persistent data store keeps them across launches (Hydra's trick), and
+// persists cookie + modhash under `username` via ApolloWebSessionSet.
+static void ApolloWebSessionHarvestFromCookieStore(WKHTTPCookieStore *cookieStore, NSString *username, NSString *modhash,
+                                                   void (^completion)(NSUInteger cookieCount)) {
+    [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+        NSDate *farFuture = [NSDate dateWithTimeIntervalSinceNow:kFarFutureCookieInterval];
+        NSMutableArray<NSString *> *pairs = [NSMutableArray array];
+        for (NSHTTPCookie *cookie in cookies) {
+            if (![cookie.domain.lowercaseString hasSuffix:@"reddit.com"]) continue;
+            [pairs addObject:[NSString stringWithFormat:@"%@=%@", cookie.name, cookie.value]];
+            if (cookie.sessionOnly || !cookie.expiresDate) {
+                NSMutableDictionary *props = [cookie.properties mutableCopy];
+                [props removeObjectForKey:NSHTTPCookieDiscard];
+                [props removeObjectForKey:NSHTTPCookieMaximumAge];
+                props[NSHTTPCookieExpires] = farFuture;
+                NSHTTPCookie *persistent = [NSHTTPCookie cookieWithProperties:props];
+                if (persistent) [cookieStore setCookie:persistent completionHandler:nil];
+            }
+        }
+        if (pairs.count > 0) {
+            ApolloWebSessionSet(username, [pairs componentsJoinedByString:@"; "], modhash);
+            // A fresh harvest supersedes any expiry verdict this launch reached
+            // for the account — re-arm detection for the NEW session.
+            ApolloWebJSONNoteSessionReauthenticated(username);
+        }
+        completion(pairs.count);
+    }];
+}
+
+#pragma mark - Auth state (source of truth: /api/me.json)
+
+// Asks Reddit who is logged in. Returns @"" if anonymous / the request fails.
+- (void)_probeLoggedInUserWithCompletion:(void (^)(NSString *username))completion {
+    if (!self.pageLoaded) { completion(@""); return; }
+    ApolloWebSessionProbeMeField(self.webView, @"name", completion);
 }
 
 // Reads the session modhash from /api/me.json (data.modhash). The modhash is
@@ -208,20 +278,7 @@ static const NSTimeInterval kFarFutureCookieInterval = 10000.0 * 24 * 60 * 60;
 // Returns @"" when absent (some anonymous/limited sessions omit it).
 - (void)_probeModhashWithCompletion:(void (^)(NSString *modhash))completion {
     if (!self.pageLoaded) { completion(@""); return; }
-    NSString *js =
-        @"try {"
-        @"  const r = await fetch('/api/me.json', {credentials: 'include'});"
-        @"  if (!r.ok) return '';"
-        @"  const j = await r.json();"
-        @"  return (j && j.data && j.data.modhash) ? j.data.modhash : '';"
-        @"} catch (e) { return ''; }";
-    [self.webView callAsyncJavaScript:js
-                            arguments:nil
-                              inFrame:nil
-                       inContentWorld:WKContentWorld.pageWorld
-                    completionHandler:^(id result, NSError *error) {
-        completion([result isKindOfClass:[NSString class]] ? (NSString *)result : @"");
-    }];
+    ApolloWebSessionProbeMeField(self.webView, @"modhash", completion);
 }
 
 - (void)_evaluateAuthState {
@@ -315,8 +372,6 @@ static const NSTimeInterval kFarFutureCookieInterval = 10000.0 * 24 * 60 * 60;
 - (void)_harvestAndFinishForUser:(NSString *)username {
     if (self.finished) return;
     self.finished = YES; // guard against the poll firing again mid-harvest
-    [self.authPollTimer invalidate];
-    self.authPollTimer = nil;
 
     WKHTTPCookieStore *cookieStore = self.webView.configuration.websiteDataStore.httpCookieStore;
     __weak typeof(self) weakSelf = self;
@@ -326,34 +381,50 @@ static const NSTimeInterval kFarFutureCookieInterval = 10000.0 * 24 * 60 * 60;
         typeof(self) s = weakSelf;
         if (!s) return;
         [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
-            // Rewrite session cookies to a far-future expiry so the persistent
-            // data store keeps them across launches (instead of discarding on quit).
-            NSDate *farFuture = [NSDate dateWithTimeIntervalSinceNow:kFarFutureCookieInterval];
-            NSMutableArray<NSString *> *pairs = [NSMutableArray array];
-            for (NSHTTPCookie *cookie in cookies) {
-                if (![cookie.domain.lowercaseString hasSuffix:@"reddit.com"]) continue;
-                [pairs addObject:[NSString stringWithFormat:@"%@=%@", cookie.name, cookie.value]];
-                if (cookie.sessionOnly || !cookie.expiresDate) {
-                    NSMutableDictionary *props = [cookie.properties mutableCopy];
-                    [props removeObjectForKey:NSHTTPCookieDiscard];
-                    [props removeObjectForKey:NSHTTPCookieMaximumAge];
-                    props[NSHTTPCookieExpires] = farFuture;
-                    NSHTTPCookie *persistent = [NSHTTPCookie cookieWithProperties:props];
-                    if (persistent) [cookieStore setCookie:persistent completionHandler:nil];
-                }
+            typeof(self) s2 = weakSelf;
+            if (!s2) return;
+            // Completeness gate: in the instant after the fetch-based login
+            // completes, the jar can briefly lack token_v2 (and /api/me.json
+            // can still omit the modhash). Harvesting that partial state ships
+            // a session that "works" for a moment then dies — the "takes a few
+            // tries to log in" loop. Defer to the 2s auth poll (bounded) until
+            // the session is complete.
+            BOOL hasTokenV2 = NO, hasRedditSession = NO;
+            for (NSHTTPCookie *c in cookies) {
+                if (![c.domain.lowercaseString hasSuffix:@"reddit.com"]) continue;
+                if ([c.name isEqualToString:@"token_v2"]) hasTokenV2 = YES;
+                else if ([c.name isEqualToString:@"reddit_session"]) hasRedditSession = YES;
             }
+            BOOL complete = hasTokenV2 && hasRedditSession && modhash.length > 0;
+            if (!complete && s2.harvestAttempts < kMaxIncompleteHarvestAttempts && s2.authPollTimer) {
+                s2.harvestAttempts += 1;
+                ApolloLog(@"[WebJSON] Incomplete session for u/%@ (token_v2=%d reddit_session=%d modhash=%d) — waiting for a complete one (attempt %lu/%lu)",
+                          username, hasTokenV2, hasRedditSession, modhash.length > 0,
+                          (unsigned long)s2.harvestAttempts, (unsigned long)kMaxIncompleteHarvestAttempts);
+                s2.finished = NO;      // let the auth poll call us again…
+                s2.awaitingLogin = YES; // …including when we got here via "Keep Current Session"
+                return;
+            }
+            if (!complete) {
+                ApolloLog(@"[WebJSON] Proceeding with an incomplete session for u/%@ after %lu attempts (token_v2=%d reddit_session=%d modhash=%d) — some flows (old.reddit) never produce every field",
+                          username, (unsigned long)s2.harvestAttempts, hasTokenV2, hasRedditSession, modhash.length > 0);
+            }
+            [s2.authPollTimer invalidate];
+            s2.authPollTimer = nil;
+
             // Persist the cookie + write token under THIS username (not a single
             // global) — ApolloWebSessionStore, keychain-backed — so it coexists
             // with any other web-session or OAuth accounts already configured.
-            ApolloWebSessionSet(username, [pairs componentsJoinedByString:@"; "], modhash);
-            ApolloLog(@"[WebJSON] Harvested session for u/%@, %lu cookies, modhash %@",
-                      username, (unsigned long)pairs.count, modhash.length > 0 ? @"captured" : @"absent");
+            ApolloWebSessionHarvestFromCookieStore(cookieStore, username, modhash, ^(NSUInteger cookieCount) {
+                ApolloLog(@"[WebJSON] Harvested session for u/%@, %lu cookies, modhash %@",
+                          username, (unsigned long)cookieCount, modhash.length > 0 ? @"captured" : @"absent");
 
-            // Synthesize a signed-in account so the account tab + write actions
-            // (vote/comment) work — they gate on AccountManager having a current
-            // account, which only loads at launch, so a restart is required.
-            BOOL synthesized = ApolloWebJSONSynthesizeSignedInAccount(username);
-            [s _finishWithUser:username accountSynthesized:synthesized];
+                // Synthesize a signed-in account so the account tab + write actions
+                // (vote/comment) work — they gate on AccountManager having a current
+                // account, which only loads at launch, so a restart is required.
+                BOOL synthesized = ApolloWebJSONSynthesizeSignedInAccount(username);
+                [s2 _finishWithUser:username accountSynthesized:synthesized];
+            });
         }];
     }];
 }
@@ -440,6 +511,56 @@ static const NSTimeInterval kFarFutureCookieInterval = 10000.0 * 24 * 60 * 60;
     [self.navigationController dismissViewControllerAnimated:YES completion:nil];
 }
 
+#pragma mark - Silent re-harvest entry point
+
++ (void)attemptSilentReharvestForUsername:(NSString *)username completion:(void (^)(BOOL success))completion {
+    completion = [completion copy];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSString *key = [[username ?: @"" stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+        if (key.length == 0) { if (completion) completion(NO); return; }
+
+        // Repeated expiry verdicts right after a "successful" silent re-harvest
+        // mean the problem isn't snapshot staleness (the one thing this can
+        // fix) — don't loop silently, let the visible prompt take over.
+        NSDate *last = sLastReharvestSuccess[key];
+        if (last && -last.timeIntervalSinceNow < kReharvestSuccessCooldown) {
+            ApolloLog(@"[WebJSON] Silent re-harvest for u/%@ already succeeded %.0fs ago and the session died again — not retrying silently", key, -last.timeIntervalSinceNow);
+            if (completion) completion(NO);
+            return;
+        }
+        // Coalesce concurrent attempts: the first one's outcome stands; later
+        // callers are dropped (documented in the header).
+        if (sReharvestsInFlight[key]) return;
+
+        ApolloLog(@"[WebJSON] Attempting silent re-harvest for u/%@ from the persistent webview jar", key);
+        ApolloWebSessionSilentReharvester *r = [ApolloWebSessionSilentReharvester new];
+        r.username = key;
+        r.completion = completion;
+
+        WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+        config.websiteDataStore = [WKWebsiteDataStore defaultDataStore];
+        r.webView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:config];
+        r.webView.navigationDelegate = r;
+
+        if (!sReharvestsInFlight) sReharvestsInFlight = [NSMutableDictionary dictionary];
+        sReharvestsInFlight[key] = r;
+
+        // Load the real homepage (not /api/me.json directly): that's the load
+        // that makes Reddit's edge refresh a stale token_v2 via Set-Cookie,
+        // exactly like the visible login flow does.
+        [r.webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://www.reddit.com/"]]];
+
+        __weak ApolloWebSessionSilentReharvester *weakR = r;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kReharvestTimeout * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            ApolloWebSessionSilentReharvester *sr = weakR;
+            if (sr && !sr.done) {
+                ApolloLog(@"[WebJSON] Silent re-harvest for u/%@ timed out after %.0fs", sr.username, kReharvestTimeout);
+                [sr _finish:NO];
+            }
+        });
+    });
+}
+
 #pragma mark - WKNavigationDelegate
 
 - (void)webView:(WKWebView *)webView
@@ -488,6 +609,66 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
     ApolloLog(@"[WebJSON] Navigation failed: %@", error);
 }
 
+@end
+
+#pragma mark - Silent re-harvest (expiry recovery without UI)
+
+@implementation ApolloWebSessionSilentReharvester
+
+- (void)_finish:(BOOL)success {
+    if (self.done) return;
+    self.done = YES;
+    self.webView.navigationDelegate = nil;
+    [self.webView stopLoading];
+    if (success) {
+        if (!sLastReharvestSuccess) sLastReharvestSuccess = [NSMutableDictionary dictionary];
+        sLastReharvestSuccess[self.username] = [NSDate date];
+    }
+    [sReharvestsInFlight removeObjectForKey:self.username];
+    if (self.completion) self.completion(success);
+}
+
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
+    if (self.done) return;
+    __weak typeof(self) weakSelf = self;
+    ApolloWebSessionProbeMeField(webView, @"name", ^(NSString *user) {
+        typeof(self) s = weakSelf;
+        if (!s || s.done) return;
+        // The persistent jar is shared across every web-session account: only
+        // harvest when it holds a live login for the SAME user whose snapshot
+        // died — anything else (logged out, different account) is a real
+        // expiry for our target and must go to the visible prompt.
+        if (![user.lowercaseString isEqualToString:s.username]) {
+            ApolloLog(@"[WebJSON] Silent re-harvest for u/%@ found %@ in the webview jar — falling through to the expiry prompt",
+                      s.username, user.length > 0 ? [NSString stringWithFormat:@"u/%@", user] : @"no login");
+            [s _finish:NO];
+            return;
+        }
+        ApolloWebSessionProbeMeField(webView, @"modhash", ^(NSString *modhash) {
+            typeof(self) s2 = weakSelf;
+            if (!s2 || s2.done) return;
+            WKHTTPCookieStore *store = webView.configuration.websiteDataStore.httpCookieStore;
+            ApolloWebSessionHarvestFromCookieStore(store, s2.username, modhash, ^(NSUInteger cookieCount) {
+                ApolloLog(@"[WebJSON] Silently re-harvested session for u/%@ (%lu cookies, modhash %@) — expiry prompt suppressed",
+                          s2.username, (unsigned long)cookieCount, modhash.length > 0 ? @"captured" : @"absent");
+                [s2 _finish:cookieCount > 0];
+            });
+        });
+    });
+}
+
+- (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error {
+    ApolloLog(@"[WebJSON] Silent re-harvest navigation failed for u/%@: %@", self.username, error.localizedDescription);
+    [self _finish:NO];
+}
+
+- (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error {
+    ApolloLog(@"[WebJSON] Silent re-harvest navigation failed for u/%@: %@", self.username, error.localizedDescription);
+    [self _finish:NO];
+}
+
+@end
+
 #pragma mark - Shared sign-in chooser (reused by the empty-state splash and the account switcher)
 
 void ApolloWebSessionPresentSignInChooser(UIViewController *host, void (^apiKeyHandler)(void)) {
@@ -524,5 +705,3 @@ void ApolloWebSessionPresentSignInChooser(UIViewController *host, void (^apiKeyH
     sheet.popoverPresentationController.sourceRect = host.view.bounds;
     [host presentViewController:sheet animated:YES completion:nil];
 }
-
-@end

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -2041,14 +2041,14 @@ typedef NS_ENUM(NSInteger, Tag) {
     }
 }
 
-// Adding ANOTHER web-session account when one already exists must clear the
-// shared WKWebView cookie jar first, or the login page would just silently
-// reuse the already-signed-in web user (see ApolloWebSessionLoginViewController.h).
+// This row is "manage/refresh my web login", NOT "add another account", so it
+// must NOT clear the shared WKWebView cookie jar: the jar usually holds the
+// live, server-rotated login this account depends on (and that the silent
+// re-harvest recovers from). The plain login flow detects an existing jar
+// login and offers Keep (re-harvest it) / Re-authenticate — exactly the right
+// choices here. Only account-ADD flows (switcher/chooser) clear the jar first.
 - (void)presentWebSessionLoginViewController {
-    BOOL hasExistingWebSession = ApolloWebSessionUsernames().count > 0;
-    ApolloWebSessionLoginViewController *vc = hasExistingWebSession
-        ? [ApolloWebSessionLoginViewController loginControllerForAdditionalAccount]
-        : [ApolloWebSessionLoginViewController new];
+    ApolloWebSessionLoginViewController *vc = [ApolloWebSessionLoginViewController new];
     UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:vc];
     [self presentViewController:nav animated:YES completion:nil];
 }

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1859,6 +1859,17 @@ static void initializeRandomSources() {
         NSArray<NSString *> *webSessionUsers = ApolloWebSessionUsernames().allObjects;
         ApolloLog(@"[WebJSON] enabled at launch, %lu web-session account(s): %@",
                   (unsigned long)webSessionUsers.count, webSessionUsers);
+        // Poison repair + bearer attribution, both before AccountManager loads
+        // the account blobs. Repair MUST run first: on a poisoned blob the
+        // victim index still carries the web-session username, so seeding
+        // first would register the victim's REAL token under that username —
+        // and the chokepoint would then cookie-rewrite the victim's post-
+        // repair identity refresh as the wrong user, re-poisoning the account
+        // the moment it's selected. Repair clears the victim's currentUser, so
+        // the seed skips it and its requests stay on the oauth path.
+        @try { ApolloWebJSONRepairPoisonedAccountBlobs(); }
+        @catch (NSException *e) { ApolloLog(@"[WebJSON][repair] launch repair threw: %@", e); }
+        ApolloWebJSONSeedBearerRegistryFromDisk();
     }
 
     // Cold-start identity: synthesize a signed-in account for every stored


### PR DESCRIPTION
Fixes a cluster of user-reported issues in the experimental **API-Key-Free (Web JSON)** mode, from the r/ApolloReborn testing threads ([1u55nc5](https://www.reddit.com/r/ApolloReborn/comments/1u55nc5/), [1uj76wq](https://www.reddit.com/r/ApolloReborn/comments/1uj76wq/)) plus device testing. Builds on #442 / #495 / #505.

## Session persistence — the "stops working a few times a day" cluster

The stored `Cookie` header was a frozen snapshot from harvest time, with `HTTPShouldHandleCookies=NO` and no `Set-Cookie` capture anywhere. Reddit rotates auth cookies server-side (notably `token_v2`), so the snapshot went stale while the *server* session stayed alive — which is exactly why the re-login browser kept saying "already logged in."

- **Capture rotated cookies.** Merge `token_v2` / `reddit_session` / `loid` / `csrf_token` / `edgebucket` from `Set-Cookie` on cookie-authed responses (and the verify probe) back into the per-account keychain session. (`ApolloWebJSONMergeSetCookiesFromResponse`)
- **Silent re-harvest before prompting.** Before showing "session expired," silently re-harvest from the persistent `WKWebsiteDataStore` — recovers the common stale-snapshot case with no UI. (`attemptSilentReharvestForUsername:`, 10-min success cooldown to avoid hot loops)
- **Stop misreading rate limits as expiry.** Three-way probe verdict (alive / dead / **inconclusive**): `429`, `5xx`, network errors, and challenge pages back off and re-probe (honoring `Retry-After`) instead of announcing expiry and latching the prompt.
- **New-modmail 403s no longer poison detection.** `/api/mod/conversations` is OAuth-only and 403s for cookie auth on every inbox refresh (~90s) for mod accounts; it's now excluded from the block-page streak.
- **Complete-harvest gate.** Require `token_v2` + `reddit_session` + modhash before finishing login (bounded retry) so a partial "works briefly then dies" session isn't shipped.
- **Settings login row.** The "Web Session Login" row no longer clears the shared cookie jar on every visit — that was forcing a manual re-login and destroying the very cookies recovery relies on. (Account-*add* flows still clear, as before.)
- **Browser-shaped write headers.** `Origin` / `Referer` / `Sec-Fetch-*` on cookie-authed writes.

## Keyless uploads & the Submit Post drawer

- **Native Reddit image upload no longer falls back to Imgur.** The upload path read the legacy `sWebSession*` globals that the #505 per-account migration permanently wipes, so the gate always failed. Now resolves the active `ApolloActiveWebSession()`. (`ApolloImageUploadHost.xm`)
- **Never-loading Submit drawer fixed.** The composer's `GET /r/<sub>/api/link_flair` fell through to `oauth.reddit.com` with the synthetic bearer → 401 → instant-success token refresh → retry, an infinite loop at ~8 req/s. `/r/<sub>/api/*` GETs now route through the web transport, and the OAuth-only flair-template lists are stubbed to empty (no flair options in keyless mode, a missing feature rather than a hang).

## Chat

- **Direct Chat row hidden for keyless accounts.** Verified live that Reddit's web JSON API returns zero children for the `[direct chat room]` `t4` bridge under cookie auth — the row only ever opened an empty list. OAuth accounts keep full chat behavior. (Real parity would need the Matrix token-exchange flow RE'd; `token_v2` is rejected directly with `M_UNKNOWN_TOKEN`.)

## Testing

- Simulator (real signed-in account via keychain-seed backup): confirmed the flair stub, cookie-merge, and modmail-streak fixes in logs; confirmed OAuth path untouched (every keyless change is gated on `ApolloWebJSONHasUsableSession()`).
- **Device: image post, multi-image post, video post, commenting, and comment editing all work in keyless mode.**

Out of scope / follow-up: a latent intermittent crash in the Show Deleted Comments font-capture (`ApolloDeletedCommentsCaptureLiveCommentBodyFont`, unrelated to this mode) will be hardened in a separate PR.