### PR TITLE
Deleted Comments: settings sub-screen, comments-menu shortcut, passive per-thread mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloCreatedAtAlert.xm \
     $(SRC_DIR)/ApolloDeletedCommentsData.m \
     $(SRC_DIR)/ApolloDeletedCommentsUI.xm \
+    $(SRC_DIR)/ApolloDeletedCommentsMenu.xm \
     $(SRC_DIR)/ApolloState.m \
     $(SRC_DIR)/ApolloShareLinks.xm \
     $(SRC_DIR)/ApolloMedia.xm \
@@ -115,6 +116,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloSignInSplash.xm \
     $(SRC_DIR)/CustomAPIViewController.m \
     $(SRC_DIR)/ApolloAISettingsViewController.m \
+    $(SRC_DIR)/ApolloDeletedCommentsSettingsViewController.m \
     $(SRC_DIR)/ApolloLinkPreviewSettingsViewController.m \
     $(SRC_DIR)/TranslationSettingsViewController.m \
     $(SRC_DIR)/SavedCategoriesViewController.m \

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -101,4 +101,12 @@ void ApolloSetLinkPreviewCardColorHex(NSString *hex);
 // `children` (an NSMutableArray<UIMenuElement *>). No-op for any other menu.
 // Called from ApolloNativeActionMenuBuildMenu as it converts the action sheet.
 void ApolloInjectPublicStickyAsSubredditIfNeeded(NSMutableArray *children, NSString *menuTitle);
+
+// ApolloDeletedCommentsMenu: when the comments view's "..." menu is being
+// built, append a "Show/Hide Deleted Comments" UIAction to `children`
+// (an NSMutableArray<UIMenuElement *>). No-op for any other menu. Called from
+// ApolloNativeActionMenuBuildMenu as it converts the action sheet; the
+// ActionController is tagged on first build so re-builds re-inject and other
+// menus can't claim the item.
+void ApolloInjectDeletedCommentsMenuItemIfNeeded(NSMutableArray *children, NSString *menuTitle, id actionController);
 __END_DECLS

--- a/src/ApolloDeletedCommentsData.h
+++ b/src/ApolloDeletedCommentsData.h
@@ -9,6 +9,16 @@ extern NSString *const ApolloDeletedCommentsArcticCacheUpdatedNotification;
 
 typedef void (^ApolloDeletedCommentsURLSessionCompletion)(NSData *data, NSURLResponse *response, NSError *error);
 
+// Master gate: global toggle OR any per-thread "Passive" override active.
+// Every deleted-comments code path checks this instead of sShowDeletedComments
+// directly so passive per-thread enables reuse the whole machinery.
+BOOL ApolloDeletedCommentsFeatureActive(void);
+// Per-thread overrides (post fullName t3_xxx; bare ids accepted). In-memory
+// only; managed by ApolloDeletedCommentsMenu.xm.
+void ApolloDeletedCommentsSetThreadOverride(NSString *linkFullName, BOOL enabled);
+BOOL ApolloDeletedCommentsHasThreadOverride(NSString *linkFullName);
+// Global toggle OR an override for this specific post (t3_xxx or bare id).
+BOOL ApolloDeletedCommentsActiveForLink(NSString *linkFullName);
 void ApolloDeletedCommentsHandleRequestObservation(NSURLRequest *request, NSString *source);
 ApolloDeletedCommentsURLSessionCompletion ApolloDeletedCommentsMaybeWrapCompletion(NSURLRequest *request, ApolloDeletedCommentsURLSessionCompletion completion);
 void ApolloDeletedCommentsInstallDelegateTransformerIfNeeded(NSURLSession *session, NSURLRequest *request);

--- a/src/ApolloDeletedCommentsData.m
+++ b/src/ApolloDeletedCommentsData.m
@@ -31,6 +31,7 @@ static NSObject *sApolloDeletedCommentsArcticLock = nil;
 static NSMutableDictionary<NSString *, NSDictionary *> *sApolloDeletedCommentsArcticCache = nil;
 static NSMutableDictionary<NSString *, NSMutableArray *> *sApolloDeletedCommentsArcticInflight = nil;
 static NSDate *sApolloDeletedCommentsArcticCooldownUntil = nil;
+static NSMutableSet<NSString *> *sApolloDeletedCommentsThreadOverrides = nil;
 
 static NSString *const ApolloDeletedCommentsMarkerKey = @"apollo_recovered_deleted_comment";
 static NSString *const ApolloDeletedCommentsReasonKey = @"apollo_recovered_deleted_reason";
@@ -50,6 +51,7 @@ static NSInteger const ApolloDeletedCommentsArcticLowRemainingThreshold = 3;
 
 static NSString *ApolloDeletedCommentsTrimmedString(NSString *s);
 static NSString *ApolloDeletedCommentsUnescapedHTMLText(NSString *s);
+static NSString *ApolloDeletedCommentsNormalizeLinkID(NSString *identifier);
 static NSString *ApolloDeletedCommentsCommentFullName(NSDictionary *data);
 static NSString *ApolloDeletedCommentsReasonForArchived(NSDictionary *archived);
 static BOOL ApolloDeletedCommentsBodyLooksDeleted(NSString *body);
