### PR TITLE
Translation: skip-list languages get no marker + keep "Show translation" after collapse/expand

### DIFF
--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -1658,6 +1658,15 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
             if ([shown isKindOfClass:[NSAttributedString class]] && shown.length > 0 &&
                 !ApolloAttributedStringEndsWithMarker(shown) &&
                 ApolloTextQualifiesAsBodyCandidate(shown.string, comment.body)) {
+                // Overwrite the saved original with the just-validated CLEAN body
+                // (same reuse rationale as ApolloAppendTranslateAffordanceForCellNode):
+                // a reused node may carry a PREVIOUS comment's saved original (never
+                // nil-cleared, and ShowOriginal's containment check can wrongly accept
+                // it when it merely contains this body), and a missing key would let a
+                // later unpin save the DECORATED text as the "original" (stacked
+                // affordances on re-pin). `shown` is marker-free and matches THIS
+                // comment's body here, so it is always the correct clean original.
+                objc_setAssociatedObject(pinnedNode, kApolloOriginalAttributedTextKey, [shown copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
                 ApolloShowOriginalWithRetranslateAffordanceForCellNode(commentCellNode, comment, pinnedNode);
             }
         }
@@ -2224,11 +2233,11 @@ static void ApolloApplyTranslationToHeaderCellNode(id headerCellNode, RDKLink *l
 
     // TAP-TO-TRANSLATE: hold the header swap until the marker is tapped. Stash
     // the tap's inputs (content assocs, auto-pin, the link + body-node handles
-    // the toggle routes through) and show the TARGET-code marker. Skip when the
-    // translation is a no-op (same-language / "Don't Translate" language) — there
-    // is nothing to reveal, so no hold and no marker.
-    if (sTapToTranslate && !ApolloTapModeIsTranslatedKey(body) &&
-        ApolloTranslatedTextDiffersFromSource(body, translatedText)) {
+    // the toggle routes through) and show the TARGET-code marker. A no-op
+    // translation (same-language / "Don't Translate" language) gets no hold and
+    // no marker — but STILL returns: tap mode must never auto-swap.
+    if (sTapToTranslate && !ApolloTapModeIsTranslatedKey(body)) {
+        if (!ApolloTranslatedTextDiffersFromSource(body, translatedText)) return;
         objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [body copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloTitlePinnedOriginalKey, @2, OBJC_ASSOCIATION_RETAIN_NONATOMIC);   // @2 = tap-mode auto-pin
@@ -2313,9 +2322,10 @@ static void ApolloApplyTranslationToPostTextNode(id owner, id textNode, NSString
         }
     }
     // TAP-TO-TRANSLATE: hold the swap; stash + auto-pin so the marker tap works.
-    // A no-op translation (same-language / skipped language) gets no hold.
-    if (sTapToTranslate && !ApolloTapModeIsTranslatedKey(sourceText) &&
-        ApolloTranslatedTextDiffersFromSource(sourceText, translatedText)) {
+    // A no-op translation (same-language / skipped language) gets no hold — but
+    // STILL returns: tap mode must never auto-swap.
+    if (sTapToTranslate && !ApolloTapModeIsTranslatedKey(sourceText)) {
+        if (!ApolloTranslatedTextDiffersFromSource(sourceText, translatedText)) return;
         objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [sourceText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloTitlePinnedOriginalKey, @2, OBJC_ASSOCIATION_RETAIN_NONATOMIC);   // @2 = tap-mode auto-pin
@@ -4067,6 +4077,9 @@ static id ApolloCommentCellNodeForTextNode(id textNode) {
 // toggles the translation back on.
 static NSAttributedString *ApolloAttributedStringByAppendingRetranslateAffordance(NSAttributedString *originalAttr) {
     if (![originalAttr isKindOfClass:[NSAttributedString class]] || originalAttr.length == 0) return originalAttr;
+    // Never stack a second affordance onto a string that already ends with one
+    // (e.g. a saved "original" that was accidentally captured post-decoration).
+    if (ApolloAttributedStringEndsWithMarker(originalAttr)) return originalAttr;
 
     NSDictionary *baseAttributes = ApolloVisualBaseAttributesFromAttributedString(originalAttr);
     UIFont *bodyFont = baseAttributes[NSFontAttributeName];
@@ -6216,9 +6229,10 @@ static void ApolloApplyTranslationToTitleNode(id titleNode, id textNode, NSStrin
     // everything the tap needs (source/translated + auto-pin so every reapply
     // path and the unowned-preempt hook respect the held state), show the
     // marker with the TARGET code ("EN" = tap for English), and bail. A no-op
-    // translation (same-language / skipped language) gets no hold and no marker.
-    if (sTapToTranslate && !ApolloTapModeIsTranslatedKey(sourceText) &&
-        ApolloTranslatedTextDiffersFromSource(sourceText, translatedText)) {
+    // translation (same-language / skipped language) gets no hold and no
+    // marker — but STILL returns: tap mode must never auto-swap.
+    if (sTapToTranslate && !ApolloTapModeIsTranslatedKey(sourceText)) {
+        if (!ApolloTranslatedTextDiffersFromSource(sourceText, translatedText)) return;
         objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [sourceText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloTitlePinnedOriginalKey, @2, OBJC_ASSOCIATION_RETAIN_NONATOMIC);   // @2 = tap-mode auto-pin

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -2203,8 +2203,11 @@ static void ApolloApplyTranslationToHeaderCellNode(id headerCellNode, RDKLink *l
 
     // TAP-TO-TRANSLATE: hold the header swap until the marker is tapped. Stash
     // the tap's inputs (content assocs, auto-pin, the link + body-node handles
-    // the toggle routes through) and show the TARGET-code marker.
-    if (sTapToTranslate && !ApolloTapModeIsTranslatedKey(body)) {
+    // the toggle routes through) and show the TARGET-code marker. Skip when the
+    // translation is a no-op (same-language / "Don't Translate" language) — there
+    // is nothing to reveal, so no hold and no marker.
+    if (sTapToTranslate && !ApolloTapModeIsTranslatedKey(body) &&
+        ApolloTranslatedTextDiffersFromSource(body, translatedText)) {
         objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [body copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloTitlePinnedOriginalKey, @2, OBJC_ASSOCIATION_RETAIN_NONATOMIC);   // @2 = tap-mode auto-pin
@@ -2289,7 +2292,9 @@ static void ApolloApplyTranslationToPostTextNode(id owner, id textNode, NSString
         }
     }
     // TAP-TO-TRANSLATE: hold the swap; stash + auto-pin so the marker tap works.
-    if (sTapToTranslate && !ApolloTapModeIsTranslatedKey(sourceText)) {
+    // A no-op translation (same-language / skipped language) gets no hold.
+    if (sTapToTranslate && !ApolloTapModeIsTranslatedKey(sourceText) &&
+        ApolloTranslatedTextDiffersFromSource(sourceText, translatedText)) {
         objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [sourceText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloTitlePinnedOriginalKey, @2, OBJC_ASSOCIATION_RETAIN_NONATOMIC);   // @2 = tap-mode auto-pin
@@ -2697,6 +2702,25 @@ static NSString *ApolloDetectDominantLanguage(NSString *text) {
     return ApolloDominantLanguageWithConfidence(text, NULL);
 }
 
+// YES if `langCode` (a base ISO code like "it") is one the user added to the
+// "Don't Translate" skip list. Skip codes are persisted lowercase and base-only
+// (TranslationSettingsViewController -normalizedLanguageCodeFromIdentifier:), and
+// ApolloDetectDominantLanguage likewise returns a lowercase base code, so a plain
+// lowercase compare is correct. Shared by the translate gate AND the marker/
+// affordance gate so a skipped language never advertises a translation control.
+static BOOL ApolloLanguageCodeIsInSkipList(NSString *langCode) {
+    if (![langCode isKindOfClass:[NSString class]] || langCode.length == 0) return NO;
+    NSArray<NSString *> *skip = sTranslationSkipLanguages;
+    if (![skip isKindOfClass:[NSArray class]] || skip.count == 0) return NO;
+
+    NSString *lower = langCode.lowercaseString;
+    for (NSString *code in skip) {
+        if (![code isKindOfClass:[NSString class]]) continue;
+        if ([code.lowercaseString isEqualToString:lower]) return YES;
+    }
+    return NO;
+}
+
 // Returns YES if the user has asked us not to translate text in `detectedLang`.
 // We intentionally do NOT short-circuit when detected == target: many comments are
 // mixed-language (e.g. mostly English with embedded Japanese), and NLLanguageRecognizer
@@ -2710,11 +2734,7 @@ static BOOL ApolloShouldSkipTranslationForText(NSString *text, NSString *targetL
     NSString *detected = ApolloDetectDominantLanguage(text);
     if (detected.length == 0) return NO;
 
-    for (NSString *code in skip) {
-        if (![code isKindOfClass:[NSString class]]) continue;
-        if ([code.lowercaseString isEqualToString:detected]) return YES;
-    }
-    return NO;
+    return ApolloLanguageCodeIsInSkipList(detected);
 }
 
 // Strict source-language detector for the Apple backend. Apple needs an EXPLICIT
@@ -3103,6 +3123,7 @@ static void ApolloMaybeTranslateCommentCellNode(id commentCellNode, BOOL forceTr
         // the control. The request below still prefetches so the tap is
         // instant when it succeeded; on a miss the tap fetches on demand.
         if (sTapToTranslate && detected.length > 0 && ![detected isEqualToString:targetLanguage] &&
+            !ApolloLanguageCodeIsInSkipList(detected) &&
             fullName.length > 0 && !ApolloTapModeIsTranslatedKey(fullName)) {
             ApolloAppendTranslateAffordanceForCellNode(commentCellNode, comment);
         }
@@ -3392,6 +3413,7 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
         // foreign — don't wait for the prefetch (a failing provider must not
         // hide the control). The request below still prefetches.
         if (sTapToTranslate && detected.length > 0 && ![detected isEqualToString:targetLanguage] &&
+            !ApolloLanguageCodeIsInSkipList(detected) &&
             !ApolloTapModeIsTranslatedKey(trimmed)) {
             id heldNode = ApolloBestPostBodyTextNode(headerCellNode, link, trimmed);
             if (heldNode) {
@@ -3476,6 +3498,7 @@ static void ApolloMaybeTranslateVisiblePostBodyForController(UIViewController *v
         // post-body layouts the header-cell walk misses) — don't wait for the
         // prefetch below.
         if (sTapToTranslate && detected.length > 0 && ![detected isEqualToString:targetLanguage] &&
+            !ApolloLanguageCodeIsInSkipList(detected) &&
             !ApolloTapModeIsTranslatedKey(sourceText)) {
             @try {
                 NSAttributedString *cur = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText));
@@ -3936,6 +3959,13 @@ static BOOL ApolloShouldShowTranslationMarkerForSource(NSString *sourceText, NSS
     if (sourceCode.length == 0) return NO;
     NSString *targetCode = ApolloResolvedTargetLanguageCode();
     if (targetCode.length > 0 && [sourceCode isEqualToString:targetCode]) return NO;
+    // Honour the user's "Don't Translate" list: text in a skipped language is
+    // never translated, so it must not carry a "Translated from …" marker or a
+    // "Translate" affordance — tapping one would just no-op (the reported bug:
+    // an Italian thread with Italian skipped still showed the label on every
+    // comment). This is the single gate for the normal-mode comment/title/
+    // header/feed markers, so returning NO here clears them all at once.
+    if (ApolloLanguageCodeIsInSkipList(sourceCode)) return NO;
     if (ApolloLocalizedSourceLanguageName(sourceCode).length == 0) return NO;
     if (outCode) *outCode = sourceCode;
     return YES;
@@ -6164,8 +6194,10 @@ static void ApolloApplyTranslationToTitleNode(id titleNode, id textNode, NSStrin
     // TAP-TO-TRANSLATE: hold the swap until the user taps the marker. Stash
     // everything the tap needs (source/translated + auto-pin so every reapply
     // path and the unowned-preempt hook respect the held state), show the
-    // marker with the TARGET code ("EN" = tap for English), and bail.
-    if (sTapToTranslate && !ApolloTapModeIsTranslatedKey(sourceText)) {
+    // marker with the TARGET code ("EN" = tap for English), and bail. A no-op
+    // translation (same-language / skipped language) gets no hold and no marker.
+    if (sTapToTranslate && !ApolloTapModeIsTranslatedKey(sourceText) &&
+        ApolloTranslatedTextDiffersFromSource(sourceText, translatedText)) {
         objc_setAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey, [sourceText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloOwnedNodeTranslatedTextKey, [translatedText copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
         objc_setAssociatedObject(textNode, kApolloTitlePinnedOriginalKey, @2, OBJC_ASSOCIATION_RETAIN_NONATOMIC);   // @2 = tap-mode auto-pin
@@ -6406,8 +6438,10 @@ static void ApolloMaybeTranslatePostTitleNode(id titleNode) {
     if ([detected isEqualToString:targetLanguage]) return;
 
     // TAP-TO-TRANSLATE: marker + hold as soon as the title is detectably
-    // foreign (detection-driven — see the comment/header equivalents).
-    if (sTapToTranslate && detected.length > 0 && !ApolloTapModeIsTranslatedKey(titleText)) {
+    // foreign (detection-driven — see the comment/header equivalents). A title
+    // in a "Don't Translate" language gets no marker (it can't be translated).
+    if (sTapToTranslate && detected.length > 0 && !ApolloLanguageCodeIsInSkipList(detected) &&
+        !ApolloTapModeIsTranslatedKey(titleText)) {
         @try {
             NSAttributedString *cur = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText));
             if ([cur isKindOfClass:[NSAttributedString class]] && cur.length > 0 &&

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -199,6 +199,7 @@ static void ApolloToggleTranslationForCommentTextNode(id textNode);
 static void ApolloEnsureMarkerTappableOnNode(id textNode);
 static void ApolloEnsureCommentsTableBreathingRoom(void);
 static void ApolloAppendTranslateAffordanceForCellNode(id cellNode, RDKComment *comment);
+static void ApolloShowOriginalWithRetranslateAffordanceForCellNode(id cellNode, RDKComment *comment, id textNode);
 static BOOL ApolloAttributedStringEndsWithMarker(NSAttributedString *attr);
 static void ApolloApplyTranslationToTitleNode(id titleNode, id textNode, NSString *sourceText, NSString *translatedText);
 // A feed post title the user tapped to pin back to ORIGINAL; gates the title
@@ -1640,6 +1641,26 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
             return;
         }
     } else if (pinName.length > 0 && sUserPinnedOriginalFullNames && [sUserPinnedOriginalFullNames containsObject:pinName]) {
+        // Pinned to original — but a collapse/expand or cell reuse rebuilds the
+        // cell with the PLAIN body, stripping the "Show translation" line. That
+        // line is the tap target, so without re-asserting it the comment would
+        // be stranded in its original language with no way back (reported bug).
+        // Idempotent: skip when the displayed text already carries our marker,
+        // and only decorate the node actually showing THIS comment's original
+        // body. The affordance is only useful when a real translation exists
+        // (it does by construction here — we were called with one that differs,
+        // or the differs check below skips a no-op).
+        if (ApolloTranslatedTextDiffersFromSource(comment.body, translatedText)) {
+            id pinnedNode = ApolloBestCommentTextNode(commentCellNode, comment);
+            NSAttributedString *shown = nil;
+            @try { shown = ((id (*)(id, SEL))objc_msgSend)(pinnedNode, @selector(attributedText)); }
+            @catch (__unused NSException *e) {}
+            if ([shown isKindOfClass:[NSAttributedString class]] && shown.length > 0 &&
+                !ApolloAttributedStringEndsWithMarker(shown) &&
+                ApolloTextQualifiesAsBodyCandidate(shown.string, comment.body)) {
+                ApolloShowOriginalWithRetranslateAffordanceForCellNode(commentCellNode, comment, pinnedNode);
+            }
+        }
         return;
     }
 
@@ -7433,6 +7454,77 @@ static void ApolloDbgTapComment(CFNotificationCenterRef c, void *o, CFStringRef 
         ApolloLog(@"[Tw/dbg] no comment affordance visible");
     });
 }
+// Pin/unpin the topmost TRANSLATION-OWNED comment (works even when the marker
+// line is absent, e.g. detection-floor comments that still translated) — same
+// toggle a marker tap drives.
+static void ApolloDbgPinComment(CFNotificationCenterRef c, void *o, CFStringRef n, const void *obj, CFDictionaryRef u) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        for (UIWindow *w in ApolloAllWindows()) {
+            NSMutableArray *nodes = [NSMutableArray array];
+            NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:256];
+            ApolloCollectAttributedTextNodes(w, 18, visited, nodes);
+            id best = nil; CGFloat bestY = CGFLOAT_MAX;
+            for (id node in nodes) {
+                BOOL owned = [objc_getAssociatedObject(node, kApolloTranslationOwnedTextNodeKey) boolValue];
+                NSAttributedString *attr = nil;
+                @try { attr = ((id (*)(id, SEL))objc_msgSend)(node, @selector(attributedText)); } @catch (__unused NSException *e) { continue; }
+                if (!owned && !ApolloAttributedStringEndsWithMarker(attr)) continue;
+                UIView *v = nil;
+                @try { if ([node respondsToSelector:@selector(view)]) v = ((UIView *(*)(id, SEL))objc_msgSend)(node, @selector(view)); } @catch (__unused NSException *e) {}
+                if (!v.window) continue;
+                CGFloat y = [v convertRect:v.bounds toView:nil].origin.y;
+                if (y > 150.0 && y < bestY) { bestY = y; best = node; }
+            }
+            if (best) {
+                ApolloLog(@"[Tw/dbg] pin-toggling owned comment at y=%.0f", bestY);
+                ApolloToggleTranslationForCommentTextNode(best);
+                return;
+            }
+        }
+        ApolloLog(@"[Tw/dbg] no owned/marked comment visible");
+    });
+}
+// Collapse/expand the comment ROW containing the topmost owned-or-marked text
+// node, by routing through the table's own didSelectRow (exactly what a finger
+// tap on the cell does) — HID taps in the sim are unreliable for this.
+static void ApolloDbgToggleCollapse(CFNotificationCenterRef c, void *o, CFStringRef n, const void *obj, CFDictionaryRef u) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UITableView *tv = GetCommentsTableView(sVisibleCommentsViewController);
+        if (!tv) { ApolloLog(@"[Tw/dbg] no comments table"); return; }
+        // Find the topmost owned/marked node's position → its row.
+        NSMutableArray *nodes = [NSMutableArray array];
+        NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:256];
+        ApolloCollectAttributedTextNodes(tv, 18, visited, nodes);
+        NSIndexPath *ip = nil; CGFloat bestY = CGFLOAT_MAX;
+        for (id node in nodes) {
+            BOOL owned = [objc_getAssociatedObject(node, kApolloTranslationOwnedTextNodeKey) boolValue];
+            BOOL pinned = objc_getAssociatedObject(node, kApolloOriginalAttributedTextKey) != nil;
+            NSAttributedString *attr = nil;
+            @try { attr = ((id (*)(id, SEL))objc_msgSend)(node, @selector(attributedText)); } @catch (__unused NSException *e) { continue; }
+            if (!owned && !pinned && !ApolloAttributedStringEndsWithMarker(attr)) continue;
+            UIView *v = nil;
+            @try { if ([node respondsToSelector:@selector(view)]) v = ((UIView *(*)(id, SEL))objc_msgSend)(node, @selector(view)); } @catch (__unused NSException *e) {}
+            if (!v.window) continue;
+            CGRect inTable = [v convertRect:v.bounds toView:tv];
+            NSIndexPath *cand = [tv indexPathForRowAtPoint:CGPointMake(CGRectGetMidX(inTable), CGRectGetMidY(inTable))];
+            if (cand && inTable.origin.y < bestY) { bestY = inTable.origin.y; ip = cand; }
+        }
+        if (!ip) {
+            // Fallback: remembered row from the previous invocation (the collapsed
+            // cell no longer contains our text node).
+            ip = objc_getAssociatedObject(tv, "apollo_dbg_collapse_ip");
+        }
+        if (!ip) { ApolloLog(@"[Tw/dbg] no target row for collapse"); return; }
+        objc_setAssociatedObject(tv, "apollo_dbg_collapse_ip", ip, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        id target = tv.delegate;
+        if ([target respondsToSelector:@selector(tableView:didSelectRowAtIndexPath:)]) {
+            ApolloLog(@"[Tw/dbg] didSelect (collapse-toggle) row=%ld sec=%ld", (long)ip.row, (long)ip.section);
+            ((void (*)(id, SEL, id, id))objc_msgSend)(target, @selector(tableView:didSelectRowAtIndexPath:), tv, ip);
+        } else {
+            ApolloLog(@"[Tw/dbg] table delegate %@ lacks didSelect", [target class]);
+        }
+    });
+}
 static void ApolloDbgDumpInsets(CFNotificationCenterRef c, void *o, CFStringRef n, const void *obj, CFDictionaryRef u) {
     dispatch_async(dispatch_get_main_queue(), ^{
         UITableView *tv = GetCommentsTableView(sVisibleCommentsViewController);
@@ -7566,6 +7658,8 @@ static void ApolloDbgOpenFirstPost(CFNotificationCenterRef c, void *o, CFStringR
     CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, ApolloDbgOpenFirstPost, CFSTR("apollofix.dbg.open"), NULL, CFNotificationSuspensionBehaviorDeliverImmediately);
     CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, ApolloDbgFlipTapMode, CFSTR("apollofix.dbg.tapmode"), NULL, CFNotificationSuspensionBehaviorDeliverImmediately);
     CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, ApolloDbgTapComment, CFSTR("apollofix.dbg.tapcomment"), NULL, CFNotificationSuspensionBehaviorDeliverImmediately);
+    CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, ApolloDbgPinComment, CFSTR("apollofix.dbg.pincomment"), NULL, CFNotificationSuspensionBehaviorDeliverImmediately);
+    CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, ApolloDbgToggleCollapse, CFSTR("apollofix.dbg.collapse"), NULL, CFNotificationSuspensionBehaviorDeliverImmediately);
     CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, ApolloDbgDumpInsets, CFSTR("apollofix.dbg.insets"), NULL, CFNotificationSuspensionBehaviorDeliverImmediately);
 #endif
 

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -149,6 +149,79 @@ static inline void ApolloMirrorRemoveLink(NSString *key) {
     if (!key) return;
     @synchronized (sLinkTranslationMirror) { [sLinkTranslationMirror removeObjectForKey:key]; }
 }
+// Mirror of the raw text-keyed cache (sTranslationCache). Titles, rich link
+// previews, and post bodies key by source text rather than fullName, so they
+// need their own suspension-proof store — iOS purges NSCache contents while
+// the app sits suspended in the background (and our memory-warning handler
+// clears the raw cache deliberately), which made every app switch re-run
+// language detection + a provider round-trip for everything visible: the
+// thread flashed back to the original language for ~a second on every
+// foreground. Insertion-order capped so an all-day session stays bounded.
+static NSMutableDictionary<NSString *, NSString *> *sRawTranslationMirror = nil;
+static NSMutableArray<NSString *> *sRawTranslationMirrorOrder = nil;
+static const NSUInteger kApolloRawTranslationMirrorCap = 4096;
+
+static void ApolloRawTranslationCacheSet(NSString *cacheKey, NSString *value) {
+    if (cacheKey.length == 0 || value.length == 0) return;
+    [sTranslationCache setObject:value forKey:cacheKey];
+    @synchronized (sRawTranslationMirror) {
+        if (!sRawTranslationMirror[cacheKey]) [sRawTranslationMirrorOrder addObject:cacheKey];
+        sRawTranslationMirror[cacheKey] = value;
+        if (sRawTranslationMirrorOrder.count > kApolloRawTranslationMirrorCap) {
+            NSRange oldest = NSMakeRange(0, sRawTranslationMirrorOrder.count / 4);
+            for (NSString *evicted in [sRawTranslationMirrorOrder subarrayWithRange:oldest]) {
+                [sRawTranslationMirror removeObjectForKey:evicted];
+            }
+            [sRawTranslationMirrorOrder removeObjectsInRange:oldest];
+        }
+    }
+}
+
+// Cache-lookup helpers that fall back to the mirror dictionaries. An NSCache
+// miss does NOT mean "never translated" — the cache is purged during
+// background suspension. The mirrors survive; on a mirror hit re-seed the
+// NSCache so subsequent lookups take the fast path again. Every read of the
+// three caches must go through these (never objectForKey: directly), or the
+// post-foreground re-apply falls through to the network path again.
+static NSString *ApolloRawTranslationCacheGet(NSString *cacheKey) {
+    if (cacheKey.length == 0) return nil;
+    NSString *hit = [sTranslationCache objectForKey:cacheKey];
+    if (hit.length > 0) return hit;
+    @synchronized (sRawTranslationMirror) { hit = sRawTranslationMirror[cacheKey]; }
+    if (hit.length > 0) [sTranslationCache setObject:hit forKey:cacheKey];
+    return hit;
+}
+static NSString *ApolloCachedCommentTranslationForFullName(NSString *fullName) {
+    if (fullName.length == 0) return nil;
+    NSString *hit = [sCommentTranslationByFullName objectForKey:fullName];
+    if (hit.length > 0) return hit;
+    @synchronized (sCommentTranslationMirror) { hit = sCommentTranslationMirror[fullName]; }
+    if (hit.length > 0) [sCommentTranslationByFullName setObject:hit forKey:fullName];
+    return hit;
+}
+static NSString *ApolloCachedLinkTranslationForKey(NSString *key) {
+    if (key.length == 0) return nil;
+    NSString *hit = [sLinkTranslationByFullName objectForKey:key];
+    if (hit.length > 0) return hit;
+    @synchronized (sLinkTranslationMirror) { hit = sLinkTranslationMirror[key]; }
+    if (hit.length > 0) [sLinkTranslationByFullName setObject:hit forKey:key];
+    return hit;
+}
+
+// Full flush — caches AND mirrors. For "forget everything" flows (the
+// skip-language list changed). Clearing only the NSCaches would leave the
+// mirror fallbacks above serving the stale entries right back.
+static void ApolloClearAllTranslationCaches(void) {
+    [sTranslationCache removeAllObjects];
+    [sCommentTranslationByFullName removeAllObjects];
+    [sLinkTranslationByFullName removeAllObjects];
+    @synchronized (sRawTranslationMirror) {
+        [sRawTranslationMirror removeAllObjects];
+        [sRawTranslationMirrorOrder removeAllObjects];
+    }
+    @synchronized (sCommentTranslationMirror) { [sCommentTranslationMirror removeAllObjects]; }
+    @synchronized (sLinkTranslationMirror) { [sLinkTranslationMirror removeAllObjects]; }
+}
 static NSMutableDictionary<NSString *, NSMutableArray *> *sPendingTranslationCallbacks;
 static __weak UIViewController *sVisibleCommentsViewController = nil;
 // Weak set of every text node we've stamped with the ownership marker. Lets
@@ -2925,7 +2998,7 @@ static void ApolloRequestTranslation(NSString *cacheKey,
                                      NSString *sourceText,
                                      NSString *targetLanguage,
                                      void (^completion)(NSString *translated, NSError *error)) {
-    NSString *cached = [sTranslationCache objectForKey:cacheKey];
+    NSString *cached = ApolloRawTranslationCacheGet(cacheKey);
     if (cached.length > 0) {
         completion(cached, nil);
         return;
@@ -2963,7 +3036,7 @@ static void ApolloRequestTranslation(NSString *cacheKey,
         }
 
         if ([restoredTranslation isKindOfClass:[NSString class]] && restoredTranslation.length > 0) {
-            [sTranslationCache setObject:restoredTranslation forKey:cacheKey];
+            ApolloRawTranslationCacheSet(cacheKey, restoredTranslation);
         }
 
         for (id callbackObj in callbacks) {
@@ -3057,7 +3130,7 @@ NSString *ApolloRichPreviewTranslatedTextIfAvailable(NSURL *url, NSString *field
     if ([detected isEqualToString:targetLanguage]) return nil;
 
     NSString *cacheKey = ApolloRichPreviewTranslationCacheKey(url, field, trimmed, targetLanguage);
-    NSString *cached = [sTranslationCache objectForKey:cacheKey];
+    NSString *cached = ApolloRawTranslationCacheGet(cacheKey);
     if (ApolloTranslatedTextDiffersFromSource(trimmed, cached)) return tapHeld ? nil : cached;
 
     @synchronized (sRichPreviewTranslationInFlightKeys) {
@@ -3134,7 +3207,7 @@ static void ApolloMaybeTranslateCommentCellNode(id commentCellNode, BOOL forceTr
     // Re-apply from the fullName cache without going to the network. This
     // makes collapse/expand and cell reuse re-show the translation immediately.
     if (fullName.length > 0) {
-        NSString *cachedTranslation = [sCommentTranslationByFullName objectForKey:fullName];
+        NSString *cachedTranslation = ApolloCachedCommentTranslationForFullName(fullName);
         if (cachedTranslation.length > 0) {
             ApolloApplyTranslationToCellNode(commentCellNode, comment, cachedTranslation);
             return;
@@ -3237,7 +3310,7 @@ static BOOL ApolloReapplyCachedTranslationForCellNode(id commentCellNode) {
         ApolloTranslationVerboseLog(@"[Translation/vote] commentReapply: empty fullName cellNode=%p", commentCellNode);
         return NO;
     }
-    NSString *cached = [sCommentTranslationByFullName objectForKey:fullName];
+    NSString *cached = ApolloCachedCommentTranslationForFullName(fullName);
     if (cached.length == 0) {
         ApolloTranslationVerboseLog(@"[Translation/vote] commentReapply: cache MISS fullName=%@", fullName);
         return NO;
@@ -3309,7 +3382,7 @@ static BOOL ApolloReapplyCachedTranslationForHeaderCellNode(id headerCellNode) {
         if ([body isKindOfClass:[NSString class]] && body.length > 0) {
             trimmed = [body stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
             NSString *cacheKey = trimmed.length > 0 ? ApolloVisiblePostCacheKey(link, trimmed, targetLanguage) : nil;
-            cached = cacheKey.length > 0 ? [sLinkTranslationByFullName objectForKey:cacheKey] : nil;
+            cached = ApolloCachedLinkTranslationForKey(cacheKey);
         }
     }
 
@@ -3429,7 +3502,7 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
 
     NSString *cacheStoreKey = ApolloVisiblePostCacheKey(link, trimmed, targetLanguage);
     if (cacheStoreKey.length > 0) {
-        NSString *cached = [sLinkTranslationByFullName objectForKey:cacheStoreKey];
+        NSString *cached = ApolloCachedLinkTranslationForKey(cacheStoreKey);
         if (cached.length > 0) {
             ApolloApplyTranslationToHeaderCellNode(headerCellNode, link, trimmed, cached);
             return;
@@ -3514,7 +3587,7 @@ static void ApolloMaybeTranslateVisiblePostBodyForController(UIViewController *v
 
     NSString *cacheStoreKey = ApolloVisiblePostCacheKey(link, sourceText, targetLanguage);
     if (cacheStoreKey.length > 0) {
-        NSString *cached = [sLinkTranslationByFullName objectForKey:cacheStoreKey];
+        NSString *cached = ApolloCachedLinkTranslationForKey(cacheStoreKey);
         if (cached.length > 0) {
             ApolloApplyTranslationToPostTextNode(viewController.view, textNode, sourceText, cached);
             return;
@@ -4237,7 +4310,7 @@ static void ApolloToggleTranslationForCommentTextNode(id textNode) {
             ApolloShowOriginalWithRetranslateAffordanceForCellNode(cellNode, comment, textNode);
         } else {
             ApolloTapModeSetKeyTranslated(fullName, YES);            // → translate now
-            NSString *cached = [sCommentTranslationByFullName objectForKey:fullName];
+            NSString *cached = ApolloCachedCommentTranslationForFullName(fullName);
             if (cached.length > 0) {
                 ApolloApplyTranslationToCellNode(cellNode, comment, cached);
             } else {
@@ -4252,7 +4325,7 @@ static void ApolloToggleTranslationForCommentTextNode(id textNode) {
 
     if ([sUserPinnedOriginalFullNames containsObject:fullName]) {
         [sUserPinnedOriginalFullNames removeObject:fullName];        // → re-translate
-        NSString *cached = [sCommentTranslationByFullName objectForKey:fullName];
+        NSString *cached = ApolloCachedCommentTranslationForFullName(fullName);
         if (cached.length > 0) ApolloApplyTranslationToCellNode(cellNode, comment, cached);
     } else {
         [sUserPinnedOriginalFullNames addObject:fullName];           // → show original
@@ -7592,6 +7665,21 @@ static void ApolloDbgOpenFirstPost(CFNotificationCenterRef c, void *o, CFStringR
         ApolloLog(@"[Tw/dbg] no table/rows");
     });
 }
+
+// Mimics what iOS does to the process while it sits suspended in the
+// background: purge every translation NSCache but leave the mirrors alone.
+// Lets the sim exercise the exact device failure mode behind "translations
+// re-translate on every app switch" without a real jetsam pass.
+static void ApolloDbgPurgeNSCaches(CFNotificationCenterRef c, void *o, CFStringRef n, const void *obj, CFDictionaryRef u) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [sTranslationCache removeAllObjects];
+        [sCommentTranslationByFullName removeAllObjects];
+        [sLinkTranslationByFullName removeAllObjects];
+        NSUInteger mirrorCount = 0;
+        @synchronized (sCommentTranslationMirror) { mirrorCount = sCommentTranslationMirror.count; }
+        ApolloLog(@"[Tw/dbg] purged all translation NSCaches (comment mirror keeps %lu)", (unsigned long)mirrorCount);
+    });
+}
 #endif
 // ==============================================================================
 
@@ -7605,6 +7693,8 @@ static void ApolloDbgOpenFirstPost(CFNotificationCenterRef c, void *o, CFStringR
     sLoggedSkippedStructuredPostFullNames = [NSMutableSet set];
     sCommentTranslationMirror = [NSMutableDictionary dictionary];
     sLinkTranslationMirror = [NSMutableDictionary dictionary];
+    sRawTranslationMirror = [NSMutableDictionary dictionary];
+    sRawTranslationMirrorOrder = [NSMutableArray array];
     sPendingTranslationCallbacks = [NSMutableDictionary dictionary];
     sRichPreviewTranslationInFlightKeys = [NSMutableSet set];
     sFeedTitleModeByFeedKey = [NSMutableDictionary dictionary];
@@ -7675,12 +7765,15 @@ static void ApolloDbgOpenFirstPost(CFNotificationCenterRef c, void *o, CFStringR
     CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, ApolloDbgPinComment, CFSTR("apollofix.dbg.pincomment"), NULL, CFNotificationSuspensionBehaviorDeliverImmediately);
     CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, ApolloDbgToggleCollapse, CFSTR("apollofix.dbg.collapse"), NULL, CFNotificationSuspensionBehaviorDeliverImmediately);
     CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, ApolloDbgDumpInsets, CFSTR("apollofix.dbg.insets"), NULL, CFNotificationSuspensionBehaviorDeliverImmediately);
+    CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, ApolloDbgPurgeNSCaches, CFSTR("apollofix.dbg.purgecaches"), NULL, CFNotificationSuspensionBehaviorDeliverImmediately);
 #endif
 
-    // Memory-warning handler: only drop the raw key->text cache (cheap to
-    // recompute via the persistent fullName caches). Do NOT wipe the
-    // per-comment / per-post caches — iOS sends memory warnings when the app
-    // is backgrounded, and clearing them caused translated threads to revert
+    // Memory-warning handler: only drop the raw key->text NSCache. Its mirror
+    // keeps the data (plain strings — tiny next to what a real warning is
+    // about), so lookups after the warning still hit via the mirror fallback
+    // instead of burning a provider round-trip. Do NOT wipe the per-comment /
+    // per-post caches — iOS sends memory warnings when the app is
+    // backgrounded, and clearing them caused translated threads to revert
     // to the original language as soon as the user returned to Apollo.
     [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidReceiveMemoryWarningNotification
                                                       object:nil
@@ -7691,9 +7784,17 @@ static void ApolloDbgOpenFirstPost(CFNotificationCenterRef c, void *o, CFStringR
 
     // App lifecycle: snapshot caches when going to background; re-apply the
     // active thread's translation on return.
+    //
+    // queue:nil — the block must run synchronously inside the notification
+    // post, while the app still has background runtime. With
+    // queue:mainQueue the block lands on the NEXT main-runloop pass, which
+    // never comes before suspension: the snapshot silently slipped to the
+    // following resume (visible in user logs as "[translation/persist]
+    // wrote …" milliseconds after the foreground heal) and was lost
+    // entirely when the app was jetsam-killed while suspended.
     [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidEnterBackgroundNotification
                                                       object:nil
-                                                       queue:[NSOperationQueue mainQueue]
+                                                       queue:nil
                                                   usingBlock:^(__unused NSNotification *note) {
         ApolloPersistTranslationCachesToDisk();
     }];
@@ -7723,9 +7824,7 @@ static void ApolloDbgOpenFirstPost(CFNotificationCenterRef c, void *o, CFStringR
                                                       object:nil
                                                        queue:[NSOperationQueue mainQueue]
                                                   usingBlock:^(__unused NSNotification *note) {
-        [sTranslationCache removeAllObjects];
-        [sCommentTranslationByFullName removeAllObjects];
-        [sLinkTranslationByFullName removeAllObjects];
+        ApolloClearAllTranslationCaches();
         @synchronized (sLoggedSkippedCommentFullNames) {
             [sLoggedSkippedCommentFullNames removeAllObjects];
         }

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -2166,6 +2166,11 @@ static id ApolloBestVisiblePostBodyTextNodeForController(UIViewController *viewC
     id best = nil;
     NSInteger bestScore = NSIntegerMin;
     for (id candidate in candidates) {
+        // Never pick OUR translated title node as the "body": once the title is
+        // swapped to the target language it no longer matches link.title, so the
+        // metadata filter below can't exclude it — a long translated title would
+        // masquerade as the post body (and get body-owned, double-driven).
+        if ([objc_getAssociatedObject(candidate, kApolloTitleOwnedTextNodeKey) boolValue]) continue;
         NSString *text = ApolloVisibleTextFromNode(candidate);
         if (text.length == 0 || ApolloPostTextLooksLikeMetadata(text, link)) continue;
 
@@ -2219,6 +2224,10 @@ static id ApolloBestPostBodyTextNode(id headerCellNode, RDKLink *link, NSString 
     id best = nil;
     NSInteger bestScore = NSIntegerMin;
     for (id n in candidates) {
+        // Same guard as the visible-body scan: a translated title no longer
+        // matches link.title, so without this a long title masquerades as the
+        // post body when the model body is unreadable.
+        if ([objc_getAssociatedObject(n, kApolloTitleOwnedTextNodeKey) boolValue]) continue;
         NSAttributedString *attr = nil;
         @try { attr = ((id (*)(id, SEL))objc_msgSend)(n, @selector(attributedText)); }
         @catch (__unused NSException *e) { continue; }
@@ -3351,6 +3360,7 @@ static NSString *ApolloPostBodyTextFromLink(RDKLink *link);
 static NSString *ApolloVisiblePostCacheKey(RDKLink *link, NSString *sourceText, NSString *targetLanguage);
 static NSString *ApolloResolvedTargetLanguageCode(void);
 static RDKLink *ApolloLinkFromHeaderCellNode(id cellNode);
+static void ApolloInstallHeaderMarkerFromTranslatedTitle(id headerCellNode);
 
 static BOOL ApolloReapplyCachedTranslationForHeaderCellNode(id headerCellNode) {
     if (!headerCellNode) return NO;
@@ -3402,6 +3412,11 @@ static BOOL ApolloReapplyCachedTranslationForHeaderCellNode(id headerCellNode) {
     }
 
     if (cached.length == 0 || trimmed.length == 0) {
+        // Title-only post (no selftext): there is no body translation to
+        // reapply, but the header may have just been rebuilt (vote tap), which
+        // replaces the PostInfoNode under the compact marker. Re-drive the
+        // marker from the translated title so it survives the rebuild.
+        if (trimmed.length == 0) ApolloInstallHeaderMarkerFromTranslatedTitle(headerCellNode);
         ApolloTranslationVerboseLog(@"[Translation/vote] headerReapply: cache MISS (link=%@ body=%lu)", link.fullName ?: @"<nil>", (unsigned long)trimmed.length);
         return NO;
     }
@@ -3451,9 +3466,18 @@ static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *f
             body = visibleBody;
         }
     }
-    if (![body isKindOfClass:[NSString class]]) return;
+    if (![body isKindOfClass:[NSString class]] || [[body stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] length] == 0) {
+        // Link/image post — no body to translate, so the body apply (the usual
+        // driver of the thread's compact info-row marker, see
+        // ApolloApplyTranslationToHeaderCellNode) will never run. Drive the
+        // marker from the translated TITLE instead. This pass re-runs on
+        // visibility/reapply events, which also heals cold-open ordering (title
+        // translated before the controller link was readable).
+        ApolloInstallHeaderMarkerFromTranslatedTitle(headerCellNode);
+        return;
+    }
     NSString *trimmed = [body stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    if (trimmed.length == 0) return;  // link/image post — nothing to translate
+    if (trimmed.length == 0) return;  // unreachable (guarded above); kept for safety
 
     // One-shot diagnostic so we can see exactly why a post body did or did
     // not get gated. Logs once per fullName per session.
@@ -6232,6 +6256,104 @@ static id ApolloTitleTextNodeFromTitleNode(id titleNode) {
     return best;
 }
 
+// Recursively scan a node's subtree for the post TITLE node (class name contains
+// "PostTitle" — covers PostTitleNode and PostTitleURLNode), depth-limited.
+static id ApolloFindPostTitleNodeInSubtree(id node, int depth) {
+    if (!node || depth < 0) return nil;
+    const char *cn = class_getName([node class]);
+    if (cn && strstr(cn, "PostTitle")) return node;
+    @try {
+        SEL subnodesSel = NSSelectorFromString(@"subnodes");
+        if ([node respondsToSelector:subnodesSel]) {
+            NSArray *subs = ((id (*)(id, SEL))objc_msgSend)(node, subnodesSel);
+            if ([subs isKindOfClass:[NSArray class]]) {
+                for (id s in subs) {
+                    id found = ApolloFindPostTitleNodeInSubtree(s, depth - 1);
+                    if (found) return found;
+                }
+            }
+        }
+    } @catch (__unused NSException *e) {}
+    return nil;
+}
+
+// True when the comments-header TITLE must drive the post's info-row marker
+// itself: title-only posts (image/link posts — no selftext) never run the header
+// BODY apply, which is otherwise the only marker driver for the post being
+// viewed (ApolloApplyTranslationToHeaderCellNode line ~2297). The ONLY case we
+// want to exclude is a post that DEFINITIVELY has a selftext body — there the
+// body apply is the canonical marker driver and we don't want a redundant
+// title-driven install. When the controller's RDKLink is unreadable (common for
+// image/rich-media post headers — ApolloLinkFromController returns nil), default
+// to YES: the post is almost always a title-only media post, and even if it has
+// a body, the body apply drives the SAME single per-PostInfoNode label with the
+// same source language, so a title-driven install is harmless (no duplicate UI).
+static BOOL ApolloCommentsHeaderTitleDrivesMarker(UIViewController *enclosingVC) {
+    RDKLink *link = ApolloLinkFromController(enclosingVC);
+    if (!link) return YES;  // link unreadable → assume title-only; body apply (if any) drives the same label
+    NSString *body = ApolloPostBodyTextFromLink(link);
+    NSString *trimmed = [body stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    return trimmed.length == 0;
+}
+
+// Title-only posts (image/link posts, no selftext): the header BODY apply — the
+// normal driver of the thread's compact info-row "🌐 PT" marker — never runs, so
+// the post being viewed showed NO language marker anywhere even though its title
+// was translated (the title apply excludes comments-header titles on the
+// assumption the body apply owns the marker). Install the marker from the
+// translated TITLE instead. Called from the header driver's and the vote-reapply
+// path's empty-body bails, which re-run on visibility/vote passes — that also
+// heals cold-open ordering (title translated before the link was readable) and
+// vote rebuilds that replace the PostInfoNode under the marker.
+static void ApolloInstallHeaderMarkerFromTranslatedTitle(id headerCellNode) {
+    if (!headerCellNode) return;
+    if (!sEnableBulkTranslation) return;
+    if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) return;
+    id titleNode = ApolloFindPostTitleNodeInSubtree(headerCellNode, 4);
+    if (!titleNode) return;
+    id textNode = ApolloTitleTextNodeFromTitleNode(titleNode);
+    if (!textNode) return;
+
+    // Tap-mode hold: the title apply held the swap and shows the TARGET code
+    // ("tap for English") — mirror that here.
+    if (sTapToTranslate) {
+        id pinVal = objc_getAssociatedObject(textNode, kApolloTitlePinnedOriginalKey);
+        if ([pinVal isKindOfClass:[NSNumber class]] && [(NSNumber *)pinVal integerValue] == 2) {
+            NSString *targetCode = ApolloResolvedTargetLanguageCode();
+            if (targetCode.length > 0) {
+                ApolloUpdatePostInfoMarkerForNode(headerCellNode, targetCode, YES, textNode);
+            }
+            return;
+        }
+    }
+
+    // Pinned back to original by a marker tap: keep showing the TARGET code
+    // (reads as "tap for English"), like the title apply's pin re-assert.
+    if (ApolloPinActiveOnNode(textNode)) {
+        NSString *pinnedSrc = objc_getAssociatedObject(textNode, kApolloTitlePinnedSourceKey);
+        NSString *currentNorm = ApolloNormalizeTextForCompare(ApolloVisibleTextFromNode(textNode));
+        if ([pinnedSrc isKindOfClass:[NSString class]] && currentNorm.length > 0 &&
+            [ApolloNormalizeTextForCompare(pinnedSrc) isEqualToString:currentNorm]) {
+            NSString *targetCode = ApolloResolvedTargetLanguageCode();
+            if (targetCode.length > 0) {
+                ApolloUpdatePostInfoMarkerForNode(headerCellNode, targetCode, sShowTranslationDetails || sTapToTranslate, textNode);
+            }
+        }
+        return;
+    }
+
+    // Normal mode: only once the title apply has actually swapped this node
+    // (ownership stamped). Re-detect the source language from the saved
+    // original — the same funnel as every other marker, so the skip-list gate
+    // stays intact.
+    if (![objc_getAssociatedObject(textNode, kApolloTitleOwnedTextNodeKey) boolValue]) return;
+    NSString *ownedSource = objc_getAssociatedObject(textNode, kApolloOwnedNodeOriginalBodyKey);
+    if (![ownedSource isKindOfClass:[NSString class]] || ownedSource.length == 0) return;
+    NSString *sourceCode = nil;
+    BOOL show = (sShowTranslationDetails || sTapToTranslate) && ApolloShouldShowTranslationMarkerForSource(ownedSource, &sourceCode);
+    ApolloUpdatePostInfoMarkerForNode(headerCellNode, sourceCode, show, textNode);
+}
+
 static void ApolloApplyTranslationToTitleNode(id titleNode, id textNode, NSString *sourceText, NSString *translatedText) {
     if (!titleNode || !textNode) return;
     if (![sourceText isKindOfClass:[NSString class]] || sourceText.length == 0) return;
@@ -6255,9 +6377,16 @@ static void ApolloApplyTranslationToTitleNode(id titleNode, id textNode, NSStrin
         } else if (pinnedSrcMatches) {
             // Re-assert the pinned-state marker (target code, e.g. "EN") so a
             // re-processed/reused cell doesn't leave a stale source code showing.
+            // Same flag split as the install below: thread-header markers follow
+            // the Comments & Posts details flag — otherwise a pinned header
+            // marker installed under that flag would be hidden by this reassert,
+            // stranding the post with no un-pin affordance.
             NSString *targetCode = ApolloResolvedTargetLanguageCode();
             if (targetCode.length > 0) {
-                ApolloUpdatePostInfoMarkerForNode(titleNode, targetCode, sShowTranslationTitleDetails || sTapToTranslate, textNode);
+                UIViewController *pinVC = ApolloEnclosingViewControllerForNode(titleNode);
+                BOOL pinIsHeaderTitle = ApolloClassLooksLikeCommentsViewController([pinVC class]);
+                BOOL pinDetailsFlag = pinIsHeaderTitle ? sShowTranslationDetails : sShowTranslationTitleDetails;
+                ApolloUpdatePostInfoMarkerForNode(titleNode, targetCode, pinDetailsFlag || sTapToTranslate, textNode);
             }
             return;
         } else {
@@ -6315,7 +6444,8 @@ static void ApolloApplyTranslationToTitleNode(id titleNode, id textNode, NSStrin
         BOOL tapIsHeaderTitle = ApolloClassLooksLikeCommentsViewController([tapVC class]);
         const char *tapTitleClass = class_getName([titleNode class]);
         BOOL tapIsPostTitle = tapTitleClass && strstr(tapTitleClass, "PostTitleNode") != NULL;
-        if (!tapIsHeaderTitle && tapIsPostTitle) {
+        // Title-only posts: the header title drives the marker (no body apply).
+        if ((!tapIsHeaderTitle || ApolloCommentsHeaderTitleDrivesMarker(tapVC)) && tapIsPostTitle) {
             NSString *targetCode = ApolloResolvedTargetLanguageCode();
             if (targetCode.length > 0) {
                 ApolloUpdatePostInfoMarkerForNode(titleNode, targetCode, YES, textNode);
@@ -6333,14 +6463,21 @@ static void ApolloApplyTranslationToTitleNode(id titleNode, id textNode, NSStrin
     BOOL isCommentsHeaderTitle = ApolloClassLooksLikeCommentsViewController([enclosingVC class]);
     // Feed titles get a compact "🌐 PT" marker on the post's metadata row
     // (PostInfoNode) — NOT appended under the title (that collided with flair
-    // pills). The comments-header post is excluded (its own apply drives the
-    // marker). Only the real PostTitleNode drives this — the feed also routes the
-    // body-preview text node through here (titleNode == textNode).
+    // pills). The comments-header post is normally excluded (its own body apply
+    // drives the marker) — EXCEPT title-only posts (image/link, no selftext),
+    // whose body apply never runs: there the translated TITLE must drive the
+    // marker or the thread shows no language marker at all. Only the real
+    // PostTitleNode drives this — the feed also routes the body-preview text
+    // node through here (titleNode == textNode).
     const char *titleNodeClass = class_getName([titleNode class]);
     BOOL titleNodeIsPostTitle = titleNodeClass && strstr(titleNodeClass, "PostTitleNode") != NULL;
-    if (!isCommentsHeaderTitle && titleNodeIsPostTitle) {
+    BOOL headerTitleDrivesMarker = isCommentsHeaderTitle && ApolloCommentsHeaderTitleDrivesMarker(enclosingVC);
+    if ((!isCommentsHeaderTitle || headerTitleDrivesMarker) && titleNodeIsPostTitle) {
         NSString *titleSourceCode = nil;
-        BOOL showTitleMarker = (sShowTranslationTitleDetails || sTapToTranslate) && ApolloShouldShowTranslationMarkerForSource(sourceText, &titleSourceCode);
+        // Thread-header markers follow the Comments & Posts details flag (same
+        // convention as the body-apply install); feed titles keep the Titles flag.
+        BOOL detailsFlag = isCommentsHeaderTitle ? sShowTranslationDetails : sShowTranslationTitleDetails;
+        BOOL showTitleMarker = (detailsFlag || sTapToTranslate) && ApolloShouldShowTranslationMarkerForSource(sourceText, &titleSourceCode);
         // Pass the text node (which carries the owned original/translated strings)
         // so tapping the marker can toggle this post's title back and forth.
         ApolloUpdatePostInfoMarkerForNode(titleNode, titleSourceCode, showTitleMarker, textNode);
@@ -6521,6 +6658,23 @@ static void ApolloMaybeTranslatePostTitleNode(id titleNode) {
             ownedTranslatedNorm.length > 0 && [currentNorm isEqualToString:ownedTranslatedNorm]) {
             if (ApolloClassLooksLikeCommentsViewController([gateVC class])) {
                 ApolloMarkVisibleTranslationApplied(ownedSource, ownedTranslated);
+                // Title-only posts (image/link, no selftext): this owned-early-
+                // return is the ONLY pass that runs for a header title whose
+                // translation was CACHED from the feed — the fresh title apply
+                // (ApolloApplyTranslationToTitleNode, which installs the marker)
+                // is skipped because the node is already owned+translated. So the
+                // thread showed no language marker at all even though its title
+                // was translated. Drive the compact info-row marker from the
+                // title here for the bodyless-header case (posts WITH a body get
+                // their marker from the header body apply, so this is inert there).
+                const char *ownTitleCls = class_getName([titleNode class]);
+                if (ownTitleCls && strstr(ownTitleCls, "PostTitleNode") &&
+                    ApolloCommentsHeaderTitleDrivesMarker(enclosingVC)) {
+                    NSString *ownHdrCode = nil;
+                    BOOL ownHdrShow = (sShowTranslationDetails || sTapToTranslate) &&
+                        ApolloShouldShowTranslationMarkerForSource(ownedSource, &ownHdrCode);
+                    ApolloUpdatePostInfoMarkerForNode(titleNode, ownHdrCode, ownHdrShow, textNode);
+                }
             } else {
                 ApolloMarkVisibleFeedTitleApplied(ownedSource, ownedTranslated);
             }
@@ -6565,7 +6719,8 @@ static void ApolloMaybeTranslatePostTitleNode(id titleNode) {
         BOOL heldIsHeaderTitle = ApolloClassLooksLikeCommentsViewController([heldVC class]);
         const char *heldCls = class_getName([titleNode class]);
         BOOL heldIsPostTitle = heldCls && strstr(heldCls, "PostTitleNode") != NULL;
-        if (!heldIsHeaderTitle && heldIsPostTitle) {
+        // Title-only posts: the header title drives the marker (no body apply).
+        if ((!heldIsHeaderTitle || ApolloCommentsHeaderTitleDrivesMarker(heldVC)) && heldIsPostTitle) {
             ApolloUpdatePostInfoMarkerForNode(titleNode, targetLanguage, YES, textNode);
         }
     }


### PR DESCRIPTION
Fixes the bug @luigi-lauro reported in https://github.com/Apollo-Reborn/Apollo-Reborn/issues/521#issuecomment-4922023408

> If for example I had Italian as a language not to translate, and I go to a thread in Italian, all comments will show the 'translated from' message and if I click on it will just switch to translate, but nothing else happens.

## What was happening

The "🌐 Translated from Italian" marker (and, in Tap to Translate mode, the "🌐 Translate" affordance) was decided purely from on-device language detection — "is this text foreign?" — and never looked at the "Don't Translate" list. That list was only consulted at the actual translate step. So a comment in a skipped language stayed untranslated (correct), but still got a marker, and tapping it just toggled a no-op because there's no translation to show.

## Fix

Make the skip list part of the "should we show a translation indicator?" decision, not just the "should we translate?" decision. All in `ApolloTranslation.xm`:

- Pulled `ApolloLanguageCodeIsInSkipList()` out of the existing skip logic so the marker path and translate path share one check.
- `ApolloShouldShowTranslationMarkerForSource()` — the single gate the normal-mode comment / title / header / feed markers all run through — now returns NO when the detected source language is on the list. One line, clears every surface (and with it the tappable region + green globe, which key off marker-presence).
- The four Tap-to-Translate detection-driven spots also skip the affordance for a skipped language.
- The three tap-mode "hold" blocks now require the translation to actually differ from the source, so a no-op (skipped or same-language) installs no hold and no marker — the comment apply path already did this, the others didn't.

## Follow-up: "Show translation" disappears after collapse/expand

Second bug from the same thread (https://github.com/Apollo-Reborn/Apollo-Reborn/issues/521#issuecomment-4928077797):

> open a thread with comments in another language / click on the auto translated comment to translate back to original language / click on comment to hide/collapse it and then click again to expand it again / the label 'translate' disappear despite the comment being still in original language and I cannot translate it anymore.

When you tap a translated comment back to the original, the comment gets "pinned" so the auto-translate pass doesn't immediately re-translate it. But collapse/expand makes Texture rebuild the cell node from Reddit's raw (original) body, and when the auto-translate pass came back around, the pin gate just bailed with a bare `return` — correct text, but nothing re-attached the "🌐 Show translation" line. Original text + no affordance = stuck, exactly the video.

Fix: the pin gate now re-asserts the affordance instead of just bailing. If the rebuilt node shows the clean original and a translation actually exists, it re-saves the clean body as the restore point and re-appends the "Show translation" line. Plus hardening from an adversarial review pass: the affordance builder is idempotent (won't stack a second marker line onto text that already ends with one), the saved original is re-validated before decorating so a marker-bearing body can never become the "original", and the tap-mode branches in the hold blocks always return instead of falling through into normal-mode marker handling.

Sim repro of luigi's exact steps (auto-translated → tap to original → collapse → expand → tap again):

![collapse/expand](https://raw.githubusercontent.com/icpryde/Apollo-Reborn/assets/skip-language-marker/pr-assets/collapse_expand_fix.png)

1. auto-translated with "Translated from Spanish" → 2. tapped back to original Spanish with "Show translation" → 3. collapsed → 4. expanded: still Spanish and the "Show translation" line **survives** (before the fix it vanished here). Tapping it re-translates, and an unpin → re-pin round trip shows exactly one affordance line (no stacking).

## Testing

Device (`make package FINALPACKAGE=1`) and simulator builds both clean.

Sim A/B on a real Spanish thread (r/argentina) — added Spanish to *Don't Translate* via the in-app Translation settings, then reopened the thread:

![before/after](https://raw.githubusercontent.com/icpryde/Apollo-Reborn/assets/skip-language-marker/pr-assets/skiplang_before_after.png)

Left (Spanish not on the list): post shows the `🌐 EN` marker and the comment shows a `🌐 Translate` line. Right (Spanish on the list): both gone, text stays Spanish. Same gate covers the normal-mode "Translated from …" label from the report.
