### PR TITLE
Settings: stronger, simpler warning when enabling Show Deleted Comments

### DIFF
--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -2137,8 +2137,8 @@ typedef NS_ENUM(NSInteger, Tag) {
     NSArray<NSIndexPath *> *paths = @[[NSIndexPath indexPathForRow:4 inSection:SectionGeneral]];
     if (sShowDeletedComments) {
         [self.tableView insertRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
-        [self showAlertWithTitle:@"Show Deleted Comments"
-                          message:@"This feature uses Arctic Shift to recover deleted comments. When Arctic Shift is slow or rate-limited, comments may load more slowly or recovered comments may not appear."];
+        [self showAlertWithTitle:@"⚠️ WARNING"
+                          message:@"This feature can slow down comment loading. If you notice comments loading slowly, turn this feature off."];
     } else {
         [self.tableView deleteRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
     }


### PR DESCRIPTION
The alert shown when turning on **Show Deleted Comments** buried the practical takeaway behind backend details (Arctic Shift, rate limiting). Users don't need to know the service name — just the symptom and the remedy.

**Before**
> **Show Deleted Comments**
> This feature uses Arctic Shift to recover deleted comments. When Arctic Shift is slow or rate-limited, comments may load more slowly or recovered comments may not appear.

**After**
> **⚠️ WARNING**
> This feature can slow down comment loading. If you notice comments loading slowly, turn this feature off.

Text-only change to the existing alert in `showDeletedCommentsSwitchToggled:` — no behavior change.