### PR TITLE
📊 Anonymous usage heartbeat (MAU): opt-out beacon + Settings › Privacy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,11 +254,27 @@ lg-previews:
 	@echo "Regenerating $(notdir $(LG_PREVIEW_HEADER)) from liquid-glass/icons.json"
 	@python3 $(LG_DIR)/scripts/generate_previews_header.py $(LG_PREVIEW_HEADER)
 
-# Move libflex into bundle for rootless deb builds
-#   Remove libflex.plist for all packages since it's not needed
+# Staged jailbreak resource bundle (holds libflex, PNGs, and the ARVariant
+# marker). Space in "Application Support" — always reference it quoted in recipes.
+STAGED_APOLLO_BUNDLE = $(THEOS_STAGING_DIR)/Library/Application Support/ApolloReborn/ApolloReborn.bundle
+
+# before-package runs after the bundle is staged but before the .deb is built.
+# Three things happen here:
+#   - libflex.dylib is moved into the bundle for rootless (its DynamicLibraries
+#     home doesn't exist rootless);
+#   - libflex.plist is dropped for every scheme (unused);
+#   - the usage-heartbeat build variant is stamped so jailbreak installs report a
+#     channel to beat.apolloreborn.app instead of "unknown". ApolloBuildVariant()
+#     reads this ARVariant.txt marker for .deb installs (there's no repackaged
+#     Info.plist to carry ARBuildVariant the way injected IPAs do). Injected IPAs
+#     stamp Info.plist at packaging time and check it first, so this file being
+#     copied into an IPA's bundle is harmless — the plist key wins.
 before-package::
 ifeq ($(THEOS_PACKAGE_SCHEME),rootless)
-	@mv $(THEOS_STAGING_DIR)/Library/MobileSubstrate/DynamicLibraries/libflex.dylib $(THEOS_STAGING_DIR)/Library/Application\ Support/ApolloReborn/ApolloReborn.bundle/libflex.dylib
+	@mv $(THEOS_STAGING_DIR)/Library/MobileSubstrate/DynamicLibraries/libflex.dylib "$(STAGED_APOLLO_BUNDLE)/libflex.dylib"
+	@printf 'deb-rootless\n' > "$(STAGED_APOLLO_BUNDLE)/ARVariant.txt"
+else
+	@printf 'deb-rootful\n' > "$(STAGED_APOLLO_BUNDLE)/ARVariant.txt"
 endif
 	@rm $(THEOS_STAGING_DIR)/Library/MobileSubstrate/DynamicLibraries/libflex.plist
 

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloSettingsTableViewController.m \
     $(SRC_DIR)/ApolloRedditMediaUpload.m \
     $(SRC_DIR)/ApolloNotificationBackend.m \
+    $(SRC_DIR)/ApolloUsageHeartbeat.m \
     $(SRC_DIR)/ApolloPushNotifications.m \
     $(SRC_DIR)/ApolloUserProfileCache.m \
     $(SRC_DIR)/ApolloSubredditInfoCache.m \

--- a/scripts/apply-patches.sh
+++ b/scripts/apply-patches.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 #   inject-tweak[:<deb>]            inject tweak dylibs (deb defaults to --deb)
 #   strip-substrate-arm64e         strip CydiaSubstrate arm64e slice
 #   patch-bundle-versions:<short>:<build>   set CFBundleShortVersionString/CFBundleVersion
+#   stamp-build-variant:<variant>  set ARBuildVariant (usage-heartbeat "c" field)
 #   inject-url-schemes:<csv>       append URL schemes to CFBundleURLTypes
 #   fix-safari-extension           repair Apollofari.appex
 #   fix-openin-extension[:<dylib>] repair OpenInUIExtension.appex
@@ -54,6 +55,7 @@ module_function() {
         inject-tweak)            echo "inject_tweak_in_app" ;;
         strip-substrate-arm64e)  echo "strip_substrate_arm64e_in_app" ;;
         patch-bundle-versions)   echo "patch_bundle_versions_in_app" ;;
+        stamp-build-variant)     echo "stamp_build_variant_in_app" ;;
         inject-url-schemes)      echo "inject_url_schemes_in_app" ;;
         fix-safari-extension)    echo "fix_safari_extension_in_app" ;;
         fix-openin-extension)    echo "fix_openin_extension_in_app" ;;

--- a/scripts/build-test-ipa.sh
+++ b/scripts/build-test-ipa.sh
@@ -109,6 +109,19 @@ else
     echo "Warning: xcodegen not found — test IPA will NOT include Reborn widgets."
 fi
 
