### PR TITLE
Fix media-post freeze when tapping "Text (optional)" on iOS 26

### DIFF
--- a/src/ApolloPhotoPostComposerScrollFix.xm
+++ b/src/ApolloPhotoPostComposerScrollFix.xm
@@ -82,6 +82,8 @@ static char kApolloMediaComposerBodyToolbarRetriesScheduledKey;
 static char kApolloMediaComposerBodyEditorFreshOpenKey;
 static char kApolloMediaComposerNativeBodyEditorOwnerKey;
 static char kApolloMediaComposerNativeBodyEditorSavedKey;
+static char kApolloMediaComposerBodyDoneItemKey;
+static char kApolloMediaComposerBodyCancelItemKey;
 static BOOL sApolloMediaComposerContextActive = NO;
 static BOOL sApolloMediaComposerPickerActive = NO;
 static BOOL sApolloMediaComposerInlineBodyPickerActive = NO;
@@ -1520,28 +1522,64 @@ static void ApolloMediaComposerConfigureNativeBodyEditor(UIViewController *edito
     UIViewController *ownerController = ApolloMediaComposerOwnerForNativeBodyEditor(editor);
     if (!ownerController) return;
 
-    editor.title = @"Text (optional)";
-    editor.navigationItem.title = @"Text (optional)";
-    UIColor *accentColor = ApolloPhotoComposerAccentColor(ownerController) ?: ownerController.view.tintColor ?: editor.view.tintColor;
+    // Idempotency guard. This runs from viewDidLoad/viewWillAppear/viewDidAppear AND
+    // viewDidLayoutSubviews. The original body allocated two fresh UIBarButtonItems and
+    // unconditionally reassigned navigationItem.rightBarButtonItem(s)/leftBarButtonItem
+    // (a *structural* nav-bar mutation) on every layout pass. On the iOS 26 Liquid Glass
+    // nav bar, _UINavigationBarContentView self-sizes its bar-button/title subtree via
+    // -_calculatedSystemLayoutSizeFittingSize inside the same CATransaction commit;
+    // reassigning the items from within a layout callback re-invalidates that measurement
+    // and re-dirties the controller's layout, so the pass never converges and the
+    // scene-update watchdog fires (0x8BADF00D) after 10s — the reported "Text (optional)"
+    // freeze. Fix: create the Done/Cancel pair once, cache it, and only write nav-bar /
+    // title / tint inputs when they actually differ, so steady-state passes are no-ops and
+    // no re-measure loop can form. (See the compose-freeze investigation; the #586 dynamic
+    // accent color only accelerated the loop, it was not the cause.)
+    UIBarButtonItem *doneItem = objc_getAssociatedObject(editor, &kApolloMediaComposerBodyDoneItemKey);
+    UIBarButtonItem *cancelItem = objc_getAssociatedObject(editor, &kApolloMediaComposerBodyCancelItemKey);
+    BOOL firstConfigure = (![doneItem isKindOfClass:[UIBarButtonItem class]] || ![cancelItem isKindOfClass:[UIBarButtonItem class]]);
 
-    UIBarButtonItem *doneItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:editor action:@selector(apollo_mediaBodyDoneButtonTapped:)];
-    UIBarButtonItem *cancelItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:editor action:@selector(apollo_mediaBodyCancelButtonTapped:)];
-    if (accentColor) {
-        doneItem.tintColor = accentColor;
-        cancelItem.tintColor = accentColor;
-        editor.view.tintColor = accentColor;
+    if (firstConfigure) {
+        UIColor *accentColor = ApolloPhotoComposerAccentColor(ownerController) ?: ownerController.view.tintColor ?: editor.view.tintColor;
+        doneItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:editor action:@selector(apollo_mediaBodyDoneButtonTapped:)];
+        cancelItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:editor action:@selector(apollo_mediaBodyCancelButtonTapped:)];
+        if (accentColor) {
+            doneItem.tintColor = accentColor;
+            cancelItem.tintColor = accentColor;
+            editor.view.tintColor = accentColor;
+        }
+        objc_setAssociatedObject(editor, &kApolloMediaComposerBodyDoneItemKey, doneItem, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(editor, &kApolloMediaComposerBodyCancelItemKey, cancelItem, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+        @try { [editor setValue:doneItem forKey:@"postBarButtonItem"]; } @catch (__unused NSException *e) {}
+        @try { [editor setValue:doneItem forKey:@"postWithCharactersRemainingBarButtonItem"]; } @catch (__unused NSException *e) {}
+        @try { [editor setValue:@NO forKey:@"submitTapped"]; } @catch (__unused NSException *e) {}
     }
-    editor.navigationItem.rightBarButtonItem = doneItem;
-    editor.navigationItem.rightBarButtonItems = @[doneItem];
-    editor.navigationItem.leftBarButtonItem = cancelItem;
 
-    @try { [editor setValue:doneItem forKey:@"postBarButtonItem"]; } @catch (__unused NSException *e) {}
-    @try { [editor setValue:doneItem forKey:@"postWithCharactersRemainingBarButtonItem"]; } @catch (__unused NSException *e) {}
-    @try { [editor setValue:@NO forKey:@"submitTapped"]; } @catch (__unused NSException *e) {}
+    if (![editor.title isEqualToString:@"Text (optional)"]) editor.title = @"Text (optional)";
+    UINavigationItem *navigationItem = editor.navigationItem;
+    if (![navigationItem.title isEqualToString:@"Text (optional)"]) navigationItem.title = @"Text (optional)";
 
+    // Only (re-)assert the items when they are not already ours; if Apollo ever clobbers
+    // them we re-apply, but steady-state passes write nothing and never touch the nav bar.
+    if (navigationItem.rightBarButtonItem != doneItem) navigationItem.rightBarButtonItem = doneItem;
+    NSArray<UIBarButtonItem *> *rightItems = navigationItem.rightBarButtonItems;
+    if (rightItems.count != 1 || rightItems.firstObject != doneItem) navigationItem.rightBarButtonItems = @[doneItem];
+    if (navigationItem.leftBarButtonItem != cancelItem) navigationItem.leftBarButtonItem = cancelItem;
+
+    // Seeding is internally one-shot (guarded by kApolloMediaComposerBodyTextViewSeededKey)
+    // and does no layout-dirtying work, so it stays callable — the text view may not exist
+    // yet on the first (viewDidLoad) pass.
     ApolloMediaComposerSeedNativeBodyEditorTextView(editor, ownerController, @"configure-native-compose");
-    ApolloMediaComposerApplyNativeEditorToolbarRestrictions(editor, ownerController, @"native-compose-configure");
-    ApolloMediaComposerScheduleNativeEditorToolbarRetries(editor, ownerController);
+
+    // The keyboard/markdown accessory toolbar is hosted asynchronously and its gating helper
+    // walks every visible window (expensive). Do it once here and let the one-shot retry
+    // schedule (0.1–2.5s) plus MarkVisibleNativeBodyTextViews catch the late toolbar, instead
+    // of walking every window on every layout pass.
+    if (firstConfigure) {
+        ApolloMediaComposerApplyNativeEditorToolbarRestrictions(editor, ownerController, @"native-compose-configure");
+        ApolloMediaComposerScheduleNativeEditorToolbarRetries(editor, ownerController);
+    }
 }
 
 static void ApolloMediaComposerSaveNativeBodyEditor(UIViewController *editor, NSString *reason, BOOL updatePreview) {


### PR DESCRIPTION
Someone hit this on a shipped 3.4.0 build (iOS 26.5.1): make a Media post, tap the **"Text (optional)"** row, and the whole app freezes and eventually gets watchdog-killed (`0x8BADF00D`, scene-update, 10s). The crash stack is a runaway Auto Layout pass — `_calculatedSystemLayoutSizeFittingSize` → `_UIViewTopDownSubtreeTraversal` inside a CATransaction commit, no tweak frames.

### What's going on
Tapping the row presents the native `ComposeViewController` body editor, and its `viewDidLayoutSubviews` re-ran `ApolloMediaComposerConfigureNativeBodyEditor` on **every** layout pass. That helper allocated a fresh Done/Cancel `UIBarButtonItem` pair and reassigned `navigationItem.rightBarButtonItem(s)`/`leftBarButtonItem` (a structural nav-bar mutation) each pass. On the iOS 26 Liquid Glass nav bar, `_UINavigationBarContentView` self-sizes its bar-button subtree via `systemLayoutSizeFittingSize` inside the same commit — so re-arming the items from within a layout callback re-invalidates that measurement and re-dirties layout, and the commit never converges.

It "worked before" because pre-26 nav bars didn't self-size that subtree, so the identical per-pass churn was just harmless jank. (The #586 dynamic theme accent only made it tip over faster — it's an amplifier, not the cause.)

### Fix
Make `ConfigureNativeBodyEditor` idempotent: create/cache the Done/Cancel pair once, do the accent + toolbar-restriction work once, and only write title / nav-item / tint inputs when they actually differ. Steady-state layout passes now touch the nav bar zero times, so no re-measure loop can form. Behaviour is otherwise unchanged (buttons still created/assigned, toolbar image-insert still gated on the Media tab, seeding still one-shot).

### Testing
Verified in the simulator (iOS 26 glass, signed in), tapping "Text (optional)" on a Media post:
- **Before:** main thread pegs 96–99% CPU and stays there, editor never presents (frozen). A `sample` shows recursive `-[UINavigationBar layoutSublayersOfLayer:]` → `_performWithFallbackEnvironment` → `_systemLayoutSizeFittingSize` → `_calculatedSystemLayoutSizeFittingSize`, matching the crash report.
- **After:** CPU idle, editor presents normally (Done/Cancel + markdown toolbar), image-insert stays disabled on the Media tab, typed body text saves back to the row.

Not device-tested yet.
