### PR TITLE
Fix comment "flicker" on every up/down-vote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloCommentsCollapse.xm \
     $(SRC_DIR)/ApolloInboxCommentScroll.xm \
     $(SRC_DIR)/ApolloStatsRowTouch.xm \
+    $(SRC_DIR)/ApolloCommentVoteFlicker.xm \
     $(SRC_DIR)/ApolloLiveCommentsFollow.xm \
     $(SRC_DIR)/ApolloLiquidGlass.xm \
     $(SRC_DIR)/ApolloLiquidGlassIconPicker.xm \

--- a/src/ApolloCommentVoteFlicker.xm
+++ b/src/ApolloCommentVoteFlicker.xm
@@ -140,6 +140,18 @@ static void ApolloVFHandleModelUpdate(id note, void (^origCall)(void)) {
 - (void)didExitVisibleState  { %orig; ApolloVFTrackCell(self, NO);  }
 %end
 
+// Feed post cells participate in the foreground heal below (their text blanks
+// the same way when the app returns from the background).
+%hook _TtC6Apollo17LargePostCellNode
+- (void)didEnterVisibleState { %orig; ApolloVFTrackCell(self, YES); }
+- (void)didExitVisibleState  { %orig; ApolloVFTrackCell(self, NO);  }
+%end
+
+%hook _TtC6Apollo19CompactPostCellNode
+- (void)didEnterVisibleState { %orig; ApolloVFTrackCell(self, YES); }
+- (void)didExitVisibleState  { %orig; ApolloVFTrackCell(self, NO);  }
+%end
+
 %hook _TtC6Apollo24CommentSectionController
 - (void)modelObjectUpdatedNotificationReceived:(id)note {
     ApolloVFHandleModelUpdate(note, ^{ %orig; });
@@ -151,3 +163,44 @@ static void ApolloVFHandleModelUpdate(id note, void (^origCall)(void)) {
     ApolloVFHandleModelUpdate(note, ^{ %orig; });
 }
 %end
+
+// ── Foreground heal (issue #217's app-switch flicker) ──────────────────────
+// Backgrounding makes Texture drop cell backing stores (cells leave the
+// visible/display range and free their rendered contents to save memory);
+// returning to the app re-displays them ASYNCHRONOUSLY, so every visible
+// comment/post body renders BLANK until its redraw lands — measured in the
+// sim at over a second of nil-contents commits after didBecomeActive, which
+// matches the "text disappears for up to a second" reports. Same nil-contents
+// mechanism as the vote flicker, so the same lever fixes it: flush the
+// re-displays synchronously during the foreground transition, before the
+// live view replaces the system snapshot. Staged passes because cells
+// re-enter the visible range at slightly different times across the
+// transition (willEnterForeground → didBecomeActive → first frames).
+static void ApolloVFForegroundHeal(const char *stage) {
+    NSArray *cells = sApolloVFVisibleCells.allObjects;
+    if (cells.count == 0) return;
+    for (ASDisplayNode *cell in cells) {
+        @try {
+            if ([cell respondsToSelector:@selector(recursivelyEnsureDisplaySynchronously:)]) {
+                [cell recursivelyEnsureDisplaySynchronously:YES];
+            }
+        } @catch (__unused NSException *e) {}
+    }
+    ApolloLog(@"[VoteFlicker] foreground heal: flushed display for %lu cell(s) (%s)",
+              (unsigned long)cells.count, stage);
+}
+
+%ctor {
+    %init;
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+    void (^heal)(NSNotification *) = ^(__unused NSNotification *n) {
+        ApolloVFForegroundHeal("now");
+        dispatch_async(dispatch_get_main_queue(), ^{ ApolloVFForegroundHeal("next-turn"); });
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(150 * NSEC_PER_MSEC)),
+                       dispatch_get_main_queue(), ^{ ApolloVFForegroundHeal("late"); });
+    };
+    [nc addObserverForName:UIApplicationWillEnterForegroundNotification object:nil
+                     queue:[NSOperationQueue mainQueue] usingBlock:heal];
+    [nc addObserverForName:UIApplicationDidBecomeActiveNotification object:nil
+                     queue:[NSOperationQueue mainQueue] usingBlock:heal];
+}