+# Stamp the usage-heartbeat build variant (ARBuildVariant in Info.plist) so this
+# test install reports a channel to beat.apolloreborn.app. Without it
+# ApolloBuildVariant() falls back to "unknown", which the server stores as
+# c=null. Default to a dedicated "dev" channel so local test-device beats stay
+# out of the real release-variant counts (glass/ipa/…). NOTE: "dev" must be in
+# the Worker's CHANNELS allowlist, otherwise the server stores it as null too.
+# Override with BUILD_VARIANT=glass to simulate a specific release channel.
+BUILD_VARIANT="${BUILD_VARIANT:-dev}"
+echo "Stamping build variant: $BUILD_VARIANT"
+"$BUILD_DIR/scripts/apply-patches.sh" --ipa "$OUTPUT_IPA" -o "$OUTPUT_IPA.bv" \
+    --module "stamp-build-variant:$BUILD_VARIANT"
+mv "$OUTPUT_IPA.bv" "$OUTPUT_IPA"
+
 echo "Verifying CydiaSubstrate linkage..."
 VERIFY_DIR="$(mktemp -d /tmp/apollo-ipa-verify-XXXXXX)"
 unzip -q "$OUTPUT_IPA" -d "$VERIFY_DIR"

--- a/scripts/build_release_variants.sh
+++ b/scripts/build_release_variants.sh
@@ -225,7 +225,8 @@ apply_patches_in_place "$STANDARD_IPA" \
     --module fix-openin-extension \
     --module "$VERSIONS_MODULE" \
     --module "$SCHEMES_MODULE" \
-    --module inject-widgets
+    --module inject-widgets \
+    --module stamp-build-variant:ipa
 
 echo ""
 echo "[2/6] Building no-extensions injected IPA..."
@@ -236,33 +237,38 @@ cyan -i "$IPA_PATH" -f "$DEB_PATH" -o "$NOEXT_IPA" -e
 apply_patches_in_place "$NOEXT_IPA" \
     --module strip-substrate-arm64e \
     --module "$VERSIONS_MODULE" \
-    --module "$SCHEMES_MODULE"
+    --module "$SCHEMES_MODULE" \
+    --module stamp-build-variant:ipa-noext
 
 echo ""
 echo "[3/6] Applying Liquid Glass patch to standard IPA..."
 bash "$APPLY_PATCHES" --ipa "$STANDARD_IPA" -o "$GLASS_IPA" \
     --module liquid-glass-binary \
     --module liquid-glass-assets \
-    --module "$VERSIONS_MODULE"
+    --module "$VERSIONS_MODULE" \
+    --module stamp-build-variant:glass
 
 echo ""
 echo "[4/6] Applying Liquid Glass patch to no-extensions IPA..."
 bash "$APPLY_PATCHES" --ipa "$NOEXT_IPA" -o "$NOEXT_GLASS_IPA" \
     --module liquid-glass-binary \
     --module liquid-glass-assets \
-    --module "$VERSIONS_MODULE"
+    --module "$VERSIONS_MODULE" \
+    --module stamp-build-variant:glass-noext
 
 echo ""
 echo "[5/6] Applying Liquid Glass icons-only patch to standard IPA..."
 bash "$APPLY_PATCHES" --ipa "$STANDARD_IPA" -o "$GLASS_ICONS_IPA" \
     --module liquid-glass-assets \
-    --module "$VERSIONS_MODULE"
+    --module "$VERSIONS_MODULE" \
+    --module stamp-build-variant:glassicons
 
 echo ""
 echo "[6/6] Applying Liquid Glass icons-only patch to no-extensions IPA..."
 bash "$APPLY_PATCHES" --ipa "$NOEXT_IPA" -o "$NOEXT_GLASS_ICONS_IPA" \
     --module liquid-glass-assets \
-    --module "$VERSIONS_MODULE"
+    --module "$VERSIONS_MODULE" \
+    --module stamp-build-variant:glassicons-noext
 
 echo ""
 echo "Created:"

--- a/scripts/modules/stamp-build-variant.sh
+++ b/scripts/modules/stamp-build-variant.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# stamp_build_variant_in_app <app_bundle> <variant>
+#
+# Sets ARBuildVariant in the main app's Info.plist so the anonymous usage
+# heartbeat (ApolloUsageHeartbeat.m) can report which build variant this install
+# came from (its "c" field), read back at runtime via ApolloBuildVariant().
+# Keep the <variant> strings in sync with the beat Worker's CHANNELS allowlist.
+
+stamp_build_variant_in_app() {
+    local app_bundle="$1"
+    local variant="$2"
+    local plist="$app_bundle/Info.plist"
+
+    if [[ ! -f "$plist" ]]; then
+        echo "Error: Info.plist not found: $plist"
+        return 1
+    fi
+    if [[ -z "$variant" ]]; then
+        echo "Error: stamp-build-variant requires a variant string"
+        return 1
+    fi
+
+    # -replace creates the key if absent and overwrites it if present, so a
+    # variant derived from an already-stamped IPA (e.g. GLASS from STANDARD)
+    # re-stamps cleanly to its own value.
+    plutil -replace ARBuildVariant -string "$variant" "$plist"
+    # Plist edits invalidate the existing code signature.
+    rm -rf "$app_bundle/_CodeSignature"
+    echo "Build variant stamped: $variant"
+}

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -28,6 +28,12 @@ UIImage *ApolloRebornOptionsSettingsIcon(CGFloat size);
 // inject-deb-local.sh). Returns nil if no layout has the file.
 NSString *ApolloBundledResourcePath(NSString *baseName, NSString *extension);
 
