### PR TITLE
Fix Open X/Twitter links in-app instead of always kicking out to Safari

### DIFF
--- a/src/ApolloShareLinks.xm
+++ b/src/ApolloShareLinks.xm
@@ -2,9 +2,19 @@
 #import <objc/runtime.h>
 #import <objc/message.h>
 
+#import <SafariServices/SafariServices.h>
+
 #import "ApolloCommon.h"
 #import "Tweak.h"
 #import "UIWindow+Apollo.h"
+
+// Apollo's own in-app browser — an SFSafariViewController subclass presented for
+// the "In-App Safari" browser option. Declared here only so we can message
+// -initWithURL:; the class itself is looked up at runtime (objc_getClass) so there
+// is no link-time dependency on the app binary.
+@interface _TtC6Apollo26ApolloSafariViewController : UIViewController
+- (instancetype)initWithURL:(NSURL *)url;
+@end
 
 // Regex for opaque share links
 static NSString *const ShareLinkRegexPattern = @"^(?:https?:)?//(?:www\\.|new\\.|np\\.)?reddit\\.com/(?:r|u)/(\\w+)/s/(\\w+)$";
@@ -348,14 +358,88 @@ static BOOL ApolloTryOpenViaUniversalLink(NSURL *url, NSString *serviceName, NSS
     return YES;
 }
 
+static BOOL ApolloIsTwitterHost(NSString *host) {
+    return ApolloHostMatchesDomains(host, @[@"twitter.com", @"x.com"]);
+}
+
+// Is the user's global "Open Links in" browser preference set to the *system*
+// browser? Mirrors Apollo's native setting (key "OpenLinksIn", tokens
+// "in-app-safari" / "external-safari"); a missing value means the in-app default.
+static BOOL ApolloOpensLinksInSystemBrowser(void) {
+    NSString *token = [[NSUserDefaults standardUserDefaults] stringForKey:@"OpenLinksIn"];
+    return [token isEqualToString:@"external-safari"];
+}
+
+// Present `url` in Apollo's in-app browser (the same SFSafariViewController
+// subclass Apollo uses for "In-App Safari"), falling back to a plain external open
+// if it can't be presented so the link is never silently dropped. Main thread only.
+static void ApolloPresentInAppSafari(NSURL *url) {
+    if (![url isKindOfClass:[NSURL class]]) return;
+
+    UIViewController *presenter = nil;
+    for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+        if ([scene isKindOfClass:[UIWindowScene class]]) {
+            UIWindow *keyWindow = ((UIWindowScene *)scene).keyWindow;
+            if (keyWindow) presenter = [keyWindow visibleViewController];
+        }
+    }
+
+    UIViewController *safariVC = nil;
+    Class apolloSafariClass = objc_getClass("_TtC6Apollo26ApolloSafariViewController");
+    if (apolloSafariClass) {
+        safariVC = [(_TtC6Apollo26ApolloSafariViewController *)[apolloSafariClass alloc] initWithURL:url];
+    }
+    if (!safariVC) {
+        safariVC = [[SFSafariViewController alloc] initWithURL:url];
+    }
+
+    if (safariVC && presenter) {
+        ApolloLog(@"[ShareLinks] Presenting X/Twitter link in in-app Safari: %@", url);
+        [presenter presentViewController:safariVC animated:YES completion:nil];
+    } else {
+        ApolloLog(@"[ShareLinks] In-app Safari unavailable, opening X/Twitter link externally: %@", url);
+        [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+    }
+}
+
+// X/Twitter links. Apollo routes these through its own "Open Tweets in" picker
+// (key OpenTwitterLinksIn) instead of the global browser setting, and Reborn hides
+// that picker — leaving tweets stuck opening in the *system* browser even when the
+// user picked In-App Safari. Bring tweets in line with every other link: open the
+// X app when it's installed (Universal Links, matching Apollo's usual behavior),
+// and otherwise honor the global browser choice — In-App Safari here (the system
+// browser case is handled by letting the original handler run). Returns YES if we
+// handled the tap (caller must not call %orig).
+static BOOL ApolloTryOpenTwitterInApp(NSURL *url) {
+    if (![url isKindOfClass:[NSURL class]] || !ApolloIsTwitterHost(url.host)) return NO;
+
+    // User wants the system browser globally: Apollo's own external open already
+    // does the right thing (X app if installed, else system Safari) — leave it be.
+    if (ApolloOpensLinksInSystemBrowser()) return NO;
+
+    NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+    components.scheme = @"https";
+    NSURL *httpsURL = components.URL ?: url;
+
+    ApolloLog(@"[ShareLinks] Routing X/Twitter link, trying X app first: %@", httpsURL);
+    [[UIApplication sharedApplication] openURL:httpsURL
+                                       options:@{UIApplicationOpenURLOptionUniversalLinksOnly: @YES}
+                             completionHandler:^(BOOL openedInXApp) {
+        if (openedInXApp) {
+            ApolloLog(@"[ShareLinks] Opened X/Twitter link in the X app: %@", httpsURL);
+            return;
+        }
+        ApolloLog(@"[ShareLinks] X app unavailable, using in-app Safari: %@", httpsURL);
+        dispatch_async(dispatch_get_main_queue(), ^{ ApolloPresentInAppSafari(httpsURL); });
+    }];
+    return YES;
+}
+
 // Unified entry point used by every tappable-link handler: route the link to its
