### PR TITLE
Theme Manager v2: share & import a theme as an image (QR card)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloThemeGalleryViewController.m \
     $(SRC_DIR)/ApolloThemeManagerIntegration.xm \
     $(SRC_DIR)/ApolloThemeIntegrations.xm \
+    $(SRC_DIR)/ApolloThemeShareImage.m \
+    $(SRC_DIR)/ApolloThemeQRScanViewController.m \
     $(SRC_DIR)/ApolloSearchInPlace.xm \
     $(SRC_DIR)/ApolloSearchHeaderOverlapFix.xm \
     $(SRC_DIR)/ApolloImageChestResolver.m \
@@ -148,7 +150,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/UIWindow+Apollo.m \
     $(SRC_DIR)/fishhook.c \
     $(SSZIPARCHIVE_FILES)
-ApolloReborn_FRAMEWORKS = UIKit Security AVFoundation AVKit OSLog NaturalLanguage ImageIO StoreKit Photos PhotosUI SafariServices SystemConfiguration WebKit AuthenticationServices CoreImage SwiftUI UniformTypeIdentifiers Metal QuartzCore
+ApolloReborn_FRAMEWORKS = UIKit Security AVFoundation AVKit OSLog NaturalLanguage ImageIO StoreKit Photos PhotosUI SafariServices SystemConfiguration WebKit AuthenticationServices CoreImage Vision LinkPresentation SwiftUI UniformTypeIdentifiers Metal QuartzCore
 ApolloReborn_LIBRARIES = z iconv
 # FoundationModels (Apple on-device AI) only ships in the iOS 26+ SDK. Weak-link
 # it so the dylib still loads on older OSes (the Swift bridge guards every call

--- a/src/ApolloThemeIntegrations.xm
+++ b/src/ApolloThemeIntegrations.xm
@@ -24,6 +24,7 @@ typedef struct { CGSize min; CGSize max; } ApolloASSizeRange;
 static char kAppliedSourceImageKey;
 static char kAppliedTemplateImageKey;
 static char kAppliedColorStateKey;
+static char kSelectionViewOwnedKey;
 
 // ApolloThemeRuntimeColor/the Accent/Selection/Card token helpers below always
 // allocate a FRESH dynamic-provider colour on every call (see ApolloThemeRuntime.h
@@ -67,7 +68,7 @@ static NSString *ListCellOwner(UITableViewCell *cell) {
     NSString *owner = NSStringFromClass([delegate class]);
     BOOL inScope = [owner containsString:@"ViewController"]
         && ([owner containsString:@"Settings"] || [owner containsString:@"Search"]
-            || [owner containsString:@"Friends"]);
+            || [owner containsString:@"Friends"] || [owner containsString:@"Inbox"]);
     return inScope ? owner : nil;
 }
 