+// The build variant string sent with the anonymous usage heartbeat, e.g.
+// "glass", "deb-rootless". The source of truth is stamped at package time (IPA
+// variants set Info.plist "ARBuildVariant"; .deb installs drop an "ARVariant.txt"
+// resource). Falls back to "unknown" when no marker is present (dev builds).
+NSString *ApolloBuildVariant(void);
+
 // Returns YES when a link-card title is a numeric-ID-style junk string —
 // contains at least one digit but no letters at all (e.g. the scraped
 // "285023 289273 400021448" title from a single-page-app page). Used to decide

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -503,8 +503,11 @@ NSString *ApolloBuildVariant(void) {
     NSString *stamped = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"ARBuildVariant"];
     if ([stamped isKindOfClass:NSString.class] && stamped.length) return stamped;
 
-    // 2. Jailbroken .deb installs (no repackaged Info.plist): read a bundled
-    //    marker dropped by the deb build, resolved across install layouts.
+    // 2. Jailbroken .deb installs (no repackaged Info.plist to carry
+    //    ARBuildVariant): read the ARVariant.txt marker stamped into
+    //    ApolloReborn.bundle by the Makefile's before-package hook — "deb-rootful"
+    //    or "deb-rootless" per THEOS_PACKAGE_SCHEME — resolved across the rootful
+    //    (/Library/...) and rootless (/var/jb/...) install layouts.
     NSString *markerPath = ApolloBundledResourcePath(@"ARVariant", @"txt");
     if (markerPath) {
         NSString *m = [[NSString stringWithContentsOfFile:markerPath encoding:NSUTF8StringEncoding error:NULL]

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -498,6 +498,22 @@ NSString *ApolloBundledResourcePath(NSString *baseName, NSString *extension) {
     return nil;
 }
 
+NSString *ApolloBuildVariant(void) {
+    // 1. IPA variants: stamped into Info.plist by build_release_variants.sh.
+    NSString *stamped = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"ARBuildVariant"];
+    if ([stamped isKindOfClass:NSString.class] && stamped.length) return stamped;
+
+    // 2. Jailbroken .deb installs (no repackaged Info.plist): read a bundled
+    //    marker dropped by the deb build, resolved across install layouts.
+    NSString *markerPath = ApolloBundledResourcePath(@"ARVariant", @"txt");
+    if (markerPath) {
+        NSString *m = [[NSString stringWithContentsOfFile:markerPath encoding:NSUTF8StringEncoding error:NULL]
+                       stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+        if (m.length) return m;
+    }
+    return @"unknown";
+}
+
 static UIImage *ApolloCachedBundledPNGNamed(NSString *resourceName) {
     static NSMutableDictionary<NSString *, UIImage *> *cache = nil;
     static dispatch_once_t onceToken;

--- a/src/ApolloUsageHeartbeat.h
+++ b/src/ApolloUsageHeartbeat.h
@@ -3,7 +3,17 @@
 __BEGIN_DECLS
 // Fire the anonymous MAU heartbeat if enabled and not already sent today.
 // Safe to call on every foreground; it self-throttles to once per day and
-// never blocks the caller. No-op when the user has opted out
-// (UDKeyDisableUsageHeartbeat). See docs at beat.apolloreborn.app.
+// never blocks the caller. No-op when the user has opted out. See docs at
+// beat.apolloreborn.app.
 void ApolloSendUsageHeartbeatIfNeeded(void);
+
+// Opt-out accessors. The disable flag is mirrored into BOTH NSUserDefaults
+// (so the stock settings machinery / backups see it) and the durable heartbeat
+// plist (so it survives a sign-in / settings restore that replaces Apollo's
+// preferences plist — the same wipe the token file already defends against).
+// "Disabled" means either store says so, so a wiped NSUserDefaults can never
+// silently re-enable a user who opted out. Always toggle via the setter, never
+// by writing UDKeyDisableUsageHeartbeat directly, or the two stores desync.
+BOOL ApolloUsageHeartbeatIsDisabled(void);
+void ApolloSetUsageHeartbeatDisabled(BOOL disabled);
 __END_DECLS

--- a/src/ApolloUsageHeartbeat.h
+++ b/src/ApolloUsageHeartbeat.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+__BEGIN_DECLS
+// Fire the anonymous MAU heartbeat if enabled and not already sent today.
+// Safe to call on every foreground; it self-throttles to once per day and
+// never blocks the caller. No-op when the user has opted out
+// (UDKeyDisableUsageHeartbeat). See docs at beat.apolloreborn.app.
+void ApolloSendUsageHeartbeatIfNeeded(void);
+__END_DECLS

--- a/src/ApolloUsageHeartbeat.m
+++ b/src/ApolloUsageHeartbeat.m
@@ -1,0 +1,151 @@
+#import "ApolloUsageHeartbeat.h"
+#import "ApolloCommon.h"
+#import "UserDefaultConstants.h"
+#import "Version.h"
+#import <UIKit/UIKit.h>
+
+// The anonymous Monthly-Active-Users beacon. Once per day at most, POSTs
+// { token, v, c, os } to the endpoint below. The token is a random UUID that
+// rotates every calendar month, so cross-month correlation is impossible — that
+// rotation is the whole privacy design; never replace it with a stable ID.
+static NSString *const kBeatURL = @"https://beat.apolloreborn.app/beat";
+
+// Persistence lives in a dedicated atomically-written plist, NOT NSUserDefaults.
+//
+// Why not NSUserDefaults: the monthly token must be stable across every launch
+// in the month (the server dedups on PRIMARY KEY(month, token) + INSERT OR
+// IGNORE, so a stable token = one row per device per month; a *changed* token
+// double-counts). A token written to NSUserDefaults was observed to vanish
+// between two launches seconds apart — not merely a cfprefsd flush-timing issue
+// (a synchronize'd write survives an app-kill because cfprefsd owns it), but
+// because signing in / restoring settings replaces Apollo's whole preferences
+// plist, wiping anything we wrote there first.
+//
+// A separate file under Library/Application Support sidesteps both: an atomic
+// write is durable the instant it returns (kill-safe), and a settings restore
+// (which only overwrites Library/Preferences + Library/Caches plists) never
+// touches it. NSHomeDirectory() resolves to Apollo's own data container.
+static NSString *const kStateMonthKey   = @"month";   // "2026-07"
+static NSString *const kStateTokenKey   = @"token";   // monthly UUID
+static NSString *const kStateLastDayKey = @"lastDay"; // "2026-07-05"
+
+static NSString *ApolloHeartbeatStatePath(void) {
+    static NSString *path;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        NSString *dir = [NSHomeDirectory() stringByAppendingPathComponent:@"Library/Application Support"];
+        [[NSFileManager defaultManager] createDirectoryAtPath:dir
+                                  withIntermediateDirectories:YES
+                                                   attributes:nil
+                                                        error:NULL];
+        path = [dir stringByAppendingPathComponent:@"ApolloRebornHeartbeat.plist"];
+    });
+    return path;
+}
+
+static NSMutableDictionary *ApolloHeartbeatReadState(void) {
+    NSDictionary *stored = [NSDictionary dictionaryWithContentsOfFile:ApolloHeartbeatStatePath()];
+    return stored ? [stored mutableCopy] : [NSMutableDictionary dictionary];
+}
+
+// Atomic write: writeToFile:atomically: stages a temp file then renames it into
+// place, so the token is on disk before this returns — a quick app-kill can't
+// lose it.
+static void ApolloHeartbeatWriteState(NSDictionary *state) {
+    [state writeToFile:ApolloHeartbeatStatePath() atomically:YES];
+}
+
+// UTC day/month keys so they line up with the server's UTC month buckets.
+static NSString *ApolloUTCKey(NSString *format) {
+    static NSDateFormatter *fmt;  // reused; guarded by the main-thread call sites
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        fmt = [NSDateFormatter new];
+        fmt.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+        fmt.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+    });
+    fmt.dateFormat = format;
+    return [fmt stringFromDate:[NSDate date]];
+}
+
+// "3.3.0" from TWEAK_VERSION ("v3.3.0").
+static NSString *ApolloHeartbeatVersion(void) {
+    NSString *v = @(TWEAK_VERSION);
+    if ([v hasPrefix:@"v"]) v = [v substringFromIndex:1];
+    return v;
+}
+
+// Returns the token for the current month, rotating (new UUID) when the month
+// changes, persisting {month, token} back into `state`. `didRotate` is set to
+// YES when a fresh token was minted (so the caller flushes immediately).
+static NSString *ApolloMonthlyToken(NSMutableDictionary *state, NSString *month, BOOL *didRotate) {
+    NSString *storedMonth = state[kStateMonthKey];
+    NSString *token       = state[kStateTokenKey];
+    if (![storedMonth isEqualToString:month] || [token length] == 0) {
+        token = [[NSUUID UUID] UUIDString];  // server lowercases; case doesn't matter
+        state[kStateMonthKey] = month;
+        state[kStateTokenKey] = token;
+        if (didRotate) *didRotate = YES;
+    }
+    return token;
+}
+
+void ApolloSendUsageHeartbeatIfNeeded(void) {
+    // Opt-out stays in NSUserDefaults (it's a user setting; losing it just means
+    // the default, enabled, which is intended). On by default, so only bail when
+    // the disable flag is explicitly set.
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:UDKeyDisableUsageHeartbeat]) return;
+
+    NSMutableDictionary *state = ApolloHeartbeatReadState();
+
+    // Once per day. Losing this only costs an extra (server-deduped) request, so
+    // it's fine that it shares the file with the token.
+    NSString *today = ApolloUTCKey(@"yyyy-MM-dd");
+    if ([state[kStateLastDayKey] isEqualToString:today]) return;
+
+    NSString *month = ApolloUTCKey(@"yyyy-MM");
+    BOOL rotated = NO;
+    NSString *token = ApolloMonthlyToken(state, month, &rotated);
+    // Flush a freshly minted token to disk NOW, before the async network call —
+    // a quick app-kill between here and the response must not lose it, or the
+    // next launch mints a different token for the same month and double-counts.
+    if (rotated) ApolloHeartbeatWriteState(state);
+
+    NSDictionary *payload = @{
+        @"token": token,
+        @"v":     ApolloHeartbeatVersion(),
+        @"c":     ApolloBuildVariant(),
+        @"os":    UIDevice.currentDevice.systemVersion,
+    };
+    NSData *body = [NSJSONSerialization dataWithJSONObject:payload options:0 error:NULL];
+    if (!body) return;
+
+    // Ephemeral: no cookies, no persistent cache, nothing left on disk.
+    NSURLSessionConfiguration *cfg = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+    cfg.HTTPShouldSetCookies = NO;
+    cfg.timeoutIntervalForRequest = 15;
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:cfg];
+
+    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:kBeatURL]];
+    req.HTTPMethod = @"POST";
+    [req setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+    req.HTTPBody = body;
+
+    NSURLSessionDataTask *task = [session dataTaskWithRequest:req
+        completionHandler:^(NSData *data, NSURLResponse *resp, NSError *error) {
+            NSInteger code = [(NSHTTPURLResponse *)resp statusCode];
+            // Only mark the day done on success, so a flaky network retries on the
+            // next foreground rather than silently losing the day. Re-read + write
+            // the state file so we don't clobber a token rotation that happened
+            // since (there isn't one within a day, but this keeps it correct).
+            if (!error && code >= 200 && code < 300) {
+                NSMutableDictionary *latest = ApolloHeartbeatReadState();
+                latest[kStateLastDayKey] = today;
+                ApolloHeartbeatWriteState(latest);
+            } else {
+                ApolloLog(@"[heartbeat] send failed (code %ld): %@", (long)code, error.localizedDescription);
+            }
+            [session finishTasksAndInvalidate];
+        }];
+    [task resume];
+}

