### PR TITLE
Redgifs: recognize modern subdomains (v3.redgifs.com) so posts play inline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloFlairColors.xm \
     $(SRC_DIR)/ApolloNativeActionMenus.xm \
     $(SRC_DIR)/ApolloHostedVideo.m \
+    $(SRC_DIR)/ApolloRedgifsSubdomainFix.xm \
     $(SRC_DIR)/ApolloShareAsImageGallery.xm \
     $(SRC_DIR)/ApolloShareAsImageLink.xm \
     $(SRC_DIR)/ApolloShareAsVideo.xm \

--- a/src/ApolloRedgifsSubdomainFix.xm
+++ b/src/ApolloRedgifsSubdomainFix.xm
@@ -1,0 +1,117 @@
+#import <Foundation/Foundation.h>
+
+#import "ApolloCommon.h"
+
+// =============================================================================
+// MARK: - Overview
+// =============================================================================
+//
+// Fix: RedGifs link posts whose URL uses a modern subdomain — most commonly
+// `v3.redgifs.com` (RedGifs' current web host), and any future `vN.`/CDN host —
+// are not recognized as RedGifs media by Apollo. Instead of an inline video
+// player they render as a dead link-preview card ("Link to v3.redgifs.com" /
+// a static poster with "Watch this GIF on RedGIFs.com…"). See issue #79.
+//
+// Root cause (reverse-engineered in Hopper): every RedGifs-detecting code path —
+// the central media-type classifier, the feed/comments-header thumbnail
+// resolvers, MediaPageViewController, MediaViewerController, and the rich-push
+// NotificationService — builds ONE host-recognition regex, constructed fresh at
+// each call site through a shared Swift NSRegularExpression wrapper. That regex
+// (embedded in the app binary) is:
+//
+//   ^http(?:s)?://(?:www\.)?(?:(?:giant|fat|thumbs|zippy)\d*\.)?redgifs.com/
+//     (?:(?:\w{2}|ifr|gifs/detail|watch)/)?(\w+)[\w-]*
+//
+// The subdomain portion only allows an optional `www.` plus a handful of legacy
+// CDN hosts (giant/fat/thumbs/zippy). `v3.redgifs.com` matches none of them, so
+// the URL fails the very first recognition step and the post is treated as a
+// plain external link.
+//
+// Note this is ONLY a recognition gap. RedGifs URLs that DO match already play
+// correctly as inline video WITH audio and a mute button: the classifier stores
+// a `.gif(host: redgifs, id:)` case, and RedGIFsClient fetches the audio-bearing
+// hd/sd MP4 from api.redgifs.com/v2/gifs/<id> (the OAuth handshake is already
+// rewritten to /v2/auth/temporary in Tweak.xm). So the whole fix is: make the
+// recognition regex accept any subdomain, and the existing (working) playback
+// path handles the rest — no per-consumer hooks, and no dependency on which
+// model/ivar a given code path read the URL from.
+//
+// Interception point: every one of those regexes is built via
+// -[NSRegularExpression initWithPattern:options:error:], so hooking that single
+// Foundation initializer and widening the RedGifs host pattern's subdomain group
+// fixes all consumers at once. The hook fast-rejects every non-RedGifs pattern
+// (the overwhelming majority) with one substring check, so it is a cheap no-op
+// for unrelated regexes.
+//
+// =============================================================================
+
+// The exact subdomain fragment Apollo's RedGifs host regex uses. Widening just
+// this fragment — rather than substituting the whole pattern — keeps the change
+// minimal and resilient to unrelated adjustments Apollo might make to the rest
+// of the pattern in a future app version.
+static NSString *const kApolloRedgifsWWWFragment = @"(?:www\\.)?";
+
+// Replacement: zero-or-more arbitrary DNS labels. Matches bare `redgifs.com`,
+// `www.`, `v3.`, `v4.`, and any future/CDN subdomain, while staying anchored to
+// `…redgifs.com` (a lookalike host such as `notredgifs.com` or `redgifs.evil.com`
+// still fails to match, exactly as before).
+static NSString *const kApolloRedgifsAnySubdomain = @"(?:[\\w-]+\\.)*";
+
+// Returns a widened copy of the RedGifs host-recognition pattern, or the input
+// unchanged for every other pattern.
+static NSString *ApolloWidenRedgifsPatternIfNeeded(NSString *pattern) {
+    if (![pattern isKindOfClass:[NSString class]] || pattern.length == 0) return pattern;
+
+    // Fast reject: only the RedGifs host recognizer is of interest.
+    if ([pattern rangeOfString:@"redgifs" options:NSCaseInsensitiveSearch].location == NSNotFound) {
+        return pattern;
+    }
+    // Only widen the specific host recognizer, identified by its `(?:www\.)?`
+    // subdomain group. Any other redgifs-mentioning pattern is left untouched.
+    NSRange wwwRange = [pattern rangeOfString:kApolloRedgifsWWWFragment];
+    if (wwwRange.location == NSNotFound) {
+        // The recognizer's shape changed (app update). Do nothing rather than
+        // risk mangling it, but leave a breadcrumb so we notice.
+        static dispatch_once_t warnOnce;
+        dispatch_once(&warnOnce, ^{
+            ApolloLog(@"[RedgifsSubdomain] RedGifs pattern present but '(?:www\\.)?' fragment "
+                      @"not found — recognizer may have changed; leaving pattern unmodified: %@", pattern);
+        });
+        return pattern;
+    }
+    // Already widened (defensive; our replacement contains no `(?:www\.)?`).
+    if ([pattern rangeOfString:kApolloRedgifsAnySubdomain].location != NSNotFound) {
+        return pattern;
+    }
+
+    NSString *widened = [pattern stringByReplacingCharactersInRange:wwwRange
+                                                         withString:kApolloRedgifsAnySubdomain];
+    static dispatch_once_t logOnce;
+    dispatch_once(&logOnce, ^{
+        ApolloLog(@"[RedgifsSubdomain] widened RedGifs host regex to accept any subdomain "
+                  @"(e.g. v3.redgifs.com now plays inline)");
+    });
+    return widened;
+}
+
+%hook NSRegularExpression
+
+- (instancetype)initWithPattern:(NSString *)pattern
+                        options:(NSRegularExpressionOptions)options
+                          error:(NSError **)error {
+    NSString *widened = ApolloWidenRedgifsPatternIfNeeded(pattern);
+    if (widened != pattern) {
+        return %orig(widened, options, error);
+    }
+    return %orig;
+}
+
+%end
+
+// =============================================================================
+// MARK: - Constructor
+// =============================================================================
+
+%ctor {
+    ApolloLog(@"[RedgifsSubdomain] ctor: NSRegularExpression host-regex hook installed");
+}