--- a/src/ApolloCommentVoteFlicker.xm
+++ b/src/ApolloCommentVoteFlicker.xm
@@ -1,0 +1,153 @@
+// ApolloCommentVoteFlicker
+//
+// Fixes the one-frame "flicker" of a comment when it is up/down-voted (and on
+// any other in-place model update): the whole comment body flashes blank for a
+// single frame before redrawing, even though only the score digit + arrow tint
+// actually change. Reported on both plain-text and media comments.
+//
+// ── Mechanism (measured in the sim, not inferred) ──────────────────────────
+// A vote delivers the updated RDKComment via the
+// "com.christianselig.ModelObjectUpdated" notification to the row's
+// -[CommentSectionController modelObjectUpdatedNotificationReceived:], which
+// reconfigures the cell in place (byline rebuild + -setNeedsLayout, re-running
+// the cell's layoutSpecThatFits:). Texture then re-displays several of the
+// cell's text/image nodes ASYNCHRONOUSLY. Instrumenting the display pipeline
+// during a real vote showed one of those nodes being committed to screen with
+// layer.contents == nil — i.e. the frame renders with that node BLANK, and the
+// async redraw only lands on the next frame. That nil-contents commit is the
+// flicker. (Whether a given node blanks depends on whether the reconfigure
+// clears/replaces it — the byline usually survives, body/text nodes don't —
+// but the fix below doesn't need to care which node it is.)
+//
+// ── Fix ────────────────────────────────────────────────────────────────────
+// Make the voted cell finish its (re)display synchronously, inside the same
+// frame, so there is never a nil-contents commit:
+//   1. neverShowPlaceholders = YES on the cell — Texture then blocks the main
+//      thread briefly to complete display of on-screen content instead of
+//      committing a placeholder/blank and filling it in a frame later.
+//   2. recursivelyEnsureDisplaySynchronously:YES right after the reconfigure,
+//      and again on the next main-queue turn — flushes the display passes the
+//      reconfigure scheduled (the -setNeedsLayout wave lands a turn later).
+// Both selectors exist in Apollo's bundled Texture (verified in the binary).
+//
+// Scope: ONLY cells that actually receive a model-update notification while
+// visible (votes, live edits). Cells never get touched during scrolling, so
+// scroll perf is unaffected; the one-off synchronous draw of an already
+// visible cell is a sub-millisecond text render on a tap — imperceptible.
+//
+// Covers both the comment rows (CommentSectionController) and the post header
+// in the comments view (CommentsHeaderSectionController) — both flicker the
+// same way when voted.
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+#import "ApolloCommon.h"
+
+@interface ASDisplayNode : NSObject
+@property (nonatomic) BOOL neverShowPlaceholders;
+- (void)recursivelyEnsureDisplaySynchronously:(BOOL)sync;
+@end
+
+// Weak set of comment/header cells currently on screen. Only consulted when a
+// model-update notification arrives, so the bookkeeping cost is two hash-table
+// ops per cell appearance.
+static NSHashTable *sApolloVFVisibleCells = nil;
+
+static void ApolloVFTrackCell(id cell, BOOL visible) {
+    if (!sApolloVFVisibleCells) sApolloVFVisibleCells = [NSHashTable weakObjectsHashTable];
+    if (visible) [sApolloVFVisibleCells addObject:cell];
+    else [sApolloVFVisibleCells removeObject:cell];
+}
+
+static id ApolloVFIvar(id obj, const char *name) {
+    if (!obj || !name) return nil;
+    Ivar iv = class_getInstanceVariable(object_getClass(obj), name);
+    if (!iv) return nil;
+    @try { return object_getIvar(obj, iv); } @catch (__unused NSException *e) { return nil; }
+}
+
+static NSString *ApolloVFFullName(id model) {
+    if (!model || ![model respondsToSelector:@selector(fullName)]) return nil;
+    @try {
+        NSString *fn = ((NSString *(*)(id, SEL))objc_msgSend)(model, @selector(fullName));
+        return [fn isKindOfClass:[NSString class]] ? fn : nil;
+    } @catch (__unused NSException *e) { return nil; }
+}
+
+// The visible cell(s) whose model matches the updated one. A vote updates
+// exactly one comment; matching by fullname keeps this surgical even when the
+// notification fires for unrelated model updates.
+static NSArray *ApolloVFCellsForUpdatedModel(id note) {
+    id model = [note isKindOfClass:[NSNotification class]] ? [(NSNotification *)note object] : nil;
+    NSString *fullName = ApolloVFFullName(model);
+    if (fullName.length == 0) return @[];
+    NSMutableArray *hits = [NSMutableArray array];
+    for (id cell in sApolloVFVisibleCells.allObjects) {
+        id m = ApolloVFIvar(cell, "comment") ?: ApolloVFIvar(cell, "link");
+        if ([ApolloVFFullName(m) isEqualToString:fullName]) [hits addObject:cell];
+    }
+    return hits;
+}
+
+static void ApolloVFEnsureSynchronousDisplay(NSArray *cells, const char *stage) {
+    for (ASDisplayNode *cell in cells) {
+        @try {
+            if ([cell respondsToSelector:@selector(setNeverShowPlaceholders:)]) {
+                cell.neverShowPlaceholders = YES;
+            }
+            if ([cell respondsToSelector:@selector(recursivelyEnsureDisplaySynchronously:)]) {
+                [cell recursivelyEnsureDisplaySynchronously:YES];
+            }
+        } @catch (__unused NSException *e) {}
+    }
+    if (cells.count > 0) {
+        ApolloLog(@"[VoteFlicker] ensured synchronous display for %lu cell(s) (%s)",
+                  (unsigned long)cells.count, stage);
+    }
+}
+
+// Shared handler body for both section-controller hooks: arm the matching
+// visible cell(s) before the reconfigure, flush the display wave right after,
+// and once more on the next runloop turn (the -setNeedsLayout relayout lands
+// there; its re-displays are what commit blank without this).
+static void ApolloVFHandleModelUpdate(id note, void (^origCall)(void)) {
+    NSArray *cells = ApolloVFCellsForUpdatedModel(note);
+    for (ASDisplayNode *cell in cells) {
+        @try {
+            if ([cell respondsToSelector:@selector(setNeverShowPlaceholders:)]) {
+                cell.neverShowPlaceholders = YES;
+            }
+        } @catch (__unused NSException *e) {}
+    }
+    origCall();
+    if (cells.count == 0) return;
+    ApolloVFEnsureSynchronousDisplay(cells, "post-reconfigure");
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ApolloVFEnsureSynchronousDisplay(cells, "next-turn");
+    });
+}
+
+%hook _TtC6Apollo15CommentCellNode
+- (void)didEnterVisibleState { %orig; ApolloVFTrackCell(self, YES); }
+- (void)didExitVisibleState  { %orig; ApolloVFTrackCell(self, NO);  }
+%end
+
+%hook _TtC6Apollo22CommentsHeaderCellNode
+- (void)didEnterVisibleState { %orig; ApolloVFTrackCell(self, YES); }
+- (void)didExitVisibleState  { %orig; ApolloVFTrackCell(self, NO);  }
+%end
+
+%hook _TtC6Apollo24CommentSectionController
+- (void)modelObjectUpdatedNotificationReceived:(id)note {
+    ApolloVFHandleModelUpdate(note, ^{ %orig; });
+}
+%end
+
+%hook _TtC6Apollo31CommentsHeaderSectionController
+- (void)modelObjectUpdatedNotificationReceived:(id)note {
+    ApolloVFHandleModelUpdate(note, ^{ %orig; });
+}
+%end

--- a/src/ApolloCommentVoteFlicker.xm
+++ b/src/ApolloCommentVoteFlicker.xm
@@ -48,6 +48,10 @@
 
 @interface ASDisplayNode : NSObject
 @property (nonatomic) BOOL neverShowPlaceholders;
+@property (nonatomic) BOOL displaysAsynchronously;
+- (NSArray<ASDisplayNode *> *)subnodes;
+- (void)setNeedsLayout;
+- (void)layoutIfNeeded;
 - (void)recursivelyEnsureDisplaySynchronously:(BOOL)sync;
 @end
 
@@ -109,6 +113,66 @@ static void ApolloVFEnsureSynchronousDisplay(NSArray *cells, const char *stage) 
     }
 }
 
+// The comment-count bubble in a feed's info row is a tiny layer-backed Texture
+// subtree. When a pushed comments controller covers the feed, Texture leaves
+// that subtree's display range and discards its backing contents. On an
+// interactive pop it normally redraws the bubble asynchronously; UIKit can
+// remove the transition snapshot one frame before that redraw commits, which
+// is the isolated bubble flicker visible on swipe-back.
+//
+// Keep this one cheap subtree synchronous for its lifetime. PostInfoNode arms
+// the initial subtree when it enters the hierarchy, then re-arms Apollo's
+// replacement subtree inside readCommentsUpdatedWithNotification:. This avoids
+// navigation timing assumptions and does not make the post body, media, or the
+// rest of the feed draw synchronously.
+static void ApolloVFStabilizeCommentsInfoNode(ASDisplayNode *node, BOOL flush) {
+    if (!node) return;
+    @try {
+        NSMutableArray<ASDisplayNode *> *pending = [NSMutableArray arrayWithObject:node];
+        while (pending.count > 0) {
+            ASDisplayNode *current = pending.lastObject;
+            [pending removeLastObject];
+            if ([current respondsToSelector:@selector(setNeverShowPlaceholders:)]) {
+                current.neverShowPlaceholders = YES;
+            }
+            if ([current respondsToSelector:@selector(setDisplaysAsynchronously:)]) {
+                current.displaysAsynchronously = NO;
+            }
+            if ([current respondsToSelector:@selector(subnodes)]) {
+                NSArray *children = current.subnodes;
+                if (children.count > 0) [pending addObjectsFromArray:children];
+            }
+        }
+        if (flush && [node respondsToSelector:@selector(recursivelyEnsureDisplaySynchronously:)]) {
+            [node recursivelyEnsureDisplaySynchronously:YES];
+        }
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            ApolloLog(@"[VoteFlicker] comments info subtree armed for synchronous display");
+        });
+    } @catch (__unused NSException *e) {}
+}
+
+static void ApolloVFRealizeUpdatedCommentsInfo(id postInfo, const char *stage) {
+    if (!postInfo) return;
+    @try {
+        ASDisplayNode *commentsInfo = (ASDisplayNode *)ApolloVFIvar(postInfo, "commentsInfoNode");
+        if (!commentsInfo) return;
+        ApolloVFStabilizeCommentsInfoNode(commentsInfo, NO);
+        if ([postInfo respondsToSelector:@selector(setNeedsLayout)]) {
+            [postInfo setNeedsLayout];
+        }
+        if ([postInfo respondsToSelector:@selector(layoutIfNeeded)]) {
+            [postInfo layoutIfNeeded];
+        }
+        ApolloVFStabilizeCommentsInfoNode(commentsInfo, YES);
+        if ([postInfo respondsToSelector:@selector(recursivelyEnsureDisplaySynchronously:)]) {
+            [postInfo recursivelyEnsureDisplaySynchronously:YES];
+        }
+        ApolloLog(@"[VoteFlicker] read-comments update realized synchronously (%s)", stage);
+    } @catch (__unused NSException *e) {}
+}
+
 // Shared handler body for both section-controller hooks: arm the matching
 // visible cell(s) before the reconfigure, flush the display wave right after,
 // and once more on the next runloop turn (the -setNeedsLayout relayout lands
