### PR TITLE
Theme Manager v2 (3/4): per-theme app-wide fonts

### DIFF
--- a/src/ApolloNativeActionMenus.xm
+++ b/src/ApolloNativeActionMenus.xm
@@ -1,5 +1,6 @@
 #import "ApolloCommon.h"
 #import "ApolloNativeActionMetadata.h"
+#import "ApolloThemeRuntime.h"
 
 #import <UIKit/UIKit.h>
 #import <objc/message.h>
@@ -144,14 +145,22 @@ static UIImage *ApolloNativeActionMenuTintedImage(UIImage *image, UIColor *tintC
 }
 
 static void ApolloNativeActionMenuStyleElementTitle(UIMenuElement *element, UIColor *tintColor) {
-    if (!element || !tintColor || ![element respondsToSelector:@selector(setAttributedTitle:)]) return;
+    if (!element || ![element respondsToSelector:@selector(setAttributedTitle:)]) return;
 
     NSString *title = element.title;
     if (title.length == 0) return;
 
-    NSAttributedString *attributedTitle = [[NSAttributedString alloc] initWithString:title attributes:@{
-        NSForegroundColorAttributeName: tintColor
-    }];
+    NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
+    if (tintColor) attributes[NSForegroundColorAttributeName] = tintColor;
+
+    UIFont *baseFont = [UIFont systemFontOfSize:17.0 weight:UIFontWeightRegular];
+    UIFont *themeFont = ApolloThemeRuntimeFont(baseFont);
+    if (themeFont && ![themeFont.fontName isEqualToString:baseFont.fontName]) {
+        attributes[NSFontAttributeName] = themeFont;
+    }
+    if (attributes.count == 0) return;
+
+    NSAttributedString *attributedTitle = [[NSAttributedString alloc] initWithString:title attributes:attributes];
     ((void (*)(id, SEL, id))objc_msgSend)(element, @selector(setAttributedTitle:), attributedTitle);
 }
 
@@ -243,10 +252,8 @@ static void ApolloNativeActionMenuStyleElement(UIMenuElement *element, BOOL mode
     UIColor *moderatorTintColor = ApolloNativeActionMenuModeratorColor();
     UIColor *elementTintColor = (!destructive && (moderatorStyle || opensModeratorMenu)) ? moderatorTintColor : nil;
 
-    if (elementTintColor) {
-        ApolloNativeActionMenuStyleElementTitle(element, elementTintColor);
-        ApolloNativeActionMenuStyleElementImage(element, elementTintColor);
-    }
+    ApolloNativeActionMenuStyleElementTitle(element, elementTintColor);
+    if (elementTintColor) ApolloNativeActionMenuStyleElementImage(element, elementTintColor);
 
     if ([element isKindOfClass:[UIAction class]]) {
         UIAction *action = (UIAction *)element;
@@ -549,9 +556,7 @@ static UIAction *ApolloNativeActionMenuAction(NSString *title, NSString *subtitl
         ApolloNativeActionMenuSelectRow(actionController, row);
     }];
 
-    if (tintColor) {
-        ApolloNativeActionMenuStyleElementTitle(action, tintColor);
-    }
+    ApolloNativeActionMenuStyleElementTitle(action, tintColor);
 
     if (subtitle.length > 0 && [action respondsToSelector:@selector(setSubtitle:)]) {
         ((void (*)(id, SEL, id))objc_msgSend)(action, @selector(setSubtitle:), subtitle);

--- a/src/ApolloThemeManagerViewController.m
+++ b/src/ApolloThemeManagerViewController.m
@@ -93,6 +93,210 @@ static NSString *ThemeInputDescription(NSString *key) {
     return nil;
 }
 
+static UIFont *ThemeFontPreviewFont(ApolloThemeFont font, CGFloat size, UIFontWeight weight) {
+    UIFont *base = ApolloThemeFontApply(ApolloThemeFontSystem, [UIFont systemFontOfSize:size weight:weight]);
+    return ApolloThemeFontApply(font, base);
+}
+
+static void ThemeManagerRefreshWindowFonts(void) {
+    for (UIWindow *window in ApolloAllWindows()) {
+        [window setNeedsLayout];
+        [window layoutIfNeeded];
+        [window.rootViewController.view setNeedsLayout];
+        [window.rootViewController.view layoutIfNeeded];
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+@interface ApolloThemeFontTile : UIControl
+@property (nonatomic, strong) UILabel *sampleLabel;
+@property (nonatomic, strong) UILabel *nameLabel;
+@property (nonatomic, strong) UILabel *detailLabel;
+@property (nonatomic, strong) UIImageView *checkView;
+- (void)configureFont:(ApolloThemeFont)font
+             selected:(BOOL)selected
+                label:(UIColor *)label
+            secondary:(UIColor *)secondary
+               accent:(UIColor *)accent
+                 fill:(UIColor *)fill;
+@end
+
+@implementation ApolloThemeFontTile
+
+- (instancetype)init {
+    self = [super initWithFrame:CGRectZero];
+    if (self) {
+        self.layer.cornerRadius = 8.0;
+        self.layer.cornerCurve = kCACornerCurveContinuous;
+        self.layer.borderWidth = 1.0;
+        self.translatesAutoresizingMaskIntoConstraints = NO;
+
+        _sampleLabel = [[UILabel alloc] init];
+        _sampleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+        _sampleLabel.text = @"Aa";
+        _sampleLabel.adjustsFontSizeToFitWidth = YES;
+        _sampleLabel.minimumScaleFactor = 0.75;
+
+        _nameLabel = [[UILabel alloc] init];
+        _nameLabel.translatesAutoresizingMaskIntoConstraints = NO;
+        _nameLabel.font = [UIFont systemFontOfSize:13.0 weight:UIFontWeightSemibold];
+        _nameLabel.adjustsFontSizeToFitWidth = YES;
+        _nameLabel.minimumScaleFactor = 0.75;
+
+        _detailLabel = [[UILabel alloc] init];
+        _detailLabel.translatesAutoresizingMaskIntoConstraints = NO;
+        _detailLabel.font = [UIFont systemFontOfSize:11.0 weight:UIFontWeightRegular];
+        _detailLabel.adjustsFontSizeToFitWidth = YES;
+        _detailLabel.minimumScaleFactor = 0.75;
+
+        UIImageSymbolConfiguration *cfg = [UIImageSymbolConfiguration configurationWithPointSize:14 weight:UIImageSymbolWeightSemibold];
+        _checkView = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"checkmark.circle.fill" withConfiguration:cfg]];
+        _checkView.translatesAutoresizingMaskIntoConstraints = NO;
+
+        [self addSubview:_sampleLabel];
+        [self addSubview:_nameLabel];
+        [self addSubview:_detailLabel];
+        [self addSubview:_checkView];
+
+        [NSLayoutConstraint activateConstraints:@[
+            [_sampleLabel.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:10.0],
+            [_sampleLabel.topAnchor constraintEqualToAnchor:self.topAnchor constant:8.0],
+            [_sampleLabel.trailingAnchor constraintLessThanOrEqualToAnchor:_checkView.leadingAnchor constant:-6.0],
+
+            [_checkView.topAnchor constraintEqualToAnchor:self.topAnchor constant:8.0],
+            [_checkView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-8.0],
+            [_checkView.widthAnchor constraintEqualToConstant:16.0],
+            [_checkView.heightAnchor constraintEqualToConstant:16.0],
+
+            [_nameLabel.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:10.0],
+            [_nameLabel.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-10.0],
+            [_nameLabel.topAnchor constraintEqualToAnchor:_sampleLabel.bottomAnchor constant:4.0],
+
+            [_detailLabel.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:10.0],
+            [_detailLabel.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-10.0],
+            [_detailLabel.topAnchor constraintEqualToAnchor:_nameLabel.bottomAnchor constant:1.0],
+            [_detailLabel.bottomAnchor constraintLessThanOrEqualToAnchor:self.bottomAnchor constant:-8.0],
+            [self.heightAnchor constraintGreaterThanOrEqualToConstant:72.0],
+        ]];
+    }
+    return self;
+}
+
+- (void)setHighlighted:(BOOL)highlighted {
+    [super setHighlighted:highlighted];
+    self.alpha = highlighted ? 0.72 : 1.0;
+}
+
+- (void)configureFont:(ApolloThemeFont)font
+             selected:(BOOL)selected
+                label:(UIColor *)label
+            secondary:(UIColor *)secondary
+               accent:(UIColor *)accent
+                 fill:(UIColor *)fill {
+    self.tag = (NSInteger)font;
+    self.backgroundColor = fill ?: UIColor.secondarySystemGroupedBackgroundColor;
+    self.layer.borderColor = (selected ? (accent ?: UIColor.systemBlueColor) : [UIColor.separatorColor colorWithAlphaComponent:0.45]).CGColor;
+    self.layer.borderWidth = selected ? 1.25 : 1.0;
+
+    UIColor *primary = label ?: UIColor.labelColor;
+    UIColor *muted = secondary ?: UIColor.secondaryLabelColor;
+    UIColor *active = accent ?: UIColor.systemBlueColor;
+
+    self.sampleLabel.textColor = selected ? active : primary;
+    self.sampleLabel.font = ThemeFontPreviewFont(font, 25.0, UIFontWeightBold);
+    self.nameLabel.text = ApolloThemeFontDisplayName(font);
+    self.nameLabel.textColor = primary;
+    self.nameLabel.font = ThemeFontPreviewFont(font, 13.0, UIFontWeightSemibold);
+    self.detailLabel.text = ApolloThemeFontDetailName(font);
+    self.detailLabel.textColor = muted;
+    self.detailLabel.font = ThemeFontPreviewFont(font, 11.0, UIFontWeightRegular);
+    self.checkView.hidden = !selected;
+    self.checkView.tintColor = active;
+    self.accessibilityLabel = [NSString stringWithFormat:@"%@, %@", self.nameLabel.text, self.detailLabel.text];
+    self.accessibilityTraits = selected ? (UIAccessibilityTraitButton | UIAccessibilityTraitSelected) : UIAccessibilityTraitButton;
+}
+
+@end
+
+typedef void (^ApolloThemeFontSelectionHandler)(ApolloThemeFont font);
+
+@interface ApolloThemeFontGridCell : UITableViewCell
+@property (nonatomic, copy) ApolloThemeFontSelectionHandler selectionHandler;
+@property (nonatomic, strong) NSArray<ApolloThemeFontTile *> *tiles;
+- (void)configureCurrent:(ApolloThemeFont)current
+                   label:(UIColor *)label
+               secondary:(UIColor *)secondary
+                  accent:(UIColor *)accent
+                    fill:(UIColor *)fill;
+@end
+
+@implementation ApolloThemeFontGridCell
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        self.selectionStyle = UITableViewCellSelectionStyleNone;
+        self.preservesSuperviewLayoutMargins = YES;
+
+        NSMutableArray *tiles = [NSMutableArray arrayWithCapacity:ApolloThemeFontCount];
+        for (NSUInteger i = 0; i < ApolloThemeFontCount; i++) {
+            ApolloThemeFontTile *tile = [[ApolloThemeFontTile alloc] init];
+            tile.tag = (NSInteger)i;
+            [tile addTarget:self action:@selector(tileTapped:) forControlEvents:UIControlEventTouchUpInside];
+            [tiles addObject:tile];
+        }
+        _tiles = [tiles copy];
+
+        UIStackView *row1 = [[UIStackView alloc] initWithArrangedSubviews:@[_tiles[0], _tiles[1]]];
+        row1.axis = UILayoutConstraintAxisHorizontal;
+        row1.spacing = 10.0;
+        row1.distribution = UIStackViewDistributionFillEqually;
+
+        UIStackView *row2 = [[UIStackView alloc] initWithArrangedSubviews:@[_tiles[2], _tiles[3]]];
+        row2.axis = UILayoutConstraintAxisHorizontal;
+        row2.spacing = 10.0;
+        row2.distribution = UIStackViewDistributionFillEqually;
+
+        UIStackView *grid = [[UIStackView alloc] initWithArrangedSubviews:@[row1, row2]];
+        grid.translatesAutoresizingMaskIntoConstraints = NO;
+        grid.axis = UILayoutConstraintAxisVertical;
+        grid.spacing = 8.0;
+        grid.distribution = UIStackViewDistributionFillEqually;
+        [self.contentView addSubview:grid];
+
+        [NSLayoutConstraint activateConstraints:@[
+            [grid.leadingAnchor constraintEqualToAnchor:self.contentView.layoutMarginsGuide.leadingAnchor],
+            [grid.trailingAnchor constraintEqualToAnchor:self.contentView.layoutMarginsGuide.trailingAnchor],
+            [grid.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:8.0],
+            [grid.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor constant:-8.0],
+        ]];
+    }
+    return self;
+}
+
+- (void)tileTapped:(ApolloThemeFontTile *)tile {
+    if (self.selectionHandler) self.selectionHandler((ApolloThemeFont)tile.tag);
+}
+
+- (void)configureCurrent:(ApolloThemeFont)current
+                   label:(UIColor *)label
+               secondary:(UIColor *)secondary
+                  accent:(UIColor *)accent
+                    fill:(UIColor *)fill {
+    for (ApolloThemeFontTile *tile in self.tiles) {
+        ApolloThemeFont font = (ApolloThemeFont)tile.tag;
+        [tile configureFont:font
+                   selected:(font == current)
+                      label:label
+                  secondary:secondary
+                     accent:accent
+                       fill:fill];
+    }
+}
+
+@end
+
 // ---------------------------------------------------------------------------
 
 @interface ApolloThemeManagerViewController () <UIColorPickerViewControllerDelegate, UIDocumentPickerDelegate>