--- a/src/ApolloUsageHeartbeat.m
+++ b/src/ApolloUsageHeartbeat.m
@@ -25,9 +25,10 @@ static NSString *const kBeatURL = @"https://beat.apolloreborn.app/beat";
 // write is durable the instant it returns (kill-safe), and a settings restore
 // (which only overwrites Library/Preferences + Library/Caches plists) never
 // touches it. NSHomeDirectory() resolves to Apollo's own data container.
-static NSString *const kStateMonthKey   = @"month";   // "2026-07"
-static NSString *const kStateTokenKey   = @"token";   // monthly UUID
-static NSString *const kStateLastDayKey = @"lastDay"; // "2026-07-05"
+static NSString *const kStateMonthKey    = @"month";    // "2026-07"
+static NSString *const kStateTokenKey     = @"token";    // monthly UUID
+static NSString *const kStateLastDayKey   = @"lastDay";  // "2026-07-05"
+static NSString *const kStateDisabledKey  = @"disabled"; // durable opt-out mirror
 
 static NSString *ApolloHeartbeatStatePath(void) {
     static NSString *path;
@@ -90,11 +91,34 @@ static NSString *ApolloMonthlyToken(NSMutableDictionary *state, NSString *month,
     return token;
 }
 
+// Opt-out is stored in two places that must agree: NSUserDefaults (so the stock
+// settings/backups see it) and the durable heartbeat plist (so it survives the
+// sign-in / settings-restore wipe that clobbers Apollo's preferences plist —
+// exactly the failure mode the token file already guards against). If we only
+// kept it in NSUserDefaults, a user who opted out would silently start beating
+// again after their next sign-in. Read "disabled" as the OR of both stores so a
+// wiped default can't re-enable them.
+BOOL ApolloUsageHeartbeatIsDisabled(void) {
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:UDKeyDisableUsageHeartbeat]) return YES;
+    return [ApolloHeartbeatReadState()[kStateDisabledKey] boolValue];
+}
+
+void ApolloSetUsageHeartbeatDisabled(BOOL disabled) {
+    [[NSUserDefaults standardUserDefaults] setBool:disabled forKey:UDKeyDisableUsageHeartbeat];
+    NSMutableDictionary *state = ApolloHeartbeatReadState();
+    state[kStateDisabledKey] = @(disabled);
+    ApolloHeartbeatWriteState(state);
+}
+
 void ApolloSendUsageHeartbeatIfNeeded(void) {
-    // Opt-out stays in NSUserDefaults (it's a user setting; losing it just means
-    // the default, enabled, which is intended). On by default, so only bail when
-    // the disable flag is explicitly set.
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:UDKeyDisableUsageHeartbeat]) return;
+#if APOLLO_SIM_BUILD
+    // Never beat from a simulator dev build: it's unstamped (c=unknown) and every
+    // reinstall wipes the container, minting a fresh token that would pollute real
+    // MAU. Compiled out entirely so no request can escape the sim.
+    return;
+#endif
+
+    if (ApolloUsageHeartbeatIsDisabled()) return;
 
     NSMutableDictionary *state = ApolloHeartbeatReadState();
 

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -35,6 +35,7 @@ typedef NS_ENUM(NSInteger, SectionIndex) {
     SectionMedia,
     SectionSubreddits,
     SectionNotificationBackend,
+    SectionPrivacy,
     SectionAbout,
     SectionCount
 };