@@ -78,19 +79,39 @@ static void ColorListCell(UITableViewCell *cell) {
     UIColor *sel = SelectionToken();
     if (!sel) return;
 
-    BOOL highlighted = cell.highlighted;
-    uint64_t state = (ApolloThemeRuntimeEpoch() << 1) | (highlighted ? 1 : 0);
-    if (ApolloThemeStateUnchanged(cell, &kAppliedColorStateKey, state)) return;
-    // Eureka cells highlight via selectedBackgroundView — idiomatic + self-restoring.
-    UIView *bg = [[UIView alloc] init];
-    bg.backgroundColor = sel;
-    cell.selectedBackgroundView = bg;
+    BOOL pressed = cell.highlighted || cell.selected;
+    uint64_t state = (ApolloThemeRuntimeEpoch() << 1) | (pressed ? 1 : 0);
+    BOOL stateChanged = !ApolloThemeStateUnchanged(cell, &kAppliedColorStateKey, state);
+
+    // Eureka cells highlight via selectedBackgroundView — but Eureka's own
+    // defaultCellUpdate closures REINSTALL a donor-coloured view (which the seam
+    // collapses onto a background token) on every row update, so an install-once
+    // replacement loses the race. Recolour whatever view is present IN PLACE —
+    // that wins regardless of install order and even repaints a press already in
+    // flight — and mark it ours so untouched passes stay cheap.
+    UIView *selView = cell.selectedBackgroundView;
+    if (!selView) {
+        selView = [[UIView alloc] init];
+        cell.selectedBackgroundView = selView;
+    }
+    if (stateChanged || !objc_getAssociatedObject(selView, &kSelectionViewOwnedKey)) {
+        selView.backgroundColor = sel;
+        objc_setAssociatedObject(selView, &kSelectionViewOwnedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    if (!stateChanged) return;
     // Apollo's OWN cells ignore selectedBackgroundView and swap backgroundColor,
-    // which the seam collapses onto the card — paint the selection directly while
-    // pressed and restore the card token on release. Skip Appearance (owns its bg).
-    BOOL isApolloCell = [NSStringFromClass([cell class]) containsString:@"Apollo"];
-    if (isApolloCell && ![owner containsString:@"Appearance"]) {
-        UIColor *want = highlighted ? sel : CardToken();
+    // which the seam collapses onto a background token — paint the selection
+    // directly while pressed/selected and restore the card token on release.
+    // (Historical note: Appearance used to be excluded because v1's own
+    // willDisplay hook painted those cells; v2 has no such hook, so the
+    // exclusion just left Appearance with no visible highlight. The injected
+    // Theme Manager row still manages its own chrome — skip only that.)
+    NSString *cellClass = NSStringFromClass([cell class]);
+    BOOL isApolloCell = [cellClass containsString:@"Apollo"]
+        && ![cellClass containsString:@"ThemeManagerRowCell"];
+    if (isApolloCell) {
+        UIColor *want = pressed ? sel : CardToken();
         if (want) {
             cell.backgroundColor = want;
             cell.contentView.backgroundColor = want;
@@ -103,6 +124,28 @@ static void ColorListCell(UITableViewCell *cell) {
 - (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated {
     %orig;
     if (ApolloThemeRuntimeIsActive() && ListCellOwner(self)) [self setNeedsLayout];
+}
+// Apollo's cells paint the same donor "selected" constant from setSelected: too
+// (a tapped row stays selected while the pushed screen is up) — without this the
+// pressed repaint flashes back to the collapsed colour the moment selection
+// replaces highlight.
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    %orig;
+    if (ApolloThemeRuntimeIsActive() && ListCellOwner(self)) [self setNeedsLayout];
+}
+// Eureka re-runs its cellUpdate closure AT HIGHLIGHT TIME (didHighlightRowAt →
+// updateCell), reinstalling its donor-coloured selection view after any earlier
+// repair pass — so recolour foreign views at the setter itself, whenever the
+// install happens. Marked (already-ours) views pass through untouched.
+- (void)setSelectedBackgroundView:(UIView *)view {
+    %orig;
+    if (!view || !ApolloThemeRuntimeIsActive()) return;
+    if (objc_getAssociatedObject(view, &kSelectionViewOwnedKey)) return;
+    if (!ListCellOwner(self)) return;
+    UIColor *sel = SelectionToken();
+    if (!sel) return;
+    view.backgroundColor = sel;
+    objc_setAssociatedObject(view, &kSelectionViewOwnedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 %end
 
@@ -137,13 +180,19 @@ static void ApplyAccentImageView(id cell) {
     icon.tintColor = accent;
 }
 
+// Also the Boxes/Inbox rows (InboxListViewController) — this cell overrides
+// layoutSubviews/setSelected: itself, so route selection colouring through here
+// rather than relying on the base-class hooks firing.
 %hook _TtC6Apollo21IconTextTableViewCell
-- (void)layoutSubviews { %orig; ApplyAccentImageView(self); }
+- (void)layoutSubviews { %orig; ApplyAccentImageView(self); ColorListCell((UITableViewCell *)self); }
 - (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated {
     %orig; ApplyAccentImageView(self);
     if (ApolloThemeRuntimeIsActive()) [(UITableViewCell *)self setNeedsLayout];
 }
-- (void)setSelected:(BOOL)selected animated:(BOOL)animated { %orig; ApplyAccentImageView(self); }
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    %orig; ApplyAccentImageView(self);
+    if (ApolloThemeRuntimeIsActive()) [(UITableViewCell *)self setNeedsLayout];
+}
 %end
 
 %hook _TtC6Apollo23IconActionTableViewCell

--- a/src/ApolloThemeManagerViewController.m
+++ b/src/ApolloThemeManagerViewController.m
@@ -8,8 +8,40 @@
 #import "ApolloThemeAIOverlay.h"
 #import "ApolloThemeGalleryCatalog.h"
 #import "ApolloThemeGalleryViewController.h"
+#import "ApolloThemeShareImage.h"
+#import "ApolloThemeQRScanViewController.h"
 #import "ApolloCommon.h"
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+#import <PhotosUI/PhotosUI.h>
+#import <LinkPresentation/LinkPresentation.h>
+
+// ---------------------------------------------------------------------------
+// Share-sheet item for the theme card
+// ---------------------------------------------------------------------------
+
+// A bare UIImage activity item gives the share sheet no preview metadata, so
+// its header shows the generic white app-icon-grid placeholder. Wrap the card
+// so the header shows the card itself + the theme name; the underlying item is
+// still the plain UIImage, so Save Image / Messages / Mail behave unchanged.
+@interface ApolloThemeCardActivityItem : NSObject <UIActivityItemSource>
+@property (nonatomic, strong) UIImage *image;
+@property (nonatomic, copy) NSString *title;
+@end
+
+@implementation ApolloThemeCardActivityItem
+- (id)activityViewControllerPlaceholderItem:(UIActivityViewController *)controller { return self.image; }
+- (id)activityViewController:(UIActivityViewController *)controller itemForActivityType:(UIActivityType)type { return self.image; }
+- (NSString *)activityViewController:(UIActivityViewController *)controller subjectForActivityType:(UIActivityType)type { return self.title ?: @""; }
+- (LPLinkMetadata *)activityViewControllerLinkMetadata:(UIActivityViewController *)controller {
+    LPLinkMetadata *metadata = [[LPLinkMetadata alloc] init];
+    metadata.title = self.title;
+    if (self.image) {
+        metadata.imageProvider = [[NSItemProvider alloc] initWithObject:self.image];
+        metadata.iconProvider = [[NSItemProvider alloc] initWithObject:self.image];
+    }
+    return metadata;
+}
+@end
 
 extern BOOL ApolloThemeOpenNativeThemePickerFromHub(UIViewController *hub);
 extern BOOL ApolloThemeOpenNativeLightDarkFromHub(UIViewController *hub);
@@ -290,7 +322,7 @@ typedef void (^ApolloThemeFontSelectionHandler)(ApolloThemeFont font);
 
 // ---------------------------------------------------------------------------
 
-@interface ApolloThemeManagerViewController () <UIColorPickerViewControllerDelegate, UIDocumentPickerDelegate>
+@interface ApolloThemeManagerViewController () <UIColorPickerViewControllerDelegate, UIDocumentPickerDelegate, PHPickerViewControllerDelegate>
 @property (nonatomic, copy) NSString *editingThemeID;     // nil = list mode
 @property (nonatomic, assign) ApolloThemeMode editingMode; // which appearance the editor shows
 @property (nonatomic, copy) NSString *pickingInputKey;     // input key currently in the colour picker
@@ -303,9 +335,10 @@ typedef void (^ApolloThemeFontSelectionHandler)(ApolloThemeFont font);
 
 // List mode:   hub IA: Current | Create | Browse | My Themes | Imported | Options
 // Editor mode: 0 Name | 1 Variant+Mode | 2 Colours | 3 Advanced | 4 Font
+//              5 Generate | 6 Preview | 7 Share | 8 Apply | 9 Delete
 //              5 Generate | 6 Preview | 7 Apply | 8 Delete
 enum { HSCurrent, HSCreate, HSBrowse, HSMyThemes, HSImported, HSOptions, HSCount };
-enum { ESName, ESVariant, ESColors, ESAdvanced, ESFont, ESGenerate, ESPreview, ESApply, ESDelete, ESCount };
+enum { ESName, ESVariant, ESColors, ESAdvanced, ESFont, ESGenerate, ESPreview, ESShare, ESApply, ESDelete, ESCount };
 
 @implementation ApolloThemeManagerViewController
 
@@ -618,7 +651,7 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESFont, ESGenerate, ESPreview, E
         }
     }
     if ((!self.editingThemeID && (ip.section == HSCreate || (ip.section == HSCurrent && ip.row > 0))) ||
-        (self.editingThemeID && (ip.section == ESGenerate || ip.section == ESApply))) {
+        (self.editingThemeID && (ip.section == ESGenerate || ip.section == ESShare || ip.section == ESApply))) {
         cell.textLabel.textColor = accent;
     }
     if (self.editingThemeID && ip.section == ESDelete) {
@@ -709,6 +742,7 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESFont, ESGenerate, ESPreview, E
             case ESFont:     return 1;
             case ESGenerate: return 1;
             case ESPreview:  return 4;
+            case ESShare:    return 1;
             case ESApply:    return 1;
             case ESDelete:   return 1;
         }
@@ -761,6 +795,8 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESFont, ESGenerate, ESPreview, E
         return @"Turn on advanced options to override text and separator colours.";
     if (self.editingThemeID && section == ESFont)
         return @"Used across the app while this theme is active. Applies immediately; the odd view catches up after scrolling or reopening.";
+    if (self.editingThemeID && section == ESShare)
+        return @"Share as an image (a picture of this theme with a QR code anyone can import) or as a theme file.";
     if (self.editingThemeID && section == ESApply)
         return @"Applying selects this theme and enables custom theming.";
     if (!self.editingThemeID && [self listSectionKind:section] == HSOptions)
@@ -1046,6 +1082,13 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESFont, ESGenerate, ESPreview, E
         }
         case ESPreview:
             return [self previewCellForRow:ip.row];
+        case ESShare: {
+            UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+            cell.textLabel.text = @"Share…";
+            cell.textLabel.textColor = self.view.tintColor;
+            cell.imageView.image = [UIImage systemImageNamed:@"square.and.arrow.up"];
+            return cell;
+        }
         case ESApply: {
             UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
             cell.textLabel.text = @"Apply Theme";
@@ -1255,6 +1298,7 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESFont, ESGenerate, ESPreview, E
             break;
         case ESFont: break;
         case ESGenerate: [self generateOppositeMode]; break;
+        case ESShare: [self shareOptionsFromIndexPath:ip]; break;
         case ESApply: [self applyTheme]; break;
         case ESDelete: [self confirmDeleteFromEditor]; break;
     }
@@ -1575,10 +1619,48 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESFont, ESGenerate, ESPreview, E
 // Import / export
 // ===========================================================================
 
+// "Import Theme…" fans out to the three routes: a .json export file, a shared
+// theme-card image (QR), or a live camera scan of someone else's card.
 - (void)importTapped {
-    UTType *json = UTTypeJSON ?: [UTType typeWithIdentifier:@"public.json"];
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Import Theme"
+                                                                   message:nil
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"From File…" style:UIAlertActionStyleDefault handler:^(UIAlertAction *x) {
+        [self presentImportDocumentPicker];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"From Photo…" style:UIAlertActionStyleDefault handler:^(UIAlertAction *x) {
+        [self presentImageImportPicker];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Scan with Camera…" style:UIAlertActionStyleDefault handler:^(UIAlertAction *x) {
+        [self presentThemeQRScanner];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    UIView *anchor = [self viewForCreateImportRow] ?: self.view;
+    sheet.popoverPresentationController.sourceView = anchor;
+    sheet.popoverPresentationController.sourceRect = anchor.bounds;
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+// The visible "Import Theme…" row cell (Create section), for iPad popover
+// anchoring; nil if it isn't laid out.
+- (UIView *)viewForCreateImportRow {
+    for (UITableViewCell *cell in self.tableView.visibleCells) {
+        NSIndexPath *ip = [self.tableView indexPathForCell:cell];
+        if (ip && [self listSectionKind:ip.section] == HSCreate) return cell;
+    }
+    return nil;
+}
+
+- (void)presentImportDocumentPicker {
+    // Widened beyond JSON: theme-card images import here too, and sideloaded
+    // installs often see .json tagged as public.data / dyn.* types.
+    NSMutableArray<UTType *> *types = [NSMutableArray array];
+    for (UTType *t in @[UTTypeJSON ?: [UTType typeWithIdentifier:@"public.json"],
+                        UTTypeImage, UTTypePlainText, UTTypeData, UTTypeItem]) {
+        if (t) [types addObject:t];
+    }
     UIDocumentPickerViewController *picker =
-        [[UIDocumentPickerViewController alloc] initForOpeningContentTypes:@[json]];
+        [[UIDocumentPickerViewController alloc] initForOpeningContentTypes:types];
     picker.delegate = self;
     picker.allowsMultipleSelection = NO;
     [self presentViewController:picker animated:YES completion:nil];
@@ -1587,21 +1669,92 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESFont, ESGenerate, ESPreview, E
 - (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
     NSURL *url = urls.firstObject;
     if (!url) return;
+    // Defer past the picker's own dismissal animation — a result alert presented
+    // while the picker is still animating out is silently dropped on device.
+    dispatch_async(dispatch_get_main_queue(), ^{ [self importThemeFromPickedURL:url]; });
+}
+
+- (void)importThemeFromPickedURL:(NSURL *)url {
     BOOL scoped = [url startAccessingSecurityScopedResource];
-    // Reject oversized files BEFORE reading into memory (spec §14.2).
+    // Theme-card images are legitimately multi-MB; only the strict JSON cap
+    // applies on the JSON branch below.
+    static const unsigned long long kMaxImportFileBytes = 40ull * 1024 * 1024;
     NSNumber *size = nil;
     [url getResourceValue:&size forKey:NSURLFileSizeKey error:NULL];
-    if (size && size.unsignedLongLongValue > [ApolloThemeStore maxImportBytes]) {
+    if (size && size.unsignedLongLongValue > kMaxImportFileBytes) {
         if (scoped) [url stopAccessingSecurityScopedResource];
         [self showError:@"That file is too large to be a theme."];
         return;
     }
     NSData *data = [NSData dataWithContentsOfURL:url];
     if (scoped) [url stopAccessingSecurityScopedResource];
+    if (!data.length) { [self showError:@"Couldn't read that file."]; return; }
+
+    // Sniff by content, not declared type: anything that decodes as an image
+    // goes down the QR route.
+    UIImage *image = [UIImage imageWithData:data];
+    if (image) { [self importFromCardImage:image]; return; }
+    if (data.length > [ApolloThemeStore maxImportBytes]) {
+        [self showError:@"That file is too large to be a theme."];
+        return;
+    }
     NSString *err = nil;
     NSDictionary *parsed = [[self store] parseImportData:data error:&err];
     if (!parsed) { [self showError:err ?: @"Couldn't read that theme."]; return; }
     [self confirmImport:parsed];
+}
+
+// Decode a picked/photographed theme card off-main (Vision on a full-res photo
+// can take a beat), then confirm on main.
+- (void)importFromCardImage:(UIImage *)image {
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        NSDictionary *parsed = ApolloThemeShareDecodeImage(image);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (!parsed) {
+                [self showError:@"This image doesn't contain an Apollo theme code. Import the original shared theme image (screenshots of it work too, as long as the QR code is visible)."];
+                return;
+            }
+            [self confirmImport:parsed];
+        });
+    });
+}
+
+- (void)presentImageImportPicker {
+    PHPickerConfiguration *config = [[PHPickerConfiguration alloc] init];
+    config.filter = [PHPickerFilter imagesFilter];
+    config.selectionLimit = 1;
+    PHPickerViewController *picker = [[PHPickerViewController alloc] initWithConfiguration:config];
+    picker.delegate = self;
+    [self presentViewController:picker animated:YES completion:nil];
+}
+
+- (void)picker:(PHPickerViewController *)picker didFinishPicking:(NSArray<PHPickerResult *> *)results {
+    PHPickerResult *result = results.firstObject;
+    // Do everything from the dismissal completion — an alert (or a fast decode's
+    // confirm) presented while the sheet is still animating out is dropped.
+    [picker dismissViewControllerAnimated:YES completion:^{
+        if (!result) return; // cancelled
+        NSItemProvider *provider = result.itemProvider;
+        if (![provider canLoadObjectOfClass:[UIImage class]]) {
+            [self showError:@"Couldn't read that image."];
+            return;
+        }
+        [provider loadObjectOfClass:[UIImage class] completionHandler:^(id<NSItemProviderReading> object, NSError *error) {
+            UIImage *image = [object isKindOfClass:[UIImage class]] ? (UIImage *)object : nil;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (!image) { [self showError:@"Couldn't read that image."]; return; }
+                [self importFromCardImage:image];
+            });
+        }];
+    }];
+}
+
+- (void)presentThemeQRScanner {
+    ApolloThemeQRScanViewController *scanner = [[ApolloThemeQRScanViewController alloc] init];
+    scanner.modalPresentationStyle = UIModalPresentationFullScreen;
+    __weak typeof(self) weakSelf = self;
+    scanner.onScan = ^(NSDictionary *parsed) { [weakSelf confirmImport:parsed]; };
+    [self presentViewController:scanner animated:YES completion:nil];
 }
 
 - (void)confirmImport:(NSDictionary *)parsed {
@@ -1613,22 +1766,74 @@ enum { ESName, ESVariant, ESColors, ESAdvanced, ESFont, ESGenerate, ESPreview, E
     [a addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
     [a addAction:[UIAlertAction actionWithTitle:@"Import" style:UIAlertActionStyleDefault handler:^(UIAlertAction *x) {
         NSString *newID = [[self store] importParsedTheme:parsed];
+        // Importing makes the new theme active — if custom theming is live,
+        // reload so the app doesn't keep the previous theme's colours.
+        if ([self store].customThemeEnabled) {
+            ApolloThemeRuntimeReload();
+            ApolloThemeRuntimeInvalidate();
+        }
         [self.tableView reloadData];
         [self openEditorForThemeID:newID];
     }]];
     [self presentViewController:a animated:YES completion:nil];
 }
 
-- (void)exportTheme:(NSDictionary *)theme {
+// ---------------------------------------------------------------------------
+// Share (editor "Share…" row) — image card or .json file
+// ---------------------------------------------------------------------------
+
+- (void)shareOptionsFromIndexPath:(NSIndexPath *)ip {
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Share Theme"
+                                                                   message:nil
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"As Image…" style:UIAlertActionStyleDefault handler:^(UIAlertAction *x) {
+        [self shareThemeAsImageFromIndexPath:ip];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"As Theme File…" style:UIAlertActionStyleDefault handler:^(UIAlertAction *x) {
+        [self shareThemeFile:[[self store] themeWithID:self.editingThemeID]
+                    fromView:[self.tableView cellForRowAtIndexPath:ip]];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    UIView *anchor = [self.tableView cellForRowAtIndexPath:ip] ?: self.view;
+    sheet.popoverPresentationController.sourceView = anchor;
+    sheet.popoverPresentationController.sourceRect = anchor.bounds;
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+- (void)shareThemeAsImageFromIndexPath:(NSIndexPath *)ip {
+    NSDictionary *theme = [[self store] themeWithID:self.editingThemeID];
+    UIImage *card = ApolloThemeShareRenderCard(theme, self.editingMode);
+    if (!card) { [self showError:@"Couldn't render a share image for this theme."]; return; }
+    ApolloThemeCardActivityItem *item = [[ApolloThemeCardActivityItem alloc] init];
+    item.image = card;
+    item.title = ([theme[@"name"] isKindOfClass:[NSString class]] && [theme[@"name"] length])
+        ? [NSString stringWithFormat:@"%@ — Apollo theme", theme[@"name"]] : @"Apollo theme";
+    UIActivityViewController *av = [[UIActivityViewController alloc] initWithActivityItems:@[item] applicationActivities:nil];
+    UIView *anchor = [self.tableView cellForRowAtIndexPath:ip] ?: self.view;
+    av.popoverPresentationController.sourceView = anchor;
+    av.popoverPresentationController.sourceRect = anchor.bounds;
+    [self presentViewController:av animated:YES completion:nil];
+}
+
+// Write the theme's portable .json to temp and share it (Save to Files /
+// Messages / Mail…). Anchored to `anchor`, falling back to view-centre.
+- (void)shareThemeFile:(NSDictionary *)theme fromView:(UIView *)anchor {
     NSData *data = [[self store] exportDataForTheme:theme];
     if (!data) { [self showError:@"Couldn't export that theme."]; return; }
     NSString *name = [[self store] exportFilenameForName:theme[@"name"]];
     NSURL *tmp = [[NSURL fileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:name];
-    [data writeToURL:tmp atomically:YES];
+    if (![data writeToURL:tmp atomically:YES]) { [self showError:@"Couldn't export that theme."]; return; }
     UIActivityViewController *av = [[UIActivityViewController alloc] initWithActivityItems:@[tmp] applicationActivities:nil];
-    av.popoverPresentationController.sourceView = self.view;
-    av.popoverPresentationController.sourceRect = CGRectMake(self.view.bounds.size.width / 2, self.view.bounds.size.height / 2, 1, 1);
+    UIView *src = anchor ?: self.view;
+    av.popoverPresentationController.sourceView = src;
+    av.popoverPresentationController.sourceRect = anchor ? src.bounds
+        : CGRectMake(src.bounds.size.width / 2, src.bounds.size.height / 2, 1, 1);
     [self presentViewController:av animated:YES completion:nil];
+}
+
+// The list's Export swipe action shares the .json file (anchored to view-centre).
+- (void)exportTheme:(NSDictionary *)theme {
+    [self shareThemeFile:theme fromView:nil];
 }
 
 - (void)showError:(NSString *)message {

--- a/src/ApolloThemeQRScanViewController.h
+++ b/src/ApolloThemeQRScanViewController.h
@@ -1,0 +1,17 @@
+#import <UIKit/UIKit.h>
+
+// Full-screen live camera scanner for Apollo theme QR codes (the third import
+// route, next to "From File…" and "From Photo…"). Present modally
+// (UIModalPresentationFullScreen). Handles the camera-permission flow itself
+// (Apollo's Info.plist already declares NSCameraUsageDescription) and shows a
+// graceful alert when no camera is available (e.g. the Simulator).
+@interface ApolloThemeQRScanViewController : UIViewController
+
+// Called on the main thread, after the scanner has dismissed itself, with the
+// already-decoded parsed-import dict (the -[ApolloThemeStore
+// parseImportData:error:] shape — ready for importParsedTheme:). Not called on
+// cancel, permission denial, or missing camera. Non-Apollo QR codes are
+// silently ignored (scanning continues).
+@property (nonatomic, copy) void (^onScan)(NSDictionary *parsed);
+
+@end

--- a/src/ApolloThemeQRScanViewController.m
+++ b/src/ApolloThemeQRScanViewController.m
@@ -1,0 +1,204 @@
+#import "ApolloThemeQRScanViewController.h"
+#import "ApolloThemeShareImage.h"
+#import "ApolloCommon.h"
+#import <AVFoundation/AVFoundation.h>
+
+@interface ApolloThemeQRScanViewController () <AVCaptureMetadataOutputObjectsDelegate>
+@property (nonatomic, strong) AVCaptureSession *session;
+@property (nonatomic, strong) AVCaptureVideoPreviewLayer *previewLayer;
+@property (nonatomic, strong) UIView *viewfinder;
+@property (nonatomic, assign) BOOL handled;   // one-shot guard against repeat detections
+@property (nonatomic, assign) BOOL didConfigure;
+@end
+
+@implementation ApolloThemeQRScanViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.backgroundColor = [UIColor blackColor];
+
+    // Dimmed instruction label near the top.
+    UILabel *hint = [[UILabel alloc] init];
+    hint.translatesAutoresizingMaskIntoConstraints = NO;
+    hint.text = @"Point at an Apollo theme QR code";
+    hint.textColor = [UIColor whiteColor];
+    hint.font = [UIFont systemFontOfSize:17 weight:UIFontWeightSemibold];
+    hint.textAlignment = NSTextAlignmentCenter;
+    hint.numberOfLines = 0;
+    hint.shadowColor = [UIColor colorWithWhite:0 alpha:0.6];
+    hint.shadowOffset = CGSizeMake(0, 1);
+    [self.view addSubview:hint];
+
+    // Centered viewfinder square.
+    UIView *finder = [[UIView alloc] init];
+    finder.translatesAutoresizingMaskIntoConstraints = NO;
+    finder.backgroundColor = [UIColor clearColor];
+    finder.layer.borderColor = [UIColor whiteColor].CGColor;
+    finder.layer.borderWidth = 3.0;
+    finder.layer.cornerRadius = 16.0;
+    [self.view addSubview:finder];
+    self.viewfinder = finder;
+
+    // Cancel button.
+    UIButton *cancel = [UIButton buttonWithType:UIButtonTypeSystem];
+    cancel.translatesAutoresizingMaskIntoConstraints = NO;
+    [cancel setTitle:@"Cancel" forState:UIControlStateNormal];
+    [cancel setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    cancel.titleLabel.font = [UIFont systemFontOfSize:17 weight:UIFontWeightSemibold];
+    cancel.backgroundColor = [UIColor colorWithWhite:0 alpha:0.5];
+    cancel.contentEdgeInsets = UIEdgeInsetsMake(10, 22, 10, 22);
+    cancel.layer.cornerRadius = 22.0;
+    [cancel addTarget:self action:@selector(cancelTapped) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:cancel];
+
+    UILayoutGuide *safe = self.view.safeAreaLayoutGuide;
+    [NSLayoutConstraint activateConstraints:@[
+        [hint.topAnchor constraintEqualToAnchor:safe.topAnchor constant:24],
+        [hint.leadingAnchor constraintEqualToAnchor:safe.leadingAnchor constant:24],
+        [hint.trailingAnchor constraintEqualToAnchor:safe.trailingAnchor constant:-24],
+
+        [finder.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+        [finder.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor],
+        [finder.widthAnchor constraintEqualToConstant:260],
+        [finder.heightAnchor constraintEqualToConstant:260],
+
+        [cancel.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+        [cancel.bottomAnchor constraintEqualToAnchor:safe.bottomAnchor constant:-28],
+    ]];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    // Bring up the camera only once the present transition has completed — a
+    // permission-denied / no-camera (e.g. Simulator) alert presented during the
+    // transition (from viewWillAppear:) can be silently dropped, leaving a blank
+    // scanner; by viewDidAppear: the VC is settled so the alert reliably shows
+    // (and the preview layer is correctly sized before startRunning).
+    if (!self.didConfigure) {
+        self.didConfigure = YES;
+        [self ensureCameraThenStart];
+    }
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
+    [self stopSession];
+}
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    self.previewLayer.frame = self.view.layer.bounds;
+}
+
+#pragma mark - Camera setup
+
+- (void)ensureCameraThenStart {
+    AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+    if (status == AVAuthorizationStatusAuthorized) {
+        [self setupAndStart];
+    } else if (status == AVAuthorizationStatusNotDetermined) {
+        [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL granted) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (granted) {
+                    [self setupAndStart];
+                } else {
+                    [self failWithTitle:@"Camera Access Needed"
+                                message:@"Allow camera access for Apollo in Settings to scan a theme QR code, or use “From Photo…” instead."];
+                }
+            });
+        }];
+    } else { // denied / restricted
+        [self failWithTitle:@"Camera Access Needed"
+                    message:@"Camera access for Apollo is turned off. Enable it in Settings to scan a theme QR code, or use “From Photo…” instead."];
+    }
+}
+
+- (void)setupAndStart {
+    AVCaptureDevice *device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
+    if (!device) { // e.g. the Simulator has no camera
+        [self failWithTitle:@"Camera Unavailable"
+                    message:@"No usable camera was found. Use “From Photo…” to import a saved theme image instead."];
+        return;
+    }
+    NSError *error = nil;
+    AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:device error:&error];
+    AVCaptureSession *session = [[AVCaptureSession alloc] init];
+    AVCaptureMetadataOutput *output = [[AVCaptureMetadataOutput alloc] init];
+    if (!input || ![session canAddInput:input] || ![session canAddOutput:output]) {
+        ApolloLog(@"ThemeScan: camera session setup failed: %@", error);
+        [self failWithTitle:@"Camera Unavailable"
+                    message:@"The camera could not be started. Use “From Photo…” instead."];
+        return;
+    }
+    [session addInput:input];
+    [session addOutput:output];
+    [output setMetadataObjectsDelegate:self queue:dispatch_get_main_queue()];
+    output.metadataObjectTypes = @[AVMetadataObjectTypeQRCode];
+    self.session = session;
+
+    AVCaptureVideoPreviewLayer *preview = [AVCaptureVideoPreviewLayer layerWithSession:session];
+    preview.videoGravity = AVLayerVideoGravityResizeAspectFill;
+    preview.frame = self.view.layer.bounds;
+    [self.view.layer insertSublayer:preview atIndex:0];
+    self.previewLayer = preview;
+
+    // startRunning blocks; keep it off the main thread.
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        [session startRunning];
+    });
+}
+
+- (void)stopSession {
+    AVCaptureSession *session = self.session;
+    if (session.isRunning) {
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+            [session stopRunning];
+        });
+    }
+}
+
+#pragma mark - Detection
+
+- (void)captureOutput:(AVCaptureOutput *)output
+        didOutputMetadataObjects:(NSArray<__kindof AVMetadataObject *> *)metadataObjects
+        fromConnection:(AVCaptureConnection *)connection {
+    if (self.handled) return;
+    for (AVMetadataObject *obj in metadataObjects) {
+        if (![obj isKindOfClass:[AVMetadataMachineReadableCodeObject class]]) continue;
+        AVMetadataMachineReadableCodeObject *code = (AVMetadataMachineReadableCodeObject *)obj;
+        if (![code.type isEqualToString:AVMetadataObjectTypeQRCode]) continue;
+
+        NSDictionary *parsed = ApolloThemeShareDecodePayload(code.stringValue);
+        if (!parsed) {
+            continue; // not an Apollo theme QR — keep scanning silently
+        }
+        self.handled = YES;
+        [[[UINotificationFeedbackGenerator alloc] init] notificationOccurred:UINotificationFeedbackTypeSuccess];
+        [self stopSession];
+        ApolloLog(@"ThemeScan: scanned theme name=%@", parsed[@"name"]);
+        void (^cb)(NSDictionary *) = self.onScan;
+        [self dismissViewControllerAnimated:YES completion:^{
+            if (cb) cb(parsed);
+        }];
+        return;
+    }
+}
+
+#pragma mark - Actions
+
+- (void)cancelTapped {
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)failWithTitle:(NSString *)title message:(NSString *)message {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title
+                                                                   message:message
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault
+                                            handler:^(UIAlertAction *action) {
+        [self dismissViewControllerAnimated:YES completion:nil];
+    }]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+@end

--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -224,6 +224,7 @@ typedef struct { uint32_t rgb; ApolloThemeToken token; uint8_t mode; } RGBTokenE
 //   separator   -> Separator           (B5B9C7 / 06214D)
 //   bar         -> BarBackground        (C5CAD9 / 031229)
 //   gray        -> SecondaryLabel       (ABABAB / 484E5B)
+//   unread      -> Selection            (95C0EE / 034388)
 static const RGBTokenEntry kDonorEntries[] = {
     { 0xC400A6, ApolloThemeTokenAccent,              ApolloThemeModeLight },
     { 0xFF00D8, ApolloThemeTokenAccent,              ApolloThemeModeDark  },
@@ -239,6 +240,15 @@ static const RGBTokenEntry kDonorEntries[] = {
     { 0x031229, ApolloThemeTokenBarBackground,       ApolloThemeModeDark  },
     { 0xABABAB, ApolloThemeTokenSecondaryLabel,      ApolloThemeModeLight },
     { 0x484E5B, ApolloThemeTokenSecondaryLabel,      ApolloThemeModeDark  },
+    // Inbox unread-message tint. Outrun's UNREAD row background comes from a
+    // dedicated per-theme getter (sub_10068ee00), not the shared role palette —
+    // these two constants are exclusive to InboxCellNode and unique in the
+    // whole binary, so swapping them here can't hit anything else. There is no
+    // "unread" token, so route it to Selection — the theme's highlight family.
+    // Apollo derives the pressed state for unread rows by darkening whatever
+    // this returns, so the pressed variant follows the theme automatically.
+    { 0x95C0EE, ApolloThemeTokenSelection,           ApolloThemeModeLight },
+    { 0x034388, ApolloThemeTokenSelection,           ApolloThemeModeDark  },
 };
 
 // Apollo's separator constants are emitted outside the donor slot and outside

--- a/src/ApolloThemeShareImage.h
+++ b/src/ApolloThemeShareImage.h
@@ -1,0 +1,55 @@
+#import <UIKit/UIKit.h>
+#import "ApolloThemeTokens.h"
+
+// "Share a theme as an image" — the social-sharing layer on top of the Theme
+// Manager's JSON import/export.
+//
+// Sharing a theme as a raw .json file is awkward on social media: Reddit and
+// the like don't host arbitrary files, so a user would have to find a third-
+// party file host first. Instead we render a single portrait IMAGE that (a)
+// shows the theme's own compiled colours as a mock Apollo post — so the post
+// doubles as a preview — and (b) carries the whole theme inside a QR code
+// printed onto the card. Another user saves that image and imports it; we read
+// the QR back and reconstruct the exact theme.
+//
+// Why a *visible* QR rather than hiding the data in the pixels: Reddit (and most
+// platforms) re-encode every uploaded image to lossy JPEG and may resize it,
+// which destroys steganography / subtle pixel encodings. A QR is high-contrast,
+// luminance-only, and carries Reed–Solomon error correction (level H here, ~30%
+// recovery), so it survives a JPEG round-trip and is decoded geometrically, not
+// pixel-exactly. The payload is tiny (~60–180 bytes via the binary codec below),
+// so the QR stays small with large modules.
+//
+// Payload format: "ApolloTheme/1/" + base64(binary blob). The blob is
+// versioned: version 0x02 carries the v2 schema (input keys × light/dark,
+// variant, advanced flag); version 0x01 is the legacy Theme Builder layout
+// (role.mode colours) from the original share feature — still decoded so cards
+// already posted keep importing. Both decode routes converge on
+// -[ApolloThemeStore parseImportData:error:], so the QR path inherits every
+// validation/normalisation guard the JSON file path has.
+
+__BEGIN_DECLS
+
+// Render the portrait share card for a stored v2 theme dict: a mock Apollo post
+// painted in the theme's compiled token colours (mirroring the editor's Preview
+// section) with the theme name as the post title, a Dark/Light-mode badge, the
+// palette, and the QR. `mode` selects which appearance the card previews (the
+// QR payload always carries both). Returns nil only for a non-dictionary theme.
+UIImage *ApolloThemeShareRenderCard(NSDictionary *theme, ApolloThemeMode mode);
+
+// Decode a theme back out of a picked image by finding the Apollo Theme QR in it
+// (Vision first for recompressed-image robustness, CIDetector fallback) and
+// validating its payload through the Store's import parser. Returns a parsed
+// import dict (the -[ApolloThemeStore parseImportData:error:] shape, ready for
+// -confirmImport:/importParsedTheme:) or nil if the image has no recognisable
+// Apollo theme QR.
+NSDictionary *ApolloThemeShareDecodeImage(UIImage *image);
+
+// Decode a raw QR payload STRING (as read from a picked image or a live camera
+// scan): checks the "ApolloTheme/1/" tag, base64-decodes (size-capped), decodes
+// the versioned binary blob, and runs the result through the Store's strict
+// import parser. Returns the parsed import dict or nil if the string isn't an
+// Apollo theme QR. Lets the camera scanner reuse the exact same decode path.
+NSDictionary *ApolloThemeShareDecodePayload(NSString *payload);
+
+__END_DECLS

--- a/src/ApolloThemeShareImage.m
+++ b/src/ApolloThemeShareImage.m
@@ -459,12 +459,15 @@ UIImage *ApolloThemeShareRenderCard(NSDictionary *theme, ApolloThemeMode mode) {
                     NSTextAlignmentLeft, NSLineBreakByTruncatingTail);
         divider(cy + 264);
 
-        // comment row
+        // comment row — the byline names the theme's font (the whole card is
+        // already drawn in it, but this labels which one it is).
         ATSDrawSymbol(@"bubble.left", CGRectMake(cx + in, cy + 288, 44, 44), gray, 30);
         ATSDrawText(@"A comment with body text", CGRectMake(tx0, cy + 282, tw, 36),
                     tfont([UIFont systemFontOfSize:30 weight:UIFontWeightRegular]), primaryText,
                     NSTextAlignmentLeft, NSLineBreakByTruncatingTail);
-        ATSDrawText(@"username · reply", CGRectMake(tx0, cy + 322, tw, 28),
+        NSString *commentMeta = [NSString stringWithFormat:@"username · %@ font",
+                                 ApolloThemeFontDisplayName(themeFont)];
+        ATSDrawText(commentMeta, CGRectMake(tx0, cy + 322, tw, 28),
                     tfont([UIFont systemFontOfSize:23 weight:UIFontWeightRegular]), gray,
                     NSTextAlignmentLeft, NSLineBreakByTruncatingTail);
         divider(cy + 368);
@@ -496,10 +499,10 @@ UIImage *ApolloThemeShareRenderCard(NSDictionary *theme, ApolloThemeMode mode) {
         ATSDrawText(@"PALETTE", CGRectMake(52, 696, 300, 24),
                     [UIFont systemFontOfSize:20 weight:UIFontWeightSemibold], muted,
                     NSTextAlignmentLeft, NSLineBreakByClipping);
-        // Name the theme's font on the right of the same row, drawn IN that font
-        // so it doubles as a specimen (e.g. "Aa  New York").
-        NSString *fontSpec = [NSString stringWithFormat:@"Aa  %@", ApolloThemeFontDisplayName(themeFont)];
-        ATSDrawText(fontSpec, CGRectMake(W / 2.0, 693, W / 2.0 - 48, 28),
+        // A small "Aa" letterform sample of the theme's font on the right of the
+        // same row (the font is named under the comment above, so keep this
+        // wordless to avoid repeating the name).
+        ATSDrawText(@"Aa", CGRectMake(W / 2.0, 693, W / 2.0 - 48, 28),
                     tfont([UIFont systemFontOfSize:22 weight:UIFontWeightSemibold]), muted,
                     NSTextAlignmentRight, NSLineBreakByTruncatingTail);
         NSUInteger count = MAX(swatchRGBs.count, (NSUInteger)1);

--- a/src/ApolloThemeShareImage.m
+++ b/src/ApolloThemeShareImage.m
@@ -1,0 +1,652 @@
+#import "ApolloThemeShareImage.h"
+#import "ApolloThemeStore.h"
+#import "ApolloThemeCompiler.h"
+#import "ApolloCommon.h"
+#import <CoreImage/CoreImage.h>
+#import <Vision/Vision.h>
+#import <math.h>
+
+// QR payload wrapper. The blob is base64'd (pure ASCII) so it rides the QR's
+// byte mode cleanly and both decoders return it reliably as a string, with no
+// binary-payloadData ambiguity. The tag lets us reject a non-Apollo QR (a random
+// URL, a Wi-Fi code, …) before we even base64-decode. The tag deliberately stays
+// "/1/" across blob versions — old builds strip it, then cleanly reject the
+// unknown version byte inside.
+static NSString *const kThemeQRTag = @"ApolloTheme/1/";
+
+// ---------------------------------------------------------------------------
+// Compact binary codec (for QR-in-image sharing). See header for the layout.
+// ---------------------------------------------------------------------------
+
+static const uint8_t kThemeBinaryMagic     = 0xA7;
+static const uint8_t kThemeBinaryVersionV1 = 0x01; // legacy Theme Builder role.mode layout
+static const uint8_t kThemeBinaryVersionV2 = 0x02; // v2 input keys + variant + flags
+static const uint8_t kThemeBinaryVersionV3 = 0x03; // v3 = v2 + per-theme font byte
+
+// v3 blob layout (all multi-byte values big-endian):
+//   [0]    magic 0xA7
+//   [1]    version 0x03
+//   [2..3] uint16 presence bitmask; bit = inputKeyIndex*2 + (dark ? 1 : 0),
+//          key order = ApolloThemeInputKeys() (accent, background, card,
+//          raised, bars, text, mutedText, separator)
+//   [4..]  3 RGB bytes per present slot, ascending slot order
+//   [+0]   variant byte (ApolloThemeVariant raw value)
+//   [+1]   flags byte (bit0 = advancedEnabled)
+//   [+2]   font byte (ApolloThemeFont raw value; 0 = system) — v3 only
+//   [+..]  name length (UTF-8 bytes, 0–120), then name UTF-8 bytes
+//   [-2..] CRC-16/CCITT-FALSE over all preceding bytes
+//
+// v2 is identical minus the font byte (decodes to font = system). The v1 blob
+// differs more: no variant/flags/font bytes, and the 8 colour slots are the
+// legacy Theme Builder roles in THEIR fixed order (see V1QRRoleKeys below) —
+// slot tables between versions are NOT interchangeable.
+
+// CRC-16/CCITT-FALSE (poly 0x1021, init 0xFFFF). Guards against a silent QR
+// error-correction mis-decode producing a plausible-but-wrong blob.
+static uint16_t ATSCRC16(const uint8_t *data, NSUInteger len) {
+    uint16_t crc = 0xFFFF;
+    for (NSUInteger i = 0; i < len; i++) {
+        crc ^= (uint16_t)data[i] << 8;
+        for (int b = 0; b < 8; b++) {
+            crc = (crc & 0x8000) ? (uint16_t)((crc << 1) ^ 0x1021) : (uint16_t)(crc << 1);
+        }
+    }
+    return crc;
+}
+
+// Max UTF-8 bytes for the name in a binary blob: comfortably inside the 1-byte
+// length field and the QR's capacity. Names long enough to hit this are
+// pathological (long combining/Zalgo/ZWJ runs); a normal name is far smaller.
+static const NSUInteger kThemeBinaryNameMaxBytes = 120;
+
+// Encode a name to UTF-8, truncated to kThemeBinaryNameMaxBytes on a composed-
+// character (grapheme) boundary so it never splits a code point and always fits
+// the 1-byte length field. A name already under budget is returned whole.
+static NSData *ATSNameBytesForBinary(NSString *name) {
+    NSData *full = [name dataUsingEncoding:NSUTF8StringEncoding] ?: [NSData data];
+    if (full.length <= kThemeBinaryNameMaxBytes) return full;
+    NSMutableData *out = [NSMutableData data];
+    [name enumerateSubstringsInRange:NSMakeRange(0, name.length)
+                             options:NSStringEnumerationByComposedCharacterSequences
+                          usingBlock:^(NSString *seq, NSRange r, NSRange er, BOOL *stop) {
+        NSData *bytes = [seq dataUsingEncoding:NSUTF8StringEncoding];
+        if (out.length + bytes.length > kThemeBinaryNameMaxBytes) { *stop = YES; return; }
+        [out appendData:bytes];
+    }];
+    return out;
+}
+
+// Encode the PORTABLE export dict ({name, variant, input, advancedEnabled, font}
+// as produced by -[ApolloThemeStore exportDataForTheme:]) into a v3 blob. Going
+// through the Store's exporter first means the blob carries exactly what the
+// .json file would — same normalisation, same advanced-override stripping when
+// the flag is off (so a recipient never resurrects overrides the sender wasn't
+// even seeing).
+static NSData *ATSEncodeBinaryV3(NSDictionary *portable) {
+    if (![portable isKindOfClass:[NSDictionary class]]) return nil;
+    NSDictionary *input = [portable[@"input"] isKindOfClass:[NSDictionary class]] ? portable[@"input"] : @{};
+    NSArray<NSString *> *keys = ApolloThemeInputKeys();
+
+    NSMutableData *out = [NSMutableData data];
+    uint8_t header[2] = { kThemeBinaryMagic, kThemeBinaryVersionV3 };
+    [out appendBytes:header length:2];
+
+    // Presence bitmask + RGB bytes in fixed slot order: slot = keyIndex*2 + (dark?1:0).
+    uint16_t mask = 0;
+    NSMutableData *colorBytes = [NSMutableData data];
+    for (NSUInteger ki = 0; ki < keys.count && ki < 8; ki++) {
+        for (NSUInteger mi = 0; mi < 2; mi++) {
+            NSDictionary *modeInput = [input[mi ? @"dark" : @"light"] isKindOfClass:[NSDictionary class]]
+                ? input[mi ? @"dark" : @"light"] : @{};
+            uint32_t rgb = 0;
+            id hex = modeInput[keys[ki]];
+            if (![hex isKindOfClass:[NSString class]] || !ApolloThemeParseHex(hex, &rgb)) continue;
+            mask |= (uint16_t)(1u << (ki * 2 + mi));
+            uint8_t bytes[3] = { (uint8_t)((rgb >> 16) & 0xFF), (uint8_t)((rgb >> 8) & 0xFF), (uint8_t)(rgb & 0xFF) };
+            [colorBytes appendBytes:bytes length:3];
+        }
+    }
+    uint8_t maskBytes[2] = { (uint8_t)(mask >> 8), (uint8_t)(mask & 0xFF) };
+    [out appendBytes:maskBytes length:2];
+    [out appendData:colorBytes];
+
+    uint8_t variant = (uint8_t)ApolloThemeVariantFromKey(portable[@"variant"]);
+    uint8_t flags = [portable[kApolloThemeAdvancedOptionsEnabledKey] boolValue] ? 0x01 : 0x00;
+    uint8_t font = (uint8_t)ApolloThemeFontFromKey(portable[kApolloThemeFontKey]); // 0 = system
+    [out appendBytes:&variant length:1];
+    [out appendBytes:&flags length:1];
+    [out appendBytes:&font length:1];
+
+    // Name, truncated to a UTF-8 BYTE budget (the Store clamp is by *character*
+    // count, not bytes — a single long combining/ZWJ cluster can blow past the
+    // 1-byte length field, so budget by bytes here on a grapheme boundary).
+    NSString *name = [portable[@"name"] isKindOfClass:[NSString class]] ? portable[@"name"] : @"Custom";
+    NSData *nameUTF8 = ATSNameBytesForBinary(name);
+    uint8_t nlen = (uint8_t)nameUTF8.length; // guaranteed ≤ kThemeBinaryNameMaxBytes ≤ 255
+    [out appendBytes:&nlen length:1];
+    [out appendData:nameUTF8];
+
+    uint16_t crc = ATSCRC16((const uint8_t *)out.bytes, out.length);
+    uint8_t crcBytes[2] = { (uint8_t)(crc >> 8), (uint8_t)(crc & 0xFF) };
+    [out appendBytes:crcBytes length:2];
+    return out;
+}
+
+// The legacy (v1 blob) role slot order — the original Theme Builder's
+// ApolloThemeBuilderRoleKeys() order, frozen here so old cards keep decoding
+// after that code was replaced by Theme Manager v2. Do NOT reorder.
+static NSArray<NSString *> *V1QRRoleKeys(void) {
+    return @[ @"accent", @"primaryBG", @"secondaryBG", @"tertiaryBG",
+              @"separator", @"bar", @"gray", @"text" ];
+}
+
+// Decode a blob (either version) into the JSON-shaped dict the Store's import
+// parser accepts: v2 → {schemaVersion, name, variant, input, advancedEnabled},
+// v1 → {name, colors} (the parser routes "colors" through its own v1→v2
+// migration mapping). Returns nil on any structural/CRC failure.
+static NSDictionary *ATSDecodeBinary(NSData *blob) {
+    if (![blob isKindOfClass:[NSData class]]) return nil;
+    const uint8_t *p = (const uint8_t *)blob.bytes;
+    NSUInteger n = blob.length;
+    // v1 minimum: magic(1) version(1) mask(2) namelen(1) crc(2); v2 adds
+    // variant+flags; v3 adds a font byte too.
+    if (n < 7) return nil;
+    if (p[0] != kThemeBinaryMagic) return nil;
+    uint8_t version = p[1];
+    if (version != kThemeBinaryVersionV1 && version != kThemeBinaryVersionV2 &&
+        version != kThemeBinaryVersionV3) return nil;
+    BOOL modern = (version == kThemeBinaryVersionV2 || version == kThemeBinaryVersionV3);
+    if (version == kThemeBinaryVersionV2 && n < 9) return nil;
+    if (version == kThemeBinaryVersionV3 && n < 10) return nil;
+    uint16_t want = (uint16_t)((uint16_t)p[n - 2] << 8 | p[n - 1]);
+    if (ATSCRC16(p, n - 2) != want) return nil;
+
+    NSUInteger dataEnd = n - 2; // payload bytes precede the 2-byte CRC
+    uint16_t mask = (uint16_t)((uint16_t)p[2] << 8 | p[3]);
+    NSUInteger idx = 4;
+
+    // Colour slots. Every version packs 16 slots as index*2 + (dark?1:0); only
+    // the key tables differ (v2/v3 share the input-key table).
+    NSMutableDictionary *lightIn = [NSMutableDictionary dictionary]; // v2/v3
+    NSMutableDictionary *darkIn = [NSMutableDictionary dictionary];  // v2/v3
+    NSMutableDictionary *v1Colors = [NSMutableDictionary dictionary];
+    NSArray<NSString *> *keys = modern ? ApolloThemeInputKeys() : V1QRRoleKeys();
+    for (NSUInteger slot = 0; slot < 16; slot++) {
+        if (!(mask & (uint16_t)(1u << slot))) continue;
+        if (idx + 3 > dataEnd) return nil;
+        NSString *hex = [NSString stringWithFormat:@"%02X%02X%02X", p[idx], p[idx + 1], p[idx + 2]];
+        idx += 3;
+        NSUInteger ki = slot / 2;
+        BOOL dark = (slot % 2) == 1;
+        if (ki >= keys.count) continue; // unknown future slot — consume and ignore
+        if (modern) {
+            (dark ? darkIn : lightIn)[keys[ki]] = hex;
+        } else {
+            v1Colors[[NSString stringWithFormat:@"%@.%@", keys[ki], dark ? @"dark" : @"light"]] = hex;
+        }
+    }
+
+    uint8_t variant = 0, flags = 0, font = 0;
+    if (modern) {
+        if (idx + 2 > dataEnd) return nil;
+        variant = p[idx++];
+        flags = p[idx++];
+        if (version == kThemeBinaryVersionV3) {
+            if (idx + 1 > dataEnd) return nil;
+            font = p[idx++];
+        }
+    }
+
+    if (idx + 1 > dataEnd) return nil;
+    uint8_t nlen = p[idx++];
+    if (idx + nlen > dataEnd) return nil;
+    NSString *name = nlen ? [[NSString alloc] initWithBytes:p + idx length:nlen encoding:NSUTF8StringEncoding] : nil;
+    if (!name.length) name = @"Imported Theme";
+
+    if (version == kThemeBinaryVersionV1) {
+        return @{ @"name": name, @"colors": v1Colors };
+    }
+    NSMutableDictionary *out = [@{
+        @"schemaVersion": @(kApolloThemeSchemaVersion),
+        @"name": name,
+        @"variant": ApolloThemeVariantKey((ApolloThemeVariant)MIN(variant, (uint8_t)ApolloThemeVariantBold)),
+        @"input": @{ @"light": lightIn, @"dark": darkIn },
+        kApolloThemeAdvancedOptionsEnabledKey: @((flags & 0x01) != 0),
+    } mutableCopy];
+    // Font only when non-system (matches the Store's absent-key convention);
+    // an unknown/out-of-range byte falls back to system via ApolloThemeFontKey.
+    if (font != ApolloThemeFontSystem && font < ApolloThemeFontCount) {
+        out[kApolloThemeFontKey] = ApolloThemeFontKey((ApolloThemeFont)font);
+    }
+    return out;
+}
+
+// Run a decoded blob dict through the Store's strict import parser so the QR
+// route inherits every guard the JSON file route has (hex whitelisting, starter
+// fill, name clamp, advanced inference), then stamp QR provenance.
+static NSDictionary *ATSParsedImportFromBlobDict(NSDictionary *blobDict, BOOL legacy) {
+    if (!blobDict) return nil;
+    NSData *json = [NSJSONSerialization dataWithJSONObject:blobDict options:0 error:NULL];
+    if (!json) return nil;
+    NSString *err = nil;
+    NSDictionary *parsed = [[ApolloThemeStore shared] parseImportData:json error:&err];
+    if (!parsed) {
+        ApolloLog(@"ThemeShare: store parser rejected QR payload: %@", err);
+        return nil;
+    }
+    NSMutableDictionary *stamped = [parsed mutableCopy];
+    stamped[@"generation"] = @{ @"source": legacy ? @"imported-qr-v1" : @"imported-qr" };
+    return stamped;
+}
+
+#pragma mark - QR generation
+
+// Generate a crisp QR UIImage (black on white) for a payload string, integer-
+// upscaled to roughly targetPx so module edges stay razor-sharp before any later
+// JPEG recompression touches them.
+static UIImage *ATSMakeQRImage(NSString *payload, CGFloat targetPx) {
+    // payload is the ASCII tag + base64, so UTF-8 encodes it exactly (1 byte/char).
+    NSData *data = [payload dataUsingEncoding:NSUTF8StringEncoding];
+    if (!data.length) return nil;
+    CIFilter *filter = [CIFilter filterWithName:@"CIQRCodeGenerator"];
+    if (!filter) return nil;
+    [filter setValue:data forKey:@"inputMessage"];
+    [filter setValue:@"H" forKey:@"inputCorrectionLevel"]; // ~30% recovery — the JPEG-survival margin
+    CIImage *ci = filter.outputImage;
+    CGFloat span = ci.extent.size.width;
+    if (span <= 0) return nil;
+    CGFloat scale = floor(targetPx / span);
+    if (scale < 1) scale = 1;
+    CIImage *scaled = [ci imageByApplyingTransform:CGAffineTransformMakeScale(scale, scale)];
+    static CIContext *ctx;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ ctx = [CIContext contextWithOptions:nil]; });
+    CGImageRef cg = [ctx createCGImage:scaled fromRect:scaled.extent];
+    if (!cg) return nil;
+    UIImage *image = [UIImage imageWithCGImage:cg];
+    CGImageRelease(cg);
+    return image;
+}
+
+#pragma mark - Card rendering
+
+static void ATSDrawText(NSString *s, CGRect rect, UIFont *font, UIColor *color,
+                        NSTextAlignment align, NSLineBreakMode lbm) {
+    if (!s.length) return;
+    NSMutableParagraphStyle *p = [[NSMutableParagraphStyle alloc] init];
+    p.alignment = align;
+    p.lineBreakMode = lbm;
+    [s drawInRect:rect withAttributes:@{ NSFontAttributeName: font,
+                                         NSForegroundColorAttributeName: color,
+                                         NSParagraphStyleAttributeName: p }];
+}
+
+// A rounded "pill" filled with bg, with vertically-centered text. Fills the
+// rounded path directly — never clip here, since clipping only shrinks the
+// context's clip region and would hide everything drawn after the pill.
+static void ATSDrawPill(CGRect rect, UIColor *bg, NSString *text, UIColor *textColor, UIFont *font) {
+    [bg setFill];
+    [[UIBezierPath bezierPathWithRoundedRect:rect cornerRadius:rect.size.height / 2.0] fill];
+    CGFloat lh = font.lineHeight;
+    CGRect tr = CGRectMake(rect.origin.x, rect.origin.y + (rect.size.height - lh) / 2.0, rect.size.width, lh);
+    ATSDrawText(text, tr, font, textColor, NSTextAlignmentCenter, NSLineBreakByClipping);
+}
+
+// Draw a tinted SF symbol centered in rect (same glyphs the editor preview
+// uses, so the card mirrors it). No-op if the symbol is unavailable.
+static void ATSDrawSymbol(NSString *name, CGRect rect, UIColor *tint, CGFloat pointSize) {
+    UIImageSymbolConfiguration *cfg =
+        [UIImageSymbolConfiguration configurationWithPointSize:pointSize weight:UIImageSymbolWeightSemibold];
+    UIImage *img = [[UIImage systemImageNamed:name withConfiguration:cfg]
+                    imageWithTintColor:(tint ?: UIColor.grayColor)
+                         renderingMode:UIImageRenderingModeAlwaysOriginal];
+    if (!img) return;
+    CGSize s = img.size;
+    // Fit inside rect preserving aspect, centered.
+    CGFloat k = MIN(rect.size.width / MAX(s.width, 1), rect.size.height / MAX(s.height, 1));
+    CGSize d = CGSizeMake(s.width * k, s.height * k);
+    [img drawInRect:CGRectMake(rect.origin.x + (rect.size.width - d.width) / 2.0,
+                               rect.origin.y + (rect.size.height - d.height) / 2.0,
+                               d.width, d.height)];
+}
+
+// Render the share card: a mock Apollo post painted in the theme's compiled
+// token colours (mirroring the editor's Preview section) with the theme name as
+// the post title, a Dark/Light-mode badge, the palette, and the QR. The QR
+// payload always carries BOTH modes; only the mock post/palette reflect `mode`.
+UIImage *ApolloThemeShareRenderCard(NSDictionary *theme, ApolloThemeMode mode) {
+    if (![theme isKindOfClass:[NSDictionary class]]) return nil;
+    BOOL dark = (mode == ApolloThemeModeDark);
+    NSString *modeKey = ApolloThemeModeKey(dark ? ApolloThemeModeDark : ApolloThemeModeLight);
+
+    const CGFloat W = 1024.0;   // portrait card: more room for the post + a big, scannable QR
+    const CGFloat H = 1280.0;
+
+    NSString *name = ([theme[@"name"] isKindOfClass:[NSString class]] && [theme[@"name"] length])
+        ? theme[@"name"] : @"Custom Theme";
+
+    // The theme's chosen app-wide font. The mock post is drawn in it (so the
+    // card previews the typeface), and it's named on the palette row.
+    ApolloThemeFont themeFont = ApolloThemeFontFromKey(theme[kApolloThemeFontKey]);
+
+    // QR payload from the Store's portable export (same normalisation +
+    // advanced-stripping as the .json file). If anything fails we still draw
+    // the card, just without a QR.
+    NSDictionary *portable = nil;
+    NSData *exportJSON = [[ApolloThemeStore shared] exportDataForTheme:theme];
+    if (exportJSON) {
+        id obj = [NSJSONSerialization JSONObjectWithData:exportJSON options:0 error:NULL];
+        if ([obj isKindOfClass:[NSDictionary class]]) portable = obj;
+    }
+    NSData *blob = portable ? ATSEncodeBinaryV3(portable) : nil;
+    NSString *payload = blob.length ? [kThemeQRTag stringByAppendingString:[blob base64EncodedStringWithOptions:0]] : nil;
+    UIImage *qr = payload ? ATSMakeQRImage(payload, 380.0) : nil;
+    if (!qr) ApolloLog(@"ThemeShare: rendering card without QR (encode failed)");
+
+    // Compiled token colours for the previewed mode (same source as the editor
+    // preview — never nil, tolerates sparse input).
+    ApolloCompiledTheme *compiled =
+        [ApolloCompiledTheme compiledThemeWithInput:theme[@"input"]
+                                            variant:ApolloThemeVariantFromKey(theme[@"variant"])
+                                    advancedEnabled:[theme[kApolloThemeAdvancedOptionsEnabledKey] boolValue]];
+    ApolloThemeMode m = dark ? ApolloThemeModeDark : ApolloThemeModeLight;
+    UIColor *(^tok)(ApolloThemeToken) = ^UIColor *(ApolloThemeToken t) {
+        return ApolloThemeUIColorFromRGB([compiled rgbForToken:t mode:m]);
+    };
+    UIColor *page        = tok(ApolloThemeTokenBackground);
+    UIColor *card        = tok(ApolloThemeTokenSecondaryBackground);
+    UIColor *accent      = tok(ApolloThemeTokenAccent);
+    UIColor *separator   = tok(ApolloThemeTokenSeparator);
+    UIColor *raised      = tok(ApolloThemeTokenTertiaryBackground); // the "Raised" input surface
+    UIColor *gray        = tok(ApolloThemeTokenSecondaryLabel);
+    UIColor *primaryText = tok(ApolloThemeTokenLabel);
+    UIColor *selection   = tok(ApolloThemeTokenSelection);
+    UIColor *muted       = tok(ApolloThemeTokenTertiaryLabel); // label faded toward the page
+
+    // Palette swatches: the user's actual input colours for this mode — the 5
+    // required surfaces plus any advanced overrides that are on and set.
+    NSDictionary *modeInput = [theme[@"input"][modeKey] isKindOfClass:[NSDictionary class]]
+        ? theme[@"input"][modeKey] : @{};
+    BOOL advancedEnabled = [theme[kApolloThemeAdvancedOptionsEnabledKey] boolValue];
+    NSMutableArray<NSNumber *> *swatchRGBs = [NSMutableArray array]; // packed 0xRRGGBB
+    for (NSString *key in ApolloThemeDefaultInputKeys()) {
+        uint32_t rgb = 0;
+        id hex = modeInput[key];
+        BOOL ok = [hex isKindOfClass:[NSString class]] && ApolloThemeParseHex(hex, &rgb);
+        [swatchRGBs addObject:@(ok ? rgb : 0x808080)];
+    }
+    if (advancedEnabled) {
+        for (NSString *key in ApolloThemeAdvancedInputKeys()) {
+            uint32_t rgb = 0;
+            id hex = modeInput[key];
+            if ([hex isKindOfClass:[NSString class]] && ApolloThemeParseHex(hex, &rgb)) {
+                [swatchRGBs addObject:@(rgb)];
+            }
+        }
+    }
+
+    UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
+    format.opaque = YES;
+    format.scale = 1.0; // 1024 logical == 1024 px, so QR module pixels are predictable
+    UIGraphicsImageRenderer *renderer =
+        [[UIGraphicsImageRenderer alloc] initWithSize:CGSizeMake(W, H) format:format];
+
+    return [renderer imageWithActions:^(UIGraphicsImageRendererContext *rc) {
+        CGContextRef ctx = rc.CGContext;
+
+        // Re-derive a base font into the theme's design (SF Pro / Rounded /
+        // New York / SF Mono), preserving size & weight. Used for the mock
+        // post's text so the card demonstrates the typeface; card chrome
+        // (wordmark, badge, QR-plate copy) stays neutral SF Pro.
+        UIFont *(^tfont)(UIFont *) = ^UIFont *(UIFont *base) {
+            UIFont *f = ApolloThemeFontApply(themeFont, base);
+            return f ?: base;
+        };
+
+        // --- page background (the theme's page colour) ---
+        [page setFill];
+        CGContextFillRect(ctx, CGRectMake(0, 0, W, H));
+
+        // --- header: accent-dot wordmark + Dark/Light-mode badge ---
+        [accent setFill];
+        CGContextFillEllipseInRect(ctx, CGRectMake(52, 46, 26, 26));
+        ATSDrawText(@"Apollo theme", CGRectMake(90, 44, 360, 34),
+                    [UIFont systemFontOfSize:27 weight:UIFontWeightSemibold], muted,
+                    NSTextAlignmentLeft, NSLineBreakByClipping);
+
+        NSString *badge = dark ? @"\U0001F319  Dark mode" : @"☀️  Light mode";
+        UIFont *badgeFont = [UIFont systemFontOfSize:23 weight:UIFontWeightSemibold];
+        CGFloat badgeW = [badge sizeWithAttributes:@{NSFontAttributeName: badgeFont}].width + 44;
+        ATSDrawPill(CGRectMake(W - 52 - badgeW, 36, badgeW, 50), raised, badge, primaryText, badgeFont);
+
+        // --- mock Apollo screen painted in the theme's colours, mirroring the
+        // editor's Preview section: post row (title = theme name) + metadata,
+        // a comment row, a tinted link row, and a selected-row sample ---
+        CGFloat cx = 48, cy = 112, cw = W - 96, ch = 560, in = 36;
+        UIBezierPath *cardPath = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(cx, cy, cw, ch) cornerRadius:26];
+        [card setFill]; [cardPath fill];
+
+        CGFloat tx0 = cx + in + 76;             // text column (right of the icon column)
+        CGFloat tw = cx + cw - in - tx0;        // text column width
+        void (^divider)(CGFloat) = ^(CGFloat y) {
+            [separator setFill];
+            CGContextFillRect(ctx, CGRectMake(cx + in, y, cw - in * 2, 2));
+        };
+
+        // subreddit header row: accent avatar + r/apolloapp + byline
+        [accent setFill];
+        CGContextFillEllipseInRect(ctx, CGRectMake(cx + in, cy + 26, 56, 56));
+        ATSDrawText(@"r/apolloapp", CGRectMake(tx0, cy + 26, tw, 30),
+                    tfont([UIFont systemFontOfSize:26 weight:UIFontWeightBold]), accent,
+                    NSTextAlignmentLeft, NSLineBreakByTruncatingTail);
+        ATSDrawText(@"u/christianselig · 2h", CGRectMake(tx0, cy + 58, tw, 26),
+                    tfont([UIFont systemFontOfSize:21 weight:UIFontWeightRegular]), gray,
+                    NSTextAlignmentLeft, NSLineBreakByTruncatingTail);
+        divider(cy + 106);
+
+        // post row: accent upvote arrow, theme name as the title (up to 2
+        // lines — metadata tucks up under a 1-line title instead of floating)
+        UIFont *titleFont = tfont([UIFont systemFontOfSize:36 weight:UIFontWeightBold]);
+        CGFloat titleH = MIN(ceil([name boundingRectWithSize:CGSizeMake(tw, 90)
+                                                     options:NSStringDrawingUsesLineFragmentOrigin
+                                                  attributes:@{NSFontAttributeName: titleFont}
+                                                     context:nil].size.height), 90);
+        ATSDrawSymbol(@"arrow.up", CGRectMake(cx + in, cy + 130, 48, 48), accent, 34);
+        ATSDrawText(name, CGRectMake(tx0, cy + 124, tw, titleH),
+                    titleFont, primaryText, NSTextAlignmentLeft, NSLineBreakByWordWrapping);
+        ATSDrawText(@"r/apollo · 3h · 142 points", CGRectMake(tx0, cy + 124 + titleH + 10, tw, 30),
+                    tfont([UIFont systemFontOfSize:24 weight:UIFontWeightRegular]), gray,
+                    NSTextAlignmentLeft, NSLineBreakByTruncatingTail);
+        divider(cy + 264);
+
+        // comment row
+        ATSDrawSymbol(@"bubble.left", CGRectMake(cx + in, cy + 288, 44, 44), gray, 30);
+        ATSDrawText(@"A comment with body text", CGRectMake(tx0, cy + 282, tw, 36),
+                    tfont([UIFont systemFontOfSize:30 weight:UIFontWeightRegular]), primaryText,
+                    NSTextAlignmentLeft, NSLineBreakByTruncatingTail);
+        ATSDrawText(@"username · reply", CGRectMake(tx0, cy + 322, tw, 28),
+                    tfont([UIFont systemFontOfSize:23 weight:UIFontWeightRegular]), gray,
+                    NSTextAlignmentLeft, NSLineBreakByTruncatingTail);
+        divider(cy + 368);
+
+        // tinted link row
+        ATSDrawSymbol(@"link", CGRectMake(cx + in, cy + 390, 44, 44), accent, 28);
+        ATSDrawText(@"Tinted link / button", CGRectMake(tx0, cy + 394, tw, 36),
+                    tfont([UIFont systemFontOfSize:30 weight:UIFontWeightSemibold]), accent,
+                    NSTextAlignmentLeft, NSLineBreakByTruncatingTail);
+
+        // selected-row sample: Selection-token band across the card bottom
+        CGFloat bandH = 96;
+        UIBezierPath *band = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(cx, cy + ch - bandH, cw, bandH)
+                                                   byRoundingCorners:(UIRectCornerBottomLeft | UIRectCornerBottomRight)
+                                                         cornerRadii:CGSizeMake(26, 26)];
+        [selection setFill]; [band fill];
+        UIBezierPath *chip = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(cx + in, cy + ch - bandH + (bandH - 36) / 2.0, 36, 36)
+                                                        cornerRadius:9];
+        [raised setFill]; [chip fill];
+        [[separator colorWithAlphaComponent:0.7] setStroke]; chip.lineWidth = 1; [chip stroke];
+        ATSDrawText(@"Selected / tapped row", CGRectMake(tx0, cy + ch - bandH + (bandH - 36) / 2.0, tw, 36),
+                    tfont([UIFont systemFontOfSize:30 weight:UIFontWeightMedium]), primaryText,
+                    NSTextAlignmentLeft, NSLineBreakByTruncatingTail);
+
+        // stroke the card outline last so it stays crisp over the band
+        [separator setStroke]; cardPath.lineWidth = 1.5; [cardPath stroke];
+
+        // --- palette: the user's chosen input colours for this mode ---
+        ATSDrawText(@"PALETTE", CGRectMake(52, 696, 300, 24),
+                    [UIFont systemFontOfSize:20 weight:UIFontWeightSemibold], muted,
+                    NSTextAlignmentLeft, NSLineBreakByClipping);
+        // Name the theme's font on the right of the same row, drawn IN that font
+        // so it doubles as a specimen (e.g. "Aa  New York").
+        NSString *fontSpec = [NSString stringWithFormat:@"Aa  %@", ApolloThemeFontDisplayName(themeFont)];
+        ATSDrawText(fontSpec, CGRectMake(W / 2.0, 693, W / 2.0 - 48, 28),
+                    tfont([UIFont systemFontOfSize:22 weight:UIFontWeightSemibold]), muted,
+                    NSTextAlignmentRight, NSLineBreakByTruncatingTail);
+        NSUInteger count = MAX(swatchRGBs.count, (NSUInteger)1);
+        CGFloat sgap = 8, sx = 48, sy = 728, sh = 46;
+        CGFloat sw = (cw - sgap * (count - 1)) / (CGFloat)count;
+        for (NSUInteger i = 0; i < swatchRGBs.count; i++) {
+            uint32_t rgb = swatchRGBs[i].unsignedIntValue;
+            CGRect r = CGRectMake(sx + i * (sw + sgap), sy, sw, sh);
+            UIBezierPath *sp = [UIBezierPath bezierPathWithRoundedRect:CGRectInset(r, 1.5, 1.5) cornerRadius:9];
+            [ApolloThemeUIColorFromRGB(rgb) setFill]; [sp fill];
+            // Adaptive contrast ring: a chip whose colour sits near the page
+            // background would otherwise vanish (dark chips on a dark card,
+            // pastels on a light one) — ring each chip with whichever of
+            // black/white contrasts more with the chip itself, so either the
+            // fill or its ring is always visible on any page.
+            BOOL darkRing = ApolloThemeContrastRatio(rgb, 0x000000) >= ApolloThemeContrastRatio(rgb, 0xFFFFFF);
+            [(darkRing ? [UIColor colorWithWhite:0.0 alpha:0.55]
+                       : [UIColor colorWithWhite:1.0 alpha:0.92]) setStroke];
+            sp.lineWidth = 3; [sp stroke];
+        }
+
+        // --- QR plate (always light, for QR contrast) ---
+        CGFloat plateTop = 806;
+        [[UIColor colorWithRed:0.965 green:0.969 blue:0.984 alpha:1.0] setFill];
+        CGContextFillRect(ctx, CGRectMake(0, plateTop, W, H - plateTop));
+        [[UIColor colorWithWhite:0.0 alpha:0.10] setFill]; // hairline divider
+        CGContextFillRect(ctx, CGRectMake(0, plateTop, W, 1));
+
+        if (qr) {
+            CGFloat qz = qr.size.width;
+            CGRect qrRect = CGRectMake(64, plateTop + (H - plateTop - qz) / 2.0, qz, qz);
+            // white quiet-zone card behind the QR
+            [[UIColor whiteColor] setFill];
+            UIRectFill(CGRectInset(qrRect, -18, -18));
+            CGContextSetInterpolationQuality(ctx, kCGInterpolationNone);
+            [qr drawInRect:qrRect];
+
+            CGFloat tx = CGRectGetMaxX(qrRect) + 36, ty = qrRect.origin.y;
+            ATSDrawText(@"Get this theme", CGRectMake(tx, ty + 96, W - tx - 48, 36),
+                        [UIFont systemFontOfSize:30 weight:UIFontWeightBold],
+                        [UIColor colorWithWhite:0.07 alpha:1.0], NSTextAlignmentLeft, NSLineBreakByTruncatingTail);
+            ATSDrawText(@"Save this image, then open Apollo → Theme Manager → Import. It carries both light & dark.",
+                        CGRectMake(tx, ty + 142, W - tx - 48, 160),
+                        [UIFont systemFontOfSize:23 weight:UIFontWeightRegular],
+                        [UIColor colorWithWhite:0.36 alpha:1.0], NSTextAlignmentLeft, NSLineBreakByWordWrapping);
+        }
+    }];
+}
+
+#pragma mark - QR decoding
+
+// An image can carry several QRs (a screenshot of a Reddit page with a promo
+// QR next to the theme card, two cards side by side, …) and detectors return
+// them in no documented order — so always prefer an Apollo-tagged payload over
+// whichever code happened to come first, falling back to the first payload
+// only so the caller can log/reject something concrete.
+static NSString *ATSPreferTagged(NSString *best, NSString *candidate) {
+    if (!candidate.length) return best;
+    if ([candidate hasPrefix:kThemeQRTag]) return candidate;
+    return best.length ? best : candidate;
+}
+
+// Vision path — more tolerant of the blur/resample a recompressed image picks up.
+static NSString *ATSReadQRVision(CIImage *ci) {
+    NSString *best = nil;
+    if (@available(iOS 11.0, *)) {
+        VNDetectBarcodesRequest *request = [[VNDetectBarcodesRequest alloc] init];
+        request.symbologies = @[VNBarcodeSymbologyQR];
+        VNImageRequestHandler *handler = [[VNImageRequestHandler alloc] initWithCIImage:ci options:@{}];
+        NSError *error = nil;
+        if (![handler performRequests:@[request] error:&error] || error) {
+            ApolloLog(@"ThemeShare: Vision QR request failed: %@", error);
+            return nil;
+        }
+        for (VNBarcodeObservation *obs in request.results) {
+            best = ATSPreferTagged(best, obs.payloadStringValue);
+            if ([best hasPrefix:kThemeQRTag]) break;
+        }
+    }
+    return best;
+}
+
+// CIDetector fallback — no extra framework, handles clean/axis-aligned codes
+// well (and is the load-bearing path in the Simulator, where Vision's QR
+// detection fails).
+static NSString *ATSReadQRCIDetector(CIImage *ci) {
+    static CIContext *ctx;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ ctx = [CIContext contextWithOptions:nil]; });
+    CIDetector *detector = [CIDetector detectorOfType:CIDetectorTypeQRCode
+                                              context:ctx
+                                              options:@{CIDetectorAccuracy: CIDetectorAccuracyHigh}];
+    NSString *best = nil;
+    for (CIFeature *feature in [detector featuresInImage:ci]) {
+        if ([feature isKindOfClass:[CIQRCodeFeature class]]) {
+            best = ATSPreferTagged(best, ((CIQRCodeFeature *)feature).messageString);
+            if ([best hasPrefix:kThemeQRTag]) break;
+        }
+    }
+    return best;
+}
+
+NSDictionary *ApolloThemeShareDecodePayload(NSString *payload) {
+    if (![payload isKindOfClass:[NSString class]] || ![payload hasPrefix:kThemeQRTag]) {
+        return nil; // not an Apollo theme QR (a URL, Wi-Fi code, other app's QR, …)
+    }
+    NSString *b64 = [payload substringFromIndex:kThemeQRTag.length];
+    NSData *blob = [[NSData alloc] initWithBase64EncodedString:b64
+                                                       options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    // A real theme blob is well under ~250 bytes; cap defensively so a hostile QR
+    // can't hand us an oversized payload before decoding (mirrors the JSON import's
+    // size guard — the QR route is otherwise the only one without one).
+    static const NSUInteger kThemeQRMaxBlobBytes = 2048;
+    if (!blob.length || blob.length > kThemeQRMaxBlobBytes) {
+        ApolloLog(@"ThemeShare: QR payload rejected (len=%lu)", (unsigned long)blob.length);
+        return nil;
+    }
+    BOOL legacy = blob.length >= 2 && ((const uint8_t *)blob.bytes)[1] == kThemeBinaryVersionV1;
+    NSDictionary *blobDict = ATSDecodeBinary(blob);
+    if (!blobDict) {
+        ApolloLog(@"ThemeShare: binary decode/validation rejected the payload");
+        return nil;
+    }
+    return ATSParsedImportFromBlobDict(blobDict, legacy);
+}
+
+NSDictionary *ApolloThemeShareDecodeImage(UIImage *image) {
+    if (![image isKindOfClass:[UIImage class]]) return nil;
+
+    CIImage *ci = image.CIImage;
+    if (!ci && image.CGImage) ci = [CIImage imageWithCGImage:image.CGImage];
+    if (!ci) {
+        ApolloLog(@"ThemeShare: could not obtain CIImage from picked image");
+        return nil;
+    }
+
+    // Vision first for recompressed-image robustness; but if the best it found
+    // is a non-Apollo QR, still give CIDetector a chance to surface the tagged
+    // one before giving up (an untagged result is a guaranteed reject anyway).
+    NSString *payload = ATSReadQRVision(ci);
+    if (![payload hasPrefix:kThemeQRTag]) {
+        NSString *alt = ATSReadQRCIDetector(ci);
+        if ([alt hasPrefix:kThemeQRTag] || !payload.length) payload = alt;
+    }
+    if (!payload.length) {
+        ApolloLog(@"ThemeShare: no QR found in image");
+        return nil;
+    }
+    return ApolloThemeShareDecodePayload(payload);
+}


### PR DESCRIPTION
Recovery PR for #546, which GitHub closed unmerged when the stacked base branch `je/theme-hub` disappeared after #576 merged. This reapplies #546 on top of current `main`.

Original author: @icpryde. The two recovered commits preserve icpryde as the git author; original reviewed/approved PR: #546.

Validation: `make package` passed locally on `recover/pr-546-share-theme-image`.

---

## What

Adds **share & import a custom theme as a single image** to **Theme Manager v2**, alongside its JSON export/import. Rebuilt on the full v2 stack — this PR now targets **`je/theme-hub`** (the 4/4 tip: #558 → #574 AI → #575 fonts → #576 hub/gallery), so it drops straight in once that stack lands.

Sharing a theme as a `.json` is awkward on social media (nowhere to host it). Instead this renders an **image card** — a mock Apollo post painted in the theme's compiled colours (mirroring the editor Preview), the palette, a Dark/Light badge, and a **QR** carrying the whole theme — that another user saves and imports.

## Screenshot

<img width="443" height="553" alt="Screenshot 2026-07-03 at 1 01 19 AM" src="https://github.com/user-attachments/assets/367742c3-8a05-466c-9c9e-0af8e530824c" />

## Font support (schema v3)

Since the fonts PR (#575) added a per-theme app-wide font, the card and codec carry it:

- The card's mock post is rendered **in the theme's font** (`ApolloThemeFontApply`), and the palette row names it as a specimen (e.g. `Aa  New York`). So the card previews the typeface, not just the colours.
- The QR blob is bumped to **version `0x03`**: `[variant][flags][font]` bytes. Older blobs still decode — `0x02` (pre-font v2 cards) → font defaults to system; `0x01` (original Theme Builder cards) → legacy role mapping. Both routes converge on the Store's `parseImportData:`, which round-trips the `font` key.

## UI (hub layout)

- **Editor → "Share…"** (new section between Preview and Apply) → **As Image…** (QR card) or **As Theme File…** (portable `.json`), then the system share sheet.
- **Create → "Import Theme…"** fans out to **From File… / From Photo… / Scan with Camera…** The document picker also accepts card **images** and sniffs by content (sideload installs mistype `.json`). Camera reuses `ApolloThemeQRScanViewController`.
- All import routes go through `parseImportData:` → the existing confirm dialog; imports stamp `generation.source = imported-qr / imported-qr-v1` and live-reload the runtime.
- Share sheet header shows the card thumbnail + `"‹name› — Apollo theme"` via `LPLinkMetadata` (a bare `UIImage` shows the generic white icon-grid placeholder).

## Runtime/UX fixes carried along (small, separable)

- **Themed selection highlight** on the Inbox boxes + Appearance rows (donor's selected-cell colour shares its dark hex with the page background, so presses collapsed onto the Background token). `ApolloThemeIntegrations.xm`.
- **Themed inbox unread tint** — unread rows kept Apollo's stock blue; two donor entries (`95C0EE`/`034388`, exclusive to InboxCellNode) route it to the Selection token. `ApolloThemeRuntime.xm`.

(The generation-sanitize fix from the earlier round is dropped — #574 added `PlistSanitized` upstream.)

## Why a visible QR

Reddit re-encodes uploads to lossy JPEG, destroying pixel-hidden data. A visible level-H QR survives (high-contrast, geometric, ~30% error correction). Payload is ~60–75 bytes.

## Testing (Apollo-Sim2, full stack: latest main + #558→#576 + this PR)

- Clean build + merge on `je/theme-hub`; tweak loads, hub renders (Current/Create/Browse/My Themes/Gallery), editor shows the Font grid + Share… row.
- **Font end-to-end**: set a theme's font to New York and applied it — the entire app (feed, comments, hub) renders in New York serif; the shared card's mock post + palette specimen render in serif too, and its QR decodes to `font=serif`.
- Card → Save Image → re-import round-trips byte-exact; the share-sheet header shows the card thumbnail (no white placeholder).
- Codec: `0x03` round-trips variant/flags/font; `0x02` and `0x01` blobs still decode (back-compat verified).
- Note: Vision's barcode engine is unavailable in the Simulator, so the `CIDetector` fallback covers image decode there; camera scan is device-only.

