### PR TITLE
Fix comment-count jump transition + landing (#622)

### DIFF
--- a/src/ApolloStatsRowTouch.xm
+++ b/src/ApolloStatsRowTouch.xm
@@ -1099,12 +1099,10 @@ static const NSTimeInterval kSRTDeadline = 6.0;    // let the comment tree load 
 static const CGFloat kSRTDrift = 4.0;
 static const int kSRTHeldToFinish = 4;
 
-static const void *kSRTGenKey   = &kSRTGenKey;   // NSNumber long
-static const void *kSRTUserKey  = &kSRTUserKey;  // NSNumber bool: user dragged -> stop
-static const void *kSRTDoneKey  = &kSRTDoneKey;  // NSNumber bool
-static const void *kSRTReadyKey = &kSRTReadyKey; // NSNumber bool: content settled -> ok to pin
-static const void *kSRTLastHKey = &kSRTLastHKey; // NSNumber double: last contentSize.height
-static const void *kSRTHeldKey  = &kSRTHeldKey;  // NSNumber int
+static const void *kSRTGenKey    = &kSRTGenKey;    // NSNumber long
+static const void *kSRTUserKey   = &kSRTUserKey;   // NSNumber bool: user dragged -> stop
+static const void *kSRTDoneKey   = &kSRTDoneKey;   // NSNumber bool
+static const void *kSRTHeldKey   = &kSRTHeldKey;   // NSNumber int: consecutive on-target ticks
 
 static long gSRTGen = 0;
 
@@ -1154,8 +1152,14 @@ static NSIndexPath *SRTFirstCommentIndexPath(id tableNode, UITableView *tableVie
     return nil;
 }
 
-// Small gap left above the action bar so its separator/hairline shows (not flush-cut).
-static const CGFloat kSRTLandingMargin = 8.0;
+// Land the action bar flush at the top of the scroll area (just under the nav
+// bar). The action bar is the *last* row of the post header, so putting its top
+// at the content-inset boundary means no post-body text peeks above it — the
+// discussion (summary + first comments) sits right below, which is where a
+// "jump to comments" tap wants to be. A previous 8pt margin left a sliver of the
+// body's final line (its descenders) hanging above the bar, which read as a
+// glitch rather than a deliberate frame (issue #622). 0 removes it cleanly.
+static const CGFloat kSRTLandingMargin = 0.0;
 
 // Content-space Y of the post's quick action bar (up/down/save/reply/share). It's a
 // subnode (quickBarNode) at the bottom of the CommentsHeaderCellNode, not its own row.
@@ -1184,8 +1188,10 @@ static CGFloat SRTQuickBarTopContentY(id tableNode, UITableView *tableView) {
     return NAN;
 }
 
-// Where to land: the action bar top (preferred, so the up/down/reply row + summary
-// stay visible), else the first comment as a fallback.
+// The content-offset that seats the landing anchor — the post's action bar
+// (preferred, so the up/down/reply row stays visible), else the first comment as a
+// fallback — at the top of the scroll area, just under the nav bar. Clamped to the
+// current scroll range. Returns NAN when there's nothing to anchor to yet.
 static CGFloat SRTLandingOffset(id tableNode, UITableView *tv, NSIndexPath *firstCommentIP) {
     CGFloat insetTop = tv.adjustedContentInset.top;
     CGFloat insetBottom = tv.adjustedContentInset.bottom;
@@ -1193,39 +1199,77 @@ static CGFloat SRTLandingOffset(id tableNode, UITableView *tv, NSIndexPath *firs
     CGFloat maxOff = MAX(-insetTop, tv.contentSize.height - viewportH + insetBottom);
     CGFloat targetTop;
     CGFloat qbTop = SRTQuickBarTopContentY(tableNode, tv);
-    if (!isnan(qbTop)) {
-        targetTop = qbTop - kSRTLandingMargin;
-    } else if (firstCommentIP) {
-        targetTop = [tv rectForRowAtIndexPath:firstCommentIP].origin.y;
-    } else {
-        return tv.contentOffset.y;
-    }
+    if (!isnan(qbTop))          targetTop = qbTop - kSRTLandingMargin;
+    else if (firstCommentIP)    targetTop = [tv rectForRowAtIndexPath:firstCommentIP].origin.y;
+    else                        return NAN;
     return MIN(MAX(targetTop - insetTop, -insetTop), maxOff);
 }
 
 // -1 not ready, 0 corrected (was off), 1 already on target.
+//
+// The landing anchor is the post's action bar, which lives at the bottom of the
+// header cell. Apollo builds that header synchronously from the RDKLink the instant
+// the CommentsViewController loads — long before the comment tree streams in over
+// the network — so its content-Y is resolvable during the push transition itself.
+// That's what lets us land *invisibly* (issue #622): we don't wait for a comment to
+// exist, we pin to the header the moment it's measured, so the view slides in
+// already scrolled to the discussion instead of opening at the top and jumping down.
 static int SRTPinLanding(UIViewController *vc) {
     id tableNode = SRTIvar(vc, "tableNode");
     UITableView *tv = SRTTableForVC(vc);
     if (!tv) return -1;
 
+    // The comments view is an ASTableNode and does NOT forward
+    // scrollViewWillBeginDragging: to the VC (device-proven — see
+    // ApolloLiveCommentsFollow), so we can't rely on that delegate callback to learn
+    // the user took over. Read the scroll state directly instead: never fight a
+    // finger on the list. A real drag/fling hands the jump over for good; a plain
+    // touch-down (tracking, e.g. tapping to collapse a comment) just skips this
+    // frame's pin so we don't tug against the touch.
+    if (tv.isDragging || tv.isDecelerating) {
+        SRTSet(vc, kSRTUserKey, @YES);
+        SRTSet(vc, kSRTDoneKey, @YES);
+        return -1;
+    }
+    if (tv.isTracking) return -1;
+
     CGFloat h = tv.contentSize.height;
     CGFloat insetTop = tv.adjustedContentInset.top;
     CGFloat insetBottom = tv.adjustedContentInset.bottom;
     CGFloat viewportH = tv.bounds.size.height;
-    if ((h + insetTop + insetBottom) <= viewportH + 1.0) return -1;   // whole thread fits — nothing to do
+    if (viewportH < 1.0) return -1;                                  // not laid out yet
+    if ((h + insetTop + insetBottom) <= viewportH + 1.0) return -1;  // whole thread fits — nothing to do
 
-    // Readiness: comments have loaded (first comment exists). Offset is the action bar.
-    NSIndexPath *first = SRTFirstCommentIndexPath(tableNode, tv);
-    if (!first || first.section >= [tv numberOfSections]) return -1;
-
+    CGFloat qbTop = SRTQuickBarTopContentY(tableNode, tv);
+    // Only pay for the first-comment scan when the header anchor is unavailable.
+    NSIndexPath *first = isnan(qbTop) ? SRTFirstCommentIndexPath(tableNode, tv) : nil;
     CGFloat desired = SRTLandingOffset(tableNode, tv, first);
+    if (isnan(desired)) return -1;                                   // nothing to anchor to yet
+
     CGFloat cur = tv.contentOffset.y;
     if (fabs(cur - desired) > kSRTDrift) {
         [tv setContentOffset:CGPointMake(tv.contentOffset.x, desired) animated:NO];
+        ApolloLog(@"[StatsRow] pin: qbTop=%.1f cur=%.1f -> %.1f (h=%.1f vh=%.1f inTop=%.1f)",
+                  qbTop, cur, desired, h, viewportH, insetTop);
         return 0;
     }
     return 1;
+}
+
+// YES when the action-bar landing is fully reachable right now — enough content
+// below it to scroll its top to the nav bar. A cold long-body post whose comments
+// haven't loaded yet is NOT reachable (the target clamps short); we keep ticking so
+// the landing finalizes once the tree grows, rather than finishing at a clamped
+// interim position.
+static BOOL SRTLandingReachable(id tableNode, UITableView *tv) {
+    CGFloat qbTop = SRTQuickBarTopContentY(tableNode, tv);
+    if (isnan(qbTop)) return NO;
+    CGFloat insetTop = tv.adjustedContentInset.top;
+    CGFloat insetBottom = tv.adjustedContentInset.bottom;
+    CGFloat viewportH = tv.bounds.size.height;
+    CGFloat maxOff = MAX(-insetTop, tv.contentSize.height - viewportH + insetBottom);
+    CGFloat target = (qbTop - kSRTLandingMargin) - insetTop;
+    return target <= maxOff + 0.5;
 }
 
 static void SRTScheduleTick(__weak UIViewController *weakVC, long gen, NSDate *deadline);
@@ -1247,36 +1291,32 @@ static void SRTTick(__weak UIViewController *weakVC, long gen, NSDate *deadline)
         return;
     }
 
-    // Wait for the comment tree + header to finish measuring, so the target
-    // offset is computed against the *final* layout (single clean placement).
-    CGFloat h = tableView.contentSize.height;
-    NSNumber *lastHN = SRTNum(vc, kSRTLastHKey);
-    BOOL hStable = (lastHN != nil) && (fabs(h - lastHN.doubleValue) < 0.5);
-    SRTSet(vc, kSRTLastHKey, @(h));
+    // Pin to the header's action bar as soon as it's measured — no waiting on the
+    // comment tree. This backstops the viewDidLayoutSubviews pin for layout passes
+    // that don't re-fire, and finalizes the cold long-body case: a post whose action
+    // bar couldn't reach the top pre-load becomes reachable once its comments arrive.
+    int r = SRTPinLanding(vc);                                 // -1 not ready, 0 corrected, 1 on target
+    // "Done" only once we're on target AND the anchor is fully reachable (comments
+    // provided the height) — otherwise a cold long-body post would finish while its
+    // comments are still loading, settling at a clamped interim position.
+    BOOL settled = (r == 1) && SRTLandingReachable(tableNode, tableView);
 
-    NSIndexPath *first = SRTFirstCommentIndexPath(tableNode, tableView);
-
-    if (first && hStable) {
-        SRTSet(vc, kSRTReadyKey, @YES);   // viewDidLayoutSubviews may now pin (flash-free)
-        int r = SRTPinLanding(vc);
-        if (r == 1) {
-            int held = [SRTNum(vc, kSRTHeldKey) intValue] + 1;
-            SRTSet(vc, kSRTHeldKey, @(held));
-            if (held >= kSRTHeldToFinish) {
-                SRTSet(vc, kSRTDoneKey, @YES);
-                ApolloLog(@"[StatsRow] landed (action bar at top) — done (gen=%ld)", gen);
-                return;
-            }
-        } else if (r == 0) {
-            SRTSet(vc, kSRTHeldKey, @(0));
-            ApolloLog(@"[StatsRow] pinned landing (action bar) row %@ (gen=%ld)", first, gen);
+    if (settled) {
+        int held = [SRTNum(vc, kSRTHeldKey) intValue] + 1;
+        SRTSet(vc, kSRTHeldKey, @(held));
+        if (held >= kSRTHeldToFinish) {
+            SRTSet(vc, kSRTDoneKey, @YES);
+            ApolloLog(@"[StatsRow] landed (action bar at top) — done (gen=%ld)", gen);
+            return;
         }
-        SRTScheduleTick(weakVC, gen, deadline);
-        return;
+    } else {
+        SRTSet(vc, kSRTHeldKey, @(0));      // still settling — reset the streak
     }
 
     if (pastDeadline) {
-        if (first) SRTPinLanding(vc);   // best effort even if height never fully settled
+        SRTPinLanding(vc);                 // one last best-effort placement
+        SRTSet(vc, kSRTDoneKey, @YES);     // stop auto-pinning past the network load window
+        ApolloLog(@"[StatsRow] jump deadline reached — settling (gen=%ld)", gen);
         return;
     }
     SRTScheduleTick(weakVC, gen, deadline);
@@ -1371,7 +1411,7 @@ static BOOL SRTShouldSuppressMenu(id interaction, CGPoint location) {
 
 %hook _TtC6Apollo22CommentsViewController
 
-- (void)viewDidAppear:(BOOL)animated {
+- (void)viewWillAppear:(BOOL)animated {
     %orig;
     if (!SRTConsumeJumpPending()) return;   // only when a bubble tap armed us
 
@@ -1379,21 +1419,41 @@ static BOOL SRTShouldSuppressMenu(id interaction, CGPoint location) {
     SRTSet(self, kSRTGenKey, @(gen));
     SRTSet(self, kSRTUserKey, @NO);
     SRTSet(self, kSRTDoneKey, @NO);
-    SRTSet(self, kSRTReadyKey, @NO);
     SRTSet(self, kSRTHeldKey, @(0));
-    objc_setAssociatedObject(self, kSRTLastHKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    // Land BEFORE the push transition paints. The post header (and its action bar)
+    // is usually already measured by now — built synchronously from the link —
+    // so this first pin makes the view slide in already scrolled to the
+    // discussion, instead of opening at the top and then jumping down (#622).
+    // viewDidLayoutSubviews + the tick loop cover the passes where the header
+    // wasn't measured at this exact instant.
+    SRTPinLanding((UIViewController *)self);
 
     NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:kSRTDeadline];
     SRTScheduleTick((UIViewController *)self, gen, deadline);
-    ApolloLog(@"[StatsRow] comments appeared with jump pending — arming scroll (gen=%ld)", gen);
+    ApolloLog(@"[StatsRow] comments will appear with jump pending — landing early (gen=%ld)", gen);
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    // Belt-and-braces: if the header measured too late to pin before the transition
+    // painted (rare), catch up now so we still land on the action bar.
+    if ([SRTNum(self, kSRTGenKey) longValue] == 0) return;   // no jump active for this VC
+    if ([SRTNum(self, kSRTDoneKey) boolValue]) return;
+    if ([SRTNum(self, kSRTUserKey) boolValue]) return;
+    SRTPinLanding((UIViewController *)self);
 }
 
 - (void)viewDidLayoutSubviews {
     %orig;
     if (![NSThread isMainThread]) return;
-    if (![SRTNum(self, kSRTReadyKey) boolValue]) return;
+    if ([SRTNum(self, kSRTGenKey) longValue] == 0) return;   // no jump active for this VC
     if ([SRTNum(self, kSRTDoneKey) boolValue]) return;
     if ([SRTNum(self, kSRTUserKey) boolValue]) return;
+    // Flash-free pin: this runs in the same layout pass in which Apollo re-parks
+    // the offset, so its top-of-post value never paints. Anchored on the header,
+    // it fires from the very first pass during the push (the proven sibling
+    // technique in ApolloInboxCommentScroll).
     SRTPinLanding((UIViewController *)self);
 }
 


### PR DESCRIPTION
Closes #622.

Tapping the comment count used to open the post at the very top and then scroll down to the action bar once the comments loaded — that's the jarring bit — and the final position left the descenders of the last body line poking out above the action bar.

This anchors the landing on the post header's action bar (`quickBarNode`), which Apollo lays out synchronously from the link long before the comment tree streams in. So we stop waiting for the first comment to exist, consume the pending jump in `viewWillAppear` instead of `viewDidAppear`, and pin from the first layout pass during the push — the view slides in already scrolled to the discussion instead of opening at the top and jumping down. Same flash-free approach `ApolloInboxCommentScroll` already uses (pin in the same layout pass Apollo re-parks, before it paints). Landing margin is now 0 so the action bar sits flush under the nav bar with no body-text sliver above it.

On the "show the action bar vs. go straight to the comments" point from the thread — I kept the action bar visible. Tapping the comment count is intent to jump into the discussion, and the action bar puts reply/vote one tap away; hiding it (aligning header-bottom to the first comment) would mean scrolling back up to reply. So it lands with the action bar at the top and "Discussion so far" + the comments right below.

One honest trade-off: on a long text post whose comments aren't loaded yet, the action bar physically can't reach the very top until the comments add height below it, so it settles up once they load (~0.4s). The action bar is visible the whole time, and it's a big improvement over the old open-at-top-then-scroll. I tried reserving table inset to hold it at the top with the spinner (zero motion) but Apollo/Texture re-sets the table's `contentInset` every frame and it fought back, so I kept the robust version.

The comments view is an `ASTableNode` that doesn't forward `scrollViewWillBeginDragging:` to the VC, so the settle loop reads the scroll state directly and hands control back the moment you touch the list, rather than fighting your scroll while comments are still loading.

Sim-tested on iOS 26 (Liquid Glass) across AskReddit / AITA / TIFU / relationship_advice — lands cleanly on the action bar with the discussion below, and normal taps still open the post at the top. Not device-tested yet.