@@ -138,6 +202,28 @@ static void ApolloVFHandleModelUpdate(id note, void (^origCall)(void)) {
 %hook _TtC6Apollo22CommentsHeaderCellNode
 - (void)didEnterVisibleState { %orig; ApolloVFTrackCell(self, YES); }
 - (void)didExitVisibleState  { %orig; ApolloVFTrackCell(self, NO);  }
+%end
+
+// CommentsInfoNode's plain -init is intentionally unavailable in Apollo's
+// Swift class, and its Texture lifecycle methods are inherited rather than
+// class-owned. PostInfoNode does own didEnterHierarchy and already has the
+// fully-built commentsInfoNode at that point, making this the reliable place
+// to arm the bubble before its first display-range entry.
+%hook _TtC6Apollo12PostInfoNode
+- (void)didEnterHierarchy {
+    %orig;
+    ASDisplayNode *commentsInfo = (ASDisplayNode *)ApolloVFIvar(self, "commentsInfoNode");
+    ApolloVFStabilizeCommentsInfoNode(commentsInfo, YES);
+}
+
+- (void)readCommentsUpdatedWithNotification:(id)notification {
+    %orig;
+    ApolloVFRealizeUpdatedCommentsInfo(self, "now");
+    __weak id weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ApolloVFRealizeUpdatedCommentsInfo(weakSelf, "next-turn");
+    });
+}
 %end
 
 // Feed post cells participate in the foreground heal below (their text blanks

--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -3952,6 +3952,41 @@ static BOOL ApolloChildrenIdentityMatches(NSArray *a, NSArray *b) {
     return YES;
 }
 