@@ -108,10 +312,10 @@ static NSString *ThemeInputDescription(NSString *key) {
 
 // List mode:   0 Enable | 1 New/Import (actions first — a long theme list must
 //              never push Generate/New/Import off-screen) | 2 Themes
-// Editor mode: 0 Name | 1 Variant+Mode | 2 Colours | 3 Advanced | 4 Generate
-//              5 Preview | 6 Apply | 7 Delete
+// Editor mode: 0 Name | 1 Variant+Mode | 2 Colours | 3 Advanced | 4 Font
+//              5 Generate | 6 Preview | 7 Apply | 8 Delete
 enum { LSEnable, LSActions, LSThemes, LSCount };
-enum { ESName, ESVariant, ESColors, ESAdvanced, ESGenerate, ESPreview, ESApply, ESDelete, ESCount };
+enum { ESName, ESVariant, ESColors, ESAdvanced, ESFont, ESGenerate, ESPreview, ESApply, ESDelete, ESCount };
 
 @implementation ApolloThemeManagerViewController
 
@@ -290,6 +494,7 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESGenerate, ESPreview, ESApply, 
             case ESVariant:  return 1;  // appearance mode (Light/Dark) only — variant is AI-only
             case ESColors:   return ApolloThemeDefaultInputKeys().count;
             case ESAdvanced: return 1 + (advancedEnabled ? ApolloThemeAdvancedInputKeys().count : 0);
+            case ESFont:     return 1;
             case ESGenerate: return 1;
             case ESPreview:  return 4;
             case ESApply:    return 1;
@@ -320,6 +525,7 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESGenerate, ESPreview, ESApply, 
         switch (section) {
             case ESColors:   return @"Colours";
             case ESAdvanced: return @"Advanced (optional)";
+            case ESFont:     return @"Font";
             case ESPreview:  return @"Preview";
         }
         return nil;
@@ -331,6 +537,8 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESGenerate, ESPreview, ESApply, 
 - (NSString *)tableView:(UITableView *)tv titleForFooterInSection:(NSInteger)section {
     if (self.editingThemeID && section == ESAdvanced)
         return @"Turn on advanced options to override text and separator colours.";
+    if (self.editingThemeID && section == ESFont)
+        return @"Used across the app while this theme is active. Some screens pick up a font change after scrolling away or relaunching.";
     if (self.editingThemeID && section == ESApply)
         return @"Applying selects this theme and enables custom theming.";
     if (!self.editingThemeID && section == LSEnable && [[self store] runtimeDisabledDueToCrash])
@@ -504,6 +712,21 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESGenerate, ESPreview, ESApply, 
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             return cell;
         }
+        case ESFont: {
+            ApolloThemeFontGridCell *cell = [[ApolloThemeFontGridCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+            ApolloThemeFont current = ApolloThemeFontFromKey(theme[kApolloThemeFontKey]);
+            UIColor *label = [self previewColorForToken:ApolloThemeTokenLabel] ?: UIColor.labelColor;
+            UIColor *secondary = [self previewColorForToken:ApolloThemeTokenSecondaryLabel] ?: UIColor.secondaryLabelColor;
+            UIColor *accent = [self previewColorForToken:ApolloThemeTokenAccent] ?: self.view.tintColor;
+            UIColor *fillBase = [self previewColorForToken:ApolloThemeTokenTertiaryBackground] ?: UIColor.tertiarySystemGroupedBackgroundColor;
+            UIColor *fill = [fillBase colorWithAlphaComponent:0.55];
+            [cell configureCurrent:current label:label secondary:secondary accent:accent fill:fill];
+            __weak typeof(self) weakSelf = self;
+            cell.selectionHandler = ^(ApolloThemeFont font) {
+                [weakSelf setThemeFont:font];
+            };
+            return cell;
+        }
         case ESGenerate: {
             UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
             ApolloThemeMode other = (self.editingMode == ApolloThemeModeLight) ? ApolloThemeModeDark : ApolloThemeModeLight;
@@ -536,6 +759,11 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESGenerate, ESPreview, ESApply, 
 - (UITableViewCell *)previewCellForRow:(NSInteger)row {
     UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:nil];
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
+    // Preview in the EDITING theme's font (Apply normalises even if the live
+    // runtime already restyled the cell's default fonts to another design).
+    ApolloThemeFont font = ApolloThemeFontFromKey([[self store] themeWithID:self.editingThemeID][kApolloThemeFontKey]);
+    cell.textLabel.font = ApolloThemeFontApply(font, cell.textLabel.font);
+    cell.detailTextLabel.font = ApolloThemeFontApply(font, cell.detailTextLabel.font);
     UIColor *card = [self previewColorForToken:ApolloThemeTokenSecondaryBackground];
     UIColor *label = [self previewColorForToken:ApolloThemeTokenLabel];
     UIColor *secondary = [self previewColorForToken:ApolloThemeTokenSecondaryLabel];
@@ -681,6 +909,7 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESGenerate, ESPreview, ESApply, 
                 [self beginPickingInputKey:ApolloThemeAdvancedInputKeys()[ip.row - 1]];
             }
             break;
+        case ESFont: break;
         case ESGenerate: [self generateOppositeMode]; break;
         case ESApply: [self applyTheme]; break;
         case ESDelete: [self confirmDeleteFromEditor]; break;
@@ -851,6 +1080,18 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESGenerate, ESPreview, ESApply, 
 - (void)advancedOptionsSwitchChanged:(UISwitch *)sw {
     if (!sw) return;
     [self setAdvancedOptionsEnabled:sw.on];
+}
+
+- (void)setThemeFont:(ApolloThemeFont)font {
+    [[self store] setFont:font themeID:self.editingThemeID];
+    // Colours are untouched, so no recompilePreview — but the live runtime
+    // must re-read sFontChoice, the current chrome needs a layout pass, and
+    // the preview rows re-render in the font.
+    [self maybeLiveReload];
+    ThemeManagerRefreshWindowFonts();
+    self.navigationItem.title = self.navigationItem.title;
+    NSIndexSet *fontSection = [NSIndexSet indexSetWithIndex:ESFont];
+    [self.tableView reloadSections:fontSection withRowAnimation:UITableViewRowAnimationNone];
 }
 
 - (void)saveColor:(UIColor *)color forCurrentKey:(BOOL)clear {

--- a/src/ApolloThemeManagerViewController.m
+++ b/src/ApolloThemeManagerViewController.m
@@ -93,18 +93,11 @@ static NSString *ThemeInputDescription(NSString *key) {
     return nil;
 }
 
+// The systemFontOfSize: base may come back already themed (the runtime's
+// UIFont factory hooks treat the tweak as Apollo code) — harmless, since
+// ApolloThemeFontApply rebuilds from a pristine descriptor either way.
 static UIFont *ThemeFontPreviewFont(ApolloThemeFont font, CGFloat size, UIFontWeight weight) {
-    UIFont *base = ApolloThemeFontApply(ApolloThemeFontSystem, [UIFont systemFontOfSize:size weight:weight]);
-    return ApolloThemeFontApply(font, base);
-}
-
-static void ThemeManagerRefreshWindowFonts(void) {
-    for (UIWindow *window in ApolloAllWindows()) {
-        [window setNeedsLayout];
-        [window layoutIfNeeded];
-        [window.rootViewController.view setNeedsLayout];
-        [window.rootViewController.view layoutIfNeeded];
-    }
+    return ApolloThemeFontApply(font, [UIFont systemFontOfSize:size weight:weight]);
 }
 
 // ---------------------------------------------------------------------------
@@ -138,17 +131,24 @@ static void ThemeManagerRefreshWindowFonts(void) {
         _sampleLabel.adjustsFontSizeToFitWidth = YES;
         _sampleLabel.minimumScaleFactor = 0.75;
 
+        // Each tile renders ITS OWN design — without the pin, the runtime's
+        // UILabel setFont: sink hook rewrites every tile into the active
+        // theme's design (all four tiles showed the selected font).
+        ApolloThemeRuntimeSetFontPinned(_sampleLabel, YES);
+
         _nameLabel = [[UILabel alloc] init];
         _nameLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _nameLabel.font = [UIFont systemFontOfSize:13.0 weight:UIFontWeightSemibold];
         _nameLabel.adjustsFontSizeToFitWidth = YES;
         _nameLabel.minimumScaleFactor = 0.75;
+        ApolloThemeRuntimeSetFontPinned(_nameLabel, YES);
 
         _detailLabel = [[UILabel alloc] init];
         _detailLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _detailLabel.font = [UIFont systemFontOfSize:11.0 weight:UIFontWeightRegular];
         _detailLabel.adjustsFontSizeToFitWidth = YES;
         _detailLabel.minimumScaleFactor = 0.75;
+        ApolloThemeRuntimeSetFontPinned(_detailLabel, YES);
 
         UIImageSymbolConfiguration *cfg = [UIImageSymbolConfiguration configurationWithPointSize:14 weight:UIImageSymbolWeightSemibold];
         _checkView = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"checkmark.circle.fill" withConfiguration:cfg]];
@@ -538,7 +538,7 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESFont, ESGenerate, ESPreview, E
     if (self.editingThemeID && section == ESAdvanced)
         return @"Turn on advanced options to override text and separator colours.";
     if (self.editingThemeID && section == ESFont)
-        return @"Used across the app while this theme is active. Some screens pick up a font change after scrolling away or relaunching.";
+        return @"Used across the app while this theme is active. Applies immediately; the odd view catches up after scrolling or reopening.";
     if (self.editingThemeID && section == ESApply)
         return @"Applying selects this theme and enables custom theming.";
     if (!self.editingThemeID && section == LSEnable && [[self store] runtimeDisabledDueToCrash])
@@ -759,8 +759,11 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESFont, ESGenerate, ESPreview, E
 - (UITableViewCell *)previewCellForRow:(NSInteger)row {
     UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:nil];
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
-    // Preview in the EDITING theme's font (Apply normalises even if the live
-    // runtime already restyled the cell's default fonts to another design).
+    // Preview in the EDITING theme's font. Pin first: without it the runtime's
+    // setFont: sink hook (and the invalidate-time refresh walk) would rewrite
+    // these into the ACTIVE theme's design, which may be a different theme.
+    ApolloThemeRuntimeSetFontPinned(cell.textLabel, YES);
+    ApolloThemeRuntimeSetFontPinned(cell.detailTextLabel, YES);
     ApolloThemeFont font = ApolloThemeFontFromKey([[self store] themeWithID:self.editingThemeID][kApolloThemeFontKey]);
     cell.textLabel.font = ApolloThemeFontApply(font, cell.textLabel.font);
     cell.detailTextLabel.font = ApolloThemeFontApply(font, cell.detailTextLabel.font);
@@ -1084,14 +1087,13 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESFont, ESGenerate, ESPreview, E
 
 - (void)setThemeFont:(ApolloThemeFont)font {
     [[self store] setFont:font themeID:self.editingThemeID];
-    // Colours are untouched, so no recompilePreview — but the live runtime
-    // must re-read sFontChoice, the current chrome needs a layout pass, and
-    // the preview rows re-render in the font.
+    // Colours are untouched, so no recompilePreview. If this theme is the live
+    // one, maybeLiveReload makes the runtime re-read the font and Invalidate's
+    // font-refresh walk re-derives everything already on screen.
     [self maybeLiveReload];
-    ThemeManagerRefreshWindowFonts();
-    self.navigationItem.title = self.navigationItem.title;
-    NSIndexSet *fontSection = [NSIndexSet indexSetWithIndex:ESFont];
-    [self.tableView reloadSections:fontSection withRowAnimation:UITableViewRowAnimationNone];
+    NSMutableIndexSet *sections = [NSMutableIndexSet indexSetWithIndex:ESFont];
+    [sections addIndex:ESPreview];
+    [self.tableView reloadSections:sections withRowAnimation:UITableViewRowAnimationNone];
 }
 
 - (void)saveColor:(UIColor *)color forCurrentKey:(BOOL)clear {

--- a/src/ApolloThemeRuntime.h
+++ b/src/ApolloThemeRuntime.h
@@ -29,6 +29,17 @@ UIColor *ApolloThemeRuntimeColor(ApolloThemeToken token);
 // theme uses the default system font.
 UIFont *ApolloThemeRuntimeFont(UIFont *base);
 
+// Mark a text control whose font the tweak sets DELIBERATELY in a specific
+// design (the theme editor's font-picker tiles and preview rows): the font
+// sink hooks and the live font-refresh walk leave pinned views untouched.
+void ApolloThemeRuntimeSetFontPinned(id view, BOOL pinned);
+
+// Walk the app's windows and re-derive system-design fonts on Apollo-owned
+// labels / text fields / text views (plus vetted nav/tab-bar chrome) into the
+// active theme's font — the live-update path after a font change. Also runs
+// as part of ApolloThemeRuntimeInvalidate. Main thread only.
+void ApolloThemeRuntimeRefreshFonts(void);
+
 // Monotonic counter bumped whenever the compiled token table or the
 // enabled/disabled state changes (reload/enable/disable). ApolloThemeRuntimeColor
 // itself always allocates a fresh dynamic-provider colour (a shared/cached

--- a/src/ApolloThemeRuntime.h
+++ b/src/ApolloThemeRuntime.h
@@ -24,6 +24,11 @@ BOOL ApolloThemeRuntimeIsActive(void);
 // Cached dynamic colour for a token, or nil if inactive / out of range.
 UIColor *ApolloThemeRuntimeColor(ApolloThemeToken token);
 
+// Re-derive a caller-provided system font in the active theme's system design.
+// Returns `base` unchanged when the theme runtime is inactive or the active
+// theme uses the default system font.
+UIFont *ApolloThemeRuntimeFont(UIFont *base);
+
 // Monotonic counter bumped whenever the compiled token table or the
 // enabled/disabled state changes (reload/enable/disable). ApolloThemeRuntimeColor
 // itself always allocates a fresh dynamic-provider colour (a shared/cached

--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -133,6 +133,22 @@ static __thread int sFontBypass = 0;
 static BOOL ClassNameLooksApolloOwned(const char *name);
 static BOOL TextSinkMayUseTheme(id object, uintptr_t caller);
 
+// Pinned views carry a font the tweak chose deliberately in a SPECIFIC design
+// (the editor's font-picker tiles and preview rows must each render their own
+// design, not the active theme's). Both the sink hooks and the refresh walk
+// skip them.
+static const void *kApolloThemeFontPinnedKey = &kApolloThemeFontPinnedKey;
+
+void ApolloThemeRuntimeSetFontPinned(id view, BOOL pinned) {
+    if (!view) return;
+    objc_setAssociatedObject(view, kApolloThemeFontPinnedKey,
+                             pinned ? @YES : nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static BOOL FontPinned(id view) {
+    return view && [objc_getAssociatedObject(view, kApolloThemeFontPinnedKey) boolValue];
+}
+
 // Re-derive a system font in the active theme's design. Caller-gated like the
 // colour hooks: only Apollo's own code (and the tweak) get themed fonts, so
 // UIKit-built chrome (system alerts, share sheet, keyboard) keeps SF Pro —
@@ -172,12 +188,16 @@ static BOOL FontLooksLikeAppleSystemDesign(UIFont *font) {
 
 static UIFont *ThemedTextSinkFont(UIFont *font, id owner, uintptr_t caller) {
     if (!sEnabled || !font || sFontBypass) return font;
+    if (FontPinned(owner)) return font;
     if (!TextSinkMayUseTheme(owner, caller)) return font;
     if (!FontLooksLikeAppleSystemDesign(font)) return font;
 
     sFontBypass++;
     UIFont *themed = ApolloThemeFontApply(sFontChoice, font);
     sFontBypass--;
+    // Preserve identity when the design didn't change, so attributed-string
+    // rewrites can skip the copy.
+    if (!themed || [themed.fontName isEqualToString:font.fontName]) return font;
     return themed;
 }
 
@@ -334,9 +354,16 @@ static BOOL ClassNameLooksApolloOwned(const char *name) {
            strstr(name, ".Apollo") != NULL;
 }
 
+// Walk supernode (Texture), then the RESPONDER chain, then superview.
+// nextResponder must outrank superview: the responder chain interleaves each
+// view's managing view controller, so a label inside an Apollo controller is
+// vetted in a few hops. The old superview-first walk had to climb the entire
+// UIKit view stack and then window→scene→application→AppDelegate — 10-13 hops
+// depending on presentation depth, which straddled the budget and made the
+// gate (and therefore all font/text theming) fail on deeper screens.
 static BOOL ObjectChainLooksApolloOwned(id object) {
     id current = object;
-    for (NSUInteger i = 0; current && i < 12; i++) {
+    for (NSUInteger i = 0; current && i < 16; i++) {
         if (ClassNameLooksApolloOwned(class_getName(object_getClass(current)))) return YES;
 
         id next = nil;
@@ -347,16 +374,16 @@ static BOOL ObjectChainLooksApolloOwned(id object) {
                 next = nil;
             }
         }
-        if (!next && [current respondsToSelector:@selector(superview)]) {
+        if (!next && [current respondsToSelector:@selector(nextResponder)]) {
             @try {
-                next = ((id (*)(id, SEL))objc_msgSend)(current, @selector(superview));
+                next = ((id (*)(id, SEL))objc_msgSend)(current, @selector(nextResponder));
             } @catch (__unused NSException *e) {
                 next = nil;
             }
         }
-        if (!next && [current respondsToSelector:@selector(nextResponder)]) {
+        if (!next && [current respondsToSelector:@selector(superview)]) {
             @try {
-                next = ((id (*)(id, SEL))objc_msgSend)(current, @selector(nextResponder));
+                next = ((id (*)(id, SEL))objc_msgSend)(current, @selector(superview));
             } @catch (__unused NSException *e) {
                 next = nil;
             }
@@ -374,35 +401,92 @@ static UINavigationBar *NavigationBarForDescendant(UIView *view) {
     return nil;
 }
 
-static BOOL NavigationBarLooksApolloOwned(UINavigationBar *bar) {
-    if (![bar isKindOfClass:[UINavigationBar class]]) return NO;
+// Nav/tab bars host their labels outside Apollo's view/responder chain, so
+// ownership is vetted at the bar: either the chain reaches an Apollo class,
+// or the bar's delegate is one (Apollo's own controllers).
+static BOOL ChromeBarLooksApolloOwned(UIView *bar) {
+    if (!([bar isKindOfClass:[UINavigationBar class]] || [bar isKindOfClass:[UITabBar class]])) return NO;
     if (ObjectChainLooksApolloOwned(bar)) return YES;
-    id delegate = bar.delegate;
+    id delegate = ((id (*)(id, SEL))objc_msgSend)(bar, @selector(delegate));
     if (delegate && ClassNameLooksApolloOwned(class_getName(object_getClass(delegate)))) return YES;
     return NO;
 }
 
+// Re-derive one live text control's font into `target`'s design. Only touches
+// fonts that are Apple system designs (explicit app fonts like markdown code
+// faces survive) and skips pinned views (the editor's picker tiles).
+static void RefreshFontOnTextControl(UIView *view, ApolloThemeFont target) {
+    if (FontPinned(view)) return;
+    UIFont *font = ((UILabel *)view).font; // UILabel/UITextField/UITextView all expose `font`
+    if (![font isKindOfClass:[UIFont class]] || !FontLooksLikeAppleSystemDesign(font)) return;
+    sFontBypass++;
+    UIFont *themed = ApolloThemeFontApply(target, font);
+    if (themed && ![themed.fontName isEqualToString:font.fontName]) {
+        // Set inside the bypass: the font is already derived, the sink hook
+        // must not re-derive it (and must not fight a target of System).
+        ((void (*)(id, SEL, id))objc_msgSend)(view, @selector(setFont:), themed);
+    }
+    sFontBypass--;
+}
+
+static BOOL ViewIsFontRefreshable(UIView *view) {
+    return [view isKindOfClass:[UILabel class]] ||
+           [view isKindOfClass:[UITextField class]] ||
+           [view isKindOfClass:[UITextView class]];
+}
+
+// `vetted` propagates a one-time ownership decision down a subtree (a vetted
+// bar's labels never chain back to Apollo classes individually). Outside a
+// vetted subtree, each text control is gated exactly like the sink hooks.
+static void RefreshFontsInViewTree(UIView *view, ApolloThemeFont target, BOOL vetted) {
+    if (!vetted && ([view isKindOfClass:[UINavigationBar class]] || [view isKindOfClass:[UITabBar class]])) {
+        if (!ChromeBarLooksApolloOwned(view)) return; // foreign chrome: leave the whole subtree alone
+        vetted = YES;
+    }
+    if (ViewIsFontRefreshable(view) && (vetted || ObjectChainLooksApolloOwned(view))) {
+        RefreshFontOnTextControl(view, target);
+    }
+    for (UIView *subview in view.subviews) {
+        RefreshFontsInViewTree(subview, target, vetted);
+    }
+}
+
+void ApolloThemeRuntimeRefreshFonts(void) {
+    // Runs even when the runtime is INACTIVE: disabling theming (or switching
+    // to the System font) must walk existing labels back to SF Pro — nothing
+    // else re-derives a font until the view happens to be recreated.
+    ApolloThemeFont target = sEnabled ? sFontChoice : ApolloThemeFontSystem;
+    for (UIWindow *window in ApolloAllWindows()) {
+        RefreshFontsInViewTree(window, target, NO);
+    }
+}
+
+// Attach-time repair: UIKit configures table/collection cell labels while the
+// cell is DETACHED (cellForRow… runs before the cell joins the table), so the
+// set-time sink gate has no superview/responder chain to vet and those fonts
+// stay SF Pro — the manager's own rows rendered unthemed while its (attached)
+// headers/footers themed fine. The moment a text control joins a window the
+// chain exists, so re-derive from didMoveToWindow. Ordering matters for the
+// hot path (every cell recycle): bail on font identity (Apply is cached)
+// BEFORE paying for the ownership walk.
+static void RethemeFontOnAttach(UIView *view) {
+    if (!sEnabled || sFontBypass) return;
+    if (!view.window) return;
+    if (FontPinned(view)) return;
+    UIFont *font = ((UILabel *)view).font; // UILabel/UITextField/UITextView all expose `font`
+    if (![font isKindOfClass:[UIFont class]] || !FontLooksLikeAppleSystemDesign(font)) return;
+    sFontBypass++;
+    UIFont *themed = ApolloThemeFontApply(sFontChoice, font);
+    if (themed && ![themed.fontName isEqualToString:font.fontName] && ObjectChainLooksApolloOwned(view)) {
+        ((void (*)(id, SEL, id))objc_msgSend)(view, @selector(setFont:), themed);
+    }
+    sFontBypass--;
+}
+
 static void ApplyThemeFontToNavigationTitleControl(UIView *titleControl) {
     if (!sEnabled || ![titleControl isKindOfClass:[UIView class]]) return;
-    UINavigationBar *bar = NavigationBarForDescendant(titleControl);
-    if (!NavigationBarLooksApolloOwned(bar)) return;
-
-    NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:titleControl];
-    while (queue.count > 0) {
-        UIView *view = queue.firstObject;
-        [queue removeObjectAtIndex:0];
-        if ([view isKindOfClass:[UILabel class]]) {
-            UILabel *label = (UILabel *)view;
-            UIFont *font = label.font;
-            if ([font isKindOfClass:[UIFont class]] && FontLooksLikeAppleSystemDesign(font)) {
-                sFontBypass++;
-                UIFont *themed = ApolloThemeFontApply(sFontChoice, font);
-                sFontBypass--;
-                if (themed && ![themed.fontName isEqualToString:font.fontName]) label.font = themed;
-            }
-        }
-        for (UIView *child in view.subviews) [queue addObject:child];
-    }
+    if (!ChromeBarLooksApolloOwned(NavigationBarForDescendant(titleControl))) return;
+    RefreshFontsInViewTree(titleControl, sFontChoice, YES);
 }
 
 static BOOL TextSinkMayUseTheme(id object, uintptr_t caller) {
@@ -745,6 +829,9 @@ void ApolloThemeRuntimeInvalidate(void) {
     dispatch_async(dispatch_get_main_queue(), ^{
         if (sPostNativeNotifications) PostThemeNotifications();
         if (sLegacyRepaint) LegacyFlipRepaint();
+        // Colours re-resolve via the trait cascade, but fonts on existing
+        // views only change if something re-derives them — walk the windows.
+        ApolloThemeRuntimeRefreshFonts();
         ApolloLog(@"ThemeRuntime: invalidate applied");
     });
 }
@@ -942,6 +1029,11 @@ void ApolloThemeRuntimeInvalidate(void) {
     %orig(ThemedAttributedText(attributedText, (id)self, caller));
 }
 
+- (void)didMoveToWindow {
+    %orig;
+    RethemeFontOnAttach((UIView *)self);
+}
+
 %end
 
 %hook UIButton
@@ -988,6 +1080,11 @@ void ApolloThemeRuntimeInvalidate(void) {
     %orig(ThemedAttributedText(attributedText, (id)self, caller));
 }
 
+- (void)didMoveToWindow {
+    %orig;
+    RethemeFontOnAttach((UIView *)self);
+}
+
 %end
 
 %hook UITextView
@@ -1000,6 +1097,11 @@ void ApolloThemeRuntimeInvalidate(void) {
 - (void)setAttributedText:(NSAttributedString *)attributedText {
     uintptr_t caller = (uintptr_t)__builtin_return_address(0);
     %orig(ThemedAttributedText(attributedText, (id)self, caller));
+}
+
+- (void)didMoveToWindow {
+    %orig;
+    RethemeFontOnAttach((UIView *)self);
 }
 
 %end

--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -27,11 +27,18 @@
 - (void)setTitle:(NSString *)title withFont:(UIFont *)font withColor:(UIColor *)color withShadowColor:(UIColor *)shadowColor withShadowOffset:(CGSize)shadowOffset forState:(NSUInteger)state;
 @end
 
+@interface _UINavigationBarTitleControl : UIControl
+@end
+
 // ===========================================================================
 // Runtime state
 // ===========================================================================
 
 static volatile bool sEnabled = false;
+// Active theme's app-wide font. Read from any thread (Texture builds
+// attributed strings off-main); a single enum-width store is atomic on arm64,
+// matching the sEnabled convention.
+static volatile ApolloThemeFont sFontChoice = ApolloThemeFontSystem;
 static uint32_t sTokens[ApolloThemeModeCount][ApolloThemeTokenCount];
 static uint64_t sEpoch = 0; // bumped whenever sTokens or sEnabled changes
 static os_unfair_lock sLock = OS_UNFAIR_LOCK_INIT;
@@ -114,6 +121,65 @@ static bool sPostNativeNotifications = true;
 // Re-entrancy guard: while a dynamic-colour provider is building a concrete
 // colour for a token, the UIColor constructor hook must not re-map it.
 static __thread int sBypassHook = 0;
+
+// ---------------------------------------------------------------------------
+// Theme font (per-theme app-wide font, spec: 4 system designs only)
+// ---------------------------------------------------------------------------
+
+// Guard against UIKit re-entering a hooked UIFont factory while we re-derive
+// a font through fontWithDescriptor:size:.
+static __thread int sFontBypass = 0;
+
+static BOOL ClassNameLooksApolloOwned(const char *name);
+static BOOL TextSinkMayUseTheme(id object, uintptr_t caller);
+
+// Re-derive a system font in the active theme's design. Caller-gated like the
+// colour hooks: only Apollo's own code (and the tweak) get themed fonts, so
+// UIKit-built chrome (system alerts, share sheet, keyboard) keeps SF Pro —
+// which also keeps the wide SF Mono design out of fixed-width system chrome.
+static UIFont *ThemedFont(UIFont *font, uintptr_t caller) {
+    if (!sEnabled || sFontChoice == ApolloThemeFontSystem || !font) return font;
+    if (sFontBypass) return font;
+    if (!CallerMayUseThemeRuntime(caller)) return font;
+    sFontBypass++;
+    UIFont *themed = ApolloThemeFontApply(sFontChoice, font);
+    sFontBypass--;
+    return themed;
+}
+
+static BOOL FontLooksLikeAppleSystemDesign(UIFont *font) {
+    if (![font isKindOfClass:[UIFont class]]) return NO;
+    NSString *fontName = font.fontName ?: @"";
+    NSString *familyName = font.familyName ?: @"";
+
+    // System-design fonts use private/postscript names rather than normal
+    // bundled font names. Keep the predicate conservative so explicit app
+    // fonts such as markdown code faces survive sink-level rewriting.
+    if ([fontName hasPrefix:@".SF"] ||
+        [fontName hasPrefix:@".NewYork"] ||
+        [fontName hasPrefix:@".AppleSystem"]) {
+        return YES;
+    }
+    if ([familyName hasPrefix:@"SF "] ||
+        [familyName hasPrefix:@"SF-"] ||
+        [familyName isEqualToString:@"New York"] ||
+        [familyName hasPrefix:@"New York"] ||
+        [familyName isEqualToString:@".AppleSystemUIFont"]) {
+        return YES;
+    }
+    return NO;
+}
+
+static UIFont *ThemedTextSinkFont(UIFont *font, id owner, uintptr_t caller) {
+    if (!sEnabled || !font || sFontBypass) return font;
+    if (!TextSinkMayUseTheme(owner, caller)) return font;
+    if (!FontLooksLikeAppleSystemDesign(font)) return font;
+
+    sFontBypass++;
+    UIFont *themed = ApolloThemeFontApply(sFontChoice, font);
+    sFontBypass--;
+    return themed;
+}
 
 // ---------------------------------------------------------------------------
 // Donor + exact Apollo palette lookup tables (spec §8.1, §11.2)
@@ -288,10 +354,55 @@ static BOOL ObjectChainLooksApolloOwned(id object) {
                 next = nil;
             }
         }
+        if (!next && [current respondsToSelector:@selector(nextResponder)]) {
+            @try {
+                next = ((id (*)(id, SEL))objc_msgSend)(current, @selector(nextResponder));
+            } @catch (__unused NSException *e) {
+                next = nil;
+            }
+        }
         if (next == current) break;
         current = next;
     }
     return NO;
+}
+
+static UINavigationBar *NavigationBarForDescendant(UIView *view) {
+    for (UIView *v = view; v != nil; v = v.superview) {
+        if ([v isKindOfClass:[UINavigationBar class]]) return (UINavigationBar *)v;
+    }
+    return nil;
+}
+
+static BOOL NavigationBarLooksApolloOwned(UINavigationBar *bar) {
+    if (![bar isKindOfClass:[UINavigationBar class]]) return NO;
+    if (ObjectChainLooksApolloOwned(bar)) return YES;
+    id delegate = bar.delegate;
+    if (delegate && ClassNameLooksApolloOwned(class_getName(object_getClass(delegate)))) return YES;
+    return NO;
+}
+
+static void ApplyThemeFontToNavigationTitleControl(UIView *titleControl) {
+    if (!sEnabled || ![titleControl isKindOfClass:[UIView class]]) return;
+    UINavigationBar *bar = NavigationBarForDescendant(titleControl);
+    if (!NavigationBarLooksApolloOwned(bar)) return;
+
+    NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:titleControl];
+    while (queue.count > 0) {
+        UIView *view = queue.firstObject;
+        [queue removeObjectAtIndex:0];
+        if ([view isKindOfClass:[UILabel class]]) {
+            UILabel *label = (UILabel *)view;
+            UIFont *font = label.font;
+            if ([font isKindOfClass:[UIFont class]] && FontLooksLikeAppleSystemDesign(font)) {
+                sFontBypass++;
+                UIFont *themed = ApolloThemeFontApply(sFontChoice, font);
+                sFontBypass--;
+                if (themed && ![themed.fontName isEqualToString:font.fontName]) label.font = themed;
+            }
+        }
+        for (UIView *child in view.subviews) [queue addObject:child];
+    }
 }
 
 static BOOL TextSinkMayUseTheme(id object, uintptr_t caller) {
@@ -334,6 +445,14 @@ UIColor *ApolloThemeRuntimeColor(ApolloThemeToken token) {
     return ApolloThemeMakeDynamicColor(token);
 }
 
+UIFont *ApolloThemeRuntimeFont(UIFont *base) {
+    if (!sEnabled || sFontChoice == ApolloThemeFontSystem || !base) return base;
+    sFontBypass++;
+    UIFont *themed = ApolloThemeFontApply(sFontChoice, base);
+    sFontBypass--;
+    return themed ?: base;
+}
+
 uint64_t ApolloThemeRuntimeEpoch(void) {
     os_unfair_lock_lock(&sLock);
     uint64_t e = sEpoch;
@@ -364,6 +483,16 @@ static NSAttributedString *ThemedAttributedText(NSAttributedString *text, id own
 
     __block NSMutableAttributedString *rewritten = nil;
     NSRange full = NSMakeRange(0, text.length);
+    [text enumerateAttribute:NSFontAttributeName
+                     inRange:full
+                     options:0
+                  usingBlock:^(id value, NSRange range, BOOL *stop) {
+        if (![value isKindOfClass:[UIFont class]]) return;
+        UIFont *replacement = ThemedTextSinkFont(value, owner, caller);
+        if (replacement == value) return;
+        if (!rewritten) rewritten = [text mutableCopy];
+        [rewritten addAttribute:NSFontAttributeName value:replacement range:range];
+    }];
     [text enumerateAttribute:NSForegroundColorAttributeName
                      inRange:full
                      options:0
@@ -375,6 +504,29 @@ static NSAttributedString *ThemedAttributedText(NSAttributedString *text, id own
         [rewritten addAttribute:NSForegroundColorAttributeName value:replacement range:range];
     }];
     return rewritten ?: text;
+}
+
+static NSAttributedString *ThemedPlaceholderText(UITextField *field, NSAttributedString *placeholder, uintptr_t caller) {
+    if (![field isKindOfClass:[UITextField class]]) return placeholder;
+    if (!TextSinkMayUseTheme(field, caller)) return placeholder;
+
+    NSMutableAttributedString *working = nil;
+    if ([placeholder isKindOfClass:[NSAttributedString class]] && placeholder.length > 0) {
+        working = [placeholder mutableCopy];
+    } else if (field.placeholder.length > 0) {
+        working = [[NSMutableAttributedString alloc] initWithString:field.placeholder];
+    }
+    if (!working.length) return placeholder;
+
+    NSRange full = NSMakeRange(0, working.length);
+    __block BOOL hasFont = NO;
+    [working enumerateAttribute:NSFontAttributeName inRange:full options:0 usingBlock:^(id value, NSRange range, BOOL *stop) {
+        if ([value isKindOfClass:[UIFont class]]) { hasFont = YES; *stop = YES; }
+    }];
+    if (!hasFont && [field.font isKindOfClass:[UIFont class]]) {
+        [working addAttribute:NSFontAttributeName value:field.font range:full];
+    }
+    return ThemedAttributedText(working, field, caller);
 }
 
 // Resolve a token's static RGB components (0..1) for a mode. The value-
@@ -417,6 +569,7 @@ void ApolloThemeRuntimeReload(void) {
     if (!theme) {
         os_unfair_lock_lock(&sLock);
         sEnabled = false;
+        sFontChoice = ApolloThemeFontSystem;
         sEpoch++;
         os_unfair_lock_unlock(&sLock);
         ApolloLog(@"ThemeRuntime: reload -> INACTIVE (enabledFlag=%d crashKill=%d activeTheme=%@)",
@@ -442,16 +595,30 @@ void ApolloThemeRuntimeReload(void) {
             sTokens[m][t] = [compiled rgbForToken:(ApolloThemeToken)t mode:(ApolloThemeMode)m];
         }
     }
+    sFontChoice = ApolloThemeFontFromKey(theme[kApolloThemeFontKey]);
     sEnabled = true;
     sEpoch++;
     os_unfair_lock_unlock(&sLock);
 
-    ApolloLog(@"ThemeRuntime: reload -> ACTIVE theme='%@' variant=%@ | light bg=#%06X card=#%06X accent=#%06X label=#%06X | dark bg=#%06X card=#%06X accent=#%06X",
-              theme[@"name"], theme[@"variant"],
+    ApolloLog(@"ThemeRuntime: reload -> ACTIVE theme='%@' variant=%@ font=%@ | light bg=#%06X card=#%06X accent=#%06X label=#%06X | dark bg=#%06X card=#%06X accent=#%06X",
+              theme[@"name"], theme[@"variant"], ApolloThemeFontKey(sFontChoice),
               sTokens[0][ApolloThemeTokenBackground], sTokens[0][ApolloThemeTokenSecondaryBackground],
               sTokens[0][ApolloThemeTokenAccent], sTokens[0][ApolloThemeTokenLabel],
               sTokens[1][ApolloThemeTokenBackground], sTokens[1][ApolloThemeTokenSecondaryBackground],
               sTokens[1][ApolloThemeTokenAccent]);
+
+    sFontBypass++;
+    UIFont *base = [UIFont systemFontOfSize:17.0 weight:UIFontWeightRegular];
+    sFontBypass--;
+    UIFont *resolved = ApolloThemeFontApply(sFontChoice, base);
+    ApolloLog(@"ThemeRuntime: font sample key=%@ base='%@' family='%@' -> resolved='%@' family='%@'",
+              ApolloThemeFontKey(sFontChoice), base.fontName, base.familyName, resolved.fontName, resolved.familyName);
+    UIFont *defaultSample = ApolloThemeFontApply(ApolloThemeFontSystem, base);
+    UIFont *roundedSample = ApolloThemeFontApply(ApolloThemeFontRounded, base);
+    UIFont *serifSample = ApolloThemeFontApply(ApolloThemeFontSerif, base);
+    UIFont *monoSample = ApolloThemeFontApply(ApolloThemeFontMono, base);
+    ApolloLog(@"ThemeRuntime: font designs default='%@' rounded='%@' serif='%@' mono='%@'",
+              defaultSample.fontName, roundedSample.fontName, serifSample.fontName, monoSample.fontName);
 }
 
 // ===========================================================================
@@ -682,6 +849,45 @@ void ApolloThemeRuntimeInvalidate(void) {
 
 %end
 
+// --- theme font (per-theme app-wide font) ---
+// Every hooked entry is a UIFont FACTORY: we let %orig build the exact font
+// Apollo asked for, then re-derive it through the descriptor design axis
+// (ApolloThemeFontApply), preserving size/weight/traits/Dynamic Type. Apollo
+// is Swift, but UIFont.systemFont(ofSize:)/preferredFont(forTextStyle:)
+// compile down to these class methods, so Texture attributed strings are
+// covered. fontWithDescriptor:size: (our own re-derive path) and
+// fontWithName: (Apollo's markdown code blocks) are deliberately NOT hooked.
+// monospacedDigitSystemFontOfSize:weight: is also left alone — those callers
+// want column-aligned counters, which every design already honours there.
+
+%hook UIFont
+
++ (UIFont *)systemFontOfSize:(CGFloat)size {
+    return ThemedFont(%orig, (uintptr_t)__builtin_return_address(0));
+}
+
++ (UIFont *)systemFontOfSize:(CGFloat)size weight:(UIFontWeight)weight {
+    return ThemedFont(%orig, (uintptr_t)__builtin_return_address(0));
+}
+
++ (UIFont *)boldSystemFontOfSize:(CGFloat)size {
+    return ThemedFont(%orig, (uintptr_t)__builtin_return_address(0));
+}
+
++ (UIFont *)italicSystemFontOfSize:(CGFloat)size {
+    return ThemedFont(%orig, (uintptr_t)__builtin_return_address(0));
+}
+
++ (UIFont *)preferredFontForTextStyle:(UIFontTextStyle)style {
+    return ThemedFont(%orig, (uintptr_t)__builtin_return_address(0));
+}
+
++ (UIFont *)preferredFontForTextStyle:(UIFontTextStyle)style compatibleWithTraitCollection:(UITraitCollection *)traitCollection {
+    return ThemedFont(%orig, (uintptr_t)__builtin_return_address(0));
+}
+
+%end
+
 %hook ASTextNode
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
@@ -709,21 +915,86 @@ void ApolloThemeRuntimeInvalidate(void) {
 
 - (void)setTitle:(NSString *)title withFont:(UIFont *)font withColor:(UIColor *)color forState:(NSUInteger)state {
     uintptr_t caller = (uintptr_t)__builtin_return_address(0);
-    %orig(title, font, ThemedTextColorForSourceColor(color, (id)self, caller), state);
+    %orig(title, ThemedTextSinkFont(font, (id)self, caller), ThemedTextColorForSourceColor(color, (id)self, caller), state);
 }
 
 - (void)setTitle:(NSString *)title withFont:(UIFont *)font withColor:(UIColor *)color withShadowColor:(UIColor *)shadowColor withShadowOffset:(CGSize)shadowOffset forState:(NSUInteger)state {
     uintptr_t caller = (uintptr_t)__builtin_return_address(0);
-    %orig(title, font, ThemedTextColorForSourceColor(color, (id)self, caller), shadowColor, shadowOffset, state);
+    %orig(title, ThemedTextSinkFont(font, (id)self, caller), ThemedTextColorForSourceColor(color, (id)self, caller), shadowColor, shadowOffset, state);
 }
 
 %end
 
 %hook UILabel
 
+- (void)setFont:(UIFont *)font {
+    uintptr_t caller = (uintptr_t)__builtin_return_address(0);
+    %orig(ThemedTextSinkFont(font, (id)self, caller));
+}
+
 - (void)setTextColor:(UIColor *)textColor {
     uintptr_t caller = (uintptr_t)__builtin_return_address(0);
     %orig(ThemedTextColorForSourceColor(textColor, (id)self, caller));
+}
+
+- (void)setAttributedText:(NSAttributedString *)attributedText {
+    uintptr_t caller = (uintptr_t)__builtin_return_address(0);
+    %orig(ThemedAttributedText(attributedText, (id)self, caller));
+}
+
+%end
+
+%hook UIButton
+
+- (void)setAttributedTitle:(NSAttributedString *)title forState:(UIControlState)state {
+    uintptr_t caller = (uintptr_t)__builtin_return_address(0);
+    %orig(ThemedAttributedText(title, (id)self, caller), state);
+}
+
+%end
+
+%hook _UINavigationBarTitleControl
+
+- (void)layoutSubviews {
+    %orig;
+    ApplyThemeFontToNavigationTitleControl((UIView *)self);
+}
+
+%end
+
+%hook UITextField
+
+- (void)setFont:(UIFont *)font {
+    uintptr_t caller = (uintptr_t)__builtin_return_address(0);
+    %orig(ThemedTextSinkFont(font, (id)self, caller));
+}
+
+- (void)setPlaceholder:(NSString *)placeholder {
+    %orig;
+    uintptr_t caller = (uintptr_t)__builtin_return_address(0);
+    NSAttributedString *themed = ThemedPlaceholderText((UITextField *)self, self.attributedPlaceholder, caller);
+    if (themed && themed != self.attributedPlaceholder) {
+        self.attributedPlaceholder = themed;
+    }
+}
+
+- (void)setAttributedPlaceholder:(NSAttributedString *)attributedPlaceholder {
+    uintptr_t caller = (uintptr_t)__builtin_return_address(0);
+    %orig(ThemedPlaceholderText((UITextField *)self, attributedPlaceholder, caller));
+}
+
+- (void)setAttributedText:(NSAttributedString *)attributedText {
+    uintptr_t caller = (uintptr_t)__builtin_return_address(0);
+    %orig(ThemedAttributedText(attributedText, (id)self, caller));
+}
+
+%end
+
+%hook UITextView
+
+- (void)setFont:(UIFont *)font {
+    uintptr_t caller = (uintptr_t)__builtin_return_address(0);
+    %orig(ThemedTextSinkFont(font, (id)self, caller));
 }
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {

--- a/src/ApolloThemeStore.h
+++ b/src/ApolloThemeStore.h
@@ -52,6 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
                mode:(ApolloThemeMode)mode
             themeID:(NSString *)themeID;
 - (void)setVariant:(ApolloThemeVariant)variant themeID:(NSString *)themeID;
+- (void)setFont:(ApolloThemeFont)font themeID:(NSString *)themeID;
 // Fill the opposite mode from the given source mode (spec §4.3).
 - (void)generateMode:(ApolloThemeMode)destMode
             fromMode:(ApolloThemeMode)srcMode

--- a/src/ApolloThemeStore.m
+++ b/src/ApolloThemeStore.m
@@ -284,11 +284,13 @@ static BOOL InputHasAnyAdvancedOverrides(NSDictionary *input) {
     NSDictionary *src = [self themeWithID:themeID];
     if (!src) return nil;
     BOOL advanced = [src[kApolloThemeAdvancedOptionsEnabledKey] boolValue];
-    return [self createThemeNamed:[src[@"name"] stringByAppendingString:@" Copy"]
-                            input:src[@"input"]
-                          variant:ApolloThemeVariantFromKey(src[@"variant"])
-            advancedOptionsEnabled:advanced
-                       generation:src[@"generation"]];
+    NSString *newID = [self createThemeNamed:[src[@"name"] stringByAppendingString:@" Copy"]
+                                       input:src[@"input"]
+                                     variant:ApolloThemeVariantFromKey(src[@"variant"])
+                       advancedOptionsEnabled:advanced
+                                  generation:src[@"generation"]];
+    [self setFont:ApolloThemeFontFromKey(src[kApolloThemeFontKey]) themeID:newID];
+    return newID;
 }
 
 - (void)renameTheme:(NSString *)themeID to:(NSString *)name {
@@ -335,6 +337,17 @@ static BOOL InputHasAnyAdvancedOverrides(NSDictionary *input) {
 - (void)setVariant:(ApolloThemeVariant)variant themeID:(NSString *)themeID {
     [self updateTheme:themeID mutations:^(NSMutableDictionary *t) {
         t[@"variant"] = ApolloThemeVariantKey(variant);
+    }];
+}
+
+// System is stored as an ABSENT key (matching every pre-font theme), so this
+// no-ops rather than bumping updatedAt when nothing actually changes.
+- (void)setFont:(ApolloThemeFont)font themeID:(NSString *)themeID {
+    if (font == ApolloThemeFontFromKey([self themeWithID:themeID][kApolloThemeFontKey])) return;
+    ApolloLog(@"ThemeStore: setFont %@ theme=%@", ApolloThemeFontKey(font), themeID);
+    [self updateTheme:themeID mutations:^(NSMutableDictionary *t) {
+        if (font == ApolloThemeFontSystem) [t removeObjectForKey:kApolloThemeFontKey];
+        else t[kApolloThemeFontKey] = ApolloThemeFontKey(font);
     }];
 }
 
@@ -480,6 +493,8 @@ static BOOL InputHasAnyAdvancedOverrides(NSDictionary *input) {
     NSDictionary *normalizedInput = NormalizeInput(theme[@"input"]);
     portable[@"input"] = advancedEnabled ? normalizedInput : StripAdvancedOverrides(normalizedInput);
     portable[kApolloThemeAdvancedOptionsEnabledKey] = @(advancedEnabled);
+    ApolloThemeFont font = ApolloThemeFontFromKey(theme[kApolloThemeFontKey]);
+    if (font != ApolloThemeFontSystem) portable[kApolloThemeFontKey] = ApolloThemeFontKey(font);
     if ([theme[@"generation"] isKindOfClass:[NSDictionary class]]) portable[@"generation"] = theme[@"generation"];
     return [NSJSONSerialization dataWithJSONObject:portable
                                            options:NSJSONWritingPrettyPrinted | NSJSONWritingSortedKeys
@@ -520,6 +535,11 @@ static BOOL InputHasAnyAdvancedOverrides(NSDictionary *input) {
         ? [obj[kApolloThemeAdvancedOptionsEnabledKey] boolValue]
         : InputHasAnyAdvancedOverrides(input);
     parsed[kApolloThemeAdvancedOptionsEnabledKey] = @(enabled);
+    // Unknown/missing font keys normalise to System (key omitted).
+    if ([obj[kApolloThemeFontKey] isKindOfClass:[NSString class]]) {
+        ApolloThemeFont font = ApolloThemeFontFromKey(obj[kApolloThemeFontKey]);
+        if (font != ApolloThemeFontSystem) parsed[kApolloThemeFontKey] = ApolloThemeFontKey(font);
+    }
     if ([obj[@"generation"] isKindOfClass:[NSDictionary class]]) {
         parsed[@"generation"] = PlistSanitized(obj[@"generation"]); // JSON null -> NSNull would poison defaults
     }
@@ -530,11 +550,13 @@ static BOOL InputHasAnyAdvancedOverrides(NSDictionary *input) {
 - (NSString *)importParsedTheme:(NSDictionary *)parsed {
     // Always mints a fresh id; never overwrites (spec §14.2).
     ApolloLog(@"ThemeStore: importParsedTheme '%@' (schema %@)", parsed[@"name"], parsed[@"schemaVersion"]);
-    return [self createThemeNamed:parsed[@"name"]
-                            input:parsed[@"input"]
-                          variant:ApolloThemeVariantFromKey(parsed[@"variant"])
-             advancedOptionsEnabled:[parsed[kApolloThemeAdvancedOptionsEnabledKey] boolValue]
-                       generation:parsed[@"generation"]];
+    NSString *newID = [self createThemeNamed:parsed[@"name"]
+                                       input:parsed[@"input"]
+                                     variant:ApolloThemeVariantFromKey(parsed[@"variant"])
+                      advancedOptionsEnabled:[parsed[kApolloThemeAdvancedOptionsEnabledKey] boolValue]
+                                  generation:parsed[@"generation"]];
+    [self setFont:ApolloThemeFontFromKey(parsed[kApolloThemeFontKey]) themeID:newID];
+    return newID;
 }
 
 - (NSString *)exportFilenameForName:(NSString *)name {

--- a/src/ApolloThemeTokens.h
+++ b/src/ApolloThemeTokens.h
@@ -73,6 +73,38 @@ typedef NS_ENUM(NSUInteger, ApolloThemeVariant) {
 NSString *ApolloThemeVariantKey(ApolloThemeVariant variant);
 ApolloThemeVariant ApolloThemeVariantFromKey(NSString *key); // defaults to Balanced
 
+#pragma mark - Font
+
+// Per-theme app-wide font. All four are the SYSTEM font family reached through
+// UIFontDescriptor's design axis (never fontWithName:), so Dynamic Type,
+// weights, and italics carry over untouched — the runtime only re-derives the
+// font Apollo already asked for.
+typedef NS_ENUM(NSUInteger, ApolloThemeFont) {
+    ApolloThemeFontSystem = 0, // SF Pro (no hook work at all)
+    ApolloThemeFontRounded,    // SF Pro Rounded
+    ApolloThemeFontSerif,      // New York
+    ApolloThemeFontMono,       // SF Mono
+    ApolloThemeFontCount
+};
+
+// "system" / "rounded" / "serif" / "mono" <-> enum, for persistence/UI.
+// Unknown keys default to System, so themes without the key are untouched.
+NSString *ApolloThemeFontKey(ApolloThemeFont font);
+ApolloThemeFont ApolloThemeFontFromKey(NSString *key);
+// Human-readable name ("SF Pro", "New York", …) and a short descriptor
+// ("Default", "Serif", …) for the editor rows.
+NSString *ApolloThemeFontDisplayName(ApolloThemeFont font);
+NSString *ApolloThemeFontDetailName(ApolloThemeFont font);
+
+#if __has_include(<UIKit/UIKit.h>)
+// Re-derive `base` in the theme font's design, preserving size, weight,
+// traits, and Dynamic Type. System applies the Default design (normalising a
+// base that already carries another design); returns `base` unchanged only
+// for a nil base or when the design descriptor can't be built. Shared by the
+// Runtime's UIFont hooks and the editor's font/preview rows.
+UIFont *ApolloThemeFontApply(ApolloThemeFont font, UIFont *base);
+#endif
+
 #pragma mark - Appearance mode index
 
 // Compiled tables are indexed [mode][token] with mode 0 = light, 1 = dark.
@@ -117,6 +149,8 @@ extern NSString * const kApolloRebornThemeRuntimeDisabledKey;   // BOOL (crash k
 // v1 data archived here for one release during migration.
 extern NSString * const kApolloRebornThemeV1BackupKey;
 extern NSString * const kApolloThemeAdvancedOptionsEnabledKey;  // BOOL
+// Theme-dict key holding an ApolloThemeFontKey() string; absent = system font.
+extern NSString * const kApolloThemeFontKey;                    // NSString
 
 // Current schema version.
 extern const NSInteger kApolloThemeSchemaVersion; // = 2

--- a/src/ApolloThemeTokens.h
+++ b/src/ApolloThemeTokens.h
@@ -97,11 +97,12 @@ NSString *ApolloThemeFontDisplayName(ApolloThemeFont font);
 NSString *ApolloThemeFontDetailName(ApolloThemeFont font);
 
 #if __has_include(<UIKit/UIKit.h>)
-// Re-derive `base` in the theme font's design, preserving size, weight,
-// traits, and Dynamic Type. System applies the Default design (normalising a
-// base that already carries another design); returns `base` unchanged only
-// for a nil base or when the design descriptor can't be built. Shared by the
-// Runtime's UIFont hooks and the editor's font/preview rows.
+// Re-derive `base` in the theme font's design, preserving size, weight, and
+// italic. Rebuilds from a pristine system descriptor, so it works from ANY
+// base — including one already carrying a different design (System normalises
+// such a base back to SF Pro). Returns `base` only when nil or when the font
+// can't be built. Shared by the Runtime's UIFont hooks and the editor's
+// font/preview rows.
 UIFont *ApolloThemeFontApply(ApolloThemeFont font, UIFont *base);
 #endif
 

--- a/src/ApolloThemeTokens.m
+++ b/src/ApolloThemeTokens.m
@@ -121,12 +121,31 @@ NSString *ApolloThemeFontDetailName(ApolloThemeFont font) {
 }
 
 #if __has_include(<UIKit/UIKit.h>)
+#import <CoreText/CoreText.h>
+
+// Derived fonts recur heavily (a handful of sizes/weights across thousands of
+// label sets), and the sink hooks run on scroll-hot paths — cache by
+// (target design, size, source postscript name). The postscript name encodes
+// design, weight, and italic, so it is a complete key. NSCache is thread-safe
+// (Texture builds attributed strings off-main).
+static NSCache<NSString *, UIFont *> *FontApplyCache(void) {
+    static NSCache<NSString *, UIFont *> *cache;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        cache = [[NSCache alloc] init];
+        cache.countLimit = 256;
+    });
+    return cache;
+}
+
 UIFont *ApolloThemeFontApply(ApolloThemeFont font, UIFont *base) {
     if (!base) return base;
-    // System applies the Default design rather than returning base as-is: the
-    // editor renders its font rows from fonts that may ALREADY carry the live
-    // theme's design (the tweak's own UIFont calls pass the runtime hook), so
-    // the SF Pro row must normalise back explicitly.
+
+    NSString *cacheKey = [NSString stringWithFormat:@"%lu|%.3f|%@",
+                          (unsigned long)font, base.pointSize, base.fontName];
+    UIFont *cached = [FontApplyCache() objectForKey:cacheKey];
+    if (cached) return cached;
+
     UIFontDescriptorSystemDesign design;
     switch (font) {
         case ApolloThemeFontRounded: design = UIFontDescriptorSystemDesignRounded;    break;
@@ -135,12 +154,44 @@ UIFont *ApolloThemeFontApply(ApolloThemeFont font, UIFont *base) {
         case ApolloThemeFontSystem:
         default:                     design = UIFontDescriptorSystemDesignDefault;    break;
     }
-    UIFontDescriptor *descriptor = [base.fontDescriptor fontDescriptorWithDesign:design];
-    if (!descriptor) return base;
-    // Size 0 keeps the descriptor's point size (i.e. base's, including any
-    // Dynamic Type scaling already applied to it).
-    UIFont *derived = [UIFont fontWithDescriptor:descriptor size:0];
-    return derived ?: base;
+
+    // Weight and italic come from CoreText (UIFont is toll-free bridged to
+    // CTFont); a UIFont's own descriptor doesn't reliably expose either as
+    // attributes. CoreText's normalised weight scale matches UIFontWeight.
+    CGFloat weight = UIFontWeightRegular;
+    BOOL italic = NO;
+    NSDictionary *ctTraits = CFBridgingRelease(CTFontCopyTraits((__bridge CTFontRef)base));
+    NSNumber *weightValue = ctTraits[(__bridge NSString *)kCTFontWeightTrait];
+    if ([weightValue isKindOfClass:[NSNumber class]]) weight = weightValue.doubleValue;
+    NSNumber *symbolic = ctTraits[(__bridge NSString *)kCTFontSymbolicTrait];
+    if ([symbolic isKindOfClass:[NSNumber class]]) italic = (symbolic.unsignedIntValue & kCTFontTraitItalic) != 0;
+
+    // Rebuild from a PRISTINE system descriptor instead of deriving from
+    // base.fontDescriptor: once a font carries a concrete non-default design
+    // (.NewYork, rounded, …), fontDescriptorWithDesign: cannot move it to a
+    // different design — the concrete family wins. Deriving from base broke
+    // both the SF Pro normalisation and serif→rounded switches (every editor
+    // tile rendered in the live theme's design). The text-style descriptor is
+    // the one public route to a system-family descriptor that does not pass
+    // through the (runtime-hooked) UIFont factories.
+    UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleBody];
+    if (font != ApolloThemeFontSystem) {
+        descriptor = [descriptor fontDescriptorWithDesign:design] ?: descriptor;
+    }
+    descriptor = [descriptor fontDescriptorByAddingAttributes:@{
+        UIFontDescriptorTraitsAttribute: @{ UIFontWeightTrait: @(weight) },
+    }];
+    if (italic) {
+        UIFontDescriptor *italicDescriptor =
+            [descriptor fontDescriptorWithSymbolicTraits:descriptor.symbolicTraits | UIFontDescriptorTraitItalic];
+        if (italicDescriptor) descriptor = italicDescriptor;
+    }
+    // Explicit size wins over the descriptor's text-style size, preserving any
+    // Dynamic Type scaling already applied to base.
+    UIFont *derived = [UIFont fontWithDescriptor:descriptor size:base.pointSize];
+    if (!derived) return base;
+    [FontApplyCache() setObject:derived forKey:cacheKey];
+    return derived;
 }
 #endif // __has_include(<UIKit/UIKit.h>)
 

--- a/src/ApolloThemeTokens.m
+++ b/src/ApolloThemeTokens.m
@@ -21,6 +21,7 @@ NSString * const kApolloRebornThemeSchemaVersionKey   = @"ApolloReborn.themeSche
 NSString * const kApolloRebornThemeRuntimeDisabledKey = @"ApolloReborn.themeRuntimeDisabled";
 NSString * const kApolloRebornThemeV1BackupKey        = @"ApolloReborn.themeV1Backup";
 NSString * const kApolloThemeAdvancedOptionsEnabledKey = @"advancedEnabled";
+NSString * const kApolloThemeFontKey                    = @"font";
 
 const NSInteger kApolloThemeSchemaVersion = 2;
 
@@ -79,6 +80,69 @@ ApolloThemeVariant ApolloThemeVariantFromKey(NSString *key) {
     if ([key isEqualToString:@"bold"])   return ApolloThemeVariantBold;
     return ApolloThemeVariantBalanced;
 }
+
+#pragma mark - Font
+
+NSString *ApolloThemeFontKey(ApolloThemeFont font) {
+    switch (font) {
+        case ApolloThemeFontRounded: return @"rounded";
+        case ApolloThemeFontSerif:   return @"serif";
+        case ApolloThemeFontMono:    return @"mono";
+        case ApolloThemeFontSystem:
+        default:                     return @"system";
+    }
+}
+
+ApolloThemeFont ApolloThemeFontFromKey(NSString *key) {
+    if ([key isEqualToString:@"rounded"]) return ApolloThemeFontRounded;
+    if ([key isEqualToString:@"serif"])   return ApolloThemeFontSerif;
+    if ([key isEqualToString:@"mono"])    return ApolloThemeFontMono;
+    return ApolloThemeFontSystem;
+}
+
+NSString *ApolloThemeFontDisplayName(ApolloThemeFont font) {
+    switch (font) {
+        case ApolloThemeFontRounded: return @"SF Pro Rounded";
+        case ApolloThemeFontSerif:   return @"New York";
+        case ApolloThemeFontMono:    return @"SF Mono";
+        case ApolloThemeFontSystem:
+        default:                     return @"SF Pro";
+    }
+}
+
+NSString *ApolloThemeFontDetailName(ApolloThemeFont font) {
+    switch (font) {
+        case ApolloThemeFontRounded: return @"Rounded";
+        case ApolloThemeFontSerif:   return @"Serif";
+        case ApolloThemeFontMono:    return @"Monospaced";
+        case ApolloThemeFontSystem:
+        default:                     return @"Default";
+    }
+}
+
+#if __has_include(<UIKit/UIKit.h>)
+UIFont *ApolloThemeFontApply(ApolloThemeFont font, UIFont *base) {
+    if (!base) return base;
+    // System applies the Default design rather than returning base as-is: the
+    // editor renders its font rows from fonts that may ALREADY carry the live
+    // theme's design (the tweak's own UIFont calls pass the runtime hook), so
+    // the SF Pro row must normalise back explicitly.
+    UIFontDescriptorSystemDesign design;
+    switch (font) {
+        case ApolloThemeFontRounded: design = UIFontDescriptorSystemDesignRounded;    break;
+        case ApolloThemeFontSerif:   design = UIFontDescriptorSystemDesignSerif;      break;
+        case ApolloThemeFontMono:    design = UIFontDescriptorSystemDesignMonospaced; break;
+        case ApolloThemeFontSystem:
+        default:                     design = UIFontDescriptorSystemDesignDefault;    break;
+    }
+    UIFontDescriptor *descriptor = [base.fontDescriptor fontDescriptorWithDesign:design];
+    if (!descriptor) return base;
+    // Size 0 keeps the descriptor's point size (i.e. base's, including any
+    // Dynamic Type scaling already applied to it).
+    UIFont *derived = [UIFont fontWithDescriptor:descriptor size:0];
+    return derived ?: base;
+}
+#endif // __has_include(<UIKit/UIKit.h>)
 
 #pragma mark - Input keys
 


### PR DESCRIPTION
**Stack 3 of 4 — merge after #574.** Base is `je/theme-ai-v2`; retargets automatically as the stack merges. Then squash-merge this one. Full order: #558 → #574 → this → hub (4/4).

Adds a per-theme app-wide font: SF Pro (default), SF Pro Rounded, New York, or SF Mono.

- All four are the system family reached through `UIFontDescriptor`'s design axis (never `fontWithName:`), so Dynamic Type, weights, and italics carry over untouched — the runtime only re-derives the font Apollo already asked for.
- Editor gains font rows with live preview; menu/action titles restyled to match (`ApolloNativeActionMenus`).

Verified: device build and simulator testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)