@@ -670,7 +671,8 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionMedia: return 14 + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows) + (sVideoHoldSpeedEnabled ? 1 : 0);
         case SectionSubreddits: return 10 - (sSubredditListEnhancements ? 0 : 1) - (sCommunityHighlights ? 0 : 1);
         case SectionNotificationBackend: return 3; // URL + Registration Token + Test Connection
-        case SectionAbout: return 5; // GitHub + Reddit + Thanks To + Export Logs + Version
+        case SectionPrivacy: return 1; // Anonymous Install Count toggle
+        case SectionAbout: return 6; // GitHub + Reddit + Thanks To + Export Logs + Privacy Policy + Version
         default: return 0;
     }
 }
@@ -685,6 +687,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionMedia: return @"Media";
         case SectionSubreddits: return @"Subreddits";
         case SectionNotificationBackend: return @"Notification Backend";
+        case SectionPrivacy: return @"Privacy";
         case SectionAbout: return @"About";
         default: return nil;
     }
@@ -701,6 +704,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionMedia: cell = [self mediaCellForRow:indexPath.row tableView:tableView]; break;
         case SectionSubreddits: cell = [self subredditCellForRow:indexPath.row tableView:tableView]; break;
         case SectionNotificationBackend: cell = [self notificationBackendCellForRow:indexPath.row tableView:tableView]; break;
