### PR TITLE
Fix blank user-flair picker on keyless (Web JSON) accounts

### DIFF
--- a/src/ApolloWebJSON.m
+++ b/src/ApolloWebJSON.m
@@ -269,13 +269,32 @@ static ApolloWebJSONPathKind ApolloWebJSONClassifyReadPath(NSString *path) {
     return ApolloWebJSONPathUnsupported;
 }
 
-// Whitelist a write (POST/PUT/DELETE). Apollo's write actions all POST to
-// oauth.reddit.com/api/<action>; the web mirror at www.reddit.com/api/<action>
-// accepts the same body with cookie + modhash auth. We allow the whole /api/
+// Whitelist a write (POST/PUT/DELETE). Apollo's write actions POST to two
+// shapes: a TOP-LEVEL endpoint (oauth.reddit.com/api/<action> — vote, comment,
+// submit, subscribe, …) and a SUBREDDIT-SCOPED one
+// (oauth.reddit.com/r/<sub>/api/<action> — flairselector, selectflair,
+// setflairenabled, …). Both mirror to www.reddit.com with cookie + modhash, so
+// both must be routed. This originally matched only the top-level form, so
+// subreddit-scoped writes fell through to oauth.reddit.com carrying the
+// synthetic dummy bearer and 401'd — most visibly the user-flair selector's
+// POST /r/<sub>/api/flairselector, which returned no options and left the flair
+// picker BLANK on every subreddit for keyless accounts. (The READ classifier
+// already routes /r/<sub>/api/* GETs like link_flair for the same reason — see
+// ApolloWebJSONClassifyReadPath; this is the write-side counterpart, and it also
+// ends the same 401→refresh→retry loop for POSTs.) We allow the whole /api/
 // surface but exclude the OAuth token endpoints (those are the identity layer's
 // job, not a content write) and media uploads (multipart, handled elsewhere).
 static BOOL ApolloWebJSONWritePathIsRoutable(NSString *path) {
-    if (![path hasPrefix:@"/api/"]) return NO;
+    BOOL topLevelAPI = [path hasPrefix:@"/api/"];
+    BOOL subredditAPI = NO;
+    if ([path hasPrefix:@"/r/"]) {
+        // /r/<sub>/api/<action> — seg == ["r", "<sub>", "api", "<action>", ...]
+        NSArray<NSString *> *seg = [[path substringFromIndex:1] componentsSeparatedByString:@"/"];
+        subredditAPI = (seg.count >= 4 && [seg[2] isEqualToString:@"api"]);
+    }
+    if (!topLevelAPI && !subredditAPI) return NO;
+    // The exclusions below are all top-level /api/ paths (token + media
+    // endpoints); no subreddit-scoped /r/<sub>/api/* path matches them.
     if ([path hasPrefix:@"/api/v1/access_token"]) return NO;
     if ([path hasPrefix:@"/api/v1/revoke_token"]) return NO;
     if ([path hasPrefix:@"/api/v1/authorize"]) return NO;


### PR DESCRIPTION
## The bug

On a **keyless (Web JSON) account**, opening a subreddit's **User Flair** picker shows a completely blank screen — on *every* subreddit. Voting, commenting, posting and inbox all work fine, so at first it looks like the flair feature itself broke.

## Root cause

The keyless Web JSON transport (`ApolloWebJSONRewriteRequest`) reroutes Reddit traffic to cookie-authed `www.reddit.com`, but its write whitelist (`ApolloWebJSONWritePathIsRoutable`) only matched **top-level** `/api/<action>` paths:

```objc
if (![path hasPrefix:@"/api/"]) return NO;
```

The user-flair selector fetches its options via **`POST /r/<sub>/api/flairselector`** — a *subreddit-scoped* path that doesn't start with `/api/`. So it was never rerouted: the request went to `oauth.reddit.com` carrying the synthetic dummy bearer the identity layer installs, Reddit `401`'d it, the options came back empty, and the picker rendered blank. Everything else works because vote/comment/submit/subscribe all POST to top-level `/api/…`, which *is* whitelisted.

This is the **write-side twin** of a bug already fixed on the read side — `ApolloWebJSONClassifyReadPath` was recently taught to route `/r/<sub>/api/*` GETs (`link_flair`) for exactly the same reason (and to end the `401→refresh→retry` loop the synthetic bearer causes). `flairselector` is a POST, so it goes through the write path, which was never patched.

## The fix

Route `/r/<sub>/api/*` writes through the cookie transport too. Restores:

- `flairselector` — flair options load (the blank screen)
- `selectflair` — committing a flair
- `setflairenabled` — the show-flair toggle
- any other subreddit-scoped write action

The existing exclusions (token endpoints, media leases, keyless image upload) are all top-level `/api/` paths, so no subreddit-scoped path can match them — they're unaffected.

## Verification

- **Routing logic** — a standalone test over the real paths confirms the decision flips exactly where intended:
  - now routed (were dropped): `/r/<sub>/api/flairselector`, `/selectflair`, `/setflairenabled`, `/friend`
  - unchanged: `/api/vote`, `/api/comment`, `/api/submit`, `/api/subscribe`
  - still excluded: `/api/v1/access_token`, `/api/media/asset.json`, `/api/v1/media/asset.json`, `/api/image_upload_s3.json`
  - correctly *not* treated as writes: `/r/<sub>`, `/r/<sub>/comments/<id>`, `/r/<sub>/about/stylesheet`, `/user/<name>/saved`
- **Builds clean** (sim tweak, arm64).
- Full end-to-end (flair picker populates on a live keyless account) is best confirmed on-device with a rebuilt IPA — same verification bar the rest of the keyless Web JSON work carries.

OAuth/API-key accounts are untouched: the rewrite early-returns for them, so their flair path never changes.