### PR TITLE
Heartbeat: preserve monthly and opt-out state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,12 +268,11 @@ STAGED_APOLLO_BUNDLE = $(THEOS_STAGING_DIR)/Library/Application Support/ApolloRe
 #   - libflex.dylib is moved into the bundle for rootless (its DynamicLibraries
 #     home doesn't exist rootless);
 #   - libflex.plist is dropped for every scheme (unused);
-#   - the usage-heartbeat build variant is stamped so jailbreak installs report a
-#     channel to beat.apolloreborn.app instead of "unknown". ApolloBuildVariant()
-#     reads this ARVariant.txt marker for .deb installs (there's no repackaged
-#     Info.plist to carry ARBuildVariant the way injected IPAs do). Injected IPAs
-#     stamp Info.plist at packaging time and check it first, so this file being
-#     copied into an IPA's bundle is harmless — the plist key wins.
+#   - the usage-heartbeat build variant marker is stamped for jailbreak installs.
+#     ApolloBuildVariant() reads ARVariant.txt for .deb installs (there's no
+#     repackaged Info.plist to carry ARBuildVariant the way injected IPAs do).
+#     Injected IPAs stamp Info.plist at packaging time and check it first, so
+#     this file being copied into an IPA's bundle is harmless — the plist key wins.
 before-package::
 ifeq ($(THEOS_PACKAGE_SCHEME),rootless)
 	@mv $(THEOS_STAGING_DIR)/Library/MobileSubstrate/DynamicLibraries/libflex.dylib "$(STAGED_APOLLO_BUNDLE)/libflex.dylib"

--- a/scripts/build-test-ipa.sh
+++ b/scripts/build-test-ipa.sh
@@ -109,13 +109,9 @@ else
     echo "Warning: xcodegen not found — test IPA will NOT include Reborn widgets."
 fi
 
-# Stamp the usage-heartbeat build variant (ARBuildVariant in Info.plist) so this
-# test install reports a channel to beat.apolloreborn.app. Without it
-# ApolloBuildVariant() falls back to "unknown", which the server stores as
-# c=null. Default to a dedicated "dev" channel so local test-device beats stay
-# out of the real release-variant counts (glass/ipa/…). NOTE: "dev" must be in
-# the Worker's CHANNELS allowlist, otherwise the server stores it as null too.
-# Override with BUILD_VARIANT=glass to simulate a specific release channel.
+# Stamp the usage-heartbeat build variant (ARBuildVariant in Info.plist) so test
+# installs can be separated from release builds in aggregate reporting. Override
+# with BUILD_VARIANT=glass to simulate a specific release channel.
 BUILD_VARIANT="${BUILD_VARIANT:-dev}"
 echo "Stamping build variant: $BUILD_VARIANT"
 "$BUILD_DIR/scripts/apply-patches.sh" --ipa "$OUTPUT_IPA" -o "$OUTPUT_IPA.bv" \

--- a/scripts/modules/stamp-build-variant.sh
+++ b/scripts/modules/stamp-build-variant.sh
@@ -2,9 +2,8 @@
 # stamp_build_variant_in_app <app_bundle> <variant>
 #
 # Sets ARBuildVariant in the main app's Info.plist so the anonymous usage
