### PR TITLE
Stats row improvements + theme accent everywhere

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,13 @@ xcrun simctl spawn "$(cat .sim/device.txt)" log show --last 2m --predicate 'subs
 - **Logging**: Use `ApolloLog` for privacy-friendly diagnostics
 - When iterating on a feature, if something isn't working, prefer outright replacing the implementation over adding fallback codepaths. Use generous amount of comments and diagnostic/debug logging.
 
+## Theme Accent in Tweak-Drawn UI
+
+- Any accent color in tweak-drawn UI comes from `ApolloThemeAccentColor()` (`ApolloThemeRuntime.h`): the custom theme's accent when one is active, else the stock Apollo theme's (all 18 themes; `kStockThemes` table in `ApolloThemeRuntime.xm`, values recovered from the binary — see docs/theme-builder-RE.md). Chain as `ApolloThemeAccentColor() ?: someView.tintColor ?: systemBlue`; never hand-roll nav/tab-bar tintColor walks (they only ever approximated the accent).
+- `UIView.tintColor` never returns nil for a real view (it inherits, bottoming out at system blue) — a fallback arm after a guaranteed-non-nil tint read is dead code. Nil only arrives via messaging a nil view, which is what the `?: systemBlue` tail covers.
+- The returned accent is a dynamic provider color. Before any `.CGColor` use (layer borders, ASDK background-thread layout), resolve it with `resolvedColorWithTraitCollection:` against an in-hierarchy view's traits — ambient resolution can pick the wrong light/dark variant when Apollo overrides the window style.
+- Text drawn on an accent fill needs `ApolloColorIsLight()` (ApolloCommon) to choose black vs white — stock monochromatic (dark) and chumbus (light) accents are near-white.
+
 ## Testing
 
 No automated test suite, must be validated manually.

--- a/docs/theme-builder-RE.md
+++ b/docs/theme-builder-RE.md
@@ -98,8 +98,11 @@ Accents (light / dark):
 | magentasplosion | FF00B2 | E800A2 |
 | sniffingWalnut | A74E00 | A74E00 |
 | fisherKing | 808286 | 76787D |
+| chumbus | F8F8F8 | 20242B* |
 | dracula | 9760FF | AD81FF |
-| mint | 37BB98 | (n/c) |
+| mint | 37BB98 | 62DFA7 |
+
+*chumbus dark becomes 000000 with UsePureBlackDarkMode (050505 with PureBlackModeReduceSmearing on top).
 
 Tinted-theme palettes (primary/secondary/tertiary bg, separator, bar, gray):
 

--- a/src/ApolloAISummary.xm
+++ b/src/ApolloAISummary.xm
@@ -25,6 +25,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloAISummary.h"
+#import "ApolloThemeRuntime.h"
 #import "ApolloState.h"
 #import "Tweak.h"
 
@@ -1593,16 +1594,12 @@ static void ApolloAIApplyRestoredState(id headerNode, NSString *fullName);
 static UIColor *ApolloAISummaryThemeAccent(id headerNode) {
     NSString *fullName = objc_getAssociatedObject(headerNode, &kApolloAIHeaderFullNameKey);
     UIViewController *vc = [sControllerByFullName objectForKey:fullName];
-    NSArray<UIColor *> *candidates = @[
-        vc.navigationController.navigationBar.tintColor ?: UIColor.clearColor,
-        vc.tabBarController.tabBar.tintColor ?: UIColor.clearColor,
-        vc.view.tintColor ?: UIColor.clearColor,
-        vc.view.window.tintColor ?: UIColor.clearColor,
-    ];
-    for (UIColor *candidate in candidates) {
-        if (candidate && candidate != UIColor.clearColor) return candidate;
-    }
-    return UIColor.systemBlueColor;
+    UIColor *accent = ApolloThemeAccentColor() ?: vc.viewIfLoaded.tintColor ?: UIColor.systemBlueColor;
+    // Consumers take .CGColor on ASDK's background layout thread, where the
+    // ambient trait collection is unspecified — resolve against the owning
+    // view's traits now so light/dark can't flip per-thread.
+    UITraitCollection *tc = vc.viewIfLoaded.traitCollection;
+    return tc ? [accent resolvedColorWithTraitCollection:tc] : accent;
 }
 
 // A baseline-aligned SF Symbol as an attributed string, sized to `font` and

--- a/src/ApolloAccountSwitcherViewController.xm
+++ b/src/ApolloAccountSwitcherViewController.xm
@@ -3,6 +3,7 @@
 #import "ApolloWebSessionStore.h"
 #import "ApolloWebSessionLoginViewController.h"
 #import "ApolloState.h"
+#import "ApolloThemeRuntime.h"
 #import "ApolloCommon.h"
 #import "UserDefaultConstants.h"
 #import "ApolloUserProfileCache.h"
@@ -384,7 +385,7 @@ static id _Nullable ApolloGetObjectIvar(id object, const char *name) {
     if (indexPath.section == 1) {
         UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"AddRow" forIndexPath:indexPath];
         cell.textLabel.text = @"Add Account…";
-        cell.textLabel.textColor = self.view.tintColor;
+        cell.textLabel.textColor = ApolloThemeAccentColor() ?: self.view.tintColor;
         cell.accessoryType = UITableViewCellAccessoryNone;
         return cell;
     }
@@ -413,7 +414,7 @@ static id _Nullable ApolloGetObjectIvar(id object, const char *name) {
     // hidden arranged subview's width to zero, which shifted the info button
     // left on every non-active row instead of leaving its slot reserved.
     UIImageView *checkmark = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"checkmark"]];
-    checkmark.tintColor = self.view.tintColor;
+    checkmark.tintColor = ApolloThemeAccentColor() ?: self.view.tintColor;
     checkmark.alpha = row.isActive ? 1.0 : 0.0;
     checkmark.contentMode = UIViewContentModeCenter;
     checkmark.frame = CGRectMake(0, 0, 20, 24);

--- a/src/ApolloBannedProfile.xm
+++ b/src/ApolloBannedProfile.xm
@@ -1,5 +1,6 @@
 #import "ApolloBannedProfile.h"
 #import "ApolloCommon.h"
+#import "ApolloThemeRuntime.h"
 #import "ApolloUserProfileCache.h"
 #import <objc/message.h>
 #import <dlfcn.h>