+// Content-equality fallback for when element-pointer identity FAILS. Apollo
+// usually reuses the child element pointers across layoutSpecThatFits: passes
+// (see ApolloChildrenIdentityMatches), but it INTERMITTENTLY hands a fresh set
+// of child ASTextNodes for byte-identical content — observed on the in-place
+// relayout Apollo runs after a comment is up/down-voted (the vote re-sets the
+// byline score and calls -setNeedsLayout on the cell). Pointer identity then
+// fails and, without this check, we would take the REBUILD path and recreate
+// the body's text-segment leaf nodes; a freshly-allocated Texture node has an
+// empty backing store and paints blank for the one async-display frame before
+// it draws — i.e. the whole comment body "flickers" on every vote. This
+// compares the children by rendered content so a score-only vote is recognised
+// as unchanged and the existing (already-drawn) leaf nodes are reused instead.
+// Runs only on the identity-mismatch slow path, never on the fast reuse path.
+static BOOL ApolloChildrenContentMatches(NSArray *a, NSArray *b) {
+    if (!a || !b) return NO;
+    if (a.count != b.count) return NO;
+    for (NSUInteger i = 0; i < a.count; i++) {
+        id ca = a[i], cb = b[i];
+        if (ca == cb) continue;
+        // Only reuse when both are text nodes with equal attributed content
+        // (equal string AND equal attributes — a link/URL edit must still
+        // rebuild so the decomposition re-scans the new URLs). Any other shape
+        // is treated conservatively as a content change → rebuild.
+        if (![ca respondsToSelector:@selector(attributedText)] ||
+            ![cb respondsToSelector:@selector(attributedText)]) {
+            return NO;
+        }
+        NSAttributedString *ta = [(ASTextNode *)ca attributedText];
+        NSAttributedString *tb = [(ASTextNode *)cb attributedText];
+        if (ta == tb) continue;
+        if (!ta || !tb || ![ta isEqualToAttributedString:tb]) return NO;
+    }
+    return YES;
+}
+
 static id ApolloModelFromNodeIvar(ASDisplayNode *node, const char *ivarName) {
     if (!node || !ivarName) return nil;
     Ivar ivar = class_getInstanceVariable([node class], ivarName);
@@ -4039,7 +4074,41 @@ static BOOL ApolloLinkButtonHasInlineHost(ASDisplayNode *linkButtonNode) {
     NSArray *cachedOrigChildren = objc_getAssociatedObject(self, &kApolloCachedOrigChildrenKey);
     NSDictionary *decomp = objc_getAssociatedObject(self, &kApolloDecompositionMapKey);
 
-    if (!ApolloChildrenIdentityMatches(cachedOrigChildren, origChildren)) {
+    BOOL identityMatches = ApolloChildrenIdentityMatches(cachedOrigChildren, origChildren);
+
+    // Vote-flicker fix: element-pointer identity USUALLY holds across passes
+    // (see ApolloChildrenIdentityMatches) but Apollo INTERMITTENTLY hands a
+    // fresh set of child ASTextNodes for byte-identical content — observed on
+    // the in-place relayout Apollo runs after a comment is up/down-voted (the
+    // vote re-sets the byline score and calls -setNeedsLayout on the cell).
+    // Without this guard the mismatch would take the rebuild path below and
+    // recreate the body's text-segment leaf nodes; a freshly-allocated Texture
+    // node has an empty backing store and paints blank for the one async-display
+    // frame before it draws — i.e. the whole comment "flickers" on every vote
+    // (and that size churn cascades a re-display onto the sibling inline image /
+    // link card too). When the content is actually unchanged, re-key the EXISTING
+    // decomposition onto the new child pointers and reuse the already-drawn leaf
+    // nodes instead — nothing is recreated, so nothing blanks. The augmented-build
+    // loop below looks leaves up by NSValue(nonretained child pointer), so the map
+    // MUST be re-keyed old→new here (positional; the content match guarantees the
+    // 1:1 correspondence). Runs only on the identity-mismatch slow path.
+    if (!identityMatches && decomp.count > 0 &&
+        cachedOrigChildren.count == origChildren.count &&
+        ApolloChildrenContentMatches(cachedOrigChildren, origChildren)) {
+        NSMutableDictionary *rekeyed = [NSMutableDictionary dictionaryWithCapacity:origChildren.count];
+        for (NSUInteger i = 0; i < origChildren.count; i++) {
+            NSArray *leaves = decomp[[NSValue valueWithNonretainedObject:cachedOrigChildren[i]]];
+            if (leaves) rekeyed[[NSValue valueWithNonretainedObject:origChildren[i]]] = leaves;
+        }
+        objc_setAssociatedObject(self, &kApolloDecompositionMapKey, rekeyed.count > 0 ? rekeyed : nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(self, &kApolloCachedOrigChildrenKey, origChildren, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        decomp = rekeyed.count > 0 ? rekeyed : nil;
+        identityMatches = YES; // content is stable — skip the rebuild below
+        ApolloLog(@"[InlineImages] vote-stable relayout: reused decomposition across pointer churn (md=%p leaves=%lu) — no rebuild, no flicker",
+                  self, (unsigned long)rekeyed.count);
+    }
+
+    if (!identityMatches) {
         // Rebuild decomposition. We do NOT removeFromSupernode the previous
         // imageNodes here — ApolloImageNodeForURL reuses them by URL. Text
         // segments ARE recreated each time (cheap, attributedText varies).

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -873,6 +873,35 @@ static NSRange ApolloRangeByTrimmingTrailingURLPunctuation(NSString *text, NSRan
     return range;
 }
 
+// Reddit comment bodies embed inline media as markdown-image tokens whose
+// "URL" is a media id — `![gif](giphy|ECtLJKdGj8jfy)`, `![img](emote|t5_…|…)`.
+// Apollo's renderer strips these from the displayed body (the gif/emote is
+// drawn from media_metadata as its own node), but `comment.body` keeps them —
+// so translating the raw body used to send the token to the provider and then
+// display it LITERALLY as text above the translation. Strip media-id tokens
+// (the `x|y` id form is never a real URL — URLs carry ://) plus the blank
+// lines they leave behind, both from text we send to providers and from
+// cached translations at apply time.
+static NSString *ApolloStripInlineMediaTokens(NSString *text) {
+    if (![text isKindOfClass:[NSString class]] || text.length == 0) return text;
+    if ([text rangeOfString:@"!["].location == NSNotFound) return text;
+    static NSRegularExpression *tokenRe = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        tokenRe = [NSRegularExpression regularExpressionWithPattern:@"!\\[[^\\]\\n]*\\]\\([a-z]+\\|[^)\\n]*\\)"
+                                                            options:0 error:NULL];
+    });
+    NSString *stripped = [tokenRe stringByReplacingMatchesInString:text options:0
+                                                             range:NSMakeRange(0, text.length)
+                                                      withTemplate:@""];
+    if (stripped.length == text.length) return text;
+    // Collapse the blank hole the token leaves (3+ newlines → 2) and trim.
+    while ([stripped rangeOfString:@"\n\n\n"].location != NSNotFound) {
+        stripped = [stripped stringByReplacingOccurrencesOfString:@"\n\n\n" withString:@"\n\n"];
+    }
+    return [stripped stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
 static NSString *ApolloProtectTranslationLinks(NSString *sourceText, NSDictionary<NSString *, NSString *> **protectedLinksOut) {
     if (protectedLinksOut) *protectedLinksOut = @{};
     if (![sourceText isKindOfClass:[NSString class]] || sourceText.length == 0) return sourceText;
@@ -1654,6 +1683,10 @@ static void ApolloTranslationHealCellDisplaySync(id cellNode) {
 static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *comment, NSString *translatedText) {
     if (!commentCellNode || ![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0) return;
     if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) return;
+    // Cached translations from before media-token stripping may still carry a
+    // literal ![gif](giphy|…) line — normalize at the point of use.
+    translatedText = ApolloStripInlineMediaTokens(translatedText);
+    if (translatedText.length == 0) return;
 
     // Respect a per-item pin: if the user tapped this comment's marker to show
     // its original language, don't (re)translate it (this also blocks the
@@ -1727,6 +1760,20 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
     objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloRegisterOwnedTextNode(textNode);
+
+    // EXACT no-op gate: the containment heuristics above decide MATCHING, but
+    // they misfire on repetitive bodies (e.g. long AAAA… strings match both
+    // the original AND the translation), letting the vote-resilience reapply
+    // fall through to a write of the very text already on screen. Every such
+    // write forces a full cell relayout (and a table re-measure whose
+    // estimated heights jump the content offset) — the visible "rows below
+    // lift up" on every vote of a translated comment. If the final display
+    // string is character-identical to what the node already shows, there is
+    // nothing to do.
+    if ([current.string isEqualToString:displayAttr.string]) {
+        ApolloTranslationVerboseLog(@"[Translation/vote] apply: display identical — exact no-op cell=%p", commentCellNode);
+        return;
+    }
 
     @try {
         ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), displayAttr);
@@ -2166,6 +2213,8 @@ static id ApolloBestPostBodyTextNode(id headerCellNode, RDKLink *link, NSString 
 static void ApolloApplyTranslationToHeaderCellNode(id headerCellNode, RDKLink *link, NSString *sourceText, NSString *translatedText) {
     if (!headerCellNode) return;
     if (![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0) return;
+    translatedText = ApolloStripInlineMediaTokens(translatedText);
+    if (translatedText.length == 0) return;
     if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) return;
     NSString *body = sourceText.length > 0 ? sourceText : ApolloPostBodyTextFromLink(link);
     if (![body isKindOfClass:[NSString class]] || body.length == 0) return;
@@ -2262,6 +2311,16 @@ static void ApolloApplyTranslationToHeaderCellNode(id headerCellNode, RDKLink *l
     objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloRegisterOwnedTextNode(textNode);
 
+    // EXACT no-op gate (see comment apply): the vote-time headerReapply
+    // re-applies the stashed post-body translation on every vote; when the
+    // node already shows exactly this text, writing it again only buys a
+    // full header re-measure and a content-offset jump.
+    if ([current.string isEqualToString:translatedAttr.string]) {
+        ApolloTranslationVerboseLog(@"[Translation/vote] headerApply: display identical — exact no-op header=%p", headerCellNode);
+        objc_setAssociatedObject(headerCellNode, kApolloHeaderTranslatedTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return;
+    }
+
     @try { ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), translatedAttr); }
     @catch (__unused NSException *e) { return; }
 
@@ -2308,6 +2367,8 @@ static void ApolloApplyTranslationToPostTextNode(id owner, id textNode, NSString
     if (!owner || !textNode) return;
     if (![sourceText isKindOfClass:[NSString class]] || sourceText.length == 0) return;
     if (![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0) return;
+    translatedText = ApolloStripInlineMediaTokens(translatedText);
+    if (translatedText.length == 0) return;
     if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) return;
     // Marker-tap pin: this post is pinned to its original language; don't re-apply.
     if (ApolloPinActiveOnNode(textNode)) {
@@ -2363,6 +2424,13 @@ static void ApolloApplyTranslationToPostTextNode(id owner, id textNode, NSString
     objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloRegisterOwnedTextNode(textNode);
+
+    // EXACT no-op gate (see comment apply): skip the write + relayout when the
+    // node already displays exactly this text.
+    if ([current.string isEqualToString:translatedAttr.string]) {
+        objc_setAssociatedObject(owner, kApolloHeaderTranslatedTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return;
+    }
 
     @try { ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setAttributedText:), translatedAttr); }
     @catch (__unused NSException *e) { return; }
@@ -2934,8 +3002,11 @@ static void ApolloRequestTranslation(NSString *cacheKey,
     // Protect proper nouns (names/places/orgs) and links from the translator, then translate
     // only what's left. Names are detected first so NLTagger sees clean text (not the link
     // sentinels); restore order is irrelevant since the two token shapes are distinct.
+    // Inline media-id tokens (![gif](giphy|…)) are stripped outright — Apollo never
+    // displays them and the provider would only mangle them.
+    NSString *mediaStripped = ApolloStripInlineMediaTokens(sourceText);
     NSDictionary<NSString *, NSString *> *protectedNames = nil;
-    NSString *nameProtected = ApolloProtectTranslationNames(sourceText, &protectedNames);
+    NSString *nameProtected = ApolloProtectTranslationNames(mediaStripped, &protectedNames);
 
     NSDictionary<NSString *, NSString *> *protectedLinks = nil;
     NSString *requestText = ApolloProtectTranslationLinks(nameProtected, &protectedLinks);
@@ -5679,7 +5750,7 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
     if (swapOut) *swapOut = nil;
 
     NSString *originalBody = objc_getAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey);
-    NSString *translatedText = objc_getAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey);
+    NSString *translatedText = ApolloStripInlineMediaTokens(objc_getAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey));
 
     if (![originalBody isKindOfClass:[NSString class]] || originalBody.length == 0 ||
         ![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0 ||

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -5698,7 +5698,22 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
     if (ApolloTextMatchesSourceOrVisualDisplay(incomingText, originalBody)) {
         ApolloTranslationVerboseLog(@"[Translation/vote] prepareSwap: incoming==original → SWAPPING to translated node=%p (incomingLen=%lu)",
                                     textNode, (unsigned long)incomingText.length);
-        if (swapOut) *swapOut = ApolloRebuildTranslatedAttrPreservingAttrs(incomingAttributedText, translatedText);
+        if (swapOut) {
+            NSAttributedString *rebuilt = ApolloRebuildTranslatedAttrPreservingAttrs(incomingAttributedText, translatedText);
+            // Re-append the "Translated from <Language>" marker line for body
+            // nodes (the builder self-gates on the details/tap settings and on
+            // source-language detection; title nodes never carry the line).
+            // Without this, the vote-time swap displayed the translation ONE
+            // LINE SHORTER than what was on screen — the row shrank, every row
+            // below shifted up, and the ~100ms-later scheduled reapply re-added
+            // the marker and shifted them back: a visible bounce on every vote
+            // of a translated comment. Marker parity makes the swap
+            // height-identical AND turns that follow-up reapply into a no-op.
+            if (rebuilt && ![objc_getAssociatedObject(textNode, kApolloTitleOwnedTextNodeKey) boolValue]) {
+                rebuilt = ApolloAttributedStringByAppendingTranslationMarker(rebuilt, originalBody);
+            }
+            *swapOut = rebuilt;
+        }
         return YES;
     }
 

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -1619,6 +1619,38 @@ static void ApolloForceRelayoutForTextNodeAndOwner(id owner, id textNode) {
     } @catch (__unused NSException *e) {}
 }
 
+// Anti-flicker heal for translation text swaps. setAttributedText: +
+// setNeedsLayout/Display schedule an ASYNCHRONOUS redisplay of the swapped
+// node; on a visible cell Texture commits the frame with the node's contents
+// cleared and fills it in a frame later — the same nil-contents blank the
+// vote fix (ApolloCommentVoteFlicker.xm) eliminates for byline updates. The
+// vote fix's flush windows end before the translation vote-resilience reapply
+// runs, so translated comments still flashed on vote. Heal at the source
+// instead: after every translation write into an on-screen cell, force the
+// cell subtree to finish display synchronously (now + next runloop turn, when
+// the relayout wave lands). Off-screen cells are skipped — isNodeLoaded is
+// checked BEFORE touching .view so unloaded nodes are never forced to load.
+static void ApolloTranslationHealCellDisplaySync(id cellNode) {
+    if (!cellNode) return;
+    @try {
+        if (![cellNode respondsToSelector:@selector(isNodeLoaded)] ||
+            !((BOOL (*)(id, SEL))objc_msgSend)(cellNode, @selector(isNodeLoaded))) return;
+        UIView *v = [cellNode respondsToSelector:@selector(view)]
+            ? ((UIView *(*)(id, SEL))objc_msgSend)(cellNode, @selector(view)) : nil;
+        if (!v.window) return;
+        if (![cellNode respondsToSelector:@selector(recursivelyEnsureDisplaySynchronously:)]) return;
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(cellNode, @selector(recursivelyEnsureDisplaySynchronously:), YES);
+        __weak id weakCell = cellNode;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            id strong = weakCell;
+            if (!strong) return;
+            @try {
+                ((void (*)(id, SEL, BOOL))objc_msgSend)(strong, @selector(recursivelyEnsureDisplaySynchronously:), YES);
+            } @catch (__unused NSException *e) {}
+        });
+    } @catch (__unused NSException *e) {}
+}
+
 static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *comment, NSString *translatedText) {
     if (!commentCellNode || ![translatedText isKindOfClass:[NSString class]] || translatedText.length == 0) return;
     if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) return;
@@ -1636,6 +1668,7 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
         if (!ApolloTapModeIsTranslatedKey(pinName)) {
             if (ApolloTranslatedTextDiffersFromSource(comment.body, translatedText)) {
                 ApolloAppendTranslateAffordanceForCellNode(commentCellNode, comment);
+                ApolloTranslationHealCellDisplaySync(commentCellNode);
             }
             return;
         }
@@ -1708,6 +1741,7 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
         ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsDisplay));
     }
     ApolloForceRelayoutForTextNodeAndOwner(commentCellNode, textNode);
+    ApolloTranslationHealCellDisplaySync(commentCellNode);
     if (displayAttr != translatedAttr) {
         ApolloEnsureMarkerTappableOnNode(textNode);
         ApolloEnsureCommentsTableBreathingRoom();
@@ -1816,6 +1850,7 @@ static void ApolloRestoreOriginalForCellNode(id commentCellNode, RDKComment *com
         ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsDisplay));
     }
     ApolloForceRelayoutForTextNodeAndOwner(commentCellNode, textNode);
+    ApolloTranslationHealCellDisplaySync(commentCellNode);
 
     objc_setAssociatedObject(commentCellNode, kApolloAppliedTranslationFullNameKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
@@ -2237,6 +2272,7 @@ static void ApolloApplyTranslationToHeaderCellNode(id headerCellNode, RDKLink *l
         ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsDisplay));
     }
 
+    ApolloTranslationHealCellDisplaySync(headerCellNode);
     objc_setAssociatedObject(headerCellNode, kApolloHeaderTranslatedTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
     // Re-entrancy guard + link recovery for vote-tap rebuild (see comment
@@ -2338,6 +2374,7 @@ static void ApolloApplyTranslationToPostTextNode(id owner, id textNode, NSString
         ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsDisplay));
     }
 
+    ApolloTranslationHealCellDisplaySync(owner);
     objc_setAssociatedObject(owner, kApolloHeaderTranslatedTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     // Mirror the per-VC stash so headerReapply has something to recover
     // from even when this code path (not ApolloApplyTranslationToHeaderCellNode)
@@ -2375,6 +2412,7 @@ static void ApolloRestoreOriginalForHeaderCellNode(id headerCellNode, RDKLink *l
     if ([textNode respondsToSelector:@selector(setNeedsDisplay)]) {
         ((void (*)(id, SEL))objc_msgSend)(textNode, @selector(setNeedsDisplay));
     }
+    ApolloTranslationHealCellDisplaySync(headerCellNode);
     objc_setAssociatedObject(headerCellNode, kApolloAppliedHeaderTranslationFullNameKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -55,6 +55,14 @@ static const void *kApolloOwnedNodeReentrancyKey = &kApolloOwnedNodeReentrancyKe
 // `ApolloControllerIsInTranslatedMode` check used by the comment-thread
 // ownership system. Set in addition to kApolloTranslationOwnedTextNodeKey.
 static const void *kApolloTitleOwnedTextNodeKey = &kApolloTitleOwnedTextNodeKey;
+// Marker for COMMENT body text nodes specifically. The vote-time marker-parity
+// append must only ever decorate comment bodies — posts show the compact
+// info-row "🌐 PT" banner instead of an appended line. "Owned but not
+// title-owned" is NOT a comment test: the post header selftext node, the
+// visible-post-body fallback node, and stash-preempt-adopted header nodes are
+// all owned without the title key. Set in addition to
+// kApolloTranslationOwnedTextNodeKey, only by the comment apply/preempt paths.
+static const void *kApolloCommentOwnedTextNodeKey = &kApolloCommentOwnedTextNodeKey;
 // Marks a UIViewController as a feed-style VC (Posts/LitePosts/SearchResults).
 // The globe-installation code uses this to gate visibility on
 // sTranslatePostTitles in addition to sEnableBulkTranslation.
@@ -1760,6 +1768,7 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
     objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [comment.body copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloCommentOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloRegisterOwnedTextNode(textNode);
 
     // EXACT no-op gate: the containment heuristics above decide MATCHING, but
@@ -1844,6 +1853,7 @@ static void ApolloRestoreOriginalForCellNode(id commentCellNode, RDKComment *com
     // Drop ownership BEFORE writing original text back, otherwise the vote-
     // resilience hook would swap the original right back to translated.
     objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloCommentOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
 
@@ -2472,6 +2482,7 @@ static void ApolloRestoreOriginalForHeaderCellNode(id headerCellNode, RDKLink *l
     if (!textNode) return;
 
     objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloCommentOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
 
@@ -4196,6 +4207,7 @@ static void ApolloShowOriginalWithRetranslateAffordanceForCellNode(id cellNode, 
     if (![original isKindOfClass:[NSAttributedString class]]) return;
 
     objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloCommentOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
 
     NSAttributedString *display = ApolloAttributedStringByAppendingRetranslateAffordance(original);
@@ -4490,6 +4502,7 @@ static void ApolloToggleTranslationForTitleNode(id textNode) {
             objc_setAssociatedObject(node, kApolloTitlePinnedOriginalKey, sTapToTranslate ? @2 : (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
             objc_setAssociatedObject(node, kApolloTitlePinnedSourceKey, [nodeSource copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
             objc_setAssociatedObject(node, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            objc_setAssociatedObject(node, kApolloCommentOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
             NSAttributedString *original = objc_getAssociatedObject(node, kApolloOriginalAttributedTextKey);
             if ([original isKindOfClass:[NSAttributedString class]]) {
                 @try { ((void (*)(id, SEL, id))objc_msgSend)(node, @selector(setAttributedText:), original); }
@@ -5527,6 +5540,7 @@ static BOOL ApolloTextMatchesSourceOrVisualDisplay(NSString *incomingText, NSStr
 static void ApolloClearTranslationOwnershipForTextNode(id textNode) {
     objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloTitleOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloCommentOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
     if (textNode && sOwnedTextNodes) {
@@ -5616,6 +5630,7 @@ static void ApolloRestoreAllOwnedTextNodes(void) {
         // Drop ownership keys FIRST so the global setAttributedText: hook
         // won't re-swap when we write the original below.
         objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(textNode, kApolloCommentOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloTitleOwnedTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
@@ -5777,16 +5792,23 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
                                     textNode, (unsigned long)incomingText.length);
         if (swapOut) {
             NSAttributedString *rebuilt = ApolloRebuildTranslatedAttrPreservingAttrs(incomingAttributedText, translatedText);
-            // Re-append the "Translated from <Language>" marker line for body
-            // nodes (the builder self-gates on the details/tap settings and on
-            // source-language detection; title nodes never carry the line).
-            // Without this, the vote-time swap displayed the translation ONE
-            // LINE SHORTER than what was on screen — the row shrank, every row
-            // below shifted up, and the ~100ms-later scheduled reapply re-added
-            // the marker and shifted them back: a visible bounce on every vote
-            // of a translated comment. Marker parity makes the swap
-            // height-identical AND turns that follow-up reapply into a no-op.
-            if (rebuilt && ![objc_getAssociatedObject(textNode, kApolloTitleOwnedTextNodeKey) boolValue]) {
+            // Re-append the "Translated from <Language>" marker line for COMMENT
+            // bodies (the builder self-gates on the details/tap settings and on
+            // source-language detection). Without this, the vote-time swap
+            // displayed the translation ONE LINE SHORTER than what was on
+            // screen — the row shrank, every row below shifted up, and the
+            // ~100ms-later scheduled reapply re-added the marker and shifted
+            // them back: a visible bounce on every vote of a translated
+            // comment. Marker parity makes the swap height-identical AND turns
+            // that follow-up reapply into a no-op.
+            // Gate on POSITIVE comment provenance, not "not title-owned": the
+            // post header selftext node, the visible-post-body fallback node,
+            // and stash-preempt-adopted header nodes are all owned WITHOUT the
+            // title key, and appending here put a comment-style "Translated
+            // from <Language>" line inside the POST (colliding with the flair
+            // pill) whenever Apollo re-rendered the thread header. Posts show
+            // the compact info-row "🌐 PT" banner instead — never the line.
+            if (rebuilt && [objc_getAssociatedObject(textNode, kApolloCommentOwnedTextNodeKey) boolValue]) {
                 rebuilt = ApolloAttributedStringByAppendingTranslationMarker(rebuilt, originalBody);
             }
             *swapOut = rebuilt;
@@ -5861,6 +5883,7 @@ static BOOL ApolloPreemptUnownedCommentTextNode(id textNode, NSAttributedString 
     objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [incomingText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translated copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloCommentOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     if (!objc_getAssociatedObject(textNode, kApolloOriginalAttributedTextKey)) {
         objc_setAssociatedObject(textNode, kApolloOriginalAttributedTextKey, [incoming copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -194,6 +194,7 @@ static BOOL ApolloRefreshVisibleTranslationAppliedForController(UIViewController
 static BOOL ApolloRefreshFeedTitleTranslationAppliedForController(UIViewController *vc);
 static NSString *ApolloDetectDominantLanguage(NSString *text);
 static NSAttributedString *ApolloAttributedStringByAppendingTranslationMarker(NSAttributedString *translatedAttr, NSString *sourceText);
+static void ApolloIndexTranslatedCommentBody(NSString *bodyKey, NSString *fullName);
 static BOOL ApolloShouldShowTranslationMarkerForSource(NSString *sourceText, NSString **outCode);
 static void ApolloToggleTranslationForCommentTextNode(id textNode);
 static void ApolloEnsureMarkerTappableOnNode(id textNode);
@@ -1815,6 +1816,11 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
         [sCommentTranslationByFullName setObject:translatedText forKey:fullName];
         ApolloMirrorSetComment(fullName, translatedText);
         objc_setAssociatedObject(commentCellNode, kApolloAppliedTranslationFullNameKey, fullName, OBJC_ASSOCIATION_COPY_NONATOMIC);
+        // Index both body forms for the unowned-node preempt: the raw model
+        // body AND the rendered string that was on screen before this write
+        // (a rebuilt node is handed the rendered form).
+        ApolloIndexTranslatedCommentBody(comment.body, fullName);
+        if (textMatchesBody) ApolloIndexTranslatedCommentBody(current.string, fullName);
     }
     ApolloMarkVisibleTranslationApplied(comment.body, translatedText);
 }
@@ -5801,6 +5807,69 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
     return NO;
 }
 
+// Comment-cell preempt (mirror of the header stash preempt below): a vote can
+// make Apollo REBUILD a comment's body text node. The fresh node carries no
+// ownership tags, so the owned-node swap in the setAttributedText: hook passes
+// Apollo's ORIGINAL body straight through — the untranslated text (one marker
+// line shorter) is visible for a frame or two until the scheduled reapply
+// swaps it back: a language flash plus a height nudge of every row below, on
+// every vote of a translated comment. To preempt it we keep an index of the
+// bodies we have translated in this session — keyed by BOTH the raw
+// comment.body and the RENDERED string that was on screen when we applied
+// (Apollo hands the rebuilt node the rendered form) — mapping to the comment
+// fullname. When an unowned node receives text matching the index while the
+// visible thread is in translated mode, swap to the cached translation
+// inline and adopt ownership, exactly like the owned-node path would have.
+static NSMutableDictionary<NSString *, NSString *> *sApolloTranslatedBodyIndex = nil;
+
+static void ApolloIndexTranslatedCommentBody(NSString *bodyKey, NSString *fullName) {
+    if (![bodyKey isKindOfClass:[NSString class]] || bodyKey.length == 0) return;
+    if (![fullName isKindOfClass:[NSString class]] || fullName.length == 0) return;
+    @synchronized ([NSMutableDictionary class]) {
+        if (!sApolloTranslatedBodyIndex) sApolloTranslatedBodyIndex = [NSMutableDictionary dictionary];
+        sApolloTranslatedBodyIndex[bodyKey] = fullName;
+    }
+}
+
+static BOOL ApolloPreemptUnownedCommentTextNode(id textNode, NSAttributedString *incoming, NSAttributedString **swapOut) {
+    if (swapOut) *swapOut = nil;
+    if (!textNode || ![incoming isKindOfClass:[NSAttributedString class]] || incoming.length == 0) return NO;
+    UIViewController *vc = sVisibleCommentsViewController;
+    if (!vc || !ApolloControllerIsInTranslatedMode(vc)) return NO;
+    NSString *incomingText = incoming.string;
+    if (incomingText.length == 0) return NO;
+    NSString *fullName = nil;
+    @synchronized ([NSMutableDictionary class]) {
+        fullName = sApolloTranslatedBodyIndex[incomingText];
+    }
+    if (fullName.length == 0) return NO;
+    // Per-item pin: user chose to see this comment's original — honor it.
+    if (sTapToTranslate && !ApolloTapModeIsTranslatedKey(fullName)) return NO;
+    if (sUserPinnedOriginalFullNames && [sUserPinnedOriginalFullNames containsObject:fullName]) return NO;
+    NSString *translated = ApolloStripInlineMediaTokens([sCommentTranslationByFullName objectForKey:fullName]);
+    if (![translated isKindOfClass:[NSString class]] || translated.length == 0) return NO;
+
+    NSAttributedString *rebuilt = ApolloRebuildTranslatedAttrPreservingAttrs(incoming, translated);
+    if (!rebuilt) return NO;
+    // Marker parity with the apply path (builder self-gates on settings +
+    // source-language detection) so the swap is height-identical.
+    rebuilt = ApolloAttributedStringByAppendingTranslationMarker(rebuilt, incomingText);
+
+    // Adopt ownership so subsequent overwrites flow through the normal owned
+    // swap. Store the RENDERED incoming string as the original-body marker —
+    // that is what Apollo hands rebuilt nodes, so future matches are exact.
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [incomingText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translated copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
+    objc_setAssociatedObject(textNode, kApolloTranslationOwnedTextNodeKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (!objc_getAssociatedObject(textNode, kApolloOriginalAttributedTextKey)) {
+        objc_setAssociatedObject(textNode, kApolloOriginalAttributedTextKey, [incoming copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    ApolloRegisterOwnedTextNode(textNode);
+    if (swapOut) *swapOut = rebuilt;
+    ApolloTranslationVerboseLog(@"[Translation/vote] preempt(comment): unowned node=%p matched body index (%@) → SYNC swap", textNode, fullName);
+    return YES;
+}
+
 // Vote-flash mitigation: when the comments header is rebuilt after a vote
 // tap, the new post-body text node has NO ownership markers yet. The
 // scheduler-based reapply path takes ~80-100ms, during which the original
@@ -5883,7 +5952,8 @@ static BOOL ApolloPreemptUnownedTextNodeFromVCStash(id textNode, NSAttributedStr
     if (![objc_getAssociatedObject(self, kApolloTranslationOwnedTextNodeKey) boolValue]) {
         // Vote-flash preempt: brand-new (rebuilt) header body text node.
         NSAttributedString *preemptSwap = nil;
-        if (ApolloPreemptUnownedTextNodeFromVCStash(self, attributedText, &preemptSwap)) {
+        if (ApolloPreemptUnownedTextNodeFromVCStash(self, attributedText, &preemptSwap) ||
+            ApolloPreemptUnownedCommentTextNode(self, attributedText, &preemptSwap)) {
             objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
             @try { %orig(preemptSwap); } @catch (__unused NSException *e) {}
             objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -5956,7 +6026,8 @@ static BOOL ApolloPreemptUnownedTextNodeFromVCStash(id textNode, NSAttributedStr
     if (![objc_getAssociatedObject(self, kApolloTranslationOwnedTextNodeKey) boolValue]) {
         // Vote-flash preempt (mirror of ASTextNode hook above).
         NSAttributedString *preemptSwap = nil;
-        if (ApolloPreemptUnownedTextNodeFromVCStash(self, attributedText, &preemptSwap)) {
+        if (ApolloPreemptUnownedTextNodeFromVCStash(self, attributedText, &preemptSwap) ||
+            ApolloPreemptUnownedCommentTextNode(self, attributedText, &preemptSwap)) {
             objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
             @try { %orig(preemptSwap); } @catch (__unused NSException *e) {}
             objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -5810,6 +5810,12 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
             // the compact info-row "🌐 PT" banner instead — never the line.
             if (rebuilt && [objc_getAssociatedObject(textNode, kApolloCommentOwnedTextNodeKey) boolValue]) {
                 rebuilt = ApolloAttributedStringByAppendingTranslationMarker(rebuilt, originalBody);
+                // Apollo may reset linkAttributeNames when it rebuilds the
+                // text node during a vote. Restore our custom marker link in
+                // the same synchronous path as the marker itself; otherwise
+                // the later reapply sees identical text and short-circuits,
+                // leaving the freshly appended marker visible but inert.
+                ApolloEnsureMarkerTappableOnNode(textNode);
             }
             *swapOut = rebuilt;
         }
@@ -5836,20 +5842,55 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
 // line shorter) is visible for a frame or two until the scheduled reapply
 // swaps it back: a language flash plus a height nudge of every row below, on
 // every vote of a translated comment. To preempt it we keep an index of the
-// bodies we have translated in this session — keyed by BOTH the raw
+// bodies we have translated in the visible thread — keyed by BOTH the raw
 // comment.body and the RENDERED string that was on screen when we applied
-// (Apollo hands the rebuilt node the rendered form) — mapping to the comment
-// fullname. When an unowned node receives text matching the index while the
-// visible thread is in translated mode, swap to the cached translation
-// inline and adopt ownership, exactly like the owned-node path would have.
-static NSMutableDictionary<NSString *, NSString *> *sApolloTranslatedBodyIndex = nil;
+// (Apollo hands the rebuilt node the rendered form) — mapping to every matching
+// comment fullname. The fresh node must then resolve its OWN enclosing comment
+// and find that fullname in the candidate set before it can adopt a translation.
+// This matters for common identical bodies such as "Thanks!": body text alone
+// is not an identity and a last-write-wins map can apply another comment's pin
+// state or cached translation.
+static NSMutableDictionary<NSString *, NSMutableSet<NSString *> *> *sApolloTranslatedBodyIndex = nil;
+static __weak UIViewController *sApolloTranslatedBodyIndexController = nil;
+static NSUInteger const kApolloTranslatedBodyIndexMaximumKeys = 2048;
+
+static NSObject *ApolloTranslatedBodyIndexLock(void) {
+    static NSObject *lock = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        lock = [NSObject new];
+    });
+    return lock;
+}
+
+// The index is only meaningful inside the CommentsVC that populated it. Clear
+// it as soon as a different thread becomes visible, and keep a hard ceiling for
+// unusually long sessions so translated comments cannot accumulate forever.
+static void ApolloScopeTranslatedBodyIndexLocked(UIViewController *controller) {
+    if (sApolloTranslatedBodyIndexController == controller) return;
+    [sApolloTranslatedBodyIndex removeAllObjects];
+    sApolloTranslatedBodyIndexController = controller;
+}
 
 static void ApolloIndexTranslatedCommentBody(NSString *bodyKey, NSString *fullName) {
     if (![bodyKey isKindOfClass:[NSString class]] || bodyKey.length == 0) return;
     if (![fullName isKindOfClass:[NSString class]] || fullName.length == 0) return;
-    @synchronized ([NSMutableDictionary class]) {
+    UIViewController *controller = sVisibleCommentsViewController;
+    if (!controller) return;
+    @synchronized (ApolloTranslatedBodyIndexLock()) {
         if (!sApolloTranslatedBodyIndex) sApolloTranslatedBodyIndex = [NSMutableDictionary dictionary];
-        sApolloTranslatedBodyIndex[bodyKey] = fullName;
+        ApolloScopeTranslatedBodyIndexLocked(controller);
+        NSMutableSet<NSString *> *fullNames = sApolloTranslatedBodyIndex[bodyKey];
+        if (!fullNames) {
+            if (sApolloTranslatedBodyIndex.count >= kApolloTranslatedBodyIndexMaximumKeys) {
+                ApolloLog(@"[Translation/vote] Body index reached %lu keys; clearing active-thread cache",
+                          (unsigned long)kApolloTranslatedBodyIndexMaximumKeys);
+                [sApolloTranslatedBodyIndex removeAllObjects];
+            }
+            fullNames = [NSMutableSet set];
+            sApolloTranslatedBodyIndex[bodyKey] = fullNames;
+        }
+        [fullNames addObject:fullName];
     }
 }
 
@@ -5860,11 +5901,22 @@ static BOOL ApolloPreemptUnownedCommentTextNode(id textNode, NSAttributedString 
     if (!vc || !ApolloControllerIsInTranslatedMode(vc)) return NO;
     NSString *incomingText = incoming.string;
     if (incomingText.length == 0) return NO;
-    NSString *fullName = nil;
-    @synchronized ([NSMutableDictionary class]) {
-        fullName = sApolloTranslatedBodyIndex[incomingText];
-    }
+
+    // Body text narrows the search, but never identifies the comment. Resolve
+    // the owning model from this fresh node so identical bodies cannot borrow
+    // another comment's translation cache or per-item pin state.
+    id cellNode = ApolloCommentCellNodeForTextNode(textNode);
+    RDKComment *comment = cellNode ? ApolloCommentFromCellNode(cellNode) : nil;
+    NSString *fullName = comment ? ApolloCommentFullName(comment) : nil;
     if (fullName.length == 0) return NO;
+
+    BOOL indexedForComment = NO;
+    @synchronized (ApolloTranslatedBodyIndexLock()) {
+        ApolloScopeTranslatedBodyIndexLocked(vc);
+        NSSet<NSString *> *fullNames = sApolloTranslatedBodyIndex[incomingText];
+        indexedForComment = [fullNames containsObject:fullName];
+    }
+    if (!indexedForComment) return NO;
     // Per-item pin: user chose to see this comment's original — honor it.
     if (sTapToTranslate && !ApolloTapModeIsTranslatedKey(fullName)) return NO;
     if (sUserPinnedOriginalFullNames && [sUserPinnedOriginalFullNames containsObject:fullName]) return NO;
@@ -5876,6 +5928,7 @@ static BOOL ApolloPreemptUnownedCommentTextNode(id textNode, NSAttributedString 
     // Marker parity with the apply path (builder self-gates on settings +
     // source-language detection) so the swap is height-identical.
     rebuilt = ApolloAttributedStringByAppendingTranslationMarker(rebuilt, incomingText);
+    ApolloEnsureMarkerTappableOnNode(textNode);
 
     // Adopt ownership so subsequent overwrites flow through the normal owned
     // swap. Store the RENDERED incoming string as the original-body marker —


### PR DESCRIPTION
**Reported:** upvoting/downvoting a comment made the whole comment flash blank for a frame. Testing surfaced a family of related flickers: text also blanked when returning to the app from the app switcher (#217's iOS case), and **translated** comments additionally flashed their original language, bounced in height, and displayed raw `![gif](giphy|…)` tokens as literal text. All measured and fixed in this PR; every fix was verified in the simulator with display-pipeline instrumentation (blank-commit scans over visible cells) and frame capture.

### The common mechanism (measured, not guessed)

Texture re-displays nodes **asynchronously**. Whenever something re-displays a visible cell's node whose backing store is empty (freshly created, dropped, or replaced), the frame commits with `layer.contents == nil` — a visible blank. Instrumentation caught this literally (`[BLANK@T0] ASTextNode … committed with nil contents`) on every unfixed vote, and for 1000ms+ after every app-switch return.

### Fixes

**`ApolloCommentVoteFlicker.xm` (new module)**
- **Votes:** when a visible comment/header cell receives a `ModelObjectUpdated`, force it to complete display synchronously in the same frame (`neverShowPlaceholders` + `recursivelyEnsureDisplaySynchronously:` post-reconfigure and next runloop turn).
- **App-switch returns:** on `willEnterForeground`/`didBecomeActive`, flush display of tracked visible cells (staged passes; feed post cells included). Backgrounding drops backing stores; the flush completes the redraw before the live view appears.

**`ApolloTranslation.xm` (translated comments — four compounding defects)**
1. **Heal at every translation write:** the vote-resilience reapply re-writes translated text on its own schedule, outside any fixed flush window — so each write site now flushes the cell's display synchronously itself (provider/timing-agnostic; off-screen bulk applies stay lazy).
2. **Marker parity in the vote-time swap:** the inline swap restored the translation *without* the "Translated from X" line — one line shorter → rows below bounced. The swap now appends the marker (builder self-gates), making it height-identical and turning the follow-up reapply into a no-op.
3. **Exact no-op gates:** the reapply's "already showing this?" containment heuristics misfire on repetitive bodies (long `AAAA…` runs match both original and translation), causing identical-text rewrites on every vote → full-table re-measures → content-offset jumps (measured up to ~370pt). All three apply paths now compare the final display string character-exact and skip write/relayout when nothing changes.
4. **Rebuild preempt:** a vote can make Apollo *rebuild* the body text node; the fresh node has no ownership tags, so the original language rendered for a few frames until the reapply caught up (frame-captured: `HACELE EL AMOR` → `GIVE HIM LOVE`). Translated comments are now indexed by raw + rendered body; an unowned node whose incoming text matches gets the cached translation (marker included, height-identical) swapped in inline before anything reaches the screen — mirroring the guard the post header already had.
5. **Media tokens:** `![gif](giphy|…)` tokens are stripped from text sent to providers and from cached translations at apply time — Apollo never displays them (the gif renders from `media_metadata` separately), and now translated comments don't either.

**`ApolloInlineImages.xm`:** decomposition cache content-keyed so media comments stop recreating their text nodes on vote relayouts.

Nothing runs during scrolling — cells are only touched on a vote, a foreground transition, or a translation write.

### Verification (simulator)

| Scenario | Unfixed | Fixed |
|---|---|---|
| Vote (real ⋯-menu votes) | blank commit at T0, every vote | blank=0 at T0→1000ms, repeated votes |
| Background → foreground | blank=8 nodes for 1000ms+ | blank=0 at every sample |
| Vote on translated comment | original-language frames + row bounce + offset jumps | preempt log confirms inline swap on rebuilt nodes; frame burst shows continuous translated text, zero row movement |
| Gif comment translated | literal `![gif](…)` line displayed | token gone, gif renders, marker intact |

Reporter-confirmed on device for the vote + app-switch cases; translated-comment fixes verified on the exact comments from the reports (r/argentina test thread). Fixes the iOS side of #217; the macOS flicker there is a different (deactivation-side) mechanism and stays open.