@@ -70,6 +72,59 @@ static NSString *ApolloDeletedCommentsRegistryBodyKey(NSString *author, NSString
     if (trimmedBody.length == 0) return nil;
     NSString *trimmedAuthor = ApolloDeletedCommentsTrimmedString(author) ?: @"";
     return [NSString stringWithFormat:@"%@\n%lu\n%@", trimmedAuthor, (unsigned long)trimmedBody.length, trimmedBody];
+}
+
+#pragma mark - ThreadOverrides
+
+// Per-thread overrides for "Passive Deleted Comments": each entry is a post
+// fullName (t3_xxx) whose comment thread has recovery turned on from the
+// comments "..." menu while the global toggle is off. In-memory only — leaving
+// the thread clears its entry (ApolloDeletedCommentsMenu.xm) and nothing
+// survives relaunch by design.
+
+static NSString *ApolloDeletedCommentsOverrideKeyForLink(NSString *linkFullName) {
+    if (![linkFullName isKindOfClass:[NSString class]]) return nil;
+    return [ApolloDeletedCommentsNormalizeLinkID(linkFullName) lowercaseString];
+}
+
+void ApolloDeletedCommentsSetThreadOverride(NSString *linkFullName, BOOL enabled) {
+    NSString *key = ApolloDeletedCommentsOverrideKeyForLink(linkFullName);
+    if (key.length == 0) return;
+    @synchronized(ApolloDeletedCommentsRegistryLock()) {
+        if (enabled) {
+            if (!sApolloDeletedCommentsThreadOverrides) {
+                sApolloDeletedCommentsThreadOverrides = [NSMutableSet set];
+            }
+            [sApolloDeletedCommentsThreadOverrides addObject:key];
+        } else {
+            [sApolloDeletedCommentsThreadOverrides removeObject:key];
+        }
+    }
+    ApolloLog(@"[DeletedComments] Thread override %@ for %@", enabled ? @"ON" : @"OFF", key);
+}
+
+BOOL ApolloDeletedCommentsHasThreadOverride(NSString *linkFullName) {
+    NSString *key = ApolloDeletedCommentsOverrideKeyForLink(linkFullName);
+    if (key.length == 0) return NO;
+    @synchronized(ApolloDeletedCommentsRegistryLock()) {
+        return [sApolloDeletedCommentsThreadOverrides containsObject:key];
+    }
+}
+
+// Master gate: the machinery runs when the global toggle is on OR any thread
+// override is active. Cell/registry-level code uses this coarse form; the
+// network entry points below additionally gate per-link so only overridden
+// threads fetch and patch while the global toggle is off.
+BOOL ApolloDeletedCommentsFeatureActive(void) {
+    if (sShowDeletedComments) return YES;
+    @synchronized(ApolloDeletedCommentsRegistryLock()) {
+        return sApolloDeletedCommentsThreadOverrides.count > 0;
+    }
+}
+
+BOOL ApolloDeletedCommentsActiveForLink(NSString *linkFullName) {
+    if (sShowDeletedComments) return YES;
+    return ApolloDeletedCommentsHasThreadOverride(linkFullName);
 }
 
 void ApolloDeletedCommentsRegisterRecoveredComment(NSString *fullName, NSString *reason) {
@@ -311,9 +366,10 @@ static BOOL ApolloDeletedCommentsIsMoreChildrenRequest(NSURLRequest *request) {
 }
 
 static BOOL ApolloDeletedCommentsShouldTransformRequest(NSURLRequest *request) {
-    if (!sShowDeletedComments || !request.URL || !ApolloDeletedCommentsIsRedditHost(request.URL.host)) return NO;
+    if (!ApolloDeletedCommentsFeatureActive() || !request.URL || !ApolloDeletedCommentsIsRedditHost(request.URL.host)) return NO;
     if (!ApolloDeletedCommentsRequestLooksLikeCommentsPayload(request)) return NO;
-    return ApolloDeletedCommentsLinkFullNameForRequest(request).length > 0;
+    NSString *linkFullName = ApolloDeletedCommentsLinkFullNameForRequest(request);
+    return linkFullName.length > 0 && ApolloDeletedCommentsActiveForLink(linkFullName);
 }
 
 static BOOL ApolloDeletedCommentsShouldTransformTask(NSURLSessionTask *task) {
@@ -323,16 +379,24 @@ static BOOL ApolloDeletedCommentsShouldTransformTask(NSURLSessionTask *task) {
 }
 
 void ApolloDeletedCommentsHandleRequestObservation(NSURLRequest *request, NSString *source) {
-    if (!sShowDeletedComments) return;
+    if (!ApolloDeletedCommentsFeatureActive()) return;
     NSString *fullName = ApolloDeletedCommentsLinkFullNameFromRedditURL(request.URL);
     if (fullName.length == 0) return;
 
+    // Track EVERY observed thread (not just gated ones) so the 45s
+    // morechildren fallback in ApolloDeletedCommentsLinkFullNameForRequest
+    // always points at the thread the user is actually in — otherwise a
+    // non-overridden thread's "load more comments" (whose URL has no link id)
+    // would be misattributed to a previously overridden thread.
     BOOL changed = ![sApolloDeletedCommentsLastObservedLinkFullName isEqualToString:fullName];
     sApolloDeletedCommentsLastObservedLinkFullName = [fullName copy];
     sApolloDeletedCommentsLastObservedLinkDate = [NSDate date];
     if (changed) {
         ApolloLog(@"[DeletedComments] Observed Reddit comments request %@ (%@)", fullName, source ?: @"unknown");
     }
+
+    // Only gated threads warm the archive and notify.
+    if (!ApolloDeletedCommentsActiveForLink(fullName)) return;
 
     if (!ApolloDeletedCommentsIsMoreChildrenRequest(request)) {
         ApolloDeletedCommentsWarmArcticCacheForLink(fullName, source ?: @"request observation");
@@ -1102,7 +1166,8 @@ static NSData *ApolloDeletedCommentsSerializedResponseData(id root, NSData *fall
 }
 
 static NSData *__attribute__((unused)) ApolloDeletedCommentsPatchResponseImmediate(NSData *data, NSURLRequest *request) {
-    NSString *linkFullName = sShowDeletedComments ? ApolloDeletedCommentsLinkFullNameForRequest(request) : nil;
+    NSString *linkFullName = ApolloDeletedCommentsLinkFullNameForRequest(request);
+    if (!ApolloDeletedCommentsActiveForLink(linkFullName)) linkFullName = nil;
     if (linkFullName.length == 0 || data.length == 0) {
         return data;
     }
@@ -1130,7 +1195,8 @@ static NSData *__attribute__((unused)) ApolloDeletedCommentsPatchResponseImmedia
 }
 
 static void ApolloDeletedCommentsPatchResponseAsync(NSData *data, NSURLRequest *request, void (^completion)(NSData *patchedData)) {
-    NSString *linkFullName = sShowDeletedComments ? ApolloDeletedCommentsLinkFullNameForRequest(request) : nil;
+    NSString *linkFullName = ApolloDeletedCommentsLinkFullNameForRequest(request);
+    if (!ApolloDeletedCommentsActiveForLink(linkFullName)) linkFullName = nil;
     if (linkFullName.length == 0 || data.length == 0) {
         completion(data);
         return;
@@ -1229,8 +1295,16 @@ static void ApolloDeletedCommentsInstallResponseTransformerForDelegate(id delega
     IMP originalDidReceiveDataIMP = didReceiveDataMethod ? method_getImplementation(didReceiveDataMethod) : NULL;
     const char *didReceiveDataTypes = didReceiveDataMethod ? method_getTypeEncoding(didReceiveDataMethod) : "v@:@@@";
     IMP didReceiveDataIMP = imp_implementationWithBlock(^(id selfObject, NSURLSession *session, NSURLSessionDataTask *dataTask, NSData *data) {
-        if (sShowDeletedComments && ApolloDeletedCommentsShouldTransformTask(dataTask) && data.length > 0) {
-            NSMutableData *buffered = objc_getAssociatedObject(dataTask, kApolloDeletedCommentsResponseDataKey);
+        // Once a task starts buffering, keep buffering even if the gate flips
+        // off mid-flight (a passive per-thread override can clear at any time,
+        // e.g. when the thread is popped) — otherwise the head of the response
+        // would be withheld from the original delegate and the tail delivered
+        // raw, corrupting the payload. didComplete below delivers by buffer
+        // presence for the same reason.
+        NSMutableData *buffered = objc_getAssociatedObject(dataTask, kApolloDeletedCommentsResponseDataKey);
+        BOOL shouldBuffer = buffered != nil ||
+            (ApolloDeletedCommentsFeatureActive() && ApolloDeletedCommentsShouldTransformTask(dataTask));
+        if (shouldBuffer && data.length > 0) {
             if (!buffered) {
                 buffered = [NSMutableData data];
                 objc_setAssociatedObject(dataTask, kApolloDeletedCommentsResponseDataKey, buffered, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -1267,11 +1341,20 @@ static void ApolloDeletedCommentsInstallResponseTransformerForDelegate(id delega
     };
 
     IMP didCompleteIMP = imp_implementationWithBlock(^(id selfObject, NSURLSession *session, NSURLSessionTask *task, NSError *error) {
-        if (sShowDeletedComments && ApolloDeletedCommentsShouldTransformTask(task)) {
-            NSMutableData *buffered = objc_getAssociatedObject(task, kApolloDeletedCommentsResponseDataKey);
+        // Deliver by buffer presence, NOT by re-evaluating the gate: if the
+        // per-thread override cleared while this task was in flight, the
+        // buffered bytes must still reach the original delegate (the patch
+        // call below no-ops for a link whose gate is off, so the payload is
+        // delivered verbatim).
+        NSMutableData *buffered = objc_getAssociatedObject(task, kApolloDeletedCommentsResponseDataKey);
+        if (buffered) {
             objc_setAssociatedObject(task, kApolloDeletedCommentsResponseDataKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
             NSURLRequest *request = task.originalRequest ?: task.currentRequest;
-            if (buffered.length > 0 && !error) {
+            if (buffered.length > 0) {
+                if (error) {
+                    deliverOriginal(session, task, buffered, error, selfObject);
+                    return;
+                }
                 ApolloDeletedCommentsPatchResponseAsync(buffered, request, ^(NSData *patchedData) {
                     deliverOriginal(session, task, patchedData.length > 0 ? patchedData : buffered, error, selfObject);
                 });

--- a/src/ApolloDeletedCommentsMenu.xm
+++ b/src/ApolloDeletedCommentsMenu.xm
@@ -1,0 +1,270 @@
+// Deleted-comments shortcut in the comments "..." menu + passive per-thread mode.
+//
+// Adds a "Show Deleted Comments" / "Hide Deleted Comments" item to the comments
+// view's overflow menu (the native Liquid Glass UIMenu built by
+// ApolloNativeActionMenus.xm, which calls ApolloInjectDeletedCommentsMenuItemIfNeeded()
+// while it assembles the children — same pattern as the Public Sticky item).
+//
+// Two behaviors, decided by the "Passive Deleted Comments" setting:
+//   - Passive OFF: the item is a plain shortcut for the global Show Deleted
+//     Comments toggle (with the same slowdown warning the settings switch shows).
+//   - Passive ON (and global toggle off): the item turns recovery on for THIS
+//     post's thread only, via a thread override in ApolloDeletedCommentsData.
+//     The override dies when the last comments view showing that post is popped
+//     or dismissed, so the next thread starts with recovery off again.
+//
+// After either toggle the thread is re-fetched through Apollo's own
+// pull-to-refresh action so the recovered (or re-hidden) comments appear
+// without leaving the screen.
+
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+#import "ApolloDeletedCommentsData.h"
+#import "UserDefaultConstants.h"
+
+// The comments VC currently presenting its "..." menu. Armed in the tap hook
+// below; menu construction happens synchronously inside that tap (see
+// ApolloNativeActionMenus' Begin/EndCapture bracket), but a short grace window
+// keeps this robust if UIKit ever defers a runloop turn. The FIRST menu built
+// while armed consumes the arm (the ActionController gets tagged with the
+// owning VC below), so a different menu opened moments later can never pick
+// up the item.
+static __weak id sApolloDCMenuArmedVC = nil;
+static CFAbsoluteTime sApolloDCMenuArmedAt = 0;
+
+// Tag on the ActionController that IS the comments "..." menu: a weak-objects
+// hash table holding the owning CommentsViewController (a plain weak assoc
+// isn't possible with objc_setAssociatedObject).
+static char kApolloDCMenuOwnerVCKey;
+
+// linkFullName key -> weak set of CommentsViewController instances currently
+// showing that post's thread. Main-thread only. When the last live VC for an
+// overridden link leaves, the override is cleared.
+static NSMutableDictionary<NSString *, NSHashTable *> *sApolloDCOverrideVCsByLink = nil;
+
+// Every live CommentsViewController (weak, self-cleaning). Needed when an
+// override is enabled from a nested "Continue this thread" push: the ancestor
+// VCs showing the same post must be tracked too, or popping the nested VC
+// would clear the override out from under the still-visible ancestor.
+static NSHashTable *sApolloDCAllCommentsVCs = nil;
+
+#pragma mark - Helpers
+
+static id ApolloDCMenuIvarObject(id object, const char *name) {
+    if (!object || !name) return nil;
+    for (Class cls = [object class]; cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
+        Ivar ivar = class_getInstanceVariable(cls, name);
+        if (ivar) return object_getIvar(object, ivar);
+    }
+    return nil;
+}
+
+// Post fullName (t3_xxx, lowercased) for a CommentsViewController, from its
+// RDKLink ivar. Nil until the first fetch completes (URL-scheme opens), but by
+// the time the "..." menu is usable the link is loaded.
+static NSString *ApolloDCMenuLinkKeyForVC(id vc) {
+    id link = ApolloDCMenuIvarObject(vc, "link");
+    if (!link) return nil;
+    NSString *fullName = nil;
+    if ([link respondsToSelector:@selector(fullName)]) {
+        fullName = ((NSString *(*)(id, SEL))objc_msgSend)(link, @selector(fullName));
+    }
+    if (![fullName isKindOfClass:[NSString class]] || fullName.length == 0) {
+        if ([link respondsToSelector:@selector(identifier)]) {
+            NSString *identifier = ((NSString *(*)(id, SEL))objc_msgSend)(link, @selector(identifier));
+            if ([identifier isKindOfClass:[NSString class]] && identifier.length > 0) {
+                fullName = [@"t3_" stringByAppendingString:identifier];
+            }
+        }
+    }
+    if (![fullName isKindOfClass:[NSString class]] || fullName.length == 0) return nil;
+    return [fullName lowercaseString];
+}
+
+static void ApolloDCMenuTrackVC(NSString *key, id vc) {
+    if (key.length == 0 || !vc) return;
+    if (!sApolloDCOverrideVCsByLink) sApolloDCOverrideVCsByLink = [NSMutableDictionary dictionary];
+    NSHashTable *table = sApolloDCOverrideVCsByLink[key];
+    if (!table) {
+        table = [NSHashTable weakObjectsHashTable];
+        sApolloDCOverrideVCsByLink[key] = table;
+    }
+    [table addObject:vc];
+}
+
+static void ApolloDCMenuUntrackVCAndMaybeClear(NSString *key, id vc) {
+    if (key.length == 0) return;
+    NSHashTable *table = sApolloDCOverrideVCsByLink[key];
+    if (vc) [table removeObject:vc];
+    if (table.allObjects.count == 0) {
+        [sApolloDCOverrideVCsByLink removeObjectForKey:key];
+        ApolloDeletedCommentsSetThreadOverride(key, NO);
+        ApolloLog(@"[DeletedCommentsMenu] Cleared per-thread override for %@ (last thread view left)", key);
+    }
+}
+
+// Self-heal: an override whose every VC deallocated without a clean pop (e.g.
+// a torn-down navigation stack) would linger forever; drop those.
+static void ApolloDCMenuSweepDeadOverrides(void) {
+    if (sApolloDCOverrideVCsByLink.count == 0) return;
+    for (NSString *key in sApolloDCOverrideVCsByLink.allKeys) {
+        if ([sApolloDCOverrideVCsByLink[key] allObjects].count == 0) {
+            ApolloDCMenuUntrackVCAndMaybeClear(key, nil);
+        }
+    }
+}
+
+// Re-fetch the thread through Apollo's own pull-to-refresh action so the
+// recovered (or re-hidden) comments appear in place.
+static void ApolloDCMenuRefreshComments(id vc) {
+    if (!vc) return;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if ([vc respondsToSelector:@selector(refreshControlActivatedWithSender:)]) {
+            ((void (*)(id, SEL, id))objc_msgSend)(vc, @selector(refreshControlActivatedWithSender:), nil);
+            ApolloLog(@"[DeletedCommentsMenu] Triggered comments refresh after toggle");
+        } else {
+            ApolloLog(@"[DeletedCommentsMenu] WARN: refreshControlActivatedWithSender: missing; pull to refresh manually");
+        }
+    });
+}
+
+static void ApolloDCMenuPresentSlowdownWarning(id vc) {
+    // Give the context menu's dismissal animation a beat before presenting.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.6 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        UIViewController *host = (UIViewController *)vc;
+        if (![host isKindOfClass:[UIViewController class]] || !host.viewLoaded || !host.view.window) return;
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"⚠️ WARNING"
+                                                                       message:@"This feature can slow down comment loading. If you notice comments loading slowly, turn this feature off."
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+        UIViewController *presenter = host.presentedViewController ?: host;
+        [presenter presentViewController:alert animated:YES completion:nil];
+    });
+}
+
+static void ApolloDCMenuHandleToggle(id vc, NSString *linkKey, BOOL wasEffective) {
+    if (wasEffective) {
+        if (linkKey.length > 0 && ApolloDeletedCommentsHasThreadOverride(linkKey)) {
+            [sApolloDCOverrideVCsByLink removeObjectForKey:linkKey];
+            ApolloDeletedCommentsSetThreadOverride(linkKey, NO);
+        }
+        if (sShowDeletedComments) {
+            sShowDeletedComments = NO;
+            [[NSUserDefaults standardUserDefaults] setBool:NO forKey:UDKeyShowDeletedComments];
+            ApolloLog(@"[DeletedCommentsMenu] Global Show Deleted Comments turned OFF from comments menu");
+        }
+    } else if (sPassiveDeletedComments) {
+        // Never set an override without a live VC to hang it on — it could
+        // never be cleared (nothing would ever untrack it).
+        if (!vc) {
+            ApolloLog(@"[DeletedCommentsMenu] WARN: comments VC gone before toggle; ignoring");
+            return;
+        }
+        ApolloDeletedCommentsSetThreadOverride(linkKey, YES);
+        ApolloDCMenuTrackVC(linkKey, vc);
+        // Track ancestor/sibling comments views of the SAME post (nested
+        // "Continue this thread" pushes) so popping the one that enabled the
+        // override doesn't clear it while another is still on the stack.
+        for (id other in sApolloDCAllCommentsVCs.allObjects) {
+            if (other != vc && [ApolloDCMenuLinkKeyForVC(other) isEqualToString:linkKey]) {
+                ApolloDCMenuTrackVC(linkKey, other);
+            }
+        }
+        ApolloLog(@"[DeletedCommentsMenu] Passive per-thread override ON for %@", linkKey);
+    } else {
+        sShowDeletedComments = YES;
+        [[NSUserDefaults standardUserDefaults] setBool:YES forKey:UDKeyShowDeletedComments];
+        ApolloLog(@"[DeletedCommentsMenu] Global Show Deleted Comments turned ON from comments menu");
+        ApolloDCMenuPresentSlowdownWarning(vc);
+    }
+    ApolloDCMenuRefreshComments(vc);
+}
+
+#pragma mark - Menu injection (called from ApolloNativeActionMenuBuildMenu)
+
+void ApolloInjectDeletedCommentsMenuItemIfNeeded(NSMutableArray *children, NSString *menuTitle, id actionController) {
+    (void)menuTitle;
+    if (!children || children.count == 0) return;
+
+    // Re-builds of an already-claimed "..." menu (the builder runs more than
+    // once per presentation) reuse the tag; otherwise the FIRST menu built
+    // while armed claims the armed VC and consumes the arm, so a different
+    // menu opened within the grace window can never pick up the item.
+    NSHashTable *ownerHolder = actionController ? objc_getAssociatedObject(actionController, &kApolloDCMenuOwnerVCKey) : nil;
+    id vc = ownerHolder.anyObject;
+    if (!vc) {
+        vc = sApolloDCMenuArmedVC;
+        if (!vc) return;
+        if (CFAbsoluteTimeGetCurrent() - sApolloDCMenuArmedAt > 1.5) return;
+        if (actionController) {
+            NSHashTable *holder = [NSHashTable weakObjectsHashTable];
+            [holder addObject:vc];
+            objc_setAssociatedObject(actionController, &kApolloDCMenuOwnerVCKey, holder, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+        sApolloDCMenuArmedVC = nil;
+    }
+
+    NSString *linkKey = ApolloDCMenuLinkKeyForVC(vc);
+    BOOL passive = sPassiveDeletedComments && !sShowDeletedComments;
+    // Per-thread toggling needs a post to key the override on.
+    if (passive && linkKey.length == 0) return;
+
+    BOOL effective = sShowDeletedComments || (linkKey.length > 0 && ApolloDeletedCommentsHasThreadOverride(linkKey));
+    NSString *title = effective ? @"Hide Deleted Comments" : @"Show Deleted Comments";
+    UIImage *image = [UIImage systemImageNamed:(effective ? @"eye.slash" : @"eye")];
+
+    __weak id weakVC = vc;
+    UIAction *toggle = [UIAction actionWithTitle:title
+                                           image:image
+                                      identifier:nil
+                                         handler:^(__unused __kindof UIAction *action) {
+        ApolloDCMenuHandleToggle(weakVC, linkKey, effective);
+    }];
+    [children addObject:toggle];
+    ApolloLog(@"[DeletedCommentsMenu] Injected '%@' (passive=%d, link=%@)", title, passive, linkKey ?: @"-");
+}
+
+#pragma mark - CommentsViewController lifecycle
+
+%hook _TtC6Apollo22CommentsViewController
+
+- (void)moreOptionsBarButtonItemTappedWithSender:(id)sender {
+    sApolloDCMenuArmedVC = self;
+    sApolloDCMenuArmedAt = CFAbsoluteTimeGetCurrent();
+    %orig;
+    // The arm is consumed by the first menu build (see the injection function);
+    // the timestamp grace window expires it if no menu was built at all.
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    if (!sApolloDCAllCommentsVCs) sApolloDCAllCommentsVCs = [NSHashTable weakObjectsHashTable];
+    [sApolloDCAllCommentsVCs addObject:self];
+    ApolloDCMenuSweepDeadOverrides();
+    NSString *linkKey = ApolloDCMenuLinkKeyForVC(self);
+    if (linkKey.length > 0 && ApolloDeletedCommentsHasThreadOverride(linkKey)) {
+        // Nested "Continue this thread" pushes of the same post keep the
+        // override alive until the whole thread is left.
+        ApolloDCMenuTrackVC(linkKey, self);
+    }
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    %orig;
+    // Only a pop/dismissal means the user left the thread; presentations
+    // (media viewer, share sheet) and pushes deeper must not clear anything.
+    UIViewController *vc = (UIViewController *)self;
+    BOOL leaving = [vc isMovingFromParentViewController] ||
+                   [vc isBeingDismissed] ||
+                   [vc.navigationController isBeingDismissed];
+    if (!leaving) return;
+    NSString *linkKey = ApolloDCMenuLinkKeyForVC(self);
+    if (linkKey.length == 0 || !ApolloDeletedCommentsHasThreadOverride(linkKey)) return;
+    ApolloDCMenuUntrackVCAndMaybeClear(linkKey, self);
+}
+
+%end

--- a/src/ApolloDeletedCommentsSettingsViewController.h
+++ b/src/ApolloDeletedCommentsSettingsViewController.h
@@ -1,10 +1,9 @@
 #import "ApolloSettingsTableViewController.h"
 
 // "Deleted Comments" sub-screen pushed from the tweak settings' General
-// section: Show Deleted Comments, Tap to Show Deleted Comments, and Passive
-// Deleted Comments (per-thread enable from the comments "..." menu).
+// section: Always Show Deleted Comments, Tap to Show Deleted Comments, and
+// Passive Deleted Comments (per-thread enable from the comments "..." menu).
+// Always Show and Passive are mutually exclusive; turning one on turns the
+// other off.
 @interface ApolloDeletedCommentsSettingsViewController : ApolloSettingsTableViewController
-// Invoked whenever a toggle changes so the presenting settings controller can
-// refresh the disclosure row's summary text.
-@property (nonatomic, copy) void (^settingsDidChange)(void);
 @end

--- a/src/ApolloDeletedCommentsSettingsViewController.h
+++ b/src/ApolloDeletedCommentsSettingsViewController.h
@@ -1,0 +1,10 @@
+#import "ApolloSettingsTableViewController.h"
+
+// "Deleted Comments" sub-screen pushed from the tweak settings' General
+// section: Show Deleted Comments, Tap to Show Deleted Comments, and Passive
+// Deleted Comments (per-thread enable from the comments "..." menu).
+@interface ApolloDeletedCommentsSettingsViewController : ApolloSettingsTableViewController
+// Invoked whenever a toggle changes so the presenting settings controller can
+// refresh the disclosure row's summary text.
+@property (nonatomic, copy) void (^settingsDidChange)(void);
+@end

--- a/src/ApolloDeletedCommentsSettingsViewController.m
+++ b/src/ApolloDeletedCommentsSettingsViewController.m
@@ -1,0 +1,125 @@
+#import "ApolloDeletedCommentsSettingsViewController.h"
+
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+#import "UserDefaultConstants.h"
+
+typedef NS_ENUM(NSInteger, ApolloDCSettingsSection) {
+    ApolloDCSettingsSectionShow = 0,   // Show + (conditional) Tap to Show
+    ApolloDCSettingsSectionPassive,    // Passive per-thread mode
+    ApolloDCSettingsSectionCount,
+};
+
+@implementation ApolloDeletedCommentsSettingsViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Deleted Comments";
+}
+
+#pragma mark - Helpers
+
+- (UITableViewCell *)switchCellWithLabel:(NSString *)label
+                                      on:(BOOL)on
+                                  action:(SEL)action {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+    cell.textLabel.text = label;
+
+    UISwitch *toggle = [[UISwitch alloc] init];
+    toggle.on = on;
+    [toggle addTarget:self action:action forControlEvents:UIControlEventValueChanged];
+    cell.accessoryView = toggle;
+    return cell;
+}
+
+- (void)noteSettingsChanged {
+    if (self.settingsDidChange) self.settingsDidChange();
+}
+
+#pragma mark - UITableViewDataSource
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return ApolloDCSettingsSectionCount;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    switch (section) {
+        case ApolloDCSettingsSectionShow: return sShowDeletedComments ? 2 : 1;
+        case ApolloDCSettingsSectionPassive: return 1;
+        default: return 0;
+    }
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
+    switch (section) {
+        case ApolloDCSettingsSectionPassive: return @"Passive Mode";
+        default: return nil;
+    }
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
+    switch (section) {
+        case ApolloDCSettingsSectionShow:
+            return @"Recovers removed and deleted comments in every thread. Tap to Show hides each recovered comment behind its removal reason until you tap it. This can slow down comment loading.";
+        case ApolloDCSettingsSectionPassive:
+            return @"With only Passive on, deleted comments stay off until you turn them on for a single thread from the ⋯ menu in the comments view. They turn off again when you leave that thread.\n\nThe ⋯ menu always includes a Show/Hide Deleted Comments shortcut.";
+        default: return nil;
+    }
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = nil;
+    if (indexPath.section == ApolloDCSettingsSectionShow) {
+        if (indexPath.row == 0) {
+            cell = [self switchCellWithLabel:@"Show Deleted Comments"
+                                          on:sShowDeletedComments
+                                      action:@selector(showDeletedCommentsSwitchToggled:)];
+        } else {
+            cell = [self switchCellWithLabel:@"Tap to Show Deleted Comments"
+                                          on:sTapToRevealDeletedComments
+                                      action:@selector(tapToRevealDeletedCommentsSwitchToggled:)];
+        }
+    } else {
+        cell = [self switchCellWithLabel:@"Passive Deleted Comments"
+                                      on:sPassiveDeletedComments
+                                  action:@selector(passiveDeletedCommentsSwitchToggled:)];
+    }
+    return cell;
+}
+
+#pragma mark - Actions
+
+- (void)showDeletedCommentsSwitchToggled:(UISwitch *)sender {
+    BOOL wasOn = sShowDeletedComments;
+    sShowDeletedComments = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sShowDeletedComments forKey:UDKeyShowDeletedComments];
+    if (sShowDeletedComments == wasOn) return;
+
+    NSArray<NSIndexPath *> *paths = @[[NSIndexPath indexPathForRow:1 inSection:ApolloDCSettingsSectionShow]];
+    if (sShowDeletedComments) {
+        [self.tableView insertRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"⚠️ WARNING"
+                                                                       message:@"This feature can slow down comment loading. If you notice comments loading slowly, turn this feature off."
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+        [self presentViewController:alert animated:YES completion:nil];
+    } else {
+        [self.tableView deleteRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
+    }
+    [self noteSettingsChanged];
+}
+
+- (void)tapToRevealDeletedCommentsSwitchToggled:(UISwitch *)sender {
+    sTapToRevealDeletedComments = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sTapToRevealDeletedComments forKey:UDKeyTapToRevealDeletedComments];
+    [self noteSettingsChanged];
+}
+
+- (void)passiveDeletedCommentsSwitchToggled:(UISwitch *)sender {
+    sPassiveDeletedComments = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sPassiveDeletedComments forKey:UDKeyPassiveDeletedComments];
+    [self noteSettingsChanged];
+}
+
+@end

--- a/src/ApolloDeletedCommentsSettingsViewController.m
+++ b/src/ApolloDeletedCommentsSettingsViewController.m
@@ -5,7 +5,7 @@
 #import "UserDefaultConstants.h"
 
 typedef NS_ENUM(NSInteger, ApolloDCSettingsSection) {
-    ApolloDCSettingsSectionShow = 0,   // Show + (conditional) Tap to Show
+    ApolloDCSettingsSectionShow = 0,   // Always Show + (conditional) Tap to Show
     ApolloDCSettingsSectionPassive,    // Passive per-thread mode
     ApolloDCSettingsSectionCount,
 };
@@ -31,10 +31,6 @@ typedef NS_ENUM(NSInteger, ApolloDCSettingsSection) {
     [toggle addTarget:self action:action forControlEvents:UIControlEventValueChanged];
     cell.accessoryView = toggle;
     return cell;
-}
-
-- (void)noteSettingsChanged {
-    if (self.settingsDidChange) self.settingsDidChange();
 }
 
 #pragma mark - UITableViewDataSource
@@ -63,7 +59,7 @@ typedef NS_ENUM(NSInteger, ApolloDCSettingsSection) {
         case ApolloDCSettingsSectionShow:
             return @"Recovers removed and deleted comments in every thread. Tap to Show hides each recovered comment behind its removal reason until you tap it. This can slow down comment loading.";
         case ApolloDCSettingsSectionPassive:
-            return @"With only Passive on, deleted comments stay off until you turn them on for a single thread from the ⋯ menu in the comments view. They turn off again when you leave that thread.\n\nThe ⋯ menu always includes a Show/Hide Deleted Comments shortcut.";
+            return @"With Passive on, deleted comments stay off until you turn them on for a single thread from the ⋯ menu in the comments view. They turn off again when you leave that thread.\n\nOnly one of Always Show and Passive can be on — turning one on turns the other off. The ⋯ menu always includes a Show/Hide Deleted Comments shortcut.";
         default: return nil;
     }
 }
@@ -72,7 +68,7 @@ typedef NS_ENUM(NSInteger, ApolloDCSettingsSection) {
     UITableViewCell *cell = nil;
     if (indexPath.section == ApolloDCSettingsSectionShow) {
         if (indexPath.row == 0) {
-            cell = [self switchCellWithLabel:@"Show Deleted Comments"
+            cell = [self switchCellWithLabel:@"Always Show Deleted Comments"
                                           on:sShowDeletedComments
                                       action:@selector(showDeletedCommentsSwitchToggled:)];
         } else {
@@ -96,30 +92,50 @@ typedef NS_ENUM(NSInteger, ApolloDCSettingsSection) {
     [[NSUserDefaults standardUserDefaults] setBool:sShowDeletedComments forKey:UDKeyShowDeletedComments];
     if (sShowDeletedComments == wasOn) return;
 
-    NSArray<NSIndexPath *> *paths = @[[NSIndexPath indexPathForRow:1 inSection:ApolloDCSettingsSectionShow]];
+    NSArray<NSIndexPath *> *tapToShowPaths = @[[NSIndexPath indexPathForRow:1 inSection:ApolloDCSettingsSectionShow]];
     if (sShowDeletedComments) {
-        [self.tableView insertRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
+        // Always Show and Passive are one-or-the-other.
+        if (sPassiveDeletedComments) {
+            sPassiveDeletedComments = NO;
+            [[NSUserDefaults standardUserDefaults] setBool:NO forKey:UDKeyPassiveDeletedComments];
+        }
+        [self.tableView beginUpdates];
+        [self.tableView insertRowsAtIndexPaths:tapToShowPaths withRowAnimation:UITableViewRowAnimationFade];
+        [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:0 inSection:ApolloDCSettingsSectionPassive]]
+                              withRowAnimation:UITableViewRowAnimationNone];
+        [self.tableView endUpdates];
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"⚠️ WARNING"
                                                                        message:@"This feature can slow down comment loading. If you notice comments loading slowly, turn this feature off."
                                                                 preferredStyle:UIAlertControllerStyleAlert];
         [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
         [self presentViewController:alert animated:YES completion:nil];
     } else {
-        [self.tableView deleteRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
+        [self.tableView deleteRowsAtIndexPaths:tapToShowPaths withRowAnimation:UITableViewRowAnimationFade];
     }
-    [self noteSettingsChanged];
 }
 
 - (void)tapToRevealDeletedCommentsSwitchToggled:(UISwitch *)sender {
     sTapToRevealDeletedComments = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sTapToRevealDeletedComments forKey:UDKeyTapToRevealDeletedComments];
-    [self noteSettingsChanged];
 }
 
 - (void)passiveDeletedCommentsSwitchToggled:(UISwitch *)sender {
+    BOOL wasOn = sPassiveDeletedComments;
     sPassiveDeletedComments = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sPassiveDeletedComments forKey:UDKeyPassiveDeletedComments];
-    [self noteSettingsChanged];
+    if (sPassiveDeletedComments == wasOn) return;
+
+    // Always Show and Passive are one-or-the-other.
+    if (sPassiveDeletedComments && sShowDeletedComments) {
+        sShowDeletedComments = NO;
+        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:UDKeyShowDeletedComments];
+        [self.tableView beginUpdates];
+        [self.tableView deleteRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:1 inSection:ApolloDCSettingsSectionShow]]
+                              withRowAnimation:UITableViewRowAnimationFade];
+        [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:0 inSection:ApolloDCSettingsSectionShow]]
+                              withRowAnimation:UITableViewRowAnimationNone];
+        [self.tableView endUpdates];
+    }
 }
 
 @end

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -329,9 +329,29 @@ static BOOL ApolloDeletedCommentsCellNodeIsDeletedPlaceholder(id cellNode) {
     return trimmedBody.length == 0 && ApolloDeletedCommentsAuthorLooksDeleted(comment.author);
 }
 
+// Passive-mode scoping: with the global toggle off, only threads whose
+// per-thread override is active may render treatment. The registries are
+// global and outlive a cleared override, so without this a stale entry could
+// stamp chips in a non-overridden thread while some other thread's override
+// is live. When the comment's linkID can't be read, fall back to the coarse
+// gate (no worse than the registries alone).
+static BOOL ApolloDeletedCommentsTreatmentAllowedForComment(RDKComment *comment) {
+    NSString *linkID = nil;
+    if ([(id)comment respondsToSelector:@selector(linkID)]) {
+        @try {
+            linkID = ((NSString *(*)(id, SEL))objc_msgSend)((id)comment, @selector(linkID));
+        } @catch (__unused NSException *e) {}
+    }
+    if (![linkID isKindOfClass:[NSString class]] || linkID.length == 0) return YES;
+    return ApolloDeletedCommentsActiveForLink(linkID);
+}
+
 static BOOL ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(id cellNode) {
-    return ApolloDeletedCommentsCellNodeIsRecovered(cellNode) ||
-           ApolloDeletedCommentsCellNodeIsDeletedPlaceholder(cellNode);
+    if (!ApolloDeletedCommentsCellNodeIsRecovered(cellNode) &&
+        !ApolloDeletedCommentsCellNodeIsDeletedPlaceholder(cellNode)) {
+        return NO;
+    }
+    return ApolloDeletedCommentsTreatmentAllowedForComment(ApolloDeletedCommentsCommentFromCellNode(cellNode));
 }
 
 static BOOL ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(id cellNode) {
@@ -577,7 +597,7 @@ static BOOL ApolloDeletedCommentsCommentIsRevealedByFullName(RDKComment *comment
 }
 
 static BOOL __attribute__((unused)) ApolloDeletedCommentsShouldKeepModelBodyHidden(RDKComment *comment) {
-    if (!sShowDeletedComments || !sTapToRevealDeletedComments || !comment) return NO;
+    if (!ApolloDeletedCommentsFeatureActive() || !sTapToRevealDeletedComments || !comment) return NO;
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     if (fullName.length == 0) return NO;
     return ApolloDeletedCommentsIsRecoveredComment(fullName) &&
@@ -623,7 +643,7 @@ static NSString *ApolloDeletedCommentsReasonLabelForCommentAndBody(RDKComment *c
 }
 
 static NSString *__attribute__((unused)) ApolloDeletedCommentsHiddenReasonLabelForCommentBody(RDKComment *comment, NSString *body) {
-    if (!sShowDeletedComments || !comment) return nil;
+    if (!ApolloDeletedCommentsFeatureActive() || !comment) return nil;
 
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     NSString *savedBody = objc_getAssociatedObject(comment, kApolloDeletedCommentsOriginalBodyKey);
@@ -1638,7 +1658,7 @@ static BOOL ApolloDeletedCommentsCellAlreadyHasHiddenPlaceholder(id cellNode, NS
 }
 
 static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsAttributedTextWithTapToRevealPlaceholder(id textNode, NSAttributedString *attributedText) {
-    if (!sShowDeletedComments || !sTapToRevealDeletedComments) return attributedText;
+    if (!ApolloDeletedCommentsFeatureActive() || !sTapToRevealDeletedComments) return attributedText;
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
     if (ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(attributedText)) return attributedText;
 
@@ -1683,7 +1703,7 @@ static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsAttribut
 }
 
 static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(id textNode, NSAttributedString *attributedText) {
-    if (!sShowDeletedComments) return attributedText;
+    if (!ApolloDeletedCommentsFeatureActive()) return attributedText;
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
     if (ApolloDeletedCommentsAttributedTextIsRevealPlaceholder(attributedText)) {
         return attributedText;
@@ -1724,7 +1744,7 @@ static NSAttributedString *ApolloDeletedCommentsAttributedTextWithReasonPrefix(i
 }
 
 static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsAttributedTextWithReasonChipIfNeeded(id textNode, NSAttributedString *attributedText) {
-    if (!sShowDeletedComments) return attributedText;
+    if (!ApolloDeletedCommentsFeatureActive()) return attributedText;
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
     if (ApolloDeletedCommentsAttributedTextHasVisibleReasonChip(attributedText)) return attributedText;
 
@@ -1946,7 +1966,7 @@ static void ApolloDeletedCommentsApplyStaticPlaceholderChip(id cellNode, NSArray
 // collapsing: tap-to-reveal is on, the body is recoverable, and it isn't revealed
 // yet. (Whether it is currently collapsed is handled by the caller.)
 static BOOL ApolloDeletedCommentsCommentArmedForReveal(RDKComment *comment) {
-    if (!sShowDeletedComments || !sTapToRevealDeletedComments || !comment) return NO;
+    if (!ApolloDeletedCommentsFeatureActive() || !sTapToRevealDeletedComments || !comment) return NO;
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
     if (fullName.length == 0) return NO;
     return ApolloDeletedCommentsIsRecoveredComment(fullName) &&
@@ -2097,7 +2117,7 @@ static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeede
 
     BOOL recovered = ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode);
     BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName);
-    BOOL shouldHide = sShowDeletedComments &&
+    BOOL shouldHide = ApolloDeletedCommentsFeatureActive() &&
                       sTapToRevealDeletedComments &&
                       recovered &&
                       !revealed;
@@ -2452,7 +2472,7 @@ static void ApolloDeletedCommentsScheduleBodyAttributesRefresh(void) {
 // System Text Size" is on).
 static void ApolloDeletedCommentsHandleContentSizeChanged(__unused NSNotification *note) {
     ApolloDeletedCommentsBodyTemplateSet(nil);
-    if (sShowDeletedComments) {
+    if (ApolloDeletedCommentsFeatureActive()) {
         ApolloDeletedCommentsScheduleBodyAttributesRefresh();
     }
 }
@@ -2479,7 +2499,7 @@ static UIView *ApolloDeletedCommentsHostListViewForCell(id cellNode) {
 }
 
 static void ApolloDeletedCommentsScheduleHostLayoutRefresh(id cellNode) {
-    if (!cellNode || !sShowDeletedComments || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return;
+    if (!cellNode || !ApolloDeletedCommentsFeatureActive() || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return;
 
     UIView *hostView = ApolloDeletedCommentsHostListViewForCell(cellNode);
     UIView *cellView = ApolloDeletedCommentsCellView(cellNode);
@@ -2526,7 +2546,7 @@ static void ApolloDeletedCommentsRemoveCellHighlight(id cellNode) {
 }
 
 static void ApolloDeletedCommentsApplyCellHighlight(id cellNode) {
-    if (!sShowDeletedComments || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) {
+    if (!ApolloDeletedCommentsFeatureActive() || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) {
         ApolloDeletedCommentsRemoveCellHighlight(cellNode);
         return;
     }
@@ -2719,7 +2739,7 @@ static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpec
                            !ApolloDeletedCommentsCellNodeIsRecovered(cellNode);
     BOOL recovered = ApolloDeletedCommentsCellNodeCanRevealRecoveredBody(cellNode);
     BOOL revealed = ApolloDeletedCommentsIsCommentRevealed(fullName);
-    BOOL shouldHide = sShowDeletedComments &&
+    BOOL shouldHide = ApolloDeletedCommentsFeatureActive() &&
                       sTapToRevealDeletedComments &&
                       recovered &&
                       !revealed;
@@ -2728,7 +2748,7 @@ static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpec
     // from the hidden "[removed]" body, so it never shows the recovered text. By
     // staying on our replacement text node and just swapping its content from the
     // chip to the body, a single tap renders the body in place.
-    BOOL revealedRecovered = sShowDeletedComments &&
+    BOOL revealedRecovered = ApolloDeletedCommentsFeatureActive() &&
                              sTapToRevealDeletedComments &&
                              recovered &&
                              revealed;
@@ -2767,7 +2787,7 @@ static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpec
         if (![tmpl isKindOfClass:[NSDictionary class]] ||
             ApolloDeletedCommentsBodyAttributeFontsDiffer(tmpl, cap)) {
             ApolloDeletedCommentsBodyTemplateSet(cap);
-            if (sShowDeletedComments) ApolloDeletedCommentsScheduleBodyAttributesRefresh();
+            if (ApolloDeletedCommentsFeatureActive()) ApolloDeletedCommentsScheduleBodyAttributesRefresh();
         }
         appAttributes = cap;
     }
@@ -2839,7 +2859,7 @@ static void ApolloDeletedCommentsApplyRecoveredArchiveToVisibleCell(id cellNode,
 }
 
 static void ApolloDeletedCommentsHandleArcticCacheUpdated(NSNotification *notification) {
-    if (!sShowDeletedComments) return;
+    if (!ApolloDeletedCommentsFeatureActive()) return;
     NSDictionary *comments = [notification.userInfo[@"comments"] isKindOfClass:[NSDictionary class]] ? notification.userInfo[@"comments"] : nil;
     if (comments.count == 0) return;
 
@@ -2879,7 +2899,7 @@ static void ApolloDeletedCommentsApplyCachedArchiveToVisibleDeletedCell(id cellN
 }
 
 static void __attribute__((unused)) ApolloDeletedCommentsRepairVisibleReasonChipIfNeeded(id cellNode) {
-    if (!sShowDeletedComments) return;
+    if (!ApolloDeletedCommentsFeatureActive()) return;
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     if (!comment || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return;
     BOOL hiddenTapToReveal = sTapToRevealDeletedComments && !ApolloDeletedCommentsCommentIsRevealedByFullName(comment);
@@ -2930,7 +2950,7 @@ static void __attribute__((unused)) ApolloDeletedCommentsRepairVisibleReasonChip
 }
 
 static void ApolloDeletedCommentsScheduleReasonChipRepair(id cellNode) {
-    if (!sShowDeletedComments || !cellNode) return;
+    if (!ApolloDeletedCommentsFeatureActive() || !cellNode) return;
     if ([objc_getAssociatedObject(cellNode, kApolloDeletedCommentsReasonChipRepairScheduledKey) boolValue]) return;
 
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
@@ -2969,13 +2989,13 @@ static void ApolloDeletedCommentsUpdateCell(id cellNode) {
     ApolloDeletedCommentsRepairVisibleReasonChipIfNeeded(cellNode);
     ApolloDeletedCommentsScheduleReasonChipRepair(cellNode);
     ApolloDeletedCommentsApplyCellHighlight(cellNode);
-    if (sShowDeletedComments && sTapToRevealDeletedComments) {
+    if (ApolloDeletedCommentsFeatureActive() && sTapToRevealDeletedComments) {
         ApolloDeletedCommentsInstallRevealTapGestureOnCell(cellNode);
     }
 }
 
 static void ApolloDeletedCommentsRefreshVisibleDeletedCells(void) {
-    if (!sShowDeletedComments) return;
+    if (!ApolloDeletedCommentsFeatureActive()) return;
     for (id cellNode in ApolloDeletedCommentsAllTrackedVisibleCells()) {
         ApolloDeletedCommentsUpdateCell(cellNode);
         ApolloDeletedCommentsRelayoutCellAndTextNode(cellNode, ApolloDeletedCommentsKnownBodyContainerNode(cellNode));
@@ -3016,7 +3036,7 @@ static BOOL ApolloDeletedCommentsIsRevealLink(id attribute, id value) {
 }
 
 static NSAttributedString *__attribute__((unused)) ApolloDeletedCommentsRenameRecoveredSpoilerLabel(id textNode, NSAttributedString *attributedText) {
-    if (!sShowDeletedComments || !sTapToRevealDeletedComments) return attributedText;
+    if (!ApolloDeletedCommentsFeatureActive() || !sTapToRevealDeletedComments) return attributedText;
     if (![attributedText isKindOfClass:[NSAttributedString class]] || attributedText.length == 0) return attributedText;
     NSString *text = ApolloDeletedCommentsTrimmedString(attributedText.string);
     if (![text isEqualToString:@"SPOILER"]) return attributedText;
@@ -3103,7 +3123,7 @@ static void ApolloDeletedCommentsCaptureLiveCommentBodyFont(id textNode, NSAttri
     // Drop the cached body template so deleted cells re-resolve at the new size, and
     // refresh the visible ones (this is what makes a text-size change propagate).
     ApolloDeletedCommentsBodyTemplateSet(nil);
-    if (sShowDeletedComments) ApolloDeletedCommentsScheduleBodyAttributesRefresh();
+    if (ApolloDeletedCommentsFeatureActive()) ApolloDeletedCommentsScheduleBodyAttributesRefresh();
 }
 
 %hook ASTextNode
@@ -3198,7 +3218,7 @@ static void ApolloDeletedCommentsCaptureLiveCommentBodyFont(id textNode, NSAttri
         objc_setAssociatedObject(bodyNode, kApolloDeletedCommentsBodyOwnerCellKey, (id)self, OBJC_ASSOCIATION_ASSIGN);
     }
     id spec = %orig;
-    if (sShowDeletedComments &&
+    if (ApolloDeletedCommentsFeatureActive() &&
         !ApolloDeletedCommentsCommentIsCollapsed(comment) &&
         ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment((id)self) &&
         spec) {

--- a/src/ApolloNativeActionMenus.xm
+++ b/src/ApolloNativeActionMenus.xm
@@ -780,6 +780,9 @@ static UIMenu *ApolloNativeActionMenuBuildMenu(id actionController, BOOL moderat
     // Issue #515: append "Public Sticky from Subreddit" when this is the removal
     // "Notify user via…" menu (no-op otherwise).
     ApolloInjectPublicStickyAsSubredditIfNeeded(children, title);
+    // Append "Show/Hide Deleted Comments" when this is a comments view's "..."
+    // menu (no-op otherwise; see ApolloDeletedCommentsMenu.xm).
+    ApolloInjectDeletedCommentsMenuItemIfNeeded(children, title, actionController);
     return [UIMenu menuWithTitle:title children:children];
 }
 

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -14,6 +14,7 @@ extern NSString *sTrendingSubredditsLimit;
 extern BOOL sBlockAnnouncements;
 extern BOOL sShowDeletedComments;
 extern BOOL sTapToRevealDeletedComments;
+extern BOOL sPassiveDeletedComments;
 extern BOOL sShowRecentlyReadThumbnails;
 extern BOOL sFeedTextPostThumbnails;
 extern NSInteger sPreferredGIFFallbackFormat;

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -14,6 +14,7 @@ NSString *sTrendingSubredditsLimit = nil;
 BOOL sBlockAnnouncements = NO;
 BOOL sShowDeletedComments = NO;
 BOOL sTapToRevealDeletedComments = NO;
+BOOL sPassiveDeletedComments = NO;
 BOOL sShowRecentlyReadThumbnails = YES;
 BOOL sFeedTextPostThumbnails = YES;
 NSInteger sPreferredGIFFallbackFormat = 1; // 0=GIF, 1=MP4

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -8,6 +8,7 @@
 #import "ApolloState.h"
 #import "ApolloUserProfileCache.h"
 #import "ApolloLinkPreviewCache.h"
+#import "ApolloDeletedCommentsSettingsViewController.h"
 #import "ApolloLinkPreviewSettingsViewController.h"
 #import "ApolloSubredditCustomBannerCache.h"
 #import "ApolloSubredditCustomIconCache.h"
@@ -469,6 +470,46 @@ typedef NS_ENUM(NSInteger, Tag) {
     }
 }
 
+- (UITableViewCell *)deletedCommentsCellForTableView:(UITableView *)tableView {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Gen_DeletedComments"];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"Cell_Gen_DeletedComments"];
+        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+        cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+    }
+    cell.textLabel.text = @"Deleted Comments";
+    NSString *detail;
+    if (sShowDeletedComments) {
+        detail = sTapToRevealDeletedComments ? @"On · Tap to Show" : @"On";
+    } else if (sPassiveDeletedComments) {
+        detail = @"Passive · per thread from the comments ⋯ menu";
+    } else {
+        detail = @"Off";
+    }
+    cell.detailTextLabel.text = detail;
+    cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+    cell.detailTextLabel.numberOfLines = 0;
+    cell.detailTextLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    return cell;
+}
+
+- (void)openDeletedCommentsSettings {
+    ApolloDeletedCommentsSettingsViewController *vc =
+        [[ApolloDeletedCommentsSettingsViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
+    __weak typeof(self) weakSelf = self;
+    vc.settingsDidChange = ^{
+        [weakSelf.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:3 inSection:SectionGeneral]]
+                                  withRowAnimation:UITableViewRowAnimationNone];
+    };
+    if (self.navigationController) {
+        [self.navigationController pushViewController:vc animated:YES];
+    } else {
+        UINavigationController *navigation =
+            [[UINavigationController alloc] initWithRootViewController:vc];
+        [self presentViewController:navigation animated:YES completion:nil];
+    }
+}
+
 // The Rich Link Preview sub-screen mutates the shared state and posts the live
 // notification itself; this just arms the deferred refresh so the feed/comments
 // rebuild once the whole settings stack is dismissed (mirrors the old in-Media
@@ -552,11 +593,9 @@ typedef NS_ENUM(NSInteger, Tag) {
         // row, so the count is its index + 1, minus the Web Session Login row when
         // the mode is off.
         case SectionAPIKeys: return kAPIKeyRowWidgetSetupCode + (sWebJSONEnabled ? 1 : 0);
-        // General base rows + the search-in-place (effectiveRow 11),
-        // follow-live-comments (effectiveRow 12) and iPad-tab-bar-bottom
-        // (effectiveRow 13) toggles, minus the conditional "Tap to Show Deleted
-        // Comments" row.
-        case SectionGeneral: return sShowDeletedComments ? 14 : 13;
+        // General base rows; the two deleted-comments toggles now live on the
+        // "Deleted Comments" sub-screen behind the disclosure row (row 3).
+        case SectionGeneral: return 13;
         case SectionApolloAI: return 1;
         case SectionLinkPreviews: return 1;
         // Media base rows (the three "Rich Link Previews" rows moved out to their
@@ -946,8 +985,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 
 - (UITableViewCell *)generalCellForRow:(NSInteger)row tableView:(UITableView *)tableView {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSInteger effectiveRow = (!sShowDeletedComments && row >= 4) ? row + 1 : row;
-    switch (effectiveRow) {
+    switch (row) {
         case 0:
             return [self switchCellWithIdentifier:@"Cell_Gen_Announce"
                                             label:@"Block Announcements"
@@ -964,21 +1002,13 @@ typedef NS_ENUM(NSInteger, Tag) {
                                                on:[defaults boolForKey:UDKeyCollapsePinnedComments]
                                            action:@selector(collapsePinnedCommentsSwitchToggled:)];
         case 3:
-            return [self switchCellWithIdentifier:@"Cell_Gen_ShowDeletedComments"
-                                            label:@"Show Deleted Comments"
-                                               on:[defaults boolForKey:UDKeyShowDeletedComments]
-                                           action:@selector(showDeletedCommentsSwitchToggled:)];
+            return [self deletedCommentsCellForTableView:tableView];
         case 4:
-            return [self switchCellWithIdentifier:@"Cell_Gen_TapToRevealDeletedComments"
-                                            label:@"Tap to Show Deleted Comments"
-                                               on:[defaults boolForKey:UDKeyTapToRevealDeletedComments]
-                                           action:@selector(tapToRevealDeletedCommentsSwitchToggled:)];
-        case 5:
             return [self switchCellWithIdentifier:@"Cell_Gen_RRThumbs"
                                             label:@"Recently Read Thumbnails"
                                                on:[defaults boolForKey:UDKeyShowRecentlyReadThumbnails]
                                            action:@selector(showRecentlyReadThumbnailsSwitchToggled:)];
-        case 6: {
+        case 5: {
             NSString *readPostMaxStr = sReadPostMaxCount > 0 ? [NSString stringWithFormat:@"%ld", (long)sReadPostMaxCount] : @"";
             return [self textFieldCellWithIdentifier:@"Cell_Gen_ReadMax"
                                                label:@"Recently Read Posts Limit"
@@ -987,17 +1017,17 @@ typedef NS_ENUM(NSInteger, Tag) {
                                                  tag:TagReadPostMaxCount
                                            numerical:YES];
         }
-        case 7:
+        case 6:
             return [self switchCellWithIdentifier:@"Cell_Gen_FilterNSFWRR"
                                             label:@"Hide NSFW in Recently Read"
                                                on:[defaults boolForKey:UDKeyFilterNSFWRecentlyRead]
                                            action:@selector(filterNSFWRecentlyReadSwitchToggled:)];
-        case 8:
+        case 7:
             return [self switchCellWithIdentifier:@"Cell_Gen_SteamApp"
                                             label:@"Open Steam Links in App"
                                                on:[defaults boolForKey:UDKeyOpenLinksInSteamApp]
                                            action:@selector(steamAppSwitchToggled:)];
-        case 9: {
+        case 8: {
             BOOL idleSupported = [self apollo_supportsAutoHideTabBarIdleSetting];
             UITableViewCell *cell = [self switchCellWithIdentifier:@"Cell_Gen_TabBarIdle"
                                                              label:@"Tab Bar Re-Expands When Idle"
@@ -1010,12 +1040,12 @@ typedef NS_ENUM(NSInteger, Tag) {
             cell.detailTextLabel.enabled = idleSupported;
             return cell;
         }
-        case 10:
+        case 9:
             return [self switchCellWithIdentifier:@"Cell_Gen_FlairColors"
                                             label:@"Color Flairs"
                                                on:[defaults boolForKey:UDKeyEnableFlairColors]
                                            action:@selector(flairColorsSwitchToggled:)];
-        case 11: {
+        case 10: {
             BOOL lgSupported = IsLiquidGlass();
             UITableViewCell *cell = [self switchCellWithIdentifier:@"Cell_Gen_KeepSearchInPlace"
                                                              label:@"Keep Search Bar In Place"
@@ -1028,13 +1058,13 @@ typedef NS_ENUM(NSInteger, Tag) {
             cell.detailTextLabel.enabled = lgSupported;
             return cell;
         }
-        case 12:
+        case 11:
             return [self switchCellWithIdentifier:@"Cell_Gen_LiveCommentsFollow"
                                             label:@"Follow New Live Comments"
                                            detail:@"During Live Update comment sort, keep the newest at the top and show a jump button when you've scrolled down."
                                                on:[defaults boolForKey:UDKeyLiveCommentsFollow]
                                            action:@selector(liveCommentsFollowSwitchToggled:)];
-        case 13: {
+        case 12: {
             // Temporary iPad stopgap (#387): dock the floating tab bar at the
             // bottom instead of the top-center pill that overlaps the search bar.
             BOOL supported = (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) && IsLiquidGlass();
@@ -1597,6 +1627,11 @@ typedef NS_ENUM(NSInteger, Tag) {
         return;
     }
 
+    if (indexPath.section == SectionGeneral && indexPath.row == 3) {
+        [self openDeletedCommentsSettings];
+        return;
+    }
+
     if (indexPath.section == SectionBackupRestore) {
         UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
         if (indexPath.row == 0) {
@@ -1724,6 +1759,7 @@ typedef NS_ENUM(NSInteger, Tag) {
     }
     if (indexPath.section == SectionApolloAI) return YES;
     if (indexPath.section == SectionLinkPreviews) return YES;
+    if (indexPath.section == SectionGeneral && indexPath.row == 3) return YES; // Deleted Comments sub-screen
     if (indexPath.section == SectionMedia) {
         NSInteger row = ApolloMediaLogicalRow(indexPath.row);
         return (row == 0 || row == 1 || row == 2 || row == 5 || row == 6 || row == 13);
@@ -2142,27 +2178,6 @@ typedef NS_ENUM(NSInteger, Tag) {
 
 - (void)collapsePinnedCommentsSwitchToggled:(UISwitch *)sender {
     [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:UDKeyCollapsePinnedComments];
-}
-
-- (void)showDeletedCommentsSwitchToggled:(UISwitch *)sender {
-    BOOL wasOn = sShowDeletedComments;
-    sShowDeletedComments = sender.isOn;
-    [[NSUserDefaults standardUserDefaults] setBool:sShowDeletedComments forKey:UDKeyShowDeletedComments];
-    if (sShowDeletedComments == wasOn) return;
-
-    NSArray<NSIndexPath *> *paths = @[[NSIndexPath indexPathForRow:4 inSection:SectionGeneral]];
-    if (sShowDeletedComments) {
-        [self.tableView insertRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
-        [self showAlertWithTitle:@"⚠️ WARNING"
-                          message:@"This feature can slow down comment loading. If you notice comments loading slowly, turn this feature off."];
-    } else {
-        [self.tableView deleteRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
-    }
-}
-
-- (void)tapToRevealDeletedCommentsSwitchToggled:(UISwitch *)sender {
-    sTapToRevealDeletedComments = sender.isOn;
-    [[NSUserDefaults standardUserDefaults] setBool:sTapToRevealDeletedComments forKey:UDKeyTapToRevealDeletedComments];
 }
 
 - (void)filterNSFWRecentlyReadSwitchToggled:(UISwitch *)sender {
@@ -2751,6 +2766,7 @@ static void ApolloReplayValetKeychainItems(NSArray<NSDictionary *> *items) {
     sReadPostMaxCount = [defaults integerForKey:UDKeyReadPostMaxCount];
     sShowDeletedComments = [defaults boolForKey:UDKeyShowDeletedComments];
     sTapToRevealDeletedComments = [defaults boolForKey:UDKeyTapToRevealDeletedComments];
+    sPassiveDeletedComments = [defaults boolForKey:UDKeyPassiveDeletedComments];
     sShowRecentlyReadThumbnails = [defaults boolForKey:UDKeyShowRecentlyReadThumbnails];
     sEnableFlairColors = [defaults boolForKey:UDKeyEnableFlairColors];
     sPreferredGIFFallbackFormat = ([defaults integerForKey:UDKeyPreferredGIFFallbackFormat] == 0) ? 0 : 1;

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -473,34 +473,17 @@ typedef NS_ENUM(NSInteger, Tag) {
 - (UITableViewCell *)deletedCommentsCellForTableView:(UITableView *)tableView {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Gen_DeletedComments"];
     if (!cell) {
-        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"Cell_Gen_DeletedComments"];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell_Gen_DeletedComments"];
         cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
         cell.selectionStyle = UITableViewCellSelectionStyleDefault;
     }
     cell.textLabel.text = @"Deleted Comments";
-    NSString *detail;
-    if (sShowDeletedComments) {
-        detail = sTapToRevealDeletedComments ? @"On · Tap to Show" : @"On";
-    } else if (sPassiveDeletedComments) {
-        detail = @"Passive · per thread from the comments ⋯ menu";
-    } else {
-        detail = @"Off";
-    }
-    cell.detailTextLabel.text = detail;
-    cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
-    cell.detailTextLabel.numberOfLines = 0;
-    cell.detailTextLabel.lineBreakMode = NSLineBreakByWordWrapping;
     return cell;
 }
 
 - (void)openDeletedCommentsSettings {
     ApolloDeletedCommentsSettingsViewController *vc =
         [[ApolloDeletedCommentsSettingsViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
-    __weak typeof(self) weakSelf = self;
-    vc.settingsDidChange = ^{
-        [weakSelf.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:3 inSection:SectionGeneral]]
-                                  withRowAnimation:UITableViewRowAnimationNone];
-    };
     if (self.navigationController) {
         [self.navigationController pushViewController:vc animated:YES];
     } else {

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1455,6 +1455,7 @@ static void initializeRandomSources() {
                                     UDKeyModernSubredditDividers: @YES,
                                     UDKeyShowDeletedComments: @NO,
                                     UDKeyTapToRevealDeletedComments: @NO,
+                                    UDKeyPassiveDeletedComments: @NO,
                                     UDKeyEnableFlairColors: @NO,
                                     UDKeyShowRecentlyReadThumbnails: @YES,
                                     UDKeyFeedTextPostThumbnails: @YES,
@@ -1530,6 +1531,7 @@ static void initializeRandomSources() {
     sBlockAnnouncements = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyBlockAnnouncements];
     sShowDeletedComments = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowDeletedComments];
     sTapToRevealDeletedComments = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyTapToRevealDeletedComments];
+    sPassiveDeletedComments = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyPassiveDeletedComments];
     sShowRecentlyReadThumbnails = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowRecentlyReadThumbnails];
     sFeedTextPostThumbnails = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyFeedTextPostThumbnails];
     sPreferredGIFFallbackFormat = ([[NSUserDefaults standardUserDefaults] integerForKey:UDKeyPreferredGIFFallbackFormat] == 0) ? 0 : 1;

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1532,6 +1532,13 @@ static void initializeRandomSources() {
     sShowDeletedComments = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowDeletedComments];
     sTapToRevealDeletedComments = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyTapToRevealDeletedComments];
     sPassiveDeletedComments = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyPassiveDeletedComments];
+    // Always Show and Passive are one-or-the-other (the settings screen
+    // enforces it on toggle); normalize any stale both-on state — Always
+    // Show wins, matching the comments-menu logic.
+    if (sShowDeletedComments && sPassiveDeletedComments) {
+        sPassiveDeletedComments = NO;
+        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:UDKeyPassiveDeletedComments];
+    }
     sShowRecentlyReadThumbnails = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowRecentlyReadThumbnails];
     sFeedTextPostThumbnails = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyFeedTextPostThumbnails];
     sPreferredGIFFallbackFormat = ([[NSUserDefaults standardUserDefaults] integerForKey:UDKeyPreferredGIFFallbackFormat] == 0) ? 0 : 1;

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -49,6 +49,10 @@ static NSString *const UDKeyOpenLinksInSteamApp = @"OpenLinksInSteamApp";
 static NSString *const UDKeyCollapsePinnedComments = @"CollapsePinnedComments";
 static NSString *const UDKeyShowDeletedComments = @"ShowDeletedComments";
 static NSString *const UDKeyTapToRevealDeletedComments = @"TapToRevealDeletedComments";
+// Passive mode: deleted comments stay off globally, but can be turned on for a
+// single comment thread from the comments "..." menu; the per-thread switch
+// resets when that thread is left. See ApolloDeletedCommentsMenu.xm.
+static NSString *const UDKeyPassiveDeletedComments = @"PassiveDeletedComments";
 static NSString *const UDKeyLegacyRevealDeletedComments = @"RevealDeletedComments";
 static NSString *const UDKeyFilterNSFWRecentlyRead = @"FilterNSFWRecentlyRead";
 static NSString *const UDKeyProxyImgurDDG = @"ProxyImgurDDG";


### PR DESCRIPTION
## What

Restructures the Show Deleted Comments settings and adds a quick toggle to the comments `⋯` menu, plus a new **Passive** mode for enabling recovery one thread at a time.

### Settings
The two toggles in the tweak settings' General section are replaced by a single **Deleted Comments** disclosure row that opens a new sub-screen:

- **Always Show Deleted Comments** — the former global toggle, renamed to contrast with Passive (keeps the ⚠️ slowdown warning on enable)
- **Tap to Show Deleted Comments** — unchanged, still only visible while Always Show is on
- **Passive Deleted Comments** — new

Always Show and Passive are one-or-the-other: turning one on turns the other off, and launch normalizes any stale both-on state (Always Show wins).

### Comments ⋯ menu
The comments view's overflow menu now always ends with **Show Deleted Comments** / **Hide Deleted Comments** (eye icon, title reflects the thread's current state):

- **Passive off**: the item is a plain shortcut for the global toggle (turning it on shows the same slowdown warning as settings).
- **Passive on** (and global toggle off): the item turns recovery on **for that post's thread only**. The override is in-memory, keyed by post fullName, and clears automatically when the last comments view showing that post is popped or dismissed — open the next thread and it's off again. Nested "Continue this thread" pushes of the same post keep it alive.

Either way the thread immediately re-fetches through Apollo's own pull-to-refresh action, so recovered (or re-hidden) comments appear in place without leaving the screen.

### Why passive mode
Recovery can slow comment loading (Arctic Shift fetch + response patching), so most people leave it off globally. Passive mode keeps the cost at zero until you actually want to see what was removed in one specific thread, and guarantees it turns itself back off.

### Screenshots
| Settings sub-screen | Comments ⋯ menu | Enable warning |
|:---:|:---:|:---:|
| <img width="250" alt="Deleted Comments settings sub-screen" src="https://github.com/user-attachments/assets/730b0ef4-9b38-4fcc-9b5d-4ce28f2bd81a" /> | <img width="250" alt="Show Deleted Comments item in the comments overflow menu" src="https://github.com/user-attachments/assets/6323ec39-7283-4002-9fc8-f0be709d4285" /> | <img width="250" alt="Slowdown warning alert on enable" src="https://github.com/user-attachments/assets/b764ee65-1608-491c-a304-de3b8ffc6691" /> |
| The new **Deleted Comments** page: Always Show / Tap to Show / Passive. Always Show and Passive are one-or-the-other. | The **Show/Hide Deleted Comments** shortcut at the bottom of the comments ⋯ menu — per-thread when Passive is on. | The same ⚠️ slowdown warning as before, shown whenever Always Show is turned on. |

## How

- `ApolloDeletedCommentsData` gains a thread-override registry (post fullName set, registry-lock guarded) and gates: `FeatureActive()` (global || any override) and `ActiveForLink()`. The network chokepoints gate per-link, so with the global toggle off only overridden threads fetch/patch; the UI treatment predicate is also scoped per-link so stale registry entries can't stamp chips in other threads. With the global toggle on, every gate short-circuits — behavior is identical to before.
- New `ApolloDeletedCommentsMenu.xm` arms the tapped CommentsViewController during `moreOptionsBarButtonItemTappedWithSender:` (menu construction runs synchronously inside it); the first menu built while armed consumes the arm and tags its ActionController, so no other menu can pick up the item. Injection happens next to the Public Sticky item in `ApolloNativeActionMenuBuildMenu`. VC lifetime tracking uses weak hash tables; pop detection via `isMovingFromParentViewController`/`isBeingDismissed`, so media viewers/share sheets over the thread don't clear anything.
- Response buffering in the delegate transformer now delivers by buffer presence instead of re-evaluating the gate, so an override cleared mid-flight can't drop or truncate a response.
- The menu item requires the native Liquid Glass menus (same path as Public Sticky); on the non-glass ActionController sheet the settings sub-screen still provides everything.

## Testing

- Sim-verified on iOS 26.5 (glass): settings restructure + row summary; sub-screen toggles incl. warning alert and conditional Tap-to-Show row; menu item in the comments ⋯ menu only; passive enable → auto-refresh → recovered comments render (red + REMOVED BY MOD chip, r/AskHistorians); title flips to Hide while active; leaving the thread clears the override (log-verified) and re-entering shows native `[removed]` again; global shortcut path incl. warning alert both directions.
- `tests/deleted_comments_tests.m` passes; device (`make package`) and simulator builds clean.
- **Not device-tested yet.**