@@ -674,20 +675,9 @@ NSString *ApolloBannedProfileBannedDescriptionText(void) {
 @end
 
 // Resolves the active Apollo theme's accent color from the host profile's chrome.
-// Apollo themes its nav/tab bars with the accent color, so prefer those over the
-// UIKit-default view tint (which stays system blue when untouched).
+// Theme accent (custom or stock Apollo theme); view tint as a last resort.
 static UIColor *ApolloBannedProfileResolveAccentColor(UIViewController *viewController) {
-    NSMutableArray<UIColor *> *candidates = [NSMutableArray array];
-    UITabBar *tabBar = viewController.tabBarController.tabBar;
-    if (tabBar.tintColor) [candidates addObject:tabBar.tintColor];
-    UINavigationBar *navBar = viewController.navigationController.navigationBar;
-    if (navBar.tintColor) [candidates addObject:navBar.tintColor];
-    if (viewController.view.window.tintColor) [candidates addObject:viewController.view.window.tintColor];
-    if (viewController.view.tintColor) [candidates addObject:viewController.view.tintColor];
-    for (UIColor *color in candidates) {
-        if ([color isKindOfClass:[UIColor class]]) return color;
-    }
-    return viewController.view.tintColor ?: [UIColor systemBlueColor];
+    return ApolloThemeAccentColor() ?: viewController.view.tintColor ?: [UIColor systemBlueColor];
 }
 
 NSString *ApolloBannedProfileMessageForUsername(NSString *username) {

--- a/src/ApolloLiveCommentsFollow.xm
+++ b/src/ApolloLiveCommentsFollow.xm
@@ -43,6 +43,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloState.h"
+#import "ApolloThemeRuntime.h"
 
 @interface _TtC6Apollo22CommentsViewController : UIViewController
 @end
@@ -370,16 +371,7 @@ static CGFloat LCFToolbarBottom(UIViewController *vc) {
 // MARK: - theming (ported from ApolloAISummary)
 
 static UIColor *LCFThemeAccent(UIViewController *vc) {
-    NSArray<UIColor *> *candidates = @[
-        vc.navigationController.navigationBar.tintColor ?: UIColor.clearColor,
-        vc.tabBarController.tabBar.tintColor ?: UIColor.clearColor,
-        vc.view.tintColor ?: UIColor.clearColor,
-        vc.view.window.tintColor ?: UIColor.clearColor,
-    ];
-    for (UIColor *c in candidates) {
-        if (c && c != UIColor.clearColor) return c;
-    }
-    return UIColor.systemBlueColor;
+    return ApolloThemeAccentColor() ?: vc.view.tintColor ?: UIColor.systemBlueColor;
 }
 
 static NSAttributedString *LCFSymbolAttachment(NSString *symbolName, UIFont *font, UIColor *tint) {
@@ -436,16 +428,20 @@ static void LCFEnsurePill(UIViewController *vc) {
 static void LCFSetPillContent(UIViewController *vc, NSString *text) {
     UIButton *btn = LCFButton(vc);
     if (!btn) return;
-    btn.backgroundColor = LCFThemeAccent(vc);
+    UIColor *accent = LCFThemeAccent(vc);
+    btn.backgroundColor = accent;
+    // Near-white accents (stock chumbus light / monochromatic dark) need dark text.
+    UIColor *fg = ApolloColorIsLight([accent resolvedColorWithTraitCollection:btn.traitCollection])
+        ? UIColor.blackColor : UIColor.whiteColor;
 
     NSMutableAttributedString *title = [[NSMutableAttributedString alloc] init];
-    NSAttributedString *chevron = LCFSymbolAttachment(@"chevron.up", btn.titleLabel.font, UIColor.whiteColor);
+    NSAttributedString *chevron = LCFSymbolAttachment(@"chevron.up", btn.titleLabel.font, fg);
     if (chevron) {
         [title appendAttributedString:chevron];
         [title appendAttributedString:[[NSAttributedString alloc] initWithString:@"  "]];
     }
     [title appendAttributedString:[[NSAttributedString alloc] initWithString:text attributes:@{
-        NSForegroundColorAttributeName: UIColor.whiteColor,
+        NSForegroundColorAttributeName: fg,
         NSFontAttributeName: btn.titleLabel.font,
     }]];
     [btn setAttributedTitle:title forState:UIControlStateNormal];

--- a/src/ApolloManualSignInViewController.m
+++ b/src/ApolloManualSignInViewController.m
@@ -1,5 +1,6 @@
 #import "ApolloManualSignInViewController.h"
 #import "ApolloCommon.h"
+#import "ApolloThemeRuntime.h"
 
 // Raw userscript URL. Opening a *.user.js link in a Gecko browser triggers
 // Tampermonkey/Violentmonkey's one-tap install prompt — far better UX than
@@ -297,7 +298,10 @@ static NSString *ARExtractParam(NSString *urlString, NSString *name) {
 
 - (UIButton *)_button:(NSString *)title filled:(BOOL)filled action:(SEL)action {
     UIButton *b = [UIButton buttonWithType:UIButtonTypeSystem];
-    
+    UIColor *tint = ApolloThemeAccentColor() ?: self.view.tintColor ?: [UIColor systemBlueColor];
+    b.tintColor = tint;   // themes both branches (UIButtonConfiguration derives from tintColor)
+    BOOL lightAccent = ApolloColorIsLight([tint resolvedColorWithTraitCollection:self.traitCollection]);
+
     // UIButtonConfiguration is iOS 15+. Apollo Reborn still loads on iOS 14
     // (jailbreak), so fall back to manual styling there.
     if (@available(iOS 15.0, *)) {
@@ -307,6 +311,8 @@ static NSString *ARExtractParam(NSString *urlString, NSString *name) {
         cfg.title = title;
         cfg.cornerStyle = UIButtonConfigurationCornerStyleLarge;
         cfg.contentInsets = NSDirectionalEdgeInsetsMake(12, 16, 12, 16);
+        // Near-white accents (stock chumbus/monochromatic) need dark text on a fill.
+        if (filled && lightAccent) cfg.baseForegroundColor = [UIColor blackColor];
         b.configuration = cfg;
     } else {
         [b setTitle:title forState:UIControlStateNormal];
@@ -314,10 +320,10 @@ static NSString *ARExtractParam(NSString *urlString, NSString *name) {
         b.contentEdgeInsets = UIEdgeInsetsMake(12, 16, 12, 16); // iOS 14 fallback; ignored under UIButtonConfiguration
         b.layer.cornerRadius = 12;
         b.clipsToBounds = YES;
-        UIColor *tint = self.view.tintColor ?: [UIColor systemBlueColor];
         if (filled) {
             b.backgroundColor = tint;
-            [b setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+            [b setTitleColor:(lightAccent ? [UIColor blackColor] : [UIColor whiteColor])
+                    forState:UIControlStateNormal];
         } else {
             b.backgroundColor = [tint colorWithAlphaComponent:0.15];
             [b setTitleColor:tint forState:UIControlStateNormal];

--- a/src/ApolloMarkdownToolbarGif.xm
+++ b/src/ApolloMarkdownToolbarGif.xm
@@ -1,5 +1,6 @@
 #import "ApolloMarkdownToolbarGif.h"
 #import "ApolloCommon.h"
+#import "ApolloThemeRuntime.h"
 #import "ApolloGiphyClient.h"
 #import "ApolloState.h"
 #import "ApolloSubredditInfoCache.h"
@@ -593,7 +594,7 @@ static void ApolloMarkdownGifApplyButtonChrome(UIButton *gifButton, UIColor *tin
 
 static UIButton *ApolloMarkdownGifMakeButton(UIControl *imageControl) {
     CGFloat slot = ApolloMarkdownGifSlotDimension(imageControl);
-    UIColor *tint = imageControl.tintColor ?: UIColor.systemTealColor;
+    UIColor *tint = ApolloThemeAccentColor() ?: imageControl.tintColor ?: UIColor.systemTealColor;
     UIButton *gifButton = [UIButton buttonWithType:UIButtonTypeSystem];
     gifButton.translatesAutoresizingMaskIntoConstraints = NO;
     gifButton.accessibilityIdentifier = kApolloMarkdownGifButtonIdentifier;

--- a/src/ApolloPhotoPostComposerScrollFix.xm
+++ b/src/ApolloPhotoPostComposerScrollFix.xm
@@ -7,6 +7,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloState.h"
+#import "ApolloThemeRuntime.h"
 #import "fishhook.h"
 
 @class PHAssetCollection;
@@ -2829,15 +2830,7 @@ static BOOL ApolloPhotoComposerTextEqualsPost(NSString *text) {
 }
 
 static UIColor *ApolloPhotoComposerAccentColor(UIViewController *controller) {
-    NSMutableArray<UIColor *> *candidates = [NSMutableArray array];
-    if (controller.tabBarController.tabBar.tintColor) [candidates addObject:controller.tabBarController.tabBar.tintColor];
-    if (controller.navigationController.navigationBar.tintColor) [candidates addObject:controller.navigationController.navigationBar.tintColor];
-    if (controller.view.tintColor) [candidates addObject:controller.view.tintColor];
-    if (controller.view.window.tintColor) [candidates addObject:controller.view.window.tintColor];
-    for (UIColor *color in candidates) {
-        if ([color isKindOfClass:[UIColor class]]) return color;
-    }
-    return nil;
+    return ApolloThemeAccentColor() ?: controller.view.tintColor;
 }
 
 static BOOL ApolloPhotoComposerApplyAccentToPostButton(UIButton *button, UIColor *accentColor) {

--- a/src/ApolloSettingsTableViewController.m
+++ b/src/ApolloSettingsTableViewController.m
@@ -1,6 +1,7 @@
 #import "ApolloSettingsTableViewController.h"
 
 #import "ApolloCommon.h"
+#import "ApolloThemeRuntime.h"
 #import <objc/runtime.h>
 
 static char kApolloAccentActionCellKey;
@@ -36,16 +37,7 @@ static char kApolloAccentActionCellKey;
 }
 
 - (UIColor *)apollo_themeAccentColor {
-    NSMutableArray<UIColor *> *candidates = [NSMutableArray array];
-    if (self.tabBarController.tabBar.tintColor) [candidates addObject:self.tabBarController.tabBar.tintColor];
-    if (self.navigationController.navigationBar.tintColor) [candidates addObject:self.navigationController.navigationBar.tintColor];
-    if (self.view.tintColor) [candidates addObject:self.view.tintColor];
-    if (self.tableView.tintColor) [candidates addObject:self.tableView.tintColor];
-    if (self.view.window.tintColor) [candidates addObject:self.view.window.tintColor];
-    for (UIColor *color in candidates) {
-        if ([color isKindOfClass:[UIColor class]]) return color;
-    }
-    return self.view.tintColor ?: [UIColor systemBlueColor];
+    return ApolloThemeAccentColor() ?: self.view.tintColor ?: [UIColor systemBlueColor];
 }
 
 - (void)apollo_applyAccentActionTextColorToCell:(UITableViewCell *)cell {

--- a/src/ApolloStatsRowTouch.xm
+++ b/src/ApolloStatsRowTouch.xm
@@ -650,6 +650,7 @@ static const void *kSRTLoupeSelKey = &kSRTLoupeSelKey;         // NSNumber: sele
 static const void *kSRTLoupeScrollLockKey = &kSRTLoupeScrollLockKey; // RETAIN: UIScrollView we disabled while the loupe is up
 static const void *kSRTLoupeCancelKey = &kSRTLoupeCancelKey;   // NSNumber BOOL: finger dragged away — release cancels
 static const void *kSRTLoupeTouchStartKey = &kSRTLoupeTouchStartKey; // NSValue CGPoint: touch-down point (window coords)
+static const void *kSRTLoupeTintKey = &kSRTLoupeTintKey;       // RETAIN: accent resolved once per hold
 
 enum { kSRTGestureTypeCommentTap = 1, kSRTGestureTypeLoupe = 2 };
 
@@ -673,13 +674,13 @@ static UIImage *SRTSnapshotStrip(UIView *cellView, CGRect stripRect) {
     }];
 }
 
-// Selection pill tint: the custom theme's accent when one is active (dynamic,
-// nil otherwise), else the window tint (Apollo's own accent), else system blue.
+// Selection pill tint: the theme accent (custom or stock Apollo theme — Mint →
+// mint, etc.), else the cell's tint, else system blue. Resolved against the
+// cell's traits now: the pill's ring paints via layer borderColor (.CGColor),
+// which would otherwise resolve against the ambient traits, not the cell's.
 static UIColor *SRTAccentTint(UIView *cellView) {
-    UIColor *themed = ApolloThemeRuntimeColor(ApolloThemeTokenAccent);
-    if (themed) return themed;
-    UIColor *t = cellView.window.tintColor ?: cellView.tintColor;
-    return t ?: [UIColor systemBlueColor];
+    UIColor *accent = ApolloThemeAccentColor() ?: cellView.tintColor ?: [UIColor systemBlueColor];
+    return [accent resolvedColorWithTraitCollection:cellView.traitCollection];
 }
 
 // Pans we force-disabled while the loupe is up (edge-swipe back, parallax
@@ -731,6 +732,7 @@ static void SRTDismissLoupe(UIGestureRecognizer *gr, BOOL animated) {
     objc_setAssociatedObject(gr, kSRTLoupeScrollLockKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(gr, kSRTLoupeDisabledPansKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(gr, kSRTLoupeCancelKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(gr, kSRTLoupeTintKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 @implementation ApolloSRTGestureDelegate
@@ -942,7 +944,8 @@ static const CGFloat kSRTCancelSlopY = 64.0;
     ApolloSRTTarget *t = targets[sel];
     CGPoint stripOrigin = [(NSValue *)objc_getAssociatedObject(gr, kSRTLoupeStripOriginKey) CGPointValue];
     CGRect rectInStrip = CGRectOffset(t.rect, -stripOrigin.x, -stripOrigin.y);
-    [loupe selectRect:rectInStrip caption:t.caption tint:SRTAccentTint(cellView)];
+    UIColor *tint = objc_getAssociatedObject(gr, kSRTLoupeTintKey) ?: SRTAccentTint(cellView);
+    [loupe selectRect:rectInStrip caption:t.caption tint:tint];
     [loupe positionAboveScreenPoint:[gr locationInView:host] inHost:host];
     if (prev && prev.integerValue != sel) {
         [[[UISelectionFeedbackGenerator alloc] init] selectionChanged];
@@ -990,6 +993,7 @@ static const CGFloat kSRTCancelSlopY = 64.0;
             objc_setAssociatedObject(gr, kSRTLoupeTargetsKey, targets, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
             objc_setAssociatedObject(gr, kSRTLoupeStripOriginKey, [NSValue valueWithCGPoint:stripRect.origin], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
             objc_setAssociatedObject(gr, kSRTLoupeCancelKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);   // fresh hold, fresh escape state
+            objc_setAssociatedObject(gr, kSRTLoupeTintKey, SRTAccentTint(cellView), OBJC_ASSOCIATION_RETAIN_NONATOMIC);   // resolve once per hold, not per touch-move
             // Lock the feed's scroll while the loupe is up so sliding to pick an icon
             // never scrolls the list; restored in SRTDismissLoupe.
             for (UIView *v = cellView; v; v = v.superview) {

--- a/src/ApolloStatsRowTouch.xm
+++ b/src/ApolloStatsRowTouch.xm
@@ -39,6 +39,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloState.h"
+#import "ApolloThemeRuntime.h"
 #import "UIWindow+Apollo.h"
 
 // MARK: - Minimal AsyncDisplayKit forward declarations
@@ -207,21 +208,20 @@ static CGRect SRTStripRect(NSArray<ApolloSRTTarget *> *targets) {
 }
 
 // The claim = where a press-and-hold belongs to the magnifier (and the context
-// menu is suppressed). Deliberately MUCH fatter than the strip — a thumb press
-// anywhere along the row band must activate:
-//   * horizontally: from the cell's left edge (the ↑ hugs the screen edge)
-//     to well past the last icon (room for the +N chip / 🌐 marker growing);
-//   * vertically: a fat band around the icons, at least 56pt tall, and on feed
-//     cells all the way down to the cell's bottom (the info row is the last
-//     line — the padding under it reads as "that corner" to a thumb).
+// menu is suppressed). Fatter than the strip, but tight against neighbours:
+// reaches the screen edge only when the ↑ actually hugs the margin (in compact
+// layouts the thumbnail/username share the line), stays clear of the ••• past
+// the last icon, and pads generously below but only slightly above (the
+// username/subreddit line sits right on top of the row).
 static CGRect SRTClaimRect(id cell, UIView *cellView, NSArray<ApolloSRTTarget *> *targets) {
     if (targets.count == 0) return CGRectNull;
     CGRect u = targets.firstObject.rect;
     for (ApolloSRTTarget *t in targets) u = CGRectUnion(u, t.rect);
 
-    CGFloat left = 0.0;                                   // reach the screen edge
-    CGFloat right = CGRectGetMaxX(u) + 32.0;
-    CGFloat top = CGRectGetMinY(u) - 20.0;
+    CGFloat minX = CGRectGetMinX(u);
+    CGFloat left = (minX <= 28.0) ? 0.0 : minX - 12.0;   // screen edge only when the row starts there
+    CGFloat right = CGRectGetMaxX(u) + 10.0;
+    CGFloat top = CGRectGetMinY(u) - 6.0;
     CGFloat bottom = CGRectGetMaxY(u) + 20.0;
 
     // Feed cells: the row is the cell's last line — claim the trailing padding.
@@ -232,13 +232,64 @@ static CGRect SRTClaimRect(id cell, UIView *cellView, NSArray<ApolloSRTTarget *>
     CGFloat cellBottom = CGRectGetHeight(cellView.bounds);
     if (!isHeader && cellBottom - CGRectGetMaxY(u) < 44.0) bottom = cellBottom;
 
-    // Comfortable minimum height, centered on the row.
-    if (bottom - top < 56.0) {
-        CGFloat mid = CGRectGetMidY(u);
-        top = mid - 28.0;
-        bottom = MAX(bottom, mid + 28.0);
-    }
+    // Comfort height is gained downward only (above is the username line).
+    if (bottom - top < 44.0) bottom = top + 44.0;
     return CGRectMake(left, top, right - left, bottom - top);
+}
+
+// X-axis distance from x to rect's horizontal span (0 when within it).
+static CGFloat SRTXEdgeDistance(CGRect rect, CGFloat x) {
+    if (x < CGRectGetMinX(rect)) return CGRectGetMinX(rect) - x;
+    if (x > CGRectGetMaxX(rect)) return x - CGRectGetMaxX(rect);
+    return 0.0;
+}
+
+// Neighbours rendered by PostInfoNode that are NOT loupe territory: the
+// subreddit/author line and the ••• button. Containment alone can't decide —
+// node rects run much bigger than their glyphs (the author line often spans
+// the whole stats row below it) — so a neighbour's grown rect only NOMINATES
+// the press and proximity decides, ties going to the loupe: on its own line,
+// the vertically nearer midline wins (crossover = mid-gap); on the stats line
+// (•••), the nearer horizontal span wins.
+static BOOL SRTPointOnExcludedNeighbour(id cell, UIView *cellView, NSArray<ApolloSRTTarget *> *targets, CGPoint pt) {
+    id postInfoNode = SRTIvar(cell, "postInfoNode");
+    if (!postInfoNode || !cellView.layer || targets.count == 0) return NO;
+    CGRect u = targets.firstObject.rect;
+    for (ApolloSRTTarget *t in targets) u = CGRectUnion(u, t.rect);
+    CGFloat statsMidY = CGRectGetMidY(u);
+    static const char *neighbours[] = {
+        "subredditIconNode", "subredditButtonNode", "authorButtonNode",
+        "flairNode", "cakedayNode", "moreOptionsButtonNode",
+    };
+    for (size_t i = 0; i < sizeof(neighbours) / sizeof(neighbours[0]); i++) {
+        ApolloSRTNode *node = (ApolloSRTNode *)SRTIvar(postInfoNode, neighbours[i]);
+        if (!node || node.isHidden) continue;
+        CALayer *layer = nil;
+        @try { layer = node.layer; } @catch (__unused id e) {}
+        if (!layer) continue;
+        CGRect rect = [layer convertRect:layer.bounds toLayer:cellView.layer];
+        if (CGRectIsEmpty(rect) || CGRectIsNull(rect) || CGRectIsInfinite(rect)) continue;
+        CGRect grown = UIEdgeInsetsInsetRect(rect, (UIEdgeInsets){-4.0, -4.0, -8.0, -4.0});
+        if (!CGRectContainsPoint(grown, pt)) continue;
+        if (fabs(CGRectGetMidY(rect) - statsMidY) > 8.0) {
+            // Own line above the stats: vertical midline proximity decides.
+            if (fabs(pt.y - CGRectGetMidY(rect)) < fabs(pt.y - statsMidY)) return YES;
+        } else {
+            // On the stats line: nearer horizontal span decides.
+            CGFloat statDist = CGFLOAT_MAX;
+            for (ApolloSRTTarget *t in targets) statDist = MIN(statDist, SRTXEdgeDistance(t.rect, pt.x));
+            if (SRTXEdgeDistance(rect, pt.x) < statDist) return YES;
+        }
+    }
+    return NO;
+}
+
+// Single source of truth for both the gesture's touch gating and the
+// context-menu suppression: inside the claim and not on an excluded neighbour.
+static BOOL SRTPointClaimedForLoupe(id cell, UIView *cellView, NSArray<ApolloSRTTarget *> *targets, CGPoint pt) {
+    CGRect claim = SRTClaimRect(cell, cellView, targets);
+    if (CGRectIsNull(claim) || !CGRectContainsPoint(claim, pt)) return NO;
+    return !SRTPointOnExcludedNeighbour(cell, cellView, targets, pt);
 }
 
 // Nearest target to a point's X (Voronoi on centers). Fills the gaps so every
@@ -598,6 +649,7 @@ static const void *kSRTLoupeStripOriginKey = &kSRTLoupeStripOriginKey; // NSValu
 static const void *kSRTLoupeSelKey = &kSRTLoupeSelKey;         // NSNumber: selected index
 static const void *kSRTLoupeScrollLockKey = &kSRTLoupeScrollLockKey; // RETAIN: UIScrollView we disabled while the loupe is up
 static const void *kSRTLoupeCancelKey = &kSRTLoupeCancelKey;   // NSNumber BOOL: finger dragged away — release cancels
+static const void *kSRTLoupeTouchStartKey = &kSRTLoupeTouchStartKey; // NSValue CGPoint: touch-down point (window coords)
 
 enum { kSRTGestureTypeCommentTap = 1, kSRTGestureTypeLoupe = 2 };
 
@@ -621,7 +673,11 @@ static UIImage *SRTSnapshotStrip(UIView *cellView, CGRect stripRect) {
     }];
 }
 
+// Selection pill tint: the custom theme's accent when one is active (dynamic,
+// nil otherwise), else the window tint (Apollo's own accent), else system blue.
 static UIColor *SRTAccentTint(UIView *cellView) {
+    UIColor *themed = ApolloThemeRuntimeColor(ApolloThemeTokenAccent);
+    if (themed) return themed;
     UIColor *t = cellView.window.tintColor ?: cellView.tintColor;
     return t ?: [UIColor systemBlueColor];
 }
@@ -679,12 +735,12 @@ static void SRTDismissLoupe(UIGestureRecognizer *gr, BOOL animated) {
 
 @implementation ApolloSRTGestureDelegate
 
-// A touch that starts inside the claim belongs to the magnifier, full stop.
+// A touch the loupe claims (SRTPointClaimedForLoupe) belongs to the magnifier.
 // Enforced with UIKit's own priority primitive: every competing press/pan on
 // the ancestor chain is wired (once, permanently) to REQUIRE THE LOUPE TO FAIL
-// before it may begin. Outside the claim the loupe never tracks the touch, so
-// it counts as failed and everything behaves stock; inside the claim the loupe
-// begins at 0.3s, the requirement is never satisfied, and the context menu /
+// before it may begin. On unclaimed touches the loupe never tracks, counts as
+// failed, and everything behaves stock; on claimed ones it begins at 0.3s
+// (unless the swipe veto fails it, releasing everyone) and the context menu /
 // swipe-back / swipe actions simply cannot start. Deterministic — no
 // enable/disable churn, no delivery-order races. (A hard disable is NOT usable
 // here: a disabled recognizer wedges UIKit's arbitration and the loupe itself
@@ -735,22 +791,24 @@ static void SRTWireCornerFailureRequirements(UIGestureRecognizer *loupe, UIView 
     if (!cell) return NO;
     if (type.integerValue == kSRTGestureTypeLoupe) {
         if (!sIconRowMagnifier) return NO;
-        // Claim + clear the field ONLY when the touch starts on the icon strip:
-        // the system press recognizers are reset there (they'd otherwise stall us
-        // and pop the context menu); outside the strip we take no touches and the
-        // context menu behaves stock.
+        // Take the touch only where the loupe owns it (in the row band, not on
+        // a subreddit/author/••• neighbour); anywhere else everything — context
+        // menu included — behaves stock.
         UIView *cellView = nil;
         @try { cellView = [(ApolloSRTNode *)cell view]; } @catch (__unused id e) {}
         if (!cellView) return NO;
         NSArray<ApolloSRTTarget *> *targets = SRTTargetsForCell(cell, cellView);
         if (targets.count == 0) return NO;
-        // A hold anywhere along the row band belongs to the magnifier — the
-        // context menu never fires there while the toggle is on; outside the
-        // band everything behaves stock.
-        CGRect claim = SRTClaimRect(cell, cellView, targets);
         CGPoint pt = [touch locationInView:cellView];
-        BOOL inside = CGRectContainsPoint(claim, pt);
-        if (inside) SRTWireCornerFailureRequirements(gr, cellView);
+        BOOL inside = SRTPointClaimedForLoupe(cell, cellView, targets, pt);
+        if (inside) {
+            // Touch-down point (window coords) — shouldBegin measures travel
+            // against it to tell a hold from a swipe.
+            objc_setAssociatedObject(gr, kSRTLoupeTouchStartKey,
+                                     [NSValue valueWithCGPoint:[touch locationInView:nil]],
+                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            SRTWireCornerFailureRequirements(gr, cellView);
+        }
         return inside;
     }
     // The comment tap only cares about the comment-bubble region.
@@ -760,13 +818,45 @@ static void SRTWireCornerFailureRequirements(UIGestureRecognizer *loupe, UIView 
     return SRTTouchHitsNode(commentsNode, cellView, touch, kSRTCommentInsets);
 }
 
-// Touch delivery already gated to the strip in shouldReceiveTouch; re-check the
-// flag and cell wiring at transition time.
+// Max finger travel between touch-down and the 0.3s mark that still reads as a
+// hold. Vertical is strict (a slow swipe must not pop the loupe); horizontal
+// gets more room (sliding along the row is the loupe's own axis).
+static const CGFloat kSRTHoldMaxTravelY = 16.0;
+static const CGFloat kSRTHoldMaxTravel  = 40.0;
+
+// Touch delivery already gated to the strip in shouldReceiveTouch; at transition
+// time re-check the flag/cell wiring and veto swipe-intent touches. Returning NO
+// fails the press cleanly, releasing every recognizer wired to wait on us.
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gr {
     NSNumber *type = objc_getAssociatedObject(gr, kSRTGestureTypeKey);
     if (type.integerValue != kSRTGestureTypeLoupe) return YES;
-    BOOL ok = sIconRowMagnifier && objc_getAssociatedObject(gr, kSRTCommentGestureCellKey) != nil;
-    return ok;
+    id cell = objc_getAssociatedObject(gr, kSRTCommentGestureCellKey);
+    if (!sIconRowMagnifier || !cell) return NO;
+
+    // The feed is already scrolling under this touch — that's a swipe, not a hold.
+    UIView *cellView = nil;
+    @try { cellView = [(ApolloSRTNode *)cell view]; } @catch (__unused id e) {}
+    for (UIView *v = cellView; v; v = v.superview) {
+        if ([v isKindOfClass:[UIScrollView class]]) {
+            if (((UIScrollView *)v).isDragging) {
+                ApolloLog(@"[StatsRow] loupe vetoed — feed is scrolling");
+                return NO;
+            }
+            break;
+        }
+    }
+    // The finger has visibly travelled since touch-down — swipe intent.
+    NSValue *startVal = objc_getAssociatedObject(gr, kSRTLoupeTouchStartKey);
+    if (startVal) {
+        CGPoint start = startVal.CGPointValue;
+        CGPoint now = [gr locationInView:nil];
+        CGFloat dx = now.x - start.x, dy = now.y - start.y;
+        if (fabs(dy) > kSRTHoldMaxTravelY || hypot(dx, dy) > kSRTHoldMaxTravel) {
+            ApolloLog(@"[StatsRow] loupe vetoed — finger travelled (%.0f, %.0f)", dx, dy);
+            return NO;
+        }
+    }
+    return YES;
 }
 
 // Always allow simultaneous recognition. Exclusivity CANNOT be used here: if any
@@ -980,11 +1070,9 @@ static void SRTInstallInfoRowGestures(id cell) {
     UILongPressGestureRecognizer *loupe = [[UILongPressGestureRecognizer alloc] initWithTarget:SRTDelegate()
                                                                                         action:@selector(srtLoupeLongPress:)];
     loupe.minimumPressDuration = 0.3;
-    // Default allowableMovement is a strict 10pt — a thumb wobbles more than
-    // that in 0.3s, silently failing the press (and with the context menu
-    // neutralized in the band, "nothing happens"). Real scroll intent still
-    // wins: the scroll pan recognizes long before this threshold matters and
-    // the loupe is exclusive, so it can't begin once a pan is active.
+    // The default 10pt is strict enough that a wobbly thumb silently fails the
+    // press. Keep it loose; swipe intent is vetoed at begin time instead
+    // (gestureRecognizerShouldBegin:).
     loupe.allowableMovement = 60.0;
     loupe.cancelsTouchesInView = YES;   // own the touch while the loupe is up
     loupe.delegate = SRTDelegate();
@@ -1204,8 +1292,8 @@ static void SRTScheduleTick(__weak UIViewController *weakVC, long gen, NSDate *d
 // (PostCellActionTaker for feed posts, CommentsHeaderSectionController for the
 // comments header) is asked for a configuration WHEN the press is recognized.
 // Return nil there and no menu appears — no timing, no arbitration. We return
-// nil only when the press lands in the icon-row claim and the magnifier is on;
-// everywhere else %orig runs and the menu behaves exactly as stock.
+// nil only where the loupe would claim the press (SRTPointClaimedForLoupe) and
+// the magnifier is on; everywhere else %orig runs and the menu behaves stock.
 static BOOL SRTShouldSuppressMenu(id interaction, CGPoint location) {
     if (!sIconRowMagnifier) return NO;
     UIView *iview = nil;
@@ -1226,9 +1314,8 @@ static BOOL SRTShouldSuppressMenu(id interaction, CGPoint location) {
     if (!cell || !cellView) return NO;
     NSArray<ApolloSRTTarget *> *targets = SRTTargetsForCell(cell, cellView);
     if (targets.count == 0) return NO;
-    CGRect claim = SRTClaimRect(cell, cellView, targets);
     CGPoint p = (iview == cellView) ? location : [iview convertPoint:location toView:cellView];
-    return CGRectContainsPoint(claim, p);
+    return SRTPointClaimedForLoupe(cell, cellView, targets, p);
 }
 
 %hook _TtC6Apollo19PostCellActionTaker

--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -5,6 +5,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloState.h"
+#import "ApolloThemeRuntime.h"
 #import "UserDefaultConstants.h"
 
 static char kApolloSubredditIndexTableKey;
@@ -88,22 +89,7 @@ static UIViewController *ApolloSubredditIndexOwningViewController(UIView *view) 
 }
 
 static UIColor *ApolloSubredditIndexThemeAccentColor(UITableView *tableView, UIView *fallbackView) {
-    UIViewController *viewController = ApolloSubredditIndexOwningViewController(tableView ?: fallbackView);
-    NSMutableArray<UIColor *> *candidates = [NSMutableArray array];
-
-    if (viewController.tabBarController.tabBar.tintColor) [candidates addObject:viewController.tabBarController.tabBar.tintColor];
-    if (viewController.navigationController.navigationBar.tintColor) [candidates addObject:viewController.navigationController.navigationBar.tintColor];
-    if (viewController.view.tintColor) [candidates addObject:viewController.view.tintColor];
-    if (tableView.tintColor) [candidates addObject:tableView.tintColor];
-    if (fallbackView.tintColor) [candidates addObject:fallbackView.tintColor];
-    if (tableView.window.tintColor) [candidates addObject:tableView.window.tintColor];
-    if (fallbackView.window.tintColor) [candidates addObject:fallbackView.window.tintColor];
-
-    for (UIColor *color in candidates) {
-        if ([color isKindOfClass:[UIColor class]]) return color;
-    }
-
-    return fallbackView.tintColor ?: tableView.tintColor ?: [UIColor systemBlueColor];
+    return ApolloThemeAccentColor() ?: fallbackView.tintColor ?: tableView.tintColor ?: [UIColor systemBlueColor];
 }
 
 static BOOL ApolloSubredditIndexColorIsVisible(UIColor *color) {

--- a/src/ApolloThemeRuntime.h
+++ b/src/ApolloThemeRuntime.h
@@ -13,8 +13,10 @@
 // currentTraitCollection guessing and no per-frame allocation.
 //
 // The runtime is deliberately small and deterministic: it knows nothing about
-// prompts, editor state, theme names, or variant generation — only the compiled
-// light/dark token table the Store + Compiler hand it.
+// prompts, editor state, or variant generation — only the compiled light/dark
+// token table the Store + Compiler hand it, plus a recovered table of the
+// stock Apollo themes' accents (served through ApolloThemeAccentColor for
+// tweak-drawn UI when no custom theme is active).
 
 __BEGIN_DECLS
 
@@ -23,6 +25,12 @@ BOOL ApolloThemeRuntimeIsActive(void);
 
 // Cached dynamic colour for a token, or nil if inactive / out of range.
 UIColor *ApolloThemeRuntimeColor(ApolloThemeToken token);
+
+// The EFFECTIVE accent for tweak-drawn UI: the custom theme's accent when one
+// is active, else the stock Apollo theme's (from a table recovered from the
+// binary's accent switch). nil only if neither can be determined — callers
+// supply their own last-resort (typically a view tint or systemBlue).
+UIColor *ApolloThemeAccentColor(void);
 
 // Re-derive a caller-provided system font in the active theme's system design.
 // Returns `base` unchanged when the theme runtime is inactive or the active

--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -746,13 +746,32 @@ static NSString * const kAppGroupSuite  = @"group.com.christianselig.apollo";
 static NSString * const kAppColorThemeKey = @"AppColorTheme";
 static const uint8_t kDonorThemeRawValue = 5; // outrun
 
-// AppColorTheme enum case names, indexed by raw value (docs/theme-builder-RE.md).
-static const char * const kAppColorThemeNames[] = {
-    "default", "nefertiti", "fieryStare", "spookyPumpkin", "solarized",
-    "outrun", "sunset", "sepia", "monochromatic", "navy", "skiesOnSkies",
-    "majesticPurple", "magentasplosion", "sniffingWalnut", "fisherKing",
-    "chumbus", "dracula", "mint",
+// Stock AppColorTheme metadata, indexed by raw value: enum case name + accent
+// {light, dark} (docs/theme-builder-RE.md; accents recovered from the 1.15.11
+// binary's accent switch — jump table 0x100ae3c14, arms off 0x10068b6bc). One
+// table so names and accents cannot drift out of index sync. chumbus dark
+// ignores the UsePureBlackDarkMode variants (000000/050505 — imperceptible).
+static const struct { const char *name; uint32_t light, dark; } kStockThemes[] = {
+    {"default",         0x007AFF, 0x2399FF},
+    {"nefertiti",       0x01A200, 0x01A200},
+    {"fieryStare",      0xFF0000, 0xFD0000},
+    {"spookyPumpkin",   0xFF6200, 0xF25D00},
+    {"solarized",       0x268BD2, 0x268BD2},
+    {"outrun",          0xC400A6, 0xFF00D8},
+    {"sunset",          0xFF6600, 0xFF7D00},
+    {"sepia",           0xB88023, 0xD3AC72},
+    {"monochromatic",   0x000000, 0xFFFFFF},
+    {"navy",            0x0058B8, 0x0060C9},
+    {"skiesOnSkies",    0x00B5F2, 0x01ADE8},
+    {"majesticPurple",  0x8800FF, 0x9C2CFF},
+    {"magentasplosion", 0xFF00B2, 0xE800A2},
+    {"sniffingWalnut",  0xA74E00, 0xA74E00},
+    {"fisherKing",      0x808286, 0x76787D},
+    {"chumbus",         0xF8F8F8, 0x20242B},
+    {"dracula",         0x9760FF, 0xAD81FF},
+    {"mint",            0x37BB98, 0x62DFA7},
 };
+enum { kStockThemeCount = sizeof(kStockThemes) / sizeof(kStockThemes[0]) };
 
 static NSUserDefaults *GroupDefaults(void) {
     static NSUserDefaults *g;
@@ -763,8 +782,8 @@ static NSUserDefaults *GroupDefaults(void) {
 
 static BOOL RawForThemeName(NSString *name, uint8_t *outRaw) {
     if (!name.length) return NO;
-    for (uint8_t i = 0; i < sizeof(kAppColorThemeNames) / sizeof(kAppColorThemeNames[0]); i++) {
-        if ([name isEqualToString:@(kAppColorThemeNames[i])]) { if (outRaw) *outRaw = i; return YES; }
+    for (uint8_t i = 0; i < kStockThemeCount; i++) {
+        if ([name isEqualToString:@(kStockThemes[i].name)]) { if (outRaw) *outRaw = i; return YES; }
     }
     return NO;
 }
@@ -788,6 +807,41 @@ static BOOL SetLiveAppColorThemeRaw(uint8_t raw) {
     *((uint8_t *)(__bridge void *)tm + ivar_getOffset(ivar)) = raw;
     ApolloLog(@"ThemeRuntime: live appColorTheme ivar set to raw %d", raw);
     return YES;
+}
+
+// Read the live appColorTheme raw byte (counterpart of SetLiveAppColorThemeRaw);
+// falls back to the persisted group-defaults selection pre-capture.
+static BOOL GetLiveAppColorThemeRaw(uint8_t *outRaw) {
+    NSObject *tm = sThemeManager;
+    if (tm) {
+        static Ivar sIvar;   // resolved once — this sits on per-cell accent paths
+        if (!sIvar) sIvar = class_getInstanceVariable(object_getClass(tm), "appColorTheme");
+        if (sIvar) { *outRaw = *((uint8_t *)(__bridge void *)tm + ivar_getOffset(sIvar)); return YES; }
+    }
+    return RawForThemeName([GroupDefaults() stringForKey:kAppColorThemeKey], outRaw);
+}
+
+// Accent of the currently-selected stock Apollo theme; nil while the custom
+// runtime is active (stock slot hijacked to the donor) or theme unknown.
+// Internal — external callers go through ApolloThemeAccentColor().
+static UIColor *ApolloThemeStockAccentColor(void) {
+    if (sEnabled) return nil;   // stock slot is hijacked to the donor theme
+    uint8_t raw = 0;
+    if (!GetLiveAppColorThemeRaw(&raw)) return nil;
+    if (raw >= kStockThemeCount) return nil;
+    uint32_t light = kStockThemes[raw].light, dark = kStockThemes[raw].dark;
+    return [UIColor colorWithDynamicProvider:^UIColor *(UITraitCollection *tc) {
+        uint32_t rgb = (tc.userInterfaceStyle == UIUserInterfaceStyleDark) ? dark : light;
+        sBypassHook++;
+        UIColor *c = ApolloThemeUIColorFromRGB(rgb);
+        sBypassHook--;
+        return c;
+    }];
+}
+
+UIColor *ApolloThemeAccentColor(void) {
+    UIColor *custom = ApolloThemeRuntimeColor(ApolloThemeTokenAccent);
+    return custom ?: ApolloThemeStockAccentColor();
 }
 
 void ApolloThemeRuntimeEnable(void) {

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -8,6 +8,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloState.h"
+#import "ApolloThemeRuntime.h"
 #import "ApolloTranslation.h"
 #import "Tweak.h"
 
@@ -3446,62 +3447,6 @@ static BOOL ApolloRefreshFeedTitleTranslationAppliedForController(UIViewControll
     return YES;
 }
 
-static UIColor *ApolloResolvedTintColor(UIColor *color, UITraitCollection *traitCollection) {
-    if (!color) return nil;
-    if (traitCollection && [color respondsToSelector:@selector(resolvedColorWithTraitCollection:)]) {
-        return [color resolvedColorWithTraitCollection:traitCollection];
-    }
-    return color;
-}
-
-static BOOL ApolloTintColorLooksLikeSystemBlue(UIColor *color, UITraitCollection *traitCollection) {
-    UIColor *resolvedColor = ApolloResolvedTintColor(color, traitCollection);
-    UIColor *resolvedBlue = ApolloResolvedTintColor([UIColor systemBlueColor], traitCollection);
-    CGFloat red = 0.0, green = 0.0, blue = 0.0, alpha = 0.0;
-    CGFloat blueRed = 0.0, blueGreen = 0.0, blueBlue = 0.0, blueAlpha = 0.0;
-    if (![resolvedColor getRed:&red green:&green blue:&blue alpha:&alpha]) return NO;
-    if (![resolvedBlue getRed:&blueRed green:&blueGreen blue:&blueBlue alpha:&blueAlpha]) return NO;
-
-    return fabs(red - blueRed) < 0.02 && fabs(green - blueGreen) < 0.02 && fabs(blue - blueBlue) < 0.02 && fabs(alpha - blueAlpha) < 0.02;
-}
-
-static UIColor *ApolloThemeTintCandidate(UIColor *color, UITraitCollection *traitCollection) {
-    if (!color || ApolloTintColorLooksLikeSystemBlue(color, traitCollection)) return nil;
-
-    CGFloat red = 0.0, green = 0.0, blue = 0.0, alpha = 1.0;
-    UIColor *resolvedColor = ApolloResolvedTintColor(color, traitCollection);
-    if ([resolvedColor getRed:&red green:&green blue:&blue alpha:&alpha] && alpha < 0.05) return nil;
-    return color;
-}
-
-static UIColor *ApolloThemeTintColorFromView(UIView *view, UITraitCollection *traitCollection, NSInteger depth) {
-    if (!view || depth < 0) return nil;
-
-    UIColor *candidate = ApolloThemeTintCandidate(view.tintColor, traitCollection);
-    if (candidate) return candidate;
-
-    for (UIView *subview in view.subviews) {
-        candidate = ApolloThemeTintColorFromView(subview, traitCollection, depth - 1);
-        if (candidate) return candidate;
-    }
-
-    return nil;
-}
-
-static UIColor *ApolloThemeTintColorFromNavigationItems(NSArray<UIBarButtonItem *> *items, UIBarButtonItem *translationItem, UITraitCollection *traitCollection) {
-    for (UIBarButtonItem *item in items) {
-        if (item == translationItem) continue;
-
-        UIColor *candidate = ApolloThemeTintCandidate(item.tintColor, traitCollection);
-        if (candidate) return candidate;
-
-        candidate = ApolloThemeTintColorFromView(item.customView, traitCollection, 4);
-        if (candidate) return candidate;
-    }
-
-    return nil;
-}
-
 // MARK: - Liquid Glass globe-merge helpers
 //
 // On iOS 26, each custom-view UIBarButtonItem is hosted in its own
@@ -3751,19 +3696,7 @@ static void ApolloUpdateTranslationUIForController(id controller) {
     }
     [globeButton setImage:globeImage forState:UIControlStateNormal];
 
-    UIColor *themeTintColor = ApolloThemeTintColorFromNavigationItems(items, translationItem, vc.traitCollection);
-    if (!themeTintColor) {
-        themeTintColor = ApolloThemeTintCandidate(vc.view.tintColor, vc.traitCollection);
-    }
-    if (!themeTintColor) {
-        themeTintColor = ApolloThemeTintCandidate(vc.navigationController.navigationBar.tintColor, vc.traitCollection);
-    }
-    if (!themeTintColor) {
-        themeTintColor = vc.view.tintColor ?: vc.navigationController.navigationBar.tintColor;
-    }
-    if (!themeTintColor) {
-        themeTintColor = [UIColor systemBlueColor];
-    }
+    UIColor *themeTintColor = ApolloThemeAccentColor() ?: vc.view.tintColor ?: [UIColor systemBlueColor];
     UIColor *resolvedTint = visibleTranslationApplied ? [UIColor systemGreenColor] : themeTintColor;
     globeButton.tintColor = resolvedTint;
     globeButton.accessibilityLabel = translatedMode

--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -5,6 +5,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloState.h"
+#import "ApolloThemeRuntime.h"
 #import "ApolloUserProfileCache.h"
 #import "ApolloSubredditInfoCache.h"
 #import "ApolloBannedProfile.h"
@@ -210,16 +211,7 @@ static void ApolloProfileScheduleTabAvatarRefresh(NSString *reason);
 }
 
 - (UIColor *)apollo_themeAccentColor {
-    NSMutableArray<UIColor *> *candidates = [NSMutableArray array];
-    if (self.hostViewController.tabBarController.tabBar.tintColor) [candidates addObject:self.hostViewController.tabBarController.tabBar.tintColor];
-    if (self.hostViewController.navigationController.navigationBar.tintColor) [candidates addObject:self.hostViewController.navigationController.navigationBar.tintColor];
-    if (self.hostViewController.view.tintColor) [candidates addObject:self.hostViewController.view.tintColor];
-    if (self.window.tintColor) [candidates addObject:self.window.tintColor];
-    if (self.tintColor) [candidates addObject:self.tintColor];
-    for (UIColor *color in candidates) {
-        if ([color isKindOfClass:[UIColor class]]) return color;
-    }
-    return [UIColor systemBlueColor];
+    return ApolloThemeAccentColor() ?: self.tintColor ?: [UIColor systemBlueColor];
 }
 
 - (void)apollo_updateEditProfileButtonColors {

--- a/src/GiphyPickerViewController.m
+++ b/src/GiphyPickerViewController.m
@@ -1,6 +1,7 @@
 #import "GiphyPickerViewController.h"
 #import "ApolloGiphyClient.h"
 #import "ApolloCommon.h"
+#import "ApolloThemeRuntime.h"
 
 #import <ImageIO/ImageIO.h>
 
@@ -65,18 +66,7 @@ static UIImage *ApolloGiphyAnimatedImageFromGIFData(NSData *data) {
 }
 
 static UIColor *ApolloGiphyAccentColorFromController(UIViewController *controller) {
-    if (!controller) return nil;
-
-    NSMutableArray<UIColor *> *candidates = [NSMutableArray array];
-    if (controller.tabBarController.tabBar.tintColor) [candidates addObject:controller.tabBarController.tabBar.tintColor];
-    if (controller.navigationController.navigationBar.tintColor) [candidates addObject:controller.navigationController.navigationBar.tintColor];
-    if (controller.view.tintColor) [candidates addObject:controller.view.tintColor];
-    if (controller.view.window.tintColor) [candidates addObject:controller.view.window.tintColor];
-
-    for (UIColor *color in candidates) {
-        if ([color isKindOfClass:[UIColor class]]) return color;
-    }
-    return nil;
+    return ApolloThemeAccentColor() ?: controller.view.tintColor;
 }
 
 static UIColor *ApolloGiphyBackgroundColorFromController(UIViewController *controller) {


### PR DESCRIPTION
### TL;DR

- Holding the username/subreddit line no longer aggressively activates the loupe; the stats row itself is as responsive as before.
- Starting a regular scroll near the stats row no longer opens the loupe.
- The loupe's selection pill matches the theme's accent
- All tweak-drawn UI (settings screens, GIF picker, sign-in buttons, AI summary, follow pill, …) now follows the theme accent instead of defaulting to blue, with legibility guards for near-white accents.

### Preview

<img width="500" alt="IMG_3843" src="https://github.com/user-attachments/assets/c1fe449e-724e-4af6-85a1-f6ffeecc35a0" />

## Loupe refinements (`ApolloStatsRowTouch.xm`)

### Tighter activation area

Holding the subreddit/username line — or the compact thumbnail — could pop the loupe: the claim band reached the screen edge and well above the stats row.

- The claim now hugs the row: screen edge only when the ↑ actually starts at the margin, slim pad above, comfort height gained downward, clear of the ••• button.
- The username/subreddit/flair/••• nodes are exclusion zones decided by **proximity, not containment** (their rects run much larger than their glyphs): the press goes to whichever line or span is nearer, ties to the loupe — so the row band itself stays fully sensitive.
- Context-menu suppression shares the same predicate; a press the loupe declines behaves completely stock.

### Swipes no longer pop the loupe

A slow up/down swipe starting on the row could still begin the hold at the 0.3s mark. Two begin-time vetoes fix it: the feed is already scrolling, or the finger has travelled like a swipe since touch-down (16pt vertically, 40pt total — horizontal gets more room since sliding along the row is the loupe's own axis).

## Theme accent everywhere

### One accent API

New `ApolloThemeAccentColor()` (theme runtime): the custom theme's accent when one is active, else the **stock** Apollo theme's — the full 18-theme light/dark accent table was recovered from the binary's palette switch (`kStockThemes`, read via the live `ThemeManager` byte), filling two gaps in `docs/theme-builder-RE.md` (mint dark `62DFA7`, chumbus `F8F8F8`/`20242B`). So on stock Mint the loupe pill is mint, not generic blue.

### Adopted across 13 surfaces, ~150 lines of duplication deleted

Twelve files each hand-rolled a "walk nav/tab/view/window tintColor, fall back to systemBlue" resolver that only approximated the accent. All collapsed to one-line `ApolloThemeAccentColor() ?: view.tintColor ?: systemBlue` chains (the walks were mostly dead anyway — `UIView.tintColor` never returns nil): loupe pill, GIF picker, subreddit index, Edit Profile button, settings base class (covers CustomAPI links/cells), banned-profile overlay, photo composer, AI summary, live-comments follow, translation globe (its 5-helper nav-bar tint-sniffing cluster deleted outright), sign-in buttons, markdown GIF button, account switcher.

### Hardening (from an adversarial review pass)

- Accents resolve against the owning view's traits before any `.CGColor` use (loupe ring, AI summary border on ASDK's background thread) so light/dark can't mismatch under Apollo's window-style override.
- Text on accent fills (follow pill, filled sign-in buttons — both branches) picks black/white via the existing `ApolloColorIsLight()`, keeping near-white stock accents (monochromatic dark, chumbus light) legible.
- Stock theme names + accents live in one struct table (no parallel-array drift); the `appColorTheme` Ivar is cached and the loupe resolves its tint once per hold.

New rules documented in `AGENTS.md` ("Theme Accent in Tweak-Drawn UI").

## Testing

Device (iOS 26), several feedback rounds: stock context menu on username/subreddit/thumbnail holds across compact (both subreddit-at-top states) and large layouts; icon band and gap presses still activate; swipes just scroll; pill/settings/GIF picker follow the theme accent for both custom themes and stock Mint. Worth a monochromatic-dark pass for the contrast guards.
