### PR TITLE
AI Summaries: fix "Discussion so far" stuck on Summarizing… in Tap-to-Summarize mode

### DIFF
--- a/src/ApolloAISummary.xm
+++ b/src/ApolloAISummary.xm
@@ -137,9 +137,9 @@ static const NSUInteger kApolloAIMaxPostChars = 1400;
 // summary (capped at kApolloAIPostResponseTokens, ~60 words) would be nearly as
 // long as the post itself, defeating the purpose. Gating well above the summary
 // length means a post summary is only offered when it actually condenses the
-// post (~300 words -> roughly a fifth the length). Short posts and boilerplate
+// post (~200 words -> roughly a third the length). Short posts and boilerplate
 // megathreads get no card at all.
-static const NSUInteger kApolloAIMinPostWords = 300;
+static const NSUInteger kApolloAIMinPostWords = 200;
 static const NSUInteger kApolloAIMinComments = 5;
 static const NSUInteger kApolloAIMinCommentChars = 500;
 // The discussion summary is generated ONCE per page open, so we can afford to
@@ -2007,9 +2007,28 @@ static void ApolloAIApplyRestoredState(id headerNode, NSString *fullName) {
         if (ApolloAISetBoxState(headerNode, NO, ApolloAIBoxStateReady, sCommentSummaryCache[fullName])) changed = YES;
     } else if ([sCommentFailed containsObject:fullName]) {
         if (ApolloAISetBoxState(headerNode, NO, ApolloAIBoxStateError, nil)) changed = YES;
-    } else if ([sCommentInFlight containsObject:fullName] ||
-               [sCapturedComments[fullName] count] >= kApolloAIMinComments) {
+    } else if ([sCommentInFlight containsObject:fullName]) {
+        // A generation is genuinely running -> show the loading card.
         if (ApolloAISetBoxState(headerNode, NO, ApolloAIBoxStateLoading, nil)) changed = YES;
+    } else if ([sCapturedComments[fullName] count] >= kApolloAIMinComments) {
+        // Enough discussion captured, but nothing is in flight yet. The state to
+        // restore depends on the mode, and MUST match what ApolloAIGenerateForController
+        // would set (same predicate) or a recycled/reappearing header desyncs:
+        //   • Auto mode: the generation pass drives it, so Loading is the correct
+        //     placeholder while that kicks off.
+        //   • Tap-to-Summarize, not yet tapped: the idle "Tap to summarize" prompt.
+        //     Restoring Loading here was the bug — it left the discussion card stuck
+        //     on "Summarizing…" forever, because no request is ever in flight until
+        //     the user taps, and a Loading card isn't tappable-to-generate (the tap
+        //     handler only starts generation from the TapToSummarize state), so the
+        //     user was wedged with a spinner that never resolved.
+        //   • Tap-to-Summarize, already tapped (key present, e.g. mid concurrency
+        //     retry): keep Loading, since generation is pending.
+        NSString *commentTapKey = [@"comment|" stringByAppendingString:fullName];
+        BOOL awaitingTap = sEnableTapToSummarize && ![sTapRequested containsObject:commentTapKey];
+        ApolloAIBoxState restored = awaitingTap ? ApolloAIBoxStateTapToSummarize
+                                                : ApolloAIBoxStateLoading;
+        if (ApolloAISetBoxState(headerNode, NO, restored, nil)) changed = YES;
     }
     if (changed) {
         // Re-query the row height AND force a real display pass (see
@@ -2801,7 +2820,11 @@ static void ApolloAIGenerateForController(UIViewController *vc) {
         ApolloAISetBoxStateOnMatchingHeaders(fullName, YES, ApolloAIBoxStateTapToSummarize, nil);
         ApolloAIForceHeaderRemeasure(fullName);
     } else if (![sPostInFlight containsObject:fullName] && ![sPostFailed containsObject:fullName]) {
-        [sTapRequested removeObject:postTapKey];   // consume a tap request, if any
+        // Do NOT consume the tap request here — see the matching note in the comment
+        // branch below. A concurrency-deferred retry must still re-drive generation
+        // rather than fall back to the idle "Tap to summarize" prompt; the cacheValid /
+        // in-flight / failed guards above short-circuit this gate on re-entry, and the
+        // whole set is cleared with the caches on reset.
         // Drop a stale cache entry generated under a different mode (e.g. a
         // post-only summary cached before this post was detected as link/both).
         if (sPostSummaryCache[fullName].length > 0) {
@@ -2927,7 +2950,14 @@ static void ApolloAIGenerateForController(UIViewController *vc) {
             ApolloAISetBoxStateOnMatchingHeaders(fullName, NO, ApolloAIBoxStateTapToSummarize, nil);
             ApolloAIForceHeaderRemeasure(fullName);
             } else {
-            [sTapRequested removeObject:commentTapKey];   // consume a tap request, if any
+            // Do NOT consume the tap request here. A transient-concurrency (code 9)
+            // deferral clears sCommentInFlight and re-enters this function ~0.75s later;
+            // if the key were already gone we'd fall back into the idle branch above and
+            // silently revert to "Tap to summarize" instead of finishing the summary the
+            // user asked for (common on posts that also have a post/link summary racing
+            // for the on-device model). The key is harmless once generation starts: the
+            // cache-hit / in-flight / failed guards all short-circuit before this gate on
+            // re-entry, and the whole set is cleared with the caches on reset.
             ApolloAIShowLoadingIfIdle(fullName, NO);
             ApolloAIForceHeaderRemeasure(fullName);
             [sCommentInFlight addObject:fullName];
@@ -3108,6 +3138,15 @@ static void ApolloAILogTableStructure(UIViewController *vc) {
         // whole session.
         [sPostSuppressed removeObject:fullName];
         [sPostEmpty removeObject:fullName];     // per-view, like sPostSuppressed
+        // A Tap-to-Summarize request authorizes generation for THIS viewing only.
+        // We no longer consume the key the instant generation starts (so a
+        // concurrency-deferred retry within the same viewing can still finish — no
+        // viewDidDisappear fires during its 0.75s wait), so clear it here instead,
+        // alongside the in-flight/failed teardown above. Without this the key would
+        // leak across viewings and a previously-tapped post would silently
+        // regenerate on reopen without a fresh tap, defeating the point of the mode.
+        [sTapRequested removeObject:[@"post|" stringByAppendingString:fullName]];
+        [sTapRequested removeObject:[@"comment|" stringByAppendingString:fullName]];
         if (sPostSummaryCache[fullName].length == 0) {
             ApolloAISetBoxStateOnMatchingHeaders(fullName, YES, ApolloAIBoxStateNone, nil);
         }


### PR DESCRIPTION
With **Tap to Summarize** on, the comments "Discussion so far" card would sit on "Summarizing…" forever and never actually summarize (and tapping it did nothing). Turned out to be a few coupled things:

**1. The main one.** `ApolloAIApplyRestoredState` runs every time a comments header (re)appears/recycles, and it was forcing the comment box to `Loading` whenever the captured-comment count hit the threshold — with no Tap-to-Summarize check. The post box doesn't do this (it only shows Loading when a request is genuinely in flight), which is why only the discussion card was affected. So a recycle/remeasure would clobber the idle "Tap to summarize the discussion" prompt with a spinner while nothing was running — and since no generation was in flight, no timeout was scheduled either, so it never resolved. A Loading-state card also isn't tappable-to-generate (the tap handler only kicks off from the `TapToSummarize` state), so the user was fully wedged.

Fix: split "genuinely in flight → Loading" from "captured but idle", and gate the idle case on the *same* predicate the generate path uses, so the restored state matches what `ApolloAIGenerateForController` would set — Tap mode + not-yet-tapped → `TapToSummarize`, otherwise `Loading`.

**2.** The tap request key was consumed the instant generation started, so a transient-concurrency (code 9) retry — pretty common on a post that also has a post/link summary racing for the on-device model, like the release thread — would re-enter the idle branch and silently revert to "Tap to summarize" instead of finishing. Now the key survives the in-session retry.

**3.** Since (2) keeps the key around, I clear it in `viewDidDisappear` (next to the existing in-flight/failed per-view teardown) so a tap only authorizes generation for that viewing — reopening the post shows the idle prompt again rather than auto-generating without a tap.

Also dropped `kApolloAIMinPostWords` 300 → 200 so shorter post bodies still get a summary.

**Testing:** iOS 26 sim. Tap mode now shows the idle "Tap to summarize the discussion" prompt and generates on tap; auto mode still auto-generates a discussion summary end-to-end (`COMMENT summary DONE`). Not device-tested yet.