### PR TITLE
Inline GIFs: fix the autoplay gate, add Tap to Play, new Inline Media settings screen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloAISettingsViewController.m \
     $(SRC_DIR)/ApolloDeletedCommentsSettingsViewController.m \
     $(SRC_DIR)/ApolloLinkPreviewSettingsViewController.m \
+    $(SRC_DIR)/InlineMediaSettingsViewController.m \
     $(SRC_DIR)/ApolloOpenInAppViewController.m \
     $(SRC_DIR)/ApolloHideNativeOpenInAppRows.xm \
     $(SRC_DIR)/TranslationSettingsViewController.m \

--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -148,7 +148,7 @@ static char kApolloOriginalImageURLKey;        // NSURL for tap/long-press when 
 static char kApolloHostMarkdownNodeKey;        // weak ref (assign association) to the host MarkdownNode
 static char kApolloAspectRatioKey;             // NSNumber height/width — NIL if unknown (no URL params yet, no DIDLOAD yet)
 static char kApolloLongPressInstalledKey;      // NSNumber BOOL — gate for one-shot UIContextMenuInteraction install
-static char kApolloPlayOverlayViewKey;         // UIView play overlay container, also used as install gate
+static char kApolloPlayOverlayViewKey;         // ApolloPlayOverlayContainer (play button OR pause badge), also used as install gate
 static char kApolloInlineAnimatedGIFKey;       // NSNumber BOOL — node loaded an animated GIF
 static char kApolloInlineGIFAnimatedImageKey;  // id — retained animated image for tap-to-play restore
 static char kApolloInlineGIFCoverImageKey;     // UIImage — first-frame cover for static pause + refresh
@@ -156,6 +156,7 @@ static char kApolloInlineGIFUserForcedPlayKey; // NSNumber BOOL — user tapped 
 static char kApolloInlineGIFPendingPolicyBlocksKey; // NSMutableArray<dispatch_block_t>
 static char kApolloInlineGIFGenerationKey;     // NSNumber — bumped on clear/reuse to invalidate async GIF policy blocks
 static char kApolloInlineGIFReloadInFlightKey; // NSNumber BOOL — internal URL/image reset in progress (settings-refresh reload, pause cover swap): suppress ClearState from the reset round trip
+static char kApolloInlineGIFOverlayReassertKey; // NSNumber BOOL — a play-overlay reassert sequence is pending for this GIF node
 static char kApolloStackedCardSyncerKey;       // ApolloStackedCardSyncer — keeps the multi-image card peeking behind imageNode
 static char kApolloImageChestItemsKey;         // NSArray<NSDictionary *> direct ImageChest CDN image entries for album pager
 
@@ -185,6 +186,8 @@ static void ApolloClearInlineGIFCoverImageReadyCallback(id anim);
 static void ApolloTrackInlineGIFPendingPolicyBlock(ASDisplayNode *node, dispatch_block_t block);
 static void ApolloInstallPlayOverlayOnView(UIView *v, ASDisplayNode *node);
 static void ApolloRemovePlayOverlayFromNode(ASDisplayNode *node);
+static void ApolloUpdateInlineGIFOverlayForNode(ASDisplayNode *node);
+static void ApolloSchedulePlayOverlayReassert(ASNetworkImageNode *imageNode, NSUInteger attempt);
 static NSDictionary *ApolloMediaMetadataForHost(ASDisplayNode *hostMarkdownNode);
 
 // MARK: - Class lookups (cached)
