### PR TITLE
Link Previews: fix compact cards stuck at full-preview height (#620 follow-up)

### DIFF
--- a/src/ApolloDeletedCommentsData.h
+++ b/src/ApolloDeletedCommentsData.h
@@ -20,6 +20,13 @@ BOOL ApolloDeletedCommentsHasThreadOverride(NSString *linkFullName);
 // Global toggle OR an override for this specific post (t3_xxx or bare id).
 BOOL ApolloDeletedCommentsActiveForLink(NSString *linkFullName);
 void ApolloDeletedCommentsHandleRequestObservation(NSURLRequest *request, NSString *source);
+// Collapse-animation window, stamped by the RDKComment setCollapsed: hook (UI.xm).
+// Modules that re-measure list rows (deleted-comments height fixup, inline link
+// previews) must defer table begin/endUpdates while this returns > 0: an empty
+// update mid-collapse re-queries every row height and restarts the native row
+// animations (the "comments collapse weirdly" glitches in #620/#630).
+void ApolloDeletedCommentsNoteCollapseEvent(void);
+NSTimeInterval ApolloDeletedCommentsCollapseSettleDelayRemaining(void);
 ApolloDeletedCommentsURLSessionCompletion ApolloDeletedCommentsMaybeWrapCompletion(NSURLRequest *request, ApolloDeletedCommentsURLSessionCompletion completion);
 void ApolloDeletedCommentsInstallDelegateTransformerIfNeeded(NSURLSession *session, NSURLRequest *request);
 void ApolloDeletedCommentsRegisterRecoveredComment(NSString *fullName, NSString *reason);

--- a/src/ApolloDeletedCommentsData.m
+++ b/src/ApolloDeletedCommentsData.m
@@ -598,12 +598,30 @@ NSString *ApolloDeletedCommentsRedditBodyHTML(NSString *body) {
     return ApolloDeletedCommentsEscapeHTML(html);
 }
 
-static void ApolloDeletedCommentsSetRecoveredBody(NSMutableDictionary *data, NSString *body) {
+// Prefer the archive's OWN markdown-rendered HTML (Arctic md2html=true, or Reddit) over the
+// local regex converter, which only knows http(s) links and **bold** and silently drops
+// italics, blockquotes, lists, code, strikethrough, superscript, spoilers, etc. Arctic's
+// body_html is raw tags with entity-escaped content (i.e. the post-unescape form). Apollo
+// unescapes a comment's body_html exactly once before parsing, so we escape it a single time
+// here to match Reddit's own body_html wire format. Falls back to the regex converter when the
+// archive has no usable HTML.
+static NSString *ApolloDeletedCommentsModelBodyHTMLForArchive(NSDictionary *archived, NSString *fallbackBody) {
+    NSString *archivedHTML = [archived[@"body_html"] isKindOfClass:[NSString class]] ? archived[@"body_html"] : nil;
+    if (archivedHTML.length > 0) {
+        NSString *archivedText = ApolloDeletedCommentsUnescapedHTMLText(archivedHTML);
+        if (!ApolloDeletedCommentsBodyLooksDeleted(archivedText)) {
+            return ApolloDeletedCommentsEscapeHTML(archivedHTML);
+        }
+    }
+    return ApolloDeletedCommentsRedditBodyHTML(fallbackBody);
+}
+
+static void ApolloDeletedCommentsSetRecoveredBody(NSMutableDictionary *data, NSDictionary *archived, NSString *body) {
     NSString *trimmed = ApolloDeletedCommentsTrimmedString(body);
     if (trimmed.length == 0) return;
 
     data[@"body"] = trimmed;
-    NSString *bodyHTML = ApolloDeletedCommentsRedditBodyHTML(trimmed);
+    NSString *bodyHTML = ApolloDeletedCommentsModelBodyHTMLForArchive(archived, trimmed);
     if (bodyHTML.length > 0) data[@"body_html"] = bodyHTML;
 }
 
@@ -646,7 +664,7 @@ BOOL ApolloDeletedCommentsApplyRecoveredArchivedCommentToObject(id comment, NSDi
     if (fullName.length == 0 || body.length == 0 || ApolloDeletedCommentsBodyLooksDeleted(body)) return NO;
 
     NSString *author = [archived[@"author"] isKindOfClass:[NSString class]] ? archived[@"author"] : nil;
-    NSString *bodyHTML = ApolloDeletedCommentsRedditBodyHTML(body);
+    NSString *bodyHTML = ApolloDeletedCommentsModelBodyHTMLForArchive(archived, body);
     NSString *resolvedReason = reason.length > 0 ? reason : ApolloDeletedCommentsReasonForArchived(archived);
 
     ApolloDeletedCommentsSetObjectValue(comment, @selector(setBody:), body);
@@ -917,9 +935,18 @@ static void ApolloDeletedCommentsFetchArcticComments(NSString *linkFullName, voi
     components.queryItems = @[
         [NSURLQueryItem queryItemWithName:@"link_id" value:linkFullName],
         [NSURLQueryItem queryItemWithName:@"limit" value:@"5000"],
-        [NSURLQueryItem queryItemWithName:@"start_depth" value:@"20"],
-        [NSURLQueryItem queryItemWithName:@"start_breadth" value:@"50"],
-        [NSURLQueryItem queryItemWithName:@"md2html" value:@"false"],
+        // Raise the collapse thresholds. Arctic folds comments beyond start_depth /
+        // start_breadth into bodyless "kind: more" stubs, and those can never be
+        // recovered — on a popular post with many top-level comments the 51st+ (at the
+        // old breadth=50) or anything past depth 20 silently dropped out. Keep it capped
+        // overall by limit=5000 so mega-threads stay bounded.
+        [NSURLQueryItem queryItemWithName:@"start_depth" value:@"50"],
+        [NSURLQueryItem queryItemWithName:@"start_breadth" value:@"500"],
+        // Have Arctic render markdown -> HTML server-side. Its body_html then carries the
+        // full formatting (links, bold, italics, quotes, lists, code, strikethrough) that
+        // we feed to Apollo's native renderer; the old local regex converter only produced
+        // links + bold.
+        [NSURLQueryItem queryItemWithName:@"md2html" value:@"true"],
     ];
     NSURL *url = components.URL;
     if (!url) {
@@ -931,15 +958,45 @@ static void ApolloDeletedCommentsFetchArcticComments(NSString *linkFullName, voi
     urlRequest.timeoutInterval = 10.0;
 
     NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        NSDictionary *comments = nil;
         NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
         ApolloDeletedCommentsRecordArcticResponse(http, error);
-        if (!error && data.length > 0) {
-            if (!http || (http.statusCode >= 200 && http.statusCode < 300)) {
-                id root = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+
+        // Separate a GENUINE tree (data is an array — possibly empty) from a TRANSIENT
+        // failure: a network error, a non-2xx status, or Arctic's app-level throttle body
+        // {"data":null,"error":"Timeout. Maybe slow down a bit"} which it returns with
+        // HTTP 200. A transient failure must NOT be cached as an empty result: an empty
+        // cache entry is non-nil, so CachedArcticComments serves it for the whole empty-TTL
+        // window and both FetchArcticComments and WarmArcticCacheForLink treat that as
+        // "already fetched" — permanently masking comments that DO exist in the archive
+        // until the entry expires. That is the "same comments repeatedly fail to load" bug.
+        BOOL transient = NO;
+        NSDictionary *comments = nil;
+        if (error || (http && !(http.statusCode >= 200 && http.statusCode < 300)) || data.length == 0) {
+            transient = YES;
+        } else {
+            id root = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+            BOOL hasAppError = [root isKindOfClass:[NSDictionary class]] &&
+                               ((NSDictionary *)root)[@"error"] &&
+                               ((NSDictionary *)root)[@"error"] != [NSNull null];
+            BOOL dataIsArray = [root isKindOfClass:[NSDictionary class]] &&
+                               [((NSDictionary *)root)[@"data"] isKindOfClass:[NSArray class]];
+            if (hasAppError || !dataIsArray) {
+                transient = YES;
+                // The app-level throttle comes back as HTTP 200, so RecordArcticResponse
+                // did not start a cooldown — back off here so we stop hammering.
+                if (hasAppError) ApolloDeletedCommentsArcticBeginCooldown(ApolloDeletedCommentsArcticErrorCooldown, @"arctic app error");
+            } else {
                 comments = ApolloDeletedCommentsArcticCommentMapFromRoot(root);
             }
         }
+
+        if (transient) {
+            // Leave the cache untouched so the next thread observation retries (after any
+            // cooldown); just release the waiters so nothing hangs.
+            ApolloDeletedCommentsFinishInflightArcticFetch(linkFullName, @{});
+            return;
+        }
+
         ApolloDeletedCommentsStoreArcticComments(linkFullName, comments ?: @{}, comments.count > 0 ? ApolloDeletedCommentsArcticSuccessCacheTTL : ApolloDeletedCommentsArcticEmptyCacheTTL);
         ApolloDeletedCommentsFinishInflightArcticFetch(linkFullName, comments ?: @{});
     }];
@@ -996,7 +1053,7 @@ static NSMutableDictionary *ApolloDeletedCommentsThingFromArchived(NSDictionary 
     data[@"id"] = identifier;
     data[@"name"] = fullName ?: [@"t1_" stringByAppendingString:identifier];
     data[@"author"] = author.length > 0 ? author : @"[deleted]";
-    ApolloDeletedCommentsSetRecoveredBody(data, body);
+    ApolloDeletedCommentsSetRecoveredBody(data, archived, body);
     data[@"parent_id"] = [archived[@"parent_id"] isKindOfClass:[NSString class]] ? archived[@"parent_id"] : @"";
     data[@"link_id"] = [archived[@"link_id"] isKindOfClass:[NSString class]] ? archived[@"link_id"] : @"";
     data[@"subreddit"] = [archived[@"subreddit"] isKindOfClass:[NSString class]] ? archived[@"subreddit"] : @"";
@@ -1057,7 +1114,7 @@ static NSUInteger ApolloDeletedCommentsPatchRedditJSONNode(id node, NSDictionary
                 if (fullName.length > 0) {
                     ApolloDeletedCommentsStoreArchivedCommentsByFullName(@{fullName: archived});
                 }
-                ApolloDeletedCommentsSetRecoveredBody(data, archivedBody);
+                ApolloDeletedCommentsSetRecoveredBody(data, archived, archivedBody);
                 if (author.length > 0) data[@"author"] = author;
                 if ([archived[@"created_utc"] respondsToSelector:@selector(doubleValue)]) data[@"created_utc"] = archived[@"created_utc"];
                 if ([archived[@"score"] respondsToSelector:@selector(integerValue)]) data[@"score"] = archived[@"score"];

--- a/src/ApolloDeletedCommentsData.m
+++ b/src/ApolloDeletedCommentsData.m
@@ -432,6 +432,11 @@ static BOOL ApolloDeletedCommentsBodyLooksDeleted(NSString *body) {
     if ([trimmed isEqualToString:@"user deleted comment"]) return YES;
     if ([trimmed rangeOfString:@"removed by moderator"].location != NSNotFound && trimmed.length < 80) return YES;
     if ([trimmed rangeOfString:@"user deleted comment"].location != NSNotFound && trimmed.length < 80) return YES;
+    // Newer Reddit placeholder for comments removed as part of a whole-thread removal.
+    // Served as an italic markdown body like "*Moderator removed thread* 🧨", so match
+    // by substring (the wrapper asterisks/emoji vary) with the same short-body guard.
+    if ([trimmed rangeOfString:@"moderator removed thread"].location != NSNotFound && trimmed.length < 80) return YES;
+    if ([trimmed rangeOfString:@"moderators removed"].location != NSNotFound && trimmed.length < 80) return YES;
     return NO;
 }
 

--- a/src/ApolloDeletedCommentsData.m
+++ b/src/ApolloDeletedCommentsData.m
@@ -605,11 +605,36 @@ NSString *ApolloDeletedCommentsRedditBodyHTML(NSString *body) {
 // unescapes a comment's body_html exactly once before parsing, so we escape it a single time
 // here to match Reddit's own body_html wire format. Falls back to the regex converter when the
 // archive has no usable HTML.
+// Arctic's md2html percent-encodes hrefs a second time when the source URL was already
+// encoded (e.g. wiki/Malgr%C3%A9-elles becomes href="...Malgr%25C3%25A9-elles"), which
+// breaks the link target and the tweak's link previews. Repair each href containing %25
+// by decoding it once — but only when the decoded URL literally appears in the raw
+// markdown body, so URLs that genuinely contain %25 are left alone.
+static NSString *ApolloDeletedCommentsRepairDoubleEncodedHrefs(NSString *html, NSString *rawBody) {
+    if (html.length == 0 || rawBody.length == 0) return html;
+    if ([html rangeOfString:@"%25"].location == NSNotFound) return html;
+
+    NSRegularExpression *hrefRe = [NSRegularExpression regularExpressionWithPattern:@"href=\"([^\"]+)\"" options:0 error:nil];
+    NSMutableString *repaired = [html mutableCopy];
+    NSArray<NSTextCheckingResult *> *matches = [hrefRe matchesInString:html options:0 range:NSMakeRange(0, html.length)];
+    for (NSInteger i = (NSInteger)matches.count - 1; i >= 0; i--) {
+        NSRange urlRange = [matches[i] rangeAtIndex:1];
+        NSString *url = [html substringWithRange:urlRange];
+        if ([url rangeOfString:@"%25"].location == NSNotFound) continue;
+        NSString *decoded = [url stringByReplacingOccurrencesOfString:@"%25" withString:@"%"];
+        if (![rawBody containsString:decoded]) continue;
+        [repaired replaceCharactersInRange:urlRange withString:decoded];
+    }
+    return repaired;
+}
+
 static NSString *ApolloDeletedCommentsModelBodyHTMLForArchive(NSDictionary *archived, NSString *fallbackBody) {
     NSString *archivedHTML = [archived[@"body_html"] isKindOfClass:[NSString class]] ? archived[@"body_html"] : nil;
     if (archivedHTML.length > 0) {
         NSString *archivedText = ApolloDeletedCommentsUnescapedHTMLText(archivedHTML);
         if (!ApolloDeletedCommentsBodyLooksDeleted(archivedText)) {
+            NSString *rawBody = [archived[@"body"] isKindOfClass:[NSString class]] ? archived[@"body"] : fallbackBody;
+            archivedHTML = ApolloDeletedCommentsRepairDoubleEncodedHrefs(archivedHTML, rawBody);
             return ApolloDeletedCommentsEscapeHTML(archivedHTML);
         }
     }
@@ -1108,6 +1133,21 @@ static NSUInteger ApolloDeletedCommentsPatchRedditJSONNode(id node, NSDictionary
             NSString *currentBodyHTML = [data[@"body_html"] isKindOfClass:[NSString class]] ? data[@"body_html"] : nil;
             BOOL currentLooksDeleted = ApolloDeletedCommentsCommentDataLooksDeleted(data);
             if (currentLooksDeleted && stats) stats->deletedLookingCount++;
+            if (currentLooksDeleted) {
+                // Reddit's server marks removed comments collapsed. Clear that up
+                // front for EVERY deleted-looking comment — not just ones whose
+                // archive already answered — so the row always renders expanded with
+                // its placeholder/reason chip, and a late-arriving archive only has
+                // to fill the body in. Before this, a slow Arctic response (bigger
+                // md2html payloads) left these as bare collapsed [deleted] stubs the
+                // user had to expand by hand (#620 round 2 regression). Collapse
+                // state is only ever server-removal here: user collapses happen
+                // in-app after parse, never in the wire JSON.
+                data[@"collapsed"] = @NO;
+                data[@"collapsed_because_crowd_control"] = @NO;
+                data[@"collapsed_reason"] = [NSNull null];
+                data[@"collapsed_reason_code"] = [NSNull null];
+            }
             if (currentLooksDeleted && archivedBody.length > 0 && !ApolloDeletedCommentsBodyLooksDeleted(archivedBody)) {
                 if (stats) stats->recoverableCount++;
                 NSString *author = [archived[@"author"] isKindOfClass:[NSString class]] ? archived[@"author"] : nil;

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -1079,20 +1079,103 @@ static UIColor *ApolloDeletedCommentsBodyLinkColor(void) {
 // here (they need Apollo's native image nodes and media_metadata the archive rarely carries),
 // but the far more common text markdown now renders. Each pass rewrites matches right-to-left
 // so ranges stay valid as the string shrinks.
+// Markdown-escapable punctuation is temporarily swapped to private-use placeholders so
+// the inline regex passes can't see it; restored to the literal characters at the end.
+static NSString *const kApolloDeletedCommentsEscapables = @"\\`*_{}[]()#+-.!~>|";
+static unichar ApolloDeletedCommentsEscapePlaceholderFor(NSUInteger idx) { return (unichar)(0xE100 + idx); }
+
 static NSAttributedString *ApolloDeletedCommentsAttributedStringFromMarkdown(NSString *markdown, NSDictionary *baseAttributes) {
     NSDictionary *base = [baseAttributes isKindOfClass:[NSDictionary class]] ? baseAttributes : @{};
-    NSMutableAttributedString *attr = [[NSMutableAttributedString alloc] initWithString:(markdown ?: @"") attributes:base];
-    if (attr.length == 0) return attr;
+    if (markdown.length == 0) return [[NSAttributedString alloc] initWithString:@"" attributes:base];
 
     UIFont *baseFont = base[NSFontAttributeName];
     if (![baseFont isKindOfClass:[UIFont class]]) baseFont = [UIFont systemFontOfSize:15.0];
+    UIColor *baseColor = base[NSForegroundColorAttributeName];
+
+    // 0) Backslash escapes (\* \_ \[ ...) — swap the escaped char to a placeholder so no
+    //    later pass treats it as syntax (fixes stray "\*" showing in recovered bodies).
+    NSMutableString *source = [markdown mutableCopy];
+    for (NSUInteger i = 0; i + 1 < source.length; i++) {
+        if ([source characterAtIndex:i] != '\\') continue;
+        unichar next = [source characterAtIndex:i + 1];
+        NSUInteger idx = [kApolloDeletedCommentsEscapables rangeOfString:[NSString stringWithCharacters:&next length:1]].location;
+        if (idx == NSNotFound) continue;
+        [source replaceCharactersInRange:NSMakeRange(i, 2)
+                              withString:[NSString stringWithCharacters:(unichar[]){ApolloDeletedCommentsEscapePlaceholderFor(idx)} length:1]];
+    }
+
+    // 1) Line-level markdown: blockquotes, bullet/numbered lists, headers. Markers are
+    //    stripped here and the line is styled via paragraph indents, so the inline passes
+    //    below never see them (fixes "> quote" and "* bullet" showing literally).
+    NSMutableAttributedString *attr = [[NSMutableAttributedString alloc] init];
+    NSParagraphStyle *baseParagraph = base[NSParagraphStyleAttributeName];
+    NSArray<NSString *> *lines = [source componentsSeparatedByString:@"\n"];
+    [lines enumerateObjectsUsingBlock:^(NSString *line, NSUInteger lineIdx, __unused BOOL *stop) {
+        NSString *content = line;
+        NSMutableDictionary *lineAttrs = [base mutableCopy];
+        NSMutableParagraphStyle *paragraph = nil;
+
+        // Blockquote: one or more leading "> " markers.
+        NSUInteger quoteLevel = 0;
+        while (YES) {
+            NSString *trimmedHead = [content stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+            if (![trimmedHead hasPrefix:@">"]) break;
+            NSRange gt = [content rangeOfString:@">"];
+            content = [content substringFromIndex:NSMaxRange(gt)];
+            if ([content hasPrefix:@" "]) content = [content substringFromIndex:1];
+            quoteLevel++;
+        }
+        if (quoteLevel > 0) {
+            paragraph = [(baseParagraph ?: [NSParagraphStyle defaultParagraphStyle]) mutableCopy];
+            paragraph.firstLineHeadIndent += 14.0 * quoteLevel;
+            paragraph.headIndent += 14.0 * quoteLevel;
+            if ([baseColor isKindOfClass:[UIColor class]]) {
+                lineAttrs[NSForegroundColorAttributeName] = [baseColor colorWithAlphaComponent:0.72];
+            }
+            lineAttrs[NSFontAttributeName] = ApolloDeletedCommentsFontByAddingTraits(baseFont, UIFontDescriptorTraitItalic);
+        } else {
+            // Header: 1-6 leading #'s.
+            NSRegularExpression *headerRe = [NSRegularExpression regularExpressionWithPattern:@"^(#{1,6})\\s+(.*)$" options:0 error:nil];
+            NSTextCheckingResult *header = [headerRe firstMatchInString:content options:0 range:NSMakeRange(0, content.length)];
+            if (header) {
+                NSUInteger level = [header rangeAtIndex:1].length;
+                content = [content substringWithRange:[header rangeAtIndex:2]];
+                CGFloat bump = level <= 2 ? 3.0 : 1.5;
+                UIFont *headerFont = ApolloDeletedCommentsFontByAddingTraits([baseFont fontWithSize:baseFont.pointSize + bump], UIFontDescriptorTraitBold);
+                lineAttrs[NSFontAttributeName] = headerFont;
+            } else {
+                // Bullet / numbered list item.
+                NSRegularExpression *bulletRe = [NSRegularExpression regularExpressionWithPattern:@"^(\\s*)[*+-]\\s+(.*)$" options:0 error:nil];
+                NSTextCheckingResult *bullet = [bulletRe firstMatchInString:content options:0 range:NSMakeRange(0, content.length)];
+                NSRegularExpression *numberRe = [NSRegularExpression regularExpressionWithPattern:@"^(\\s*)(\\d{1,3})[.)]\\s+(.*)$" options:0 error:nil];
+                NSTextCheckingResult *number = bullet ? nil : [numberRe firstMatchInString:content options:0 range:NSMakeRange(0, content.length)];
+                if (bullet || number) {
+                    NSString *marker = bullet ? @"•" : [NSString stringWithFormat:@"%@.", [content substringWithRange:[number rangeAtIndex:2]]];
+                    NSString *item = [content substringWithRange:[(bullet ?: number) rangeAtIndex:bullet ? 2 : 3]];
+                    content = [NSString stringWithFormat:@"%@ %@", marker, item];
+                    paragraph = [(baseParagraph ?: [NSParagraphStyle defaultParagraphStyle]) mutableCopy];
+                    paragraph.firstLineHeadIndent += 6.0;
+                    paragraph.headIndent += 20.0;
+                }
+            }
+        }
+
+        if (paragraph) lineAttrs[NSParagraphStyleAttributeName] = paragraph;
+        if (lineIdx > 0) {
+            // The newline carries the PREVIOUS line's paragraph style ending; give it the
+            // new line's attrs so indents apply from the line start.
+            [attr appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n" attributes:lineAttrs]];
+        }
+        [attr appendAttributedString:[[NSAttributedString alloc] initWithString:content attributes:lineAttrs]];
+    }];
+    if (attr.length == 0) return [[NSAttributedString alloc] initWithString:@"" attributes:base];
 
     NSString *(^substr)(NSRange) = ^NSString *(NSRange r) {
         if (r.location == NSNotFound || NSMaxRange(r) > attr.string.length) return nil;
         return [attr.string substringWithRange:r];
     };
 
-    // 1) Links [text](http(s)://url) — capture url before the replace, keep the visible text.
+    // 2) Links [text](http(s)://url) — capture url before the replace, keep the visible text.
     NSRegularExpression *linkRe = [NSRegularExpression regularExpressionWithPattern:@"\\[([^\\]\\n]+?)\\]\\((https?://[^\\s)]+)\\)" options:0 error:nil];
     UIColor *linkColor = ApolloDeletedCommentsBodyLinkColor();
     NSArray<NSTextCheckingResult *> *linkMatches = [linkRe matchesInString:attr.string options:0 range:NSMakeRange(0, attr.string.length)];
@@ -1138,6 +1221,31 @@ static NSAttributedString *ApolloDeletedCommentsAttributedStringFromMarkdown(NSS
     inlinePass(@"(?<![\\*_])[\\*_]([^\\*_\\n]+?)[\\*_](?![\\*_])", ^(NSRange r) {
         [attr addAttribute:NSFontAttributeName value:ApolloDeletedCommentsFontByAddingTraits(baseFont, UIFontDescriptorTraitItalic) range:r];
     });
+
+    // 6) Bare URLs (Reddit autolinks these) — only where no link attribute exists yet.
+    NSRegularExpression *bareURLRe = [NSRegularExpression regularExpressionWithPattern:@"https?://[^\\s<>\"\\)\\]]+" options:0 error:nil];
+    NSArray<NSTextCheckingResult *> *bareMatches = [bareURLRe matchesInString:attr.string options:0 range:NSMakeRange(0, attr.string.length)];
+    for (NSInteger i = (NSInteger)bareMatches.count - 1; i >= 0; i--) {
+        NSTextCheckingResult *m = bareMatches[i];
+        if ([attr attribute:NSLinkAttributeName atIndex:m.range.location effectiveRange:NULL]) continue;
+        NSURL *linkURL = [NSURL URLWithString:substr(m.range) ?: @""];
+        if (!linkURL) continue;
+        [attr addAttribute:NSLinkAttributeName value:linkURL range:m.range];
+        if (linkColor) [attr addAttribute:NSForegroundColorAttributeName value:linkColor range:m.range];
+    }
+
+    // 7) Restore backslash-escaped characters to their literals.
+    for (NSUInteger idx = 0; idx < kApolloDeletedCommentsEscapables.length; idx++) {
+        unichar placeholder = ApolloDeletedCommentsEscapePlaceholderFor(idx);
+        NSString *needle = [NSString stringWithCharacters:&placeholder length:1];
+        unichar literal = [kApolloDeletedCommentsEscapables characterAtIndex:idx];
+        NSString *replacement = [NSString stringWithCharacters:&literal length:1];
+        NSRange search = [attr.string rangeOfString:needle];
+        while (search.location != NSNotFound) {
+            [attr replaceCharactersInRange:search withString:replacement];
+            search = [attr.string rangeOfString:needle];
+        }
+    }
 
     return attr;
 }
@@ -2583,6 +2691,22 @@ static UIView *ApolloDeletedCommentsHostListViewForCell(id cellNode) {
     return nil;
 }
 
+// Native comment collapse/expand animations run ~0.3-0.5s; give them a little headroom.
+static const NSTimeInterval kApolloDeletedCommentsCollapseSettleWindow = 0.65;
+static NSTimeInterval sApolloDeletedCommentsLastCollapseEventUptime = 0;
+
+static void ApolloDeletedCommentsNoteCollapseEvent(void) {
+    sApolloDeletedCommentsLastCollapseEventUptime = CACurrentMediaTime();
+}
+
+// Seconds until the current collapse animation (if any) has settled; 0 when idle.
+static NSTimeInterval ApolloDeletedCommentsCollapseSettleDelayRemaining(void) {
+    if (sApolloDeletedCommentsLastCollapseEventUptime <= 0) return 0;
+    NSTimeInterval elapsed = CACurrentMediaTime() - sApolloDeletedCommentsLastCollapseEventUptime;
+    if (elapsed >= kApolloDeletedCommentsCollapseSettleWindow) return 0;
+    return kApolloDeletedCommentsCollapseSettleWindow - elapsed;
+}
+
 static void ApolloDeletedCommentsScheduleHostLayoutRefresh(id cellNode) {
     if (!cellNode || !ApolloDeletedCommentsFeatureActive() || !ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) return;
 
@@ -2594,12 +2718,28 @@ static void ApolloDeletedCommentsScheduleHostLayoutRefresh(id cellNode) {
     objc_setAssociatedObject(hostView, kApolloDeletedCommentsHostLayoutRefreshScheduledKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     __weak UIView *weakHostView = hostView;
     __weak UIView *weakCellView = cellView;
+    __weak id weakCellNode = cellNode;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.03 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         UIView *strongHostView = weakHostView;
         UIView *strongCellView = weakCellView;
         if (![strongHostView isKindOfClass:[UIView class]]) return;
 
         objc_setAssociatedObject(strongHostView, kApolloDeletedCommentsHostLayoutRefreshScheduledKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+        // A collapse/expand animation is in flight: even a non-animated empty
+        // begin/endUpdates here re-queries every row height and restarts the native
+        // delete/insert animations mid-flight (rows visibly jump/glide the wrong
+        // way — issue #620 round 2). Re-arm the refresh for after the animation
+        // settles instead of fighting it.
+        NSTimeInterval settleDelay = ApolloDeletedCommentsCollapseSettleDelayRemaining();
+        if (settleDelay > 0) {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)((settleDelay + 0.03) * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                id strongCellNode = weakCellNode;
+                if (strongCellNode) ApolloDeletedCommentsScheduleHostLayoutRefresh(strongCellNode);
+            });
+            return;
+        }
+
         for (UIView *view = strongCellView; view && view != strongHostView.superview; view = view.superview) {
             [view setNeedsLayout];
             [view setNeedsDisplay];
@@ -2953,7 +3093,24 @@ static void ApolloDeletedCommentsApplyRecoveredArchiveToVisibleCell(id cellNode,
     if (!ApolloDeletedCommentsVisibleCommentNeedsRecoveredArchive(comment, archivedBody)) return;
 
     NSString *reason = ApolloDeletedCommentsDeletedPlaceholderReason(fullName) ?: ApolloDeletedCommentsRecoveredReasonForComment(fullName);
+    BOOL wasCollapsedBeforeApply = ApolloDeletedCommentsCommentIsCollapsed(comment);
     if (!ApolloDeletedCommentsApplyRecoveredArchivedCommentToObject((id)comment, archived, reason)) return;
+
+    // Reddit's server marks removed comments collapsed, and the inline JSON patch
+    // clears that flag (data[@"collapsed"] = @NO) — but when the archive loses the
+    // race and arrives here, after the model was already parsed, the comment stays
+    // collapsed and shows as a bare [deleted] header the user must expand by hand
+    // (regression noted in #620 round 2: bigger Arctic payloads lose the race more
+    // often). We only reach this line for a comment whose body still looked deleted
+    // (VisibleCommentNeedsRecoveredArchive above), so a collapsed state here is the
+    // server's removal-collapse, not a user choice — expand it natively.
+    if (wasCollapsedBeforeApply && [(id)comment respondsToSelector:@selector(setCollapsed:)]) {
+        @try {
+            ((void (*)(id, SEL, BOOL))objc_msgSend)((id)comment, @selector(setCollapsed:), NO);
+            ApolloLog(@"[DeletedComments] Un-collapsed late-recovered comment %@", fullName);
+        } @catch (__unused NSException *e) {}
+    }
+
     objc_setAssociatedObject((id)comment, kApolloDeletedCommentsOriginalBodyKey, [archivedBody copy], OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject((id)comment, kApolloDeletedCommentsOriginalBodyHTMLKey, ApolloDeletedCommentsPlainBodyHTML(archivedBody), OBJC_ASSOCIATION_COPY_NONATOMIC);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -3474,6 +3631,15 @@ static void ApolloDeletedCommentsRevealCommentInsteadOfCollapsing(RDKComment *co
         objc_setAssociatedObject((id)self, kApolloDeletedCommentsSuppressNextCollapseKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         return;
     }
+
+    // Stamp the collapse/expand moment. The host-wide height fixup
+    // (ScheduleHostLayoutRefresh) defers itself while a collapse animation is in
+    // flight: an empty beginUpdates/endUpdates mid-animation re-queries every row
+    // height and restarts the native delete/insert animations, which is what made
+    // sibling rows glide the wrong way during a collapse (issue #620, round 2).
+    // Parse-time setCollapsed: storms also stamp this, but that only delays the
+    // initial height fixup by <=0.65s, which is harmless.
+    ApolloDeletedCommentsNoteCollapseEvent();
 
     // Collapse/expand stays fully native here and never reveals: revealing is a
     // separate chip-region tap handled by the cell's reveal recognizer. (Earlier

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -3820,13 +3820,25 @@ static void ApolloDeletedCommentsRevealCommentInsteadOfCollapsing(RDKComment *co
     }
 
     // Stamp the collapse/expand moment. The host-wide height fixup
-    // (ScheduleHostLayoutRefresh) defers itself while a collapse animation is in
-    // flight: an empty beginUpdates/endUpdates mid-animation re-queries every row
-    // height and restarts the native delete/insert animations, which is what made
+    // (ScheduleHostLayoutRefresh) and the link-preview module's row-height
+    // refresh defer themselves while a collapse animation is in flight: an
+    // empty beginUpdates/endUpdates mid-animation re-queries every row height
+    // and restarts the native delete/insert animations, which is what made
     // sibling rows glide the wrong way during a collapse (issue #620, round 2).
-    // Parse-time setCollapsed: storms also stamp this, but that only delays the
-    // initial height fixup by <=0.65s, which is harmless.
-    ApolloDeletedCommentsNoteCollapseEvent();
+    //
+    // Main-thread setters only: a collapse that animates the table always
+    // originates on main (user tap, Apollo's own UI-driven collapses, our
+    // late-archive un-collapse). Model PARSING also calls setCollapsed: — in
+    // background-thread storms, one per comment, on every thread open — and
+    // stamping those armed the window at exactly the moment link-preview
+    // placeholders shrink to their final compact size, deferring (and with
+    // cell reuse, losing) their row-height refresh: the stretched compact
+    // cards reported in #620. No table animation can be running from a
+    // background parse, so those stamps protected nothing. This also keeps
+    // the stamp variable main-thread-only (it was cross-thread racy before).
+    if ([NSThread isMainThread]) {
+        ApolloDeletedCommentsNoteCollapseEvent();
+    }
 
     // Collapse/expand stays fully native here and never reveals: revealing is a
     // separate chip-region tap handled by the cell's reveal recognizer. (Earlier

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -828,6 +828,21 @@ static id ApolloDeletedCommentsKnownBodyTextNode(id commentCellNode) {
 }
 
 static void ApolloDeletedCommentsRelayoutCellAndTextNode(id cellNode, id textNode) {
+    // Invalidating node layout mid-collapse resizes rows while the native
+    // delete/insert animation is running — visible as ghosting/misdirected row
+    // motion (#630 rounds 2-3). Defer the whole relayout until it settles. Reveal
+    // taps never stamp the window, so they stay instant.
+    NSTimeInterval settleDelay = ApolloDeletedCommentsCollapseSettleDelayRemaining();
+    if (settleDelay > 0) {
+        __weak id weakCellNode = cellNode;
+        __weak id weakTextNode = textNode;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)((settleDelay + 0.03) * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            id strongCellNode = weakCellNode;
+            if (strongCellNode) ApolloDeletedCommentsRelayoutCellAndTextNode(strongCellNode, weakTextNode);
+        });
+        return;
+    }
+
     SEL selectors[] = {
         @selector(invalidateCalculatedLayout),
         @selector(setNeedsLayout),
@@ -1232,6 +1247,43 @@ static NSAttributedString *ApolloDeletedCommentsAttributedStringFromMarkdown(NSS
         if (!linkURL) continue;
         [attr addAttribute:NSLinkAttributeName value:linkURL range:m.range];
         if (linkColor) [attr addAttribute:NSForegroundColorAttributeName value:linkColor range:m.range];
+    }
+
+    // 6b) Superscript: ^(grouped text) and ^word. Runs AFTER links because citation
+    //     markup like [^(\[8\])](url) leaves ^(…) inside the link's visible text —
+    //     without this pass those show as literal "^([8])" fragments ("superscripts
+    //     make the renderer freak out", #630 round 3). Scale each existing font run
+    //     (preserves bold/italic/link fonts) and raise the baseline.
+    void (^applySuperscript)(NSRange) = ^(NSRange r) {
+        if (r.length == 0) return;
+        [attr enumerateAttribute:NSFontAttributeName inRange:r options:0
+                      usingBlock:^(UIFont *font, NSRange runRange, __unused BOOL *stop) {
+            UIFont *runFont = [font isKindOfClass:[UIFont class]] ? font : baseFont;
+            [attr addAttribute:NSFontAttributeName value:[runFont fontWithSize:MAX(8.0, runFont.pointSize * 0.72)] range:runRange];
+        }];
+        [attr addAttribute:NSBaselineOffsetAttributeName value:@(baseFont.pointSize * 0.30) range:r];
+    };
+    // Grouped form first; loop a few times for adjacent/nested markers.
+    NSRegularExpression *superGroupRe = [NSRegularExpression regularExpressionWithPattern:@"\\^\\(([^()\\n]*)\\)" options:0 error:nil];
+    for (int pass = 0; pass < 3; pass++) {
+        NSArray<NSTextCheckingResult *> *ms = [superGroupRe matchesInString:attr.string options:0 range:NSMakeRange(0, attr.string.length)];
+        if (ms.count == 0) break;
+        for (NSInteger i = (NSInteger)ms.count - 1; i >= 0; i--) {
+            NSTextCheckingResult *m = ms[i];
+            NSString *inner = substr([m rangeAtIndex:1]) ?: @"";
+            [attr replaceCharactersInRange:m.range withString:inner];
+            applySuperscript(NSMakeRange(m.range.location, inner.length));
+        }
+    }
+    // Bare form: ^word (no parens). Reddit superscripts a single token.
+    NSRegularExpression *superBareRe = [NSRegularExpression regularExpressionWithPattern:@"\\^([^\\s^()\\[\\]]+)" options:0 error:nil];
+    NSArray<NSTextCheckingResult *> *bareSupers = [superBareRe matchesInString:attr.string options:0 range:NSMakeRange(0, attr.string.length)];
+    for (NSInteger i = (NSInteger)bareSupers.count - 1; i >= 0; i--) {
+        NSTextCheckingResult *m = bareSupers[i];
+        NSString *inner = substr([m rangeAtIndex:1]) ?: @"";
+        if (inner.length == 0) continue;
+        [attr replaceCharactersInRange:m.range withString:inner];
+        applySuperscript(NSMakeRange(m.range.location, inner.length));
     }
 
     // 7) Restore backslash-escaped characters to their literals.
@@ -2289,6 +2341,129 @@ static void ApolloDeletedCommentsInstallRevealTapGestureOnCell(id cellNode) {
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsRevealTapGestureKey, gesture, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+#pragma mark - Link taps in recovered bodies
+
+// Resolve the NSLink URL under a tap on the cell, if any. The recovered body is our
+// own replacement ASTextNode (attached to the captured MarkdownNode), so we convert
+// the touch into that node's coordinate space and ask ASTextNode's own link hit-test.
+// Works whether or not the node has a loaded view (rasterized cells included) because
+// the conversion goes through the node hierarchy, not the view hierarchy.
+static NSURL *ApolloDeletedCommentsLinkURLAtCellPoint(id cellNode, CGPoint pointInCellView) {
+    if (!cellNode) return nil;
+    id markdownNode = objc_getAssociatedObject(cellNode, kApolloDeletedCommentsCellMarkdownNodeKey);
+    id replacement = markdownNode ? objc_getAssociatedObject(markdownNode, kApolloDeletedCommentsBodyReplacementTextNodeKey) : nil;
+
+    // A recovered body has two shapes: our single replacement ASTextNode (late/tap-to-
+    // reveal renders) or Apollo's native MarkdownNode with one ASTextNode PER PARAGRAPH
+    // (inline-patched comments). Hit-test every text node under the markdown node so a
+    // tap on any paragraph resolves its link.
+    NSMutableArray *candidates = [NSMutableArray array];
+    if (replacement) [candidates addObject:replacement];
+    NSHashTable *visited = [[NSHashTable alloc] initWithOptions:NSHashTableObjectPointerPersonality capacity:16];
+    ApolloDeletedCommentsCollectAttributedTextNodes(markdownNode ?: cellNode, 6, visited, candidates);
+    id knownText = ApolloDeletedCommentsKnownBodyTextNode(cellNode);
+    if (knownText && ![candidates containsObject:knownText]) [candidates addObject:knownText];
+
+    SEL convertSel = @selector(convertPoint:toNode:);
+    SEL linkSel = NSSelectorFromString(@"linkAttributeValueAtPoint:attributeName:range:");
+    for (id textNode in candidates) {
+        if (![cellNode respondsToSelector:convertSel] || ![textNode respondsToSelector:linkSel]) continue;
+        @try {
+            CGPoint nodePoint = ((CGPoint (*)(id, SEL, CGPoint, id))objc_msgSend)(cellNode, convertSel, pointInCellView, textNode);
+            NSString *attributeName = nil;
+            NSRange linkRange = NSMakeRange(NSNotFound, 0);
+            id value = ((id (*)(id, SEL, CGPoint, NSString **, NSRange *))objc_msgSend)(textNode, linkSel, nodePoint, &attributeName, &linkRange);
+            if ([value isKindOfClass:[NSURL class]]) return (NSURL *)value;
+            if ([value isKindOfClass:[NSString class]]) return [NSURL URLWithString:(NSString *)value];
+        } @catch (__unused NSException *e) {}
+    }
+    return nil;
+}
+
+static const void *kApolloDeletedCommentsLinkTapGestureKey = &kApolloDeletedCommentsLinkTapGestureKey;
+
+@interface ApolloDeletedCommentsLinkTapHandler : NSObject <UIGestureRecognizerDelegate>
+@property (nonatomic, weak) id cellNode;
+@end
+
+@implementation ApolloDeletedCommentsLinkTapHandler
+
+- (void)apolloLinkTap:(UITapGestureRecognizer *)recognizer {
+    if (recognizer.state != UIGestureRecognizerStateEnded) return;
+    id cellNode = self.cellNode;
+    if (!cellNode) return;
+    NSURL *url = ApolloDeletedCommentsLinkURLAtCellPoint(cellNode, [recognizer locationInView:recognizer.view]);
+    if (!url) return;
+
+    UIViewController *presenter = nil;
+    for (UIResponder *responder = recognizer.view; responder; responder = responder.nextResponder) {
+        if ([responder isKindOfClass:[UIViewController class]]) { presenter = (UIViewController *)responder; break; }
+    }
+    if (!presenter) return;
+    ApolloLog(@"[DeletedComments] Opening recovered-body link %@", url.absoluteString);
+    ApolloPresentWebURLFromViewController(presenter, url);
+}
+
+// Claim the tap only when a link is actually under the finger; every other tap
+// (collapse, expand, reveal chip, buttons) passes through untouched.
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
+    id cellNode = self.cellNode;
+    if (!cellNode || !ApolloDeletedCommentsFeatureActive()) return NO;
+    return ApolloDeletedCommentsLinkURLAtCellPoint(cellNode, [touch locationInView:gestureRecognizer.view]) != nil;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return YES;
+}
+
+// Same arbitration as the reveal tap: Apollo's single-tap collapse must wait for —
+// and be cancelled by — a successful link tap, so tapping a link never collapses.
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    if (![otherGestureRecognizer isKindOfClass:[UITapGestureRecognizer class]]) return NO;
+    if (((UITapGestureRecognizer *)otherGestureRecognizer).numberOfTapsRequired > 1) return NO;
+    id cellNode = self.cellNode;
+    if (!cellNode) return NO;
+    CGPoint p = [otherGestureRecognizer locationInView:gestureRecognizer.view];
+    return ApolloDeletedCommentsLinkURLAtCellPoint(cellNode, p) != nil;
+}
+@end
+
+// One persistent recognizer per cell view (mirrors the reveal-tap install; the
+// delegate gates per-tap so it is inert on cells without recovered links).
+static void ApolloDeletedCommentsInstallLinkTapGestureOnCell(id cellNode) {
+    if (!cellNode || ![cellNode respondsToSelector:@selector(view)]) return;
+    UIView *view = nil;
+    @try {
+        view = ((UIView *(*)(id, SEL))objc_msgSend)(cellNode, @selector(view));
+    } @catch (__unused NSException *e) {
+        return;
+    }
+    if (![view isKindOfClass:[UIView class]]) return;
+
+    UITapGestureRecognizer *existing = objc_getAssociatedObject(cellNode, kApolloDeletedCommentsLinkTapGestureKey);
+    if ([existing isKindOfClass:[UITapGestureRecognizer class]]) {
+        if (existing.view == view) return;
+        @try { [existing.view removeGestureRecognizer:existing]; } @catch (__unused NSException *e) {}
+        objc_setAssociatedObject(cellNode, kApolloDeletedCommentsLinkTapGestureKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    ApolloDeletedCommentsLinkTapHandler *handler = [ApolloDeletedCommentsLinkTapHandler new];
+    handler.cellNode = cellNode;
+
+    UITapGestureRecognizer *gesture = [[UITapGestureRecognizer alloc] initWithTarget:handler
+                                                                              action:@selector(apolloLinkTap:)];
+    gesture.delegate = handler;
+    gesture.cancelsTouchesInView = YES;   // a link tap must not also collapse the row
+    gesture.delaysTouchesBegan = NO;
+    gesture.delaysTouchesEnded = NO;
+    objc_setAssociatedObject(gesture, kApolloDeletedCommentsLinkTapGestureKey, handler, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    @try { [view addGestureRecognizer:gesture]; } @catch (__unused NSException *e) { return; }
+    objc_setAssociatedObject(cellNode, kApolloDeletedCommentsLinkTapGestureKey, gesture, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 static void __attribute__((unused)) ApolloDeletedCommentsApplyTapToRevealIfNeeded(id cellNode) {
     RDKComment *comment = ApolloDeletedCommentsCommentFromCellNode(cellNode);
     NSString *fullName = ApolloDeletedCommentsFullNameForComment(comment);
@@ -2692,15 +2867,17 @@ static UIView *ApolloDeletedCommentsHostListViewForCell(id cellNode) {
 }
 
 // Native comment collapse/expand animations run ~0.3-0.5s; give them a little headroom.
+// Exported (ApolloDeletedCommentsData.h) so other row-measuring modules — inline link
+// previews in particular — can defer their own table updates during the window.
 static const NSTimeInterval kApolloDeletedCommentsCollapseSettleWindow = 0.65;
 static NSTimeInterval sApolloDeletedCommentsLastCollapseEventUptime = 0;
 
-static void ApolloDeletedCommentsNoteCollapseEvent(void) {
+void ApolloDeletedCommentsNoteCollapseEvent(void) {
     sApolloDeletedCommentsLastCollapseEventUptime = CACurrentMediaTime();
 }
 
 // Seconds until the current collapse animation (if any) has settled; 0 when idle.
-static NSTimeInterval ApolloDeletedCommentsCollapseSettleDelayRemaining(void) {
+NSTimeInterval ApolloDeletedCommentsCollapseSettleDelayRemaining(void) {
     if (sApolloDeletedCommentsLastCollapseEventUptime <= 0) return 0;
     NSTimeInterval elapsed = CACurrentMediaTime() - sApolloDeletedCommentsLastCollapseEventUptime;
     if (elapsed >= kApolloDeletedCommentsCollapseSettleWindow) return 0;
@@ -2885,6 +3062,11 @@ static id ApolloDeletedCommentsBodyReplacementTextNode(id markdownNode, id cellN
     if (!textNode || !textNodeClass || ![textNode isKindOfClass:textNodeClass]) {
         textNode = [[textNodeClass alloc] init];
         if (!textNode) return nil;
+        // Advertise NSLink ranges so -linkAttributeValueAtPoint: (used by the cell-level
+        // link-tap gesture) can resolve the URL under a touch.
+        @try {
+            ((void (*)(id, SEL, id))objc_msgSend)(textNode, @selector(setLinkAttributeNames:), @[NSLinkAttributeName]);
+        } @catch (__unused NSException *e) {}
         objc_setAssociatedObject(markdownNode, kApolloDeletedCommentsBodyReplacementTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         @try {
             ((void (*)(id, SEL, id))objc_msgSend)(markdownNode, @selector(addSubnode:), textNode);
@@ -3256,6 +3438,11 @@ static void ApolloDeletedCommentsUpdateCell(id cellNode) {
     ApolloDeletedCommentsApplyCellHighlight(cellNode);
     if (ApolloDeletedCommentsFeatureActive() && sTapToRevealDeletedComments) {
         ApolloDeletedCommentsInstallRevealTapGestureOnCell(cellNode);
+    }
+    if (ApolloDeletedCommentsFeatureActive() && ApolloDeletedCommentsCellNodeShouldShowDeletedTreatment(cellNode)) {
+        // Links inside recovered bodies open on tap (delegate-gated: only claims the
+        // tap when a link is under the finger, so collapse/expand stay native).
+        ApolloDeletedCommentsInstallLinkTapGestureOnCell(cellNode);
     }
 }
 

--- a/src/ApolloDeletedCommentsUI.xm
+++ b/src/ApolloDeletedCommentsUI.xm
@@ -1057,6 +1057,91 @@ static BOOL ApolloDeletedCommentsBodyAttributesNeedRefresh(NSDictionary *attribu
     return NO;
 }
 
+static UIFont *ApolloDeletedCommentsFontByAddingTraits(UIFont *base, UIFontDescriptorSymbolicTraits traits) {
+    if (![base isKindOfClass:[UIFont class]]) base = [UIFont systemFontOfSize:15.0];
+    UIFontDescriptor *descriptor = [base.fontDescriptor fontDescriptorWithSymbolicTraits:(base.fontDescriptor.symbolicTraits | traits)];
+    if (!descriptor) return base;
+    UIFont *result = [UIFont fontWithDescriptor:descriptor size:base.pointSize];
+    return result ?: base;
+}
+
+static UIColor *ApolloDeletedCommentsBodyLinkColor(void) {
+    for (UIWindow *window in ApolloAllWindows()) {
+        UIColor *tint = window.tintColor;
+        if ([tint isKindOfClass:[UIColor class]]) return tint;
+    }
+    return [UIColor systemBlueColor];
+}
+
+// Render a recovered comment's raw markdown body into an attributed string so links, bold,
+// italics, strikethrough and inline code display as formatting instead of literal
+// "[text](url)" / "**text**" source (issue #620 D). Inline Reddit images can't be reproduced
+// here (they need Apollo's native image nodes and media_metadata the archive rarely carries),
+// but the far more common text markdown now renders. Each pass rewrites matches right-to-left
+// so ranges stay valid as the string shrinks.
+static NSAttributedString *ApolloDeletedCommentsAttributedStringFromMarkdown(NSString *markdown, NSDictionary *baseAttributes) {
+    NSDictionary *base = [baseAttributes isKindOfClass:[NSDictionary class]] ? baseAttributes : @{};
+    NSMutableAttributedString *attr = [[NSMutableAttributedString alloc] initWithString:(markdown ?: @"") attributes:base];
+    if (attr.length == 0) return attr;
+
+    UIFont *baseFont = base[NSFontAttributeName];
+    if (![baseFont isKindOfClass:[UIFont class]]) baseFont = [UIFont systemFontOfSize:15.0];
+
+    NSString *(^substr)(NSRange) = ^NSString *(NSRange r) {
+        if (r.location == NSNotFound || NSMaxRange(r) > attr.string.length) return nil;
+        return [attr.string substringWithRange:r];
+    };
+
+    // 1) Links [text](http(s)://url) — capture url before the replace, keep the visible text.
+    NSRegularExpression *linkRe = [NSRegularExpression regularExpressionWithPattern:@"\\[([^\\]\\n]+?)\\]\\((https?://[^\\s)]+)\\)" options:0 error:nil];
+    UIColor *linkColor = ApolloDeletedCommentsBodyLinkColor();
+    NSArray<NSTextCheckingResult *> *linkMatches = [linkRe matchesInString:attr.string options:0 range:NSMakeRange(0, attr.string.length)];
+    for (NSInteger i = (NSInteger)linkMatches.count - 1; i >= 0; i--) {
+        NSTextCheckingResult *m = linkMatches[i];
+        NSString *text = substr([m rangeAtIndex:1]);
+        NSString *url = substr([m rangeAtIndex:2]);
+        if (text.length == 0) continue;
+        [attr replaceCharactersInRange:m.range withString:text];
+        NSRange r = NSMakeRange(m.range.location, text.length);
+        NSURL *linkURL = url.length > 0 ? [NSURL URLWithString:url] : nil;
+        if (linkURL) [attr addAttribute:NSLinkAttributeName value:linkURL range:r];
+        if (linkColor) [attr addAttribute:NSForegroundColorAttributeName value:linkColor range:r];
+    }
+
+    // Generic inline pass: replace each match with capture group 1's text and style that range.
+    void (^inlinePass)(NSString *, void (^)(NSRange)) = ^(NSString *pattern, void (^style)(NSRange)) {
+        NSRegularExpression *re = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:nil];
+        if (!re) return;
+        NSArray<NSTextCheckingResult *> *ms = [re matchesInString:attr.string options:0 range:NSMakeRange(0, attr.string.length)];
+        for (NSInteger i = (NSInteger)ms.count - 1; i >= 0; i--) {
+            NSTextCheckingResult *m = ms[i];
+            NSString *inner = substr([m rangeAtIndex:1]);
+            if (inner.length == 0) continue;
+            [attr replaceCharactersInRange:m.range withString:inner];
+            style(NSMakeRange(m.range.location, inner.length));
+        }
+    };
+
+    // 2) Inline code `code`
+    inlinePass(@"`([^`\\n]+?)`", ^(NSRange r) {
+        [attr addAttribute:NSFontAttributeName value:[UIFont monospacedSystemFontOfSize:baseFont.pointSize weight:UIFontWeightRegular] range:r];
+    });
+    // 3) Bold **text** or __text__
+    inlinePass(@"\\*\\*([^\\n]+?)\\*\\*|__([^\\n]+?)__", ^(NSRange r) {
+        [attr addAttribute:NSFontAttributeName value:ApolloDeletedCommentsFontByAddingTraits(baseFont, UIFontDescriptorTraitBold) range:r];
+    });
+    // 4) Strikethrough ~~text~~
+    inlinePass(@"~~([^\\n]+?)~~", ^(NSRange r) {
+        [attr addAttribute:NSStrikethroughStyleAttributeName value:@(NSUnderlineStyleSingle) range:r];
+    });
+    // 5) Italic *text* or _text_ (single delimiter; run last so it doesn't eat ** / __)
+    inlinePass(@"(?<![\\*_])[\\*_]([^\\*_\\n]+?)[\\*_](?![\\*_])", ^(NSRange r) {
+        [attr addAttribute:NSFontAttributeName value:ApolloDeletedCommentsFontByAddingTraits(baseFont, UIFontDescriptorTraitItalic) range:r];
+    });
+
+    return attr;
+}
+
 static NSAttributedString *ApolloDeletedCommentsBodyAttributedText(NSAttributedString *templateText, NSString *body) {
     NSMutableDictionary *attributes = ApolloDeletedCommentsBodyAttributesFromAttributedText(templateText);
     if (ApolloDeletedCommentsBodyAttributesNeedRefresh(attributes)) {
@@ -1065,7 +1150,7 @@ static NSAttributedString *ApolloDeletedCommentsBodyAttributedText(NSAttributedS
     if (!attributes) {
         attributes = ApolloDeletedCommentsDefaultBodyAttributes();
     }
-    return [[NSAttributedString alloc] initWithString:body ?: @"" attributes:attributes];
+    return ApolloDeletedCommentsAttributedStringFromMarkdown(body ?: @"", attributes);
 }
 
 static NSAttributedString *ApolloDeletedCommentsBodyTextByNormalizingFont(NSAttributedString *attributedText) {
@@ -2520,20 +2605,34 @@ static void ApolloDeletedCommentsScheduleHostLayoutRefresh(id cellNode) {
             [view setNeedsDisplay];
         }
 
-        @try {
-            if ([strongHostView isKindOfClass:[UICollectionView class]]) {
-                [(UICollectionView *)strongHostView performBatchUpdates:nil completion:nil];
-            } else if ([strongHostView isKindOfClass:[UITableView class]]) {
-                UITableView *tableView = (UITableView *)strongHostView;
-                [tableView beginUpdates];
-                [tableView endUpdates];
-            } else {
+        // Commit the deleted-cell height correction WITHOUT animation. This is an internal
+        // re-measure to pick up a taller recovered body / reason chip — NOT a user-initiated
+        // collapse or expand. Animating it makes a deleted sibling that just grew glide
+        // downward while the native collapse is animating rows upward, i.e. the "second
+        // comment goes down instead of up" wrong-direction collapse in issue #620. Suppress
+        // both the implicit UITableView row animation and the Core Animation actions so the
+        // row snaps to its correct height. Native collapse/expand animates via its own path
+        // and is untouched.
+        void (^commit)(void) = ^{
+            @try {
+                if ([strongHostView isKindOfClass:[UICollectionView class]]) {
+                    [(UICollectionView *)strongHostView performBatchUpdates:nil completion:nil];
+                } else if ([strongHostView isKindOfClass:[UITableView class]]) {
+                    UITableView *tableView = (UITableView *)strongHostView;
+                    [tableView beginUpdates];
+                    [tableView endUpdates];
+                } else {
+                    [strongHostView setNeedsLayout];
+                    [strongHostView layoutIfNeeded];
+                }
+            } @catch (__unused NSException *e) {
                 [strongHostView setNeedsLayout];
-                [strongHostView layoutIfNeeded];
             }
-        } @catch (__unused NSException *e) {
-            [strongHostView setNeedsLayout];
-        }
+        };
+        [CATransaction begin];
+        [CATransaction setDisableActions:YES];
+        [UIView performWithoutAnimation:commit];
+        [CATransaction commit];
     });
 }
 
@@ -2752,8 +2851,17 @@ static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpec
                              sTapToRevealDeletedComments &&
                              recovered &&
                              revealed;
+    // In the default "Show" mode (no tap-to-reveal) a recovered comment would otherwise
+    // fall through to %orig, whose MarkdownNode renders the raw markdown SOURCE as literal
+    // text ("[text](url)", "**bold**") because its display nodes were built while the body
+    // was still "[removed]". Own the layout here too so we render the recovered body through
+    // our markdown-aware attributed-string builder — that's the fix for the "markdown not
+    // rendered" half of issue #620 D.
+    BOOL autoShowRecovered = ApolloDeletedCommentsFeatureActive() &&
+                             !sTapToRevealDeletedComments &&
+                             recovered;
 
-    if (!(placeholderOnly || shouldHide || revealedRecovered)) {
+    if (!(placeholderOnly || shouldHide || revealedRecovered || autoShowRecovered)) {
         return nil;
     }
 
@@ -2794,9 +2902,9 @@ static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpec
 
     NSAttributedString *original = nil;
     if (appAttributes && resolvedBody.length > 0) {
-        original = [[NSAttributedString alloc] initWithString:resolvedBody attributes:appAttributes];
+        original = ApolloDeletedCommentsAttributedStringFromMarkdown(resolvedBody, appAttributes);
     } else if (nativeAttributes && resolvedBody.length > 0) {
-        original = [[NSAttributedString alloc] initWithString:resolvedBody attributes:nativeAttributes];
+        original = ApolloDeletedCommentsAttributedStringFromMarkdown(resolvedBody, nativeAttributes);
     } else {
         original = ApolloDeletedCommentsBodyAttributedText(templateText, resolvedBody);
     }
@@ -2805,8 +2913,8 @@ static id __attribute__((unused)) ApolloDeletedCommentsDeletedMarkdownLayoutSpec
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodesKey, @[textNode], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(cellNode, kApolloDeletedCommentsHiddenTextNodeKey, textNode, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     NSDictionary *chipAttributes = ApolloDeletedCommentsReasonChipBaseAttributes(original, cellNode);
-    if (revealedRecovered) {
-        // Show the recovered body itself.
+    if (revealedRecovered || autoShowRecovered) {
+        // Show the recovered body itself (rendered markdown), with the reason chip.
         displayText = ApolloDeletedCommentsAttributedTextWithReasonPrefix(textNode, original);
     } else if (placeholderOnly) {
         displayText = ApolloDeletedCommentsReasonChipAttributedText(ApolloDeletedCommentsReasonLabelForComment(comment),

--- a/src/ApolloInlineLinkPreviews.xm
+++ b/src/ApolloInlineLinkPreviews.xm
@@ -5,6 +5,7 @@
 // metadata. Falls back to Apollo's native card when metadata is missing.
 
 #import "ApolloCommon.h"
+#import "ApolloDeletedCommentsData.h"
 #import "ApolloLinkPreviewCache.h"
 #import "ApolloLinkPreviewFetcher.h"
 #import "ApolloBannedProfile.h"
@@ -3108,6 +3109,20 @@ static ASDisplayNode *ApolloLPFindOwningCellNode(ASDisplayNode *node) {
 }
 
 static BOOL ApolloLPInvokeScrollViewHeightRefresh(ASDisplayNode *node) {
+    // A comment collapse/expand animation is running: an empty begin/endUpdates
+    // now re-queries every row height mid-animation and restarts the native row
+    // animations (ghosting / rows sliding the wrong way — #630). Re-run the
+    // refresh once the collapse settles instead.
+    NSTimeInterval settleDelay = ApolloDeletedCommentsCollapseSettleDelayRemaining();
+    if (settleDelay > 0) {
+        __weak ASDisplayNode *weakNode = node;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)((settleDelay + 0.03) * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            ASDisplayNode *strongNode = weakNode;
+            if (strongNode) ApolloLPInvokeScrollViewHeightRefresh(strongNode);
+        });
+        return YES;
+    }
+
     UIView *view = ApolloLPViewForNode(node);
     for (UIView *current = view; current; current = current.superview) {
         if ([current isKindOfClass:[UITableView class]]) {

--- a/src/ApolloInlineLinkPreviews.xm
+++ b/src/ApolloInlineLinkPreviews.xm
@@ -125,6 +125,10 @@ static char kApolloLinkPreviewNodesKey;
 static char kApolloLinkPreviewFetchInFlightKey;
 static char kApolloLinkPreviewOriginalHostShellKey;
 static char kApolloLinkPreviewRenderedPlaceholderKey;
+// V24: context of the last RICH render (hero/compact), for detecting a
+// final-hero -> final-compact flip that has no placeholder mark. Atomic
+// association: written from Texture's background measurement threads.
+static char kApolloLPLastRenderedContextKey;
 static char kApolloLinkPreviewBackgroundColorPresetKey;
 static char kApolloLinkPreviewAreaKey;
 static char kApolloLinkPreviewContextMenuInstalledKey;
@@ -148,7 +152,7 @@ typedef struct {
 
 static void ApolloLPLogOncePerHost(NSString *host, NSString *event);
 static void ApolloLPTriggerRelayoutForHost(ASDisplayNode *node, NSString *host);
-static BOOL ApolloLPInvokeRowReloadIfPossible(ASDisplayNode *startNode, NSString *host);
+static BOOL ApolloLPInvokeRowReloadIfPossible(ASDisplayNode *startNode, ASDisplayNode *originNode, NSString *host);
 static ASDisplayNode *ApolloLPFindOwningCellNode(ASDisplayNode *node);
 static void ApolloLPNoteRowReloadMissForNode(ASDisplayNode *node, NSString *host);
 static BOOL ApolloLPIsRedditUserProfileURL(NSURL *url);
@@ -1045,7 +1049,7 @@ static void ApolloLPStartFallbackImageFetch(ASNetworkImageNode *imageNode, NSURL
                     ApolloLog(@"[LinkPreviews] V21-dead-image-compact-reflow host=%@", hostCopy ?: ApolloLPHost(imageURL));
                     ApolloLPTriggerRelayoutForHost(hostNode, hostCopy);
                     ASDisplayNode *cellNode = ApolloLPFindOwningCellNode(hostNode);
-                    if (!ApolloLPInvokeRowReloadIfPossible(cellNode ?: hostNode, hostCopy)) {
+                    if (!ApolloLPInvokeRowReloadIfPossible(cellNode ?: hostNode, hostNode, hostCopy)) {
                         ApolloLPNoteRowReloadMissForNode(hostNode, hostCopy);
                     }
                 }
@@ -1581,7 +1585,7 @@ static BOOL ApolloLPFireRowReloadFromAttachedNodesForURL(NSString *urlString, NS
         UIView *view = loaded ? ApolloLPViewForNode(node) : nil;
         if (!view.window) continue; // only an on-screen tree can resolve its row's index path
         ASDisplayNode *cellNode = ApolloLPFindOwningCellNode(node);
-        if (ApolloLPInvokeRowReloadIfPossible(cellNode ?: node, host)) {
+        if (ApolloLPInvokeRowReloadIfPossible(cellNode ?: node, node, host)) {
             fired = YES;
         }
     }
@@ -1626,6 +1630,13 @@ static void ApolloLPRunCrossNodeRowReloadPoll(void) {
 // the V23 cross-instance reload keyed by the node's URL. Try to fire right
 // away — when the preview resolves while the row is already on screen, the
 // display tree is attached and the row heals immediately.
+//
+// V24: the map entry is armed even when the immediate fire reports success —
+// a YES from the fire only means a reload was SCHEDULED, and its async body
+// can still drop on the visibility guard. The poll drains the entry on the
+// next fire (an extra reload of an already-correct row is harmless and
+// documented as such above), so arming unconditionally trades one cheap
+// reload for never losing the row.
 static void ApolloLPNoteRowReloadMissForNode(ASDisplayNode *node, NSString *host) {
     if (!node) return;
     objc_setAssociatedObject(node, &kApolloLPPendingRowReloadHostKey, host ?: @"?", OBJC_ASSOCIATION_COPY_NONATOMIC);
@@ -1633,12 +1644,11 @@ static void ApolloLPNoteRowReloadMissForNode(ASDisplayNode *node, NSString *host
     NSURL *url = objc_getAssociatedObject(node, &kApolloLinkPreviewURLKey);
     NSString *urlString = url.absoluteString;
     if (urlString.length == 0) return;
-    if (ApolloLPFireRowReloadFromAttachedNodesForURL(urlString, host)) {
-        ApolloLog(@"[LinkPreviews] V23-cross-node-row-reload host=%@", host ?: @"?");
-        return;
-    }
     ApolloLPPendingCrossNodeRowReloads()[urlString] = [NSDate date];
     ApolloLPScheduleCrossNodeRowReloadPoll();
+    if (ApolloLPFireRowReloadFromAttachedNodesForURL(urlString, host)) {
+        ApolloLog(@"[LinkPreviews] V23-cross-node-row-reload host=%@", host ?: @"?");
+    }
 }
 
 static void ApolloLPMarkNodeForColorRefresh(ASDisplayNode *node) {
@@ -3108,38 +3118,72 @@ static ASDisplayNode *ApolloLPFindOwningCellNode(ASDisplayNode *node) {
     return nil;
 }
 
+static void ApolloLPPerformScrollViewHeightRefresh(UIView *scrollView) {
+    if ([scrollView isKindOfClass:[UITableView class]]) {
+        UITableView *tableView = (UITableView *)scrollView;
+        [tableView beginUpdates];
+        [tableView endUpdates];
+    } else if ([scrollView isKindOfClass:[UICollectionView class]]) {
+        [(UICollectionView *)scrollView performBatchUpdates:nil completion:nil];
+    }
+}
+
+// V24: settle-deferred begin/endUpdates. Holds the RESOLVED scroll view
+// strongly instead of re-walking from a weak node after the wait: the row
+// reload that usually accompanies this refresh re-creates the cell node, so
+// a weak node reference dies before the collapse settles and the deferred
+// refresh silently vanished — leaving compact cards stranded inside their
+// tall hero-measured rows (#620 stretched-card report). The table view
+// outlives the animation, one pending refresh per table is enough (an empty
+// begin/endUpdates re-queries EVERY row height), and the retry is bounded so
+// a long collapse-event storm can't queue forever — after the cap we fire
+// anyway, which at worst re-runs the (rare) mid-animation glitch this gate
+// exists to avoid, never a permanently wrong layout.
+static char kApolloLPSettleRefreshPendingKey;
+
+static void ApolloLPScheduleSettleDeferredHeightRefresh(UIView *scrollView, NSTimeInterval settleDelay, NSInteger attemptsLeft) {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)((settleDelay + 0.03) * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        NSTimeInterval remaining = ApolloDeletedCommentsCollapseSettleDelayRemaining();
+        if (remaining > 0 && attemptsLeft > 0) {
+            ApolloLPScheduleSettleDeferredHeightRefresh(scrollView, remaining, attemptsLeft - 1);
+            return;
+        }
+        objc_setAssociatedObject(scrollView, &kApolloLPSettleRefreshPendingKey, nil, OBJC_ASSOCIATION_RETAIN);
+        if (!scrollView.window) return; // screen went away; nothing left to fix
+        ApolloLog(@"[LinkPreviews] V24-settle-deferred-height-refresh fired attemptsLeft=%ld", (long)attemptsLeft);
+        ApolloLPPerformScrollViewHeightRefresh(scrollView);
+    });
+}
+
 static BOOL ApolloLPInvokeScrollViewHeightRefresh(ASDisplayNode *node) {
+    // Resolve the enclosing table/collection view FIRST, while the caller's
+    // node is still alive and attached — a deferred walk routinely fails
+    // after cell reuse (V24, see above).
+    UIView *view = ApolloLPViewForNode(node);
+    UIView *scrollView = nil;
+    for (UIView *current = view; current; current = current.superview) {
+        if ([current isKindOfClass:[UITableView class]] || [current isKindOfClass:[UICollectionView class]]) {
+            scrollView = current;
+            break;
+        }
+    }
+    if (!scrollView) return NO;
+
     // A comment collapse/expand animation is running: an empty begin/endUpdates
     // now re-queries every row height mid-animation and restarts the native row
     // animations (ghosting / rows sliding the wrong way — #630). Re-run the
-    // refresh once the collapse settles instead.
+    // refresh once the collapse settles instead, coalesced per scroll view.
     NSTimeInterval settleDelay = ApolloDeletedCommentsCollapseSettleDelayRemaining();
     if (settleDelay > 0) {
-        __weak ASDisplayNode *weakNode = node;
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)((settleDelay + 0.03) * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            ASDisplayNode *strongNode = weakNode;
-            if (strongNode) ApolloLPInvokeScrollViewHeightRefresh(strongNode);
-        });
+        if (!objc_getAssociatedObject(scrollView, &kApolloLPSettleRefreshPendingKey)) {
+            objc_setAssociatedObject(scrollView, &kApolloLPSettleRefreshPendingKey, @YES, OBJC_ASSOCIATION_RETAIN);
+            ApolloLPScheduleSettleDeferredHeightRefresh(scrollView, settleDelay, 6);
+        }
         return YES;
     }
 
-    UIView *view = ApolloLPViewForNode(node);
-    for (UIView *current = view; current; current = current.superview) {
-        if ([current isKindOfClass:[UITableView class]]) {
-            UITableView *tableView = (UITableView *)current;
-            [tableView beginUpdates];
-            [tableView endUpdates];
-            return YES;
-        }
-
-        if ([current isKindOfClass:[UICollectionView class]]) {
-            UICollectionView *collectionView = (UICollectionView *)current;
-            [collectionView performBatchUpdates:nil completion:nil];
-            return YES;
-        }
-    }
-
-    return NO;
+    ApolloLPPerformScrollViewHeightRefresh(scrollView);
+    return YES;
 }
 
 static id ApolloLPTextureNodeForScrollView(UIView *scrollView) {
@@ -3192,7 +3236,26 @@ static void ApolloLPLogRowReloadMissAncestry(ASDisplayNode *startNode, UIView *c
     ApolloLPLogOncePerHost(host, [NSString stringWithFormat:@"V23-miss-node-chain %@", [nodeChain componentsJoinedByString:@" > "]]);
 }
 
-static BOOL ApolloLPInvokeRowReloadIfPossible(ASDisplayNode *startNode, NSString *host) {
+// V24: the async reload bodies below can still drop their reload when the
+// captured index path has left the visible set by the time the block runs
+// (fast scroll, or a native collapse animation mutating the table — the very
+// situation the settle gate detects). The synchronous YES already told the
+// caller "handled", which suppresses the V20/V23 miss bookkeeping — so a
+// dropped reload used to disarm every healer at once and the row kept its
+// stale hero height forever (#620 stretched compact cards). Re-note the miss
+// from the block instead of silently returning: that re-arms the V20 pending
+// mark and the V23 cross-node map, whose 1s poll reloads the row as soon as
+// it is back on screen. `originNode` is the LinkButtonNode that owns the
+// preview (it carries the URL association the bookkeeping needs); if it has
+// been deallocated the cell was re-created, which re-measures with cached
+// metadata and heals the height by itself — nothing to re-arm.
+static void ApolloLPRenoteDroppedRowReload(ASDisplayNode *originNode, NSString *host, NSInteger row) {
+    if (!originNode) return;
+    ApolloLog(@"[LinkPreviews] V24-row-reload-dropped-renote host=%@ row=%ld", host ?: @"?", (long)row);
+    ApolloLPNoteRowReloadMissForNode(originNode, host);
+}
+
+static BOOL ApolloLPInvokeRowReloadIfPossible(ASDisplayNode *startNode, ASDisplayNode *originNode, NSString *host) {
     UIView *cellView = ApolloLPViewForNode(startNode);
     if (!cellView) {
         ApolloLPLogOncePerHost(host, @"V12-row-reload-miss no-view");
@@ -3216,9 +3279,13 @@ static BOOL ApolloLPInvokeRowReloadIfPossible(ASDisplayNode *startNode, NSString
 
             NSString *hostCopy = [host copy];
             NSIndexPath *indexPathCopy = [indexPath copy];
+            __weak ASDisplayNode *weakOriginNode = originNode;
             dispatch_async(dispatch_get_main_queue(), ^{
                 @try {
-                    if (![[tableView indexPathsForVisibleRows] containsObject:indexPathCopy]) return;
+                    if (![[tableView indexPathsForVisibleRows] containsObject:indexPathCopy]) {
+                        ApolloLPRenoteDroppedRowReload(weakOriginNode, hostCopy, indexPathCopy.row);
+                        return;
+                    }
                     ApolloLPInvokeTextureScrollRelayoutIfPossible(tableView, hostCopy, @"table");
                     [tableView reloadRowsAtIndexPaths:@[indexPathCopy] withRowAnimation:UITableViewRowAnimationNone];
                     ApolloLPLogOncePerHost(hostCopy, [NSString stringWithFormat:@"V12-row-reload kind=table row=%ld", (long)indexPathCopy.row]);
@@ -3235,9 +3302,13 @@ static BOOL ApolloLPInvokeRowReloadIfPossible(ASDisplayNode *startNode, NSString
 
             NSString *hostCopy = [host copy];
             NSIndexPath *indexPathCopy = [indexPath copy];
+            __weak ASDisplayNode *weakOriginNode = originNode;
             dispatch_async(dispatch_get_main_queue(), ^{
                 @try {
-                    if (![[collectionView indexPathsForVisibleItems] containsObject:indexPathCopy]) return;
+                    if (![[collectionView indexPathsForVisibleItems] containsObject:indexPathCopy]) {
+                        ApolloLPRenoteDroppedRowReload(weakOriginNode, hostCopy, indexPathCopy.item);
+                        return;
+                    }
                     ApolloLPInvokeTextureScrollRelayoutIfPossible(collectionView, hostCopy, @"collection");
                     [collectionView performBatchUpdates:^{
                         [collectionView reloadItemsAtIndexPaths:@[indexPathCopy]];
@@ -3333,7 +3404,7 @@ static void ApolloLPTriggerPlaceholderContextRelayout(ASDisplayNode *node, NSStr
               host ?: @"(nohost)", ApolloLPContextLogName(fromContext), ApolloLPContextLogName(toContext));
     ApolloLPTriggerRelayoutInternal(node, NO, host);
     ASDisplayNode *cellNode = ApolloLPFindOwningCellNode(node);
-    if (!ApolloLPInvokeRowReloadIfPossible(cellNode ?: node, host)) {
+    if (!ApolloLPInvokeRowReloadIfPossible(cellNode ?: node, node, host)) {
         ApolloLPNoteRowReloadMissForNode(node, host);
     }
 
@@ -3343,7 +3414,7 @@ static void ApolloLPTriggerPlaceholderContextRelayout(ASDisplayNode *node, NSStr
         ASDisplayNode *strongNode = weakNode;
         if (!strongNode) return;
         ASDisplayNode *strongCellNode = ApolloLPFindOwningCellNode(strongNode);
-        if (ApolloLPInvokeRowReloadIfPossible(strongCellNode ?: strongNode, hostCopy)) {
+        if (ApolloLPInvokeRowReloadIfPossible(strongCellNode ?: strongNode, strongNode, hostCopy)) {
             objc_setAssociatedObject(strongNode, &kApolloLPPendingRowReloadHostKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
             NSURL *url = objc_getAssociatedObject(strongNode, &kApolloLinkPreviewURLKey);
             if (url.absoluteString.length > 0) {
@@ -3406,7 +3477,7 @@ static void ApolloLPRunOverflowHeightCheck(ASDisplayNode *node, NSString *host, 
         if (overflow > 8.0) {
             ApolloLog(@"[LinkPreviews] V18-stale-row-height host=%@ overflow=%.0fpt -> reloading row",
                       host ?: @"?", overflow);
-            ApolloLPInvokeRowReloadIfPossible(node, host);
+            ApolloLPInvokeRowReloadIfPossible(node, node, host);
         }
     } @catch (__unused NSException *exception) {}
 }
@@ -4163,12 +4234,28 @@ static id ApolloLPNativeLinkSpecWithBannedHintIfNeeded(id linkButtonNode, NSURL 
         : ApolloLPBuildCompactCardSpec((ASDisplayNode *)self, url, displayPreview, finalVariant);
     if (richSpec) {
         NSNumber *renderedPlaceholder = objc_getAssociatedObject(self, &kApolloLinkPreviewRenderedPlaceholderKey);
-        if (renderedPlaceholder) {
+        // V24: also track the CONTEXT of every rich render. A final-hero card
+        // can later re-render final-compact with no placeholder involved at
+        // all (the multi-link rule counts links via a cell-subtree walk, so a
+        // measurement against a not-yet-complete subtree can resolve hero and
+        // a later one compact). That flip had NO relayout trigger — the
+        // compact card kept the hero row height and V18's overflow geometry
+        // is blind to oversize rows. Fire the same shrink relayout for it.
+        NSNumber *lastRenderedContext = objc_getAssociatedObject(self, &kApolloLPLastRenderedContextKey);
+        objc_setAssociatedObject(self, &kApolloLPLastRenderedContextKey, @(context), OBJC_ASSOCIATION_RETAIN);
+        BOOL finalShrankToCompact = !renderedPlaceholder &&
+            [lastRenderedContext isKindOfClass:[NSNumber class]] &&
+            lastRenderedContext.unsignedIntegerValue == ApolloLPContextSelfText &&
+            context == ApolloLPContextCompact;
+        if (renderedPlaceholder || finalShrankToCompact) {
             objc_setAssociatedObject(self, &kApolloLinkPreviewRenderedPlaceholderKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
             __weak ASDisplayNode *weakSelf = (ASDisplayNode *)self;
             NSString *hostCopy = [host copy];
-            ApolloLPContext placeholderContext = (ApolloLPContext)[renderedPlaceholder unsignedIntegerValue];
-            BOOL placeholderShrankToCompact = placeholderContext == ApolloLPContextSelfText && context == ApolloLPContextCompact;
+            ApolloLPContext placeholderContext = renderedPlaceholder ? (ApolloLPContext)[renderedPlaceholder unsignedIntegerValue] : ApolloLPContextSelfText;
+            BOOL placeholderShrankToCompact = (placeholderContext == ApolloLPContextSelfText && context == ApolloLPContextCompact) || finalShrankToCompact;
+            if (finalShrankToCompact) {
+                ApolloLPLogOncePerHost(host, @"V24-final-hero-to-compact-shrink");
+            }
             dispatch_async(dispatch_get_main_queue(), ^{
                 ASDisplayNode *strongSelf = weakSelf;
                 if (!strongSelf) return;
@@ -4227,7 +4314,13 @@ static id ApolloLPNativeLinkSpecWithBannedHintIfNeeded(id linkButtonNode, NSURL 
             ASDisplayNode *strongSelf = weakSelf;
             if (!strongSelf) return;
             ASDisplayNode *cellNode = ApolloLPFindOwningCellNode(strongSelf);
-            ApolloLPInvokeRowReloadIfPossible(cellNode ?: strongSelf, pendingHost);
+            // V24: the mark was consumed above; if the reload can't even be
+            // scheduled, re-arm instead of discarding the result — otherwise
+            // this re-fire was one-shot and a single failed walk stranded the
+            // row at its stale height.
+            if (!ApolloLPInvokeRowReloadIfPossible(cellNode ?: strongSelf, strongSelf, pendingHost)) {
+                ApolloLPNoteRowReloadMissForNode(strongSelf, pendingHost);
+            }
         });
     }
     ApolloLPScheduleOverflowHeightCheck((ASDisplayNode *)self, @"visible-check");

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1002,6 +1002,14 @@ static NSURLRequest *ApolloLocalFastFailRequest(NSString *path) {
     ApolloRedditCaptureBearerTokenFromRequest(request, @"__NSCFLocalSessionTask _originalRequest");
     ApolloRedditCaptureBearerTokenFromRequest(currentRequest, @"__NSCFLocalSessionTask _currentRequest");
 
+    // Observe comments requests at RESUME time as well as at task creation. Once the
+    // app has been running for a while, Apollo can hand us tasks whose creation never
+    // passed through the hooked dataTaskWith… selectors (seen with single-comment
+    // permalink views: only the resume fired, so the Arctic warm never started and the
+    // deleted comment rendered as a bare chip — issue #620 round 2). Observation is
+    // cheap (parses reddit-host comments URLs only) and warming is deduped downstream.
+    ApolloDeletedCommentsHandleRequestObservation(request ?: currentRequest, @"onqueue_resume");
+
     NSURLRequest *redditMediaRequest = ApolloRedditMaybeRewriteSubmitRequest(request) ?: ApolloRedditMaybeRewriteSubmitRequest(currentRequest);
     if (!redditMediaRequest) {
         redditMediaRequest = ApolloRedditMaybeRewriteCommentRequest(request) ?: ApolloRedditMaybeRewriteCommentRequest(currentRequest);


### PR DESCRIPTION
**stacked on #630** — the first commits here are that branch; the actual fix is the last commit. merge #630 first and this shrinks to a one-commit diff.

follow-up to @Uranosphaerite's report on #620: link previews that are supposed to collapse to the compact view were keeping their full-preview height — compact card content floating at the top of a huge empty box.

turned out to be a regression from the round-3 collapse-animation guard in #630, plus a couple of pre-existing holes it exposed:

- multi-link comments render hero placeholders first and only collapse to compact once metadata arrives; a row-height refresh (empty `beginUpdates`/`endUpdates`) then snaps the row down. in comment threads that refresh is the *only* path that re-queries row heights
- the round-3 guard deferred that refresh behind a weak node reference that usually dies before the wait ends (row reloads re-create texture cell nodes), so the refresh silently never happened
- worse, the "wait for the collapse animation to settle" window was being armed by apollo's own comment parsing — it calls `setCollapsed:` on every comment while a thread loads, from background threads — so the window was hot on every thread open, exactly when preview fetches complete. deleted comments toggle on or off
- and the row reload reports success when it's only been *scheduled*; if the row left the visible set by the time it ran (fast scroll, mid-animation table), it silently dropped AND had already suppressed the backup healers

fixes:

- only main-thread `setCollapsed:` (user taps / UI collapses that actually animate the table) arms the settle window now. background parse storms can't have a collapse animation running, so stamping them protected nothing
- the settle-gated height refresh resolves the table up front and holds it strongly through the deferral, coalesced per table with a bounded retry, instead of re-walking from a weak node
- dropped row reloads re-arm the V20/V23 healers instead of disarming them; the cross-node map is armed even when the immediate fire "succeeds" (an extra reload of a correct row is harmless, a lost one isn't)
- bonus: a hero card that re-renders compact on a later measurement pass (the multi-link count can settle late on a detached tree) now fires the same shrink refresh — that flip previously had no trigger at all, which is probably why this occasionally showed up on older builds too

tested in the sim on the same kind of askhistorians thread as the report (removed comments everywhere + multi-link source comments), fresh preview cache, fast scroll during the fetch window: cards land compact at compact height, and the wrong-direction-collapse protection from round 3 still engages for real collapses only.