+        case SectionPrivacy: cell = [self privacyCellForRow:indexPath.row tableView:tableView]; break;
         case SectionAbout: cell = [self aboutCellForRow:indexPath.row tableView:tableView]; break;
         default: cell = [[UITableViewCell alloc] init]; break;
     }
@@ -1472,6 +1476,18 @@ typedef NS_ENUM(NSInteger, Tag) {
     return cell;
 }
 
+- (UITableViewCell *)privacyCellForRow:(NSInteger)row tableView:(UITableView *)tableView {
+    // Single row: the anonymous usage heartbeat opt-out. The stored flag is a
+    // *disable* flag (default NO = enabled), so the switch shows the inverse.
+    // The explanatory text (with the tappable privacy-policy link) is the
+    // section footer — see footerAttributedTextForSection:.
+    BOOL enabled = ![[NSUserDefaults standardUserDefaults] boolForKey:UDKeyDisableUsageHeartbeat];
+    return [self switchCellWithIdentifier:@"Cell_Privacy_Heartbeat"
+                                    label:@"Anonymous Install Count"
+                                       on:enabled
+                                   action:@selector(usageHeartbeatSwitchToggled:)];
+}
+
 - (UITableViewCell *)aboutCellForRow:(NSInteger)row tableView:(UITableView *)tableView {
     switch (row) {
         case 0: return [self subtitleCellWithIdentifier:@"Cell_About_GitHub"
@@ -1510,6 +1526,17 @@ typedef NS_ENUM(NSInteger, Tag) {
             return cell;
         }
         case 4: {
+            UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"Cell_About_Privacy"];
+            if (!cell) {
+                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell_About_Privacy"];
+            }
+            cell.textLabel.text = @"Privacy Policy";
+            cell.imageView.image = [self iconImageFromEmoji:@"🔒" size:32];
+            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+            cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+            return cell;
+        }
+        case 5: {
             UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"Cell_About_Version"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_About_Version"];
@@ -1649,6 +1676,14 @@ typedef NS_ENUM(NSInteger, Tag) {
             attributes:@{NSFontAttributeName: [UIFont systemFontOfSize:13], NSLinkAttributeName: [NSURL URLWithString:@"https://github.com/nickclyde/apollo-backend"]}]];
         [text appendAttributedString:[[NSAttributedString alloc] initWithString:@" instance. Requires a paid Apple Developer account on the signing side for APNs to function. Leave empty to disable."
             attributes:plainAttrs]];
+    } else if (section == SectionPrivacy) {
+        text = [[NSMutableAttributedString alloc]
+            initWithString:@"Sends one anonymous heartbeat so we can estimate active Apollo Reborn installs. No Reddit activity, account details, or feature usage is collected. More details can be found in our "
+            attributes:plainAttrs];
+        [text appendAttributedString:[[NSAttributedString alloc] initWithString:@"privacy policy"
+            attributes:@{NSFontAttributeName: [UIFont systemFontOfSize:13], NSForegroundColorAttributeName: [self apollo_themeAccentColor], NSLinkAttributeName: [NSURL URLWithString:@"https://apolloreborn.app/privacy"]}]];
+        [text appendAttributedString:[[NSAttributedString alloc] initWithString:@"."
+            attributes:plainAttrs]];
     } else {
         return nil;
     }
@@ -1772,6 +1807,8 @@ typedef NS_ENUM(NSInteger, Tag) {
             [self pushThanksToViewController];
         } else if (indexPath.row == 3) {
             [self exportLogs];
+        } else if (indexPath.row == 4) {
+            [self presentURLInApolloBrowser:[NSURL URLWithString:@"https://apolloreborn.app/privacy"]];
         }
     } else if (indexPath.section == SectionMedia) {
         UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
@@ -1872,7 +1909,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         NSInteger row = ApolloMediaLogicalRow(indexPath.row);
         return (row == 0 || row == 1 || row == 2 || row == 3 || row == 6 || row == 7 || row == 14);
     }