-# heartbeat (ApolloUsageHeartbeat.m) can report which build variant this install
-# came from (its "c" field), read back at runtime via ApolloBuildVariant().
-# Keep the <variant> strings in sync with the beat Worker's CHANNELS allowlist.
+# heartbeat (ApolloUsageHeartbeat.m) can include release-channel metadata, read
+# back at runtime via ApolloBuildVariant().
 
 stamp_build_variant_in_app() {
     local app_bundle="$1"

--- a/src/ApolloUsageHeartbeat.h
+++ b/src/ApolloUsageHeartbeat.h
@@ -3,17 +3,16 @@
 __BEGIN_DECLS
 // Fire the anonymous MAU heartbeat if enabled and not already sent today.
 // Safe to call on every foreground; it self-throttles to once per day and
-// never blocks the caller. No-op when the user has opted out. See docs at
-// beat.apolloreborn.app.
+// never blocks the caller. No-op when the user has opted out.
 void ApolloSendUsageHeartbeatIfNeeded(void);
 
-// Opt-out accessors. The disable flag is mirrored into BOTH NSUserDefaults
-// (so the stock settings machinery / backups see it) and the durable heartbeat
-// plist (so it survives a sign-in / settings restore that replaces Apollo's
-// preferences plist — the same wipe the token file already defends against).
-// "Disabled" means either store says so, so a wiped NSUserDefaults can never
-// silently re-enable a user who opted out. Always toggle via the setter, never
-// by writing UDKeyDisableUsageHeartbeat directly, or the two stores desync.
+// Opt-out accessors. The disable flag is mirrored into two stores so the choice
+// survives every wipe path: NSUserDefaults (stock settings / backups, fast) and
+// the Keychain (survives a full delete-and-reinstall, which wipes the app
+// container and NSUserDefaults with it). "Disabled" means EITHER store says so,
+// so no single wipe can silently re-enable a user who opted out. Always toggle
+// via the setter, never by writing UDKeyDisableUsageHeartbeat directly, or the
+// stores desync.
 BOOL ApolloUsageHeartbeatIsDisabled(void);
 void ApolloSetUsageHeartbeatDisabled(BOOL disabled);
 __END_DECLS

--- a/src/ApolloUsageHeartbeat.m
+++ b/src/ApolloUsageHeartbeat.m
@@ -3,19 +3,31 @@
 #import "UserDefaultConstants.h"
 #import "Version.h"
 #import <UIKit/UIKit.h>
+#import <Security/Security.h>
+#import <CommonCrypto/CommonCrypto.h>
 
-// The anonymous Monthly-Active-Users beacon. Once per day at most, POSTs
-// { token, v, c, os } to the endpoint below. The token is a random UUID that
-// rotates every calendar month, so cross-month correlation is impossible — that
-// rotation is the whole privacy design; never replace it with a stable ID.
+// The anonymous Monthly-Active-Users beacon. Once per day at most, posts a
+// monthly identifier plus coarse app/OS metadata to the endpoint below.
+//
+// The token rotates every calendar month and is deliberately uncorrelatable
+// across months — that rotation is the whole privacy design. It is derived on
+// device as token = HMAC-SHA256(seed, "YYYY-MM"), where `seed` is a random value
+// that lives only in the Keychain and NEVER leaves the device (only the monthly
+// HMAC is transmitted). Two consequences, both intended:
+//   - Within a month the token is stable even across an app reinstall (the
+//     Keychain outlives the container), so app reinstalls do not reset the
+//     monthly identity.
+//   - Across months the transmitted tokens are independent hashes; without the
+//     seed (which never leaves the device) they cannot be linked over time.
+// Never transmit the seed, and never derive a token that ignores the month — that
+// would turn this into a cross-month identifier and break the privacy promise.
 static NSString *const kBeatURL = @"https://beat.apolloreborn.app/beat";
 
 // Persistence lives in a dedicated atomically-written plist, NOT NSUserDefaults.
 //
 // Why not NSUserDefaults: the monthly token must be stable across every launch
-// in the month (the server dedups on PRIMARY KEY(month, token) + INSERT OR
-// IGNORE, so a stable token = one row per device per month; a *changed* token
-// double-counts). A token written to NSUserDefaults was observed to vanish
+// in the month.
+// A token written to NSUserDefaults was observed to vanish
 // between two launches seconds apart — not merely a cfprefsd flush-timing issue
 // (a synchronize'd write survives an app-kill because cfprefsd owns it), but
 // because signing in / restoring settings replaces Apollo's whole preferences
@@ -26,9 +38,21 @@ static NSString *const kBeatURL = @"https://beat.apolloreborn.app/beat";
 // (which only overwrites Library/Preferences + Library/Caches plists) never
 // touches it. NSHomeDirectory() resolves to Apollo's own data container.
 static NSString *const kStateMonthKey    = @"month";    // "2026-07"
-static NSString *const kStateTokenKey     = @"token";    // monthly UUID
+static NSString *const kStateTokenKey     = @"token";    // cached derived token for `month`
 static NSString *const kStateLastDayKey   = @"lastDay";  // "2026-07-05"
-static NSString *const kStateDisabledKey  = @"disabled"; // durable opt-out mirror
+static NSString *const kStateDisabledKey  = @"disabled"; // legacy opt-out mirror (read once for migration; no longer written)
+
+// Keychain: the device seed that monthly tokens are derived from. Unlike the
+// Application Support file above (which lives in the app container and is wiped
+// by a full delete-and-reinstall), a Keychain item survives app deletion, so a
+// reinstall within the same month re-derives the same token. Mirrors the SecItem
+// pattern in ApolloWebSessionStore.m — the app
+// already trusts the Keychain to survive re-signs for login sessions, so the
+// seed inherits that same durability (and in the one case it doesn't survive, a
+// re-sign under a different Apple ID, the user is logged out anyway).
+static NSString *const kHeartbeatKeychainService       = @"com.christianselig.Apollo.heartbeat";
+static NSString *const kHeartbeatKeychainSeedAccount    = @"deviceSeed";
+static NSString *const kHeartbeatKeychainOptOutAccount  = @"optOut";
 
 static NSString *ApolloHeartbeatStatePath(void) {
     static NSString *path;
@@ -56,7 +80,7 @@ static void ApolloHeartbeatWriteState(NSDictionary *state) {
     [state writeToFile:ApolloHeartbeatStatePath() atomically:YES];
 }
 
-// UTC day/month keys so they line up with the server's UTC month buckets.
+// UTC day/month keys keep all clients on the same calendar boundary.
 static NSString *ApolloUTCKey(NSString *format) {
     static NSDateFormatter *fmt;  // reused; guarded by the main-thread call sites
     static dispatch_once_t once;
@@ -76,70 +100,184 @@ static NSString *ApolloHeartbeatVersion(void) {
     return v;
 }
 
-// Returns the token for the current month, rotating (new UUID) when the month
-// changes, persisting {month, token} back into `state`. `didRotate` is set to
-// YES when a fresh token was minted (so the caller flushes immediately).
+// ── Device seed (Keychain) ───────────────────────────────────────────────────
+static NSData *ApolloHeartbeatKeychainReadSeed(void) {
+    NSDictionary *query = @{
+        (__bridge id)kSecClass:       (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService: kHeartbeatKeychainService,
+        (__bridge id)kSecAttrAccount: kHeartbeatKeychainSeedAccount,
+        (__bridge id)kSecReturnData:  (__bridge id)kCFBooleanTrue,
+        (__bridge id)kSecMatchLimit:  (__bridge id)kSecMatchLimitOne,
+    };
+    CFTypeRef result = NULL;
+    OSStatus st = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
+    if (st != errSecSuccess || !result) return nil;
+    return (__bridge_transfer NSData *)result;
+}
+
+static void ApolloHeartbeatKeychainWriteSeed(NSData *seed) {
+    NSDictionary *match = @{
+        (__bridge id)kSecClass:       (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService: kHeartbeatKeychainService,
+        (__bridge id)kSecAttrAccount: kHeartbeatKeychainSeedAccount,
+    };
+    NSDictionary *update = @{ (__bridge id)kSecValueData: seed };
+    OSStatus st = SecItemUpdate((__bridge CFDictionaryRef)match, (__bridge CFDictionaryRef)update);
+    if (st == errSecItemNotFound) {
+        NSMutableDictionary *add = [match mutableCopy];
+        add[(__bridge id)kSecValueData] = seed;
+        // AfterFirstUnlock: readable once the device has been unlocked since boot,
+        // matching ApolloWebSessionStore so a foreground beat isn't blocked by a
+        // still-locked keychain right after a reboot.
+        add[(__bridge id)kSecAttrAccessible] = (__bridge id)kSecAttrAccessibleAfterFirstUnlock;
+        st = SecItemAdd((__bridge CFDictionaryRef)add, NULL);
+    }
+    if (st != errSecSuccess) ApolloLog(@"[heartbeat] keychain seed write failed (OSStatus %d)", (int)st);
+}
+
+// The device seed: 32 CSPRNG bytes, created once and reused forever. Never
+// transmitted — only monthly HMACs of it leave the device.
+static NSData *ApolloHeartbeatDeviceSeed(void) {
+    NSData *seed = ApolloHeartbeatKeychainReadSeed();
+    if (seed.length >= 16) return seed;
+    NSMutableData *fresh = [NSMutableData dataWithLength:32];
+    if (SecRandomCopyBytes(kSecRandomDefault, fresh.length, fresh.mutableBytes) != errSecSuccess) {
+        uuid_t u; [[NSUUID UUID] getUUIDBytes:u];  // vanishingly unlikely fallback
+        fresh = [NSMutableData dataWithBytes:u length:sizeof(u)];
+    }
+    ApolloHeartbeatKeychainWriteSeed(fresh);
+    return fresh;
+}
+
+// token(month) = first 16 bytes of HMAC-SHA256(seed, month), formatted as a
+// lowercase UUID string. Deterministic per (seed, month): identical across
+// reinstalls within a month, independent (unlinkable without the seed) across
+// months.
+static NSString *ApolloDerivedMonthlyToken(NSData *seed, NSString *month) {
+    NSData *msg = [month dataUsingEncoding:NSUTF8StringEncoding];
+    unsigned char mac[CC_SHA256_DIGEST_LENGTH];
+    CCHmac(kCCHmacAlgSHA256, seed.bytes, seed.length, msg.bytes, msg.length, mac);
+    return [NSString stringWithFormat:
+            @"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], mac[6], mac[7],
+            mac[8], mac[9], mac[10], mac[11], mac[12], mac[13], mac[14], mac[15]];
+}
+
+// Returns the token for the current month. Reuses the cached token when it's
+// still the same month — this carries a token minted by an OLDER app version (a
+// random UUID) through the end of its month, so updating mid-month doesn't add a
+// second row. Otherwise (new month, first run, or a reinstall that wiped the
+// cache) it derives from the Keychain seed; because derivation is deterministic,
+// a reinstall re-derives the same value. `didRotate` is set when a fresh token
+// was written (so the caller flushes the cache).
 static NSString *ApolloMonthlyToken(NSMutableDictionary *state, NSString *month, BOOL *didRotate) {
     NSString *storedMonth = state[kStateMonthKey];
     NSString *token       = state[kStateTokenKey];
-    if (![storedMonth isEqualToString:month] || [token length] == 0) {
-        token = [[NSUUID UUID] UUIDString];  // server lowercases; case doesn't matter
-        state[kStateMonthKey] = month;
-        state[kStateTokenKey] = token;
-        if (didRotate) *didRotate = YES;
-    }
+    if ([storedMonth isEqualToString:month] && token.length > 0) return token;
+
+    token = ApolloDerivedMonthlyToken(ApolloHeartbeatDeviceSeed(), month);
+    state[kStateMonthKey] = month;
+    state[kStateTokenKey] = token;
+    if (didRotate) *didRotate = YES;
     return token;
 }
 
-// Opt-out is stored in two places that must agree: NSUserDefaults (so the stock
-// settings/backups see it) and the durable heartbeat plist (so it survives the
-// sign-in / settings-restore wipe that clobbers Apollo's preferences plist —
-// exactly the failure mode the token file already guards against). If we only
-// kept it in NSUserDefaults, a user who opted out would silently start beating
-// again after their next sign-in. Read "disabled" as the OR of both stores so a
-// wiped default can't re-enable them.
+// Opt-out mirror in the Keychain. The item's PRESENCE means "opted out"; opting
+// back in removes it. Like the device seed, this outlives a delete-and-reinstall
+// (the NSUserDefaults + container plist mirrors do not), which fixes the consent
+// bug where someone who turned the heartbeat OFF, deleted the app, and
+// reinstalled came back silently opted IN (the on-by-default state).
+static BOOL ApolloHeartbeatKeychainReadOptOut(void) {
+    NSDictionary *query = @{
+        (__bridge id)kSecClass:       (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService: kHeartbeatKeychainService,
+        (__bridge id)kSecAttrAccount: kHeartbeatKeychainOptOutAccount,
+        (__bridge id)kSecMatchLimit:  (__bridge id)kSecMatchLimitOne,
+    };
+    return SecItemCopyMatching((__bridge CFDictionaryRef)query, NULL) == errSecSuccess;
+}
+
+static void ApolloHeartbeatKeychainWriteOptOut(BOOL optedOut) {
+    NSDictionary *match = @{
+        (__bridge id)kSecClass:       (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecAttrService: kHeartbeatKeychainService,
+        (__bridge id)kSecAttrAccount: kHeartbeatKeychainOptOutAccount,
+    };
+    if (!optedOut) { SecItemDelete((__bridge CFDictionaryRef)match); return; }
+    NSMutableDictionary *add = [match mutableCopy];
+    add[(__bridge id)kSecValueData]      = [@"1" dataUsingEncoding:NSUTF8StringEncoding];
+    add[(__bridge id)kSecAttrAccessible] = (__bridge id)kSecAttrAccessibleAfterFirstUnlock;
+    OSStatus st = SecItemAdd((__bridge CFDictionaryRef)add, NULL);
+    if (st != errSecSuccess && st != errSecDuplicateItem)
+        ApolloLog(@"[heartbeat] keychain opt-out write failed (OSStatus %d)", (int)st);
+}
+
+// One-time migration for opt-outs made by older builds, which stored the flag
+// only in NSUserDefaults + the container plist — neither survives a reinstall.
+// Back a pre-existing opt-out into the Keychain so it becomes durable too;
+// without this, an already-opted-out user would still get silently re-enabled by
+// their next reinstall (the bug the Keychain mirror fixes going forward).
+static void ApolloHeartbeatMigrateOptOutToKeychain(void) {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        if (ApolloHeartbeatKeychainReadOptOut()) return; // already durable
+        BOOL ud     = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyDisableUsageHeartbeat];
+        BOOL legacy = [ApolloHeartbeatReadState()[kStateDisabledKey] boolValue];
+        if (ud || legacy) ApolloHeartbeatKeychainWriteOptOut(YES);
+    });
+}
+
+// Opt-out lives in two stores: NSUserDefaults (fast, and what the stock settings
+// machinery / backups see) and the Keychain (which survives every wipe path,
+// including a full delete-and-reinstall that takes the app container and
+// NSUserDefaults with it). "Disabled" is the OR of the two, so a wiped
+// NSUserDefaults can't silently re-enable a user who opted out, and the setter
+// writes both together. (Older builds also mirrored this into the container
+// plist; that copy is now redundant with the Keychain — see the migration above
+// — and is no longer read or written, which also removes a read-modify-write
+// race with the beat's completion handler.)
 BOOL ApolloUsageHeartbeatIsDisabled(void) {
     if ([[NSUserDefaults standardUserDefaults] boolForKey:UDKeyDisableUsageHeartbeat]) return YES;
-    return [ApolloHeartbeatReadState()[kStateDisabledKey] boolValue];
+    return ApolloHeartbeatKeychainReadOptOut();
 }
 
 void ApolloSetUsageHeartbeatDisabled(BOOL disabled) {
     [[NSUserDefaults standardUserDefaults] setBool:disabled forKey:UDKeyDisableUsageHeartbeat];
-    NSMutableDictionary *state = ApolloHeartbeatReadState();
-    state[kStateDisabledKey] = @(disabled);
-    ApolloHeartbeatWriteState(state);
+    ApolloHeartbeatKeychainWriteOptOut(disabled);
 }
 
 void ApolloSendUsageHeartbeatIfNeeded(void) {
 #if APOLLO_SIM_BUILD
-    // Never beat from a simulator dev build: it's unstamped (c=unknown) and every
-    // reinstall wipes the container, minting a fresh token that would pollute real
-    // MAU. Compiled out entirely so no request can escape the sim.
+    // Never send from simulator dev builds. They are frequently wiped/reinstalled
+    // during local iteration and should not be included in release telemetry.
     return;
 #endif
 
+    ApolloHeartbeatMigrateOptOutToKeychain();
     if (ApolloUsageHeartbeatIsDisabled()) return;
 
     NSMutableDictionary *state = ApolloHeartbeatReadState();
 
-    // Once per day. Losing this only costs an extra (server-deduped) request, so
-    // it's fine that it shares the file with the token.
+    // Once per day. Losing this only costs an extra best-effort send, so it's
+    // fine that it shares the file with the token.
     NSString *today = ApolloUTCKey(@"yyyy-MM-dd");
     if ([state[kStateLastDayKey] isEqualToString:today]) return;
 
     NSString *month = ApolloUTCKey(@"yyyy-MM");
     BOOL rotated = NO;
     NSString *token = ApolloMonthlyToken(state, month, &rotated);
-    // Flush a freshly minted token to disk NOW, before the async network call —
-    // a quick app-kill between here and the response must not lose it, or the
-    // next launch mints a different token for the same month and double-counts.
+    // Flush the freshly cached token now. This is no longer correctness-critical
+    // (the token is derived deterministically from the Keychain seed, so a launch
+    // that lost this write re-derives the identical value), but it keeps the fast
+    // path fast and preserves an adopted legacy token across the transition month.
     if (rotated) ApolloHeartbeatWriteState(state);
 
+    if (token.length == 0) return; // derivation always yields one; guard anyway
     NSDictionary *payload = @{
         @"token": token,
-        @"v":     ApolloHeartbeatVersion(),
-        @"c":     ApolloBuildVariant(),
-        @"os":    UIDevice.currentDevice.systemVersion,
+        @"v":     ApolloHeartbeatVersion() ?: @"",
+        @"c":     ApolloBuildVariant()     ?: @"unknown",
+        @"os":    UIDevice.currentDevice.systemVersion ?: @"",
     };
     NSData *body = [NSJSONSerialization dataWithJSONObject:payload options:0 error:NULL];
     if (!body) return;

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -2342,8 +2342,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 }
 
 - (void)usageHeartbeatSwitchToggled:(UISwitch *)sender {
-    // Mirror the opt-out into both NSUserDefaults and the durable heartbeat plist
-    // so a sign-in / settings restore can't silently re-enable it. on = NOT disabled.
+    // Mirror the opt-out into durable storage. on = NOT disabled.
     ApolloSetUsageHeartbeatDisabled(!sender.isOn);
 }
 

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -2051,10 +2051,8 @@ static void initializeRandomSources() {
     }
 
     // Anonymous MAU heartbeat: fire on every foreground; the once-a-day throttle
-    // (and the opt-out flag) inside ApolloSendUsageHeartbeatIfNeeded handle the
-    // rest. Registering the observer here avoids hunting for an app-lifecycle
-    // hook. beat.apolloreborn.app is our own first-party, opt-out-able endpoint
-    // and is deliberately NOT in the blockedUrls telemetry list.
+    // and opt-out flag inside ApolloSendUsageHeartbeatIfNeeded handle the rest.
+    // Registering the observer here avoids hunting for an app-lifecycle hook.
     [[NSNotificationCenter defaultCenter]
         addObserverForName:UIApplicationDidBecomeActiveNotification
                     object:nil

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -287,9 +287,9 @@ static NSString *const UDKeyLastDeviceTokenHex = @"BarkLastDeviceTokenHex";
 // hosted icon on Bark notifications via the push URL's ?icon= parameter.
 static NSString *const UDKeyBarkSelectedIconName = @"BarkSelectedIconName";
 
-// Anonymous MAU heartbeat (beat.apolloreborn.app). ON by default; this is the
-// opt-OUT, mirroring the DisableApollonouncements pattern (a disable flag that
-// defaults to NO gives us on-by-default). See ApolloUsageHeartbeat.{h,m}.
+// Anonymous MAU heartbeat. ON by default; this is the opt-OUT, mirroring the
+// DisableApollonouncements pattern (a disable flag that defaults to NO gives us
+// on-by-default). See ApolloUsageHeartbeat.{h,m}.
 static NSString *const UDKeyDisableUsageHeartbeat = @"DisableUsageHeartbeat";
 // Internal bookkeeping for the heartbeat (not user-facing).
 static NSString *const UDKeyHeartbeatMonth   = @"UsageHeartbeatMonth";   // "2026-07"


### PR DESCRIPTION
## Summary

- Keep the anonymous heartbeat's monthly client state in durable on-device storage so reinstalling the app does not reset it mid-month.
- Mirror the heartbeat opt-out into durable storage, including a one-time migration for existing opt-outs.
- Add defensive nil guards around heartbeat metadata and trim public comments around build metadata.

## Validation

- `make package`

This PR is intentionally scoped to client-side persistence and consent behavior.