-// dedicated app if the matching "Open ... in App" toggle is on. Steam keeps its
-// own helper (it normalizes the host first); GitHub / Bluesky use the generic
-// Universal Links opener. Keys here must match UserDefaultConstants.h.
-//
-// X/Twitter is intentionally absent: Apollo already ships a native "Open Tweets
-// in" picker (key OpenTwitterLinksIn) that even supports third-party clients
-// (Tweetbot/Twitterrific/etc.), so a Reborn toggle would only duplicate it.
+// dedicated app / preferred browser. Steam keeps its own helper (it normalizes the
+// host first); GitHub / Bluesky use the generic Universal Links opener; X/Twitter
+// has its own helper (see ApolloTryOpenTwitterInApp above). Keys here must match
+// UserDefaultConstants.h.
 static BOOL ApolloTryOpenInDedicatedApp(NSURL *url, void (^fallbackHandler)(void)) {
     if (![url isKindOfClass:[NSURL class]]) return NO;
     if (ApolloTryOpenInSteamApp(url, fallbackHandler)) return YES;
@@ -364,6 +448,7 @@ static BOOL ApolloTryOpenInDedicatedApp(NSURL *url, void (^fallbackHandler)(void
         ApolloTryOpenViaUniversalLink(url, @"GitHub", @"OpenLinksInGitHubApp", fallbackHandler)) return YES;
     if (ApolloIsBlueskyHost(host) &&
         ApolloTryOpenViaUniversalLink(url, @"Bluesky", @"OpenLinksInBlueskyApp", fallbackHandler)) return YES;
+    if (ApolloIsTwitterHost(host) && ApolloTryOpenTwitterInApp(url)) return YES;
     return NO;
 }
 


### PR DESCRIPTION
Someone flagged that twitter/x.com links always open in Safari even when their browser is set to In-App Safari, so figured out what's going on.

### What's happening
Apollo doesn't route tweet links through the normal "Open Links in" browser setting — it has its own separate `OpenTwitterLinksIn` picker (leftover from the Tweetbot/Twitterrific days). In the disassembly the central link router only takes the in-app `ApolloSafariViewController` path when that value is literally `inAppSafari`; anything else (including `externalBrowser`) does an external `openURL`, which lands in the X app if it's installed and otherwise dumps you into system Safari.

The catch: Reborn hides that "Open Tweets in" row (it's a `.hidden` Eureka row), so there's no way to change it — tweets are just permanently stuck opening in the system browser, ignoring your In-App Safari choice.

The dedicated-app comment in `ApolloShareLinks.xm` actually calls this out — it left X out on purpose because "Apollo already ships a native Open Tweets in picker." That reasoning doesn't hold once we hide the picker, so this wires X up like the others.

### The fix
Treat X/Twitter like every other link, matching what the reporter expected:
- **X app installed** → open it (Universal Links, same as GitHub/Bluesky, same as Apollo normally does)
- **Not installed** → honor your global browser setting: In-App Safari opens it inside Apollo; System Default still goes out to Safari (we just let Apollo's own external open handle that case)

It's all in the existing `ApolloTryOpenInDedicatedApp` path, so it covers every tappable-link handler (feed, comments, post headers, inbox).

### Testing
Verified in the iOS 26 simulator (no X app installed, so it exercises the fallback):
- **In-App Safari** → tweet opens in Apollo's in-app browser sheet (loads x.com inside Apollo), doesn't kick out to Safari ✅
- **System Default** → routing bails out and leaves Apollo's external open alone ✅

Only sim-testable so far — Universal Links opening the actual X app needs a device (the sim can't install X). If someone with the X app installed can confirm it still opens the app, that'd be great.