### PR TITLE
Fix native menus: use the iOS 26 liquid-glass morph presentation

### DIFF
--- a/src/ApolloNativeActionMenus.xm
+++ b/src/ApolloNativeActionMenus.xm
@@ -23,6 +23,11 @@ static BOOL sApolloNativeActionMenuNextPresentationModeratorStyle = NO;
 @interface ApolloNativeActionMenuPresenter : NSObject <UIContextMenuInteractionDelegate>
 @property (nonatomic, strong) UIMenu *menu;
 @property (nonatomic, weak) UIView *sourceView;
+// Issue #249: the REAL tapped control (sort/ellipsis bar button, cell "..."
+// button). The interaction stays on the invisible proxy anchor, but the
+// highlight/dismiss previews target this view so the iOS 26 liquid-glass
+// "magic morph" has a visible source to bloom out of.
+@property (nonatomic, weak) UIView *morphSourceView;
 @property (nonatomic, strong) UIContextMenuInteraction *interaction;
 @property (nonatomic, assign) BOOL removeSourceViewOnEnd;
 @end
@@ -32,6 +37,23 @@ static BOOL ApolloNativeActionMenusEnabled(void) {
         return IsLiquidGlass() && objc_getClass("_UIContextMenuPlatformMetrics_Glass") != Nil;
     }
     return NO;
+}
+
+// Issue #249: whether UIKit's liquid-glass menu morph ("magic morph") is on.
+// _UIContextMenuMagicMorphAnimationEnabled() gates on _UISolariumEnabled() +
+// an internal preference; UIKit consults it when deciding to swap the source
+// preview for a morphable one (UIContextMenuInteraction.mm) and when picking
+// _UIContextMenuLiquidMorphPresentationAnimation (_UIContextMenuPresentation.mm).
+// If the symbol is gone in a future UIKit, assume on — this code only runs on
+// glass builds where Solarium is active, and a wrong YES just means an overlap
+// style UIKit ignores.
+static BOOL ApolloNativeActionMenuMagicMorphEnabled(void) {
+    static BOOL (*sEnabledFn)(void);
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sEnabledFn = (BOOL (*)(void))dlsym(RTLD_DEFAULT, "_UIContextMenuMagicMorphAnimationEnabled");
+    });
+    return sEnabledFn ? sEnabledFn() : YES;
 }
 
 static NSString *ApolloDecodeSwiftString(uint64_t w0, uint64_t w1) {
@@ -802,7 +824,51 @@ static UIMenu *ApolloNativeActionMenuBuildMenu(id actionController, BOOL moderat
     }];
 }
 