-    if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 || indexPath.row == 3)) return YES;
+    if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 || indexPath.row == 3 || indexPath.row == 4)) return YES;
     if (indexPath.section == SectionNotificationBackend && indexPath.row == 2) return YES;
     return NO;
 }
@@ -2153,6 +2190,11 @@ typedef NS_ENUM(NSInteger, Tag) {
 - (void)blockAnnouncementsSwitchToggled:(UISwitch *)sender {
     sBlockAnnouncements = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sBlockAnnouncements forKey:UDKeyBlockAnnouncements];
+}
+
+- (void)usageHeartbeatSwitchToggled:(UISwitch *)sender {
+    // Stored flag is a *disable* flag (default NO = enabled), so on = NOT disabled.
+    [[NSUserDefaults standardUserDefaults] setBool:!sender.isOn forKey:UDKeyDisableUsageHeartbeat];
 }
 
 - (void)flexSwitchToggled:(UISwitch *)sender {

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -1,6 +1,7 @@
 #import "CustomAPIViewController.h"
 #import "ApolloCommon.h"
 #import "ApolloNotificationBackend.h"
+#import "ApolloUsageHeartbeat.h"
 #import "ApolloWebSessionLoginViewController.h"
 #import "ApolloAISettingsViewController.h"
 #import "ApolloWebSessionStore.h"
@@ -1481,7 +1482,7 @@ typedef NS_ENUM(NSInteger, Tag) {
     // *disable* flag (default NO = enabled), so the switch shows the inverse.
     // The explanatory text (with the tappable privacy-policy link) is the
     // section footer — see footerAttributedTextForSection:.
-    BOOL enabled = ![[NSUserDefaults standardUserDefaults] boolForKey:UDKeyDisableUsageHeartbeat];
+    BOOL enabled = !ApolloUsageHeartbeatIsDisabled();
     return [self switchCellWithIdentifier:@"Cell_Privacy_Heartbeat"
                                     label:@"Anonymous Install Count"
                                        on:enabled
@@ -2193,8 +2194,9 @@ typedef NS_ENUM(NSInteger, Tag) {
 }
 
 - (void)usageHeartbeatSwitchToggled:(UISwitch *)sender {
-    // Stored flag is a *disable* flag (default NO = enabled), so on = NOT disabled.
-    [[NSUserDefaults standardUserDefaults] setBool:!sender.isOn forKey:UDKeyDisableUsageHeartbeat];
+    // Mirror the opt-out into both NSUserDefaults and the durable heartbeat plist
+    // so a sign-in / settings restore can't silently re-enable it. on = NOT disabled.
+    ApolloSetUsageHeartbeatDisabled(!sender.isOn);
 }
 
 - (void)flexSwitchToggled:(UISwitch *)sender {

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -14,6 +14,7 @@
 #import "ApolloImageUploadHost.h"
 #import "ApolloImgChestUpload.h"
 #import "ApolloNotificationBackend.h"
+#import "ApolloUsageHeartbeat.h"
 #import "ApolloPushNotifications.h"
 #import "ApolloState.h"
 #import "Tweak.h"
@@ -1925,4 +1926,17 @@ static void initializeRandomSources() {
             [settingsNavController pushViewController:vc animated:YES];
         });
     }
+
+    // Anonymous MAU heartbeat: fire on every foreground; the once-a-day throttle
+    // (and the opt-out flag) inside ApolloSendUsageHeartbeatIfNeeded handle the
+    // rest. Registering the observer here avoids hunting for an app-lifecycle
+    // hook. beat.apolloreborn.app is our own first-party, opt-out-able endpoint
+    // and is deliberately NOT in the blockedUrls telemetry list.
+    [[NSNotificationCenter defaultCenter]
+        addObserverForName:UIApplicationDidBecomeActiveNotification
+                    object:nil
+                     queue:[NSOperationQueue mainQueue]
+                usingBlock:^(NSNotification *note) {
+        ApolloSendUsageHeartbeatIfNeeded();
+    }];
 }

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -242,6 +242,15 @@ static NSString *const UDKeyNotificationBackendURL = @"NotificationBackendURL";
 // endpoints (/v1/device, /v1/device/{apns}/account[s]).
 static NSString *const UDKeyNotificationBackendRegistrationToken = @"NotificationBackendRegistrationToken";
 
+// Anonymous MAU heartbeat (beat.apolloreborn.app). ON by default; this is the
+// opt-OUT, mirroring the DisableApollonouncements pattern (a disable flag that
+// defaults to NO gives us on-by-default). See ApolloUsageHeartbeat.{h,m}.
+static NSString *const UDKeyDisableUsageHeartbeat = @"DisableUsageHeartbeat";
+// Internal bookkeeping for the heartbeat (not user-facing).
+static NSString *const UDKeyHeartbeatMonth   = @"UsageHeartbeatMonth";   // "2026-07"
+static NSString *const UDKeyHeartbeatToken   = @"UsageHeartbeatToken";   // monthly UUID
+static NSString *const UDKeyHeartbeatLastDay = @"UsageHeartbeatLastDay"; // "2026-07-05"
+
 // Feed thumbnails for text posts with embedded images (off = native behavior).
 static NSString *const UDKeyFeedTextPostThumbnails = @"FeedTextPostThumbnails";
 


### PR DESCRIPTION
## 📊 Apollo Reborn — anonymous usage heartbeat (MAU)

We just added a tiny heartbeat so we can finally see real active-user numbers. Context: the site's "unique visitors" is inflated ~10x by AltStore/SideStore/Signulous clients hitting our JSON/assets in the background, so it's useless as an audience metric. This fixes that.

### What each device sends
At most **once/day**, **on by default** (one-tap off in **Settings → Privacy**):

| field | value |
|---|---|
| `token` | a random ID that regenerates every month |
| `v` | app version (e.g. `3.3.0`) |
| `c` | build variant (base / glass / glass-icons, ext vs no-extensions, deb rootful/rootless) |
| `os` | iOS version (e.g. `18.5`) |

That's the whole payload. Nothing else.

### Why it's useful
- Actual MAU, not sideload-client noise
- Which builds people really run → where to spend effort (e.g. is Liquid Glass worth maintaining? how many no-extensions / free-Apple-ID users?)
- iOS version spread → what we can safely require or drop

### Why it's privacy-conscious
- **No IP is ever logged or stored** — not in our code, by design
- The token is **random and rotates monthly**, so it can't recognize you month-to-month or link activity over time. It's not a device ID — it exists only to avoid double-counting within one month
- No account, no per-feature tracking — the server only ever aggregates `COUNT(*)` per month
- Data lives on Cloudflare, auto-deleted after ~13 months
- Fully disclosed in our public **privacy policy**, and it stays consistent with us blocking the original Apollo's Bugsnag/Mixpanel/Statsig/TelemetryDeck telemetry — we didn't replace one tracker with another

**Net: enough to run the project well, deliberately too little to identify or follow anyone.**

---

## How it works (technical)

**Client** — `src/ApolloUsageHeartbeat.{h,m}`, fired from a `UIApplicationDidBecomeActiveNotification` observer registered in `Tweak.xm`'s `%ctor`. It self-throttles to once/day and no-ops when opted out, so it's cheap to call on every foreground.

**Persistence (the important bit).** `{month, token}` is stored in an **atomically-written plist** at `Library/Application Support/ApolloRebornHeartbeat.plist` — *not* NSUserDefaults. During testing a UserDefaults-backed token was seen to vanish between two launches seconds apart, producing two tokens = a double-count. The cause wasn't flush timing (a `synchronize`'d write survives an app-kill because `cfprefsd` owns it) — it was that **signing in / restoring settings replaces Apollo's whole preferences plist**, wiping anything we'd written there. A dedicated file sidesteps both failure modes: an atomic write is durable the instant it returns (kill-safe), and a settings restore (which only rewrites `Library/Preferences` + `Library/Caches`) never touches it. The freshly minted token is flushed **before** the network call.

