### PR TITLE
Per-account sign-in mode: truthful switcher labels + account-aware API settings

### DIFF
--- a/src/ApolloAccountCredentials.h
+++ b/src/ApolloAccountCredentials.h
@@ -74,6 +74,28 @@ NSString *ApolloEffectiveRedirectURI(void);
 // ([[RDKClient sharedClient] currentUser].username), or nil if none/unavailable.
 NSString * _Nullable ApolloActiveAccountUsername(void);
 
+// Interactive OAuth (API-key) sign-in tracking. Auth modes are mutually
+// exclusive per account, but nothing used to enforce the transition: an
+// account that once had a web session and later signs in WITH an API key kept
+// its stale web-session entry, which permanently masked it as "keyless" (the
+// entry wins at the transport chokepoint and in the switcher badge). The OAuth
+// callback arms this flag; the RDKClient user-install hook consumes it — but
+// ONLY for a username that did not yet exist in the persisted account blobs
+// at arm time (see the implementation note in ApolloAccountCredentials.m for
+// why identity-binding is required: the install hooks also fire from
+// NSKeyedUnarchiver decodes and background identity refreshes of stored
+// accounts, which must never spend the flag or remove a session).
+//
+// Arm when an OAuth authorization callback carrying ?code= is delivered
+// (both the universal WKWebView flow and native ASWebAuthenticationSession).
+void ApolloNoteInteractiveOAuthSignIn(void);
+// Disarm without consuming (sign-in cancelled or failed).
+void ApolloCancelInteractiveOAuthSignIn(void);
+// Consume for `username`: YES exactly once, iff armed within the last 120
+// seconds AND `username` was not present in the account blobs at arm time.
+// Installs for pre-existing usernames return NO without disarming.
+BOOL ApolloTakeInteractiveOAuthSignInForNewUsername(NSString *username);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ApolloAccountCredentials.h
+++ b/src/ApolloAccountCredentials.h
@@ -81,8 +81,9 @@ NSString * _Nullable ApolloActiveAccountUsername(void);
 // entry wins at the transport chokepoint and in the switcher badge). The OAuth
 // callback arms this flag; the RDKClient user-install hook consumes it — but
 // ONLY for a username that did not yet exist in the persisted account blobs
-// at arm time (see the implementation note in ApolloAccountCredentials.m for
-// why identity-binding is required: the install hooks also fire from
+// OR the web-session username index at arm time (see the implementation note
+// in ApolloAccountCredentials.m for why identity-binding is required: the
+// install hooks also fire from
 // NSKeyedUnarchiver decodes and background identity refreshes of stored
 // accounts, which must never spend the flag or remove a session).
 //
@@ -92,7 +93,7 @@ void ApolloNoteInteractiveOAuthSignIn(void);
 // Disarm without consuming (sign-in cancelled or failed).
 void ApolloCancelInteractiveOAuthSignIn(void);
 // Consume for `username`: YES exactly once, iff armed within the last 120
-// seconds AND `username` was not present in the account blobs at arm time.
+// seconds AND `username` was not present in either identity source at arm time.
 // Installs for pre-existing usernames return NO without disarming.
 BOOL ApolloTakeInteractiveOAuthSignInForNewUsername(NSString *username);
 

--- a/src/ApolloAccountCredentials.m
+++ b/src/ApolloAccountCredentials.m
@@ -1,4 +1,5 @@
 #import "ApolloAccountCredentials.h"
+#import "ApolloWebSessionStore.h"
 #import "ApolloState.h"
 #import "ApolloCommon.h"
 #import "Defaults.h"
@@ -209,11 +210,16 @@ NSString *ApolloEffectiveRedirectURI(void) {
 // design therefore spends the flag on whatever stored account decodes first
 // (and, catastrophically, would remove THAT account's web session).
 //
-// Instead, arming snapshots the usernames already present in the account
-// blobs; only an install for a username NOT in that snapshot — the genuinely
-// new sign-in — consumes. Installs for pre-existing usernames pass through
-// WITHOUT disarming, so decode/refresh traffic can't spend the flag. The
-// trade-off is that re-authenticating an already-present username via OAuth
+// Instead, arming snapshots every identity already known through EITHER the
+// account blobs or the per-account web-session index. The second source is
+// essential: a synthesized keyless account can be archived before its
+// currentUser.username is readable, then have that username backfilled while
+// decoding. Looking only at RedditAccounts2 would misclassify that existing
+// account as the new OAuth sign-in and delete its healthy web session.
+// Only an install absent from both identity sources consumes. Installs for
+// pre-existing usernames pass through WITHOUT disarming, so decode/refresh
+// traffic can't spend the flag. The trade-off is that re-authenticating an
+// already-present username via OAuth
 // doesn't auto-remove its stale web session — that case is served by the
 // explicit "Use API Key Instead…" flow (switcher ellipsis / settings toggle).
 static os_unfair_lock sOAuthSignInLock = OS_UNFAIR_LOCK_INIT;
@@ -240,9 +246,10 @@ static NSSet<NSString *> *ApolloAllPersistedAccountUsernames(void) {
 void ApolloNoteInteractiveOAuthSignIn(void) {
     // Snapshot BEFORE arming: the decode below fires the hooked setters
     // itself, and they must observe the flag as still disarmed.
-    NSSet<NSString *> *preexisting = ApolloAllPersistedAccountUsernames();
+    NSMutableSet<NSString *> *preexisting = [ApolloAllPersistedAccountUsernames() mutableCopy];
+    [preexisting unionSet:ApolloWebSessionUsernames()];
     os_unfair_lock_lock(&sOAuthSignInLock);
-    sOAuthSignInPreexisting = preexisting;
+    sOAuthSignInPreexisting = [preexisting copy];
     sOAuthSignInArmedAt = CFAbsoluteTimeGetCurrent();
     os_unfair_lock_unlock(&sOAuthSignInLock);
     ApolloLog(@"[AccountCredentials] Interactive OAuth sign-in callback received — armed web-session cleanup (%lu pre-existing account(s))",

--- a/src/ApolloAccountCredentials.m
+++ b/src/ApolloAccountCredentials.m
@@ -195,3 +195,87 @@ NSString *ApolloEffectiveRedirectURI(void) {
     }
     return sRedirectURI.length > 0 ? sRedirectURI : defaultRedirectURI;
 }
+
+#pragma mark - Interactive OAuth sign-in tracking
+
+// Arm/consume with a TTL, bound to the signed-in identity. The consume site
+// (the RDKClient user-install hooks in ApolloUserAvatars.xm) fires far more
+// often than "a sign-in just completed": -setCurrentUser: is invoked by
+// NSKeyedUnarchiver's KVC decode of RedditAccounts2 — which
+// ApolloActiveAccountUsername() above performs on every call, including for
+// the sign-in's own token-exchange request — and
+// -updateCurrentUserWithNewUser: fires for every background identity refresh
+// of every stored account. A naive "first install after arming consumes"
+// design therefore spends the flag on whatever stored account decodes first
+// (and, catastrophically, would remove THAT account's web session).
+//
+// Instead, arming snapshots the usernames already present in the account
+// blobs; only an install for a username NOT in that snapshot — the genuinely
+// new sign-in — consumes. Installs for pre-existing usernames pass through
+// WITHOUT disarming, so decode/refresh traffic can't spend the flag. The
+// trade-off is that re-authenticating an already-present username via OAuth
+// doesn't auto-remove its stale web session — that case is served by the
+// explicit "Use API Key Instead…" flow (switcher ellipsis / settings toggle).
+static os_unfair_lock sOAuthSignInLock = OS_UNFAIR_LOCK_INIT;
+static CFAbsoluteTime sOAuthSignInArmedAt = 0;
+static NSSet<NSString *> *sOAuthSignInPreexisting = nil; // lowercased usernames at arm time
+
+// All lowercased usernames currently in the persisted RedditAccounts2 blob.
+static NSSet<NSString *> *ApolloAllPersistedAccountUsernames(void) {
+    NSMutableSet<NSString *> *names = [NSMutableSet set];
+    NSUserDefaults *group = [[NSUserDefaults alloc] initWithSuiteName:kApolloAccountCredsGroupSuite];
+    id accounts = ApolloAccountCredsUnarchive([group objectForKey:@"RedditAccounts2"]);
+    if (![accounts isKindOfClass:[NSArray class]]) return names;
+    for (id client in (NSArray *)accounts) {
+        NSString *username = nil;
+        @try { username = [[client valueForKey:@"currentUser"] valueForKey:@"username"]; }
+        @catch (__unused NSException *e) { continue; }
+        if ([username isKindOfClass:[NSString class]] && username.length > 0) {
+            [names addObject:ApolloNormalizeUsername(username)];
+        }
+    }
+    return names;
+}
+
+void ApolloNoteInteractiveOAuthSignIn(void) {
+    // Snapshot BEFORE arming: the decode below fires the hooked setters
+    // itself, and they must observe the flag as still disarmed.
+    NSSet<NSString *> *preexisting = ApolloAllPersistedAccountUsernames();
+    os_unfair_lock_lock(&sOAuthSignInLock);
+    sOAuthSignInPreexisting = preexisting;
+    sOAuthSignInArmedAt = CFAbsoluteTimeGetCurrent();
+    os_unfair_lock_unlock(&sOAuthSignInLock);
+    ApolloLog(@"[AccountCredentials] Interactive OAuth sign-in callback received — armed web-session cleanup (%lu pre-existing account(s))",
+              (unsigned long)preexisting.count);
+}
+
+void ApolloCancelInteractiveOAuthSignIn(void) {
+    os_unfair_lock_lock(&sOAuthSignInLock);
+    sOAuthSignInArmedAt = 0;
+    sOAuthSignInPreexisting = nil;
+    os_unfair_lock_unlock(&sOAuthSignInLock);
+}
+
+BOOL ApolloTakeInteractiveOAuthSignInForNewUsername(NSString *username) {
+    NSString *key = ApolloNormalizeUsername(username);
+    if (key.length == 0) return NO;
+    BOOL consumed = NO;
+    os_unfair_lock_lock(&sOAuthSignInLock);
+    if (sOAuthSignInArmedAt > 0) {
+        if ((CFAbsoluteTimeGetCurrent() - sOAuthSignInArmedAt) >= 120.0) {
+            // Expired (e.g. the code->token exchange failed after the
+            // callback) — disarm lazily so nothing later can consume it.
+            sOAuthSignInArmedAt = 0;
+            sOAuthSignInPreexisting = nil;
+        } else if (![sOAuthSignInPreexisting containsObject:key]) {
+            // A username that wasn't in the blobs at arm time: this IS the
+            // new sign-in. Consume. Pre-existing usernames fall through
+            // WITHOUT disarming (decode/background-refresh traffic).
+            consumed = YES;
+            sOAuthSignInArmedAt = 0;
+            sOAuthSignInPreexisting = nil;
+        }
+    }
+    os_unfair_lock_unlock(&sOAuthSignInLock);
+    return consumed;
+}

--- a/src/ApolloAccountSwitcherViewController.xm
+++ b/src/ApolloAccountSwitcherViewController.xm
@@ -133,7 +133,9 @@ static NSArray<ApolloSwitcherAccountRow *> *ApolloSwitcherLoadAccountRows(void) 
         // presence test, with no OAuth divergence logic to run for these rows.
         if (ApolloWebSessionFor(username) != nil) {
             row.isWebSession = YES;
-            row.keyStatusText = @"Web session";
+            // Deliberately short — the subtitle shares the row with the
+            // checkmark + ellipsis accessories and truncates past ~20 chars.
+            row.keyStatusText = @"API-key-free";
             [rows addObject:row];
             return;
         }
@@ -151,11 +153,11 @@ static NSArray<ApolloSwitcherAccountRow *> *ApolloSwitcherLoadAccountRows(void) 
             || ![ (entry.redirectURI ?: @"") isEqualToString:(sRedirectURI ?: @"") ]
         );
         if (divergesFromDefault) {
-            row.keyStatusText = @"Custom key";
+            row.keyStatusText = @"API key · custom";
         } else if (sRedditClientId.length > 0) {
-            row.keyStatusText = @"Default key";
+            row.keyStatusText = @"API key · default";
         } else {
-            row.keyStatusText = @"No key set";
+            row.keyStatusText = @"No API key set";
         }
         [rows addObject:row];
     }];
