### PR TITLE
Add "Comment Link Host": post comment images as plain Imgur/Img Chest links

### DIFF
--- a/src/ApolloImageUploadHost.xm
+++ b/src/ApolloImageUploadHost.xm
@@ -525,6 +525,123 @@ static BOOL ApolloBoolFromFormValue(NSString *value, BOOL defaultValue) {
     return defaultValue;
 }
 
+// MARK: - Comment Link Host (plain-link comment uploads)
+
+// URLs uploaded via the Comment Link Host this session (Imgur/ImgChest links that
+// landed in a comment editor; window armed in ApolloMarkdownToolbarGif.xm). Apollo
+// inserts a freshly-uploaded image into the editor wrapped in a markdown embed
+// (`![img](<link>)`), and Reddit renders a media embed around an EXTERNAL URL in a
+// comment as literal markdown — so at send time (/api/comment, /api/editusertext)
+// any embed wrapping one of THESE URLs is unwrapped back to the bare link. The
+// registry scoping means user-typed embeds, giphy tokens, and staged Reddit
+// uploads are never touched.
+static NSMutableSet<NSString *> *sCommentLinkUploadedURLs = nil;
+
+static NSObject *ApolloCommentLinkUploadedURLsLock(void) {
+    static NSObject *lock;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ lock = [NSObject new]; });
+    return lock;
+}
+
+static void ApolloCommentLinkRecordUploadedURL(NSString *urlString) {
+    NSString *trimmed = ApolloTrimmedString(urlString);
+    if (trimmed.length == 0) return;
+    @synchronized(ApolloCommentLinkUploadedURLsLock()) {
+        if (!sCommentLinkUploadedURLs) sCommentLinkUploadedURLs = [NSMutableSet new];
+        // Session-scoped; the cap only guards a pathological session.
+        if (sCommentLinkUploadedURLs.count >= 200) [sCommentLinkUploadedURLs removeAllObjects];
+        [sCommentLinkUploadedURLs addObject:trimmed];
+    }
+    ApolloLog(@"[CommentLinkHost] Recorded plain-link upload host=%@", [NSURL URLWithString:trimmed].host ?: @"(unparsed)");
+}
+
+static BOOL ApolloCommentLinkHasUploadedURLs(void) {
+    @synchronized(ApolloCommentLinkUploadedURLsLock()) {
+        return sCommentLinkUploadedURLs.count > 0;
+    }
+}
+
+static BOOL ApolloCommentLinkURLWasUploaded(NSString *urlString) {
+    if (urlString.length == 0) return NO;
+    @synchronized(ApolloCommentLinkUploadedURLsLock()) {
+        return [sCommentLinkUploadedURLs containsObject:urlString];
+    }
+}
+
+// Records `data.link` from a REAL Imgur upload response (the Comment Link Host =
+// Imgur path lets Apollo's own upload proceed untouched). Returns YES if a link
+// was found and recorded.
+static BOOL ApolloCommentLinkRecordUploadedURLFromImgurResponse(NSData *data) {
+    if (data.length == 0) return NO;
+    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    NSDictionary *payload = [json isKindOfClass:[NSDictionary class]] && [json[@"data"] isKindOfClass:[NSDictionary class]] ? json[@"data"] : nil;
+    NSString *link = [payload[@"link"] isKindOfClass:[NSString class]] ? payload[@"link"] : nil;
+    if (ApolloTrimmedString(link).length == 0) return NO;
+    ApolloCommentLinkRecordUploadedURL(link);
+    return YES;
+}
+
+// Matches markdown IMAGE embeds `![alt](inner)` only; group 1 = inner. Plain
+// `[title](url)` links are left alone — a link is what the feature wants, and
+// the user may have added the title deliberately via "Add Title To Link".
+static NSRegularExpression *ApolloCommentLinkMarkdownEmbedRegex(void) {
+    static NSRegularExpression *regex;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        regex = [[NSRegularExpression alloc] initWithPattern:@"!\\[[^\\]\\n]*\\]\\(([^)\\s]+)\\)" options:0 error:nil];
+    });
+    return regex;
+}
+
+// Unwraps embeds whose inner URL is a recorded link-host upload. nil if unchanged.
+static NSString *ApolloCommentLinkTextByUnwrappingUploadedEmbeds(NSString *text) {
+    if (text.length == 0 || [text rangeOfString:@"]("].location == NSNotFound) return nil;
+    NSRegularExpression *regex = ApolloCommentLinkMarkdownEmbedRegex();
+    NSArray<NSTextCheckingResult *> *matches = regex ? [regex matchesInString:text options:0 range:NSMakeRange(0, text.length)] : nil;
+    if (matches.count == 0) return nil;
+
+    NSMutableString *rewritten = [text mutableCopy];
+    BOOL changed = NO;
+    for (NSTextCheckingResult *match in [matches reverseObjectEnumerator]) {
+        NSString *inner = ApolloTrimmedString([text substringWithRange:[match rangeAtIndex:1]]);
+        if (!ApolloCommentLinkURLWasUploaded(inner)) continue;
+        [rewritten replaceCharactersInRange:match.range withString:inner];
+        changed = YES;
+    }
+    return changed ? rewritten : nil;
+}
+
+// Form-encoded-body pass over the `text` pair(s). nil if unchanged.
+static NSString *ApolloCommentLinkFormBodyByUnwrappingUploadedEmbeds(NSString *body) {
+    if (body.length == 0 || !ApolloCommentLinkHasUploadedURLs()) return nil;
+    NSArray<NSString *> *pairs = [body componentsSeparatedByString:@"&"];
+    NSMutableArray<NSString *> *outPairs = [NSMutableArray arrayWithCapacity:pairs.count];
+    BOOL changed = NO;
+    for (NSString *pair in pairs) {
+        NSRange equals = [pair rangeOfString:@"="];
+        NSString *key = ApolloFormDecodeComponent(equals.location == NSNotFound ? pair : [pair substringToIndex:equals.location]);
+        NSString *value = ApolloFormDecodeComponent(equals.location == NSNotFound ? @"" : [pair substringFromIndex:equals.location + 1]);
+        if ([key isEqualToString:@"text"]) {
+            NSString *unwrapped = ApolloCommentLinkTextByUnwrappingUploadedEmbeds(value);
+            if (unwrapped) {
+                value = unwrapped;
+                changed = YES;
+            }
+        }
+        [outPairs addObject:[NSString stringWithFormat:@"%@=%@", ApolloFormEncodeComponent(key), ApolloFormEncodeComponent(value)]];
+    }
+    return changed ? [outPairs componentsJoinedByString:@"&"] : nil;
+}
+
+static NSURLRequest *ApolloCommentLinkRequestWithFormBody(NSURLRequest *request, NSString *body) {
+    NSMutableURLRequest *modifiedRequest = [request mutableCopy];
+    NSData *newBody = [body dataUsingEncoding:NSUTF8StringEncoding];
+    [modifiedRequest setHTTPBody:newBody];
+    [modifiedRequest setValue:[NSString stringWithFormat:@"%lu", (unsigned long)newBody.length] forHTTPHeaderField:@"Content-Length"];
+    return modifiedRequest;
+}
+
 static BOOL ApolloSubmitURLStringLooksLikeHostedMedia(NSString *urlString) {
     if (![urlString isKindOfClass:[NSString class]] || urlString.length == 0) return NO;
     if (ApolloStringContainsRedditUploadedMedia(urlString)) return YES;
@@ -1581,6 +1698,14 @@ NSURLRequest *ApolloRedditMaybeRewriteCommentRequest(NSURLRequest *request) {
     if (bodyData.length == 0) return nil;
     NSString *body = [[NSString alloc] initWithData:bodyData encoding:NSUTF8StringEncoding];
 
+    // Comment Link Host: unwrap markdown embeds around link-host uploads FIRST so
+    // both rewrite paths below (and the no-rewrite exits) see the plain-link body.
+    NSString *linkUnwrappedBody = ApolloCommentLinkFormBodyByUnwrappingUploadedEmbeds(body);
+    if (linkUnwrappedBody) {
+        ApolloLog(@"[CommentLinkHost] Unwrapped link-host embed(s) in %@ body", request.URL.path);
+        body = linkUnwrappedBody;
+    }
+
     // Native-Giphy fast path: when `text` contains `![gif](giphy|<id>)` tokens
     // (emitted by ApolloMarkdownToolbarGif), build a proper Reddit RTJSON
     // document with `{e:gif,id:giphy|<id>}` blocks and replace any existing
@@ -1656,7 +1781,7 @@ NSURLRequest *ApolloRedditMaybeRewriteCommentRequest(NSURLRequest *request) {
 
         if (giphyRichTextJSONString.length == 0) {
             ApolloLog(@"[RedditUpload] Native giphy detected but no RTJSON built (text pair missing?) — leaving %@ submit untouched", request.URL.path);
-            return nil;
+            return linkUnwrappedBody ? ApolloCommentLinkRequestWithFormBody(request, body) : nil;
         }
 
         if (!replacedRichTextJSON) {
@@ -1680,7 +1805,9 @@ NSURLRequest *ApolloRedditMaybeRewriteCommentRequest(NSURLRequest *request) {
         return giphyModified;
     }
 
-    if (!ApolloStringContainsRedditUploadedMedia(body)) return nil;
+    if (!ApolloStringContainsRedditUploadedMedia(body)) {
+        return linkUnwrappedBody ? ApolloCommentLinkRequestWithFormBody(request, body) : nil;
+    }
 
     NSArray<NSString *> *pairs = [body componentsSeparatedByString:@"&"];
     NSMutableArray<NSString *> *rewrittenPairs = [NSMutableArray arrayWithCapacity:pairs.count + 2];
@@ -1750,7 +1877,9 @@ NSURLRequest *ApolloRedditMaybeRewriteCommentRequest(NSURLRequest *request) {
         [rewrittenPairs addObject:[NSString stringWithFormat:@"%@=%@", ApolloFormEncodeComponent(@"return_rtjson"), ApolloFormEncodeComponent(@"true")]];
     }
 
-    if (!changed) return nil;
+    // The rewritten pairs were built from the (possibly link-unwrapped) body, so a
+    // link-host unwrap alone still warrants delivering the modified request.
+    if (!changed && !linkUnwrappedBody) return nil;
 
     NSMutableURLRequest *modifiedRequest = [request mutableCopy];
     NSData *newBody = [[rewrittenPairs componentsJoinedByString:@"&"] dataUsingEncoding:NSUTF8StringEncoding];
@@ -2924,13 +3053,35 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
 - (NSURLSessionUploadTask *)uploadTaskWithRequest:(NSURLRequest *)request fromData:(NSData *)bodyData completionHandler:(void (^)(NSData *, NSURLResponse *, NSError *))completionHandler {
     ApolloRedditCaptureBearerTokenFromRequest(request, @"NSURLSession uploadTaskWithRequest:fromData:");
 
+    // Comment Link Host: an upload initiated from the comment/reply editor (window
+    // armed by the photo-button hook in ApolloMarkdownToolbarGif.xm) routes to the
+    // chosen link host and gets posted as a plain link — subreddits can disallow
+    // native image/GIF comments, but a link always posts. Consulted ahead of the
+    // provider branches so it overrides Reddit/cookie routing; a pending CHAT
+    // upload keeps precedence (it clears its own window on consumption below).
+    BOOL commentLinkImgChest = NO;
+    BOOL commentLinkImgur = NO;
+    if (completionHandler && ApolloIsImgurImageUploadRequest(request) &&
+        !ApolloChatImageUploadPending() && ApolloCommentLinkUploadPending()) {
+        NSString *linkMIMEType = ApolloMediaMIMETypeForFilename(nil, [request valueForHTTPHeaderField:@"Content-Type"]);
+        // ImgChest needs a key and can't host video; those cases still honor the
+        // plain-link intent by falling through to Apollo's own Imgur upload.
+        commentLinkImgChest = (sCommentLinkHost == CommentLinkHostImgChest &&
+                               ApolloImgChestUploadAvailable() &&
+                               !ApolloMediaMIMETypeIsVideo(linkMIMEType));
+        commentLinkImgur = !commentLinkImgChest;
+        ApolloLog(@"[CommentLinkHost] Routing comment-editor upload to %@ (fromData)", commentLinkImgChest ? @"ImgChest" : @"Imgur");
+    }
+
     // ImgChest host: divert Apollo's Imgur image upload to the ImgChest API
     // and answer with a synthetic Imgur response carrying the ImgChest link.
     // ImgChest uses its own API key (not Reddit's bearer), so this runs ahead of
     // the keyless Web JSON fallback below and always returns when it applies.
-    if ((sImageUploadProvider == ImageUploadProviderImgChest || ApolloChatImageUploadPending()) && completionHandler && ApolloIsImgurImageUploadRequest(request)) {
+    if ((sImageUploadProvider == ImageUploadProviderImgChest || ApolloChatImageUploadPending() || commentLinkImgChest) &&
+        !commentLinkImgur && completionHandler && ApolloIsImgurImageUploadRequest(request)) {
         BOOL chestForChat = ApolloChatImageUploadPending();   // capture now; the upload completes asynchronously
         if (chestForChat) ApolloChatClearImageUpload();        // window consumed: don't let it leak to a later non-chat upload
+        BOOL chestForCommentLink = commentLinkImgChest;
         NSString *chestMIMEType = ApolloMediaMIMETypeForFilename(nil, [request valueForHTTPHeaderField:@"Content-Type"]);
         if (!ApolloImgChestUploadAvailable() || ApolloMediaMIMETypeIsVideo(chestMIMEType)) {
             ApolloLog(@"[ImgChestUpload] %@ — falling back to Imgur (fromData)",
@@ -2951,6 +3102,12 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
                 // For a chat send, swap the long CDN file URL for the short imgchest.com/p/<id> post URL
                 // (the chat renderer resolves it back to the image inline via ApolloImageChestResolver).
                 NSURL *sendLink = (chestForChat ? (ApolloImgChestPostURLForUploadedLink(link) ?: link) : link);
+                if (chestForCommentLink) {
+                    // The comment-body rewrite unwraps Apollo's `![img](...)` embed
+                    // around this exact URL back to a plain link at send time.
+                    ApolloCommentLinkRecordUploadedURL(link.absoluteString);
+                    ApolloCommentLinkShowUploadedToast(@"Img Chest");
+                }
                 NSData *synthetic = ApolloSyntheticImgurUploadResponseData(sendLink, chestMIMEType);
                 NSHTTPURLResponse *fake = [[NSHTTPURLResponse alloc] initWithURL:requestURL
                                                                       statusCode:200
@@ -2960,6 +3117,24 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
             });
         };
         return %orig(ApolloRedditUploadFastFailRequest(), bodyData ?: [NSData data], chestWrapped);
+    }
+
+    // Comment Link Host = Imgur (or Img Chest unavailable / video): let Apollo's
+    // own Imgur upload run untouched — even when the Media Upload Host is Reddit
+    // or the keyless cookie path would normally claim it — and record the returned
+    // link so the comment-body rewrite can unwrap Apollo's markdown embed into a
+    // plain link. Keyless Web JSON sessions still need an Imgur key for this.
+    if (commentLinkImgur) {
+        if ([ApolloRedditUploadBearerToken() isEqualToString:ApolloWebJSONSyntheticBearerToken] && sImgurClientId.length == 0) {
+            ApolloWarnKeylessUploadUnavailableOnce();
+        }
+        void (^linkRecordingHandler)(NSData *, NSURLResponse *, NSError *) = ^(NSData *data, NSURLResponse *response, NSError *error) {
+            if (!error && ApolloCommentLinkRecordUploadedURLFromImgurResponse(data)) {
+                ApolloCommentLinkShowUploadedToast(@"Imgur");
+            }
+            completionHandler(data, response, error);
+        };
+        return %orig(request, bodyData, linkRecordingHandler);
     }
 
     // Keyless Web JSON session (no real OAuth bearer, just the synthetic
@@ -3056,12 +3231,29 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
 - (NSURLSessionUploadTask *)uploadTaskWithRequest:(NSURLRequest *)request fromFile:(NSURL *)fileURL completionHandler:(void (^)(NSData *, NSURLResponse *, NSError *))completionHandler {
     ApolloRedditCaptureBearerTokenFromRequest(request, @"NSURLSession uploadTaskWithRequest:fromFile:");
 
+    // Comment Link Host (see the fromData: hook): comment/reply-editor uploads go
+    // to the chosen link host and are posted as a plain link; chat keeps precedence.
+    BOOL commentLinkImgChest = NO;
+    BOOL commentLinkImgur = NO;
+    if (completionHandler && ApolloIsImgurImageUploadRequest(request) &&
+        !ApolloChatImageUploadPending() && ApolloCommentLinkUploadPending()) {
+        NSString *linkFilename = fileURL.lastPathComponent.length > 0 ? fileURL.lastPathComponent : @"apollo-upload.jpg";
+        NSString *linkMIMEType = ApolloMediaMIMETypeForFilename(linkFilename, [request valueForHTTPHeaderField:@"Content-Type"]);
+        commentLinkImgChest = (sCommentLinkHost == CommentLinkHostImgChest &&
+                               ApolloImgChestUploadAvailable() &&
+                               !ApolloMediaMIMETypeIsVideo(linkMIMEType));
+        commentLinkImgur = !commentLinkImgChest;
+        ApolloLog(@"[CommentLinkHost] Routing comment-editor upload to %@ (fromFile)", commentLinkImgChest ? @"ImgChest" : @"Imgur");
+    }
+
     // ImgChest host (see the fromData: hook) — runs ahead of the keyless Web JSON
     // fallback since it authenticates with its own API key, and always returns when
     // ImgChest is the selected provider for an Imgur upload request.
-    if ((sImageUploadProvider == ImageUploadProviderImgChest || ApolloChatImageUploadPending()) && completionHandler && ApolloIsImgurImageUploadRequest(request)) {
+    if ((sImageUploadProvider == ImageUploadProviderImgChest || ApolloChatImageUploadPending() || commentLinkImgChest) &&
+        !commentLinkImgur && completionHandler && ApolloIsImgurImageUploadRequest(request)) {
         BOOL chestForChat = ApolloChatImageUploadPending();   // capture now; the upload completes asynchronously
         if (chestForChat) ApolloChatClearImageUpload();        // window consumed: don't let it leak to a later non-chat upload
+        BOOL chestForCommentLink = commentLinkImgChest;
         NSString *chestFilename = fileURL.lastPathComponent.length > 0 ? fileURL.lastPathComponent : @"apollo-upload.jpg";
         NSString *chestMIMEType = ApolloMediaMIMETypeForFilename(chestFilename, [request valueForHTTPHeaderField:@"Content-Type"]);
         NSData *chestData = [NSData dataWithContentsOfURL:fileURL];
@@ -3082,6 +3274,12 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
                 // For a chat send, swap the long CDN file URL for the short imgchest.com/p/<id> post URL
                 // (the chat renderer resolves it back to the image inline via ApolloImageChestResolver).
                 NSURL *sendLink = (chestForChat ? (ApolloImgChestPostURLForUploadedLink(link) ?: link) : link);
+                if (chestForCommentLink) {
+                    // The comment-body rewrite unwraps Apollo's `![img](...)` embed
+                    // around this exact URL back to a plain link at send time.
+                    ApolloCommentLinkRecordUploadedURL(link.absoluteString);
+                    ApolloCommentLinkShowUploadedToast(@"Img Chest");
+                }
                 NSData *synthetic = ApolloSyntheticImgurUploadResponseData(sendLink, chestMIMEType);
                 NSHTTPURLResponse *fake = [[NSHTTPURLResponse alloc] initWithURL:requestURL
                                                                       statusCode:200
@@ -3091,6 +3289,22 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
             });
         };
         return %orig(ApolloRedditUploadFastFailRequest(), fileURL, chestWrapped);
+    }
+
+    // Comment Link Host = Imgur (or Img Chest unavailable / video): see the
+    // fromData: hook — pass the upload through to Apollo's own Imgur path and
+    // record the returned link for the plain-link comment-body rewrite.
+    if (commentLinkImgur) {
+        if ([ApolloRedditUploadBearerToken() isEqualToString:ApolloWebJSONSyntheticBearerToken] && sImgurClientId.length == 0) {
+            ApolloWarnKeylessUploadUnavailableOnce();
+        }
+        void (^linkRecordingHandler)(NSData *, NSURLResponse *, NSError *) = ^(NSData *data, NSURLResponse *response, NSError *error) {
+            if (!error && ApolloCommentLinkRecordUploadedURLFromImgurResponse(data)) {
+                ApolloCommentLinkShowUploadedToast(@"Imgur");
+            }
+            completionHandler(data, response, error);
+        };
+        return %orig(request, fileURL, linkRecordingHandler);
     }
 
     // See the fromData: hook. Keyless Web JSON image uploads go to Reddit via the

--- a/src/ApolloImageUploadHost.xm
+++ b/src/ApolloImageUploadHost.xm
@@ -3064,13 +3064,21 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
     if (completionHandler && ApolloIsImgurImageUploadRequest(request) &&
         !ApolloChatImageUploadPending() && ApolloCommentLinkUploadPending()) {
         NSString *linkMIMEType = ApolloMediaMIMETypeForFilename(nil, [request valueForHTTPHeaderField:@"Content-Type"]);
-        // ImgChest needs a key and can't host video; those cases still honor the
-        // plain-link intent by falling through to Apollo's own Imgur upload.
+        // ImgChest can't host video and needs its API key; Imgur needs an Imgur
+        // client id (the request chokepoints sign uploads with it — a keyless
+        // Imgur upload just 401s). When the chosen leg is unusable fall through
+        // to the other; when NEITHER is usable leave both flags NO so the upload
+        // takes the normal provider routing — a native upload that works beats a
+        // doomed keyless one.
         commentLinkImgChest = (sCommentLinkHost == CommentLinkHostImgChest &&
                                ApolloImgChestUploadAvailable() &&
                                !ApolloMediaMIMETypeIsVideo(linkMIMEType));
-        commentLinkImgur = !commentLinkImgChest;
-        ApolloLog(@"[CommentLinkHost] Routing comment-editor upload to %@ (fromData)", commentLinkImgChest ? @"ImgChest" : @"Imgur");
+        commentLinkImgur = (!commentLinkImgChest && sImgurClientId.length > 0);
+        if (commentLinkImgChest || commentLinkImgur) {
+            ApolloLog(@"[CommentLinkHost] Routing comment-editor upload to %@ (fromData)", commentLinkImgChest ? @"ImgChest" : @"Imgur");
+        } else {
+            ApolloLog(@"[CommentLinkHost] No usable link host (missing key or video) — using normal upload routing (fromData)");
+        }
     }
 
     // ImgChest host: divert Apollo's Imgur image upload to the ImgChest API
@@ -3119,15 +3127,12 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
         return %orig(ApolloRedditUploadFastFailRequest(), bodyData ?: [NSData data], chestWrapped);
     }
 
-    // Comment Link Host = Imgur (or Img Chest unavailable / video): let Apollo's
-    // own Imgur upload run untouched — even when the Media Upload Host is Reddit
-    // or the keyless cookie path would normally claim it — and record the returned
-    // link so the comment-body rewrite can unwrap Apollo's markdown embed into a
-    // plain link. Keyless Web JSON sessions still need an Imgur key for this.
+    // Comment Link Host = Imgur (or Img Chest unavailable / video, with an Imgur
+    // client id configured): let Apollo's own Imgur upload run untouched — even
+    // when the Media Upload Host is Reddit or the keyless cookie path would
+    // normally claim it — and record the returned link so the comment-body
+    // rewrite can unwrap Apollo's markdown embed into a plain link.
     if (commentLinkImgur) {
-        if ([ApolloRedditUploadBearerToken() isEqualToString:ApolloWebJSONSyntheticBearerToken] && sImgurClientId.length == 0) {
-            ApolloWarnKeylessUploadUnavailableOnce();
-        }
         void (^linkRecordingHandler)(NSData *, NSURLResponse *, NSError *) = ^(NSData *data, NSURLResponse *response, NSError *error) {
             if (!error && ApolloCommentLinkRecordUploadedURLFromImgurResponse(data)) {
                 ApolloCommentLinkShowUploadedToast(@"Imgur");
@@ -3239,11 +3244,17 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
         !ApolloChatImageUploadPending() && ApolloCommentLinkUploadPending()) {
         NSString *linkFilename = fileURL.lastPathComponent.length > 0 ? fileURL.lastPathComponent : @"apollo-upload.jpg";
         NSString *linkMIMEType = ApolloMediaMIMETypeForFilename(linkFilename, [request valueForHTTPHeaderField:@"Content-Type"]);
+        // See the fromData: hook — fall through to normal routing when neither
+        // link-host leg is usable (missing key / video).
         commentLinkImgChest = (sCommentLinkHost == CommentLinkHostImgChest &&
                                ApolloImgChestUploadAvailable() &&
                                !ApolloMediaMIMETypeIsVideo(linkMIMEType));
-        commentLinkImgur = !commentLinkImgChest;
-        ApolloLog(@"[CommentLinkHost] Routing comment-editor upload to %@ (fromFile)", commentLinkImgChest ? @"ImgChest" : @"Imgur");
+        commentLinkImgur = (!commentLinkImgChest && sImgurClientId.length > 0);
+        if (commentLinkImgChest || commentLinkImgur) {
+            ApolloLog(@"[CommentLinkHost] Routing comment-editor upload to %@ (fromFile)", commentLinkImgChest ? @"ImgChest" : @"Imgur");
+        } else {
+            ApolloLog(@"[CommentLinkHost] No usable link host (missing key or video) — using normal upload routing (fromFile)");
+        }
     }
 
     // ImgChest host (see the fromData: hook) — runs ahead of the keyless Web JSON
@@ -3291,13 +3302,11 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
         return %orig(ApolloRedditUploadFastFailRequest(), fileURL, chestWrapped);
     }
 
-    // Comment Link Host = Imgur (or Img Chest unavailable / video): see the
-    // fromData: hook — pass the upload through to Apollo's own Imgur path and
-    // record the returned link for the plain-link comment-body rewrite.
+    // Comment Link Host = Imgur (or Img Chest unavailable / video, with an Imgur
+    // client id configured): see the fromData: hook — pass the upload through to
+    // Apollo's own Imgur path and record the returned link for the plain-link
+    // comment-body rewrite.
     if (commentLinkImgur) {
-        if ([ApolloRedditUploadBearerToken() isEqualToString:ApolloWebJSONSyntheticBearerToken] && sImgurClientId.length == 0) {
-            ApolloWarnKeylessUploadUnavailableOnce();
-        }
         void (^linkRecordingHandler)(NSData *, NSURLResponse *, NSError *) = ^(NSData *data, NSURLResponse *response, NSError *error) {
             if (!error && ApolloCommentLinkRecordUploadedURLFromImgurResponse(data)) {
                 ApolloCommentLinkShowUploadedToast(@"Imgur");

--- a/src/ApolloMarkdownToolbarGif.h
+++ b/src/ApolloMarkdownToolbarGif.h
@@ -9,3 +9,20 @@ void ApolloMarkdownGifInstall(void);
 /// (`ApolloMedia.xm`) so all three sites agree on the exact token shape.
 /// Capture group 1 is the bare Giphy GIF ID.
 NSRegularExpression *ApolloNativeGiphyMarkdownTokenRegex(void);
+
+/// Comment Link Host support (UDKeyCommentLinkHost / sCommentLinkHost). The
+/// markdown toolbar's photo-button hook in ApolloMarkdownToolbarGif.xm arms a
+/// short window when the tap comes from a comment/reply editor;
+/// ApolloImageUploadHost.xm consults it to route that upload to the chosen link
+/// host and post it as a plain link instead of native Reddit media.
+#ifdef __cplusplus
+extern "C" {
+#endif
+BOOL ApolloCommentLinkUploadPending(void);
+void ApolloCommentLinkClearUpload(void);
+/// Keyboard-anchored toast confirming the plain-link upload ("Uploaded to
+/// <hostName> — ..."), shown once per compose session.
+void ApolloCommentLinkShowUploadedToast(NSString *hostName);
+#ifdef __cplusplus
+}
+#endif

--- a/src/ApolloMarkdownToolbarGif.xm
+++ b/src/ApolloMarkdownToolbarGif.xm
@@ -1,6 +1,7 @@
 #import "ApolloMarkdownToolbarGif.h"
 #import "ApolloCommon.h"
 #import "ApolloGiphyClient.h"
+#import "ApolloState.h"
 #import "ApolloSubredditInfoCache.h"
 #import "CustomAPIViewController.h"
 #import "GiphyPickerViewController.h"
@@ -1289,9 +1290,14 @@ static void ApolloMarkdownGifApplyMediaGating(UIViewController *composeControlle
 
     ApolloSubredditInfoCache *cache = [ApolloSubredditInfoCache sharedCache];
     ApolloSubredditInfo *cached = [cache cachedInfoForSubreddit:subreddit];
+    // With a Comment Link Host set, photo uploads from the comment editor post as
+    // a plain link (always allowed) instead of native Reddit media, so the image
+    // button stays enabled even where the subreddit disallows image comments. The
+    // GIF (Giphy) button still submits native gif RTJSON, so its gate stays.
+    BOOL imagesPostAsLinks = (sCommentLinkHost != CommentLinkHostOff);
     if (cached && cached.commentMediaInfoAvailable) {
         ApolloMarkdownGifApplyGatingStates(imageControl, gifButton, subreddit,
-                                           cached.allowsImageComments, cached.allowsGifComments);
+                                           cached.allowsImageComments || imagesPostAsLinks, cached.allowsGifComments);
         return;
     }
 
@@ -1413,6 +1419,55 @@ static void ApolloMarkdownGifSetActiveComposeController(UIViewController *contro
     sApolloMarkdownGifActiveComposeController = controller;
 }
 
+#pragma mark - Comment Link Host (plain-link comment uploads)
+
+// When a Comment Link Host is set (sCommentLinkHost != Off), a photo picked from
+// the COMMENT/REPLY editor should upload to that host and land in the comment as
+// a plain link rather than a native Reddit media upload (which some subreddits
+// disallow). The upload interception lives at the network layer
+// (ApolloImageUploadHost.xm) where no editor context exists, so — like the chat
+// photo flag in ApolloChatComposer.xm — we arm a short wall-clock window when the
+// markdown toolbar's photo button is tapped in a comment-kind composer.
+//
+// Unlike the chat flag, the window is NOT cleared when an upload consumes it: one
+// picker session can upload several images. Instead it is cleared when the arming
+// composer is torn down, when the photo button is tapped in a non-comment
+// composer, and by the deadline itself.
+static double sApolloCommentLinkUploadUntil = 0.0;
+static __weak UIViewController *sApolloCommentLinkArmedComposer = nil;
+static char kApolloCommentLinkToastShownKey;
+
+static void ApolloCommentLinkMarkUpload(UIViewController *composer) {
+    sApolloCommentLinkUploadUntil = [NSDate timeIntervalSinceReferenceDate] + 180.0;   // generous window for the picker
+    sApolloCommentLinkArmedComposer = composer;
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+BOOL ApolloCommentLinkUploadPending(void) {
+    return sCommentLinkHost != CommentLinkHostOff &&
+           [NSDate timeIntervalSinceReferenceDate] < sApolloCommentLinkUploadUntil;
+}
+void ApolloCommentLinkClearUpload(void) {
+    sApolloCommentLinkUploadUntil = 0.0;
+    sApolloCommentLinkArmedComposer = nil;
+}
+void ApolloCommentLinkShowUploadedToast(NSString *hostName) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *composer = sApolloCommentLinkArmedComposer ?: ApolloMarkdownGifActiveComposeController();
+        if (!composer) return;
+        if (objc_getAssociatedObject(composer, &kApolloCommentLinkToastShownKey)) return;   // once per compose session
+        objc_setAssociatedObject(composer, &kApolloCommentLinkToastShownKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        NSString *message = [NSString stringWithFormat:@"Uploaded to %@ — this will post as a plain link, not a Reddit image upload.",
+                             hostName.length > 0 ? hostName : @"the link host"];
+        ApolloMarkdownGifShowGatingToast(composer, message);
+    });
+}
+#ifdef __cplusplus
+}
+#endif
+
 static void ApolloMarkdownGifScheduleInjection(UIViewController *composeController, NSString *reason) {
     if (composeController && ApolloMarkdownGifComposeSessionHasGif(composeController)) return;
 
@@ -1503,6 +1558,40 @@ void ApolloMarkdownGifInstall(void) {
 - (void)viewDidLayoutSubviews {
     %orig;
     ApolloMarkdownGifThrottledTryInject((UIViewController *)self, @"compose-layout");
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    %orig;
+    // A torn-down comment editor takes its comment-link upload window with it, so
+    // the plain-link routing can't leak onto uploads from a later composer. Only
+    // on real teardown — a fullscreen picker presented OVER the editor also
+    // triggers viewDidDisappear, and the upload it produces still needs the window.
+    UIViewController *controller = (UIViewController *)self;
+    if ((controller.isBeingDismissed || controller.isMovingFromParentViewController) &&
+        controller == sApolloCommentLinkArmedComposer) {
+        ApolloCommentLinkClearUpload();
+    }
+}
+
+%end
+
+// The markdown toolbar's photo button ("Add photos"). Arm the comment-link window
+// BEFORE Apollo opens the picker when the active composer is genuinely composing
+// a comment/reply; clear any stale window otherwise (the post composer's body
+// editor and the fullscreen chat editor share this toolbar).
+%hook _TtC6Apollo20QuickBarKeyboardView
+
+- (void)cameraButtonTapped:(id)sender {
+    if (sCommentLinkHost != CommentLinkHostOff) {
+        UIViewController *composer = ApolloMarkdownGifActiveComposeController();
+        if (ApolloMarkdownGifResolveCommentSubreddit(composer).length > 0) {
+            ApolloCommentLinkMarkUpload(composer);
+            ApolloLog(@"[CommentLinkHost] Armed comment-editor upload window (host=%ld)", (long)sCommentLinkHost);
+        } else {
+            ApolloCommentLinkClearUpload();
+        }
+    }
+    %orig;
 }
 
 %end

--- a/src/ApolloMarkdownToolbarGif.xm
+++ b/src/ApolloMarkdownToolbarGif.xm
@@ -5,6 +5,7 @@
 #import "ApolloSubredditInfoCache.h"
 #import "CustomAPIViewController.h"
 #import "GiphyPickerViewController.h"
+#import "UserDefaultConstants.h"
 
 #import <objc/runtime.h>
 #import <objc/message.h>
@@ -1426,19 +1427,23 @@ static void ApolloMarkdownGifSetActiveComposeController(UIViewController *contro
 // a plain link rather than a native Reddit media upload (which some subreddits
 // disallow). The upload interception lives at the network layer
 // (ApolloImageUploadHost.xm) where no editor context exists, so — like the chat
-// photo flag in ApolloChatComposer.xm — we arm a short wall-clock window when the
-// markdown toolbar's photo button is tapped in a comment-kind composer.
+// photo flag in ApolloChatComposer.xm — we arm a window when the markdown
+// toolbar's photo button is tapped in a comment-kind composer.
 //
 // Unlike the chat flag, the window is NOT cleared when an upload consumes it: one
-// picker session can upload several images. Instead it is cleared when the arming
-// composer is torn down, when the photo button is tapped in a non-comment
-// composer, and by the deadline itself.
+// picker session can upload several images. Its real scope is the arming
+// composer's LIFETIME — the weak ref zeroes on dealloc, so the window dies with
+// the composer no matter how it was torn down — plus an explicit clear on
+// teardown (below) and on a non-comment photo tap. The wall-clock deadline is
+// only a long backstop: a short one quietly expired mid photo-pick and reverted
+// the upload to native media routing, exactly in the gated subreddits where the
+// image button was enabled on the promise of a link.
 static double sApolloCommentLinkUploadUntil = 0.0;
 static __weak UIViewController *sApolloCommentLinkArmedComposer = nil;
 static char kApolloCommentLinkToastShownKey;
 
 static void ApolloCommentLinkMarkUpload(UIViewController *composer) {
-    sApolloCommentLinkUploadUntil = [NSDate timeIntervalSinceReferenceDate] + 180.0;   // generous window for the picker
+    sApolloCommentLinkUploadUntil = [NSDate timeIntervalSinceReferenceDate] + 1800.0;   // backstop only; scope = composer lifetime
     sApolloCommentLinkArmedComposer = composer;
 }
 
@@ -1447,6 +1452,7 @@ extern "C" {
 #endif
 BOOL ApolloCommentLinkUploadPending(void) {
     return sCommentLinkHost != CommentLinkHostOff &&
+           sApolloCommentLinkArmedComposer != nil &&   // weak: dies with the arming composer
            [NSDate timeIntervalSinceReferenceDate] < sApolloCommentLinkUploadUntil;
 }
 void ApolloCommentLinkClearUpload(void) {
@@ -1565,11 +1571,17 @@ void ApolloMarkdownGifInstall(void) {
     // A torn-down comment editor takes its comment-link upload window with it, so
     // the plain-link routing can't leak onto uploads from a later composer. Only
     // on real teardown — a fullscreen picker presented OVER the editor also
-    // triggers viewDidDisappear, and the upload it produces still needs the window.
+    // triggers viewDidDisappear, and the upload it produces still needs the
+    // window. Apollo presents the composer wrapped in a UINavigationController,
+    // and UIKit sets the dismissal flag on the presented CONTAINER, not its
+    // children — so walk the ancestor chain rather than checking only self.
     UIViewController *controller = (UIViewController *)self;
-    if ((controller.isBeingDismissed || controller.isMovingFromParentViewController) &&
-        controller == sApolloCommentLinkArmedComposer) {
-        ApolloCommentLinkClearUpload();
+    if (controller != sApolloCommentLinkArmedComposer) return;
+    for (UIViewController *ancestor = controller; ancestor; ancestor = ancestor.parentViewController) {
+        if (ancestor.isBeingDismissed || ancestor.isMovingFromParentViewController) {
+            ApolloCommentLinkClearUpload();
+            return;
+        }
     }
 }
 
@@ -1679,5 +1691,12 @@ void ApolloMarkdownGifInstall(void) {
     }];
     [[NSNotificationCenter defaultCenter] addObserverForName:UIKeyboardDidHideNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(__unused NSNotification *note) {
         ApolloMarkdownGifKeyboardHidden(note);
+    }];
+    // Comment Link Host toggled while a composer is open (e.g. iPad multitasking):
+    // re-apply the media gating so the image button's blocked/enabled state
+    // reflects the new setting immediately instead of after the next appearance.
+    [[NSNotificationCenter defaultCenter] addObserverForName:ApolloCommentLinkHostChangedNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(__unused NSNotification *note) {
+        UIViewController *composer = ApolloMarkdownGifActiveComposeController();
+        if (composer) ApolloMarkdownGifApplyMediaGating(composer);
     }];
 }

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -183,6 +183,19 @@ typedef NS_ENUM(NSInteger, ImageUploadProvider) {
 };
 extern NSInteger sImageUploadProvider;
 
+// Comment Link Host: secondary host for images added in the COMMENT/REPLY editor.
+// Off (default) keeps comment uploads on the Media Upload Host above. Imgur/ImgChest
+// route comment-editor uploads to that host and post the result as a plain link in
+// the comment body (no native Reddit media), so image/GIF replies still work in
+// subreddits that disallow media comments. Posts and chat are unaffected. Armed per
+// photo-button tap in ApolloMarkdownToolbarGif.xm; routed in ApolloImageUploadHost.xm.
+typedef NS_ENUM(NSInteger, CommentLinkHost) {
+    CommentLinkHostOff = 0,
+    CommentLinkHostImgur = 1,
+    CommentLinkHostImgChest = 2,
+};
+extern NSInteger sCommentLinkHost;
+
 // Most recently observed Reddit bearer token, captured from outgoing Authorization
 // headers. Used by the native Reddit image upload path. nil if Apollo hasn't made an
 // authenticated Reddit API call yet.

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -53,6 +53,7 @@ NSInteger sLinkPreviewCardColor = ApolloLinkPreviewCardColorNeutral;
 NSString *sLinkPreviewCardColorHex = nil;
 volatile uint32_t sLinkPreviewCardColorPacked = 0;
 NSInteger sImageUploadProvider = ImageUploadProviderImgur;
+NSInteger sCommentLinkHost = CommentLinkHostOff;
 
 NSString *sLatestRedditBearerToken = nil;
 

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -435,6 +435,9 @@ typedef NS_ENUM(NSInteger, Tag) {
 - (void)setCommentLinkHost:(NSInteger)host {
     sCommentLinkHost = host;
     [[NSUserDefaults standardUserDefaults] setInteger:sCommentLinkHost forKey:UDKeyCommentLinkHost];
+    // An open comment composer's image-button gate depends on this (the button
+    // un-blocks while a link host is set) — let it re-apply immediately.
+    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloCommentLinkHostChangedNotification object:nil];
 
     NSIndexPath *indexPath = [NSIndexPath indexPathForRow:3 inSection:SectionMedia];
     if ([[self.tableView indexPathsForVisibleRows] containsObject:indexPath]) {
@@ -455,6 +458,13 @@ typedef NS_ENUM(NSInteger, Tag) {
         [self setCommentLinkHost:CommentLinkHostOff];
     }]];
     [sheet addAction:[UIAlertAction actionWithTitle:imgurTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        // Uploads are signed with the Imgur client id at the request chokepoint;
+        // keyless ones just 401 — refuse the host rather than fail silently later.
+        if (sImgurClientId.length == 0) {
+            [self showAlertWithTitle:@"Imgur API Key Required"
+                             message:@"Add your Imgur API key in the API Keys section first, then select Imgur as the comment link host."];
+            return;
+        }
         [self setCommentLinkHost:CommentLinkHostImgur];
     }]];
     [sheet addAction:[UIAlertAction actionWithTitle:imgChestTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSInteger, SectionIndex) {
 // Alignment + Autoplay Inline GIFs) when Inline Media Previews is off. These helpers
 // centralize the physical<->logical row mapping so the index math stays consistent.
 static const NSInteger kApolloMediaInlineDependentRows = 2;
-static const NSInteger kApolloMediaFirstInlineDependentRow = 5;
+static const NSInteger kApolloMediaFirstInlineDependentRow = 6;
 
 // Map a physical (visible) Media row to its logical row.
 static NSInteger ApolloMediaLogicalRow(NSInteger physicalRow) {
@@ -423,6 +423,60 @@ typedef NS_ENUM(NSInteger, Tag) {
     [self presentViewController:sheet animated:YES completion:nil];
 }
 
+- (NSString *)commentLinkHostText {
+    switch (sCommentLinkHost) {
+        case CommentLinkHostImgur:    return @"Imgur";
+        case CommentLinkHostImgChest: return @"Img Chest";
+        case CommentLinkHostOff:
+        default:                      return @"Off";
+    }
+}
+
+- (void)setCommentLinkHost:(NSInteger)host {
+    sCommentLinkHost = host;
+    [[NSUserDefaults standardUserDefaults] setInteger:sCommentLinkHost forKey:UDKeyCommentLinkHost];
+
+    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:3 inSection:SectionMedia];
+    if ([[self.tableView indexPathsForVisibleRows] containsObject:indexPath]) {
+        [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
+    }
+}
+
+- (void)presentCommentLinkHostSheetFromSourceView:(UIView *)sourceView {
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Comment Link Host"
+                                                                   message:@"Images added to a comment or reply upload to this host and are inserted as a plain link instead of a native Reddit image — so they still work in subreddits that don't allow images or GIFs in comments. Apollo shows the linked image inline; other apps and the website show a tappable link. Posts keep using the Media Upload Host."
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+
+    NSString *offTitle = (sCommentLinkHost == CommentLinkHostOff) ? @"Off (Current)" : @"Off";
+    NSString *imgurTitle = (sCommentLinkHost == CommentLinkHostImgur) ? @"Imgur (Current)" : @"Imgur";
+    NSString *imgChestTitle = (sCommentLinkHost == CommentLinkHostImgChest) ? @"Img Chest (Current)" : @"Img Chest";
+
+    [sheet addAction:[UIAlertAction actionWithTitle:offTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self setCommentLinkHost:CommentLinkHostOff];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:imgurTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self setCommentLinkHost:CommentLinkHostImgur];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:imgChestTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        // Same gate as the Media Upload Host picker: uploading needs an API token.
+        if (sImageChestAPIToken.length == 0) {
+            [self showAlertWithTitle:@"Img Chest API Key Required"
+                             message:@"Add your Img Chest API key in the API Keys section first, then select Img Chest as the comment link host."];
+            return;
+        }
+        [self setCommentLinkHost:CommentLinkHostImgChest];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    if (popover && sourceView) {
+        popover.sourceView = sourceView;
+        popover.sourceRect = sourceView.bounds;
+    }
+
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
 - (NSString *)linkPreviewModeTextForMode:(NSInteger)mode {
     switch (mode) {
         case ApolloLinkPreviewModeOff:     return @"Off";
@@ -560,10 +614,11 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionApolloAI: return 1;
         case SectionLinkPreviews: return 1;
         // Media base rows (the three "Rich Link Previews" rows moved out to their
-        // own SectionLinkPreviews) plus the chat inline-media toggle and the
-        // "Hold for Video Speed" toggle, minus the two inline-dependent rows when
-        // off, plus the hold-speed picker (logical row 13) when that toggle is on.
-        case SectionMedia: return 13 + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows) + (sVideoHoldSpeedEnabled ? 1 : 0);
+        // own SectionLinkPreviews) plus the "Comment Link Host" picker, the chat
+        // inline-media toggle and the "Hold for Video Speed" toggle, minus the two
+        // inline-dependent rows when off, plus the hold-speed picker (logical row
+        // 14) when that toggle is on.
+        case SectionMedia: return 14 + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows) + (sVideoHoldSpeedEnabled ? 1 : 0);
         case SectionSubreddits: return 10 - (sSubredditListEnhancements ? 0 : 1) - (sCommunityHighlights ? 0 : 1);
         case SectionNotificationBackend: return 3; // URL + Registration Token + Test Connection
         case SectionAbout: return 5; // GitHub + Reddit + Thanks To + Export Logs + Version
@@ -1113,17 +1168,29 @@ typedef NS_ENUM(NSInteger, Tag) {
             cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
             return cell;
         }
-        case 3:
+        case 3: {
+            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_CommentLinkHost"];
+            if (!cell) {
+                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_CommentLinkHost"];
+                cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+            }
+            cell.textLabel.text = @"Comment Link Host";
+            cell.detailTextLabel.text = [self commentLinkHostText];
+            cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+            return cell;
+        }
+        case 4:
             return [self switchCellWithIdentifier:@"Cell_Media_ProxyImgur"
                                             label:@"Proxy Imgur via DuckDuckGo"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyProxyImgurDDG]
                                            action:@selector(proxyImgurDDGSwitchToggled:)];
-        case 4:
+        case 5:
             return [self switchCellWithIdentifier:@"Cell_Media_InlineImages"
                                             label:@"Inline Media Previews"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableInlineImages]
                                            action:@selector(inlineImagesSwitchToggled:)];
-        case 5: {
+        case 6: {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_InlineImageAlignment"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_InlineImageAlignment"];
@@ -1135,7 +1202,7 @@ typedef NS_ENUM(NSInteger, Tag) {
             cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
             return cell;
         }
-        case 6: {
+        case 7: {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_AutoplayInlineGIFs"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_AutoplayInlineGIFs"];
@@ -1147,22 +1214,22 @@ typedef NS_ENUM(NSInteger, Tag) {
             cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
             return cell;
         }
-        case 7:
+        case 8:
             return [self switchCellWithIdentifier:@"Cell_Media_TextPostThumbnails"
                                             label:@"Text Post Thumbnails"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyFeedTextPostThumbnails]
                                            action:@selector(textPostThumbnailsSwitchToggled:)];
-        case 8:
+        case 9:
             return [self switchCellWithIdentifier:@"Cell_Media_UserAvatars"
                                             label:@"Show User Profile Pictures"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars]
                                            action:@selector(userAvatarsSwitchToggled:)];
-        case 9:
+        case 10:
             return [self switchCellWithIdentifier:@"Cell_Media_ProfileTabAvatar"
                                             label:@"Profile Picture Tab Icon"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon]
                                            action:@selector(profileTabAvatarSwitchToggled:)];
-        case 10:
+        case 11:
             // Single toggle for Reborn's detailed profile page: banner, large
             // avatar/snoovatar, display name, bio, and the Social Links band (all of
             // which live in the custom header). Off → Apollo's compact stock profile.
@@ -1170,14 +1237,14 @@ typedef NS_ENUM(NSInteger, Tag) {
                                             label:@"Show Detailed Profiles"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowDetailedProfiles]
                                            action:@selector(showDetailedProfilesSwitchToggled:)];
-        case 11:
+        case 12:
             return [self switchCellWithIdentifier:@"Cell_Media_ChatMedia"
                                             label:@"Inline Media in Chat"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableChatMedia]
                                            action:@selector(chatMediaSwitchToggled:)];
-        case 12:
+        case 13:
             // Master toggle for "Hold for Video Speed". When on, the hold-speed
-            // picker (logical row 13) is shown below; when off, the right side of a
+            // picker (logical row 14) is shown below; when off, the right side of a
             // fullscreen video keeps Apollo's normal long-press menu. The gesture is
             // explained in the section footer, matching the sibling Media toggles
             // (which are plain switches with no inline subtitle).
@@ -1185,7 +1252,7 @@ typedef NS_ENUM(NSInteger, Tag) {
                                             label:@"Hold for Video Speed"
                                                on:sVideoHoldSpeedEnabled
                                            action:@selector(videoHoldSpeedSwitchToggled:)];
-        case 13: {
+        case 14: {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_HoldSpeedValue"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_HoldSpeedValue"];
@@ -1513,7 +1580,7 @@ typedef NS_ENUM(NSInteger, Tag) {
             attributes:plainAttrs]];
     } else if (section == SectionMedia) {
         text = [[NSMutableAttributedString alloc]
-            initWithString:@"Media Upload Host selects where Apollo uploads media attached to posts and comments.\n\nProxying routes Imgur image requests through DuckDuckGo to bypass regional blocks; albums and uploads are unsupported by the proxy."
+            initWithString:@"Media Upload Host selects where Apollo uploads media attached to posts and comments.\n\nComment Link Host uploads images added to a comment or reply to Imgur or Img Chest and inserts a plain link instead of a native Reddit image, so they work even in subreddits that don't allow images in comments. Apollo still shows the linked image inline.\n\nProxying routes Imgur image requests through DuckDuckGo to bypass regional blocks; albums and uploads are unsupported by the proxy."
             attributes:plainAttrs];
     } else if (section == SectionNotificationBackend) {
         text = [[NSMutableAttributedString alloc]
@@ -1645,11 +1712,13 @@ typedef NS_ENUM(NSInteger, Tag) {
             [self presentUnmuteCommentsVideosModeSheetFromSourceView:cell];
         } else if (row == 2) {
             [self presentImageUploadProviderSheetFromSourceView:cell];
-        } else if (row == 5) {
-            [self presentInlineImageAlignmentSheetFromSourceView:cell];
+        } else if (row == 3) {
+            [self presentCommentLinkHostSheetFromSourceView:cell];
         } else if (row == 6) {
+            [self presentInlineImageAlignmentSheetFromSourceView:cell];
+        } else if (row == 7) {
             [self presentAutoplayInlineGIFModeSheetFromSourceView:cell];
-        } else if (row == 13) {
+        } else if (row == 14) {
             [self presentVideoHoldSpeedSheetFromSourceView:cell];
         }
     } else if (indexPath.section == SectionNotificationBackend && indexPath.row == 2) {
@@ -1726,7 +1795,7 @@ typedef NS_ENUM(NSInteger, Tag) {
     if (indexPath.section == SectionLinkPreviews) return YES;
     if (indexPath.section == SectionMedia) {
         NSInteger row = ApolloMediaLogicalRow(indexPath.row);
-        return (row == 0 || row == 1 || row == 2 || row == 5 || row == 6 || row == 13);
+        return (row == 0 || row == 1 || row == 2 || row == 3 || row == 6 || row == 7 || row == 14);
     }
     if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 || indexPath.row == 3)) return YES;
     if (indexPath.section == SectionNotificationBackend && indexPath.row == 2) return YES;
@@ -2299,11 +2368,11 @@ typedef NS_ENUM(NSInteger, Tag) {
     sEnableInlineImages = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sEnableInlineImages forKey:UDKeyEnableInlineImages];
     if (sEnableInlineImages == wasOn) return;
-    // Two adjacent rows are gated on this toggle: Inline Media Alignment (logical 5)
-    // and Autoplay Inline GIFs (logical 6). Insert/delete both to keep row counts consistent.
+    // Two adjacent rows are gated on this toggle: Inline Media Alignment (logical 6)
+    // and Autoplay Inline GIFs (logical 7). Insert/delete both to keep row counts consistent.
     NSArray<NSIndexPath *> *paths = @[
-        [NSIndexPath indexPathForRow:5 inSection:SectionMedia],
         [NSIndexPath indexPathForRow:6 inSection:SectionMedia],
+        [NSIndexPath indexPathForRow:7 inSection:SectionMedia],
     ];
     if (sEnableInlineImages) {
         [self.tableView insertRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
@@ -2352,7 +2421,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 - (void)setInlineImageAlignment:(ApolloInlineImageAlignment)alignment {
     sInlineImageAlignment = alignment;
     [[NSUserDefaults standardUserDefaults] setInteger:sInlineImageAlignment forKey:UDKeyInlineImageAlignment];
-    NSIndexPath *alignmentRow = [NSIndexPath indexPathForRow:5 inSection:SectionMedia];
+    NSIndexPath *alignmentRow = [NSIndexPath indexPathForRow:6 inSection:SectionMedia];
     [self.tableView reloadRowsAtIndexPaths:@[alignmentRow] withRowAnimation:UITableViewRowAnimationNone];
 }
 
@@ -2403,7 +2472,7 @@ typedef NS_ENUM(NSInteger, Tag) {
     sAutoplayInlineGIFMode = mode;
     // The autoplay module observes this key via KVO and re-evaluates visible inline GIFs.
     [[NSUserDefaults standardUserDefaults] setInteger:sAutoplayInlineGIFMode forKey:UDKeyAutoplayInlineGIFs];
-    NSIndexPath *autoplayRow = [NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(6) inSection:SectionMedia];
+    NSIndexPath *autoplayRow = [NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(7) inSection:SectionMedia];
     [self.tableView reloadRowsAtIndexPaths:@[autoplayRow] withRowAnimation:UITableViewRowAnimationNone];
 }
 
@@ -2414,10 +2483,10 @@ typedef NS_ENUM(NSInteger, Tag) {
     sVideoHoldSpeedEnabled = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sVideoHoldSpeedEnabled forKey:UDKeyVideoHoldSpeedEnabled];
     if (sVideoHoldSpeedEnabled == wasOn) return;
-    // The "Hold Speed" picker (logical row 13) is the last Media row and is shown
+    // The "Hold Speed" picker (logical row 14) is the last Media row and is shown
     // only while this toggle is on. Insert/delete it so the row counts stay
-    // consistent. ApolloMediaPhysicalRow(13) accounts for the inline-dependent gap.
-    NSIndexPath *pickerPath = [NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(13) inSection:SectionMedia];
+    // consistent. ApolloMediaPhysicalRow(14) accounts for the inline-dependent gap.
+    NSIndexPath *pickerPath = [NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(14) inSection:SectionMedia];
     if (sVideoHoldSpeedEnabled) {
         [self.tableView insertRowsAtIndexPaths:@[pickerPath] withRowAnimation:UITableViewRowAnimationFade];
     } else {
@@ -2432,7 +2501,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 - (void)setVideoHoldSpeed:(float)speed {
     sVideoHoldSpeed = ApolloSanitizedHoldSpeed(speed);
     [[NSUserDefaults standardUserDefaults] setFloat:sVideoHoldSpeed forKey:UDKeyVideoHoldSpeed];
-    NSIndexPath *pickerPath = [NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(13) inSection:SectionMedia];
+    NSIndexPath *pickerPath = [NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(14) inSection:SectionMedia];
     if ([[self.tableView indexPathsForVisibleRows] containsObject:pickerPath]) {
         [self.tableView reloadRowsAtIndexPaths:@[pickerPath] withRowAnimation:UITableViewRowAnimationNone];
     }
@@ -2758,6 +2827,8 @@ static void ApolloReplayValetKeychainItems(NSArray<NSDictionary *> *items) {
     sVideoHoldSpeedEnabled = [defaults boolForKey:UDKeyVideoHoldSpeedEnabled];
     sVideoHoldSpeed = ApolloSanitizedHoldSpeed([defaults floatForKey:UDKeyVideoHoldSpeed]);
     sImageUploadProvider = [defaults integerForKey:UDKeyImageUploadProvider];
+    sCommentLinkHost = [defaults integerForKey:UDKeyCommentLinkHost];
+    if (sCommentLinkHost < CommentLinkHostOff || sCommentLinkHost > CommentLinkHostImgChest) sCommentLinkHost = CommentLinkHostOff;
     sLinkPreviewCardColor = [defaults integerForKey:UDKeyLinkPreviewCardColor];
     if (sLinkPreviewCardColor < ApolloLinkPreviewCardColorNeutral || sLinkPreviewCardColor > ApolloLinkPreviewCardColorSlate) {
         sLinkPreviewCardColor = ApolloLinkPreviewCardColorNeutral;

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1474,6 +1474,7 @@ static void initializeRandomSources() {
                                     UDKeyLinkPreviewCommentsMode: @(ApolloLinkPreviewModeFull),
                                     UDKeyLinkPreviewCardColor: @(ApolloLinkPreviewCardColorNeutral),
                                     UDKeyImageUploadProvider: @(ImageUploadProviderImgur),
+                                    UDKeyCommentLinkHost: @(CommentLinkHostOff),
                                     UDKeyShowUserAvatars: @NO,
                                     UDKeyUseProfileAvatarTabIcon: @NO,
                                     UDKeyShowDetailedProfiles: @YES,
@@ -1582,6 +1583,8 @@ static void initializeRandomSources() {
     ApolloSetLinkPreviewCardColorHex(cardColorHex);
     ApolloLog(@"[LinkPreviews] settings loaded bodyMode=%ld commentsMode=%ld cardColor=%ld cardColorHex=%@", (long)sLinkPreviewBodyMode, (long)sLinkPreviewCommentsMode, (long)sLinkPreviewCardColor, sLinkPreviewCardColorHex ?: @"(default)");
     sImageUploadProvider = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyImageUploadProvider];
+    sCommentLinkHost = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyCommentLinkHost];
+    if (sCommentLinkHost < CommentLinkHostOff || sCommentLinkHost > CommentLinkHostImgChest) sCommentLinkHost = CommentLinkHostOff;
     sShowUserAvatars = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars];
     sUseProfileAvatarTabIcon = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon];
     sShowDetailedProfiles = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowDetailedProfiles];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -53,6 +53,12 @@ static NSString *const UDKeyLegacyRevealDeletedComments = @"RevealDeletedComment
 static NSString *const UDKeyFilterNSFWRecentlyRead = @"FilterNSFWRecentlyRead";
 static NSString *const UDKeyProxyImgurDDG = @"ProxyImgurDDG";
 static NSString *const UDKeyImageUploadProvider = @"ImageUploadProvider";
+// Secondary host for images added in the COMMENT/REPLY editor (CommentLinkHost
+// enum). Off (default) keeps comment uploads on the Media Upload Host above;
+// Imgur/Img Chest route comment-editor uploads there and post the result as a
+// plain link (no native Reddit media) so they work in subreddits that disallow
+// image/GIF comments. See ApolloMarkdownToolbarGif.xm + ApolloImageUploadHost.xm.
+static NSString *const UDKeyCommentLinkHost = @"CommentLinkHost";
 static NSString *const UDKeyShowUserAvatars = @"ShowUserAvatars";
 static NSString *const UDKeyUseProfileAvatarTabIcon = @"UseProfileAvatarTabIcon";
 // When ON (default), profile pages show Reborn's detailed profile — the banner,

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -59,6 +59,9 @@ static NSString *const UDKeyImageUploadProvider = @"ImageUploadProvider";
 // plain link (no native Reddit media) so they work in subreddits that disallow
 // image/GIF comments. See ApolloMarkdownToolbarGif.xm + ApolloImageUploadHost.xm.
 static NSString *const UDKeyCommentLinkHost = @"CommentLinkHost";
+// Posted after sCommentLinkHost changes so open composers re-apply the comment
+// media-permission gating (the image button un-blocks while a link host is set).
+static NSString *const ApolloCommentLinkHostChangedNotification = @"ApolloCommentLinkHostChangedNotification";
 static NSString *const UDKeyShowUserAvatars = @"ShowUserAvatars";
 static NSString *const UDKeyUseProfileAvatarTabIcon = @"UseProfileAvatarTabIcon";
 // When ON (default), profile pages show Reborn's detailed profile — the banner,


### PR DESCRIPTION
## Problem

Some subreddits disallow image/GIF uploads in comments. With **Media Upload Host = Reddit**, a comment image becomes a *native* Reddit media comment (staged asset → `richtext_json` img block → i.redd.it), which those subreddits reject — so there's currently no good way to attach an image to a reply there. Sometimes you just want to drop the picture as a link and move on.

## Feature

New **Comment Link Host** picker (Off / Imgur / Img Chest, default Off) directly under Media Upload Host. When set, an image added from the **comment/reply editor** uploads to the chosen host and is inserted as a **bare direct-image link** (`https://cdn.imgchest.com/files/<id>.jpeg` / `https://i.imgur.com/<id>.<ext>`), so the comment posts as a plain link that works everywhere:

- Apollo renders the linked image inline via Inline Media Previews; the website and other clients show a normal tappable link.
- **Posts and chat are unaffected** — the Media Upload Host keeps governing those.
- A keyboard-anchored toast (once per compose session) tells you the upload will post as a plain link, not a Reddit image upload.
- The comment media-permission gating no longer blocks the toolbar's photo button in restricted subreddits while a link host is set (a link always posts — that's the point of the feature). The Giphy button still posts native gif RTJSON, so its gate is unchanged.
- Reddit is deliberately not offered as a link host: staged Reddit assets only publish through native media comments, so a bare staged link would be dead.

## How it works

Mirrors the existing chat photo→ImgChest flag, since the upload interception lives at the network layer where no editor context exists:

- **Arming** (`ApolloMarkdownToolbarGif.xm`): `QuickBarKeyboardView cameraButtonTapped:` arms a window when the active composer is genuinely composing a comment/reply (the proven `correspondingLink`/`commentBeingRepliedTo`/`commentBeingEdited` runtime-ivar test — post-body and PM/modmail editors never arm). The window is scoped to the arming composer's **lifetime** (weak ref, 30-min backstop), survives multi-image picker sessions, and clears on composer teardown (ancestor-chain `isBeingDismissed` walk — UIKit sets the flag on the presented nav container, not its children) or a non-comment photo tap.
- **Routing** (`ApolloImageUploadHost.xm`): the `uploadTaskWithRequest:` hooks consult the window ahead of the provider branches, so the link host overrides Reddit/cookie routing; a pending chat upload keeps precedence. Img Chest reuses the existing interception (direct CDN link, no chat post-URL swap); Imgur passes Apollo's own upload through untouched and records `data.link` from the real response. If the chosen leg is unusable (missing key, video), it falls through to the other leg or to normal provider routing — never a doomed keyless upload.
- **Send-time cleanup**: recorded link-host URLs that end up wrapped in a markdown image embed (`![img](url)`) are unwrapped back to the bare link in `/api/comment` and `/api/editusertext` bodies. Registry-scoped, so giphy tokens, staged Reddit uploads, and deliberate `[title](url)` links are never touched. (In practice Apollo inserts the bare URL in the comment editor, so this is a safety net.)
- Both picker options are gated on their API key being configured, and toggling the setting live re-applies the composer gating via a notification.

## Screenshots

**The new setting.** "Comment Link Host" sits directly under Media Upload Host — shown here in the override setup: posts keep uploading natively to Reddit, while comment images go to Img Chest as plain links. Off (the default) leaves everything exactly as it is today.

<img width="420" alt="Comment Link Host setting" src="https://github.com/user-attachments/assets/89d1e8b4-74f4-4fa0-86a8-0183afef0168" />

**The heads-up in the editor.** When the upload finishes, a toast above the markdown toolbar confirms it went to the link host and will post as a plain link, not a Reddit image upload. Shown once per comment so it doesn't nag on multi-image replies.

<img width="560" alt="Plain-link upload toast" src="https://github.com/user-attachments/assets/279d5146-0c28-4f31-a59c-a3ecc580ef7f" />

**The end result, live.** An image comment posted in r/Soccer (a sub where native image comments are disallowed): the comment body is just the bare `cdn.imgchest.com` link, which Apollo renders inline like a normal image comment via Inline Media Previews — the website and other clients show a regular tappable link.

<img width="420" alt="Posted comment rendering inline" src="https://github.com/user-attachments/assets/a264a710-a3c4-49a5-9899-6b479ed713cb" />

## Testing

Verified in the iOS 26 simulator (Liquid Glass), signed in:

- Comment Link Host = Img Chest, **Media Upload Host = Img Chest and = Reddit (the override case)**: reply upload routed to ImgChest both times, bare CDN URL inserted in the editor, posted comment body on Reddit is exactly the plain link, renders inline in Apollo.
- Toast shown once per compose session; second image in the same session doesn't re-toast.
- Post composer photo/video picks take the unchanged native path (no link routing); chat unaffected.
- Draft cancel + re-open, picker cancel, and non-comment editors don't leak the window.
- Device build (`make package`) compiles clean against `main`.