**Server dedup is the real guarantee.** The Worker's `PRIMARY KEY(month, token)` + `INSERT OR IGNORE` means a stable monthly token = exactly one row per device per month; the daily client throttle is only there to cut request volume, not to guarantee the count. Requests use an ephemeral `NSURLSession` (no cookies, no persisted cache).

**Opt-out** — `UDKeyDisableUsageHeartbeat` (default `NO` = enabled), surfaced as the **Anonymous Install Count** switch in a new **Settings → Privacy** section, with the disclosure text + a link to the privacy policy in the footer. The About section also gains a **Privacy Policy** row.

**Build variant (`c`)** — `ApolloBuildVariant()` reads `Info.plist` `ARBuildVariant` (IPA variants) or a bundled `ARVariant.txt` (debs), falling back to `"unknown"`. A new `stamp-build-variant` apply-patches module writes the key at package time; it's wired into `build_release_variants.sh` for all six IPA variants, and into `build-test-ipa.sh` (which stamps a dedicated `"dev"` channel so local test-device beats stay out of the real release counts). Keep the channel strings in sync with the Worker's `CHANNELS` allowlist — an unrecognized value is stored as `null` (still counts toward MAU, just no breakdown).

`beat.apolloreborn.app` is deliberately **not** in the `blockedUrls` list (that list only neutralizes the original Apollo's telemetry).

### Testing notes
- Delete the app before retesting so you start from clean state (fresh container = no stored token).
- New rows show `c=dev` for test-IPA installs — that's the fingerprint for this binary. Add `"dev"` to the Worker's `CHANNELS` allowlist or it lands as `null`.