@@ -1685,19 +1688,33 @@ static id ApolloFindResponderForSelector(SEL sel, id imageNode) {
 }
 
 - (void)imageNodeTapped:(id)imageNode {
-    // Inline tap-to-play only when the play-button overlay is showing
-    // (Tap to Play mode, or WiFi Only while blocked). Never mode has no
-    // overlay — the tap falls through to the media viewer like any image.
+    // Tap-to-play GIFs: the play button / corner pause badge overlay
+    // (ApolloPlayOverlayContainer) swallows taps on its own icon zone and
+    // toggles inline playback there. Any other tap on the GIF lands here
+    // and falls through to the media viewer below — fullscreen stays
+    // reachable with the overlay up, exactly like a plain image.
+    //
+    // Self-heal: Texture can recycle the node's backing view on a
+    // relayout-from-above (async cover sizing, metadata rebuilds) and
+    // silently drop the container (see ApolloSchedulePlayOverlayReassert).
+    // With the overlay detached there is no icon zone, so without this a
+    // tap-to-play GIF would be unplayable inline until a settings change.
+    // Fall back to the whole-GIF toggle in that state; Start/Stop re-run
+    // the overlay mapper, which re-attaches the proper overlay.
     if ([objc_getAssociatedObject(imageNode, &kApolloInlineAnimatedGIFKey) boolValue] &&
-        (objc_getAssociatedObject(imageNode, &kApolloPlayOverlayViewKey) ||
-         (!ApolloShouldAutoplayInlineGIFCached() && ApolloPausedInlineGIFWantsPlayOverlay()))) {
-        if ([objc_getAssociatedObject(imageNode, &kApolloInlineGIFUserForcedPlayKey) boolValue]) {
-            // Tap while force-playing — pause back to the cover + play button.
-            ApolloStopInlineGIFPlayback((ASNetworkImageNode *)imageNode);
-        } else {
-            ApolloStartInlineGIFPlayback((ASNetworkImageNode *)imageNode);
+        !ApolloShouldAutoplayInlineGIFCached() && ApolloPausedInlineGIFWantsPlayOverlay()) {
+        UIView *overlay = objc_getAssociatedObject(imageNode, &kApolloPlayOverlayViewKey);
+        UIView *nodeView = ([imageNode respondsToSelector:@selector(isNodeLoaded)] && [imageNode isNodeLoaded])
+            ? [imageNode view] : nil;
+        if (!overlay || !nodeView || overlay.superview != nodeView) {
+            ApolloLog(@"[AutoplayGIF] tap heal node=%p overlay=%p detached=1", imageNode, overlay);
+            if ([objc_getAssociatedObject(imageNode, &kApolloInlineGIFUserForcedPlayKey) boolValue]) {
+                ApolloStopInlineGIFPlayback((ASNetworkImageNode *)imageNode);
+            } else {
+                ApolloStartInlineGIFPlayback((ASNetworkImageNode *)imageNode);
+            }
+            return;
         }
-        return;
     }
 
     NSArray *imageChestItems = objc_getAssociatedObject(imageNode, &kApolloImageChestItemsKey);
@@ -2055,15 +2072,10 @@ static void ApolloGateNativeInlineAnimatedImageIfNeeded(ASDisplayNode *node) {
         ApolloRegisterInlineGIFNode(strong);
 
         ApolloMarkHostedInlineGIFViewWhenLoaded((ASNetworkImageNode *)strong, generation);
-        if (!ApolloShouldAutoplayInlineGIFCached()) {
-            ASDisplayNode *displayNode = (ASDisplayNode *)strong;
-            if ([displayNode respondsToSelector:@selector(isNodeLoaded)] && [displayNode isNodeLoaded]) {
-                UIView *view = [displayNode view];
-                if (view && cover && cover.size.width > 0 && ApolloPausedInlineGIFWantsPlayOverlay()) {
-                    ApolloInstallPlayOverlayOnView(view, displayNode);
-                }
-            }
-        }
+        // Attach the play button (or pause badge, when this set is the
+        // tap-to-play re-inject) as soon as the view exists; no-ops until
+        // node load, after which the playback policy's pause path installs.
+        ApolloUpdateInlineGIFOverlayForNode((ASDisplayNode *)strong);
 
         ApolloApplyInlineGIFPlaybackPolicyWithCover((ASNetworkImageNode *)strong, cover, 0);
         if (cover && cover.size.width > 0 && cover.size.height > 0) return;
@@ -2316,13 +2328,64 @@ static UIImage *ApolloPlayOverlayImage(void) {
 }
 
 
-// A UIView that centers its single subview in layoutSubviews, AND on
+// The small corner pause badge shown on a tap-to-play GIF while the user has
+// it playing — same visual language as the play circle, scaled down.
+static UIImage *ApolloInlineGIFPauseBadgeImage(void) {
+    static UIImage *image;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        CGFloat side = 30.0;
+        UIGraphicsBeginImageContextWithOptions(CGSizeMake(side, side), NO, 0.0);
+        CGContextRef ctx = UIGraphicsGetCurrentContext();
+        CGPoint center = CGPointMake(side * 0.5, side * 0.5);
+        CGRect circleRect = CGRectInset(CGRectMake(0, 0, side, side), 1.5, 1.5);
+
+        CGContextSaveGState(ctx);
+        CGContextSetShadowWithColor(ctx, CGSizeZero, 3.0, [UIColor colorWithWhite:0.0 alpha:0.55].CGColor);
+        CGContextSetFillColorWithColor(ctx, [UIColor colorWithWhite:0.0 alpha:0.45].CGColor);
+        CGContextFillEllipseInRect(ctx, circleRect);
+        CGContextRestoreGState(ctx);
+
+        CGContextSetStrokeColorWithColor(ctx, [UIColor colorWithWhite:1.0 alpha:0.85].CGColor);
+        CGContextSetLineWidth(ctx, 1.5);
+        CGContextStrokeEllipseInRect(ctx, CGRectInset(circleRect, 0.75, 0.75));
+
+        [[UIColor whiteColor] setFill];
+        CGFloat barW = 3.0, barH = 11.0, gap = 5.0;
+        [[UIBezierPath bezierPathWithRoundedRect:CGRectMake(center.x - gap * 0.5 - barW, center.y - barH * 0.5, barW, barH)
+                                    cornerRadius:1.0] fill];
+        [[UIBezierPath bezierPathWithRoundedRect:CGRectMake(center.x + gap * 0.5, center.y - barH * 0.5, barW, barH)
+                                    cornerRadius:1.0] fill];
+
+        image = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+    });
+    return image;
+}
+
+// Overlay styles: the centered play button (paused tap-to-play GIFs + inline
+// video posters) and the corner pause badge (tap-to-play GIF while playing).
+typedef NS_ENUM(NSInteger, ApolloInlineOverlayStyle) {
+    ApolloInlineOverlayStylePlay = 0,
+    ApolloInlineOverlayStylePauseBadge = 1,
+};
+
+// A UIView that positions its single subview in layoutSubviews, AND on
 // every observed bounds change of its host layer. Texture sets layer
 // frames directly without going through UIView's setBounds:, so neither
 // autoresizingMask nor layoutSubviews fire on resize. KVO on the host
 // layer's bounds is the only reliable signal.
+//
+// For tap-to-play GIFs the icon zone is interactive: a tap on (or near) the
+// icon toggles inline playback and is swallowed there. A tap anywhere else on
+// the GIF fails pointInside: and lands on the imageNode's own tap action —
+// the fullscreen media viewer — so fullscreen stays reachable exactly like a
+// plain image. Video-poster overlays keep userInteractionEnabled=NO: the
+// whole poster opens the player, and the circle is just a visual cue.
 @interface ApolloPlayOverlayContainer : UIView
 @property (nonatomic, weak) CALayer *observedLayer;
+@property (nonatomic, weak) ASNetworkImageNode *overlayImageNode;
+@property (nonatomic) ApolloInlineOverlayStyle overlayStyle;
 @end
 @implementation ApolloPlayOverlayContainer
 - (void)layoutSubviews {
@@ -2332,10 +2395,26 @@ static UIImage *ApolloPlayOverlayImage(void) {
 - (void)recenter {
     for (UIView *sub in self.subviews) {
         CGSize s = sub.bounds.size;
-        sub.center = CGPointMake(self.bounds.size.width * 0.5,
-                                  self.bounds.size.height * 0.5);
+        if (self.overlayStyle == ApolloInlineOverlayStylePauseBadge) {
+            sub.center = CGPointMake(self.bounds.size.width - 6.0 - s.width * 0.5,
+                                     self.bounds.size.height - 6.0 - s.height * 0.5);
+        } else {
+            sub.center = CGPointMake(self.bounds.size.width * 0.5,
+                                      self.bounds.size.height * 0.5);
+        }
         sub.bounds = (CGRect){CGPointZero, s};
     }
+}
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
+    // Only the icon zone belongs to the overlay; everything else falls
+    // through to the imageNode (media viewer tap, long-press menu).
+    if (!self.userInteractionEnabled) return NO;
+    UIView *icon = self.subviews.firstObject;
+    if (!icon || icon.hidden) return NO;
+    CGRect zone = icon.frame;
+    CGFloat padX = MAX(0.0, (44.0 - CGRectGetWidth(zone)) * 0.5);
+    CGFloat padY = MAX(0.0, (44.0 - CGRectGetHeight(zone)) * 0.5);
+    return CGRectContainsPoint(CGRectInset(zone, -padX, -padY), point);
 }
 - (void)observeValueForKeyPath:(NSString *)keyPath
                       ofObject:(id)object
@@ -2349,6 +2428,27 @@ static UIImage *ApolloPlayOverlayImage(void) {
 }
 - (void)dealloc {
     [_observedLayer removeObserver:self forKeyPath:@"bounds"];
+}
+@end
+
+// The overlay tap targets the dispatcher singleton, not the container
+// itself — UIGestureRecognizer retains its target, so a self-targeting
+// recognizer would cycle container -> recognizer -> container and leak a
+// container on every play/pause style swap.
+@interface ApolloInlineImageDispatcher (ApolloInlineGIFOverlay)
+- (void)inlineGIFOverlayZoneTapped:(UITapGestureRecognizer *)recognizer;
+@end
+@implementation ApolloInlineImageDispatcher (ApolloInlineGIFOverlay)
+- (void)inlineGIFOverlayZoneTapped:(UITapGestureRecognizer *)recognizer {
+    ApolloPlayOverlayContainer *container = (ApolloPlayOverlayContainer *)recognizer.view;
+    if (![container isKindOfClass:[ApolloPlayOverlayContainer class]]) return;
+    ASNetworkImageNode *node = container.overlayImageNode;
+    if (!node) return;
+    if (container.overlayStyle == ApolloInlineOverlayStylePauseBadge) {
+        ApolloStopInlineGIFPlayback(node);
+    } else {
+        ApolloStartInlineGIFPlayback(node);
+    }
 }
 @end
 
@@ -2427,6 +2527,7 @@ static void ApolloClearInlineGIFNodeState(ASNetworkImageNode *node) {
     objc_setAssociatedObject(node, &kApolloInlineGIFCoverImageKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(node, &kApolloInlineAnimatedGIFKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(node, &kApolloInlineGIFUserForcedPlayKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(node, &kApolloInlineGIFOverlayReassertKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(node, &kApolloHostMarkdownNodeKey, nil, OBJC_ASSOCIATION_ASSIGN);
     ApolloUnregisterInlineGIFNode(node);
 }
@@ -2467,17 +2568,43 @@ static BOOL ApolloInlineGIFImageNodeIsLiveForRefresh(ASNetworkImageNode *node) {
     }
 }
 
-static void ApolloInstallPlayOverlayOnView(UIView *v, ASDisplayNode *node) {
+// Idempotently attach the requested overlay style; swaps in place when the
+// node transitions between paused (play button) and user-playing (pause
+// badge). Stored under kApolloPlayOverlayViewKey so every existing removal
+// path (clear state, cell reuse, settings refresh) cleans up either style.
+static void ApolloInstallOverlayWithStyleOnView(UIView *v, ASDisplayNode *node, ApolloInlineOverlayStyle style) {
     if (!v || !node) return;
-    if (objc_getAssociatedObject(node, &kApolloPlayOverlayViewKey)) return;
+    ApolloPlayOverlayContainer *existing = objc_getAssociatedObject(node, &kApolloPlayOverlayViewKey);
+    if (existing) {
+        if ([existing isKindOfClass:[ApolloPlayOverlayContainer class]] &&
+            existing.overlayStyle == style && existing.superview == v) {
+            return;
+        }
+        ApolloRemovePlayOverlayFromNode(node);
+    }
 
     ApolloPlayOverlayContainer *container = [[ApolloPlayOverlayContainer alloc] initWithFrame:v.bounds];
-    container.userInteractionEnabled = NO;
     container.backgroundColor = [UIColor clearColor];
+    container.overlayStyle = style;
+    container.overlayImageNode = (ASNetworkImageNode *)node;
 
-    UIImageView *icon = [[UIImageView alloc] initWithImage:ApolloPlayOverlayImage()];
+    // Only tap-to-play GIFs get the interactive icon zone. Video posters
+    // (no inline-GIF flag) stay pure visuals — the whole poster is the tap
+    // target for the player, exactly as before.
+    BOOL gifTapToPlay = [objc_getAssociatedObject(node, &kApolloInlineAnimatedGIFKey) boolValue];
+    container.userInteractionEnabled = gifTapToPlay;
+    if (gifTapToPlay) {
+        UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc]
+            initWithTarget:[ApolloInlineImageDispatcher shared]
+                    action:@selector(inlineGIFOverlayZoneTapped:)];
+        [container addGestureRecognizer:tap];
+    }
+
+    BOOL badge = (style == ApolloInlineOverlayStylePauseBadge);
+    UIImageView *icon = [[UIImageView alloc]
+        initWithImage:badge ? ApolloInlineGIFPauseBadgeImage() : ApolloPlayOverlayImage()];
     icon.userInteractionEnabled = NO;
-    icon.frame = CGRectMake(0, 0, 72, 72);
+    icon.frame = badge ? CGRectMake(0, 0, 30, 30) : CGRectMake(0, 0, 72, 72);
     [container addSubview:icon];
 
     [v addSubview:container];
@@ -2490,31 +2617,79 @@ static void ApolloInstallPlayOverlayOnView(UIView *v, ASDisplayNode *node) {
     [container recenter];
 
     objc_setAssociatedObject(node, &kApolloPlayOverlayViewKey, container, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    // GIF overlays get the same detach-heal as video posters: an async
+    // relayout-from-above (cover sizing, metadata rebuild) can recycle the
+    // backing view and silently drop the container — and with it the only
+    // inline play/pause tap zone. One pending sequence per node.
+    if (gifTapToPlay &&
+        ![objc_getAssociatedObject(node, &kApolloInlineGIFOverlayReassertKey) boolValue]) {
+        objc_setAssociatedObject(node, &kApolloInlineGIFOverlayReassertKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloSchedulePlayOverlayReassert((ASNetworkImageNode *)node, 0);
+    }
+}
+
+static void ApolloInstallPlayOverlayOnView(UIView *v, ASDisplayNode *node) {
+    ApolloInstallOverlayWithStyleOnView(v, node, ApolloInlineOverlayStylePlay);
+}
+
+// Single source of truth mapping a hosted inline GIF's state to its overlay:
+//   autoplaying globally                       -> none (tap opens the viewer)
+//   paused + Tap to Play / blocked WiFi Only   -> centered play button
+//   user-started playback (forced play)        -> corner pause badge
+//   paused + Never                             -> none (pure static cover)
+static void ApolloUpdateInlineGIFOverlayForNode(ASDisplayNode *node) {
+    if (!node) return;
+    if (![objc_getAssociatedObject(node, &kApolloInlineAnimatedGIFKey) boolValue]) return;
+    if (![node respondsToSelector:@selector(isNodeLoaded)] || ![node isNodeLoaded]) return;
+    UIView *view = [node view];
+    if (!view) return;
+    if (ApolloShouldAutoplayInlineGIFCached() || !ApolloPausedInlineGIFWantsPlayOverlay()) {
+        ApolloRemovePlayOverlayFromNode(node);
+        return;
+    }
+    BOOL forced = [objc_getAssociatedObject(node, &kApolloInlineGIFUserForcedPlayKey) boolValue];
+    ApolloInstallOverlayWithStyleOnView(view, node,
+        forced ? ApolloInlineOverlayStylePauseBadge : ApolloInlineOverlayStylePlay);
 }
 
 // The play overlay is first added in onDidLoad while the node still has
 // zero bounds, then relies on KVO to recenter once Texture assigns the
-// real frame. Two things break that for inline video thumbnails:
-//   1. When the async DASH/poster resolve triggers a relayout-from-above,
-//      Texture can recycle the node's backing view and silently drop our
-//      manually-added overlay subview (the association still points at the
-//      now-detached container).
+// real frame. Two things break that for inline video thumbnails AND
+// tap-to-play GIF overlays:
+//   1. When an async resolve (DASH poster, GIF cover sizing, metadata
+//      rebuild) triggers a relayout-from-above, Texture can recycle the
+//      node's backing view and silently drop our manually-added overlay
+//      subview (the association still points at the now-detached container).
 //   2. If the very first layout pass already gave the node real bounds,
 //      the KVO "new bounds" notification may have fired before the overlay
 //      was attached.
-// Re-assert the overlay a few times after load so it survives view
+// Re-assert the overlay a few times after install so it survives view
 // recycling and late sizing. Idempotent when the overlay is already
-// correctly attached.
-static void ApolloScheduleVideoPlayOverlayReassert(ASNetworkImageNode *imageNode, NSUInteger attempt) {
+// correctly attached. GIF nodes re-derive their overlay from state (play
+// button vs pause badge vs none); video posters reinstall the play circle.
+static void ApolloSchedulePlayOverlayReassertMode(ASNetworkImageNode *imageNode, NSUInteger attempt, BOOL forGIF) {
     static const NSTimeInterval delays[] = {0.10, 0.25, 0.50, 1.0, 1.75, 2.5};
     static const NSUInteger maxAttempts = sizeof(delays) / sizeof(delays[0]);
-    if (!imageNode || attempt >= maxAttempts) return;
+    if (!imageNode) return;
+    if (attempt >= maxAttempts) {
+        if (forGIF) {
+            objc_setAssociatedObject(imageNode, &kApolloInlineGIFOverlayReassertKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+        return;
+    }
 
     __weak ASNetworkImageNode *weak = imageNode;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delays[attempt] * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{
         ASNetworkImageNode *node = weak;
         if (!node) return;
+        if (forGIF && ![objc_getAssociatedObject(node, &kApolloInlineAnimatedGIFKey) boolValue]) {
+            // The node was cleared/reused since this sequence was scheduled —
+            // stop; whatever the node shows now, it isn't our GIF anymore.
+            objc_setAssociatedObject(node, &kApolloInlineGIFOverlayReassertKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            return;
+        }
         BOOL loaded = [node respondsToSelector:@selector(isNodeLoaded)] && [node isNodeLoaded];
         UIView *view = loaded ? [node view] : nil;
         if (view) {
@@ -2528,7 +2703,11 @@ static void ApolloScheduleVideoPlayOverlayReassert(ASNetworkImageNode *imageNode
                 overlay = nil;
             }
             if (!overlay) {
-                ApolloInstallPlayOverlayOnView(view, node);
+                if (forGIF) {
+                    ApolloUpdateInlineGIFOverlayForNode(node);
+                } else {
+                    ApolloInstallPlayOverlayOnView(view, node);
+                }
             } else {
                 [view bringSubviewToFront:overlay];
                 if ([overlay isKindOfClass:[ApolloPlayOverlayContainer class]]) {
@@ -2536,8 +2715,13 @@ static void ApolloScheduleVideoPlayOverlayReassert(ASNetworkImageNode *imageNode
                 }
             }
         }
-        ApolloScheduleVideoPlayOverlayReassert(node, attempt + 1);
+        ApolloSchedulePlayOverlayReassertMode(node, attempt + 1, forGIF);
     });
+}
+
+static void ApolloSchedulePlayOverlayReassert(ASNetworkImageNode *imageNode, NSUInteger attempt) {
+    ApolloSchedulePlayOverlayReassertMode(imageNode, attempt,
+        [objc_getAssociatedObject(imageNode, &kApolloInlineAnimatedGIFKey) boolValue]);
 }
 
 // Pause inline GIF playback without clearing animatedImage via KVC — that path
@@ -2576,16 +2760,10 @@ static void ApolloPauseInlineGIFNode(ASNetworkImageNode *imageNode, UIImage *cov
         objc_setAssociatedObject(imageNode, &kApolloInlineGIFReloadInFlightKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
 
-    if (view) {
-        // Never mode is a pure static cover — tap falls through to the normal
-        // image tap (media viewer). Tap to Play / blocked WiFi Only get the
-        // inline play button.
-        if (ApolloPausedInlineGIFWantsPlayOverlay()) {
-            ApolloInstallPlayOverlayOnView(view, imageNode);
-        } else {
-            ApolloRemovePlayOverlayFromNode(imageNode);
-        }
-    }
+    // Never mode is a pure static cover — tap falls through to the normal
+    // image tap (media viewer). Tap to Play / blocked WiFi Only get the
+    // inline play button (forced-play was cleared above, so never a badge).
+    ApolloUpdateInlineGIFOverlayForNode(imageNode);
 }
 
 BOOL ApolloPauseInlineGIFNodeForAutoplay(id imageNode) {
@@ -2739,7 +2917,7 @@ static void ApolloApplyInlineGIFPlaybackPolicyWithCover(ASNetworkImageNode *imag
         BOOL shouldPlay = forcedPlay || ApolloShouldAutoplayInlineGIFCached();
 
         if (shouldPlay) {
-            ApolloRemovePlayOverlayFromNode(strong);
+            ApolloUpdateInlineGIFOverlayForNode(strong);
             if (ApolloResumeInlineGIFPlaybackIfPossible(strong)) {
                 ApolloLog(@"[AutoplayGIF] policy node=%p retry=%lu shouldPlay=1 resume=1 forced=%d",
                           strong, (unsigned long)retryIndex, forcedPlay);
@@ -2834,7 +3012,9 @@ static BOOL ApolloResumeInlineGIFPlaybackIfPossible(ASNetworkImageNode *imageNod
     BOOL forcedPlay = [objc_getAssociatedObject(imageNode, &kApolloInlineGIFUserForcedPlayKey) boolValue];
     if (forcedPlay) ApolloSetInlineGIFUserForcedPlay(animView, YES);
     ApolloApplyFLAnimatedImageViewAutoplayGate(animView);
-    ApolloRemovePlayOverlayFromNode(imageNode);
+    // Autoplay resume drops the overlay; a user-forced (tap-to-play) resume
+    // swaps the play button for the corner pause badge.
+    ApolloUpdateInlineGIFOverlayForNode(imageNode);
     ApolloLog(@"[AutoplayGIF] resume node=%p animView=%p forced=%d", imageNode, animView, forcedPlay);
     return YES;
 }
@@ -2852,7 +3032,9 @@ static void ApolloStartInlineGIFPlayback(ASNetworkImageNode *imageNode) {
             return;
         }
 
-        ApolloRemovePlayOverlayFromNode(imageNode);
+        // Forced-play was set above — this swaps the play button for the
+        // corner pause badge right away, before the re-inject lands.
+        ApolloUpdateInlineGIFOverlayForNode(imageNode);
 
         // Nothing to resume — the pause's cover swap made Texture drop its
         // animatedImage. Re-inject the retained copy; that re-runs the
@@ -2874,10 +3056,10 @@ static void ApolloStartInlineGIFPlayback(ASNetworkImageNode *imageNode) {
     });
 }
 
-// Second tap on a tap-to-play GIF: pause it back to the static cover + play
-// button. ApolloPauseInlineGIFNode clears the forced-play flags, halts both
-// animation pipelines, swaps the cover in, and re-installs the overlay per
-// the current mode — so the next tap plays it again.
+// Tap on the corner pause badge of a playing tap-to-play GIF: pause it back
+// to the static cover + play button. ApolloPauseInlineGIFNode clears the
+// forced-play flags, halts both animation pipelines, swaps the cover in, and
+// re-installs the overlay per the current mode — so the next tap plays again.
 static void ApolloStopInlineGIFPlayback(ASNetworkImageNode *imageNode) {
     if (!imageNode) return;
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -3049,7 +3231,7 @@ static ASNetworkImageNode *ApolloMakeInlineVideoThumbnailNode(NSURL *videoURL,
         }
 
         if (v) ApolloInstallPlayOverlayOnView(v, img);
-        ApolloScheduleVideoPlayOverlayReassert(img, 0);
+        ApolloSchedulePlayOverlayReassert(img, 0);
         if (v && ![objc_getAssociatedObject(img, &kApolloLongPressInstalledKey) boolValue]) {
             NSURL *u = objc_getAssociatedObject(img, &kApolloImageURLKey);
             objc_setAssociatedObject(v, &kApolloImageURLKey, u, OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -12,6 +12,7 @@
 #import "ApolloMediaAutoplay.h"
 #import "ApolloState.h"
 #import "Tweak.h"
+#import "UserDefaultConstants.h"
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
@@ -154,6 +155,7 @@ static char kApolloInlineGIFCoverImageKey;     // UIImage — first-frame cover 
 static char kApolloInlineGIFUserForcedPlayKey; // NSNumber BOOL — user tapped play on paused GIF
 static char kApolloInlineGIFPendingPolicyBlocksKey; // NSMutableArray<dispatch_block_t>
 static char kApolloInlineGIFGenerationKey;     // NSNumber — bumped on clear/reuse to invalidate async GIF policy blocks
+static char kApolloInlineGIFReloadInFlightKey; // NSNumber BOOL — internal URL/image reset in progress (settings-refresh reload, pause cover swap): suppress ClearState from the reset round trip
 static char kApolloStackedCardSyncerKey;       // ApolloStackedCardSyncer — keeps the multi-image card peeking behind imageNode
 static char kApolloImageChestItemsKey;         // NSArray<NSDictionary *> direct ImageChest CDN image entries for album pager
 
@@ -171,6 +173,7 @@ static inline BOOL ApolloImageNodeHasInlineHost(id node) {
 
 static void ApolloApplyInlineGIFPlaybackPolicyWithCover(ASNetworkImageNode *imageNode, UIImage *cover, NSUInteger retryIndex);
 static void ApolloStartInlineGIFPlayback(ASNetworkImageNode *imageNode);
+static void ApolloStopInlineGIFPlayback(ASNetworkImageNode *imageNode);
 static BOOL ApolloResumeInlineGIFPlaybackIfPossible(ASNetworkImageNode *imageNode);
 static void ApolloClearInlineGIFNodeState(ASNetworkImageNode *node);
 static NSUInteger ApolloInlineGIFGenerationForNode(id node);
@@ -1682,10 +1685,18 @@ static id ApolloFindResponderForSelector(SEL sel, id imageNode) {
 }
 
 - (void)imageNodeTapped:(id)imageNode {
+    // Inline tap-to-play only when the play-button overlay is showing
+    // (Tap to Play mode, or WiFi Only while blocked). Never mode has no
+    // overlay — the tap falls through to the media viewer like any image.
     if ([objc_getAssociatedObject(imageNode, &kApolloInlineAnimatedGIFKey) boolValue] &&
         (objc_getAssociatedObject(imageNode, &kApolloPlayOverlayViewKey) ||
-         !ApolloShouldAutoplayInlineGIFCached())) {
-        ApolloStartInlineGIFPlayback((ASNetworkImageNode *)imageNode);
+         (!ApolloShouldAutoplayInlineGIFCached() && ApolloPausedInlineGIFWantsPlayOverlay()))) {
+        if ([objc_getAssociatedObject(imageNode, &kApolloInlineGIFUserForcedPlayKey) boolValue]) {
+            // Tap while force-playing — pause back to the cover + play button.
+            ApolloStopInlineGIFPlayback((ASNetworkImageNode *)imageNode);
+        } else {
+            ApolloStartInlineGIFPlayback((ASNetworkImageNode *)imageNode);
+        }
         return;
     }
 
@@ -1880,6 +1891,103 @@ static BOOL ApolloPresentOrResolveImageChestAlbumURL(NSURL *url, UIView *sourceV
 
 @end
 
+// MARK: - Native inline animated media gating
+//
+// Apollo renders some comment/selftext animated media itself (giphy-picker
+// tokens, native ![gif](...) embeds, animated snoomoji) as MarkdownNode
+// children the tweak doesn't create. Those nodes were never marked as inline
+// GIFs, so the FLAnimatedImageView hooks let them animate regardless of the
+// Autoplay Inline GIFs mode. Flag any un-hosted animated node living under a
+// MarkdownNode and gate it in place (stop/start only — no cover/overlay/URL
+// reload machinery). Feed media (RichMediaNode) has no MarkdownNode ancestor
+// and stays governed by Apollo's native autoplay setting.
+static BOOL ApolloNodeDescendsFromMarkdownNode(ASDisplayNode *node) {
+    ASDisplayNode *cursor = node.supernode;
+    int depth = 0;
+    while (cursor && depth < 12) {
+        if ([NSStringFromClass([cursor class]) containsString:@"MarkdownNode"]) return YES;
+        cursor = cursor.supernode;
+        depth++;
+    }
+    return NO;
+}
+
+static void ApolloActivateNativeInlineGIFGate(ASDisplayNode *node) {
+    ApolloFlagNativeInlineGIFNode(node);
+    ApolloRegisterInlineGIFNode(node);
+    if (!ApolloApplyNativeInlineGIFAutoplayGate(node) &&
+        [node respondsToSelector:@selector(onDidLoad:)]) {
+        // Node not loaded yet — gate the instant its view is created so the
+        // animation never gets a free first run.
+        __weak ASDisplayNode *weakNode = node;
+        [node onDidLoad:^(__kindof ASDisplayNode *loaded) {
+            ASDisplayNode *strong = weakNode;
+            if (!strong || (id)loaded != (id)strong) return;
+            ApolloApplyNativeInlineGIFAutoplayGate(strong);
+        }];
+    }
+    ApolloLog(@"[AutoplayGIF] native inline GIF gated node=%p class=%@",
+              node, NSStringFromClass([node class]));
+}
+
+// Mark a hosted inline GIF node's backing view the moment it exists — via
+// onDidLoad for prefetched nodes — so the FLAnimatedImageView hooks gate
+// playback from the very first frame. Marking used to wait for the playback
+// policy to run with a downloaded cover, so a freshly loaded GIF animated for
+// as long as its cover fetch took (seconds on slow hosts; indefinitely when
+// the fetch failed) even with autoplay off.
+static void ApolloMarkHostedInlineGIFViewWhenLoaded(ASNetworkImageNode *node, NSUInteger generation) {
+    if (!node) return;
+    if ([node respondsToSelector:@selector(isNodeLoaded)] && [node isNodeLoaded]) {
+        UIView *view = [node view];
+        if (view) {
+            ApolloMarkViewAsInlineGIF(view);
+            UIView *animView = ApolloFindFLAnimatedImageViewInView(view);
+            if (animView) ApolloApplyFLAnimatedImageViewAutoplayGate(animView);
+        }
+        return;
+    }
+    if (![node respondsToSelector:@selector(onDidLoad:)]) return;
+    __weak ASNetworkImageNode *weakNode = node;
+    [node onDidLoad:^(__kindof ASDisplayNode *loaded) {
+        ASNetworkImageNode *strong = weakNode;
+        if (!strong || (id)loaded != (id)strong) return;
+        if (!ApolloInlineGIFGenerationMatches(strong, generation)) return;
+        if (![objc_getAssociatedObject(strong, &kApolloInlineAnimatedGIFKey) boolValue]) return;
+        UIView *view = [strong view];
+        if (!view) return;
+        ApolloMarkViewAsInlineGIF(view);
+        UIView *animView = ApolloFindFLAnimatedImageViewInView(view);
+        if (animView) ApolloApplyFLAnimatedImageViewAutoplayGate(animView);
+        // Re-run the playback policy now that the view exists so the static
+        // cover and (mode-dependent) play overlay land immediately.
+        UIImage *storedCover = objc_getAssociatedObject(strong, &kApolloInlineGIFCoverImageKey);
+        ApolloApplyInlineGIFPlaybackPolicyWithCover(strong, storedCover, 0);
+    }];
+}
+
+static void ApolloGateNativeInlineAnimatedImageIfNeeded(ASDisplayNode *node) {
+    if (!node) return;
+    __weak ASDisplayNode *weakNode = node;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ASDisplayNode *strong = weakNode;
+        if (!strong || ApolloImageNodeHasInlineHost(strong)) return;
+        if (ApolloNodeDescendsFromMarkdownNode(strong)) {
+            ApolloActivateNativeInlineGIFGate(strong);
+            return;
+        }
+        // The node may not be attached to its supernode yet (async decode) —
+        // check once more after attachment settles.
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            ASDisplayNode *retryNode = weakNode;
+            if (!retryNode || ApolloImageNodeHasInlineHost(retryNode)) return;
+            if (!ApolloNodeDescendsFromMarkdownNode(retryNode)) return;
+            ApolloActivateNativeInlineGIFGate(retryNode);
+        });
+    });
+}
+
 // MARK: - %hook ASImageNode (animated image — GIF support)
 //
 // ASNetworkImageNode bypasses the public setAnimatedImage: setter and calls
@@ -1892,6 +2000,9 @@ static BOOL ApolloPresentOrResolveImageChestAlbumURL(NSURL *url, UIView *sourceV
 
 - (void)_locked_setAnimatedImage:(id)animatedImage {
     BOOL hosted = ApolloImageNodeHasInlineHost(self);
+    if (!hosted && animatedImage) {
+        ApolloGateNativeInlineAnimatedImageIfNeeded((ASDisplayNode *)self);
+    }
     if (hosted && animatedImage && !ApolloInlineGIFAnimatedImageArgumentIsUsable(animatedImage)) {
         ApolloLog(@"[InlineImages] _locked_setAnimatedImage rejecting unusable animatedImage node=%p", self);
         ApolloClearInlineGIFNodeState((ASNetworkImageNode *)self);
@@ -1901,6 +2012,11 @@ static BOOL ApolloPresentOrResolveImageChestAlbumURL(NSURL *url, UIView *sourceV
     if (!hosted) return;
 
     if (!animatedImage) {
+        if ([objc_getAssociatedObject(self, &kApolloInlineGIFReloadInFlightKey) boolValue]) {
+            // Settings-refresh reload resets URL/image before re-setting them —
+            // keep the node's inline-GIF state so the re-download re-gates.
+            return;
+        }
         __weak ASImageNode *weakSelf = self;
         NSUInteger generation = ApolloInlineGIFGenerationForNode(self);
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -1938,15 +2054,13 @@ static BOOL ApolloPresentOrResolveImageChestAlbumURL(NSURL *url, UIView *sourceV
         objc_setAssociatedObject(strong, &kApolloInlineGIFAnimatedImageKey, anim, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         ApolloRegisterInlineGIFNode(strong);
 
+        ApolloMarkHostedInlineGIFViewWhenLoaded((ASNetworkImageNode *)strong, generation);
         if (!ApolloShouldAutoplayInlineGIFCached()) {
             ASDisplayNode *displayNode = (ASDisplayNode *)strong;
             if ([displayNode respondsToSelector:@selector(isNodeLoaded)] && [displayNode isNodeLoaded]) {
                 UIView *view = [displayNode view];
-                if (view) {
-                    ApolloMarkViewAsInlineGIF(view);
-                    if (cover && cover.size.width > 0) {
-                        ApolloInstallPlayOverlayOnView(view, displayNode);
-                    }
+                if (view && cover && cover.size.width > 0 && ApolloPausedInlineGIFWantsPlayOverlay()) {
+                    ApolloInstallPlayOverlayOnView(view, displayNode);
                 }
             }
         }
@@ -1997,7 +2111,8 @@ static BOOL ApolloPresentOrResolveImageChestAlbumURL(NSURL *url, UIView *sourceV
 %hook ASNetworkImageNode
 
 - (void)setURL:(NSURL *)URL {
-    if (ApolloImageNodeHasInlineHost(self)) {
+    if (ApolloImageNodeHasInlineHost(self) &&
+        ![objc_getAssociatedObject(self, &kApolloInlineGIFReloadInFlightKey) boolValue]) {
         NSURL *previous = [self respondsToSelector:@selector(URL)] ? [self URL] : nil;
         if ((previous && URL && ![previous isEqual:URL]) || (previous && !URL)) {
             ApolloLog(@"[AutoplayGIF] clearing GIF state on URL change node=%p", self);
@@ -2321,21 +2436,29 @@ static void ApolloClearInlineGIFNodeState(ASNetworkImageNode *node) {
 static BOOL ApolloInlineGIFImageNodeIsLiveForRefresh(ASNetworkImageNode *node) {
     if (!ApolloInlineGIFNodeIsRegistryEligible(node)) {
         if (node) ApolloUnregisterInlineGIFNode(node);
+        ApolloLog(@"[AutoplayGIF] live-check node=%p ineligible", node);
         return NO;
     }
     if (!node) return NO;
     if (![objc_getAssociatedObject(node, &kApolloInlineAnimatedGIFKey) boolValue]) {
         ApolloUnregisterInlineGIFNode(node);
+        ApolloLog(@"[AutoplayGIF] live-check node=%p no-anim-flag", node);
         return NO;
     }
     @try {
-        if (![node respondsToSelector:@selector(isNodeLoaded)] || ![node isNodeLoaded]) return NO;
-        if (!node.supernode) {
-            ApolloUnregisterInlineGIFNode(node);
+        if (![node respondsToSelector:@selector(isNodeLoaded)] || ![node isNodeLoaded]) {
+            ApolloLog(@"[AutoplayGIF] live-check node=%p not-loaded", node);
             return NO;
         }
-        NSURL *url = node.URL;
-        return [url isKindOfClass:[NSURL class]] && url.absoluteString.length > 0;
+        if (!node.supernode) {
+            ApolloUnregisterInlineGIFNode(node);
+            ApolloLog(@"[AutoplayGIF] live-check node=%p no-supernode", node);
+            return NO;
+        }
+        // Deliberately no node.URL requirement: the tweak's GIF pipeline loads
+        // through its own downloader and never sets the node URL, so a URL
+        // check disqualified every hosted GIF from settings-refresh handling.
+        return YES;
     } @catch (NSException *exception) {
         ApolloLog(@"[AutoplayGIF] live-check failed node=%p class=%@ reason=%@",
                   node, NSStringFromClass([node class]), exception.reason);
@@ -2435,13 +2558,33 @@ static void ApolloPauseInlineGIFNode(ASNetworkImageNode *imageNode, UIImage *cov
             ApolloApplyFLAnimatedImageViewAutoplayGate(animView);
         }
     }
+    // Also halt Texture's own animated-image display in case this node's GIF
+    // renders through the PIN pipeline rather than an FLAnimatedImageView.
+    if ([imageNode respondsToSelector:@selector(setAnimatedImagePaused:)]) {
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(imageNode, @selector(setAnimatedImagePaused:), YES);
+    }
 
     if (cover && cover.size.width > 0 && [imageNode respondsToSelector:@selector(setImage:)]) {
+        // setImage: makes Texture clear the node's animatedImage, which fires
+        // our _locked_setAnimatedImage:(nil) hook. Without the in-flight flag
+        // that scheduled ApolloClearInlineGIFNodeState — silently wiping the
+        // GIF flag, removing the play overlay, and unregistering the node the
+        // moment it was paused (so taps opened the viewer instead of playing
+        // inline, and settings refreshes found nothing to resume).
+        objc_setAssociatedObject(imageNode, &kApolloInlineGIFReloadInFlightKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         [imageNode setImage:cover];
+        objc_setAssociatedObject(imageNode, &kApolloInlineGIFReloadInFlightKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
 
     if (view) {
-        ApolloInstallPlayOverlayOnView(view, imageNode);
+        // Never mode is a pure static cover — tap falls through to the normal
+        // image tap (media viewer). Tap to Play / blocked WiFi Only get the
+        // inline play button.
+        if (ApolloPausedInlineGIFWantsPlayOverlay()) {
+            ApolloInstallPlayOverlayOnView(view, imageNode);
+        } else {
+            ApolloRemovePlayOverlayFromNode(imageNode);
+        }
     }
 }
 
@@ -2472,19 +2615,29 @@ BOOL ApolloReloadInlineGIFImageNodeForAutoplay(id imageNode) {
     ASNetworkImageNode *node = (ASNetworkImageNode *)imageNode;
     if (!ApolloInlineGIFImageNodeIsLiveForRefresh(node)) return NO;
 
-    BOOL wasPaused = objc_getAssociatedObject(node, &kApolloPlayOverlayViewKey) != nil;
-    if (!wasPaused) {
-        ApolloRemovePlayOverlayFromNode(node);
-        if (ApolloResumeInlineGIFPlaybackIfPossible(node)) {
-            ApolloLog(@"[AutoplayGIF] resume-only node=%p", node);
-            return NO;
-        }
-        // GIF still loading on a fresh comment row — _locked_setAnimatedImage policy handles it.
+    ApolloRemovePlayOverlayFromNode(node);
+    if (ApolloResumeInlineGIFPlaybackIfPossible(node)) {
+        ApolloLog(@"[AutoplayGIF] resume-only node=%p", node);
         return NO;
     }
+    // No live FLAnimatedImageView to resume (the pause's cover swap tears the
+    // playback state down) — re-inject the retained animated image, same as
+    // tap-to-play. The tweak's GIF pipeline doesn't set node.URL, so a URL
+    // round trip usually isn't available.
+    id storedAnim = objc_getAssociatedObject(node, &kApolloInlineGIFAnimatedImageKey);
+    if (storedAnim && [node respondsToSelector:@selector(setAnimatedImage:)]) {
+        @try {
+            [(id)node setAnimatedImage:storedAnim];
+        } @catch (NSException *exception) {
+            ApolloLog(@"[AutoplayGIF] reload reinject failed node=%p reason=%@", node, exception.reason);
+            ApolloUnregisterInlineGIFNode(node);
+            return NO;
+        }
+        ApolloLog(@"[AutoplayGIF] reload reinject node=%p", node);
+        return YES;
+    }
 
-    if (![node respondsToSelector:@selector(clearImage)] ||
-        ![node respondsToSelector:@selector(setURL:)] ||
+    if (![node respondsToSelector:@selector(setURL:)] ||
         ![node respondsToSelector:@selector(URL)]) {
         ApolloUnregisterInlineGIFNode(node);
         return NO;
@@ -2495,16 +2648,25 @@ BOOL ApolloReloadInlineGIFImageNodeForAutoplay(id imageNode) {
 
     ApolloCancelInlineGIFPendingPolicyBlocks(node);
     ApolloInlineGIFBumpGeneration(node);
-    ApolloRemovePlayOverlayFromNode(node);
     objc_setAssociatedObject(node, &kApolloInlineGIFUserForcedPlayKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
+    // This AsyncDisplayKit build has no -clearImage; reset through the URL
+    // round trip (setURL:nil clears image + animatedImage internally). The
+    // in-flight flag keeps our setURL:/_locked_setAnimatedImage hooks from
+    // clearing the node's inline-GIF state during the reset.
+    objc_setAssociatedObject(node, &kApolloInlineGIFReloadInFlightKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    BOOL reloadOK = YES;
     @try {
-        [node clearImage];
+        if ([node respondsToSelector:@selector(setImage:)]) [node setImage:nil];
         [node setURL:nil];
         [node setURL:url];
     } @catch (NSException *exception) {
         ApolloLog(@"[AutoplayGIF] reload failed node=%p class=%@ reason=%@",
                   node, NSStringFromClass([node class]), exception.reason);
+        reloadOK = NO;
+    }
+    objc_setAssociatedObject(node, &kApolloInlineGIFReloadInFlightKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (!reloadOK) {
         ApolloUnregisterInlineGIFNode(node);
         return NO;
     }
@@ -2649,8 +2811,25 @@ static BOOL ApolloResumeInlineGIFPlaybackIfPossible(ASNetworkImageNode *imageNod
     UIView *view = [imageNode respondsToSelector:@selector(view)] ? [imageNode view] : nil;
     if (!view) return NO;
 
+    // Mirror of the pause path: release Texture's animated-image pause in case
+    // this node's GIF renders through the PIN pipeline.
+    if ([imageNode respondsToSelector:@selector(setAnimatedImagePaused:)]) {
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(imageNode, @selector(setAnimatedImagePaused:), NO);
+    }
+
     UIView *animView = ApolloFindFLAnimatedImageViewInView(view);
     if (!animView) return NO;
+
+    // The pause's cover swap makes Texture drop the view's animatedImage —
+    // with no animation data "resuming" would just leave the cover frozen.
+    // Report NO so callers fall back to re-injecting/reloading the GIF.
+    id currentAnim = nil;
+    @try {
+        if ([animView respondsToSelector:@selector(animatedImage)]) {
+            currentAnim = [animView valueForKey:@"animatedImage"];
+        }
+    } @catch (__unused NSException *exception) {}
+    if (!currentAnim) return NO;
 
     BOOL forcedPlay = [objc_getAssociatedObject(imageNode, &kApolloInlineGIFUserForcedPlayKey) boolValue];
     if (forcedPlay) ApolloSetInlineGIFUserForcedPlay(animView, YES);
@@ -2674,8 +2853,37 @@ static void ApolloStartInlineGIFPlayback(ASNetworkImageNode *imageNode) {
         }
 
         ApolloRemovePlayOverlayFromNode(imageNode);
+
+        // Nothing to resume — the pause's cover swap made Texture drop its
+        // animatedImage. Re-inject the retained copy; that re-runs the
+        // _locked_setAnimatedImage flow, and the playback policy honors the
+        // forced-play flag set above.
+        id storedAnim = objc_getAssociatedObject(imageNode, &kApolloInlineGIFAnimatedImageKey);
+        if (storedAnim && [imageNode respondsToSelector:@selector(setAnimatedImage:)]) {
+            @try {
+                [(id)imageNode setAnimatedImage:storedAnim];
+                ApolloLog(@"[AutoplayGIF] userPlay node=%p reinject=1", imageNode);
+                return;
+            } @catch (NSException *exception) {
+                ApolloLog(@"[AutoplayGIF] userPlay reinject failed node=%p reason=%@", imageNode, exception.reason);
+            }
+        }
+
         ApolloApplyInlineGIFPlaybackPolicyWithCover(imageNode, nil, 0);
         ApolloLog(@"[AutoplayGIF] userPlay node=%p resume=0 policy=1", imageNode);
+    });
+}
+
+// Second tap on a tap-to-play GIF: pause it back to the static cover + play
+// button. ApolloPauseInlineGIFNode clears the forced-play flags, halts both
+// animation pipelines, swaps the cover in, and re-installs the overlay per
+// the current mode — so the next tap plays it again.
+static void ApolloStopInlineGIFPlayback(ASNetworkImageNode *imageNode) {
+    if (!imageNode) return;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIImage *cover = objc_getAssociatedObject(imageNode, &kApolloInlineGIFCoverImageKey);
+        ApolloPauseInlineGIFNode(imageNode, cover);
+        ApolloLog(@"[AutoplayGIF] userPause node=%p cover=%d", imageNode, cover != nil);
     });
 }
 
@@ -2991,8 +3199,48 @@ static const CGFloat kApolloMinTallImageWidth = 85.0;
 // sizing stays unchanged.
 static const CGFloat kApolloMaxScreenHeightFraction = 0.6;
 
+// MARK: - Inline media layout registry (live size/alignment changes)
+//
+// Every inline media leaf that measures through ApolloWrapImageNodeForLayout
+// is tracked weakly so the Inline Media settings screen can re-measure the
+// visible comments the moment Size or Alignment changes — no leaving the
+// thread and coming back.
+static NSHashTable *sApolloInlineMediaLayoutNodes = nil;
+
+static void ApolloRegisterInlineMediaLayoutNode(ASDisplayNode *node) {
+    if (!node) return;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        sApolloInlineMediaLayoutNodes = [NSHashTable weakObjectsHashTable];
+    });
+    @synchronized (sApolloInlineMediaLayoutNodes) {
+        [sApolloInlineMediaLayoutNodes addObject:node];
+    }
+}
+
+static void ApolloRefreshInlineMediaLayout(void) {
+    if (!sApolloInlineMediaLayoutNodes) return;
+    NSArray *nodes = nil;
+    @synchronized (sApolloInlineMediaLayoutNodes) {
+        nodes = sApolloInlineMediaLayoutNodes.allObjects;
+    }
+    SEL relayoutSel = NSSelectorFromString(@"_u_setNeedsLayoutFromAbove");
+    NSUInteger relaid = 0;
+    for (ASDisplayNode *node in nodes) {
+        if (![node respondsToSelector:relayoutSel]) continue;
+        @try {
+            if (!node.supernode) continue;
+            ((void (*)(id, SEL))objc_msgSend)(node, relayoutSel);
+            relaid++;
+        } @catch (__unused NSException *exception) {}
+    }
+    ApolloLog(@"[InlineImages] media layout refresh nodes=%lu relaid=%lu",
+              (unsigned long)nodes.count, (unsigned long)relaid);
+}
+
 static ASLayoutSpec *ApolloWrapImageNodeForLayout(ASNetworkImageNode *imageNode,
                                                    CGFloat rowMaxWidth) {
+    ApolloRegisterInlineMediaLayoutNode((ASDisplayNode *)imageNode);
     NSNumber *ratioNum = objc_getAssociatedObject(imageNode, &kApolloAspectRatioKey);
     if (!ratioNum) {
         // Unknown ratio → omit from layout. Including with a guessed ratio
@@ -3059,6 +3307,13 @@ static ASLayoutSpec *ApolloWrapImageNodeForLayout(ASNetworkImageNode *imageNode,
 
     ASRatioLayoutSpec *ratioSpec = [ApolloASRatioLayoutSpecClass() ratioLayoutSpecWithRatio:containerRatio child:imageNode];
     [[ratioSpec style] setValue:@(ApolloASStackLayoutAlignSelfStretch) forKey:@"alignSelf"];
+
+    // User-selected inline media size (100/75/50% of the row width). Applied
+    // as a width cap so the ratio spec keeps height proportional; the slack
+    // distribution below then positions the smaller container per alignment.
+    if (sInlineMediaSizePercent > 0 && sInlineMediaSizePercent < 100) {
+        containerWidth = MIN(containerWidth, rowMaxWidth * (sInlineMediaSizePercent / 100.0));
+    }
 
     // Position the container horizontally per user preference.
     // Only has a visual effect when containerWidth < rowMaxWidth (tall portrait
@@ -3738,4 +3993,10 @@ static BOOL ApolloLinkButtonHasInlineHost(ASDisplayNode *linkButtonNode) {
 
 %ctor {
     ApolloMediaAutoplayInstall();
+    [[NSNotificationCenter defaultCenter] addObserverForName:ApolloInlineMediaLayoutDidChangeNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(__unused NSNotification *note) {
+        ApolloRefreshInlineMediaLayout();
+    }];
 }

--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -2328,43 +2328,65 @@ static UIImage *ApolloPlayOverlayImage(void) {
 }
 
 
-// The small corner pause badge shown on a tap-to-play GIF while the user has
-// it playing — same visual language as the play circle, scaled down.
-static UIImage *ApolloInlineGIFPauseBadgeImage(void) {
-    static UIImage *image;
-    static dispatch_once_t once;
-    dispatch_once(&once, ^{
-        CGFloat side = 30.0;
-        UIGraphicsBeginImageContextWithOptions(CGSizeMake(side, side), NO, 0.0);
-        CGContextRef ctx = UIGraphicsGetCurrentContext();
-        CGPoint center = CGPointMake(side * 0.5, side * 0.5);
-        CGRect circleRect = CGRectInset(CGRectMake(0, 0, side, side), 1.5, 1.5);
+// The small corner badges for tap-to-play GIFs — play triangle while paused,
+// pause bars while playing. Same visual language as the video play circle,
+// scaled down and consistent between the two states (both live bottom-right).
+static UIImage *ApolloInlineGIFBadgeImage(BOOL pause) {
+    CGFloat side = 30.0;
+    UIGraphicsBeginImageContextWithOptions(CGSizeMake(side, side), NO, 0.0);
+    CGContextRef ctx = UIGraphicsGetCurrentContext();
+    CGPoint center = CGPointMake(side * 0.5, side * 0.5);
+    CGRect circleRect = CGRectInset(CGRectMake(0, 0, side, side), 1.5, 1.5);
 
-        CGContextSaveGState(ctx);
-        CGContextSetShadowWithColor(ctx, CGSizeZero, 3.0, [UIColor colorWithWhite:0.0 alpha:0.55].CGColor);
-        CGContextSetFillColorWithColor(ctx, [UIColor colorWithWhite:0.0 alpha:0.45].CGColor);
-        CGContextFillEllipseInRect(ctx, circleRect);
-        CGContextRestoreGState(ctx);
+    CGContextSaveGState(ctx);
+    CGContextSetShadowWithColor(ctx, CGSizeZero, 3.0, [UIColor colorWithWhite:0.0 alpha:0.55].CGColor);
+    CGContextSetFillColorWithColor(ctx, [UIColor colorWithWhite:0.0 alpha:0.45].CGColor);
+    CGContextFillEllipseInRect(ctx, circleRect);
+    CGContextRestoreGState(ctx);
 
-        CGContextSetStrokeColorWithColor(ctx, [UIColor colorWithWhite:1.0 alpha:0.85].CGColor);
-        CGContextSetLineWidth(ctx, 1.5);
-        CGContextStrokeEllipseInRect(ctx, CGRectInset(circleRect, 0.75, 0.75));
+    CGContextSetStrokeColorWithColor(ctx, [UIColor colorWithWhite:1.0 alpha:0.85].CGColor);
+    CGContextSetLineWidth(ctx, 1.5);
+    CGContextStrokeEllipseInRect(ctx, CGRectInset(circleRect, 0.75, 0.75));
 
-        [[UIColor whiteColor] setFill];
+    [[UIColor whiteColor] setFill];
+    if (pause) {
         CGFloat barW = 3.0, barH = 11.0, gap = 5.0;
         [[UIBezierPath bezierPathWithRoundedRect:CGRectMake(center.x - gap * 0.5 - barW, center.y - barH * 0.5, barW, barH)
                                     cornerRadius:1.0] fill];
         [[UIBezierPath bezierPathWithRoundedRect:CGRectMake(center.x + gap * 0.5, center.y - barH * 0.5, barW, barH)
                                     cornerRadius:1.0] fill];
+    } else {
+        // Nudged right so the triangle reads optically centered.
+        UIBezierPath *triangle = [UIBezierPath bezierPath];
+        [triangle moveToPoint:CGPointMake(center.x - 3.75, center.y - 6.0)];
+        [triangle addLineToPoint:CGPointMake(center.x - 3.75, center.y + 6.0)];
+        [triangle addLineToPoint:CGPointMake(center.x + 6.25, center.y)];
+        [triangle closePath];
+        [triangle fill];
+    }
 
-        image = UIGraphicsGetImageFromCurrentImageContext();
-        UIGraphicsEndImageContext();
-    });
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
     return image;
 }
 
-// Overlay styles: the centered play button (paused tap-to-play GIFs + inline
-// video posters) and the corner pause badge (tap-to-play GIF while playing).
+static UIImage *ApolloInlineGIFPauseBadgeImage(void) {
+    static UIImage *image;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ image = ApolloInlineGIFBadgeImage(YES); });
+    return image;
+}
+
+static UIImage *ApolloInlineGIFPlayBadgeImage(void) {
+    static UIImage *image;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ image = ApolloInlineGIFBadgeImage(NO); });
+    return image;
+}
+
+// Overlay styles: the play affordance (bottom-right badge on paused
+// tap-to-play GIFs; big centered circle on inline video posters) and the
+// bottom-right pause badge (tap-to-play GIF while playing).
 typedef NS_ENUM(NSInteger, ApolloInlineOverlayStyle) {
     ApolloInlineOverlayStylePlay = 0,
     ApolloInlineOverlayStylePauseBadge = 1,
@@ -2386,6 +2408,9 @@ typedef NS_ENUM(NSInteger, ApolloInlineOverlayStyle) {
 @property (nonatomic, weak) CALayer *observedLayer;
 @property (nonatomic, weak) ASNetworkImageNode *overlayImageNode;
 @property (nonatomic) ApolloInlineOverlayStyle overlayStyle;
+// GIF overlays pin the badge bottom-right (play AND pause, so the control
+// sits in one consistent spot); video posters center their play circle.
+@property (nonatomic) BOOL cornerPlacement;
 @end
 @implementation ApolloPlayOverlayContainer
 - (void)layoutSubviews {
@@ -2395,7 +2420,7 @@ typedef NS_ENUM(NSInteger, ApolloInlineOverlayStyle) {
 - (void)recenter {
     for (UIView *sub in self.subviews) {
         CGSize s = sub.bounds.size;
-        if (self.overlayStyle == ApolloInlineOverlayStylePauseBadge) {
+        if (self.cornerPlacement) {
             sub.center = CGPointMake(self.bounds.size.width - 6.0 - s.width * 0.5,
                                      self.bounds.size.height - 6.0 - s.height * 0.5);
         } else {
@@ -2593,6 +2618,7 @@ static void ApolloInstallOverlayWithStyleOnView(UIView *v, ASDisplayNode *node, 
     // target for the player, exactly as before.
     BOOL gifTapToPlay = [objc_getAssociatedObject(node, &kApolloInlineAnimatedGIFKey) boolValue];
     container.userInteractionEnabled = gifTapToPlay;
+    container.cornerPlacement = gifTapToPlay;
     if (gifTapToPlay) {
         UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc]
             initWithTarget:[ApolloInlineImageDispatcher shared]
@@ -2600,11 +2626,22 @@ static void ApolloInstallOverlayWithStyleOnView(UIView *v, ASDisplayNode *node, 
         [container addGestureRecognizer:tap];
     }
 
+    // GIF overlays: play and pause are the SAME small bottom-right badge so
+    // the control sits in one consistent spot and never covers the artwork.
+    // Video posters keep the big centered play circle.
     BOOL badge = (style == ApolloInlineOverlayStylePauseBadge);
-    UIImageView *icon = [[UIImageView alloc]
-        initWithImage:badge ? ApolloInlineGIFPauseBadgeImage() : ApolloPlayOverlayImage()];
+    UIImage *iconImage;
+    CGRect iconFrame;
+    if (gifTapToPlay) {
+        iconImage = badge ? ApolloInlineGIFPauseBadgeImage() : ApolloInlineGIFPlayBadgeImage();
+        iconFrame = CGRectMake(0, 0, 30, 30);
+    } else {
+        iconImage = ApolloPlayOverlayImage();
+        iconFrame = CGRectMake(0, 0, 72, 72);
+    }
+    UIImageView *icon = [[UIImageView alloc] initWithImage:iconImage];
     icon.userInteractionEnabled = NO;
-    icon.frame = badge ? CGRectMake(0, 0, 30, 30) : CGRectMake(0, 0, 72, 72);
+    icon.frame = iconFrame;
     [container addSubview:icon];
 
     [v addSubview:container];
@@ -2635,7 +2672,7 @@ static void ApolloInstallPlayOverlayOnView(UIView *v, ASDisplayNode *node) {
 
 // Single source of truth mapping a hosted inline GIF's state to its overlay:
 //   autoplaying globally                       -> none (tap opens the viewer)
-//   paused + Tap to Play / blocked WiFi Only   -> centered play button
+//   paused + Tap to Play / blocked WiFi Only   -> corner play badge
 //   user-started playback (forced play)        -> corner pause badge
 //   paused + Never                             -> none (pure static cover)
 static void ApolloUpdateInlineGIFOverlayForNode(ASDisplayNode *node) {

--- a/src/ApolloMediaAutoplay.h
+++ b/src/ApolloMediaAutoplay.h
@@ -15,7 +15,8 @@ BOOL ApolloShouldAutoplayInlineGIF(void);
 /// Invalidated when settings, reachability, or Low Power Mode changes.
 BOOL ApolloShouldAutoplayInlineGIFCached(void);
 
-/// Current inline-GIF autoplay mode as a normalized string (never / only-on-wifi / always).
+/// Current inline-GIF autoplay mode as a normalized string
+/// (never / tap-to-play / only-on-wifi / always).
 NSString *ApolloAutoplayGIFModeString(void);
 
 /// YES when Apollo's NATIVE Autoplay GIFs/Videos setting is effectively off
@@ -23,6 +24,16 @@ NSString *ApolloAutoplayGIFModeString(void);
 /// own runtime decision (see the implementation for the verified semantics);
 /// independent of the tweak's Autoplay Inline GIFs setting.
 BOOL ApolloNativeAutoplayEffectivelyOff(void);
+
+/// One-time migration for the legacy "Default (Follow Apollo)" mode (0):
+/// resolves Apollo's native Autoplay GIFs/Videos setting to the equivalent
+/// explicit mode so existing users keep their current behavior.
+NSInteger ApolloResolveLegacyDefaultAutoplayGIFMode(void);
+
+/// YES when a paused inline GIF should show the play-button overlay for
+/// inline tap-to-play (Tap to Play mode, or WiFi Only while blocked).
+/// Never mode shows a pure static cover with no overlay.
+BOOL ApolloPausedInlineGIFWantsPlayOverlay(void);
 
 /// YES for URLs that are typically animated GIFs (not static JPEG/PNG/WebP).
 BOOL ApolloURLLooksLikeAnimatedGIF(NSURL *url);
@@ -56,6 +67,19 @@ void ApolloUnregisterInlineGIFNode(id imageNode);
 
 /// YES when object is a live ASNetworkImageNode suitable for the inline GIF registry.
 BOOL ApolloInlineGIFNodeIsRegistryEligible(id imageNode);
+
+/// Flag an Apollo-native inline animated node (giphy-picker embeds, native
+/// ![gif](...) tokens, animated snoomoji) so the registry gates it too. These
+/// nodes are paused/resumed in place (no cover/overlay/URL reload machinery).
+void ApolloFlagNativeInlineGIFNode(id imageNode);
+
+/// YES when the node was flagged via ApolloFlagNativeInlineGIFNode.
+BOOL ApolloNodeIsNativeInlineGIF(id imageNode);
+
+/// Apply the current autoplay decision to a native inline animated node:
+/// stops/starts its FLAnimatedImageView subview and toggles Texture's
+/// animatedImagePaused. Returns YES when a live node was updated.
+BOOL ApolloApplyNativeInlineGIFAutoplayGate(id imageNode);
 
 /// Re-evaluate autoplay for all registered inline GIF nodes.
 void ApolloRefreshVisibleInlineGIFAutoplay(void);

--- a/src/ApolloMediaAutoplay.m
+++ b/src/ApolloMediaAutoplay.m
@@ -6,6 +6,7 @@
 
 #import <SystemConfiguration/SystemConfiguration.h>
 #import <netinet/in.h>
+#import <objc/message.h>
 #import <objc/runtime.h>
 
 // Apollo's native General > Autoplay GIFs/Videos preference. Followed only when the
@@ -15,6 +16,7 @@ static NSString *const kApolloGroupSuiteName = @"group.com.christianselig.apollo
 
 static const void *kApolloInlineAnimatedGIFViewKey = &kApolloInlineAnimatedGIFViewKey;
 static const void *kApolloInlineGIFUserForcedPlayViewKey = &kApolloInlineGIFUserForcedPlayViewKey;
+static const void *kApolloNativeInlineGIFNodeKey = &kApolloNativeInlineGIFNodeKey;
 
 static SCNetworkReachabilityRef sReachability = NULL;
 static NSHashTable *sInlineGIFNodes = nil;
@@ -35,6 +37,7 @@ static BOOL ApolloNetworkIsOnWiFi(void);
 static BOOL ApolloNetworkIsOnCellular(void);
 static void ApolloLogAutoplayDecision(NSString *mode, BOOL shouldPlay);
 static void ApolloReloadAutoplayInlineGIFModeFromDefaults(void);
+static NSString *ApolloNativeAutoplayGIFModeString(void);
 
 static Class ApolloASNetworkImageNodeClass(void) {
     static Class cls = Nil;
@@ -47,13 +50,65 @@ static Class ApolloASNetworkImageNodeClass(void) {
 
 BOOL ApolloInlineGIFNodeIsRegistryEligible(id imageNode) {
     if (!imageNode || imageNode == (id)[NSNull null]) return NO;
+    // Native inline animated nodes (giphy-picker embeds, snoomoji) are gated in
+    // place — they only need liveness introspection, not the URL-reload API.
+    if (ApolloNodeIsNativeInlineGIF(imageNode)) {
+        return [imageNode respondsToSelector:@selector(isNodeLoaded)] &&
+               [imageNode respondsToSelector:@selector(supernode)];
+    }
     Class cls = ApolloASNetworkImageNodeClass();
     if (!cls || ![imageNode isKindOfClass:cls]) return NO;
-    if (![imageNode respondsToSelector:@selector(clearImage)]) return NO;
+    // Deliberately no -clearImage requirement: Apollo's AsyncDisplayKit build
+    // doesn't implement it, and requiring it left this registry permanently
+    // empty — settings changes never paused or resumed any on-screen GIF.
     if (![imageNode respondsToSelector:@selector(setURL:)]) return NO;
     if (![imageNode respondsToSelector:@selector(URL)]) return NO;
     if (![imageNode respondsToSelector:@selector(isNodeLoaded)]) return NO;
     if (![imageNode respondsToSelector:@selector(supernode)]) return NO;
+    return YES;
+}
+
+void ApolloFlagNativeInlineGIFNode(id imageNode) {
+    if (!imageNode) return;
+    objc_setAssociatedObject(imageNode, kApolloNativeInlineGIFNodeKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+BOOL ApolloNodeIsNativeInlineGIF(id imageNode) {
+    if (!imageNode) return NO;
+    return [objc_getAssociatedObject(imageNode, kApolloNativeInlineGIFNodeKey) boolValue];
+}
+
+// Stops/starts a native inline animated node in place. Covers both Texture
+// animation pipelines: an FLAnimatedImageView subview (gated through the
+// FLAnimatedImageView hooks once the node view is marked) and Texture's own
+// animated-image display (toggled via animatedImagePaused).
+BOOL ApolloApplyNativeInlineGIFAutoplayGate(id imageNode) {
+    if (!ApolloNodeIsNativeInlineGIF(imageNode)) return NO;
+    if (![imageNode respondsToSelector:@selector(isNodeLoaded)] ||
+        !((BOOL (*)(id, SEL))objc_msgSend)(imageNode, @selector(isNodeLoaded))) {
+        return NO;
+    }
+    BOOL shouldPlay = ApolloShouldAutoplayInlineGIFCached();
+    @try {
+        UIView *view = nil;
+        if ([imageNode respondsToSelector:@selector(view)]) {
+            view = ((UIView *(*)(id, SEL))objc_msgSend)(imageNode, @selector(view));
+        }
+        if (!view) return NO;
+        ApolloMarkViewAsInlineGIF(view);
+        UIView *animView = ApolloFindFLAnimatedImageViewInView(view);
+        if (animView) {
+            ApolloApplyFLAnimatedImageViewAutoplayGate(animView);
+        }
+        if ([imageNode respondsToSelector:@selector(setAnimatedImagePaused:)]) {
+            ((void (*)(id, SEL, BOOL))objc_msgSend)(imageNode, @selector(setAnimatedImagePaused:), !shouldPlay);
+        }
+    } @catch (NSException *exception) {
+        ApolloLog(@"[AutoplayGIF] native gate failed node=%p class=%@ reason=%@",
+                  imageNode, NSStringFromClass([imageNode class]), exception.reason);
+        ApolloUnregisterInlineGIFNode(imageNode);
+        return NO;
+    }
     return YES;
 }
 
@@ -109,7 +164,7 @@ static BOOL ApolloComputeShouldAutoplayInlineGIF(NSString **outMode) {
     NSString *mode = ApolloAutoplayGIFModeString();
     BOOL shouldPlay = NO;
 
-    if ([mode isEqualToString:@"never"]) {
+    if ([mode isEqualToString:@"never"] || [mode isEqualToString:@"tap-to-play"]) {
         shouldPlay = NO;
     } else if ([mode isEqualToString:@"only-on-wifi"]) {
         shouldPlay = ApolloNetworkIsOnWiFi();
@@ -156,13 +211,28 @@ static void ApolloStartReachabilityMonitor(void) {
     });
 }
 
+NSInteger ApolloResolveLegacyDefaultAutoplayGIFMode(void) {
+    NSString *native = ApolloNativeAutoplayGIFModeString();
+    if ([native isEqualToString:@"always"]) return ApolloAutoplayInlineGIFModeAlways;
+    if ([native isEqualToString:@"only-on-wifi"] || [native containsString:@"wifi"]) {
+        return ApolloAutoplayInlineGIFModeWiFiOnly;
+    }
+    return ApolloAutoplayInlineGIFModeNever;
+}
+
 // Reloads and validates the inline-GIF autoplay mode from user defaults into the
 // shared sAutoplayInlineGIFMode global. Called on KVO changes so external/defaults-
-// driven edits are reflected even when the settings UI isn't the writer.
+// driven edits are reflected even when the settings UI isn't the writer. Legacy
+// Default (0) / out-of-range values (e.g. a restored old backup) resolve to the
+// explicit equivalent of Apollo's native setting and are persisted so the
+// migration happens once.
 static void ApolloReloadAutoplayInlineGIFModeFromDefaults(void) {
     NSInteger mode = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyAutoplayInlineGIFs];
-    if (mode < ApolloAutoplayInlineGIFModeDefault || mode > ApolloAutoplayInlineGIFModeAlways) {
-        mode = ApolloAutoplayInlineGIFModeDefault;
+    if (mode < ApolloAutoplayInlineGIFModeNever || mode > ApolloAutoplayInlineGIFModeTapToPlay) {
+        mode = ApolloResolveLegacyDefaultAutoplayGIFMode();
+        // Persisting re-fires this KVO handler once; the stored value is
+        // valid on the second pass so it terminates immediately.
+        [[NSUserDefaults standardUserDefaults] setInteger:mode forKey:UDKeyAutoplayInlineGIFs];
     }
     sAutoplayInlineGIFMode = mode;
 }
@@ -182,11 +252,12 @@ static NSString *ApolloNativeAutoplayGIFModeString(void) {
 
 NSString *ApolloAutoplayGIFModeString(void) {
     switch (sAutoplayInlineGIFMode) {
-        case ApolloAutoplayInlineGIFModeNever:    return @"never";
-        case ApolloAutoplayInlineGIFModeWiFiOnly: return @"only-on-wifi";
-        case ApolloAutoplayInlineGIFModeAlways:   return @"always";
+        case ApolloAutoplayInlineGIFModeNever:     return @"never";
+        case ApolloAutoplayInlineGIFModeTapToPlay: return @"tap-to-play";
+        case ApolloAutoplayInlineGIFModeWiFiOnly:  return @"only-on-wifi";
+        case ApolloAutoplayInlineGIFModeAlways:    return @"always";
         case ApolloAutoplayInlineGIFModeDefault:
-        default:                                  return ApolloNativeAutoplayGIFModeString();
+        default:                                   return ApolloNativeAutoplayGIFModeString();
     }
 }
 
@@ -225,6 +296,17 @@ BOOL ApolloNativeAutoplayEffectivelyOff(void) {
     SCNetworkReachabilityFlags flags = 0;
     if (!SCNetworkReachabilityGetFlags(reachability, &flags)) return NO;
     return (flags & kSCNetworkReachabilityFlagsReachable) && (flags & kSCNetworkReachabilityFlagsIsWWAN);
+}
+
+// Whether a paused inline GIF should carry a play-button overlay for inline
+// tap-to-play. Tap to Play mode always wants it; WiFi Only wants it while
+// blocked (cellular). Never mode is a pure static cover — tapping falls
+// through to the normal image tap (media viewer).
+BOOL ApolloPausedInlineGIFWantsPlayOverlay(void) {
+    NSString *mode = ApolloAutoplayGIFModeString();
+    if ([mode isEqualToString:@"tap-to-play"]) return YES;
+    if ([mode isEqualToString:@"only-on-wifi"]) return !ApolloShouldAutoplayInlineGIFCached();
+    return NO;
 }
 
 static void ApolloLogAutoplayDecision(NSString *mode, BOOL shouldPlay) {
@@ -505,6 +587,14 @@ void ApolloRefreshVisibleInlineGIFAutoplay(void) {
             if (!ApolloInlineGIFNodeIsRegistryEligible(node)) {
                 ApolloUnregisterInlineGIFNode(node);
                 prunedCount++;
+                continue;
+            }
+            if (ApolloNodeIsNativeInlineGIF(node)) {
+                if (ApolloApplyNativeInlineGIFAutoplayGate(node)) {
+                    if (shouldPlay) reloadCount++; else pauseCount++;
+                } else {
+                    skipCount++;
+                }
                 continue;
             }
             if (shouldPlay) {

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -126,12 +126,25 @@ extern NSInteger sInlineImageAlignment;
 // Defaults to Default. Only takes effect when Inline Media Previews
 // (sEnableInlineImages) is on. See ApolloMediaAutoplay.m.
 typedef NS_ENUM(NSInteger, ApolloAutoplayInlineGIFMode) {
-    ApolloAutoplayInlineGIFModeDefault  = 0, // follow Apollo's Autoplay GIFs/Videos
-    ApolloAutoplayInlineGIFModeNever    = 1,
-    ApolloAutoplayInlineGIFModeWiFiOnly = 2,
-    ApolloAutoplayInlineGIFModeAlways   = 3,
+    // Legacy value: "follow Apollo's native Autoplay GIFs/Videos setting".
+    // No longer offered in the UI — resolved once at load into the explicit
+    // equivalent (see ApolloResolveLegacyDefaultAutoplayGIFMode) so persisted
+    // settings keep their behavior.
+    ApolloAutoplayInlineGIFModeDefault   = 0,
+    ApolloAutoplayInlineGIFModeNever     = 1, // static cover, no play overlay (tap opens viewer)
+    ApolloAutoplayInlineGIFModeWiFiOnly  = 2, // autoplay on WiFi; Tap to Play on cellular
+    ApolloAutoplayInlineGIFModeAlways    = 3,
+    ApolloAutoplayInlineGIFModeTapToPlay = 4, // static cover + play button; tap toggles play/pause inline
+    // 4 appended so persisted values keep meaning; display order is
+    // Always, WiFi Only, Tap to Play, Never.
 };
 extern NSInteger sAutoplayInlineGIFMode;
+
+// Display width of inline media (images/GIFs) in comments/selftext as a
+// percentage of the row width (50/75/100, default 100). Plain scalar — read
+// from Texture background layout threads (layoutSpecThatFits:), so keep it a
+// simple aligned integer, never an object.
+extern NSInteger sInlineMediaSizePercent;
 
 typedef NS_ENUM(NSInteger, ApolloLinkPreviewMode) {
     ApolloLinkPreviewModeOff = 0,

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -50,6 +50,7 @@ BOOL sEnableTapToSummarize = NO;
 BOOL sEnableAIAutoExpandSummaries = NO;
 NSInteger sInlineImageAlignment = ApolloInlineImageAlignmentCenter;
 NSInteger sAutoplayInlineGIFMode = ApolloAutoplayInlineGIFModeDefault;
+NSInteger sInlineMediaSizePercent = 100;
 NSInteger sLinkPreviewBodyMode = ApolloLinkPreviewModeOff;
 NSInteger sLinkPreviewCommentsMode = ApolloLinkPreviewModeOff;
 NSInteger sLinkPreviewCardColor = ApolloLinkPreviewCardColorNeutral;

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -13,6 +13,7 @@
 #import "ApolloLinkPreviewCache.h"
 #import "ApolloDeletedCommentsSettingsViewController.h"
 #import "ApolloLinkPreviewSettingsViewController.h"
+#import "InlineMediaSettingsViewController.h"
 #import "ApolloOpenInAppViewController.h"
 #import "ApolloSubredditCustomBannerCache.h"
 #import "ApolloSubredditCustomIconCache.h"
@@ -34,6 +35,7 @@ typedef NS_ENUM(NSInteger, SectionIndex) {
     SectionAPIKeys,
     SectionGeneral,
     SectionApolloAI,
+    SectionInlineMedia,   // single row -> InlineMediaSettingsViewController
     SectionLinkPreviews,
     SectionMedia,
     SectionSubreddits,
@@ -42,28 +44,6 @@ typedef NS_ENUM(NSInteger, SectionIndex) {
     SectionAbout,
     SectionCount
 };
-
-// The Media section hides two adjacent inline-media-dependent rows (Inline Media
-// Alignment + Autoplay Inline GIFs) when Inline Media Previews is off. These helpers
-// centralize the physical<->logical row mapping so the index math stays consistent.
-static const NSInteger kApolloMediaInlineDependentRows = 2;
-static const NSInteger kApolloMediaFirstInlineDependentRow = 6;
-
-// Map a physical (visible) Media row to its logical row.
-static NSInteger ApolloMediaLogicalRow(NSInteger physicalRow) {
-    if (!sEnableInlineImages && physicalRow >= kApolloMediaFirstInlineDependentRow) {
-        return physicalRow + kApolloMediaInlineDependentRows;
-    }
-    return physicalRow;
-}
-
-// Map a logical Media row to its physical (visible) row.
-static NSInteger ApolloMediaPhysicalRow(NSInteger logicalRow) {
-    if (!sEnableInlineImages && logicalRow >= kApolloMediaFirstInlineDependentRow + kApolloMediaInlineDependentRows) {
-        return logicalRow - kApolloMediaInlineDependentRows;
-    }
-    return logicalRow;
-}
 
 // Row indices within SectionNotificationBackend. The Bark rows are always
 // visible: on builds without a push entitlement Bark is the only delivery
@@ -554,6 +534,48 @@ typedef NS_ENUM(NSInteger, Tag) {
     }
 }
 
+- (UITableViewCell *)inlineMediaCellForTableView:(UITableView *)tableView {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_InlineMedia"];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"Cell_InlineMedia"];
+        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+        cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+    }
+    cell.textLabel.text = @"Inline Media Settings";
+    NSString *detail;
+    if (!sEnableInlineImages) {
+        detail = @"Off";
+    } else {
+        NSString *autoplay;
+        switch (sAutoplayInlineGIFMode) {
+            case ApolloAutoplayInlineGIFModeTapToPlay: autoplay = @"Tap to Play"; break;
+            case ApolloAutoplayInlineGIFModeWiFiOnly:  autoplay = @"WiFi Only"; break;
+            case ApolloAutoplayInlineGIFModeAlways:    autoplay = @"Always"; break;
+            case ApolloAutoplayInlineGIFModeNever:
+            default:                                   autoplay = @"Never"; break;
+        }
+        detail = [NSString stringWithFormat:@"On \u00b7 Autoplay %@ \u00b7 Size %ld%%",
+                  autoplay, (long)sInlineMediaSizePercent];
+    }
+    cell.detailTextLabel.text = detail;
+    cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+    cell.detailTextLabel.numberOfLines = 0;
+    cell.detailTextLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    return cell;
+}
+
+- (void)openInlineMediaSettings {
+    InlineMediaSettingsViewController *vc =
+        [[InlineMediaSettingsViewController alloc] initWithStyle:UITableViewStyleInsetGrouped];
+    if (self.navigationController) {
+        [self.navigationController pushViewController:vc animated:YES];
+    } else {
+        UINavigationController *navigation =
+            [[UINavigationController alloc] initWithRootViewController:vc];
+        [self presentViewController:navigation animated:YES completion:nil];
+    }
+}
+
 - (UITableViewCell *)deletedCommentsCellForTableView:(UITableView *)tableView {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Gen_DeletedComments"];
     if (!cell) {
@@ -624,7 +646,7 @@ typedef NS_ENUM(NSInteger, Tag) {
     }
     // Refresh the Apollo AI and Rich Link Previews status subtitles after returning
     // from their subviews.
-    [self.tableView reloadSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(SectionApolloAI, 2)]
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(SectionApolloAI, 3)]
                   withRowAnimation:UITableViewRowAnimationNone];
 }
 
@@ -680,13 +702,13 @@ typedef NS_ENUM(NSInteger, Tag) {
         // toggles. No conditional rows remain, so the count is constant.
         case SectionGeneral: return 14;
         case SectionApolloAI: return 1;
+        case SectionInlineMedia: return 1;
         case SectionLinkPreviews: return 1;
-        // Media base rows (the three "Rich Link Previews" rows moved out to their
-        // own SectionLinkPreviews) plus the "Comment Link Host" picker, the chat
-        // inline-media toggle and the "Hold for Video Speed" toggle, minus the two
-        // inline-dependent rows when off, plus the hold-speed picker (logical row
-        // 14) when that toggle is on.
-        case SectionMedia: return 14 + (sEnableInlineImages ? 0 : -kApolloMediaInlineDependentRows) + (sVideoHoldSpeedEnabled ? 1 : 0);
+        // Media base rows. The inline-media rows (Previews toggle, Alignment,
+        // Autoplay Inline GIFs) moved to the Inline Media sub-screen
+        // (SectionInlineMedia). The hold-speed picker (row 11) shows only while
+        // its toggle is on.
+        case SectionMedia: return 11 + (sVideoHoldSpeedEnabled ? 1 : 0);
         case SectionSubreddits: return 10 - (sSubredditListEnhancements ? 0 : 1) - (sCommunityHighlights ? 0 : 1);
         case SectionNotificationBackend: return kNotifBackendRowCount;
         case SectionPrivacy: return 1; // Anonymous Install Count toggle
@@ -701,6 +723,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionAPIKeys: return @"API Keys";
         case SectionGeneral: return @"General";
         case SectionApolloAI: return @"Apollo AI";
+        case SectionInlineMedia: return @"Inline Media";
         case SectionLinkPreviews: return @"Rich Link Previews";
         case SectionMedia: return @"Media";
         case SectionSubreddits: return @"Subreddits";
@@ -718,6 +741,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionAPIKeys: cell = [self apiKeyCellForRow:indexPath.row tableView:tableView]; break;
         case SectionGeneral: cell = [self generalCellForRow:indexPath.row tableView:tableView]; break;
         case SectionApolloAI: cell = [self apolloAICellForTableView:tableView]; break;
+        case SectionInlineMedia: cell = [self inlineMediaCellForTableView:tableView]; break;
         case SectionLinkPreviews: cell = [self linkPreviewsCellForTableView:tableView]; break;
         case SectionMedia: cell = [self mediaCellForRow:indexPath.row tableView:tableView]; break;
         case SectionSubreddits: cell = [self subredditCellForRow:indexPath.row tableView:tableView]; break;
@@ -1210,8 +1234,6 @@ typedef NS_ENUM(NSInteger, Tag) {
 }
 
 - (UITableViewCell *)mediaCellForRow:(NSInteger)row tableView:(UITableView *)tableView {
-    // When the inline-dependent rows are hidden, physical rows map to later logical rows.
-    row = ApolloMediaLogicalRow(row);
     switch (row) {
         case 0: {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_GIFFallbackFormat"];
@@ -1266,51 +1288,24 @@ typedef NS_ENUM(NSInteger, Tag) {
                                             label:@"Proxy Imgur via DuckDuckGo"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyProxyImgurDDG]
                                            action:@selector(proxyImgurDDGSwitchToggled:)];
+        // Inline Media Previews / Alignment / Autoplay Inline GIFs moved to the
+        // Inline Media Settings sub-screen (SectionInlineMedia).
         case 5:
-            return [self switchCellWithIdentifier:@"Cell_Media_InlineImages"
-                                            label:@"Inline Media Previews"
-                                               on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableInlineImages]
-                                           action:@selector(inlineImagesSwitchToggled:)];
-        case 6: {
-            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_InlineImageAlignment"];
-            if (!cell) {
-                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_InlineImageAlignment"];
-                cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-            }
-            cell.textLabel.text = @"Inline Media Alignment";
-            cell.detailTextLabel.text = [self inlineImageAlignmentText];
-            cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
-            return cell;
-        }
-        case 7: {
-            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_AutoplayInlineGIFs"];
-            if (!cell) {
-                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_AutoplayInlineGIFs"];
-                cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
-            }
-            cell.textLabel.text = @"Autoplay Inline GIFs";
-            cell.detailTextLabel.text = [self autoplayInlineGIFModeText];
-            cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
-            return cell;
-        }
-        case 8:
             return [self switchCellWithIdentifier:@"Cell_Media_TextPostThumbnails"
                                             label:@"Text Post Thumbnails"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyFeedTextPostThumbnails]
                                            action:@selector(textPostThumbnailsSwitchToggled:)];
-        case 9:
+        case 6:
             return [self switchCellWithIdentifier:@"Cell_Media_UserAvatars"
                                             label:@"Show User Profile Pictures"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars]
                                            action:@selector(userAvatarsSwitchToggled:)];
-        case 10:
+        case 7:
             return [self switchCellWithIdentifier:@"Cell_Media_ProfileTabAvatar"
                                             label:@"Profile Picture Tab Icon"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon]
                                            action:@selector(profileTabAvatarSwitchToggled:)];
-        case 11:
+        case 8:
             // Single toggle for Reborn's detailed profile page: banner, large
             // avatar/snoovatar, display name, bio, and the Social Links band (all of
             // which live in the custom header). Off → Apollo's compact stock profile.
@@ -1318,14 +1313,14 @@ typedef NS_ENUM(NSInteger, Tag) {
                                             label:@"Show Detailed Profiles"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowDetailedProfiles]
                                            action:@selector(showDetailedProfilesSwitchToggled:)];
-        case 12:
+        case 9:
             return [self switchCellWithIdentifier:@"Cell_Media_ChatMedia"
                                             label:@"Inline Media in Chat"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableChatMedia]
                                            action:@selector(chatMediaSwitchToggled:)];
-        case 13:
+        case 10:
             // Master toggle for "Hold for Video Speed". When on, the hold-speed
-            // picker (logical row 14) is shown below; when off, the right side of a
+            // picker (row 11) is shown below; when off, the right side of a
             // fullscreen video keeps Apollo's normal long-press menu. The gesture is
             // explained in the section footer, matching the sibling Media toggles
             // (which are plain switches with no inline subtitle).
@@ -1333,7 +1328,7 @@ typedef NS_ENUM(NSInteger, Tag) {
                                             label:@"Hold for Video Speed"
                                                on:sVideoHoldSpeedEnabled
                                            action:@selector(videoHoldSpeedSwitchToggled:)];
-        case 14: {
+        case 11: {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_HoldSpeedValue"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_HoldSpeedValue"];
@@ -1821,6 +1816,11 @@ typedef NS_ENUM(NSInteger, Tag) {
         return;
     }
 
+    if (indexPath.section == SectionInlineMedia) {
+        [self openInlineMediaSettings];
+        return;
+    }
+
     if (indexPath.section == SectionLinkPreviews) {
         [self openLinkPreviewSettings];
         return;
@@ -1880,20 +1880,15 @@ typedef NS_ENUM(NSInteger, Tag) {
         }
     } else if (indexPath.section == SectionMedia) {
         UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
-        NSInteger row = ApolloMediaLogicalRow(indexPath.row);
-        if (row == 0) {
+        if (indexPath.row == 0) {
             [self presentPreferredGIFFallbackFormatSheetFromSourceView:cell];
-        } else if (row == 1) {
+        } else if (indexPath.row == 1) {
             [self presentUnmuteCommentsVideosModeSheetFromSourceView:cell];
-        } else if (row == 2) {
+        } else if (indexPath.row == 2) {
             [self presentImageUploadProviderSheetFromSourceView:cell];
-        } else if (row == 3) {
+        } else if (indexPath.row == 3) {
             [self presentCommentLinkHostSheetFromSourceView:cell];
-        } else if (row == 6) {
-            [self presentInlineImageAlignmentSheetFromSourceView:cell];
-        } else if (row == 7) {
-            [self presentAutoplayInlineGIFModeSheetFromSourceView:cell];
-        } else if (row == 14) {
+        } else if (indexPath.row == 11) {
             [self presentVideoHoldSpeedSheetFromSourceView:cell];
         }
     } else if (indexPath.section == SectionNotificationBackend) {
@@ -2007,6 +2002,7 @@ typedef NS_ENUM(NSInteger, Tag) {
             row == kAPIKeyRowWebSessionLogin || row == kAPIKeyRowWidgetSetupCode) return YES;
     }
     if (indexPath.section == SectionApolloAI) return YES;
+    if (indexPath.section == SectionInlineMedia) return YES;
     if (indexPath.section == SectionLinkPreviews) return YES;
     if (indexPath.section == SectionGeneral) {
         // Only the "Deleted Comments" (row 3) and "Open in App" (row 7)
@@ -2014,8 +2010,8 @@ typedef NS_ENUM(NSInteger, Tag) {
         return indexPath.row == 3 || indexPath.row == 7;
     }
     if (indexPath.section == SectionMedia) {
-        NSInteger row = ApolloMediaLogicalRow(indexPath.row);
-        return (row == 0 || row == 1 || row == 2 || row == 3 || row == 6 || row == 7 || row == 14);
+        return (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 ||
+                indexPath.row == 3 || indexPath.row == 11);
     }
     if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 || indexPath.row == 3 || indexPath.row == 4)) return YES;
     if (indexPath.section == SectionNotificationBackend) {
@@ -2617,118 +2613,8 @@ typedef NS_ENUM(NSInteger, Tag) {
     [self presentViewController:alert animated:YES completion:nil];
 }
 
-- (void)inlineImagesSwitchToggled:(UISwitch *)sender {
-    BOOL wasOn = sEnableInlineImages;
-    sEnableInlineImages = sender.isOn;
-    [[NSUserDefaults standardUserDefaults] setBool:sEnableInlineImages forKey:UDKeyEnableInlineImages];
-    if (sEnableInlineImages == wasOn) return;
-    // Two adjacent rows are gated on this toggle: Inline Media Alignment (logical 6)
-    // and Autoplay Inline GIFs (logical 7). Insert/delete both to keep row counts consistent.
-    NSArray<NSIndexPath *> *paths = @[
-        [NSIndexPath indexPathForRow:6 inSection:SectionMedia],
-        [NSIndexPath indexPathForRow:7 inSection:SectionMedia],
-    ];
-    if (sEnableInlineImages) {
-        [self.tableView insertRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
-    } else {
-        [self.tableView deleteRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationFade];
-    }
-}
-
-- (NSString *)inlineImageAlignmentText {
-    switch (sInlineImageAlignment) {
-        case ApolloInlineImageAlignmentLeft:  return @"Left";
-        case ApolloInlineImageAlignmentRight: return @"Right";
-        default:                              return @"Center";
-    }
-}
-
-- (void)presentInlineImageAlignmentSheetFromSourceView:(UIView *)sourceView {
-    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Inline Media Alignment"
-                                                                   message:@"Choose how inline media is positioned"
-                                                            preferredStyle:UIAlertControllerStyleActionSheet];
-
-    NSString *centerTitle = (sInlineImageAlignment == ApolloInlineImageAlignmentCenter) ? @"Center (Current)" : @"Center";
-    NSString *leftTitle   = (sInlineImageAlignment == ApolloInlineImageAlignmentLeft)   ? @"Left (Current)"   : @"Left";
-    NSString *rightTitle  = (sInlineImageAlignment == ApolloInlineImageAlignmentRight)  ? @"Right (Current)"  : @"Right";
-
-    [sheet addAction:[UIAlertAction actionWithTitle:centerTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
-        [self setInlineImageAlignment:ApolloInlineImageAlignmentCenter];
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:leftTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
-        [self setInlineImageAlignment:ApolloInlineImageAlignmentLeft];
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:rightTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
-        [self setInlineImageAlignment:ApolloInlineImageAlignmentRight];
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
-
-    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
-    if (popover && sourceView) {
-        popover.sourceView = sourceView;
-        popover.sourceRect = sourceView.bounds;
-    }
-
-    [self presentViewController:sheet animated:YES completion:nil];
-}
-
-- (void)setInlineImageAlignment:(ApolloInlineImageAlignment)alignment {
-    sInlineImageAlignment = alignment;
-    [[NSUserDefaults standardUserDefaults] setInteger:sInlineImageAlignment forKey:UDKeyInlineImageAlignment];
-    NSIndexPath *alignmentRow = [NSIndexPath indexPathForRow:6 inSection:SectionMedia];
-    [self.tableView reloadRowsAtIndexPaths:@[alignmentRow] withRowAnimation:UITableViewRowAnimationNone];
-}
-
-- (NSString *)autoplayInlineGIFModeText {
-    switch (sAutoplayInlineGIFMode) {
-        case ApolloAutoplayInlineGIFModeNever:    return @"Never";
-        case ApolloAutoplayInlineGIFModeWiFiOnly: return @"WiFi Only";
-        case ApolloAutoplayInlineGIFModeAlways:   return @"Always";
-        case ApolloAutoplayInlineGIFModeDefault:
-        default:                                  return @"Default";
-    }
-}
-
-- (void)presentAutoplayInlineGIFModeSheetFromSourceView:(UIView *)sourceView {
-    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Autoplay Inline GIFs"
-                                                                   message:@"Default follows Apollo's Autoplay GIFs/Videos setting in General."
-                                                            preferredStyle:UIAlertControllerStyleActionSheet];
-
-    NSString *defaultTitle = (sAutoplayInlineGIFMode == ApolloAutoplayInlineGIFModeDefault)  ? @"Default (Current)"   : @"Default";
-    NSString *alwaysTitle  = (sAutoplayInlineGIFMode == ApolloAutoplayInlineGIFModeAlways)   ? @"Always (Current)"    : @"Always";
-    NSString *wifiTitle    = (sAutoplayInlineGIFMode == ApolloAutoplayInlineGIFModeWiFiOnly) ? @"WiFi Only (Current)" : @"WiFi Only";
-    NSString *neverTitle   = (sAutoplayInlineGIFMode == ApolloAutoplayInlineGIFModeNever)    ? @"Never (Current)"     : @"Never";
-
-    [sheet addAction:[UIAlertAction actionWithTitle:defaultTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
-        [self setAutoplayInlineGIFMode:ApolloAutoplayInlineGIFModeDefault];
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:alwaysTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
-        [self setAutoplayInlineGIFMode:ApolloAutoplayInlineGIFModeAlways];
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:wifiTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
-        [self setAutoplayInlineGIFMode:ApolloAutoplayInlineGIFModeWiFiOnly];
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:neverTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
-        [self setAutoplayInlineGIFMode:ApolloAutoplayInlineGIFModeNever];
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
-
-    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
-    if (popover && sourceView) {
-        popover.sourceView = sourceView;
-        popover.sourceRect = sourceView.bounds;
-    }
-
-    [self presentViewController:sheet animated:YES completion:nil];
-}
-
-- (void)setAutoplayInlineGIFMode:(ApolloAutoplayInlineGIFMode)mode {
-    sAutoplayInlineGIFMode = mode;
-    // The autoplay module observes this key via KVO and re-evaluates visible inline GIFs.
-    [[NSUserDefaults standardUserDefaults] setInteger:sAutoplayInlineGIFMode forKey:UDKeyAutoplayInlineGIFs];
-    NSIndexPath *autoplayRow = [NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(7) inSection:SectionMedia];
-    [self.tableView reloadRowsAtIndexPaths:@[autoplayRow] withRowAnimation:UITableViewRowAnimationNone];
-}
+// Inline Media Previews / Alignment / Autoplay Inline GIFs UI moved to
+// InlineMediaSettingsViewController (SectionInlineMedia row).
 
 #pragma mark - Hold for Video Speed
 
@@ -2737,10 +2623,10 @@ typedef NS_ENUM(NSInteger, Tag) {
     sVideoHoldSpeedEnabled = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sVideoHoldSpeedEnabled forKey:UDKeyVideoHoldSpeedEnabled];
     if (sVideoHoldSpeedEnabled == wasOn) return;
-    // The "Hold Speed" picker (logical row 14) is the last Media row and is shown
+    // The "Hold Speed" picker (row 11) is the last Media row and is shown
     // only while this toggle is on. Insert/delete it so the row counts stay
-    // consistent. ApolloMediaPhysicalRow(14) accounts for the inline-dependent gap.
-    NSIndexPath *pickerPath = [NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(14) inSection:SectionMedia];
+    // consistent.
+    NSIndexPath *pickerPath = [NSIndexPath indexPathForRow:11 inSection:SectionMedia];
     if (sVideoHoldSpeedEnabled) {
         [self.tableView insertRowsAtIndexPaths:@[pickerPath] withRowAnimation:UITableViewRowAnimationFade];
     } else {
@@ -2755,7 +2641,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 - (void)setVideoHoldSpeed:(float)speed {
     sVideoHoldSpeed = ApolloSanitizedHoldSpeed(speed);
     [[NSUserDefaults standardUserDefaults] setFloat:sVideoHoldSpeed forKey:UDKeyVideoHoldSpeed];
-    NSIndexPath *pickerPath = [NSIndexPath indexPathForRow:ApolloMediaPhysicalRow(14) inSection:SectionMedia];
+    NSIndexPath *pickerPath = [NSIndexPath indexPathForRow:11 inSection:SectionMedia];
     if ([[self.tableView indexPathsForVisibleRows] containsObject:pickerPath]) {
         [self.tableView reloadRowsAtIndexPaths:@[pickerPath] withRowAnimation:UITableViewRowAnimationNone];
     }

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -708,7 +708,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         // Autoplay Inline GIFs) moved to the Inline Media sub-screen
         // (SectionInlineMedia). The hold-speed picker (row 11) shows only while
         // its toggle is on.
-        case SectionMedia: return 11 + (sVideoHoldSpeedEnabled ? 1 : 0);
+        case SectionMedia: return 10 + (sVideoHoldSpeedEnabled ? 1 : 0);
         case SectionSubreddits: return 10 - (sSubredditListEnhancements ? 0 : 1) - (sCommunityHighlights ? 0 : 1);
         case SectionNotificationBackend: return kNotifBackendRowCount;
         case SectionPrivacy: return 1; // Anonymous Install Count toggle
@@ -1313,14 +1313,11 @@ typedef NS_ENUM(NSInteger, Tag) {
                                             label:@"Show Detailed Profiles"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowDetailedProfiles]
                                            action:@selector(showDetailedProfilesSwitchToggled:)];
+        // "Inline Media in Chat" moved to the Inline Media Settings sub-screen
+        // (SectionInlineMedia), alongside Inline Media Previews.
         case 9:
-            return [self switchCellWithIdentifier:@"Cell_Media_ChatMedia"
-                                            label:@"Inline Media in Chat"
-                                               on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableChatMedia]
-                                           action:@selector(chatMediaSwitchToggled:)];
-        case 10:
             // Master toggle for "Hold for Video Speed". When on, the hold-speed
-            // picker (row 11) is shown below; when off, the right side of a
+            // picker (row 10) is shown below; when off, the right side of a
             // fullscreen video keeps Apollo's normal long-press menu. The gesture is
             // explained in the section footer, matching the sibling Media toggles
             // (which are plain switches with no inline subtitle).
@@ -1328,7 +1325,7 @@ typedef NS_ENUM(NSInteger, Tag) {
                                             label:@"Hold for Video Speed"
                                                on:sVideoHoldSpeedEnabled
                                            action:@selector(videoHoldSpeedSwitchToggled:)];
-        case 11: {
+        case 10: {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Media_HoldSpeedValue"];
             if (!cell) {
                 cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Media_HoldSpeedValue"];
@@ -1888,7 +1885,7 @@ typedef NS_ENUM(NSInteger, Tag) {
             [self presentImageUploadProviderSheetFromSourceView:cell];
         } else if (indexPath.row == 3) {
             [self presentCommentLinkHostSheetFromSourceView:cell];
-        } else if (indexPath.row == 11) {
+        } else if (indexPath.row == 10) {
             [self presentVideoHoldSpeedSheetFromSourceView:cell];
         }
     } else if (indexPath.section == SectionNotificationBackend) {
@@ -2011,7 +2008,7 @@ typedef NS_ENUM(NSInteger, Tag) {
     }
     if (indexPath.section == SectionMedia) {
         return (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 ||
-                indexPath.row == 3 || indexPath.row == 11);
+                indexPath.row == 3 || indexPath.row == 10);
     }
     if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 || indexPath.row == 3 || indexPath.row == 4)) return YES;
     if (indexPath.section == SectionNotificationBackend) {
@@ -2582,14 +2579,6 @@ typedef NS_ENUM(NSInteger, Tag) {
     [[NSNotificationCenter defaultCenter] postNotificationName:ApolloSocialLinksToggleChangedNotification object:nil];
 }
 
-- (void)chatMediaSwitchToggled:(UISwitch *)sender {
-    // Master toggle for chat media (inline images/GIFs/emoji/snoomoji + working media sends +
-    // tap-to-fullscreen). Open chats re-render their cells on next display/scroll, so no
-    // immediate-refresh notification is needed. Independent of Show User Profile Pictures.
-    sEnableChatMedia = sender.isOn;
-    [[NSUserDefaults standardUserDefaults] setBool:sEnableChatMedia forKey:UDKeyEnableChatMedia];
-}
-
 - (void)promptClearAllCachesFromSourceView:(UIView *)sourceView {
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Clear Tweak Caches?"
                                                                    message:@"This removes cached profile pictures, banners, link previews, and remembered banned-profile dismissals."
@@ -2623,10 +2612,10 @@ typedef NS_ENUM(NSInteger, Tag) {
     sVideoHoldSpeedEnabled = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sVideoHoldSpeedEnabled forKey:UDKeyVideoHoldSpeedEnabled];
     if (sVideoHoldSpeedEnabled == wasOn) return;
-    // The "Hold Speed" picker (row 11) is the last Media row and is shown
+    // The "Hold Speed" picker (row 10) is the last Media row and is shown
     // only while this toggle is on. Insert/delete it so the row counts stay
     // consistent.
-    NSIndexPath *pickerPath = [NSIndexPath indexPathForRow:11 inSection:SectionMedia];
+    NSIndexPath *pickerPath = [NSIndexPath indexPathForRow:10 inSection:SectionMedia];
     if (sVideoHoldSpeedEnabled) {
         [self.tableView insertRowsAtIndexPaths:@[pickerPath] withRowAnimation:UITableViewRowAnimationFade];
     } else {
@@ -2641,7 +2630,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 - (void)setVideoHoldSpeed:(float)speed {
     sVideoHoldSpeed = ApolloSanitizedHoldSpeed(speed);
     [[NSUserDefaults standardUserDefaults] setFloat:sVideoHoldSpeed forKey:UDKeyVideoHoldSpeed];
-    NSIndexPath *pickerPath = [NSIndexPath indexPathForRow:11 inSection:SectionMedia];
+    NSIndexPath *pickerPath = [NSIndexPath indexPathForRow:10 inSection:SectionMedia];
     if ([[self.tableView indexPathsForVisibleRows] containsObject:pickerPath]) {
         [self.tableView reloadRowsAtIndexPaths:@[pickerPath] withRowAnimation:UITableViewRowAnimationNone];
     }

--- a/src/InlineMediaSettingsViewController.h
+++ b/src/InlineMediaSettingsViewController.h
@@ -1,0 +1,8 @@
+#import "ApolloSettingsTableViewController.h"
+
+/// "Inline Media Settings" sub-screen (pushed from the Apollo Reborn settings
+/// root, directly above Rich Link Preview Settings). Hosts the inline media
+/// master toggle, alignment, GIF autoplay mode, and the media / link-card size
+/// sliders, with a live fake-comment preview that tracks every control.
+@interface InlineMediaSettingsViewController : ApolloSettingsTableViewController
+@end

--- a/src/InlineMediaSettingsViewController.m
+++ b/src/InlineMediaSettingsViewController.m
@@ -172,6 +172,151 @@ static UILabel *ApolloIMName(UIView *parent, NSString *text) {
 
 @end
 
+// MARK: - Detent slider (50 / 75 / 100)
+
+static NSInteger ApolloIMSnapPercent(float value) {
+    if (value < 62.5f) return 50;
+    if (value < 87.5f) return 75;
+    return 100;
+}
+
+// UISlider with exactly three stops. Unlike a stock slider, tracking begins
+// from a touch anywhere on the bar (not just on the thumb), and the thumb
+// snaps between the detents while dragging — with a selection tick on each
+// snap. Tick marks at both ends and the middle show the three positions so
+// it doesn't read as a free-flowing slider.
+@interface ApolloIMDetentSlider : UISlider
+@property (nonatomic, strong) NSArray<UIView *> *tickViews;
+@property (nonatomic, strong) UISelectionFeedbackGenerator *feedback;
+// Pan recognizers up the view chain (Apollo's swipe-anywhere-back, the nav
+// pop edge gesture) suspended for the duration of a drag — they otherwise
+// steal the horizontal drag mid-track and pop the screen.
+@property (nonatomic, strong) NSHashTable<UIGestureRecognizer *> *suspendedPans;
+@end
+
+@implementation ApolloIMDetentSlider
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    if ((self = [super initWithFrame:frame])) {
+        NSMutableArray<UIView *> *ticks = [NSMutableArray array];
+        for (int i = 0; i < 3; i++) {
+            UIView *tick = [[UIView alloc] init];
+            tick.backgroundColor = [UIColor tertiaryLabelColor];
+            tick.userInteractionEnabled = NO;
+            tick.layer.cornerRadius = 1.0;
+            // Behind the track/thumb subviews: the track covers the middle of
+            // each tick, leaving the ends peeking above and below the bar.
+            [self insertSubview:tick atIndex:0];
+            [ticks addObject:tick];
+        }
+        _tickViews = ticks;
+        _feedback = [[UISelectionFeedbackGenerator alloc] init];
+    }
+    return self;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGRect track = [self trackRectForBounds:self.bounds];
+    const CGFloat fractions[3] = {0.0, 0.5, 1.0};
+    for (NSUInteger i = 0; i < self.tickViews.count && i < 3; i++) {
+        CGFloat x = CGRectGetMinX(track) + fractions[i] * CGRectGetWidth(track);
+        self.tickViews[i].frame = CGRectMake(x - 1.0, CGRectGetMidY(track) - 7.0, 2.0, 14.0);
+    }
+}
+
+- (void)apollo_applyTouch:(UITouch *)touch {
+    CGRect track = [self trackRectForBounds:self.bounds];
+    CGFloat width = MAX(1.0, CGRectGetWidth(track));
+    CGFloat fraction = ([touch locationInView:self].x - CGRectGetMinX(track)) / width;
+    fraction = MIN(1.0, MAX(0.0, fraction));
+    float raw = self.minimumValue + fraction * (self.maximumValue - self.minimumValue);
+    float snapped = (float)ApolloIMSnapPercent(raw);
+    if ((NSInteger)lroundf(self.value) != (NSInteger)snapped) {
+        [self setValue:snapped animated:YES];
+        [self.feedback selectionChanged];
+        [self sendActionsForControlEvents:UIControlEventValueChanged];
+    }
+}
+
+// Same recipe as the stats-row loupe (SRTDisableCompetingPans): the
+// interactive pop recognizer must be fetched from the navigation controller
+// explicitly — it is not reliably reachable by walking the touched view's
+// superview chain — and Apollo's full-width back-swipe / parallax transition
+// pans match by class name, not only by UIPanGestureRecognizer ancestry.
+- (void)apollo_suspendCompetingPans {
+    NSHashTable<UIGestureRecognizer *> *suspended = [NSHashTable weakObjectsHashTable];
+
+    UINavigationController *nav = nil;
+    for (UIResponder *r = self.nextResponder; r && !nav; r = r.nextResponder) {
+        if ([r isKindOfClass:[UINavigationController class]]) {
+            nav = (UINavigationController *)r;
+        } else if ([r isKindOfClass:[UIViewController class]]) {
+            nav = ((UIViewController *)r).navigationController;
+        }
+    }
+    UIGestureRecognizer *pop = nav.interactivePopGestureRecognizer;
+    if (pop && pop.isEnabled) {
+        pop.enabled = NO;
+        [suspended addObject:pop];
+        ApolloLog(@"[InlineMedia] slider suspend pop=%@ on=%@",
+                  NSStringFromClass([pop class]), NSStringFromClass([pop.view class]));
+    }
+
+    for (UIView *view = self.superview; view; view = view.superview) {
+        for (UIGestureRecognizer *gesture in view.gestureRecognizers) {
+            if (gesture == pop || !gesture.enabled) continue;
+            // Leave the enclosing scroll view's own pan alone — UIControl
+            // tracking already defers vertical scrolling correctly.
+            if ([view isKindOfClass:[UIScrollView class]] &&
+                gesture == ((UIScrollView *)view).panGestureRecognizer) continue;
+            NSString *cls = NSStringFromClass([gesture class]);
+            BOOL panLike = [gesture isKindOfClass:[UIPanGestureRecognizer class]]
+                || [cls containsString:@"ParallaxTransition"];
+            if (!panLike) continue;
+            gesture.enabled = NO;   // also cancels any in-flight recognition
+            [suspended addObject:gesture];
+            ApolloLog(@"[InlineMedia] slider suspend pan=%@ on=%@",
+                      cls, NSStringFromClass([view class]));
+        }
+    }
+    self.suspendedPans = suspended;
+}
+
+- (void)apollo_resumeCompetingPans {
+    for (UIGestureRecognizer *gesture in self.suspendedPans) {
+        gesture.enabled = YES;
+    }
+    self.suspendedPans = nil;
+}
+
+- (BOOL)beginTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
+    ApolloLog(@"[InlineMedia] slider beginTracking x=%.0f", [touch locationInView:self].x);
+    [self apollo_suspendCompetingPans];
+    [self.feedback prepare];
+    [self apollo_applyTouch:touch];
+    return YES;
+}
+
+- (BOOL)continueTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
+    [self apollo_applyTouch:touch];
+    return YES;
+}
+
+- (void)endTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
+    ApolloLog(@"[InlineMedia] slider endTracking value=%.0f", self.value);
+    [super endTrackingWithTouch:touch withEvent:event];
+    [self apollo_resumeCompetingPans];
+}
+
+- (void)cancelTrackingWithEvent:(UIEvent *)event {
+    ApolloLog(@"[InlineMedia] slider cancelTracking value=%.0f", self.value);
+    [super cancelTrackingWithEvent:event];
+    [self apollo_resumeCompetingPans];
+}
+
+@end
+
 // MARK: - Controller
 
 typedef NS_ENUM(NSInteger, ApolloIMSection) {
@@ -191,7 +336,6 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
 @interface InlineMediaSettingsViewController ()
 @property (nonatomic, strong) ApolloInlineMediaPreviewView *previewView;
 @property (nonatomic, strong) UILabel *mediaSizeValueLabel;
-@property (nonatomic, weak) UISlider *mediaSlider;
 @end
 
 @implementation InlineMediaSettingsViewController
@@ -277,7 +421,7 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
     [cell.contentView addSubview:value];
     if (valueLabelOut) *valueLabelOut = value;
 
-    UISlider *slider = [[UISlider alloc] init];
+    ApolloIMDetentSlider *slider = [[ApolloIMDetentSlider alloc] init];
     slider.minimumValue = 50.0;
     slider.maximumValue = 100.0;
     slider.value = (float)percent;
@@ -286,10 +430,6 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
     slider.accessibilityLabel = label;
     slider.translatesAutoresizingMaskIntoConstraints = NO;
     [slider addTarget:self action:action forControlEvents:UIControlEventValueChanged];
-    // Tap anywhere on the track to jump straight to that detent — with only
-    // three stops this beats dragging the thumb.
-    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(sliderTapped:)];
-    [slider addGestureRecognizer:tap];
     [cell.contentView addSubview:slider];
 
     UILayoutGuide *margins = cell.contentView.layoutMarginsGuide;
@@ -305,12 +445,6 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
         [slider.bottomAnchor constraintEqualToAnchor:cell.contentView.bottomAnchor constant:-10.0],
     ]];
     return cell;
-}
-
-static NSInteger ApolloIMSnapPercent(float value) {
-    if (value < 62.5f) return 50;
-    if (value < 87.5f) return 75;
-    return 100;
 }
 
 // MARK: Value strings
@@ -400,9 +534,6 @@ static NSInteger ApolloIMSnapPercent(float value) {
                                                            action:@selector(mediaSizeSliderChanged:)
                                                        valueLabel:&valueLabel];
                     self.mediaSizeValueLabel = valueLabel;
-                    for (UIView *sub in cell.contentView.subviews) {
-                        if ([sub isKindOfClass:[UISlider class]]) { self.mediaSlider = (UISlider *)sub; break; }
-                    }
                     return cell;
                 }
             }
@@ -443,19 +574,6 @@ static NSInteger ApolloIMSnapPercent(float value) {
     [[NSUserDefaults standardUserDefaults] setBool:sEnableInlineImages forKey:UDKeyEnableInlineImages];
     [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:ApolloIMSectionOptions]
                   withRowAnimation:UITableViewRowAnimationNone];
-}
-
-- (void)sliderTapped:(UITapGestureRecognizer *)gesture {
-    UISlider *slider = (UISlider *)gesture.view;
-    if (![slider isKindOfClass:[UISlider class]] || !slider.enabled) return;
-    CGRect track = [slider trackRectForBounds:slider.bounds];
-    CGFloat x = [gesture locationInView:slider].x;
-    CGFloat fraction = (x - CGRectGetMinX(track)) / MAX(1.0, CGRectGetWidth(track));
-    fraction = MIN(1.0, MAX(0.0, fraction));
-    slider.value = slider.minimumValue + fraction * (slider.maximumValue - slider.minimumValue);
-    if (slider == self.mediaSlider) {
-        [self mediaSizeSliderChanged:slider];
-    }
 }
 
 - (void)mediaSizeSliderChanged:(UISlider *)slider {

--- a/src/InlineMediaSettingsViewController.m
+++ b/src/InlineMediaSettingsViewController.m
@@ -143,8 +143,9 @@ static UILabel *ApolloIMName(UIView *parent, NSString *text) {
                      self.alignment == ApolloInlineImageAlignmentRight ? slack : slack * 0.5);
     self.mediaBlock.frame = CGRectMake(mediaX, y, mediaWidth, mediaHeight);
     self.gifBadge.frame = CGRectMake(8, mediaHeight - 26, 40, 18);
-    CGFloat playSide = MIN(52.0, mediaHeight * 0.4);
-    self.playIcon.frame = CGRectMake((mediaWidth - playSide) * 0.5, (mediaHeight - playSide) * 0.5, playSide, playSide);
+    // Matches the real overlay: a small play badge pinned bottom-right.
+    CGFloat playSide = 26.0;
+    self.playIcon.frame = CGRectMake(mediaWidth - 6.0 - playSide, mediaHeight - 6.0 - playSide, playSide, playSide);
     self.playIcon.hidden = !self.showsPlayOverlay;
     y += mediaHeight + 18;
 
@@ -496,7 +497,7 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
         case ApolloIMSectionMaster:
             return @"Render image, GIF, and video links inside post text and comments instead of leaving them as plain links.";
         case ApolloIMSectionOptions:
-            return @"Tap to Play shows a paused GIF with a play button — the button plays that one GIF inline, a small corner pause button stops it, and tapping the rest of the GIF opens the fullscreen viewer as usual. Never shows a static preview (tap opens the viewer). WiFi Only autoplays on WiFi and behaves like Tap to Play on cellular.";
+            return @"Tap to Play shows a paused GIF with a play button in the bottom corner — it plays that one GIF inline and becomes a pause button, and tapping the rest of the GIF opens the fullscreen viewer as usual. Never shows a static preview (tap opens the viewer). WiFi Only autoplays on WiFi and behaves like Tap to Play on cellular.";
         default:
             return nil;
     }

--- a/src/InlineMediaSettingsViewController.m
+++ b/src/InlineMediaSettingsViewController.m
@@ -1,0 +1,539 @@
+#import "InlineMediaSettingsViewController.h"
+#import "ApolloCommon.h"
+#import "ApolloMediaAutoplay.h"
+#import "ApolloState.h"
+#import "UserDefaultConstants.h"
+
+// MARK: - Live preview (fake comments)
+//
+// Same pattern as ApolloLPPreviewCardsView (Rich Link Preview settings): a
+// standalone UIView owned by the controller, re-hosted into its cell on every
+// cellForRow so it survives reloadData, with one apply/refresh entry point the
+// controls call continuously while dragging. Frame-based layout — this is a
+// plain settings view, not a Texture hook, so laying out subviews here is fine.
+
+@interface ApolloInlineMediaPreviewView : UIView
+@property (nonatomic) CGFloat mediaFraction;   // 0.5 / 0.75 / 1.0
+@property (nonatomic) NSInteger alignment;     // ApolloInlineImageAlignment
+@property (nonatomic) BOOL showsPlayOverlay;   // paused modes that tap-to-play
+
+@property (nonatomic, strong) UIView *avatarOne;
+@property (nonatomic, strong) UILabel *nameOne;
+@property (nonatomic, strong) UIView *textBarOne;
+@property (nonatomic, strong) UIView *mediaBlock;
+@property (nonatomic, strong) UILabel *gifBadge;
+@property (nonatomic, strong) UIImageView *playIcon;
+@property (nonatomic, strong) UIView *avatarTwo;
+@property (nonatomic, strong) UILabel *nameTwo;
+@property (nonatomic, strong) UIView *textBarTwo;
+@property (nonatomic, strong) UIView *cardBlock;
+@property (nonatomic, strong) UIView *cardThumb;
+@property (nonatomic, strong) UIView *cardLineOne;
+@property (nonatomic, strong) UIView *cardLineTwo;
+@end
+
+@implementation ApolloInlineMediaPreviewView
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    if ((self = [super initWithFrame:frame])) {
+        _mediaFraction = 1.0;
+        _alignment = ApolloInlineImageAlignmentCenter;
+        [self build];
+    }
+    return self;
+}
+
+static UIView *ApolloIMBar(UIView *parent, CGFloat alpha) {
+    UIView *bar = [[UIView alloc] init];
+    bar.backgroundColor = [[UIColor secondaryLabelColor] colorWithAlphaComponent:alpha];
+    bar.layer.cornerRadius = 4.0;
+    [parent addSubview:bar];
+    return bar;
+}
+
+static UIView *ApolloIMAvatar(UIView *parent) {
+    UIView *avatar = [[UIView alloc] init];
+    avatar.backgroundColor = [UIColor systemFillColor];
+    avatar.layer.cornerRadius = 12.0;
+    [parent addSubview:avatar];
+    return avatar;
+}
+
+static UILabel *ApolloIMName(UIView *parent, NSString *text) {
+    UILabel *label = [[UILabel alloc] init];
+    label.text = text;
+    label.font = [UIFont systemFontOfSize:12.0 weight:UIFontWeightSemibold];
+    label.textColor = [UIColor secondaryLabelColor];
+    [parent addSubview:label];
+    return label;
+}
+
+- (void)build {
+    self.avatarOne = ApolloIMAvatar(self);
+    self.nameOne = ApolloIMName(self, @"u/GifEnjoyer · 2h");
+    self.textBarOne = ApolloIMBar(self, 0.35);
+
+    self.mediaBlock = [[UIView alloc] init];
+    self.mediaBlock.backgroundColor = [UIColor systemFillColor];
+    self.mediaBlock.layer.cornerRadius = 10.0;
+    self.mediaBlock.clipsToBounds = YES;
+    [self addSubview:self.mediaBlock];
+
+    self.gifBadge = [[UILabel alloc] init];
+    self.gifBadge.text = @" GIF ";
+    self.gifBadge.font = [UIFont systemFontOfSize:11.0 weight:UIFontWeightBold];
+    self.gifBadge.textColor = [UIColor whiteColor];
+    self.gifBadge.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.6];
+    self.gifBadge.layer.cornerRadius = 4.0;
+    self.gifBadge.clipsToBounds = YES;
+    [self.mediaBlock addSubview:self.gifBadge];
+
+    UIImage *play = [UIImage systemImageNamed:@"play.circle.fill"];
+    self.playIcon = [[UIImageView alloc] initWithImage:play];
+    self.playIcon.tintColor = [[UIColor whiteColor] colorWithAlphaComponent:0.9];
+    self.playIcon.contentMode = UIViewContentModeScaleAspectFit;
+    [self.mediaBlock addSubview:self.playIcon];
+
+    self.avatarTwo = ApolloIMAvatar(self);
+    self.nameTwo = ApolloIMName(self, @"u/LinkLover · 1h");
+    self.textBarTwo = ApolloIMBar(self, 0.35);
+
+    self.cardBlock = [[UIView alloc] init];
+    self.cardBlock.backgroundColor = [UIColor secondarySystemFillColor];
+    self.cardBlock.layer.cornerRadius = 10.0;
+    self.cardBlock.clipsToBounds = YES;
+    [self addSubview:self.cardBlock];
+
+    self.cardThumb = [[UIView alloc] init];
+    self.cardThumb.backgroundColor = [UIColor systemFillColor];
+    self.cardThumb.layer.cornerRadius = 6.0;
+    [self.cardBlock addSubview:self.cardThumb];
+    self.cardLineOne = ApolloIMBar(self.cardBlock, 0.5);
+    self.cardLineTwo = ApolloIMBar(self.cardBlock, 0.3);
+}
+
++ (CGFloat)preferredHeight {
+    // Sized for the 100% media block on typical widths; smaller fractions
+    // simply leave breathing room. Row height stays fixed so live slider
+    // drags never force table reloads.
+    return 384.0;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGFloat W = self.bounds.size.width;
+    if (W <= 0) return;
+    CGFloat margin = 12.0;
+    CGFloat rowWidth = W - margin * 2.0;
+    CGFloat y = 10.0;
+
+    self.avatarOne.frame = CGRectMake(margin, y, 24, 24);
+    self.nameOne.frame = CGRectMake(margin + 32, y + 4, rowWidth - 32, 16);
+    y += 32;
+    self.textBarOne.frame = CGRectMake(margin, y, rowWidth * 0.86, 10);
+    y += 20;
+
+    // Media block — width follows the media slider, aspect fixed at 16:9,
+    // horizontal position follows the alignment setting (same slack rule as
+    // ApolloWrapImageNodeForLayout).
+    CGFloat mediaWidth = MAX(60.0, rowWidth * self.mediaFraction);
+    CGFloat mediaHeight = mediaWidth * 9.0 / 16.0;
+    CGFloat slack = rowWidth - mediaWidth;
+    CGFloat mediaX = margin + (self.alignment == ApolloInlineImageAlignmentLeft ? 0.0 :
+                     self.alignment == ApolloInlineImageAlignmentRight ? slack : slack * 0.5);
+    self.mediaBlock.frame = CGRectMake(mediaX, y, mediaWidth, mediaHeight);
+    self.gifBadge.frame = CGRectMake(8, mediaHeight - 26, 40, 18);
+    CGFloat playSide = MIN(52.0, mediaHeight * 0.4);
+    self.playIcon.frame = CGRectMake((mediaWidth - playSide) * 0.5, (mediaHeight - playSide) * 0.5, playSide, playSide);
+    self.playIcon.hidden = !self.showsPlayOverlay;
+    y += mediaHeight + 18;
+
+    self.avatarTwo.frame = CGRectMake(margin, y, 24, 24);
+    self.nameTwo.frame = CGRectMake(margin + 32, y + 4, rowWidth - 32, 16);
+    y += 32;
+    self.textBarTwo.frame = CGRectMake(margin, y, rowWidth * 0.62, 10);
+    y += 20;
+
+    // Link preview card mock — fixed full width (card sizing is handled by the
+    // Compact/Full modes in Rich Link Preview Settings, not by this screen).
+    CGFloat cardWidth = rowWidth;
+    CGFloat cardHeight = 72.0;
+    self.cardBlock.frame = CGRectMake(margin + (rowWidth - cardWidth) * 0.5, y, cardWidth, cardHeight);
+    self.cardThumb.frame = CGRectMake(8, 8, 56, 56);
+    CGFloat lineX = 72.0;
+    self.cardLineOne.frame = CGRectMake(lineX, 14, MAX(40.0, cardWidth - lineX - 12), 12);
+    self.cardLineTwo.frame = CGRectMake(lineX, 36, MAX(30.0, (cardWidth - lineX - 12) * 0.7), 10);
+}
+
+- (void)refresh {
+    [self setNeedsLayout];
+    [self layoutIfNeeded];
+}
+
+@end
+
+// MARK: - Controller
+
+typedef NS_ENUM(NSInteger, ApolloIMSection) {
+    ApolloIMSectionPreview = 0,
+    ApolloIMSectionMaster,
+    ApolloIMSectionOptions,
+    ApolloIMSectionCount,
+};
+
+typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
+    ApolloIMOptionsRowAlignment = 0,
+    ApolloIMOptionsRowAutoplay,
+    ApolloIMOptionsRowMediaSize,
+    ApolloIMOptionsRowCount,
+};
+
+@interface InlineMediaSettingsViewController ()
+@property (nonatomic, strong) ApolloInlineMediaPreviewView *previewView;
+@property (nonatomic, strong) UILabel *mediaSizeValueLabel;
+@property (nonatomic, weak) UISlider *mediaSlider;
+@end
+
+@implementation InlineMediaSettingsViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Inline Media";
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.tableView reloadData];
+}
+
+// MARK: Preview plumbing
+
+- (ApolloInlineMediaPreviewView *)ensurePreviewView {
+    if (!self.previewView) {
+        self.previewView = [[ApolloInlineMediaPreviewView alloc] initWithFrame:CGRectZero];
+    }
+    [self syncPreviewState];
+    return self.previewView;
+}
+
+- (void)syncPreviewState {
+    self.previewView.mediaFraction = sInlineMediaSizePercent / 100.0;
+    self.previewView.alignment = sInlineImageAlignment;
+    NSString *mode = ApolloAutoplayGIFModeString();
+    self.previewView.showsPlayOverlay = [mode isEqualToString:@"tap-to-play"];
+    [self.previewView refresh];
+}
+
+// MARK: Cell helpers (repo-wide patterns — see PictureInPictureViewController)
+
+- (UITableViewCell *)switchCellLabel:(NSString *)label on:(BOOL)on enabled:(BOOL)enabled action:(SEL)action {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:nil];
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+    cell.textLabel.text = label;
+    cell.textLabel.enabled = enabled;
+    UISwitch *sw = [[UISwitch alloc] init];
+    sw.on = on;
+    sw.enabled = enabled;
+    [sw addTarget:self action:action forControlEvents:UIControlEventValueChanged];
+    cell.accessoryView = sw;
+    return cell;
+}
+
+- (UITableViewCell *)valueCellLabel:(NSString *)label detail:(NSString *)detail enabled:(BOOL)enabled {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:nil];
+    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    cell.selectionStyle = enabled ? UITableViewCellSelectionStyleDefault : UITableViewCellSelectionStyleNone;
+    cell.textLabel.text = label;
+    cell.textLabel.enabled = enabled;
+    cell.detailTextLabel.text = detail;
+    cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+    return cell;
+}
+
+// Slider row with a title, a live "NN%" value label, and a 50/75/100-detent
+// slider underneath. The slider snaps to the three stops while dragging and
+// updates the preview continuously.
+- (UITableViewCell *)sliderCellLabel:(NSString *)label
+                             percent:(NSInteger)percent
+                             enabled:(BOOL)enabled
+                              action:(SEL)action
+                          valueLabel:(UILabel * __strong *)valueLabelOut {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+
+    UILabel *title = [[UILabel alloc] init];
+    title.text = label;
+    title.font = [UIFont systemFontOfSize:17.0];
+    title.enabled = enabled;
+    title.translatesAutoresizingMaskIntoConstraints = NO;
+    [cell.contentView addSubview:title];
+
+    UILabel *value = [[UILabel alloc] init];
+    value.text = [NSString stringWithFormat:@"%ld%%", (long)percent];
+    value.font = [UIFont monospacedDigitSystemFontOfSize:17.0 weight:UIFontWeightRegular];
+    value.textColor = [UIColor secondaryLabelColor];
+    value.textAlignment = NSTextAlignmentRight;
+    value.translatesAutoresizingMaskIntoConstraints = NO;
+    [cell.contentView addSubview:value];
+    if (valueLabelOut) *valueLabelOut = value;
+
+    UISlider *slider = [[UISlider alloc] init];
+    slider.minimumValue = 50.0;
+    slider.maximumValue = 100.0;
+    slider.value = (float)percent;
+    slider.enabled = enabled;
+    slider.continuous = YES;
+    slider.accessibilityLabel = label;
+    slider.translatesAutoresizingMaskIntoConstraints = NO;
+    [slider addTarget:self action:action forControlEvents:UIControlEventValueChanged];
+    // Tap anywhere on the track to jump straight to that detent — with only
+    // three stops this beats dragging the thumb.
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(sliderTapped:)];
+    [slider addGestureRecognizer:tap];
+    [cell.contentView addSubview:slider];
+
+    UILayoutGuide *margins = cell.contentView.layoutMarginsGuide;
+    [NSLayoutConstraint activateConstraints:@[
+        [title.leadingAnchor constraintEqualToAnchor:margins.leadingAnchor],
+        [title.topAnchor constraintEqualToAnchor:cell.contentView.topAnchor constant:10.0],
+        [value.trailingAnchor constraintEqualToAnchor:margins.trailingAnchor],
+        [value.centerYAnchor constraintEqualToAnchor:title.centerYAnchor],
+        [value.leadingAnchor constraintGreaterThanOrEqualToAnchor:title.trailingAnchor constant:8.0],
+        [slider.leadingAnchor constraintEqualToAnchor:margins.leadingAnchor],
+        [slider.trailingAnchor constraintEqualToAnchor:margins.trailingAnchor],
+        [slider.topAnchor constraintEqualToAnchor:title.bottomAnchor constant:6.0],
+        [slider.bottomAnchor constraintEqualToAnchor:cell.contentView.bottomAnchor constant:-10.0],
+    ]];
+    return cell;
+}
+
+static NSInteger ApolloIMSnapPercent(float value) {
+    if (value < 62.5f) return 50;
+    if (value < 87.5f) return 75;
+    return 100;
+}
+
+// MARK: Value strings
+
+- (NSString *)alignmentText {
+    switch (sInlineImageAlignment) {
+        case ApolloInlineImageAlignmentLeft:  return @"Left";
+        case ApolloInlineImageAlignmentRight: return @"Right";
+        default:                              return @"Center";
+    }
+}
+
+- (NSString *)autoplayModeText {
+    switch (sAutoplayInlineGIFMode) {
+        case ApolloAutoplayInlineGIFModeTapToPlay: return @"Tap to Play";
+        case ApolloAutoplayInlineGIFModeWiFiOnly:  return @"WiFi Only";
+        case ApolloAutoplayInlineGIFModeAlways:    return @"Always";
+        case ApolloAutoplayInlineGIFModeNever:
+        default:                                   return @"Never";
+    }
+}
+
+// MARK: Table
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return ApolloIMSectionCount;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    switch (section) {
+        case ApolloIMSectionPreview:  return 1;
+        case ApolloIMSectionMaster:   return 1;
+        case ApolloIMSectionOptions:  return ApolloIMOptionsRowCount;
+        default:                      return 0;
+    }
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
+    switch (section) {
+        case ApolloIMSectionPreview:  return @"Preview";
+        case ApolloIMSectionMaster:   return @"Inline Media";
+        case ApolloIMSectionOptions:  return @"Comments & Posts";
+        default:                      return nil;
+    }
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
+    switch (section) {
+        case ApolloIMSectionMaster:
+            return @"Render image, GIF, and video links inside post text and comments instead of leaving them as plain links.";
+        case ApolloIMSectionOptions:
+            return @"Tap to Play shows a paused GIF with a play button — tapping plays or pauses that one GIF inline. Never shows a static preview (tap opens the viewer). WiFi Only autoplays on WiFi and behaves like Tap to Play on cellular.";
+        default:
+            return nil;
+    }
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    BOOL inlineOn = sEnableInlineImages;
+    switch (indexPath.section) {
+        case ApolloIMSectionPreview: {
+            UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+            cell.selectionStyle = UITableViewCellSelectionStyleNone;
+            ApolloInlineMediaPreviewView *preview = [self ensurePreviewView];
+            [preview removeFromSuperview];
+            preview.frame = cell.contentView.bounds;
+            preview.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+            [cell.contentView addSubview:preview];
+            return cell;
+        }
+        case ApolloIMSectionMaster:
+            return [self switchCellLabel:@"Inline Media Previews"
+                                      on:sEnableInlineImages
+                                 enabled:YES
+                                  action:@selector(inlineMediaSwitchToggled:)];
+        case ApolloIMSectionOptions:
+            switch (indexPath.row) {
+                case ApolloIMOptionsRowAlignment:
+                    return [self valueCellLabel:@"Inline Media Alignment" detail:[self alignmentText] enabled:inlineOn];
+                case ApolloIMOptionsRowAutoplay:
+                    return [self valueCellLabel:@"Autoplay Inline GIFs" detail:[self autoplayModeText] enabled:inlineOn];
+                case ApolloIMOptionsRowMediaSize: {
+                    UILabel *valueLabel = nil;
+                    UITableViewCell *cell = [self sliderCellLabel:@"Inline Media Size"
+                                                          percent:sInlineMediaSizePercent
+                                                          enabled:inlineOn
+                                                           action:@selector(mediaSizeSliderChanged:)
+                                                       valueLabel:&valueLabel];
+                    self.mediaSizeValueLabel = valueLabel;
+                    for (UIView *sub in cell.contentView.subviews) {
+                        if ([sub isKindOfClass:[UISlider class]]) { self.mediaSlider = (UISlider *)sub; break; }
+                    }
+                    return cell;
+                }
+            }
+            break;
+    }
+    return [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == ApolloIMSectionPreview) return [ApolloInlineMediaPreviewView preferredHeight];
+    if (indexPath.section == ApolloIMSectionOptions && indexPath.row == ApolloIMOptionsRowMediaSize) {
+        return 88.0;
+    }
+    return UITableViewAutomaticDimension;
+}
+
+- (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section != ApolloIMSectionOptions) return NO;
+    if (!sEnableInlineImages) return NO;
+    return indexPath.row == ApolloIMOptionsRowAlignment || indexPath.row == ApolloIMOptionsRowAutoplay;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    if (indexPath.section != ApolloIMSectionOptions || !sEnableInlineImages) return;
+    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+    if (indexPath.row == ApolloIMOptionsRowAlignment) {
+        [self presentAlignmentSheetFromSourceView:cell];
+    } else if (indexPath.row == ApolloIMOptionsRowAutoplay) {
+        [self presentAutoplayModeSheetFromSourceView:cell];
+    }
+}
+
+// MARK: Actions
+
+- (void)inlineMediaSwitchToggled:(UISwitch *)sw {
+    sEnableInlineImages = sw.on;
+    [[NSUserDefaults standardUserDefaults] setBool:sEnableInlineImages forKey:UDKeyEnableInlineImages];
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:ApolloIMSectionOptions]
+                  withRowAnimation:UITableViewRowAnimationNone];
+}
+
+- (void)sliderTapped:(UITapGestureRecognizer *)gesture {
+    UISlider *slider = (UISlider *)gesture.view;
+    if (![slider isKindOfClass:[UISlider class]] || !slider.enabled) return;
+    CGRect track = [slider trackRectForBounds:slider.bounds];
+    CGFloat x = [gesture locationInView:slider].x;
+    CGFloat fraction = (x - CGRectGetMinX(track)) / MAX(1.0, CGRectGetWidth(track));
+    fraction = MIN(1.0, MAX(0.0, fraction));
+    slider.value = slider.minimumValue + fraction * (slider.maximumValue - slider.minimumValue);
+    if (slider == self.mediaSlider) {
+        [self mediaSizeSliderChanged:slider];
+    }
+}
+
+- (void)mediaSizeSliderChanged:(UISlider *)slider {
+    NSInteger percent = ApolloIMSnapPercent(slider.value);
+    if ((NSInteger)lroundf(slider.value) != percent) [slider setValue:(float)percent animated:NO];
+    self.mediaSizeValueLabel.text = [NSString stringWithFormat:@"%ld%%", (long)percent];
+    if (percent != sInlineMediaSizePercent) {
+        sInlineMediaSizePercent = percent;
+        [[NSUserDefaults standardUserDefaults] setInteger:percent forKey:UDKeyInlineMediaSizePercent];
+        // Re-measure visible comments so the change applies without leaving
+        // the thread.
+        [[NSNotificationCenter defaultCenter] postNotificationName:ApolloInlineMediaLayoutDidChangeNotification
+                                                            object:nil];
+    }
+    [self syncPreviewState];
+}
+
+// MARK: Sheets
+
+- (void)presentAlignmentSheetFromSourceView:(UIView *)sourceView {
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Inline Media Alignment"
+                                                                   message:@"Horizontal position of inline media narrower than the row."
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+    NSArray<NSNumber *> *values = @[@(ApolloInlineImageAlignmentCenter),
+                                    @(ApolloInlineImageAlignmentLeft),
+                                    @(ApolloInlineImageAlignmentRight)];
+    NSArray<NSString *> *titles = @[@"Center", @"Left", @"Right"];
+    for (NSUInteger i = 0; i < values.count; i++) {
+        NSInteger value = values[i].integerValue;
+        NSString *title = titles[i];
+        if (sInlineImageAlignment == value) title = [title stringByAppendingString:@" (Current)"];
+        [sheet addAction:[UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+            sInlineImageAlignment = value;
+            [[NSUserDefaults standardUserDefaults] setInteger:value forKey:UDKeyInlineImageAlignment];
+            // Re-measure visible comments so the change applies without
+            // leaving the thread.
+            [[NSNotificationCenter defaultCenter] postNotificationName:ApolloInlineMediaLayoutDidChangeNotification
+                                                                object:nil];
+            [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:ApolloIMOptionsRowAlignment
+                                                                        inSection:ApolloIMSectionOptions]]
+                                  withRowAnimation:UITableViewRowAnimationNone];
+            [self syncPreviewState];
+        }]];
+    }
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    sheet.popoverPresentationController.sourceView = sourceView;
+    sheet.popoverPresentationController.sourceRect = sourceView.bounds;
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+- (void)presentAutoplayModeSheetFromSourceView:(UIView *)sourceView {
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Autoplay Inline GIFs"
+                                                                   message:@"Tap to Play pauses GIFs behind a play button; tapping plays or pauses that GIF inline."
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+    NSArray<NSNumber *> *values = @[@(ApolloAutoplayInlineGIFModeAlways),
+                                    @(ApolloAutoplayInlineGIFModeWiFiOnly),
+                                    @(ApolloAutoplayInlineGIFModeTapToPlay),
+                                    @(ApolloAutoplayInlineGIFModeNever)];
+    NSArray<NSString *> *titles = @[@"Always", @"WiFi Only", @"Tap to Play", @"Never"];
+    for (NSUInteger i = 0; i < values.count; i++) {
+        NSInteger value = values[i].integerValue;
+        NSString *title = titles[i];
+        if (sAutoplayInlineGIFMode == value) title = [title stringByAppendingString:@" (Current)"];
+        [sheet addAction:[UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+            sAutoplayInlineGIFMode = value;
+            // The KVO observer in ApolloMediaAutoplay picks this write up and
+            // refreshes every registered on-screen GIF immediately.
+            [[NSUserDefaults standardUserDefaults] setInteger:value forKey:UDKeyAutoplayInlineGIFs];
+            [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:ApolloIMOptionsRowAutoplay
+                                                                        inSection:ApolloIMSectionOptions]]
+                                  withRowAnimation:UITableViewRowAnimationNone];
+            [self syncPreviewState];
+        }]];
+    }
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    sheet.popoverPresentationController.sourceView = sourceView;
+    sheet.popoverPresentationController.sourceRect = sourceView.bounds;
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+@end

--- a/src/InlineMediaSettingsViewController.m
+++ b/src/InlineMediaSettingsViewController.m
@@ -496,7 +496,7 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
         case ApolloIMSectionMaster:
             return @"Render image, GIF, and video links inside post text and comments instead of leaving them as plain links.";
         case ApolloIMSectionOptions:
-            return @"Tap to Play shows a paused GIF with a play button — tapping plays or pauses that one GIF inline. Never shows a static preview (tap opens the viewer). WiFi Only autoplays on WiFi and behaves like Tap to Play on cellular.";
+            return @"Tap to Play shows a paused GIF with a play button — the button plays that one GIF inline, a small corner pause button stops it, and tapping the rest of the GIF opens the fullscreen viewer as usual. Never shows a static preview (tap opens the viewer). WiFi Only autoplays on WiFi and behaves like Tap to Play on cellular.";
         default:
             return nil;
     }

--- a/src/InlineMediaSettingsViewController.m
+++ b/src/InlineMediaSettingsViewController.m
@@ -181,6 +181,45 @@ static NSInteger ApolloIMSnapPercent(float value) {
     return 100;
 }
 
+// The three stops and the midpoint boundaries between them (62.5, 87.5).
+static const NSInteger kApolloIMStops[] = {50, 75, 100};
+static const int kApolloIMStopCount = 3;
+
+// Detent selection WITH hysteresis. The plain nearest-stop snap above flips
+// the instant `raw` crosses a boundary — fine for a tap, fatal for a drag:
+// a real fingertip held near a boundary jitters a pixel or two every frame
+// (120Hz on ProMotion), so `raw` oscillates across the boundary and the
+// caller re-fires the selection haptic each flip, producing a *continuous
+// rumble* instead of one tick. (The Simulator's synthetic drags are perfectly
+// smooth, so this only reproduces on device — which is why it slipped through.)
+//
+// Hysteresis adds a dead-band: once parked on a detent, the finger must cross
+// the boundary by kApolloIMHysteresis before the detent changes. The band is
+// far wider than any jitter, so a held finger stays put and the haptic fires
+// exactly once per deliberate crossing. Multi-step fast drags still work — the
+// loops walk as many stops as `raw` clears.
+static const float kApolloIMHysteresis = 6.0f;  // percent units (range is 50)
+
+static NSInteger ApolloIMSnapPercentHysteretic(float raw, NSInteger current) {
+    int idx = 0;
+    BOOL found = NO;
+    for (int i = 0; i < kApolloIMStopCount; i++) {
+        if (kApolloIMStops[i] == current) { idx = i; found = YES; break; }
+    }
+    if (!found) return ApolloIMSnapPercent(raw);   // current off-grid: hard snap
+    // Move up while the finger is clearly past the upper boundary…
+    while (idx < kApolloIMStopCount - 1) {
+        float boundary = (kApolloIMStops[idx] + kApolloIMStops[idx + 1]) / 2.0f;
+        if (raw > boundary + kApolloIMHysteresis) idx++; else break;
+    }
+    // …and down while clearly below the lower boundary.
+    while (idx > 0) {
+        float boundary = (kApolloIMStops[idx - 1] + kApolloIMStops[idx]) / 2.0f;
+        if (raw < boundary - kApolloIMHysteresis) idx--; else break;
+    }
+    return kApolloIMStops[idx];
+}
+
 // UISlider with exactly three stops. Unlike a stock slider, tracking begins
 // from a touch anywhere on the bar (not just on the thumb), and the thumb
 // snaps between the detents while dragging — with a selection tick on each
@@ -237,7 +276,9 @@ static NSInteger ApolloIMSnapPercent(float value) {
     CGFloat fraction = ([touch locationInView:self].x - CGRectGetMinX(track)) / width;
     fraction = MIN(1.0, MAX(0.0, fraction));
     float raw = self.minimumValue + fraction * (self.maximumValue - self.minimumValue);
-    NSInteger snapped = ApolloIMSnapPercent(raw);
+    // Hysteretic snap keyed off the current detent — a held finger's jitter
+    // can't flip it across a boundary, so the haptic fires once per crossing.
+    NSInteger snapped = ApolloIMSnapPercentHysteretic(raw, self.lastSnappedPercent);
     if (snapped != self.lastSnappedPercent) {
         self.lastSnappedPercent = snapped;      // one haptic per detent crossing
         [self setValue:(float)snapped animated:YES];
@@ -326,6 +367,12 @@ typedef NS_ENUM(NSInteger, ApolloIMSection) {
     ApolloIMSectionMaster,
     ApolloIMSectionOptions,
     ApolloIMSectionCount,
+};
+
+typedef NS_ENUM(NSInteger, ApolloIMMasterRow) {
+    ApolloIMMasterRowPreviews = 0,   // inline media in posts + comments
+    ApolloIMMasterRowChat,           // inline media in Chat / DMs
+    ApolloIMMasterRowCount,
 };
 
 typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
@@ -478,7 +525,7 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     switch (section) {
         case ApolloIMSectionPreview:  return 1;
-        case ApolloIMSectionMaster:   return 1;
+        case ApolloIMSectionMaster:   return ApolloIMMasterRowCount;
         case ApolloIMSectionOptions:  return ApolloIMOptionsRowCount;
         default:                      return 0;
     }
@@ -496,7 +543,7 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
     switch (section) {
         case ApolloIMSectionMaster:
-            return @"Render image, GIF, and video links inside post text and comments instead of leaving them as plain links.";
+            return @"Inline Media Previews renders image, GIF, and video links inside post text and comments instead of leaving them as plain links. Inline Media in Chat does the same for direct messages.";
         case ApolloIMSectionOptions:
             return @"Tap to Play shows a paused GIF with a play button in the bottom corner — it plays that one GIF inline and becomes a pause button, and tapping the rest of the GIF opens the fullscreen viewer as usual. Never shows a static preview (tap opens the viewer). WiFi Only autoplays on WiFi and behaves like Tap to Play on cellular.";
         default:
@@ -518,6 +565,12 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
             return cell;
         }
         case ApolloIMSectionMaster:
+            if (indexPath.row == ApolloIMMasterRowChat) {
+                return [self switchCellLabel:@"Inline Media in Chat"
+                                          on:sEnableChatMedia
+                                     enabled:YES
+                                      action:@selector(chatMediaSwitchToggled:)];
+            }
             return [self switchCellLabel:@"Inline Media Previews"
                                       on:sEnableInlineImages
                                  enabled:YES
@@ -576,6 +629,15 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
     [[NSUserDefaults standardUserDefaults] setBool:sEnableInlineImages forKey:UDKeyEnableInlineImages];
     [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:ApolloIMSectionOptions]
                   withRowAnimation:UITableViewRowAnimationNone];
+}
+
+// Master toggle for chat media (inline images/GIFs/emoji/snoomoji + working
+// media sends + tap-to-fullscreen). Open chats re-render their cells on next
+// display/scroll, so no immediate-refresh notification is needed. Independent
+// of the posts/comments inline toggle and of Show User Profile Pictures.
+- (void)chatMediaSwitchToggled:(UISwitch *)sw {
+    sEnableChatMedia = sw.on;
+    [[NSUserDefaults standardUserDefaults] setBool:sEnableChatMedia forKey:UDKeyEnableChatMedia];
 }
 
 - (void)mediaSizeSliderChanged:(UISlider *)slider {

--- a/src/InlineMediaSettingsViewController.m
+++ b/src/InlineMediaSettingsViewController.m
@@ -3,6 +3,8 @@
 #import "ApolloMediaAutoplay.h"
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
+#import <QuartzCore/QuartzCore.h>
+#import <objc/runtime.h>
 
 // MARK: - Live preview (fake comments)
 //
@@ -228,15 +230,23 @@ static NSInteger ApolloIMSnapPercentHysteretic(float raw, NSInteger current) {
 @interface ApolloIMDetentSlider : UISlider
 @property (nonatomic, strong) NSArray<UIView *> *tickViews;
 @property (nonatomic, strong) UISelectionFeedbackGenerator *feedback;
-// Pan recognizers up the view chain (Apollo's swipe-anywhere-back, the nav
-// pop edge gesture) suspended for the duration of a drag — they otherwise
-// steal the horizontal drag mid-track and pop the screen.
-@property (nonatomic, strong) NSHashTable<UIGestureRecognizer *> *suspendedPans;
 // The detent the selection haptic last fired for. Change-detection keys off
 // THIS, not self.value: setValue:animated:YES leaves self.value reporting the
 // mid-animation thumb position, so reading it back each continueTracking frame
 // would re-trip the guard every frame and turn one tap into a continuous buzz.
 @property (nonatomic) NSInteger lastSnappedPercent;
+// Confirmation guard: a new detent must be seen on N consecutive tracking
+// frames before it commits + fires. A single-frame (or alternating) flip — the
+// signature of jitter — never accumulates the streak, so it can NEVER produce a
+// haptic, whatever the underlying input pattern. Belt-and-suspenders on top of
+// the hysteresis dead-band. A deliberate crossing holds the new detent for many
+// frames, so it confirms in ~2 frames (imperceptible).
+@property (nonatomic) NSInteger pendingPercent;
+@property (nonatomic) NSInteger pendingStreak;
+// Post-fire lockout: after a haptic, ignore further changes for a short window.
+// Deliberate detent crossings are >150ms apart, so both fire; any residual rapid
+// oscillation the streak guard misses is hard-capped to <1 tick per lockout.
+@property (nonatomic) CFTimeInterval lastFireTime;
 @end
 
 @implementation ApolloIMDetentSlider
@@ -260,6 +270,43 @@ static NSInteger ApolloIMSnapPercentHysteretic(float raw, NSInteger current) {
     return self;
 }
 
+// iOS 26 attaches a private _UIFluidSliderInteraction to every UISlider. Its
+// feedback conductor plays a CONTINUOUS "fluid" scrub haptic as the value
+// modulates — a separate system from our one-tap-per-detent selectionChanged,
+// and the real source of the "constant vibration while dragging" reports (our
+// haptic tracer never saw it because it isn't a public UIFeedbackGenerator).
+// We do our own detent tracking (UIControl beginTracking/continueTracking) and
+// our own single tap, so we refuse the fluid interaction outright — this leaves
+// classic UIControl tracking (still fired on device, per the logs) untouched.
+- (void)addInteraction:(id<UIInteraction>)interaction {
+    if ([NSStringFromClass([interaction class]) containsString:@"FluidSliderInteraction"]) {
+        return;
+    }
+    [super addInteraction:interaction];
+}
+
+// Belt-and-suspenders: if a fluid interaction was already attached (added before
+// we could refuse it, or via a path that bypasses addInteraction:), strip it and
+// nil the private edge/modulation feedback generators when we enter a window.
+- (void)didMoveToWindow {
+    [super didMoveToWindow];
+    if (!self.window) return;
+    for (id<UIInteraction> ix in [self.interactions copy]) {
+        if ([NSStringFromClass([ix class]) containsString:@"FluidSliderInteraction"]) {
+            [self removeInteraction:ix];
+        }
+    }
+    for (NSString *sel in @[@"_setModulationFeedbackGenerator:", @"_setEdgeFeedbackGenerator:"]) {
+        SEL s = NSSelectorFromString(sel);
+        if ([self respondsToSelector:s]) {
+            #pragma clang diagnostic push
+            #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+            [self performSelector:s withObject:nil];
+            #pragma clang diagnostic pop
+        }
+    }
+}
+
 - (void)layoutSubviews {
     [super layoutSubviews];
     CGRect track = [self trackRectForBounds:self.bounds];
@@ -279,65 +326,36 @@ static NSInteger ApolloIMSnapPercentHysteretic(float raw, NSInteger current) {
     // Hysteretic snap keyed off the current detent — a held finger's jitter
     // can't flip it across a boundary, so the haptic fires once per crossing.
     NSInteger snapped = ApolloIMSnapPercentHysteretic(raw, self.lastSnappedPercent);
-    if (snapped != self.lastSnappedPercent) {
-        self.lastSnappedPercent = snapped;      // one haptic per detent crossing
+
+    // Confirmation streak: count consecutive frames the candidate detent differs
+    // from the committed one. Only a sustained change (deliberate crossing) fires.
+    if (snapped == self.lastSnappedPercent) {
+        self.pendingStreak = 0;
+    } else if (snapped == self.pendingPercent) {
+        self.pendingStreak++;
+    } else {
+        self.pendingPercent = snapped;
+        self.pendingStreak = 1;
+    }
+    CFTimeInterval now = CACurrentMediaTime();
+    BOOL lockedOut = (now - self.lastFireTime) < 0.15;   // 150ms post-fire window
+    BOOL confirmed = (snapped != self.lastSnappedPercent) && (self.pendingStreak >= 2) && !lockedOut;
+
+    if (confirmed) {
+        self.lastSnappedPercent = snapped;      // one haptic per confirmed crossing
+        self.pendingStreak = 0;
+        self.lastFireTime = now;
         [self setValue:(float)snapped animated:YES];
         [self.feedback selectionChanged];
         [self sendActionsForControlEvents:UIControlEventValueChanged];
     }
 }
 
-// Same recipe as the stats-row loupe (SRTDisableCompetingPans): the
-// interactive pop recognizer must be fetched from the navigation controller
-// explicitly — it is not reliably reachable by walking the touched view's
-// superview chain — and Apollo's full-width back-swipe / parallax transition
-// pans match by class name, not only by UIPanGestureRecognizer ancestry.
-- (void)apollo_suspendCompetingPans {
-    NSHashTable<UIGestureRecognizer *> *suspended = [NSHashTable weakObjectsHashTable];
-
-    UINavigationController *nav = nil;
-    for (UIResponder *r = self.nextResponder; r && !nav; r = r.nextResponder) {
-        if ([r isKindOfClass:[UINavigationController class]]) {
-            nav = (UINavigationController *)r;
-        } else if ([r isKindOfClass:[UIViewController class]]) {
-            nav = ((UIViewController *)r).navigationController;
-        }
-    }
-    UIGestureRecognizer *pop = nav.interactivePopGestureRecognizer;
-    if (pop && pop.isEnabled) {
-        pop.enabled = NO;
-        [suspended addObject:pop];
-    }
-
-    for (UIView *view = self.superview; view; view = view.superview) {
-        for (UIGestureRecognizer *gesture in view.gestureRecognizers) {
-            if (gesture == pop || !gesture.enabled) continue;
-            // Leave the enclosing scroll view's own pan alone — UIControl
-            // tracking already defers vertical scrolling correctly.
-            if ([view isKindOfClass:[UIScrollView class]] &&
-                gesture == ((UIScrollView *)view).panGestureRecognizer) continue;
-            NSString *cls = NSStringFromClass([gesture class]);
-            BOOL panLike = [gesture isKindOfClass:[UIPanGestureRecognizer class]]
-                || [cls containsString:@"ParallaxTransition"];
-            if (!panLike) continue;
-            gesture.enabled = NO;   // also cancels any in-flight recognition
-            [suspended addObject:gesture];
-        }
-    }
-    self.suspendedPans = suspended;
-}
-
-- (void)apollo_resumeCompetingPans {
-    for (UIGestureRecognizer *gesture in self.suspendedPans) {
-        gesture.enabled = YES;
-    }
-    self.suspendedPans = nil;
-}
-
 - (BOOL)beginTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
     // Sync to the settled value before the drag; self.value isn't animating yet.
     self.lastSnappedPercent = (NSInteger)lroundf(self.value);
-    [self apollo_suspendCompetingPans];
+    self.pendingPercent = self.lastSnappedPercent;
+    self.pendingStreak = 0;
     [self.feedback prepare];
     [self apollo_applyTouch:touch];
     return YES;
@@ -348,16 +366,39 @@ static NSInteger ApolloIMSnapPercentHysteretic(float raw, NSInteger current) {
     return YES;
 }
 
-- (void)endTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
-    [super endTrackingWithTouch:touch withEvent:event];
-    [self apollo_resumeCompetingPans];
-}
+@end
 
-- (void)cancelTrackingWithEvent:(UIEvent *)event {
-    [super cancelTrackingWithEvent:event];
-    [self apollo_resumeCompetingPans];
-}
+// MARK: - Table view (keeps the slider drag from scrolling the screen)
 
+// The settings table is isa-swizzled to this class in viewDidLoad. It overrides
+// two UIScrollView touch-arbitration hooks, scoped to the size slider only, so
+// the screen never scrolls out from under a slider drag — WITHOUT any per-drag
+// state to enable/restore (the earlier scrollEnabled / canCancelContentTouches
+// / pan-disabling approaches either collapsed the layout or left the table
+// stuck when UIControl end-tracking didn't fire).
+@interface ApolloIMSettingsTableView : UITableView
+@end
+@implementation ApolloIMSettingsTableView
+static BOOL ApolloIMViewIsInSlider(UIView *view) {
+    for (UIView *v = view; v; v = v.superview) {
+        if ([v isKindOfClass:[ApolloIMDetentSlider class]]) return YES;
+    }
+    return NO;
+}
+// A touch on the slider must reach it immediately (not after the scroll-detection
+// delay), or a mostly-vertical drag is claimed by the table before the slider
+// ever begins tracking.
+- (BOOL)touchesShouldBegin:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event inContentView:(UIView *)view {
+    if (ApolloIMViewIsInSlider(view)) return YES;
+    return [super touchesShouldBegin:touches withEvent:event inContentView:view];
+}
+// Once the slider is tracking, never cancel it to scroll — this is what stops
+// the screen moving up/down during a drag. Other rows keep the default (YES),
+// so normal scrolling by dragging from a row is unaffected.
+- (BOOL)touchesShouldCancelInContentView:(UIView *)view {
+    if (ApolloIMViewIsInSlider(view)) return NO;
+    return [super touchesShouldCancelInContentView:view];
+}
 @end
 
 // MARK: - Controller
@@ -392,6 +433,16 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.title = @"Inline Media";
+    // Route slider-drag touch arbitration through ApolloIMSettingsTableView so a
+    // drag on the size slider scrubs it instead of scrolling the screen. The
+    // subclass adds no ivars, so isa-swizzling the existing table view is safe.
+    if (![self.tableView isKindOfClass:[ApolloIMSettingsTableView class]]) {
+        object_setClass(self.tableView, [ApolloIMSettingsTableView class]);
+    }
+    // Deliver slider touches immediately (the subclass's touchesShouldBegin only
+    // applies while content touches are delayed; NO makes tracking begin at once
+    // for a vertical drag too).
+    self.tableView.delaysContentTouches = NO;
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/src/InlineMediaSettingsViewController.m
+++ b/src/InlineMediaSettingsViewController.m
@@ -193,6 +193,11 @@ static NSInteger ApolloIMSnapPercent(float value) {
 // pop edge gesture) suspended for the duration of a drag — they otherwise
 // steal the horizontal drag mid-track and pop the screen.
 @property (nonatomic, strong) NSHashTable<UIGestureRecognizer *> *suspendedPans;
+// The detent the selection haptic last fired for. Change-detection keys off
+// THIS, not self.value: setValue:animated:YES leaves self.value reporting the
+// mid-animation thumb position, so reading it back each continueTracking frame
+// would re-trip the guard every frame and turn one tap into a continuous buzz.
+@property (nonatomic) NSInteger lastSnappedPercent;
 @end
 
 @implementation ApolloIMDetentSlider
@@ -232,9 +237,10 @@ static NSInteger ApolloIMSnapPercent(float value) {
     CGFloat fraction = ([touch locationInView:self].x - CGRectGetMinX(track)) / width;
     fraction = MIN(1.0, MAX(0.0, fraction));
     float raw = self.minimumValue + fraction * (self.maximumValue - self.minimumValue);
-    float snapped = (float)ApolloIMSnapPercent(raw);
-    if ((NSInteger)lroundf(self.value) != (NSInteger)snapped) {
-        [self setValue:snapped animated:YES];
+    NSInteger snapped = ApolloIMSnapPercent(raw);
+    if (snapped != self.lastSnappedPercent) {
+        self.lastSnappedPercent = snapped;      // one haptic per detent crossing
+        [self setValue:(float)snapped animated:YES];
         [self.feedback selectionChanged];
         [self sendActionsForControlEvents:UIControlEventValueChanged];
     }
@@ -260,8 +266,6 @@ static NSInteger ApolloIMSnapPercent(float value) {
     if (pop && pop.isEnabled) {
         pop.enabled = NO;
         [suspended addObject:pop];
-        ApolloLog(@"[InlineMedia] slider suspend pop=%@ on=%@",
-                  NSStringFromClass([pop class]), NSStringFromClass([pop.view class]));
     }
 
     for (UIView *view = self.superview; view; view = view.superview) {
@@ -277,8 +281,6 @@ static NSInteger ApolloIMSnapPercent(float value) {
             if (!panLike) continue;
             gesture.enabled = NO;   // also cancels any in-flight recognition
             [suspended addObject:gesture];
-            ApolloLog(@"[InlineMedia] slider suspend pan=%@ on=%@",
-                      cls, NSStringFromClass([view class]));
         }
     }
     self.suspendedPans = suspended;
@@ -292,7 +294,8 @@ static NSInteger ApolloIMSnapPercent(float value) {
 }
 
 - (BOOL)beginTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
-    ApolloLog(@"[InlineMedia] slider beginTracking x=%.0f", [touch locationInView:self].x);
+    // Sync to the settled value before the drag; self.value isn't animating yet.
+    self.lastSnappedPercent = (NSInteger)lroundf(self.value);
     [self apollo_suspendCompetingPans];
     [self.feedback prepare];
     [self apollo_applyTouch:touch];
@@ -305,13 +308,11 @@ static NSInteger ApolloIMSnapPercent(float value) {
 }
 
 - (void)endTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
-    ApolloLog(@"[InlineMedia] slider endTracking value=%.0f", self.value);
     [super endTrackingWithTouch:touch withEvent:event];
     [self apollo_resumeCompetingPans];
 }
 
 - (void)cancelTrackingWithEvent:(UIEvent *)event {
-    ApolloLog(@"[InlineMedia] slider cancelTracking value=%.0f", self.value);
     [super cancelTrackingWithEvent:event];
     [self apollo_resumeCompetingPans];
 }

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -13,6 +13,7 @@
 #import "ApolloDeletedCommentsData.h"
 #import "ApolloImageUploadHost.h"
 #import "ApolloImgChestUpload.h"
+#import "ApolloMediaAutoplay.h"
 #import "ApolloNotificationBackend.h"
 #import "ApolloUsageHeartbeat.h"
 #import "ApolloPushNotifications.h"
@@ -1563,6 +1564,7 @@ static void initializeRandomSources() {
                                     UDKeyEnableChatMedia: @YES,
                                     UDKeyInlineImageAlignment: @(ApolloInlineImageAlignmentCenter),
                                     UDKeyAutoplayInlineGIFs: @(ApolloAutoplayInlineGIFModeDefault),
+                                    UDKeyInlineMediaSizePercent: @100,
                                     UDKeyLinkPreviewBodyMode: @(ApolloLinkPreviewModeFull),
                                     UDKeyLinkPreviewCommentsMode: @(ApolloLinkPreviewModeFull),
                                     UDKeyLinkPreviewCardColor: @(ApolloLinkPreviewCardColorNeutral),
@@ -1667,9 +1669,17 @@ static void initializeRandomSources() {
         [standardDefaults setInteger:sInlineImageAlignment forKey:UDKeyInlineImageAlignment];
     }
     sAutoplayInlineGIFMode = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyAutoplayInlineGIFs];
-    if (sAutoplayInlineGIFMode < ApolloAutoplayInlineGIFModeDefault || sAutoplayInlineGIFMode > ApolloAutoplayInlineGIFModeAlways) {
-        sAutoplayInlineGIFMode = ApolloAutoplayInlineGIFModeDefault;
+    if (sAutoplayInlineGIFMode < ApolloAutoplayInlineGIFModeNever || sAutoplayInlineGIFMode > ApolloAutoplayInlineGIFModeTapToPlay) {
+        // Legacy "Default (Follow Apollo)" (0) / invalid values: resolve
+        // Apollo's native Autoplay GIFs/Videos setting once so behavior is
+        // unchanged, then own the setting explicitly from here on.
+        sAutoplayInlineGIFMode = ApolloResolveLegacyDefaultAutoplayGIFMode();
         [standardDefaults setInteger:sAutoplayInlineGIFMode forKey:UDKeyAutoplayInlineGIFs];
+    }
+    sInlineMediaSizePercent = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyInlineMediaSizePercent];
+    if (sInlineMediaSizePercent != 50 && sInlineMediaSizePercent != 75 && sInlineMediaSizePercent != 100) {
+        sInlineMediaSizePercent = 100;
+        [standardDefaults setInteger:sInlineMediaSizePercent forKey:UDKeyInlineMediaSizePercent];
     }
     sLinkPreviewBodyMode = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyLinkPreviewBodyMode];
     if (sLinkPreviewBodyMode < ApolloLinkPreviewModeOff || sLinkPreviewBodyMode > ApolloLinkPreviewModeFull) {

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -121,10 +121,15 @@ static NSString *const UDKeyEnableChatMedia = @"EnableChatMedia";
 // Horizontal alignment for inline media that is narrower than the row (e.g. tall portrait images).
 // 0 = Center (default), 1 = Left, 2 = Right.
 static NSString *const UDKeyInlineImageAlignment = @"InlineImageAlignment";
-// Autoplay for inline GIF/animated media previews. 0 = Default (follow Apollo's
-// native "Autoplay GIFs/Videos"), 1 = Never, 2 = WiFi Only, 3 = Always. Only
-// meaningful when Inline Media Previews (UDKeyEnableInlineImages) is on.
+// Autoplay for inline GIF/animated media previews. 0 = legacy Default (follow
+// Apollo's native "Autoplay GIFs/Videos", migrated at load), 1 = Never,
+// 2 = WiFi Only, 3 = Always, 4 = Tap to Play (static cover + play button;
+// tap toggles play/pause inline). Only meaningful when Inline Media Previews
+// (UDKeyEnableInlineImages) is on.
 static NSString *const UDKeyAutoplayInlineGIFs = @"AutoplayInlineGIFs";
+// Display width of inline media (images/GIFs) in comments and selftext as a
+// percentage of the row width: 50, 75, or 100 (default).
+static NSString *const UDKeyInlineMediaSizePercent = @"InlineMediaSizePercent";
 
 // Bulk translation feature
 static NSString *const UDKeyEnableBulkTranslation = @"EnableBulkTranslation";
@@ -305,3 +310,6 @@ static NSString *const UDKeyLinkPreviewCardColor = @"LinkPreviewCardColor";
 // hex paints the whole card that exact color, with auto-contrasted text.
 static NSString *const UDKeyLinkPreviewCardColorHex = @"LinkPreviewCardColorHex";
 static NSString *const ApolloLinkPreviewModeDidChangeNotification = @"ApolloLinkPreviewModeDidChangeNotification";
+// Posted by the Inline Media settings screen when size/alignment changes so
+// visible comments re-measure their inline media immediately.
+static NSString *const ApolloInlineMediaLayoutDidChangeNotification = @"ApolloInlineMediaLayoutDidChangeNotification";


### PR DESCRIPTION
## Problem

With Autoplay Inline GIFs set to Never (or WiFi Only), only some comment GIFs actually stopped animating — others kept playing. Repro'd on r/Destiny threads with mixed GIF sources.

Turned out to be four separate bugs stacked on top of each other:

1. **GIFs played until their cover downloaded.** The gate only landed after the static cover image finished fetching, so GIFs from slow hosts (gifbin took 9-13s in testing) visibly animated under Never, and a failed cover fetch meant the GIF animated forever. Reddit-hosted GIFs have fast covers so they stopped instantly — that's exactly the "some stop, some don't" split.
2. **Pausing a GIF destroyed its own state.** The pause swaps in the static cover via `setImage:`, which makes Texture clear the node's `animatedImage` — firing our nil-animatedImage hook, which wiped the GIF flag, removed the play overlay, and unregistered the node the moment it paused. This is why paused GIFs never showed a play button and why tapping them opened the media viewer.
3. **The settings-refresh registry was dead.** Node eligibility required `-clearImage`, which doesn't exist in Apollo's AsyncDisplayKit build, so changing the setting never paused/resumed anything already on screen.
4. **The liveness check required `node.URL`**, which the tweak's GIF pipeline never sets (it loads through its own downloader) — so even with 1-3 fixed, every registered node was skipped on refresh.

Also gates Apollo-native inline animated media (nodes under a `MarkdownNode`), which ignored the setting entirely. Feed media stays governed by Apollo's native autoplay setting.

## New stuff

- **Tap to Play mode** — GIF shows its static cover with a play button; tapping plays or pauses that one GIF inline. WiFi Only now behaves like Tap to Play while on cellular. Never is a plain static cover — tap opens the viewer like any image.
- **Legacy "Default (Follow Apollo)" removed from the picker** — every behavior it produced is one of the explicit options, it just hid which one behind Settings > General. Existing users on Default are migrated once at load to whatever their General setting resolves to, so nobody's behavior changes.
- **Inline Media settings sub-screen** (sits right above Rich Link Preview Settings): the Inline Media Previews toggle, Alignment, and Autoplay rows moved here from the Media section, plus a new **Inline Media Size** slider (100/75/50% of row width, tap-to-set detents) — all with a live fake-comment preview that tracks every control.
- **Size and alignment apply live** — visible comments re-measure immediately via a lightweight weak registry of inline media nodes, no leaving the thread and coming back.

## See it in action
<img width="500" height="1087" alt="inline media gif options" src="https://github.com/user-attachments/assets/8242248e-1d00-47c1-b912-b9e3f8a11dbe" />



## Testing

Sim-verified on iOS 26 (Liquid Glass), signed-in account, threads with mixed GIF sources:
- All four modes at render time, plus live mode switches in both directions (pause applies covers/overlays, resume re-injects the retained animated image)
- Tap to Play full cycle: play → pause → play, inline, no viewer
- Size/alignment live re-measure (100% → 50% shrinks in place, row heights re-flow)
- Default→explicit migration preserves the selected mode across relaunches
- Works the same with API keys and API-key-free (all render-side hooks)

Not device-tested yet — and WiFi Only's cellular half physically can't be exercised in the simulator, so that's the main thing to check on device.