@@ -624,31 +626,13 @@ static id _Nullable ApolloGetObjectIvar(id object, const char *name) {
     });
 }
 
-// Blocks starting (or re-starting) a web-session login while the master
-// "API-Key-Free Mode" switch is off. Without this, a session could be
-// harvested and stored for an account that ApolloWebJSONHasUsableSession()
-// (gated on sWebJSONEnabled) will never actually treat as usable — the
-// account would have no working OAuth key (none configured) AND no working
-// cookie transport (flag off), so every request just hangs forever with no
-// visible error. Settings already hides its own "Web Session Accounts" row
-// the same way; this is the switcher's equivalent gate.
-- (BOOL)presentWebJSONDisabledAlertIfNeeded {
-    if (sWebJSONEnabled) return NO;
-    UIAlertController *alert = [UIAlertController
-        alertControllerWithTitle:@"API-Key-Free Mode Is Off"
-                          message:@"Turn on \"API-Key-Free Mode\" in Settings → API Keys first — otherwise a web-session account has no working way to authenticate and every request will hang."
-                   preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
-    [self presentViewController:alert animated:YES completion:nil];
-    return YES;
-}
-
 // Web-session ("API-Key-Free") sign-in: presents the WKWebView login flow. If a
 // web-session account already exists, the shared persistent cookie jar needs
 // clearing first so the login form actually shows instead of silently reusing
-// the existing web user (see ApolloWebSessionLoginViewController.h).
+// the existing web user (see ApolloWebSessionLoginViewController.h). No master-
+// flag gate: the mode is chosen per account at sign-in, and a successful
+// harvest enables the transport flag itself.
 - (void)presentWebSessionAddAccount {
-    if ([self presentWebJSONDisabledAlertIfNeeded]) return;
     BOOL hasExistingWebSession = ApolloWebSessionUsernames().count > 0;
     ApolloWebSessionLoginViewController *vc = hasExistingWebSession
         ? [ApolloWebSessionLoginViewController loginControllerForAdditionalAccount]
@@ -658,21 +642,28 @@ static id _Nullable ApolloGetObjectIvar(id object, const char *name) {
 }
 
 // Tapping a web-session row's edit button: there's no API key to edit, so
-// offer re-sign-in instead (the same flow as adding an additional account —
-// clears the cookie jar first, since whatever's there belongs to THIS account
-// and the user is explicitly choosing to replace it).
+// offer re-sign-in (the same flow as adding an additional account — clears the
+// cookie jar first, since whatever's there belongs to THIS account and the
+// user is explicitly choosing to replace it) or switching the account over to
+// API-key sign-in (removes the web session; see ApolloPresentSwitchToAPIKeyFlow).
 - (void)presentWebSessionActionsForUsername:(NSString *)username {
     UIAlertController *sheet = [UIAlertController
         alertControllerWithTitle:[NSString stringWithFormat:@"u/%@", username]
-                          message:@"Signed in via web session (no API key needed)."
+                          message:@"Signed in without an API key (web session)."
                    preferredStyle:UIAlertControllerStyleActionSheet];
     [sheet addAction:[UIAlertAction actionWithTitle:@"Re-Sign In"
                                               style:UIAlertActionStyleDefault
                                             handler:^(UIAlertAction *a) {
-        if ([self presentWebJSONDisabledAlertIfNeeded]) return;
         ApolloWebSessionLoginViewController *vc = [ApolloWebSessionLoginViewController loginControllerForAdditionalAccount];
         UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:vc];
         [self presentViewController:nav animated:YES completion:nil];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Use API Key Instead…"
+                                              style:UIAlertActionStyleDefault
+                                            handler:^(UIAlertAction *a) {
+        ApolloPresentSwitchToAPIKeyFlow(self, username, ^(BOOL switched) {
+            if (switched) [self reloadRows];
+        });
     }]];
     [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
     sheet.popoverPresentationController.sourceView = self.view;

--- a/src/ApolloSignInSplash.xm
+++ b/src/ApolloSignInSplash.xm
@@ -6,18 +6,15 @@
 // -signInSplashViewSignInButtonTappedWithSender:, which normally goes straight
 // to the OAuth/API-key sign-in flow.
 //
-// When API-Key-Free Mode is enabled we intercept that tap and present the
-// two-way chooser (same sheet as the account switcher's "Add Account") so the
-// user can pick either OAuth or the keyless web-session path. The "Create
-// Account" button is left untouched.
+// We intercept that tap and present the two-way chooser (same sheet as the
+// account switcher's "Add Account") so the user can pick either OAuth or the
+// keyless web-session path. Not gated on the Web JSON master flag: the mode is
+// chosen per account at sign-in, and a keyless harvest enables the transport
+// flag itself. The "Create Account" button is left untouched.
 
 %hook _TtC6Apollo21ProfileViewController
 
 - (void)signInSplashViewSignInButtonTappedWithSender:(id)sender {
-    if (!sWebJSONEnabled) {
-        %orig;
-        return;
-    }
     UIViewController *host = (UIViewController *)self;
     ApolloWebSessionPresentSignInChooser(host, ^{ %orig; });
 }
@@ -27,10 +24,6 @@
 %hook _TtC6Apollo19InboxViewController
 
 - (void)signInSplashViewSignInButtonTappedWithSender:(id)sender {
-    if (!sWebJSONEnabled) {
-        %orig;
-        return;
-    }
     UIViewController *host = (UIViewController *)self;
     ApolloWebSessionPresentSignInChooser(host, ^{ %orig; });
 }

--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -2716,11 +2716,13 @@ static void ApolloPinAccountToCurrentDefaultCredentialsIfNeeded(id currentUser) 
     // previous keyless sign-in under the same name). Without this the stale
     // entry permanently wins at the transport chokepoint and badges the
     // account "web session" in the switcher. Identity-bound: the flag only
-    // consumes for a username that was NOT in the account blobs when the
-    // OAuth callback armed it, so the heavy routine traffic through these
-    // hooks — NSKeyedUnarchiver decodes of RedditAccounts2 (which fire
-    // -setCurrentUser: per stored account), background identity refreshes,
-    // keyless synthesis — can never spend the flag or remove a session.
+    // consumes for a username that was absent from BOTH the account blobs and
+    // web-session index when the OAuth callback armed it. The harvest path
+    // also cancels any unfinished OAuth attempt before keyless synthesis, so
+    // the heavy routine traffic through these hooks — NSKeyedUnarchiver
+    // decodes of RedditAccounts2 (which fire -setCurrentUser: per stored
+    // account), background identity refreshes, keyless synthesis — can never
+    // spend the flag or remove a healthy session.
     if (ApolloTakeInteractiveOAuthSignInForNewUsername(username) && ApolloWebSessionFor(username) != nil) {
         ApolloWebSessionRemove(username);
         ApolloLog(@"[AccountCredentials] u/%@ signed in with an API key — removed its stale web session (now an OAuth account)", username);

--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -11,6 +11,7 @@
 #import "ApolloBannedProfile.h"
 #import "ApolloProfileSocialLinks.h"
 #import "ApolloAccountCredentials.h"
+#import "ApolloWebSessionStore.h"
 
 static NSString *const ApolloUserAvatarsToggleChangedNotification = @"ApolloUserAvatarsToggleChangedNotification";
 static NSString *const ApolloProfileTabAvatarIconChangedNotification = @"ApolloProfileTabAvatarIconChangedNotification";
@@ -2708,6 +2709,23 @@ static void ApolloPinAccountToCurrentDefaultCredentialsIfNeeded(id currentUser) 
     @try { username = [currentUser valueForKey:@"username"]; }
     @catch (__unused NSException *e) { return; }
     if (![username isKindOfClass:[NSString class]] || username.length == 0) return;
+
+    // Auth modes are mutually exclusive per account: completing an interactive
+    // OAuth (API-key) sign-in is an explicit choice of API-key auth for this
+    // username, so drop any web-session entry it may still carry (e.g. a
+    // previous keyless sign-in under the same name). Without this the stale
+    // entry permanently wins at the transport chokepoint and badges the
+    // account "web session" in the switcher. Identity-bound: the flag only
+    // consumes for a username that was NOT in the account blobs when the
+    // OAuth callback armed it, so the heavy routine traffic through these
+    // hooks — NSKeyedUnarchiver decodes of RedditAccounts2 (which fire
+    // -setCurrentUser: per stored account), background identity refreshes,
+    // keyless synthesis — can never spend the flag or remove a session.
+    if (ApolloTakeInteractiveOAuthSignInForNewUsername(username) && ApolloWebSessionFor(username) != nil) {
+        ApolloWebSessionRemove(username);
+        ApolloLog(@"[AccountCredentials] u/%@ signed in with an API key — removed its stale web session (now an OAuth account)", username);
+    }
+
     if (ApolloAccountCredentialsFor(username) != nil) return;
 
     ApolloAccountCredentialsSet(username, sRedditClientId, sRedditClientSecret, sRedirectURI);

--- a/src/ApolloWebJSON.h
+++ b/src/ApolloWebJSON.h
@@ -169,6 +169,25 @@ void ApolloWebJSONSeedBearerRegistryFromDisk(void);
 // synthesis.
 void ApolloWebJSONRepairPoisonedAccountBlobs(void);
 
+// Posted (main thread) whenever sWebJSONEnabled is flipped OUTSIDE the Custom
+// API settings screen — e.g. a keyless harvest auto-enabling it while that
+// screen sits behind the login sheet. The screen's SectionAPIKeys row count
+// depends on the flag (the Web Session Login row only exists while it's on),
+// and a page-sheet dismissal does NOT fire viewWillAppear on the presenter,
+// so without this signal the table's committed row count goes stale and the
+// next row-level update throws NSInternalInconsistencyException.
+extern NSString * const ApolloWebJSONEnabledDidChangeNotification;
+
+// YES if the persisted account blobs (RedditAccounts2 + the Valet sensitive
+// array) contain an account for `username` (case-insensitive) whose stored
+// credential is REAL — a non-synthetic access token or a non-empty refresh
+// token. That marks a genuine OAuth (API-key) account; a keyless-synthesized
+// account's sensitive dict only ever holds a synthetic bearer and no refresh
+// token. Used by the legacy-session migration to avoid converting an OAuth
+// account to keyless just because the old single-global web session happened
+// to be harvested under its username. Implemented in ApolloWebJSONIdentity.xm.
+BOOL ApolloWebJSONDiskAccountHasRealCredential(NSString *username);
+
 // Returns a copy of `url` with the internal probe fragment applied. The
 // fragment is stripped by NSURLSession before transmission so it never reaches
 // Reddit's servers; the rewrite and block-page counter hooks read it from the

--- a/src/ApolloWebJSON.m
+++ b/src/ApolloWebJSON.m
@@ -9,6 +9,7 @@
 #import <Security/Security.h>
 
 NSString *const ApolloWebJSONSessionExpiredNotification = @"ApolloWebJSONSessionExpiredNotification";
+NSString *const ApolloWebJSONEnabledDidChangeNotification = @"ApolloWebJSONEnabledDidChangeNotification";
 NSString *const ApolloWebJSONSyntheticBearerToken = @"apollo-webjson-cookie-session";
 
 #pragma mark - Synthetic bearer helpers + bearer-ownership registry
@@ -1281,6 +1282,19 @@ void ApolloWebJSONLoadPersistedCredentials(void) {
         && ApolloWebSessionFor(sWebSessionUsername) == nil) {
         ApolloWebSessionSet(sWebSessionUsername, sWebSessionCookieHeader, sWebSessionModhash);
         ApolloLog(@"[WebJSON] Migrated legacy global web session to per-account store for u/%@", sWebSessionUsername);
+        // When that username ALSO has a real OAuth credential on disk this
+        // migration makes the web session win (entry presence == keyless), so
+        // the account's API key goes unused. That's deliberate: a real-but-
+        // REVOKED token (the "Reddit killed our keys" restore population,
+        // whose harvested session is their only working login) is
+        // indistinguishable offline from a live one, and dropping the session
+        // for them would brick the account outright. The switcher now labels
+        // the state truthfully ("API-key-free") and offers a one-tap "Use API
+        // Key Instead…" for accounts whose key actually works — warn so the
+        // state is at least visible in the log.
+        if (ApolloWebJSONDiskAccountHasRealCredential(sWebSessionUsername)) {
+            ApolloLog(@"[WebJSON] Note: u/%@ also has a real OAuth credential on disk — the migrated web session takes precedence; switch it back via the account switcher (ellipsis → Use API Key Instead) if the key is still valid", sWebSessionUsername);
+        }
         // Clear the now-redundant legacy keychain items so the session isn't
         // duplicated indefinitely. The in-memory sWebSession* globals are left
         // populated for the remainder of THIS launch — a few cosmetic call

--- a/src/ApolloWebJSONIdentity.xm
+++ b/src/ApolloWebJSONIdentity.xm
@@ -559,6 +559,26 @@ void ApolloWebJSONSeedBearerRegistryFromDisk(void) {
     if (seeded > 0) ApolloLog(@"[WebJSON][identity] Seeded bearer registry from disk (%lu account(s))", (unsigned long)seeded);
 }
 
+BOOL ApolloWebJSONDiskAccountHasRealCredential(NSString *username) {
+    if (username.length == 0) return NO;
+    NSString *lowerUsername = username.lowercaseString;
+    NSUserDefaults *group = [[NSUserDefaults alloc] initWithSuiteName:kApolloGroupSuite];
+    id accountsObj = ApolloWebJSONUnarchive([group objectForKey:@"RedditAccounts2"]);
+    NSArray *accounts = [accountsObj isKindOfClass:[NSArray class]] ? accountsObj : @[];
+    if (accounts.count == 0) return NO;
+    NSArray<NSDictionary *> *valet = ApolloWebJSONReadValetAccountsArray(NULL) ?: @[];
+
+    for (NSUInteger i = 0; i < accounts.count && i < valet.count; i++) {
+        if (![ApolloWebJSONUsernameAtIndex(accounts, i) isEqualToString:lowerUsername]) continue;
+        NSDictionary *sensitive = [valet[i] isKindOfClass:[NSDictionary class]] ? valet[i] : nil;
+        NSString *accessToken  = [sensitive[@"accessToken"]  isKindOfClass:[NSString class]] ? sensitive[@"accessToken"]  : nil;
+        NSString *refreshToken = [sensitive[@"refreshToken"] isKindOfClass:[NSString class]] ? sensitive[@"refreshToken"] : nil;
+        if (refreshToken.length > 0) return YES;
+        if (accessToken.length > 0 && !ApolloWebJSONBearerIsSynthetic(accessToken)) return YES;
+    }
+    return NO;
+}
+
 // One-shot launch repair for installs poisoned by the pre-fix cross-account
 // identity leak (see ApolloWebJSONRewriteRequest's bearer-attribution comment):
 // a cookie-rewritten /api/v1/me answered an OAuth account's identity refresh

--- a/src/ApolloWebSessionLoginViewController.h
+++ b/src/ApolloWebSessionLoginViewController.h
@@ -63,8 +63,27 @@ extern "C" {
 //   • "Sign In With API Key"          → invokes apiKeyHandler
 //   • "Sign In Without API Key (Experimental)" → presents ApolloWebSessionLoginViewController
 //   • "Cancel"
-// Only call this when sWebJSONEnabled is YES (the caller is responsible for that gate).
+// Not gated on sWebJSONEnabled: the mode is chosen per account at sign-in, and
+// a successful keyless harvest enables the transport flag itself.
 void ApolloWebSessionPresentSignInChooser(UIViewController *host, void (^apiKeyHandler)(void));
+
+// Per-account mode conversions (shared by the Custom API settings screen's
+// API-Key-Free switch and the account switcher's per-account menu).
+//
+// Keyless -> API key: confirms with the user, removes u/`username`'s stored
+// web session, then (because the in-memory client still carries a synthetic
+// cookie-session credential until the account blobs are reloaded) offers to
+// quit Apollo so the account comes back on its real OAuth credential.
+// `completion(YES)` fires only when the user confirmed and the session was
+// removed; `completion(NO)` on cancel. Completion is optional.
+void ApolloPresentSwitchToAPIKeyFlow(UIViewController *host, NSString *username, void (^ _Nullable completion)(BOOL switched));
+
+// API key -> keyless: confirms, then presents the web-session login so the
+// user signs u/`username` in on reddit.com. The harvest stores the session
+// under whatever username actually logs in (normally the same account) and
+// enables the transport flag; the account's stored API key is kept but goes
+// unused while the web session exists.
+void ApolloPresentSwitchToKeylessFlow(UIViewController *host, NSString *username);
 
 #ifdef __cplusplus
 }

--- a/src/ApolloWebSessionLoginViewController.m
+++ b/src/ApolloWebSessionLoginViewController.m
@@ -240,6 +240,13 @@ static void ApolloWebSessionProbeMeField(WKWebView *webView, NSString *field, vo
 // persists cookie + modhash under `username` via ApolloWebSessionSet.
 static void ApolloWebSessionHarvestFromCookieStore(WKHTTPCookieStore *cookieStore, NSString *username, NSString *modhash,
                                                    void (^completion)(NSUInteger cookieCount)) {
+    // Choosing or refreshing keyless auth supersedes any unfinished OAuth
+    // attempt. In particular, a failed OAuth token exchange can leave its
+    // cleanup discriminator armed for up to 120 seconds; synthesizing the new
+    // keyless account below fires RDKClient's user-install hook and would
+    // otherwise consume that stale signal and immediately delete the session
+    // this harvest just stored.
+    ApolloCancelInteractiveOAuthSignIn();
     [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
         NSDate *farFuture = [NSDate dateWithTimeIntervalSinceNow:kFarFutureCookieInterval];
         NSMutableArray<NSString *> *pairs = [NSMutableArray array];

--- a/src/ApolloWebSessionLoginViewController.m
+++ b/src/ApolloWebSessionLoginViewController.m
@@ -1,6 +1,7 @@
 #import "ApolloWebSessionLoginViewController.h"
 #import "ApolloWebJSON.h"
 #import "ApolloWebSessionStore.h"
+#import "ApolloAccountCredentials.h"
 #import "ApolloState.h"
 #import "ApolloCommon.h"
 #import "UIWindow+Apollo.h"
@@ -259,6 +260,27 @@ static void ApolloWebSessionHarvestFromCookieStore(WKHTTPCookieStore *cookieStor
             // A fresh harvest supersedes any expiry verdict this launch reached
             // for the account — re-arm detection for the NEW session.
             ApolloWebJSONNoteSessionReauthenticated(username);
+            // A web-session account only works while the Web JSON transport is
+            // enabled. The mode is chosen per account at sign-in now (the
+            // choosers no longer gate on the master flag), so signing in
+            // without an API key IS the opt-in — flip the internal flag on
+            // rather than leaving the fresh session with no working transport.
+            if (!sWebJSONEnabled) {
+                sWebJSONEnabled = YES;
+                [[NSUserDefaults standardUserDefaults] setBool:YES forKey:UDKeyWebJSONEnabled];
+                ApolloLog(@"[WebJSON] Enabled Web JSON transport — u/%@ signed in without an API key", username);
+            }
+            // Tell the Custom API screen to re-derive itself. It may be
+            // sitting right behind this login page sheet (whose dismissal
+            // fires no viewWillAppear on the presenter), and BOTH its
+            // SectionAPIKeys row count (flag-dependent Web Session Login row)
+            // and its per-account rows (the just-harvested account is keyless
+            // now) are stale after a harvest — even one that didn't flip the
+            // flag. A stale committed row count makes the next row-level
+            // table update throw, so this must fire on every harvest.
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [[NSNotificationCenter defaultCenter] postNotificationName:ApolloWebJSONEnabledDidChangeNotification object:nil];
+            });
         }
         completion(pairs.count);
     }];
@@ -684,15 +706,9 @@ void ApolloWebSessionPresentSignInChooser(UIViewController *host, void (^apiKeyH
     [sheet addAction:[UIAlertAction actionWithTitle:@"Sign In Without API Key (Experimental)"
                                               style:UIAlertActionStyleDefault
                                             handler:^(UIAlertAction *a) {
-        if (!sWebJSONEnabled) {
-            UIAlertController *alert = [UIAlertController
-                alertControllerWithTitle:@"API-Key-Free Mode Is Off"
-                                  message:@"Turn on \"API-Key-Free Mode\" in Settings → API Keys first — otherwise a web-session account has no working way to authenticate and every request will hang."
-                           preferredStyle:UIAlertControllerStyleAlert];
-            [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
-            [host presentViewController:alert animated:YES completion:nil];
-            return;
-        }
+        // No master-flag gate here: API-key-free is chosen per account at
+        // sign-in, and a successful harvest enables the transport flag itself
+        // (ApolloWebSessionHarvestFromCookieStore).
         BOOL hasExistingWebSession = ApolloWebSessionUsernames().count > 0;
         ApolloWebSessionLoginViewController *vc = hasExistingWebSession
             ? [ApolloWebSessionLoginViewController loginControllerForAdditionalAccount]
@@ -704,4 +720,69 @@ void ApolloWebSessionPresentSignInChooser(UIViewController *host, void (^apiKeyH
     sheet.popoverPresentationController.sourceView = host.view;
     sheet.popoverPresentationController.sourceRect = host.view.bounds;
     [host presentViewController:sheet animated:YES completion:nil];
+}
+
+#pragma mark - Per-account mode conversions
+
+void ApolloPresentSwitchToAPIKeyFlow(UIViewController *host, NSString *username, void (^completion)(BOOL switched)) {
+    if (username.length == 0) { if (completion) completion(NO); return; }
+    completion = [completion copy];
+
+    // What would the account fall back to? A real OAuth credential on disk plus
+    // an API key (its own or the default) means the switch "just works" after a
+    // relaunch; anything less means the user has to sign in again with a key.
+    ApolloAccountCredentialEntry *entry = ApolloAccountCredentialsFor(username);
+    BOOL hasKey = entry.clientId.length > 0 || sRedditClientId.length > 0;
+    BOOL hasRealCredential = ApolloWebJSONDiskAccountHasRealCredential(username);
+    BOOL cleanSwitch = hasKey && hasRealCredential;
+
+    NSString *message = cleanSwitch
+        ? [NSString stringWithFormat:@"u/%@ will stop using its web session and go back to signing in with its API key. Apollo needs to quit and reopen to finish the switch.", username]
+        : [NSString stringWithFormat:@"u/%@ signed in without an API key, and no API-key sign-in is stored for it. Its web session will be removed — you'll then need to sign it in again with an API key (Accounts → Add Account).", username];
+
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Use API Key Instead?"
+                                                                   message:message
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Switch to API Key"
+                                              style:(cleanSwitch ? UIAlertActionStyleDefault : UIAlertActionStyleDestructive)
+                                            handler:^(UIAlertAction *a) {
+        ApolloWebSessionRemove(username);
+        ApolloLog(@"[WebJSON] u/%@ switched to API-key sign-in — web session removed", username);
+        if (completion) completion(YES);
+
+        // The in-memory RDKClient for this account still carries a synthetic
+        // cookie-session credential (installed at launch); the real OAuth
+        // credential is only reloaded from the account blobs on the next
+        // launch, so requests for this account are dead until then.
+        UIAlertController *quit = [UIAlertController alertControllerWithTitle:@"Quit & Reopen to Finish"
+                                                                      message:[NSString stringWithFormat:@"u/%@ switches to its API key the next time Apollo starts.", username]
+                                                               preferredStyle:UIAlertControllerStyleAlert];
+        [quit addAction:[UIAlertAction actionWithTitle:@"Quit Apollo" style:UIAlertActionStyleDefault handler:^(UIAlertAction *q) {
+            exit(0);
+        }]];
+        [quit addAction:[UIAlertAction actionWithTitle:@"Later" style:UIAlertActionStyleCancel handler:nil]];
+        [host presentViewController:quit animated:YES completion:nil];
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction *a) {
+        if (completion) completion(NO);
+    }]];
+    [host presentViewController:alert animated:YES completion:nil];
+}
+
+void ApolloPresentSwitchToKeylessFlow(UIViewController *host, NSString *username) {
+    if (username.length == 0) return;
+    UIAlertController *alert = [UIAlertController
+        alertControllerWithTitle:@"Sign In Without API Key?"
+                         message:[NSString stringWithFormat:@"You'll sign in to reddit.com as u/%@ in a web view. The account's stored API key stays saved but won't be used while the web session exists.", username]
+                  preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Continue" style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) {
+        // The add-account variant clears the shared cookie jar first so the
+        // web view isn't pre-signed-in as some OTHER account — the user must
+        // authenticate as the account they're converting.
+        ApolloWebSessionLoginViewController *vc = [ApolloWebSessionLoginViewController loginControllerForAdditionalAccount];
+        UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:vc];
+        [host presentViewController:nav animated:YES completion:nil];
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    [host presentViewController:alert animated:YES completion:nil];
 }

--- a/src/ApolloWebSessionStore.h
+++ b/src/ApolloWebSessionStore.h
@@ -20,8 +20,11 @@ NS_ASSUME_NONNULL_BEGIN
 // The session is sensitive (it IS the account's live login, not just an API
 // client secret), so it's kept in the keychain — reusing ApolloWebJSON.m's
 // existing service string so the simulator's Valet/SecItem virtualization keeps
-// covering it. The global `sWebJSONEnabled` flag remains the master kill-switch
-// (per product decision); only the *session data* moves per-account.
+// covering it. The global `sWebJSONEnabled` flag still exists as the internal
+// transport gate, but it is auto-managed rather than user-facing: a keyless
+// sign-in (harvest) turns it on, and launch turns it on whenever stored
+// sessions exist. The Settings switch that used to write it now reflects and
+// converts the ACTIVE account's sign-in mode instead.
 
 @interface ApolloWebSessionEntry : NSObject
 @property (nonatomic, copy) NSString *cookieHeader;

--- a/src/CustomAPIViewController.h
+++ b/src/CustomAPIViewController.h
@@ -3,6 +3,10 @@
 
 @interface CustomAPIViewController : ApolloSettingsTableViewController <UITextFieldDelegate, UITextViewDelegate, UIDocumentPickerDelegate> {
     BOOL _isRestoreOperation;
+    // Snapshot of the derived state SectionAPIKeys renders from, so
+    // -viewWillAppear can skip its section reload when nothing changed and
+    // avoid the inset-grouped card flashing full-width during the push.
+    NSString *_apollo_lastAPIKeysSignature;
 }
 @end
 

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -7,6 +7,7 @@
 #import "ApolloWebSessionLoginViewController.h"
 #import "ApolloAISettingsViewController.h"
 #import "ApolloWebSessionStore.h"
+#import "ApolloWebJSON.h"
 #import "ApolloAccountCredentials.h"
 #import "ApolloState.h"
 #import "ApolloUserProfileCache.h"
@@ -212,6 +213,102 @@ typedef NS_ENUM(NSInteger, Tag) {
 
 - (BOOL)apollo_usesCustomOAuthSignIn {
     return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseCustomOAuthSignIn];
+}
+
+#pragma mark - Active-account awareness
+
+// The Reddit credential rows and the API-Key-Free switch reflect the ACTIVE
+// account: each account signs in either with an API key (its per-account
+// entry, falling back to the global default) or without one (a stored web
+// session) — see ApolloAccountCredentials.h / ApolloWebSessionStore.h. The
+// other fields (Imgur/Giphy/ImgChest/User Agent) stay global.
+
+- (NSString *)apollo_activeUsername {
+    return ApolloActiveAccountUsername();
+}
+
+- (BOOL)apollo_activeAccountIsKeyless {
+    NSString *active = [self apollo_activeUsername];
+    return active.length > 0 && ApolloWebSessionFor(active) != nil;
+}
+
+// The three Reddit fields form ONE credential (a client id, ITS secret, ITS
+// redirect URI) — an installed-app client id requires an EMPTY secret, so
+// mixing entry and global values per FIELD could pair a custom client id with
+// the default's secret and corrupt a working setup on the next save. Decide
+// custom-vs-default once per ACCOUNT (same divergence rule as the account
+// switcher's badge) and resolve the whole triple from that source.
+- (BOOL)apollo_activeAccountUsesCustomCredentials {
+    NSString *active = [self apollo_activeUsername];
+    if (active.length == 0) return NO;
+    ApolloAccountCredentialEntry *entry = ApolloAccountCredentialsFor(active);
+    if (!entry) return NO;
+    return ![(entry.clientId ?: @"") isEqualToString:(sRedditClientId ?: @"")]
+        || ![(entry.clientSecret ?: @"") isEqualToString:(sRedditClientSecret ?: @"")]
+        || ![(entry.redirectURI ?: @"") isEqualToString:(sRedirectURI ?: @"")];
+}
+
+- (NSString *)apollo_activeAccountFieldForTag:(NSInteger)tag {
+    if ([self apollo_activeAccountUsesCustomCredentials]) {
+        ApolloAccountCredentialEntry *entry = ApolloAccountCredentialsFor([self apollo_activeUsername]);
+        if (tag == TagRedditClientId)     return entry.clientId ?: @"";
+        if (tag == TagRedditClientSecret) return entry.clientSecret ?: @"";
+        if (tag == TagRedirectURI)        return entry.redirectURI ?: @"";
+        return @"";
+    }
+    if (tag == TagRedditClientId)     return sRedditClientId ?: @"";
+    if (tag == TagRedditClientSecret) return sRedditClientSecret ?: @"";
+    if (tag == TagRedirectURI)        return sRedirectURI ?: @"";
+    return @"";
+}
+
+// Persists an edited Reddit credential field, keeping the triple coherent:
+// - Custom-key account active: the edit goes to ITS entry only (the other two
+//   fields keep the entry's values verbatim); the global default is untouched.
+// - Default-following account active: the edit goes to the global default,
+//   and the account is re-pinned to the updated default as a whole triple so
+//   it keeps following it (display, pin, and runtime resolution stay in
+//   agreement — note that changing the client id invalidates the account's
+//   refresh token either way; Apollo re-prompts for sign-in when that bites).
+// - Nobody signed in: edits write the global default as before.
+- (void)apollo_saveRedditCredentialField:(NSInteger)tag value:(NSString *)value {
+    value = value ?: @"";
+    NSString *active = [self apollo_activeUsername];
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+
+    if (active.length > 0 && ![self apollo_activeAccountIsKeyless]
+        && [self apollo_activeAccountUsesCustomCredentials]) {
+        ApolloAccountCredentialEntry *entry = ApolloAccountCredentialsFor(active) ?: [ApolloAccountCredentialEntry new];
+        NSString *clientId    = tag == TagRedditClientId     ? value : (entry.clientId ?: @"");
+        NSString *secret      = tag == TagRedditClientSecret ? value : (entry.clientSecret ?: @"");
+        NSString *redirectURI = tag == TagRedirectURI        ? value : (entry.redirectURI ?: @"");
+        ApolloAccountCredentialsSet(active, clientId, secret, redirectURI);
+        return;
+    }
+
+    if (tag == TagRedditClientId) {
+        sRedditClientId = value;
+        [defaults setValue:value forKey:UDKeyRedditClientId];
+    } else if (tag == TagRedditClientSecret) {
+        sRedditClientSecret = value;
+        [defaults setValue:value forKey:UDKeyRedditClientSecret];
+    } else if (tag == TagRedirectURI) {
+        sRedirectURI = value;
+        [defaults setValue:value forKey:UDKeyRedirectURI];
+    }
+
+    if (active.length > 0 && ![self apollo_activeAccountIsKeyless]) {
+        ApolloAccountCredentialsSet(active, sRedditClientId, sRedditClientSecret, sRedirectURI);
+    }
+}
+
+// Dim + disable a Reddit credential row while the active account is keyless —
+// the values don't apply to it (footer explains). Re-enabled when an API-key
+// account (or no account) is active.
+- (void)apollo_applyKeylessAppearanceToCell:(UITableViewCell *)cell {
+    BOOL keyless = [self apollo_activeAccountIsKeyless];
+    cell.userInteractionEnabled = !keyless;
+    cell.contentView.alpha = keyless ? 0.4 : 1.0;
 }
 
 - (NSString *)apollo_redirectURIDetailText {
@@ -608,20 +705,36 @@ typedef NS_ENUM(NSInteger, Tag) {
     self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
     [self apollo_disableAutoHideTabBarIdleIfUnsupported];
 
+    // sWebJSONEnabled can flip outside this screen while it's on the stack —
+    // a keyless harvest auto-enables it behind the login page sheet, and
+    // page-sheet dismissal fires no viewWillAppear here. The SectionAPIKeys
+    // row count depends on the flag, so a stale committed count would make
+    // the next row-level update throw. reloadData resyncs unconditionally.
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(apollo_webJSONEnabledDidChangeExternally)
+                                                 name:ApolloWebJSONEnabledDidChangeNotification
+                                               object:nil];
+
     [[ApolloSubredditInfoCache sharedCache] requestInfoForSubreddit:kApolloRebornSubredditName completion:^(ApolloSubredditInfo *info) {
         (void)info;
     }];
 }
 
+- (void)apollo_webJSONEnabledDidChangeExternally {
+    [self.tableView reloadData];
+}
+
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     [self apollo_applyTheme];
-    // Refresh the Web Session Login status line after returning from the login
-    // flow (signed-in user / write-token availability may have just changed).
-    if (sWebJSONEnabled && [self.tableView numberOfRowsInSection:SectionAPIKeys] > kAPIKeyRowWebSessionLogin) {
-        [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:kAPIKeyRowWebSessionLogin inSection:SectionAPIKeys]]
-                              withRowAnimation:UITableViewRowAnimationNone];
-    }
+    // The Reddit credential rows, the API-Key-Free switch, and the section
+    // footer all reflect the ACTIVE account (which may have changed while this
+    // screen was off-screen — account switch, keyless sign-in completing, a
+    // conversion), and the Web Session Login row's existence tracks
+    // sWebJSONEnabled, which a keyless sign-in can flip on from outside this
+    // screen. Reload the whole section so row count and contents re-derive
+    // from current state.
+    [self apollo_reloadAPIKeysSection];
     // Refresh the Apollo AI and Rich Link Previews status subtitles after returning
     // from their subviews.
     [self.tableView reloadSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(SectionApolloAI, 2)]
@@ -937,20 +1050,26 @@ typedef NS_ENUM(NSInteger, Tag) {
         // inline label-left/field-right layout — "Reddit API Key (Default)"
         // and "Reddit API Secret (Default)" are long enough to crowd the
         // field at the inline layout's fixed 0.55 width.
-        case 0:
+        case 0: {
+            BOOL keyless = [self apollo_activeAccountIsKeyless];
             cell = [self stackedTextFieldCellWithIdentifier:@"Cell_API_Reddit"
                                                        label:@"Reddit API Key"
-                                                 placeholder:@"Reddit API Key"
-                                                        text:sRedditClientId
+                                                 placeholder:(keyless ? @"Not used — account is API-key-free" : @"Reddit API Key")
+                                                        text:(keyless ? @"" : [self apollo_activeAccountFieldForTag:TagRedditClientId])
                                                          tag:TagRedditClientId];
+            [self apollo_applyKeylessAppearanceToCell:cell];
             break;
-        case 1:
+        }
+        case 1: {
+            BOOL keyless = [self apollo_activeAccountIsKeyless];
             cell = [self stackedTextFieldCellWithIdentifier:@"Cell_API_RedditSecret"
                                                        label:@"Reddit API Secret"
-                                                 placeholder:@"Required for \"Web app\" clients; empty otherwise"
-                                                        text:sRedditClientSecret
+                                                 placeholder:(keyless ? @"Not used — account is API-key-free" : @"Required for \"Web app\" clients; empty otherwise")
+                                                        text:(keyless ? @"" : [self apollo_activeAccountFieldForTag:TagRedditClientSecret])
                                                          tag:TagRedditClientSecret];
+            [self apollo_applyKeylessAppearanceToCell:cell];
             break;
+        }
         case 2:
             cell = [self stackedTextFieldCellWithIdentifier:@"Cell_API_Imgur"
                                                        label:@"Imgur API Key"
@@ -974,13 +1093,15 @@ typedef NS_ENUM(NSInteger, Tag) {
                                                      detail:@"Required for GIF picker. Get one at developers.giphy.com"];
             break;
         case 5: {
+            BOOL keyless = [self apollo_activeAccountIsKeyless];
             UITableViewCell *cell = [self stackedTextFieldCellWithIdentifier:@"Cell_API_Redirect"
                                                                       label:@"Redirect URI"
-                                                                placeholder:defaultRedirectURI
-                                                                       text:sRedirectURI
+                                                                placeholder:(keyless ? @"Not used — account is API-key-free" : defaultRedirectURI)
+                                                                       text:(keyless ? @"" : [self apollo_activeAccountFieldForTag:TagRedirectURI])
                                                                         tag:TagRedirectURI
                                                                       detail:[self apollo_redirectURIDetailText]];
             [self apollo_applyRedirectURITextColorToCell:cell];
+            [self apollo_applyKeylessAppearanceToCell:cell];
             return cell;
         }
         case 6:
@@ -1014,12 +1135,28 @@ typedef NS_ENUM(NSInteger, Tag) {
             cell.textLabel.text = @"Giphy & ImgChest API Key Setup";
             return cell;
         }
-        case kAPIKeyRowWebJSONSwitch:
+        case kAPIKeyRowWebJSONSwitch: {
+            // Reflects the ACTIVE account's sign-in mode, not a global master:
+            // ON = the current account signs in without an API key (it has a
+            // stored web session), OFF = it uses an API key. Toggling converts
+            // THAT account (webJSONSwitchToggled). With nobody signed in it
+            // falls back to the internal transport flag.
+            NSString *active = [self apollo_activeUsername];
+            BOOL on = active.length > 0 ? [self apollo_activeAccountIsKeyless] : sWebJSONEnabled;
+            NSString *detail;
+            if (active.length > 0 && on) {
+                detail = [NSString stringWithFormat:@"u/%@ signs in to reddit.com without an API key (web session). Turn off to switch it back to its API key. Each account has its own setting.", active];
+            } else if (active.length > 0) {
+                detail = [NSString stringWithFormat:@"u/%@ signs in with an API key. Turn on to sign it in to reddit.com without one (web session). Each account has its own setting.", active];
+            } else {
+                detail = @"Lets accounts sign in to reddit.com instead of using API keys (OAuth). Each account chooses its mode when it's added — from the account switcher or the sign-in screen.";
+            }
             return [self switchCellWithIdentifier:@"Cell_API_WebJSON"
                                             label:@"API-Key-Free Mode (Experimental)"
-                                           detail:@"Master switch: lets accounts sign in to reddit.com instead of using API keys (OAuth). Add or manage individual web-session accounts from the account switcher."
-                                               on:sWebJSONEnabled
+                                           detail:detail
+                                               on:on
                                            action:@selector(webJSONSwitchToggled:)];
+        }
         case kAPIKeyRowWebSessionLogin: {
             // Subtitle style so we can surface the harvested account / status.
             UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"Cell_API_WebSessionLogin"];
@@ -1707,8 +1844,16 @@ typedef NS_ENUM(NSInteger, Tag) {
             attributes:plainAttrs];
         [text appendAttributedString:[[NSAttributedString alloc] initWithString:@"more info"
             attributes:@{NSFontAttributeName: [UIFont systemFontOfSize:13], NSForegroundColorAttributeName: [self apollo_themeAccentColor], NSLinkAttributeName: [NSURL URLWithString:@"https://github.com/Apollo-Reborn/Apollo-Reborn?tab=readme-ov-file#dont-have-an-api-key"]}]];
-        [text appendAttributedString:[[NSAttributedString alloc] initWithString:@"). The Reddit API Key/Secret/Redirect URI above are the default, used by any signed-in account that doesn't have its own key — set a different key per account from the account switcher."
-            attributes:plainAttrs]];
+        NSString *perAccountNote;
+        NSString *activeUsername = [self apollo_activeUsername];
+        if (activeUsername.length > 0 && [self apollo_activeAccountIsKeyless]) {
+            perAccountNote = [NSString stringWithFormat:@"). u/%@ signs in without an API key (web session), so the Reddit fields above don't apply to it — they remain the default for accounts that do use a key. Manage each account's sign-in from the account switcher.", activeUsername];
+        } else if (activeUsername.length > 0) {
+            perAccountNote = [NSString stringWithFormat:@"). The Reddit API Key/Secret/Redirect URI above are the ones u/%@ signs in with. Other accounts keep their own keys — manage them from the account switcher (tap the ellipsis next to an account).", activeUsername];
+        } else {
+            perAccountNote = @"). The Reddit API Key/Secret/Redirect URI above are the default, used by any signed-in account that doesn't have its own key — set a different key per account from the account switcher.";
+        }
+        [text appendAttributedString:[[NSAttributedString alloc] initWithString:perAccountNote attributes:plainAttrs]];
     } else if (section == SectionSubreddits) {
         text = [[NSMutableAttributedString alloc]
             initWithString:@"Configure custom subreddit sources by providing a URL to a plaintext file with line-separated subreddit names (without /r/). "
@@ -2224,12 +2369,10 @@ typedef NS_ENUM(NSInteger, Tag) {
 - (void)textFieldDidEndEditing:(UITextField *)textField {
     if (textField.tag == TagRedditClientId) {
         textField.text = [textField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-        sRedditClientId = textField.text;
-        [[NSUserDefaults standardUserDefaults] setValue:sRedditClientId forKey:UDKeyRedditClientId];
+        [self apollo_saveRedditCredentialField:TagRedditClientId value:textField.text];
     } else if (textField.tag == TagRedditClientSecret) {
         textField.text = [textField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-        sRedditClientSecret = textField.text;
-        [[NSUserDefaults standardUserDefaults] setValue:sRedditClientSecret forKey:UDKeyRedditClientSecret];
+        [self apollo_saveRedditCredentialField:TagRedditClientSecret value:textField.text];
     } else if (textField.tag == TagImgurClientId) {
         textField.text = [textField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
         sImgurClientId = textField.text;
@@ -2243,8 +2386,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         [[NSUserDefaults standardUserDefaults] setValue:textField.text ?: @"" forKey:UDKeyGiphyAPIKey];
     } else if (textField.tag == TagRedirectURI) {
         textField.text = [textField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-        sRedirectURI = textField.text;
-        [[NSUserDefaults standardUserDefaults] setValue:sRedirectURI forKey:UDKeyRedirectURI];
+        [self apollo_saveRedditCredentialField:TagRedirectURI value:textField.text];
         textField.textColor = ([self apollo_usesCustomOAuthSignIn] || [self isRedirectURISchemeValid:textField.text]) ? [UIColor labelColor] : [UIColor systemRedColor];
     } else if (textField.tag == TagUserAgent) {
         textField.text = [textField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
@@ -2359,30 +2501,42 @@ typedef NS_ENUM(NSInteger, Tag) {
 }
 
 - (void)webJSONSwitchToggled:(UISwitch *)sender {
-    // Turning this OFF while ANY account has a stored web session leaves that
-    // account with no working transport: no OAuth key is configured (it never
-    // needed one) and cookie auth just got disabled by this flag — every
-    // request for it would hang forever with no visible error. Confirm before
-    // applying so that's a deliberate choice, not a surprise.
-    NSUInteger webSessionCount = ApolloWebSessionUsernames().count;
-    if (sender.isOn == NO && sWebJSONEnabled && webSessionCount > 0) {
-        [sender setOn:YES animated:YES]; // revert the visual toggle pending confirmation
-        NSString *who = webSessionCount == 1 ? @"An account" : [NSString stringWithFormat:@"%lu accounts", (unsigned long)webSessionCount];
-        UIAlertController *alert = [UIAlertController
-            alertControllerWithTitle:@"Turn Off API-Key-Free Mode?"
-                             message:[NSString stringWithFormat:
-                                 @"%@ signed in via a web session, not an API key. Turning this off will make every request for it hang. Remove or re-sign-in that account first, or turn it back on if you change your mind.", who]
-                      preferredStyle:UIAlertControllerStyleAlert];
+    // Per-account semantics: the switch shows (and changes) the ACTIVE
+    // account's sign-in mode. Toggling ON converts the current API-key account
+    // to a web-session sign-in; toggling OFF removes the current account's web
+    // session so it goes back to its API key. Both flows confirm first and are
+    // owned by ApolloWebSessionLoginViewController.m; the switch snaps back
+    // visually and the row re-renders from actual state afterward.
+    NSString *active = [self apollo_activeUsername];
+    if (active.length > 0) {
+        BOOL keylessNow = [self apollo_activeAccountIsKeyless];
         __weak typeof(self) weakSelf = self;
-        [alert addAction:[UIAlertAction actionWithTitle:@"Turn Off Anyway" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *a) {
-            [sender setOn:NO animated:YES];
-            [weakSelf _applyWebJSONEnabled:NO];
-        }]];
-        [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
-        [self presentViewController:alert animated:YES completion:nil];
+        if (sender.isOn && !keylessNow) {
+            [sender setOn:NO animated:YES]; // pending the sign-in actually completing
+            ApolloPresentSwitchToKeylessFlow(self, active);
+        } else if (!sender.isOn && keylessNow) {
+            [sender setOn:YES animated:YES]; // pending confirmation
+            ApolloPresentSwitchToAPIKeyFlow(self, active, ^(BOOL switched) {
+                if (switched) [weakSelf apollo_reloadAPIKeysSection];
+            });
+        } else {
+            // Visual state drifted from the account's actual mode (e.g. the
+            // account changed underneath a stale render) — resync the section.
+            [self apollo_reloadAPIKeysSection];
+        }
         return;
     }
+
+    // Nobody signed in: fall back to the internal transport flag (it also
+    // gates the missing-API-key launch nag). Turning it off with stored web
+    // sessions can't happen here — sessions imply a signed-in account, which
+    // takes the per-account path above.
     [self _applyWebJSONEnabled:sender.isOn];
+}
+
+- (void)apollo_reloadAPIKeysSection {
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:SectionAPIKeys]
+                  withRowAnimation:UITableViewRowAnimationNone];
 }
 
 - (void)_applyWebJSONEnabled:(BOOL)enabled {
@@ -2391,13 +2545,11 @@ typedef NS_ENUM(NSInteger, Tag) {
     [[NSUserDefaults standardUserDefaults] setBool:sWebJSONEnabled forKey:UDKeyWebJSONEnabled];
     if (sWebJSONEnabled == wasOn) return;
 
-    // The Web Session Login row only exists while the mode is on.
-    NSArray<NSIndexPath *> *loginPaths = @[[NSIndexPath indexPathForRow:kAPIKeyRowWebSessionLogin inSection:SectionAPIKeys]];
-    if (sWebJSONEnabled) {
-        [self.tableView insertRowsAtIndexPaths:loginPaths withRowAnimation:UITableViewRowAnimationFade];
-    } else {
-        [self.tableView deleteRowsAtIndexPaths:loginPaths withRowAnimation:UITableViewRowAnimationFade];
-    }
+    // The Web Session Login row only exists while the mode is on — and the
+    // flag can also be flipped from OUTSIDE this screen (harvest, launch
+    // enforcement), so a targeted insert/delete against a possibly-stale
+    // committed row count is exception bait. reloadData is unconditional.
+    [self.tableView reloadData];
 }
 
 // This row is "manage/refresh my web login", NOT "add another account", so it

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -715,6 +715,11 @@ typedef NS_ENUM(NSInteger, Tag) {
                                                  name:ApolloWebJSONEnabledDidChangeNotification
                                                object:nil];
 
+    // The initial data-source pass builds SectionAPIKeys from current state, so
+    // seed the baseline with it — the first -viewWillAppear then sees "no
+    // change" and skips the redundant (flash-inducing) section reload.
+    _apollo_lastAPIKeysSignature = [self apollo_currentAPIKeysSignature];
+
     [[ApolloSubredditInfoCache sharedCache] requestInfoForSubreddit:kApolloRebornSubredditName completion:^(ApolloSubredditInfo *info) {
         (void)info;
     }];
@@ -722,6 +727,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 
 - (void)apollo_webJSONEnabledDidChangeExternally {
     [self.tableView reloadData];
+    _apollo_lastAPIKeysSignature = [self apollo_currentAPIKeysSignature];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -733,8 +739,11 @@ typedef NS_ENUM(NSInteger, Tag) {
     // conversion), and the Web Session Login row's existence tracks
     // sWebJSONEnabled, which a keyless sign-in can flip on from outside this
     // screen. Reload the whole section so row count and contents re-derive
-    // from current state.
-    [self apollo_reloadAPIKeysSection];
+    // from current state — but ONLY when that state actually changed, since
+    // reloading it here (mid-push) flashes the inset-grouped card full-width.
+    if (![[self apollo_currentAPIKeysSignature] isEqualToString:(_apollo_lastAPIKeysSignature ?: @"")]) {
+        [self apollo_reloadAPIKeysSection];
+    }
     // Refresh the Apollo AI and Rich Link Previews status subtitles after returning
     // from their subviews.
     [self.tableView reloadSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(SectionApolloAI, 2)]
@@ -2534,9 +2543,38 @@ typedef NS_ENUM(NSInteger, Tag) {
     [self _applyWebJSONEnabled:sender.isOn];
 }
 
+// Everything SectionAPIKeys renders that can change while this screen is off
+// the top of the stack, folded into one comparable string. If it's identical
+// to what the section was last built from, a reload would only re-render the
+// same content — and doing that inside -viewWillAppear makes the inset-grouped
+// card briefly re-lay-out at the wrong width mid-push (the visible full-width
+// flash the reload guard exists to avoid). The inputs:
+//   - active username           → the credential rows, switch state, footer
+//   - sWebJSONEnabled           → whether the Web Session Login row exists (row count)
+//   - active-account keyless    → switch on/off + credential-row dimming
+//   - active-account custom     → which Reddit credential triple is shown
+//   - web-session count         → the Web Session Login row's summary subtitle
+//   - pending-restart (+ user)  → its "quit & reopen to activate" nudge
+// The global Imgur/Giphy/ImgChest/User-Agent fields only change from this
+// screen's own text fields, so they need no entry here.
+- (NSString *)apollo_currentAPIKeysSignature {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    return [NSString stringWithFormat:@"%@|%d|%d|%d|%lu|%d|%@",
+            [self apollo_activeUsername] ?: @"",
+            sWebJSONEnabled ? 1 : 0,
+            [self apollo_activeAccountIsKeyless] ? 1 : 0,
+            [self apollo_activeAccountUsesCustomCredentials] ? 1 : 0,
+            (unsigned long)ApolloWebSessionUsernames().count,
+            [defaults boolForKey:UDKeyWebJSONPendingRestart] ? 1 : 0,
+            [defaults stringForKey:UDKeyWebJSONPendingRestartUsername] ?: @""];
+}
+
 - (void)apollo_reloadAPIKeysSection {
     [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:SectionAPIKeys]
                   withRowAnimation:UITableViewRowAnimationNone];
+    // The section now reflects current state — re-baseline so the next
+    // -viewWillAppear doesn't reload again for a state it already shows.
+    _apollo_lastAPIKeysSignature = [self apollo_currentAPIKeysSignature];
 }
 
 - (void)_applyWebJSONEnabled:(BOOL)enabled {
@@ -2550,6 +2588,7 @@ typedef NS_ENUM(NSInteger, Tag) {
     // enforcement), so a targeted insert/delete against a possibly-stale
     // committed row count is exception bait. reloadData is unconditional.
     [self.tableView reloadData];
+    _apollo_lastAPIKeysSignature = [self apollo_currentAPIKeysSignature];
 }
 
 // This row is "manage/refresh my web login", NOT "add another account", so it

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -392,11 +392,28 @@ static const char kARCompletion = '\0';
 - (instancetype)initWithURL:(NSURL *)URL
         callbackURLScheme:(NSString *)callbackURLScheme
         completionHandler:(void (^)(NSURL *, NSError *))completionHandler {
-    id result = %orig;
+    // Wrap the completion so BOTH sign-in flows (native ASWebAuthenticationSession
+    // and our WKWebView replacement, which reads the associated handler) report
+    // the outcome of the interactive OAuth sign-in: a callback URL carrying
+    // ?code= arms the stale-web-session cleanup consumed by the RDKClient
+    // user-install hook (ApolloUserAvatars.xm); a cancel/failure disarms it.
+    void (^original)(NSURL *, NSError *) = [completionHandler copy];
+    void (^wrapped)(NSURL *, NSError *) = ^(NSURL *callbackURL, NSError *error) {
+        BOOL gotAuthCode = NO;
+        if (callbackURL && !error) {
+            for (NSURLQueryItem *item in [NSURLComponents componentsWithURL:callbackURL resolvingAgainstBaseURL:NO].queryItems) {
+                if ([item.name isEqualToString:@"code"] && item.value.length > 0) { gotAuthCode = YES; break; }
+            }
+        }
+        if (gotAuthCode) ApolloNoteInteractiveOAuthSignIn();
+        else ApolloCancelInteractiveOAuthSignIn();
+        if (original) original(callbackURL, error);
+    };
+    id result = %orig(URL, callbackURLScheme, wrapped);
     id target = result ?: self;
     objc_setAssociatedObject(target, &kARScheme,     callbackURLScheme, OBJC_ASSOCIATION_COPY);
     objc_setAssociatedObject(target, &kARAuthURL,    URL,               OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    objc_setAssociatedObject(target, &kARCompletion, completionHandler, OBJC_ASSOCIATION_COPY);
+    objc_setAssociatedObject(target, &kARCompletion, wrapped,           OBJC_ASSOCIATION_COPY);
     return result;
 }
 
@@ -1981,6 +1998,19 @@ static void initializeRandomSources() {
     // where sWebJSONEnabled is read). Migrates any legacy NSUserDefaults cookie,
     // then any legacy single-global session, into the per-account store.
     ApolloWebJSONLoadPersistedCredentials();
+    // Per-account coherence: a stored web session IS that account's sign-in —
+    // it only works while the Web JSON transport is enabled. The mode is
+    // chosen per account now (sign-in choosers no longer gate on this flag,
+    // and turning an account's mode off REMOVES its session), so "sessions
+    // exist but the flag is off" is a stale kill-switch state from an older
+    // build; without this the accounts would badge as keyless in the switcher
+    // while every one of their requests hangs.
+    if (!sWebJSONEnabled && ApolloWebSessionUsernames().count > 0) {
+        sWebJSONEnabled = YES;
+        [[NSUserDefaults standardUserDefaults] setBool:YES forKey:UDKeyWebJSONEnabled];
+        ApolloLog(@"[WebJSON] Enabled Web JSON transport at launch — %lu web-session account(s) exist",
+                  (unsigned long)ApolloWebSessionUsernames().count);
+    }
     if (sWebJSONEnabled) {
         NSArray<NSString *> *webSessionUsers = ApolloWebSessionUsernames().allObjects;
         ApolloLog(@"[WebJSON] enabled at launch, %lu web-session account(s): %@",


### PR DESCRIPTION
## Per-account sign-in mode: truthful switcher labels + account-aware API settings

@nickclyde tagging you directly since this sits right on top of your #562 / #505 per-account work and partly corrects one edge of the #562 migration — want your read on the approach before this goes anywhere.

### Screenshot

<img width="362" height="421" alt="Simulator Screenshot - Apollo-Sim2 - 2026-07-08 at 00 05 44" src="https://github.com/user-attachments/assets/ff419cbd-279f-45c4-b17d-f11479b567dc" />

### The bug (as a user hits it)

Two accounts: **iChopPryde** signed in with a Dystopia API key, **RemZeroBestGirl** signed in keyless (web session). In the account switcher **both rows say "Web session"**, and the Custom API screen (the API-Key-Free toggle, Redirect URI, key fields) shows one global state regardless of which account is active. So there's no way to tell which account is on a key vs keyless, and the settings don't reflect the account you're actually looking at.

### Root cause (this is the interesting part)

The label isn't wrong — iChopPryde genuinely *had* become a keyless account, silently. Here's the chain:

- Web JSON mode used to be a single global cookie/modhash/username trio. At some point a session got harvested while signed in as iChopPryde (its username landed in the legacy `sessionUsername` keychain item).
- `ApolloWebJSONLoadPersistedCredentials()` (the stage-2 migration in #562) copies that legacy global session into the per-account store keyed by whatever `sessionUsername` held — i.e. `ApolloWebSessionSet("iChopPryde", …)`.
- In the new model **presence of a web-session entry *is* the definition of "this account is keyless"** (`ApolloWebSessionFor(u) != nil`). So iChopPryde now reads as keyless everywhere: the switcher badge, and — more importantly — the transport chokepoint. Its requests get cookie-rewritten and **its API key is silently unused**.
- Nothing ever removed a web-session entry when an account was (or became) an API-key account, so it stuck.

I reproduced this exactly in the sim (seeded the legacy `sessionCookieHeader`/`sessionModhash`/`sessionUsername` trio + a real per-account session for the keyless account) and got a pixel-match to the reported screenshots.

### What this PR does

**Truthful, per-account labels** (`ApolloAccountSwitcherViewController.xm`)
Row subtitles are now `API key · default` / `API key · custom` / `API-key-free` / `No API key set` instead of the blanket "Web session".

**Settings screen follows the active account** (`CustomAPIViewController.m`)
- The **API-Key-Free switch reflects the active account's mode**: ON iff that account has a stored web session, OFF if it uses a key. Toggling *converts that account* — ON presents the web-session login for it; OFF confirms, removes its session, and prompts a quit&reopen (the real OAuth credential only reloads from the account blobs at launch).
- **Reddit API Key / Secret / Redirect URI show the active account's effective credentials**, resolved as a coherent *triple* from one source (the account's custom entry if it diverges from the default, else the default) — never mixed per-field, since an installed-app client id needs an empty secret and pairing a custom id with the default's secret would corrupt a working setup. For a keyless account the three fields render empty + dimmed ("Not used — account is API-key-free").
- Edits to a default-following account re-pin it to the updated default; edits to a custom-key account write only its entry. Footer now names the active account and explains where its credentials come from.

**Stale-session hygiene**
- **Interactive OAuth sign-in removes any leftover web session for that username.** The `?code=` callback (both the universal WKWebView flow and native `ASWebAuthenticationSession`) arms a flag; the `RDKClient` user-install hook consumes it and calls `ApolloWebSessionRemove`. Details on why this is identity-bound below — it was the scariest part.
- **Manual escape hatch for already-migrated installs**: the ⋯ menu on a keyless row gains **"Use API Key Instead…"** (removes the session after confirming). This is what a currently-affected device uses to un-stick an account like iChopPryde — the migration already happened for them, so an automatic heal can't retroactively fire.

**Master flag is now internal / auto-managed** (`Tweak.xm`, `ApolloWebSessionStore.h`, choosers)
`sWebJSONEnabled` stops being a user-facing master switch. A keyless harvest enables it; launch enables it whenever any stored session exists (a session *is* that account's only working sign-in, so leaving the flag off would hang every one of its requests). The sign-in choosers (Add Account / splash / re-sign-in) no longer gate on it — choosing keyless at sign-in is the opt-in. The old Settings switch now means "the active account's mode," per above.

### The migration edge — where I chose NOT to be clever, and want your opinion

My first pass added a guard: during the stage-2 migration, if `sessionUsername` also has a **real** credential on disk (non-synthetic access token or non-empty refresh token), *drop* the legacy session instead of converting the account to keyless — on the theory "this is really an OAuth account, don't make it keyless."

I backed that out. Two problems:
1. **It can't tell a live key from a revoked one.** The "Reddit killed our keys" restore population (your `SeedBearerRegistryFromDisk` comment's audience) has a real-but-dead token *and* a deliberately harvested web session that is their only working login. The guard would drop that session and brick the account.
2. **Ordering vs `RepairPoisonedAccountBlobs`.** The guard runs inside `LoadPersistedCredentials()` (before the repair in `%ctor`). On a poisoned blob the victim OAuth index carries the keyless username paired with the victim's real token, so the guard would misfire *and* then the repair's `ApolloWebSessionFor(username) == nil` early-out would skip healing it — strictly worse than doing nothing.

So the migration now **migrates as before, and just logs a note** when the username also has a real credential. The truthful label + the "Use API Key Instead…" affordance are the safe recovery path instead of a fragile automatic one. If you'd rather handle this at migration time, I think it'd need to run *after* the poison repair and key off "does this username have a synthetic-token index" (proof of a real keyless sign-in) rather than "has any real token" — happy to do that instead if you prefer.

### On the OAuth-cleanup flag being identity-bound

Worth calling out because it's a subtle trap in this codebase. My first version consumed the armed flag on the *first* `RDKClient` user-install after the callback. That's wrong: `-setCurrentUser:` fires from `NSKeyedUnarchiver`'s KVC decode of `RedditAccounts2` — which `ApolloActiveAccountUsername()` does on **every** call, including for the sign-in's own token-exchange request — and `-updateCurrentUserWithNewUser:` fires on every background `/api/v1/me` refresh. So "first install wins" would spend the flag on whatever stored account decoded first and could `ApolloWebSessionRemove` **a healthy keyless account's live session**.

Fixed by binding the consume to identity: arming snapshots the usernames already in the blobs, and only an install for a *not-previously-present* username (the genuinely new sign-in) consumes; installs for existing usernames pass through without disarming. Trade-off: re-authing an already-present username with a key doesn't auto-heal — that's what the manual ⋯ flow covers.

### Also fixed (found in review)

- Keyless conversion from the settings screen flips `sWebJSONEnabled` behind a page sheet, whose dismissal fires no `viewWillAppear` on the presenter → stale `SectionAPIKeys` row count → next batch update throws `NSInternalInconsistencyException`. Added `ApolloWebJSONEnabledDidChangeNotification` (posted after every harvest) → the settings screen `reloadData`s; `_applyWebJSONEnabled` also `reloadData`s instead of a targeted insert/delete against a possibly-stale count.

### Testing

- **Sim-verified** on the reproduced two-account state (Apollo-Sim2, iOS 26 glass): both labels correct, per-account settings reflection on each account, both conversion confirm flows, and iChopPryde transporting over its real key again (live feed/profile load) after the ⋯ → "Use API Key Instead…" heal.
- **Device `make package` builds clean** (iOS 14 floor / 26.0 SDK).
- **Not device-tested yet**, and the auto-cleanup-on-OAuth-sign-in path can't be exercised in the sim (needs a real reddit.com OAuth round-trip). The manual heal, labels, and per-account reflection all are.

Single commit, based on current `main` (`0de44d9`). Let me know if the migration handling or the flag semantics rub you the wrong way — happy to iterate.