+// Issue #249: UIKit's iOS 26 liquid-glass menu bloom only runs when the menu
+// style asks for it. -[_UIContextMenuLiquidMorphPresentationAnimation
+// sourcePreviewMorphsToMenu] requires preferredLayout == 3 (compact/actions-
+// only) AND shouldMenuOverlapSourcePreview == YES; without a delegate style
+// UIKit uses +[_UIContextMenuStyle defaultStyle] (layout 100, overlap NO) and
+// the presentation degrades to the legacy fade. Mirror what UIKit's own
+// button-menu path builds in _UIControlMenuSupportDefaultMenuStyle().
+- (id)_contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction styleForMenuWithConfiguration:(__unused UIContextMenuConfiguration *)configuration {
+    Class styleClass = objc_getClass("_UIContextMenuStyle");
+    SEL defaultStyleSelector = NSSelectorFromString(@"defaultStyle");
+    if (!styleClass || ![styleClass respondsToSelector:defaultStyleSelector]) return nil;
+
+    id style = ((id (*)(id, SEL))objc_msgSend)(styleClass, defaultStyleSelector);
+    if (!style) return nil;
+
+    SEL setPreferredLayoutSelector = NSSelectorFromString(@"setPreferredLayout:");
+    if ([style respondsToSelector:setPreferredLayoutSelector]) {
+        ((void (*)(id, SEL, NSInteger))objc_msgSend)(style, setPreferredLayoutSelector, 3);
+    }
+    SEL setOverlapSelector = NSSelectorFromString(@"setShouldMenuOverlapSourcePreview:");
+    if ([style respondsToSelector:setOverlapSelector]) {
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(style, setOverlapSelector, ApolloNativeActionMenuMagicMorphEnabled());
+    }
+    return style;
+}
+
 - (UITargetedPreview *)contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction previewForHighlightingMenuWithConfiguration:(__unused UIContextMenuConfiguration *)configuration {
+    // Issue #249: give the liquid morph a visible source. UIKit swaps this
+    // preview for -[UITargetedPreview _resolvedMorphablePreview] and blooms
+    // the menu out of it; the native button path builds it over the control's
+    // _morphView (the glass background platter when there is one, else the
+    // control itself) — see _UIControlMenuSupportTargetedPreviewOverViews().
+    UIView *morphSource = self.morphSourceView;
+    if (morphSource.window) {
+        UIView *morphView = morphSource;
+        SEL morphViewSelector = NSSelectorFromString(@"_morphView");
+        if ([morphSource respondsToSelector:morphViewSelector]) {
+            UIView *resolved = ((id (*)(id, SEL))objc_msgSend)(morphSource, morphViewSelector);
+            if (resolved.window) morphView = resolved;
+        }
+        return [[UITargetedPreview alloc] initWithView:morphView];
+    }
+
+    // Fallback (real control gone/windowless): the invisible proxy anchor.
+    // No morph in this case, but the menu still appears anchored correctly.
     UIView *sourceView = self.sourceView;
     if (!sourceView) return nil;
 
@@ -820,15 +886,26 @@ static UIMenu *ApolloNativeActionMenuBuildMenu(id actionController, BOOL moderat
     return [self contextMenuInteraction:interaction previewForHighlightingMenuWithConfiguration:configuration];
 }
 
-- (void)contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction willEndForConfiguration:(__unused UIContextMenuConfiguration *)configuration animator:(__unused id<UIContextMenuInteractionAnimating>)animator {
+- (void)contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction willEndForConfiguration:(__unused UIContextMenuConfiguration *)configuration animator:(id<UIContextMenuInteractionAnimating>)animator {
     UIView *sourceView = self.sourceView;
     UIContextMenuInteraction *menuInteraction = self.interaction;
-    if (sourceView && menuInteraction) {
+    if (!sourceView || !menuInteraction) return;
+
+    BOOL removeSourceViewOnEnd = self.removeSourceViewOnEnd;
+    // Issue #249: tear down at dismissal END, not START — removing the anchor
+    // (the interaction's host view) while the menu is still morphing back into
+    // the source button cuts the dismissal animation short.
+    void (^teardown)(void) = ^{
         [sourceView removeInteraction:menuInteraction];
         objc_setAssociatedObject(sourceView, &kApolloNativeActionMenuControllerKey, nil, OBJC_ASSOCIATION_ASSIGN);
-        if (self.removeSourceViewOnEnd) {
+        if (removeSourceViewOnEnd) {
             [sourceView removeFromSuperview];
         }
+    };
+    if (animator) {
+        [animator addCompletion:teardown];
+    } else {
+        teardown();
     }
 }
 
@@ -972,6 +1049,7 @@ static BOOL ApolloNativeActionMenuPresent(id presenter, id actionController, voi
     ApolloNativeActionMenuPresenter *menuPresenter = [ApolloNativeActionMenuPresenter new];
     menuPresenter.menu = menu;
     menuPresenter.sourceView = anchorView;
+    menuPresenter.morphSourceView = sourceView;
     menuPresenter.removeSourceViewOnEnd = removeAnchorViewOnEnd;
 
     UIContextMenuInteraction *interaction = [[UIContextMenuInteraction alloc] initWithDelegate:menuPresenter];
@@ -984,6 +1062,18 @@ static BOOL ApolloNativeActionMenuPresent(id presenter, id actionController, voi
 
     [anchorView addInteraction:interaction];
     objc_setAssociatedObject(anchorView, &kApolloNativeActionMenuControllerKey, menuPresenter, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    // Issue #249: a programmatic presentation has no active click driver, so
+    // -[UIContextMenuInteraction menuAppearance] falls back to the interaction's
+    // fallbackDriverStyle — which defaults to 0 and resolves to the "rich"
+    // (long-press preview) appearance instead of the compact button-menu one.
+    // Compact appearance is what makes UIKit force preferredLayout 3 and compute
+    // the glass attachment point. UIKit's own programmatic presenters set the
+    // fallback first (UITextItemInteractionHandler, _UISearchSuggestionController).
+    SEL fallbackDriverStyleSelector = NSSelectorFromString(@"_setFallbackDriverStyle:");
+    if ([interaction respondsToSelector:fallbackDriverStyleSelector]) {
+        ((void (*)(id, SEL, NSUInteger))objc_msgSend)(interaction, fallbackDriverStyleSelector, 1);
+    }
 
     CGPoint location = CGPointMake(CGRectGetMidX(anchorView.bounds), CGRectGetMidY(anchorView.bounds));
     ((void (*)(id, SEL, CGPoint))objc_msgSend)(interaction, NSSelectorFromString(@"_presentMenuAtLocation:"), location);

--- a/src/ApolloNativeActionMenus.xm
+++ b/src/ApolloNativeActionMenus.xm
@@ -831,7 +831,9 @@ static UIMenu *ApolloNativeActionMenuBuildMenu(id actionController, BOOL moderat
 // UIKit uses +[_UIContextMenuStyle defaultStyle] (layout 100, overlap NO) and
 // the presentation degrades to the legacy fade. Mirror what UIKit's own
 // button-menu path builds in _UIControlMenuSupportDefaultMenuStyle().
-- (id)_contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction styleForMenuWithConfiguration:(__unused UIContextMenuConfiguration *)configuration {
+// NOTE: layout 3 swaps the presentation to the actions-only controller, so
+// this style is only correct for menus that have NO preview platter.
+static id ApolloNativeActionMenuCompactMenuStyle(void) {
     Class styleClass = objc_getClass("_UIContextMenuStyle");
     SEL defaultStyleSelector = NSSelectorFromString(@"defaultStyle");
     if (!styleClass || ![styleClass respondsToSelector:defaultStyleSelector]) return nil;
@@ -848,6 +850,10 @@ static UIMenu *ApolloNativeActionMenuBuildMenu(id actionController, BOOL moderat
         ((void (*)(id, SEL, BOOL))objc_msgSend)(style, setOverlapSelector, ApolloNativeActionMenuMagicMorphEnabled());
     }
     return style;
+}
+
+- (id)_contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction styleForMenuWithConfiguration:(__unused UIContextMenuConfiguration *)configuration {
+    return ApolloNativeActionMenuCompactMenuStyle();
 }
 
 - (UITargetedPreview *)contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction previewForHighlightingMenuWithConfiguration:(__unused UIContextMenuConfiguration *)configuration {
@@ -983,6 +989,20 @@ typedef UIMenu * (^ApolloNativeActionMenuProvider)(NSArray<UIMenuElement *> *sug
     UIContextMenuConfiguration *configuration = %orig;
     sApolloNativeActionMenuConfigurationSourceView = previousSourceView;
     return configuration;
+}
+
+// Issue #249 follow-up: the media viewer's long-press menu has no preview
+// platter (the media is already fullscreen), so it can adopt the compact
+// glass style and grow in liquid-style like a button menu instead of
+// popping in. Previewed menus keep the native rich style — layout 3 would
+// drop their preview platter.
+%new
+- (id)_contextMenuInteraction:(UIContextMenuInteraction *)interaction styleForMenuWithConfiguration:(UIContextMenuConfiguration *)configuration {
+    if (!ApolloNativeActionMenusEnabled()) return nil;
+    id previewProvider = nil;
+    @try { previewProvider = [configuration valueForKey:@"previewProvider"]; } @catch (__unused NSException *exception) {}
+    if (previewProvider) return nil;
+    return ApolloNativeActionMenuCompactMenuStyle();
 }
 %end
 


### PR DESCRIPTION
Fixes #249.

## Problem

On Liquid Glass builds, the converted native menus (feed/comments sort, the "..." bar button, cell "..." menus — everything ApolloNativeActionMenus presents) pop in with the old fade animation instead of the iOS 26 one where the menu morphs out of the tapped button as a glass bubble (the video in the issue shows the expected animation).

## Before / After

| Before (generic pop) | After (iOS 26 glass morph) |
| :---: | :---: |
| <img alt="before - wrong glass animations" src="https://github.com/user-attachments/assets/e3cb6c15-c348-4e44-87aa-a71e8d5e69e8" width="320"> | <img alt="after - correct glass animations" src="https://github.com/user-attachments/assets/05fdb8bb-738c-410e-a876-4ca68d4cc7b0" width="320"> |

Before: the menu just fades in at full size, detached from the button. After: it blooms out of the tapped button as a liquid-glass bubble and morphs back into it on dismissal, matching native iOS 26 menus.

## Root cause

Our conversion presents the UIMenu programmatically: a `UIContextMenuInteraction` on an invisible 1×1 proxy anchor + the private `_presentMenuAtLocation:`. That path misses three things UIKit needs before it will run the liquid-glass morph (all verified in the iOS 26.1 UIKitCore decompile):

1. `-[_UIContextMenuLiquidMorphPresentationAnimation sourcePreviewMorphsToMenu]` requires the menu style to be compact (`preferredLayout == 3`) with `shouldMenuOverlapSourcePreview == YES`. With no delegate-supplied style, UIKit falls back to `+[_UIContextMenuStyle defaultStyle]` (layout 100, no overlap) → generic pop.
2. A programmatic present has no active click driver, so `menuAppearance` resolves to "rich" (the long-press preview appearance) instead of "compact" (the button-menu appearance that forces layout 3 and computes the glass attachment point). UIKit's own programmatic presenters (`UITextItemInteractionHandler`, search suggestions) call `_setFallbackDriverStyle:1` before `_presentMenuAtLocation:` — we didn't.
3. Even with both style gates open, the morph needs a visible source: UIKit swaps the highlight preview for `-[UITargetedPreview _resolvedMorphablePreview]` and blooms the menu out of it. Ours wrapped the invisible 1×1 proxy, so there was nothing to bloom from. Native button menus build the preview over the control's `_morphView` (the glass platter when there is one).

## Fix

All in `ApolloNativeActionMenus.xm`, so every converted surface gets it at once:

- The presenter now implements `_contextMenuInteraction:styleForMenuWithConfiguration:` returning defaultStyle + `preferredLayout 3` + `shouldMenuOverlapSourcePreview` (mirrors UIKit's own `_UIControlMenuSupportDefaultMenuStyle()`, including checking `_UIContextMenuMagicMorphAnimationEnabled()` via dlsym).
- `_setFallbackDriverStyle:1` on the interaction before presenting.
- Highlight/dismiss previews target the real tapped control (via `_morphView` when available) instead of the proxy anchor. The proxy still hosts the interaction — we don't want to stack interactions on Apollo's own views — and stays as the preview fallback when the control is gone/windowless.
- Teardown (interaction + proxy removal) moved from `willEnd` to the dismissal animator's completion so the morph-back isn't cut short.
- Follow-up commit: the fullscreen media viewer's long-press menu (Share Link / Download Video / Playback Speed) has no preview platter, so it now adopts the same compact glass style and grows in liquid-style instead of popping in. Long-press menus that DO have a preview (feed video/image/link, post/comment cells) are untouched — runtime inspection shows they already use the glass metrics and match native iOS 26 behavior exactly (the OS deliberately doesn't bloom preview menus).

Everything private is behind `respondsToSelector:`/`dlsym` guards; if any of it changes in a future UIKit the behavior just degrades back to exactly what ships today.

## Testing (sim, glass, iOS 26.5)

- Feed sort menu blooms out of the sort button and morphs back on dismissal — matches the issue's reference video
- Nav "..." menu, in-cell post "..." (12 items), and the chained sort → "Top → Sort by Top for…" second menu all morph correctly
- Selecting an item still works (sort switched Best → Hot, bar icon updated, feed re-sorted), source buttons all restored after dismissal, no exceptions in the logs
- Non-glass builds unaffected (whole module is gated on `ApolloNativeActionMenusEnabled`)
- Device build compiles; not device-tested yet

