### PR TITLE
Remove the "Subscribe to r/ApolloApp?" pop-up on first sign-in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloAccountCredentials.m \
     $(SRC_DIR)/ApolloAccountSwitcherViewController.xm \
     $(SRC_DIR)/ApolloSignInSplash.xm \
+    $(SRC_DIR)/ApolloHideSubscribePrompt.xm \
     $(SRC_DIR)/CustomAPIViewController.m \
     $(SRC_DIR)/ApolloAISettingsViewController.m \
     $(SRC_DIR)/ApolloDeletedCommentsSettingsViewController.m \

--- a/src/ApolloHideSubscribePrompt.xm
+++ b/src/ApolloHideSubscribePrompt.xm
@@ -1,0 +1,58 @@
+// ApolloHideSubscribePrompt
+//
+// Removes the "Subscribe to r/ApolloApp?" pop-up that Apollo throws up the
+// first time you sign in with a Reddit account ("The official subreddit for
+// this app! Subscribe to the community for news on the app, feature requests,
+// and more!"). It's an unwanted extra tap on every fresh login, so we just
+// never let it appear.
+//
+// How it works: Apollo builds this as a stock UIAlertController and shows it
+// with -[UIViewController presentViewController:animated:completion:] from deep
+// inside its post-login "sync subscribed subreddits" routine (Hopper:
+// sub_100839a70, the branch gated on the subreddit name matching "apolloapp").
+// That same routine presents plenty of *legitimate* alerts (errors, other
+// confirmations), so we can't blanket-suppress presentation — we match on the
+// two exact, unique prompt titles and pass everything else straight through.
+//
+// Suppressing the presentation is side-effect free: Apollo fires the alert with
+// a nil completion and only mutates state from the No/Yes action handlers, which
+// only run on a user tap. Never presenting it == the user silently declined,
+// which is exactly the desired behavior.
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+#import "ApolloCommon.h"
+
+// The two prompt variants, verbatim from the Apollo binary's __cstring
+// (0x100a86eb0 / 0x100a86f50). Matching the exact titles — rather than a
+// "Subscribe to r/ApolloApp" prefix — avoids ever catching a genuine subscribe
+// confirmation for an unrelated subreddit (e.g. a hypothetical r/ApolloApple).
+static BOOL ApolloIsAppSubredditSubscribePrompt(UIViewController *presented) {
+    if (![presented isKindOfClass:[UIAlertController class]]) return NO;
+
+    NSString *title = [(UIAlertController *)presented title];
+    if (title.length == 0) return NO;
+
+    return [title isEqualToString:@"Subscribe to r/ApolloApp?"] ||
+           [title isEqualToString:@"Subscribe to r/ApolloAppBeta Beta Subreddit?"];
+}
+
+%hook UIViewController
+
+- (void)presentViewController:(UIViewController *)viewControllerToPresent
+                     animated:(BOOL)animated
+                   completion:(void (^)(void))completion {
+    if (ApolloIsAppSubredditSubscribePrompt(viewControllerToPresent)) {
+        ApolloLog(@"Suppressed the r/ApolloApp subscribe prompt (\"%@\")",
+                  [(UIAlertController *)viewControllerToPresent title]);
+        // Honor the presentation contract: the completion block normally runs
+        // once the alert finishes animating in. Apollo passes nil here, but a
+        // future/other caller might not, so fire it rather than swallow it.
+        if (completion) completion();
+        return;
+    }
+    %orig;
+}
+
+%end


### PR DESCRIPTION
When you first sign in with your Reddit account you get hit with this "Subscribe to r/ApolloApp?" pop-up asking you to join the app's subreddit. It's just an extra annoying step everyone has to dismiss on every fresh login, so this gets rid of it for good.

**How it works:** the prompt is a plain `UIAlertController` Apollo shows from its post-login "sync subscribed subreddits" routine. That same code path also shows a bunch of legit alerts (errors, other confirmations), so I couldn't just block presentation across the board. New `ApolloHideSubscribePrompt.xm` hooks `-[UIViewController presentViewController:animated:completion:]` and only swallows the two exact prompt titles ("Subscribe to r/ApolloApp?" and the beta "Subscribe to r/ApolloAppBeta Beta Subreddit?"), letting everything else through. Checked the binary — those are the only two titles that start with "Subscribe to r/", so no chance of eating a real subscribe confirmation for some other subreddit.

Swallowing it is harmless: Apollo fires the alert with a nil completion and only changes any state from the No/Yes handlers (which need a tap), so never showing it is the same as the user tapping No.

<img width="539" height="458" alt="Pop up during log in" src="https://github.com/user-attachments/assets/c1cb9276-d3b3-4254-83f5-ac79478345af" />

**Testing:** sim-verified (drove the real-titled alert through the app — it gets suppressed, a differently-titled control alert still shows fine so it's not over-broad). Device `make package` builds clean. Haven't run a real fresh sign-in on device yet.
