### PR TITLE
Hide Bars on Scroll: fix legacy nav bar stuttering before it collapses

### DIFF
--- a/src/ApolloAutoHideTabBar.xm
+++ b/src/ApolloAutoHideTabBar.xm
@@ -386,8 +386,8 @@ static void ApolloForEachVisibleTabBarController(void (^block)(UITabBarControlle
 }
 
 // Mirror nav-bar visibility onto the tab bar. Called from every nav-bar
-// hide/show entry point, including the gesture-driven path. iOS <26 only —
-// on iOS 26 we use the native UITabBarController.tabBarMinimizeBehavior path.
+// hide/show entry point. iOS <26 only — on iOS 26 we use the native
+// UITabBarController.tabBarMinimizeBehavior path.
 static void ApolloMirrorNavBarStateToTabBar(UINavigationController *nav, BOOL navHidden, BOOL animated) {
     if (ApolloSupportsNativeTabBarMinimize()) return;
     UITabBarController *tbc = ApolloLocateTabBarController(nav);
@@ -399,17 +399,35 @@ static void ApolloMirrorNavBarStateToTabBar(UINavigationController *nav, BOOL na
     }
 }
 
+// hidesBarsOnSwipe drives the nav bar through a percent-driven interactive
+// transition: UIKit calls setNavigationBarHidden:animated: the moment the pan
+// crosses the hide threshold (via _gestureRecognizedInteractiveHide:), then
+// scrubs that animation with the finger. Mirroring the tab bar from inside
+// that call kicks off setTabBarHidden: + a layout pass while UIKit's
+// transition is still in flight, which clobbers it — the nav bar (and the tab
+// bar with it) visibly snaps back to fully visible before hiding again
+// (issue #382, "legacy navigation bar stutters before collapsing"). Skip the
+// mirror while the swipe gesture is actively panning; _apolloBarHideSwipeFired:
+// mirrors the settled state once the gesture ends.
+static BOOL ApolloBarSwipeGestureActive(UINavigationController *nav) {
+    if (!nav.hidesBarsOnSwipe) return NO;
+    UIGestureRecognizerState state = nav.barHideOnSwipeGestureRecognizer.state;
+    return state == UIGestureRecognizerStateBegan || state == UIGestureRecognizerStateChanged;
+}
+
 %hook UINavigationController
 
 - (void)setNavigationBarHidden:(BOOL)hidden {
     %orig;
     if (ApolloSupportsNativeTabBarMinimize()) return;
+    if (ApolloBarSwipeGestureActive(self)) return;
     ApolloMirrorNavBarStateToTabBar(self, hidden, NO);
 }
 
 - (void)setNavigationBarHidden:(BOOL)hidden animated:(BOOL)animated {
     %orig;
     if (ApolloSupportsNativeTabBarMinimize()) return;
+    if (ApolloBarSwipeGestureActive(self)) return;
     ApolloMirrorNavBarStateToTabBar(self, hidden, animated);
 }
 

--- a/src/ApolloAutoHideTabBar.xm
+++ b/src/ApolloAutoHideTabBar.xm
@@ -206,6 +206,8 @@ static void ApolloReapplyNativeMinimizeBehavior(UITabBarController *tbc, NSStrin
 
 static NSString *const ApolloTabBarSlideDownAnimationKey = @"apolloTabBarSlideDown";
 static NSString *const ApolloTabBarSlideUpAnimationKey = @"apolloTabBarSlideUp";
+// KVC key stamped on each slide-down animation with its owning generation.
+static NSString *const ApolloTabBarSlideGenerationKey = @"apolloTabBarSlideGeneration";
 
 static BOOL ApolloTabBarLooksHidden(UITabBar *tabBar) {
     if (!tabBar) return NO;
@@ -331,7 +333,14 @@ static void ApolloHideTabBar(UITabBarController *tbc, BOOL animated) {
     NSInteger generation = ApolloBumpTabBarMirrorGeneration(tbc);
     objc_setAssociatedObject(tbc, &kApolloTabBarHideInFlightKey, @(generation), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     tabBar.transform = CGAffineTransformIdentity;
-    [tabBar.layer removeAnimationForKey:ApolloTabBarSlideUpAnimationKey];
+    // Take over from an in-flight reveal slide, starting the hide from where
+    // the bar currently appears instead of snapping it to rest first.
+    CGFloat slideFromTy = 0.0;
+    if ([tabBar.layer animationForKey:ApolloTabBarSlideUpAnimationKey]) {
+        CALayer *presentation = tabBar.layer.presentationLayer;
+        slideFromTy = presentation ? [[presentation valueForKeyPath:@"transform.translation.y"] doubleValue] : 0.0;
+        [tabBar.layer removeAnimationForKey:ApolloTabBarSlideUpAnimationKey];
+    }
 
     // Slide the bar off the bottom ourselves. Two traps here:
     //  - Do NOT use setTabBarHidden:YES animated:YES: on iOS 26 with a
@@ -348,12 +357,18 @@ static void ApolloHideTabBar(UITabBarController *tbc, BOOL animated) {
     // system flag is then flipped non-animated at completion for
     // safe-area/state correctness.
     CABasicAnimation *slide = [CABasicAnimation animationWithKeyPath:@"transform.translation.y"];
-    slide.fromValue = @0;
+    slide.fromValue = @(slideFromTy);
     slide.toValue = @(ApolloTabBarSlideDistance(tabBar));
     slide.duration = 0.25;
     slide.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseIn];
     slide.fillMode = kCAFillModeForwards;
     slide.removedOnCompletion = NO;
+    // Stamp the slide with its generation so a stale completion can tell
+    // whether the key still holds ITS animation. A rapid Hide→Show→Hide
+    // within the slide duration re-uses the key for the newer hide; the old
+    // completion must not tear that live animation down (the bar would snap
+    // back to its resting position — the very pop this module exists to fix).
+    [slide setValue:@(generation) forKey:ApolloTabBarSlideGenerationKey];
 
     [CATransaction begin];
     [CATransaction setCompletionBlock:^{
@@ -361,16 +376,35 @@ static void ApolloHideTabBar(UITabBarController *tbc, BOOL animated) {
         if (inFlight.integerValue == generation) {
             objc_setAssociatedObject(tbc, &kApolloTabBarHideInFlightKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         }
+        CAAnimation *active = [tabBar.layer animationForKey:ApolloTabBarSlideDownAnimationKey];
+        BOOL keyStillOurs = [[active valueForKey:ApolloTabBarSlideGenerationKey] integerValue] == generation;
         NSInteger current = [objc_getAssociatedObject(tbc, &kApolloTabBarMirrorGenerationKey) integerValue];
         if (current != generation) {
-            // A Show took over mid-slide; it owns the bar now.
-            [tabBar.layer removeAnimationForKey:ApolloTabBarSlideDownAnimationKey];
+            // A Show or newer Hide took over mid-slide; only clean up the
+            // filled-forward animation if it is still ours.
+            if (keyStillOurs) {
+                [tabBar.layer removeAnimationForKey:ApolloTabBarSlideDownAnimationKey];
+            }
             return;
         }
         // Same runloop tick — the fill removal and the hidden flip commit in
         // one transaction, so no intermediate frame renders.
-        [tabBar.layer removeAnimationForKey:ApolloTabBarSlideDownAnimationKey];
+        if (keyStillOurs) {
+            [tabBar.layer removeAnimationForKey:ApolloTabBarSlideDownAnimationKey];
+        }
         commitHidden();
+        // The hidden flip just changed the bottom safe-area inset; animate the
+        // resulting layout so floating safe-area-anchored views (e.g. the
+        // jump-to-bottom button in comments) glide into the freed space
+        // instead of jumping. The swipe gesture and UIKit's interactive
+        // transition are long finished here, so this cannot clobber them.
+        [UIView animateWithDuration:0.15
+                              delay:0.0
+                            options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseOut
+                         animations:^{
+            [tbc.view setNeedsLayout];
+            [tbc.view layoutIfNeeded];
+        } completion:nil];
     }];
     [tabBar.layer addAnimation:slide forKey:ApolloTabBarSlideDownAnimationKey];
     [CATransaction commit];
@@ -538,8 +572,14 @@ static BOOL sApolloInBarHideSwipeHandler = NO;
         return;
     }
     sApolloInBarHideSwipeHandler = YES;
-    %orig;
-    sApolloInBarHideSwipeHandler = NO;
+    @try {
+        %orig;
+    } @finally {
+        // If the handler ever raises, the flag must not stick — a stuck YES
+        // would make tabBarController return nil app-wide for Apollo's nav
+        // controllers.
+        sApolloInBarHideSwipeHandler = NO;
+    }
 }
 
 %end

--- a/src/ApolloAutoHideTabBar.xm
+++ b/src/ApolloAutoHideTabBar.xm
@@ -204,25 +204,46 @@ static void ApolloReapplyNativeMinimizeBehavior(UITabBarController *tbc, NSStrin
               anyWantsMinimize, sAutoHideTabBarShowOnIdle, reason ?: @"unknown");
 }
 
+static NSString *const ApolloTabBarSlideDownAnimationKey = @"apolloTabBarSlideDown";
+static NSString *const ApolloTabBarSlideUpAnimationKey = @"apolloTabBarSlideUp";
+
 static BOOL ApolloTabBarLooksHidden(UITabBar *tabBar) {
     if (!tabBar) return NO;
     if (tabBar.hidden) return YES;
     if (tabBar.alpha < 0.95) return YES;
     if (tabBar.transform.ty != 0.0 || tabBar.transform.tx != 0.0) return YES;
+    // An in-flight hide slide keeps the model pristine (explicit layer
+    // animation); it still counts as hidden so a reveal can take over.
+    if ([tabBar.layer animationForKey:ApolloTabBarSlideDownAnimationKey]) return YES;
     UIView *parent = tabBar.superview;
     if (parent && tabBar.frame.origin.y >= parent.bounds.size.height - 1.0) return YES;
     return NO;
 }
 
-// Monotonically increasing token per tab bar controller; a Hide whose fade is
+// Monotonically increasing token per tab bar controller; a Hide whose slide is
 // still in flight abandons its completion work when a Show (or newer Hide)
 // has started since.
 static char kApolloTabBarMirrorGenerationKey;
+// Non-nil while an animated hide-slide is in flight (holds that slide's
+// generation). Repeat Hide calls during the slide — the gesture-end mirror and
+// UIKit's transition-completion setNavigationBarHidden: both fire — must be
+// no-ops, or the second call restarts the slide from the resting position and
+// the bar visibly snaps back.
+static char kApolloTabBarHideInFlightKey;
 
 static NSInteger ApolloBumpTabBarMirrorGeneration(UITabBarController *tbc) {
     NSInteger generation = [objc_getAssociatedObject(tbc, &kApolloTabBarMirrorGenerationKey) integerValue] + 1;
     objc_setAssociatedObject(tbc, &kApolloTabBarMirrorGenerationKey, @(generation), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     return generation;
+}
+
+// How far the bar must translate to be fully off the bottom of the screen
+// (bar height plus anything below it, e.g. the home-indicator area).
+static CGFloat ApolloTabBarSlideDistance(UITabBar *tabBar) {
+    UIView *parent = tabBar.superview;
+    CGFloat below = parent ? MAX(0.0, parent.bounds.size.height - CGRectGetMaxY(tabBar.frame)) : 0.0;
+    CGFloat distance = CGRectGetHeight(tabBar.frame) + below;
+    return distance > 1.0 ? distance : 120.0;
 }
 
 static void ApolloShowTabBar(UITabBarController *tbc, BOOL animated) {
@@ -234,23 +255,45 @@ static void ApolloShowTabBar(UITabBarController *tbc, BOOL animated) {
               tabBar.hidden, tabBar.alpha,
               tabBar.transform.tx, tabBar.transform.ty, tabBar.frame.origin.y);
     ApolloBumpTabBarMirrorGeneration(tbc);
+    objc_setAssociatedObject(tbc, &kApolloTabBarHideInFlightKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-    if ([tbc respondsToSelector:@selector(setTabBarHidden:animated:)]) {
-        [tbc setTabBarHidden:NO animated:animated];
+    // Where the bar currently appears, so the reveal slides up from there:
+    // fully parked below the screen when hidden, or mid-flight if a hide
+    // slide is still running.
+    CGFloat startTy = 0.0;
+    if ([tabBar.layer animationForKey:ApolloTabBarSlideDownAnimationKey]) {
+        CALayer *presentation = tabBar.layer.presentationLayer;
+        startTy = presentation ? [[presentation valueForKeyPath:@"transform.translation.y"] doubleValue] : 0.0;
+        [tabBar.layer removeAnimationForKey:ApolloTabBarSlideDownAnimationKey];
+    } else if (tabBar.hidden) {
+        startTy = ApolloTabBarSlideDistance(tabBar);
+    } else if (tabBar.transform.ty > 0.0) {
+        startTy = tabBar.transform.ty;
     }
-    void (^apply)(void) = ^{
-        tabBar.hidden = NO;
-        tabBar.alpha = 1.0;
-        tabBar.transform = CGAffineTransformIdentity;
-    };
-    if (animated) {
-        [UIView animateWithDuration:0.25
-                              delay:0.0
-                            options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseOut
-                         animations:apply
-                         completion:nil];
-    } else {
-        apply();
+
+    // Restore the model state outright (non-animated so the safe area updates
+    // once); the explicit layer animation below renders the slide-up. A UIView
+    // block animation on view.transform is NOT safe here — Apollo's own
+    // gesture-end handler writes the bar's model state right after us, which
+    // cancels or re-anchors it (see the hide path).
+    if (tabBar.hidden) {
+        if ([tbc respondsToSelector:@selector(setTabBarHidden:animated:)]) {
+            [tbc setTabBarHidden:NO animated:NO];
+        } else {
+            tabBar.hidden = NO;
+        }
+    }
+    tabBar.hidden = NO;
+    tabBar.alpha = 1.0;
+    tabBar.transform = CGAffineTransformIdentity;
+
+    if (animated && startTy > 0.5) {
+        CABasicAnimation *slideUp = [CABasicAnimation animationWithKeyPath:@"transform.translation.y"];
+        slideUp.fromValue = @(startTy);
+        slideUp.toValue = @0;
+        slideUp.duration = 0.25;
+        slideUp.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+        [tabBar.layer addAnimation:slideUp forKey:ApolloTabBarSlideUpAnimationKey];
     }
 }
 
@@ -261,9 +304,7 @@ static void ApolloHideTabBar(UITabBarController *tbc, BOOL animated) {
 
     ApolloLog(@"[AutoHideTabBarFix] Hide (animated=%d)", animated);
 
-    NSInteger generation = ApolloBumpTabBarMirrorGeneration(tbc);
     BOOL canSystemHide = [tbc respondsToSelector:@selector(setTabBarHidden:animated:)];
-    tabBar.transform = CGAffineTransformIdentity;
 
     void (^commitHidden)(void) = ^{
         if (canSystemHide) {
@@ -276,28 +317,63 @@ static void ApolloHideTabBar(UITabBarController *tbc, BOOL animated) {
     };
 
     if (!animated) {
+        objc_setAssociatedObject(tbc, &kApolloTabBarHideInFlightKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        tabBar.transform = CGAffineTransformIdentity;
         commitHidden();
         return;
     }
 
-    // Fade the bar out ourselves. Do NOT use setTabBarHidden:YES animated:YES:
-    // on iOS 26 with a legacy-linked (pre-26 SDK) app, that animation never
-    // moves the bar's model position — it stacks additive position animations
-    // that net out to a visible up-and-back "bounce" and only actually hides
-    // the bar by flipping .hidden at completion (issue #382's tab-bar pop).
-    // A plain alpha fade matches Apollo's own hide-on-swipe fade (its gesture
-    // handler animates the same property in the same direction, so the two
-    // compose instead of fighting), then the system flag is flipped
-    // non-animated at the end for safe-area/state correctness.
-    [UIView animateWithDuration:0.25
-                          delay:0.0
-                        options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseIn
-                     animations:^{ tabBar.alpha = 0.0; }
-                     completion:^(__unused BOOL finished) {
+    // A slide is already running — the gesture-end mirror and UIKit's
+    // transition-completion setNavigationBarHidden: both land here. Restarting
+    // would snap the bar back to its resting position for a frame.
+    if (objc_getAssociatedObject(tbc, &kApolloTabBarHideInFlightKey)) return;
+
+    NSInteger generation = ApolloBumpTabBarMirrorGeneration(tbc);
+    objc_setAssociatedObject(tbc, &kApolloTabBarHideInFlightKey, @(generation), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    tabBar.transform = CGAffineTransformIdentity;
+    [tabBar.layer removeAnimationForKey:ApolloTabBarSlideUpAnimationKey];
+
+    // Slide the bar off the bottom ourselves. Two traps here:
+    //  - Do NOT use setTabBarHidden:YES animated:YES: on iOS 26 with a
+    //    legacy-linked (pre-26 SDK) app, that animation never moves the bar's
+    //    model position — it stacks additive position animations that net out
+    //    to a visible up-and-back "bounce" and only actually hides the bar by
+    //    flipping .hidden at completion (issue #382's tab-bar pop).
+    //  - Do NOT animate view.transform with a UIView block animation: Apollo's
+    //    own gesture-end handler writes the bar's model state right after us,
+    //    which re-anchors the additive animation and plays the slide from
+    //    ABOVE the bar's resting position instead of down off-screen.
+    // An explicit layer animation on transform.translation.y is immune to
+    // both — model writes by other actors don't remove or re-anchor it. The
+    // system flag is then flipped non-animated at completion for
+    // safe-area/state correctness.
+    CABasicAnimation *slide = [CABasicAnimation animationWithKeyPath:@"transform.translation.y"];
+    slide.fromValue = @0;
+    slide.toValue = @(ApolloTabBarSlideDistance(tabBar));
+    slide.duration = 0.25;
+    slide.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseIn];
+    slide.fillMode = kCAFillModeForwards;
+    slide.removedOnCompletion = NO;
+
+    [CATransaction begin];
+    [CATransaction setCompletionBlock:^{
+        NSNumber *inFlight = objc_getAssociatedObject(tbc, &kApolloTabBarHideInFlightKey);
+        if (inFlight.integerValue == generation) {
+            objc_setAssociatedObject(tbc, &kApolloTabBarHideInFlightKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
         NSInteger current = [objc_getAssociatedObject(tbc, &kApolloTabBarMirrorGenerationKey) integerValue];
-        if (current != generation) return; // a Show/newer Hide took over mid-fade
+        if (current != generation) {
+            // A Show took over mid-slide; it owns the bar now.
+            [tabBar.layer removeAnimationForKey:ApolloTabBarSlideDownAnimationKey];
+            return;
+        }
+        // Same runloop tick — the fill removal and the hidden flip commit in
+        // one transaction, so no intermediate frame renders.
+        [tabBar.layer removeAnimationForKey:ApolloTabBarSlideDownAnimationKey];
         commitHidden();
     }];
+    [tabBar.layer addAnimation:slide forKey:ApolloTabBarSlideDownAnimationKey];
+    [CATransaction commit];
 }
 
 static void ApolloScheduleIdleRevealTimer(UITabBarController *tbc) {
@@ -442,6 +518,44 @@ static BOOL ApolloBarSwipeGestureActive(UINavigationController *nav) {
 }
 
 %end
+
+// Apollo's own barHideOnSwipeGesturePanned: (a manually-added second target on
+// UIKit's swipe gesture) animates the tab bar itself at gesture end — a fade
+// in comment threads, a direct hide in the feed — which fights the slide this
+// module drives and reads as a stutter. Every tab-bar touch in that handler
+// is guarded by `if (self.tabBarController != nil)`, so returning nil from
+// that getter for exactly the duration of the handler makes Apollo skip its
+// tab-bar work while keeping its statusBarBackgroundView and contentInset
+// bookkeeping intact. The mirror in this module is then the only thing
+// animating the tab bar.
+static BOOL sApolloInBarHideSwipeHandler = NO;
+
+%hook _TtC6Apollo26ApolloNavigationController
+
+- (void)barHideOnSwipeGesturePanned:(UIPanGestureRecognizer *)gr {
+    if (ApolloSupportsNativeTabBarMinimize()) {
+        %orig;
+        return;
+    }
+    sApolloInBarHideSwipeHandler = YES;
+    %orig;
+    sApolloInBarHideSwipeHandler = NO;
+}
+
+%end
+
+%hook UIViewController
+
+- (UITabBarController *)tabBarController {
+    if (sApolloInBarHideSwipeHandler &&
+        [self isKindOfClass:objc_getClass("_TtC6Apollo26ApolloNavigationController")]) {
+        return nil;
+    }
+    return %orig;
+}
+
+%end
+
 
 // hidesBarsOnSwipe entry point. Two modes:
 //   iOS 26+: hijack the toggle — instead of letting the nav bar hide on

--- a/src/ApolloAutoHideTabBar.xm
+++ b/src/ApolloAutoHideTabBar.xm
@@ -214,6 +214,17 @@ static BOOL ApolloTabBarLooksHidden(UITabBar *tabBar) {
     return NO;
 }
 
+// Monotonically increasing token per tab bar controller; a Hide whose fade is
+// still in flight abandons its completion work when a Show (or newer Hide)
+// has started since.
+static char kApolloTabBarMirrorGenerationKey;
+
+static NSInteger ApolloBumpTabBarMirrorGeneration(UITabBarController *tbc) {
+    NSInteger generation = [objc_getAssociatedObject(tbc, &kApolloTabBarMirrorGenerationKey) integerValue] + 1;
+    objc_setAssociatedObject(tbc, &kApolloTabBarMirrorGenerationKey, @(generation), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return generation;
+}
+
 static void ApolloShowTabBar(UITabBarController *tbc, BOOL animated) {
     if (!tbc) return;
     UITabBar *tabBar = tbc.tabBar;
@@ -222,6 +233,7 @@ static void ApolloShowTabBar(UITabBarController *tbc, BOOL animated) {
     ApolloLog(@"[AutoHideTabBarFix] Show (hidden=%d alpha=%.2f tx=%.1f ty=%.1f y=%.1f)",
               tabBar.hidden, tabBar.alpha,
               tabBar.transform.tx, tabBar.transform.ty, tabBar.frame.origin.y);
+    ApolloBumpTabBarMirrorGeneration(tbc);
 
     if ([tbc respondsToSelector:@selector(setTabBarHidden:animated:)]) {
         [tbc setTabBarHidden:NO animated:animated];
@@ -249,45 +261,43 @@ static void ApolloHideTabBar(UITabBarController *tbc, BOOL animated) {
 
     ApolloLog(@"[AutoHideTabBarFix] Hide (animated=%d)", animated);
 
-    // Prefer the system path: it slides the tab bar AND recomputes safe-area
-    // insets in one coordinated animation, so floating views anchored to the
-    // safe area (e.g. the blue jump-to-bottom button in CommentsVC) reflow
-    // smoothly alongside the fade instead of jumping after it completes.
-    if ([tbc respondsToSelector:@selector(setTabBarHidden:animated:)]) {
-        // Keep alpha at 1 so the system's slide/fade reads naturally; reset
-        // any leftover transform that the broken native path may have left.
-        tabBar.alpha = 1.0;
-        tabBar.transform = CGAffineTransformIdentity;
-        [tbc setTabBarHidden:YES animated:animated];
-        // Force the floating overlay (jump-to-bottom button etc) to reflow
-        // during the same animation tick by pumping a layout pass on the
-        // tab bar controller's view inside the animation block.
-        if (animated) {
-            [UIView animateWithDuration:0.25
-                                  delay:0.0
-                                options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseInOut
-                             animations:^{
-                [tbc.view setNeedsLayout];
-                [tbc.view layoutIfNeeded];
-            } completion:nil];
+    NSInteger generation = ApolloBumpTabBarMirrorGeneration(tbc);
+    BOOL canSystemHide = [tbc respondsToSelector:@selector(setTabBarHidden:animated:)];
+    tabBar.transform = CGAffineTransformIdentity;
+
+    void (^commitHidden)(void) = ^{
+        if (canSystemHide) {
+            [tbc setTabBarHidden:YES animated:NO];
+        } else {
+            tabBar.hidden = YES;
         }
+        // Leave alpha at 1 so the flag alone controls visibility from here on.
+        tabBar.alpha = 1.0;
+    };
+
+    if (!animated) {
+        commitHidden();
         return;
     }
 
-    // Fallback (shouldn't happen on iOS): plain alpha+hidden.
-    void (^apply)(void) = ^{ tabBar.alpha = 0.0; };
-    if (animated) {
-        [UIView animateWithDuration:0.25
-                              delay:0.0
-                            options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseIn
-                         animations:apply
-                         completion:^(BOOL finished) {
-            if (finished) tabBar.hidden = YES;
-        }];
-    } else {
-        apply();
-        tabBar.hidden = YES;
-    }
+    // Fade the bar out ourselves. Do NOT use setTabBarHidden:YES animated:YES:
+    // on iOS 26 with a legacy-linked (pre-26 SDK) app, that animation never
+    // moves the bar's model position — it stacks additive position animations
+    // that net out to a visible up-and-back "bounce" and only actually hides
+    // the bar by flipping .hidden at completion (issue #382's tab-bar pop).
+    // A plain alpha fade matches Apollo's own hide-on-swipe fade (its gesture
+    // handler animates the same property in the same direction, so the two
+    // compose instead of fighting), then the system flag is flipped
+    // non-animated at the end for safe-area/state correctness.
+    [UIView animateWithDuration:0.25
+                          delay:0.0
+                        options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseIn
+                     animations:^{ tabBar.alpha = 0.0; }
+                     completion:^(__unused BOOL finished) {
+        NSInteger current = [objc_getAssociatedObject(tbc, &kApolloTabBarMirrorGenerationKey) integerValue];
+        if (current != generation) return; // a Show/newer Hide took over mid-fade
+        commitHidden();
+    }];
 }
 
 static void ApolloScheduleIdleRevealTimer(UITabBarController *tbc) {

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -89,7 +89,19 @@ NSString *ApolloCollectAILogs(void) {
 // Get the SDK version from the main binary's LC_BUILD_VERSION load command
 // Returns 0 if not found, otherwise packed version (major << 16 | minor << 8 | patch)
 static uint32_t GetLinkedSDKVersion(void) {
-    const struct mach_header_64 *header = (const struct mach_header_64 *)_dyld_get_image_header(0);
+    // Find the main executable by filetype instead of assuming image index 0.
+    // In the simulator the injected tweak dylib can occupy index 0, which made
+    // IsLiquidGlass() read the dylib's own SDK (always current) instead of
+    // Apollo's — masking every legacy (non-glass) code path during sim testing.
+    const struct mach_header_64 *header = NULL;
+    for (uint32_t i = 0; i < _dyld_image_count(); i++) {
+        const struct mach_header *h = _dyld_get_image_header(i);
+        if (h && h->filetype == MH_EXECUTE) {
+            header = (const struct mach_header_64 *)h;
+            break;
+        }
+    }
+    if (!header) header = (const struct mach_header_64 *)_dyld_get_image_header(0);
     if (!header) return 0;
 
     uintptr_t cursor = (uintptr_t)header + sizeof(struct mach_header_64);


### PR DESCRIPTION
Fixes #382.

## Before / After

| Before (stutter) | After (clean slide) |
| :---: | :---: |
| <img alt="before" src="https://github.com/user-attachments/assets/5d738874-f7f0-4f6a-a923-16c946ef179b" width="320"> | <img alt="after" src="https://github.com/user-attachments/assets/cf208202-0924-496b-95dc-e065e6fd3a2b" width="320"> |

## Problem

With **Hide Bars on Scroll** enabled on a legacy (non-Liquid-Glass) build, scrolling down makes the navigation bar start to collapse, then both the nav bar **and** the tab bar pop back fully visible for a beat, and only then do they actually hide. Repeats on every hide, and the same brief pop shows up when you keep scrolling with the bars already hidden. Matches the video in the issue.

## Root cause — one gesture, four actors fighting over two bars

On modern iOS, `hidesBarsOnSwipe` runs the nav bar through a **percent-driven interactive transition**: the moment the pan crosses the hide threshold, UIKit's `_gestureRecognizedInteractiveHide:` calls `setNavigationBarHidden:YES animated:YES` and then scrubs that animation with the finger. Captured mid-pan in the sim:

```
setNavigationBarHidden:1 animated:1
  ← -[UINavigationController _setBarsHidden:allowAnimation:]
  ← -[_UIAnimationCoordinator animateTransition:]
  ← -[UIPercentDrivenInteractiveTransition startInteractiveTransition:]
  ← -[UINavigationController _gestureRecognizedInteractiveHide:]   ← still panning
```

Fighting over the bars during that one gesture:

1. **The legacy tab-bar mirror reacted from inside UIKit's in-flight transition.** `ApolloAutoHideTabBar.xm` hooks that setter and kicked off a tab-bar hide plus a forced layout pass mid-pan, clobbering the interactive animation — both bars snapped back to fully visible before hiding again. (The original stutter.)
2. **Animated `setTabBarHidden:` is broken on this OS/app combo.** On iOS 26 with a legacy-linked (pre-26 SDK) app, `[UITabBarController setTabBarHidden:YES animated:YES]` never moves the bar's model position — a 60Hz presentation-layer trace shows additive position animations that net out to a visible up-and-back bounce, with the bar only disappearing when `.hidden` flips at completion.
3. **Apollo's own `barHideOnSwipeGesturePanned:`** (a second target Apollo adds to UIKit's swipe recognizer — the legacy-era action selector; UIKit's own action is `_gestureRecognizedInteractiveHide:` on modern iOS) animates the tab bar itself at gesture end — a fade in comment threads, a direct hide in the feed. Its model-state writes cancel or re-anchor any UIView block animation run against the same bar.
4. **UIKit re-invokes `setNavigationBarHidden:`** when the interactive transition completes, so gesture-end work can fire twice; a restarted hide animation snapped the bar back to its resting position for a frame.

## Fix

- **Skip the mirror while the swipe gesture is actively panning** (`ApolloBarSwipeGestureActive()`, guarded by `hidesBarsOnSwipe` so the lazy getter doesn't create the recognizer). The gesture-end observer already mirrors the settled state; programmatic hide/show keeps the immediate mirror.
- **Drive the tab bar's hide as an explicit `CABasicAnimation` slide** on `transform.translation.y` — off the bottom of the screen, matching how the nav bar slides off the top. Explicit layer animations are immune to other actors' model writes (unlike UIView block animations, which actor 3 cancels/re-anchors). The filled-forward animation is committed by flipping `setTabBarHidden:YES` non-animated in the same transaction as the fill removal, so no intermediate frame renders and safe areas/state stay correct. The reveal mirrors it: restore model state non-animated, slide up from wherever the bar currently appears (including taking over mid-hide).
- **Silence Apollo's competing gesture-end tab-bar animation.** Every tab-bar touch in Apollo's handler is guarded by `if (self.tabBarController != nil)`, so a scoped hook returns nil from that getter for exactly the duration of the handler. Apollo's statusBarBackgroundView and contentInset bookkeeping still run; this module becomes the only thing animating the tab bar.
- **In-flight token** makes repeat Hide calls during a slide no-ops (fixes actor 4), and a generation counter lets a reveal cleanly take over a hide mid-slide.

Supporting fix in `ApolloCommon.m`: `GetLinkedSDKVersion()` now finds the main executable by `MH_EXECUTE` filetype instead of assuming dyld image index 0. On device image 0 *is* the app binary, so behavior there is unchanged — but in the simulator the injected tweak dylib can land at index 0, which made `IsLiquidGlass()` read the dylib's own (always-current) SDK. That forced every sim run down the Liquid Glass code path and made legacy-path bugs like this one impossible to reproduce or test in the simulator.

## Testing

Verified in the iOS 26.5 simulator against a legacy (iOS 16-linked) Apollo shell, frame-by-frame (template-matching the tab bar's screen position per frame at 30fps, plus a 60Hz presentation-layer trace):

- **Before:** hide starts mid-pan → both bars pop back fully visible → hide again; tab bar bounces up-and-back at gesture end.
- **After (hide):** nav bar slides off the top with the pan; at gesture end the tab bar slides down off-screen, fully opaque, monotonic — feed and comment threads, first gesture after launch and repeats.
- **After (reveal):** tab bar slides back up from the bottom edge, nav bar completes its interactive reveal; no flicker.
- Device build (`make package`) compiles clean against `main`. Not yet tested on a physical device.