### PR DESCRIPTION
Fixes #79.

## Problem

RedGifs link posts whose URL uses a non-`www` subdomain — most commonly **`v3.redgifs.com`** (RedGifs' current web host) — render as a dead link-preview card (poster image + "Watch this GIF on RedGIFs.com…") instead of an inline video player. Tapping does nothing useful.

Posts on `www.redgifs.com` / bare `redgifs.com` work fine, which is why the bug looks intermittent depending on which host the submitter's link used.

## Root cause

Every RedGifs-detecting code path — the central media-type classifier, the feed and comments-header thumbnail resolvers, `MediaPageViewController`, `MediaViewerController`, and the rich-push NotificationService — matches the post host against one regex whose subdomain group only allows an optional `www.` plus a handful of dead legacy CDN hosts:

```
^http(?:s)?://(?:www\.)?(?:(?:giant|fat|thumbs|zippy)\d*\.)?redgifs.com/(?:(?:\w{2}|ifr|gifs/detail|watch)/)?(\w+)[\w-]*
```

`v3.redgifs.com` matches none of those, so the URL fails the very first recognition step and the post is treated as a plain external link.

This is **only** a recognition gap. RedGifs URLs that do match already play correctly as inline video **with audio and a mute button** — the classifier stores a `.gif(host: redgifs, id:)` case and `RedGIFsClient` fetches the audio-bearing hd/sd MP4 from `api.redgifs.com/v2/gifs/<id>` (the OAuth handshake is already rewritten to `/v2/auth/temporary`). So the whole fix is to widen recognition; the existing playback path handles everything else. (This also means there is no separate "no audio" bug — the model only ever fetches the audio-bearing hd/sd renditions, never `silent`.)

## Fix

New module `src/ApolloRedgifsSubdomainFix.xm`. Every one of those regexes is constructed via `-[NSRegularExpression initWithPattern:options:error:]`, so the hook intercepts that one Foundation initializer and, **only** for the RedGifs host pattern (guarded by a `"redgifs"` + `"(?:www\.)?"` substring check), replaces `(?:www\.)?` with `(?:[\w-]+\.)*`:

- Matches any subdomain: bare `redgifs.com`, `www.`, `v3.`, `v4.`, `media.`, legacy CDN hosts, and any future host.
- The id capture group is preserved (`v3.redgifs.com/watch/<id>` → `<id>`).
- Lookalike hosts still fail to match (`notredgifs.com`, `redgifs.evil.com`).
- Fast-rejects every non-RedGifs pattern with a single substring check, so it is a no-op for unrelated regexes.

Always-on (no toggle), consistent with the existing RedGifs OAuth rewrite in `Tweak.xm`.

## Testing

Verified in the iOS 26 simulator (Liquid Glass):

- **`v3.redgifs.com` post → now plays as an inline video with a working mute button** (was a dead link card).
- **No regressions:** `www.redgifs.com` posts, `v.redd.it` videos, and `i.redd.it` animated GIFs all still render inline; app stable, no crashes.
- Device build (`make package`) compiles clean against `main`.

Not yet exercised on a physical device; behavior is identical to the already-working `www.redgifs.com` path once the URL is recognized.