### PR TITLE
Recently Read: bump revisited posts reliably, auto-refresh on return, and bug/crash fixes

### DIFF
--- a/src/ApolloRecentlyRead.xm
+++ b/src/ApolloRecentlyRead.xm
@@ -10,11 +10,51 @@
 #import "fishhook.h"
 
 // MARK: - Recently Read Posts
+//
+// Apollo's ReadPostsTracker keeps read-post IDs in an NSMutableOrderedSet
+// (bare IDs, newest appended at the end, trimmed to 5000 from the front)
+// guarded by a private CONCURRENT dispatch queue: every native write is an
+// async .barrier block on that queue and every native read is a dispatch_sync
+// (confirmed in Hopper). The "ReadPostIDs" NSUserDefaults key is only
+// persisted on scene-background / app-terminate, so the in-memory set is the
+// sole in-session source of truth. We mirror the same queue discipline below
+// so our reads are ordered after any pending native mark and never race the
+// barrier writers.
 
 // Direct access to ReadPostsTracker's in-memory ordered set via fishhook + ObjC runtime
 static __unsafe_unretained id sReadPostsTracker = nil;
 static Ivar sReadPostIDsIvar = NULL;
 static void *sTrackerTypeMetadata = NULL;
+// Cached resolved values - both ivars are assigned once in the tracker's init
+// and never replaced, and the tracker itself lives for the app's lifetime.
+static __unsafe_unretained NSMutableOrderedSet *sTrackerReadPostIDsCached = nil;
+static BOOL sReadPostIDsLookupFailed = NO;
+static dispatch_queue_t sTrackerQueueCached = nil;
+static BOOL sTrackerQueueLookupFailed = NO;
+
+// Post IDs are stored bare (no t3_ prefix) in the tracker's set
+static NSString *ApolloBarePostID(NSString *postID) {
+    return [postID hasPrefix:@"t3_"] ? [postID substringFromIndex:3] : postID;
+}
+
+// Scan the tracker's ivar list for a name containing nameSubstr
+static Ivar ApolloTrackerIvarNamed(const char *nameSubstr) {
+    if (!sReadPostsTracker) return NULL;
+    Ivar found = NULL;
+    unsigned int ivarCount = 0;
+    Ivar *ivars = class_copyIvarList([sReadPostsTracker class], &ivarCount);
+    if (ivars) {
+        for (unsigned int i = 0; i < ivarCount; i++) {
+            const char *name = ivar_getName(ivars[i]);
+            if (name && strstr(name, nameSubstr)) {
+                found = ivars[i];
+                break;
+            }
+        }
+        free(ivars);
+    }
+    return found;
+}
 
 // fishhook: briefly hook swift_allocObject to capture the ReadPostsTracker singleton
 static void *(*orig_swift_allocObject)(void *type, size_t size, size_t alignMask);
@@ -30,23 +70,18 @@ static void *hooked_swift_allocObject(void *type, size_t size, size_t alignMask)
 
 // Retrieve the in-memory NSMutableOrderedSet of read post IDs from the tracker
 static NSMutableOrderedSet *getTrackerReadPostIDs(void) {
-    if (!sReadPostsTracker) return nil;
+    // Cached so the hot-path NSMutableOrderedSet addObject: hook below is a
+    // pointer compare after the first resolution.
+    if (sTrackerReadPostIDsCached) return sTrackerReadPostIDsCached;
+    if (sReadPostIDsLookupFailed || !sReadPostsTracker) return nil;
 
-    // Lazily find the ivar by name
+    // Lazily find the ivar by name. Latch on failure - this runs inside the
+    // app-wide NSMutableOrderedSet addObject: hook, so a renamed ivar must
+    // not turn every add into an ivar-list scan.
     if (!sReadPostIDsIvar) {
-        unsigned int ivarCount = 0;
-        Ivar *ivars = class_copyIvarList([sReadPostsTracker class], &ivarCount);
-        if (ivars) {
-            for (unsigned int i = 0; i < ivarCount; i++) {
-                const char *name = ivar_getName(ivars[i]);
-                if (name && strstr(name, "readPostIDs")) {
-                    sReadPostIDsIvar = ivars[i];
-                    break;
-                }
-            }
-            free(ivars);
-        }
+        sReadPostIDsIvar = ApolloTrackerIvarNamed("readPostIDs");
         if (!sReadPostIDsIvar) {
+            sReadPostIDsLookupFailed = YES;
             ApolloLog(@"[RecentlyRead] readPostIDs ivar not found");
             return nil;
         }
@@ -54,21 +89,112 @@ static NSMutableOrderedSet *getTrackerReadPostIDs(void) {
 
     id value = object_getIvar(sReadPostsTracker, sReadPostIDsIvar);
     if ([value isKindOfClass:[NSMutableOrderedSet class]]) {
-        return (NSMutableOrderedSet *)value;
+        sTrackerReadPostIDsCached = (NSMutableOrderedSet *)value;
+        return sTrackerReadPostIDsCached;
     }
     return nil;
 }
 
+// Retrieve the tracker's private concurrent dispatch queue (ivar "dispatchQueue")
+static dispatch_queue_t getTrackerQueue(void) {
+    if (sTrackerQueueCached) return sTrackerQueueCached;
+    if (sTrackerQueueLookupFailed || !sReadPostsTracker) return nil;
+
+    Ivar queueIvar = ApolloTrackerIvarNamed("dispatchQueue");
+    if (!queueIvar) {
+        sTrackerQueueLookupFailed = YES;
+        ApolloLog(@"[RecentlyRead] dispatchQueue ivar not found - falling back to direct set access");
+        return nil;
+    }
+
+    id value = object_getIvar(sReadPostsTracker, queueIvar);
+    // Sanity-check the class: barrier semantics only mean anything on a real
+    // private dispatch queue.
+    if (value && [value isKindOfClass:objc_getClass("OS_dispatch_queue")]) {
+        sTrackerQueueCached = (dispatch_queue_t)value;
+    } else {
+        sTrackerQueueLookupFailed = YES;
+        ApolloLog(@"[RecentlyRead] dispatchQueue ivar is not a dispatch queue - falling back to direct set access");
+    }
+    return sTrackerQueueCached;
+}
+
+// Snapshot the tracker's in-memory IDs. Reads go through dispatch_sync on the
+// tracker's queue when available so they are ordered AFTER any pending native
+// barrier write (Apollo enqueues marks as async barrier blocks) - this is
+// what guarantees a refresh sees a just-marked post. -[NSOrderedSet array]
+// returns a live proxy, not a snapshot, so the copy MUST be materialized
+// inside the block. Returns nil when the tracker isn't captured.
+static NSArray<NSString *> *ApolloReadPostIDsSnapshot(void) {
+    NSMutableOrderedSet *trackerSet = getTrackerReadPostIDs();
+    if (!trackerSet) return nil;
+
+    dispatch_queue_t queue = getTrackerQueue();
+    __block NSArray *snapshot = nil;
+    if (queue) {
+        dispatch_sync(queue, ^{
+            snapshot = [[NSArray alloc] initWithArray:[trackerSet array]];
+        });
+    } else {
+        // Queue unavailable (unexpected) - best-effort direct read, matching
+        // the old behavior.
+        snapshot = [[NSArray alloc] initWithArray:[trackerSet array]];
+    }
+    return snapshot;
+}
+
+// Mutate the tracker's set with the same async-barrier discipline native
+// writes use. The block must not dispatch to other queues (deadlock risk for
+// the dispatch_sync readers).
+static void ApolloMutateTrackerSet(void (^mutation)(NSMutableOrderedSet *trackerSet)) {
+    NSMutableOrderedSet *trackerSet = getTrackerReadPostIDs();
+    if (!trackerSet) return;
+
+    dispatch_queue_t queue = getTrackerQueue();
+    if (queue) {
+        dispatch_barrier_async(queue, ^{
+            mutation(trackerSet);
+        });
+    } else {
+        mutation(trackerSet);
+    }
+}
+
+// Mark a post as read in the tracker (stored as a bare ID, matching native
+// storage). Returns YES when the mark was enqueued. Re-adding an existing ID
+// bumps it to the most-recent slot via the NSMutableOrderedSet addObject:
+// hook below. Note: this writes the tracker's set directly, so the native
+// Reddit-account batch counters (hide-read sync, Premium visited sync) never
+// see tweak marks - there is no stable native entry point to route through.
+static BOOL ApolloMarkPostIDAsRead(NSString *postID) {
+    if (postID.length == 0) return NO;
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DisableMarkingPostsRead"]) return NO;
+    if (!getTrackerReadPostIDs()) {
+        ApolloLog(@"[RecentlyRead] Cannot mark %@ read - tracker not captured yet", postID);
+        return NO;
+    }
+
+    NSString *bareID = ApolloBarePostID(postID);
+    NSString *prefixedID = [@"t3_" stringByAppendingString:bareID];
+    ApolloMutateTrackerSet(^(NSMutableOrderedSet *trackerSet) {
+        // Drop a legacy prefixed twin so the two ID forms can't coexist as
+        // duplicate entries.
+        [trackerSet removeObject:prefixedID];
+        [trackerSet addObject:bareID];
+    });
+    return YES;
+}
+
 // Flush the in-memory ReadPostIDs to NSUserDefaults so backup captures current state
 void ApolloFlushReadPostIDsToDefaults(void) {
-    NSMutableOrderedSet *trackerSet = getTrackerReadPostIDs();
-    if (trackerSet && trackerSet.count > 0) {
-        ApolloLog(@"[RecentlyRead] Flushing %lu in-memory ReadPostIDs to NSUserDefaults", (unsigned long)trackerSet.count);
-        [[NSUserDefaults standardUserDefaults] setObject:[trackerSet array] forKey:@"ReadPostIDs"];
+    NSArray *postIDs = ApolloReadPostIDsSnapshot();
+    if (postIDs.count > 0) {
+        ApolloLog(@"[RecentlyRead] Flushing %lu in-memory ReadPostIDs to NSUserDefaults", (unsigned long)postIDs.count);
+        [[NSUserDefaults standardUserDefaults] setObject:postIDs forKey:@"ReadPostIDs"];
     } else {
-        ApolloLog(@"[RecentlyRead] Flush skipped — tracker %s, count: %lu",
+        ApolloLog(@"[RecentlyRead] Flush skipped - tracker %s, count: %lu",
                   sReadPostsTracker ? "available" : "nil",
-                  (unsigned long)(trackerSet ? trackerSet.count : 0));
+                  (unsigned long)postIDs.count);
     }
 }
 
@@ -81,6 +207,19 @@ void ApolloFlushReadPostIDsToDefaults(void) {
 @property (nonatomic, assign) BOOL hasMorePages;
 @property (nonatomic, assign) BOOL isFetchingPage;
 @property (nonatomic, assign) BOOL hasLoadedOnce;
+// Bumped by every refresh/clear; in-flight fetch completions drop themselves
+// when their captured generation is stale.
+@property (nonatomic, assign) NSUInteger fetchGeneration;
+// The next completing page replaces self.posts (pull-to-refresh) instead of
+// appending (pagination).
+@property (nonatomic, assign) BOOL pendingReplace;
+// Consecutive auto-chained fetches after pages that surfaced zero visible
+// rows (fully filtered or fully deleted) - capped so a pathological history
+// can't fan out into dozens of back-to-back API calls.
+@property (nonatomic, assign) NSUInteger emptyPageChainCount;
+// Full names the API stopped returning (deleted/removed posts) - skipped by
+// soft refreshes so they aren't re-requested on every return to the screen.
+@property (nonatomic, strong) NSMutableSet<NSString *> *knownMissingFullNames;
 @property (nonatomic, strong) UIActivityIndicatorView *spinner;
 @property (nonatomic, strong) UIActivityIndicatorView *footerSpinner;
 @end
@@ -227,6 +366,10 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
     self.hasMorePages = NO;
     self.isFetchingPage = NO;
     self.hasLoadedOnce = NO;
+    self.fetchGeneration = 0;
+    self.pendingReplace = NO;
+    self.emptyPageChainCount = 0;
+    self.knownMissingFullNames = [NSMutableSet set];
 
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.tableView.rowHeight = UITableViewAutomaticDimension;
@@ -267,26 +410,28 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
     if (!self.hasLoadedOnce) {
         self.hasLoadedOnce = YES;
         [self refreshPosts];
+    } else {
+        // Returning to the screen (a nav pop runs the top VC's
+        // viewWillDisappear first, so a just-left post is already marked):
+        // sync the list with the tracker's current order in place, with no
+        // spinner and no clearing.
+        [self softRefreshPosts];
     }
 }
 
 - (void)_pullToRefreshTriggered {
-    if (self.isFetchingPage) {
-        [self.refreshControl endRefreshing];
-        return;
-    }
+    // Supersedes any in-flight fetch via the generation counter instead of
+    // being silently swallowed.
     [self refreshPosts];
 }
 
 - (NSArray<NSString *> *)recentReadFullNames {
-    NSMutableOrderedSet *trackerSet = getTrackerReadPostIDs();
-    NSArray *postIDs = nil;
-    if (trackerSet && trackerSet.count > 0) {
-        postIDs = [trackerSet array];
-    } else {
+    NSArray *postIDs = ApolloReadPostIDsSnapshot();
+    if (postIDs.count == 0) {
+        // Tracker missing or empty - fall back to the persisted mirror (only
+        // written on backgrounding, but better than nothing pre-capture).
         postIDs = [[NSUserDefaults standardUserDefaults] stringArrayForKey:@"ReadPostIDs"];
     }
-
     if (postIDs.count == 0) return @[];
 
     NSUInteger maxCount = postIDs.count;
@@ -294,16 +439,22 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
         maxCount = MIN(postIDs.count, (NSUInteger)sReadPostMaxCount);
     }
 
-    NSArray *recentIDs = [postIDs subarrayWithRange:NSMakeRange(postIDs.count - maxCount, maxCount)];
-    NSMutableArray<NSString *> *fullNames = [NSMutableArray arrayWithCapacity:recentIDs.count];
-    for (NSString *postID in recentIDs) {
-        if ([postID hasPrefix:@"t3_"]) {
-            [fullNames addObject:postID];
-        } else {
-            [fullNames addObject:[@"t3_" stringByAppendingString:postID]];
-        }
+    // Single backward pass (newest IDs are at the END of storage): emit
+    // newest-first, normalized to t3_ fullnames, deduped keeping the most
+    // recent occurrence so a bare/prefixed twin can't produce duplicate rows.
+    // This runs on every return to the screen, so avoid multi-pass copies of
+    // a potentially 5000-entry history.
+    NSMutableArray<NSString *> *fullNames = [NSMutableArray arrayWithCapacity:maxCount];
+    NSMutableSet<NSString *> *seen = [NSMutableSet setWithCapacity:maxCount];
+    NSUInteger scanned = 0;
+    for (NSString *postID in [postIDs reverseObjectEnumerator]) {
+        if (scanned++ >= maxCount) break;
+        NSString *fullName = [postID hasPrefix:@"t3_"] ? postID : [@"t3_" stringByAppendingString:postID];
+        if ([seen containsObject:fullName]) continue;
+        [seen addObject:fullName];
+        [fullNames addObject:fullName];
     }
-    return [[[fullNames reverseObjectEnumerator] allObjects] copy];
+    return [fullNames copy];
 }
 
 - (void)setFooterLoading:(BOOL)loading {
@@ -323,26 +474,151 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
     }
 }
 
+// Invalidate any in-flight fetch: its completion sees a stale generation and
+// drops all state writes. The caller owns the fetch state from here on.
+- (void)_invalidateInFlightFetches {
+    self.fetchGeneration++;
+    self.isFetchingPage = NO;
+    self.pendingReplace = NO;
+    self.emptyPageChainCount = 0;
+    [self setFooterLoading:NO];
+}
+
+// Full refresh: restart pagination against the tracker's current order.
+// Existing content stays visible until the fresh first page arrives (the
+// completion replaces it); the center spinner only shows for an initial load
+// of an empty list.
 - (void)refreshPosts {
-    self.posts = [NSMutableArray array];
-    self.filteredPosts = [NSMutableArray array];
+    [self _invalidateInFlightFetches];
+    // Deleted/removed posts get another chance on an explicit refresh.
+    [self.knownMissingFullNames removeAllObjects];
+
     self.allPostFullNames = [self recentReadFullNames];
     self.nextFetchIndex = 0;
     self.hasMorePages = (self.allPostFullNames.count > 0);
-    self.isFetchingPage = NO;
-
-    [self.spinner startAnimating];
-    self.tableView.backgroundView = self.spinner;
-    [self setFooterLoading:NO];
-    [self.tableView reloadData];
+    self.pendingReplace = YES;
 
     if (!self.hasMorePages) {
-        [self.spinner stopAnimating];
+        self.pendingReplace = NO;
         [self.refreshControl endRefreshing];
-        [self showEmptyState];
+        [self _applyFullNames:@[] windowLength:0 linksByName:@{}];
         return;
     }
     [self fetchNextPageIfNeeded];
+    [self _updateBackgroundState];
+}
+
+// Soft refresh (auto-run on return to the screen): bring the list in line
+// with the tracker's current order without clearing the UI. Reuses
+// already-fetched links, fetches only IDs we haven't loaded, and no-ops when
+// nothing changed. A pure reorder is fully local and instant.
+- (void)softRefreshPosts {
+    // Live check - don't yank rows out from under an open swipe action.
+    // (tableView.isEditing is YES while trailing swipe actions are shown.)
+    if (self.tableView.isEditing) return;
+
+    // A failed initial/replace load leaves IDs behind with nothing fetched
+    // (cursor still 0); the order comparison below can't detect that, so
+    // restart the full fetch instead of no-opping forever.
+    if (self.posts.count == 0 && self.allPostFullNames.count > 0 &&
+        self.nextFetchIndex == 0 && !self.isFetchingPage) {
+        [self refreshPosts];
+        return;
+    }
+
+    NSArray<NSString *> *newAll = [self recentReadFullNames];
+    if ([newAll isEqualToArray:self.allPostFullNames]) return; // common case: nothing changed
+
+    ApolloLog(@"[RecentlyRead] Soft refresh: order changed (%lu ids)", (unsigned long)newAll.count);
+    [self _invalidateInFlightFetches];
+    NSUInteger generation = self.fetchGeneration;
+
+    if (newAll.count == 0) {
+        [self _applyFullNames:@[] windowLength:0 linksByName:@{}];
+        return;
+    }
+
+    // Preserve the loaded depth (at least one page) so a deep scroll position
+    // doesn't collapse underneath the user.
+    NSUInteger windowLen = MIN(newAll.count, MAX(self.nextFetchIndex, (NSUInteger)kRecentlyReadPageSize));
+    NSArray<NSString *> *window = [newAll subarrayWithRange:NSMakeRange(0, windowLen)];
+
+    NSMutableDictionary<NSString *, RDKLink *> *linksByName = [NSMutableDictionary dictionaryWithCapacity:self.posts.count];
+    for (RDKLink *link in self.posts) {
+        if (link.fullName) linksByName[link.fullName] = link;
+    }
+    NSMutableArray<NSString *> *missing = [NSMutableArray array];
+    for (NSString *fullName in window) {
+        if (!linksByName[fullName] && ![self.knownMissingFullNames containsObject:fullName]) {
+            [missing addObject:fullName];
+        }
+    }
+
+    if (missing.count == 0) {
+        // Pure reorder - applied before the pop transition even finishes.
+        [self _applyFullNames:newAll windowLength:windowLen linksByName:linksByName];
+        return;
+    }
+    if (missing.count > kRecentlyReadPageSize) {
+        // Too much new content to patch in - do a regular (non-clearing) refresh.
+        [self refreshPosts];
+        return;
+    }
+
+    Class RDKClientClass = objc_getClass("RDKClient");
+    id client = [RDKClientClass sharedClient];
+    if (!client) {
+        [self _applyFullNames:newAll windowLength:windowLen linksByName:linksByName];
+        return;
+    }
+
+    ApolloLog(@"[RecentlyRead] Soft refresh: fetching %lu missing posts", (unsigned long)missing.count);
+    self.isFetchingPage = YES;
+    [self _updateBackgroundState];
+    [client thingsByFullNames:missing completion:^(NSArray *things, NSError *fetchError) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (generation != self.fetchGeneration) return; // superseded
+            self.isFetchingPage = NO;
+            if (fetchError || !things) {
+                ApolloLog(@"[RecentlyRead] Soft refresh fetch error: %@", fetchError);
+                // Keep the old order/content rather than committing a new
+                // order with holes behind the pagination cursor - the next
+                // return retries because allPostFullNames still differs from
+                // the tracker.
+                [self _updateBackgroundState];
+                return;
+            }
+            for (id thing in things) {
+                if ([thing isKindOfClass:objc_getClass("RDKLink")]) {
+                    NSString *fn = [(RDKLink *)thing fullName];
+                    if (fn) linksByName[fn] = thing;
+                }
+            }
+            for (NSString *fullName in missing) {
+                if (!linksByName[fullName]) [self.knownMissingFullNames addObject:fullName];
+            }
+            [self _applyFullNames:newAll windowLength:windowLen linksByName:linksByName];
+        });
+    }];
+}
+
+// Swap in a new ID order, rebuilding self.posts from known links. Pagination
+// state is reset to the window so infinite scroll continues cleanly below it.
+- (void)_applyFullNames:(NSArray<NSString *> *)newAll
+           windowLength:(NSUInteger)windowLen
+            linksByName:(NSDictionary<NSString *, RDKLink *> *)linksByName {
+    NSMutableArray *newPosts = [NSMutableArray arrayWithCapacity:windowLen];
+    for (NSUInteger i = 0; i < windowLen; i++) {
+        RDKLink *link = linksByName[newAll[i]];
+        if (link) [newPosts addObject:link];
+    }
+    self.allPostFullNames = newAll;
+    self.posts = newPosts;
+    self.nextFetchIndex = windowLen;
+    self.hasMorePages = (windowLen < newAll.count);
+    [self _refilterPosts];
+    [self.tableView reloadData];
+    [self _updateBackgroundState];
 }
 
 - (void)_clearAllTapped {
@@ -351,25 +627,20 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
         preferredStyle:UIAlertControllerStyleAlert];
     [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
     [alert addAction:[UIAlertAction actionWithTitle:@"Clear All" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
-        // Clear the tracker's in-memory set directly
-        NSMutableOrderedSet *trackerSet = getTrackerReadPostIDs();
-        if (trackerSet) {
+        // Kill any in-flight page fetch so its completion can't repopulate
+        // the cleared list.
+        [self _invalidateInFlightFetches];
+        // Clear the tracker's in-memory set (barrier, like native writes)
+        ApolloMutateTrackerSet(^(NSMutableOrderedSet *trackerSet) {
             [trackerSet removeAllObjects];
-        }
+        });
         // Also clear NSUserDefaults
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"ReadPostIDs"];
         if (self.searchController.isActive) {
             self.searchController.active = NO;
         }
-        self.posts = [NSMutableArray array];
-        self.filteredPosts = [NSMutableArray array];
-        self.allPostFullNames = @[];
-        self.nextFetchIndex = 0;
-        self.hasMorePages = NO;
-        self.isFetchingPage = NO;
-        [self setFooterLoading:NO];
-        [self.tableView reloadData];
-        [self showEmptyState];
+        [self.knownMissingFullNames removeAllObjects];
+        [self _applyFullNames:@[] windowLength:0 linksByName:@{}];
     }]];
     [self presentViewController:alert animated:YES completion:nil];
 }
@@ -378,12 +649,9 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
     if (self.isFetchingPage || !self.hasMorePages) return;
     if (self.nextFetchIndex >= self.allPostFullNames.count) {
         self.hasMorePages = NO;
-        [self.spinner stopAnimating];
         [self setFooterLoading:NO];
         [self.refreshControl endRefreshing];
-        if (self.posts.count == 0) {
-            [self showEmptyState];
-        }
+        [self _updateBackgroundState];
         return;
     }
 
@@ -391,17 +659,15 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
     id client = [RDKClientClass sharedClient];
     if (!client) {
         ApolloLog(@"[RecentlyRead] RDKClient sharedClient is nil");
-        [self.spinner stopAnimating];
         [self.refreshControl endRefreshing];
-        if (self.posts.count == 0) {
-            [self showEmptyState];
-        }
+        [self _updateBackgroundState];
         return;
     }
 
     self.isFetchingPage = YES;
-    BOOL initialPage = (self.posts.count == 0);
-    if (!initialPage) {
+    NSUInteger generation = self.fetchGeneration;
+    BOOL replacing = self.pendingReplace;
+    if (!replacing && self.posts.count > 0) {
         [self setFooterLoading:YES];
     }
 
@@ -412,15 +678,21 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
 
     [client thingsByFullNames:pageFullNames completion:^(NSArray *things, NSError *fetchError) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            self.isFetchingPage = NO;
-            [self.spinner stopAnimating];
-            [self setFooterLoading:NO];
+            // End-refresh is UI-only and safe either way; everything else must
+            // not run for a superseded fetch (the superseding refresh already
+            // reset isFetchingPage/footer and owns all state).
             [self.refreshControl endRefreshing];
+            if (generation != self.fetchGeneration) {
+                ApolloLog(@"[RecentlyRead] Dropping superseded page fetch (generation %lu)", (unsigned long)generation);
+                return;
+            }
+            self.isFetchingPage = NO;
+            [self setFooterLoading:NO];
             if (fetchError || !things) {
                 ApolloLog(@"[RecentlyRead] Fetch error: %@", fetchError);
-                if (self.posts.count == 0) {
-                    [self showEmptyState];
-                }
+                // Keep whatever is on screen. A pending replace stays pending
+                // so the next fetch retries page 1 in the new order.
+                [self _updateBackgroundState];
                 return;
             }
 
@@ -437,27 +709,65 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
             NSMutableArray *ordered = [NSMutableArray arrayWithCapacity:pageFullNames.count];
             for (NSString *fn in pageFullNames) {
                 id thing = thingsByName[fn];
-                if (thing) [ordered addObject:thing];
+                if (thing) {
+                    [ordered addObject:thing];
+                } else {
+                    // Deleted/removed on Reddit - remember so soft refreshes
+                    // don't re-request it every time.
+                    [self.knownMissingFullNames addObject:fn];
+                }
             }
 
-            [self.posts addObjectsFromArray:ordered];
-            [self _refilterPosts];
-            if (self.activePosts.count == 0 && ![self isSearchActive]) {
-                [self showEmptyState];
-            } else if (self.activePosts.count > 0) {
-                self.tableView.backgroundView = nil;
+            if (replacing) {
+                self.pendingReplace = NO;
+                self.posts = [ordered mutableCopy];
             } else {
-                [self _updateBackgroundForSearch];
+                // Guard against duplicate rows if fetch windows ever overlap.
+                NSMutableSet *existingNames = [NSMutableSet setWithCapacity:self.posts.count];
+                for (RDKLink *existing in self.posts) {
+                    if (existing.fullName) [existingNames addObject:existing.fullName];
+                }
+                for (RDKLink *fetched in ordered) {
+                    if (!fetched.fullName || ![existingNames containsObject:fetched.fullName]) {
+                        [self.posts addObject:fetched];
+                    }
+                }
             }
+            [self _refilterPosts];
             [self.tableView reloadData];
+            [self _updateBackgroundState];
+
+            // A page can surface zero visible rows (fully NSFW-filtered, or
+            // every post deleted on Reddit) while more pages remain - chase a
+            // few more so the screen doesn't dead-end, but cap the auto-chain
+            // so a pathological history can't fan out into dozens of
+            // back-to-back API calls.
+            if (self.activePosts.count > 0) {
+                self.emptyPageChainCount = 0;
+            } else if (self.hasMorePages && ![self isSearchActive] && self.emptyPageChainCount < 3) {
+                self.emptyPageChainCount++;
+                [self fetchNextPageIfNeeded];
+            }
         });
     }];
 }
 
-- (void)showEmptyState {
-    [self setFooterLoading:NO];
+// Single owner of the table's backgroundView (spinner / empty / no-matches),
+// derived from current state instead of being written from scattered paths.
+- (void)_updateBackgroundState {
+    if (self.posts.count == 0 && self.isFetchingPage) {
+        [self.spinner startAnimating];
+        self.tableView.backgroundView = self.spinner;
+        return;
+    }
+    [self.spinner stopAnimating];
+    if (self.activePosts.count > 0) {
+        self.tableView.backgroundView = nil;
+        return;
+    }
     UILabel *emptyLabel = [[UILabel alloc] init];
-    emptyLabel.text = @"No recently read posts";
+    // posts.count > 0 here means everything is hidden by search/NSFW filter.
+    emptyLabel.text = self.posts.count > 0 ? @"No matching posts" : @"No recently read posts";
     emptyLabel.textAlignment = NSTextAlignmentCenter;
     emptyLabel.textColor = [UIColor secondaryLabelColor];
     emptyLabel.font = [UIFont systemFontOfSize:17 weight:UIFontWeightRegular];
@@ -501,23 +811,10 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
     self.filteredPosts = filtered;
 }
 
-- (void)_updateBackgroundForSearch {
-    if ([self isSearchActive] && self.activePosts.count == 0 && self.posts.count > 0) {
-        UILabel *noResults = [[UILabel alloc] init];
-        noResults.text = @"No matching posts";
-        noResults.textAlignment = NSTextAlignmentCenter;
-        noResults.textColor = [UIColor secondaryLabelColor];
-        noResults.font = [UIFont systemFontOfSize:17 weight:UIFontWeightRegular];
-        self.tableView.backgroundView = noResults;
-    } else if (self.activePosts.count > 0) {
-        self.tableView.backgroundView = nil;
-    }
-}
-
 - (void)updateSearchResultsForSearchController:(UISearchController *)searchController {
     [self _refilterPosts];
     [self.tableView reloadData];
-    [self _updateBackgroundForSearch];
+    [self _updateBackgroundState];
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
@@ -615,14 +912,41 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
     return url;
 }
 
+// Clear the imageView's task handle only if it still belongs to the
+// completing task - a newer task for a reused cell may own it by now.
+static void RecentlyReadClearThumbTask(UIImageView *thumbnailView, NSURLSessionDataTask *completedTask) {
+    if (objc_getAssociatedObject(thumbnailView, &kThumbTaskKey) == completedTask) {
+        objc_setAssociatedObject(thumbnailView, &kThumbTaskKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+}
+
 - (void)configureThumbnailImageView:(UIImageView *)thumbnailView forLink:(RDKLink *)link {
+    NSURL *thumbURL = [self thumbnailURLForLink:link];
+    // absoluteString can be nil for edge-case NSURLs; NSCache keys must not be
+    NSString *urlString = thumbURL ? (thumbURL.absoluteString ?: @"") : nil;
+    NSString *currentURL = objc_getAssociatedObject(thumbnailView, &kThumbURLKey);
     NSURLSessionDataTask *oldTask = objc_getAssociatedObject(thumbnailView, &kThumbTaskKey);
+    NSCache<NSString *, UIImage *> *cache = RecentlyReadThumbnailCache();
+
+    if (urlString && [currentURL isEqualToString:urlString]) {
+        // Same target (e.g. a reload after a soft refresh): keep what's
+        // loaded or in flight instead of flashing back to the placeholder.
+        UIImage *cachedSame = [cache objectForKey:urlString];
+        if (cachedSame) {
+            thumbnailView.contentMode = UIViewContentModeScaleAspectFill;
+            thumbnailView.image = cachedSame;
+            return;
+        }
+        if (oldTask && oldTask.state == NSURLSessionTaskStateRunning) {
+            return;
+        }
+    }
+
     if (oldTask) {
         [oldTask cancel];
         objc_setAssociatedObject(thumbnailView, &kThumbTaskKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
 
-    NSURL *thumbURL = [self thumbnailURLForLink:link];
     if (!thumbURL) {
         thumbnailView.contentMode = UIViewContentModeCenter;
         thumbnailView.image = RecentlyReadNoThumbnailPlaceholderImage(link.isSelfPost);
@@ -630,10 +954,8 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
         return;
     }
 
-    NSString *urlString = thumbURL.absoluteString ?: @"";
     objc_setAssociatedObject(thumbnailView, &kThumbURLKey, urlString, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-    NSCache<NSString *, UIImage *> *cache = RecentlyReadThumbnailCache();
     UIImage *cached = [cache objectForKey:urlString];
     if (cached) {
         thumbnailView.contentMode = UIViewContentModeScaleAspectFill;
@@ -644,44 +966,26 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
     thumbnailView.contentMode = UIViewContentModeScaleAspectFill;
     thumbnailView.image = RecentlyReadNoThumbnailPlaceholderImage(NO);
     __weak UIImageView *weakThumb = thumbnailView;
-    NSURLSessionDataTask *task = [RecentlyReadThumbnailSession() dataTaskWithURL:thumbURL
-                                                               completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        if (error || data.length == 0) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                UIImageView *strongThumb = weakThumb;
-                if (!strongThumb) return;
-                NSString *current = objc_getAssociatedObject(strongThumb, &kThumbURLKey);
-                if ([current isEqualToString:urlString]) {
-                    strongThumb.image = RecentlyReadNoThumbnailPlaceholderImage(NO);
-                }
-                objc_setAssociatedObject(strongThumb, &kThumbTaskKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            });
-            return;
-        }
-        UIImage *image = [UIImage imageWithData:data];
-        if (!image) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                UIImageView *strongThumb = weakThumb;
-                if (!strongThumb) return;
-                NSString *current = objc_getAssociatedObject(strongThumb, &kThumbURLKey);
-                if ([current isEqualToString:urlString]) {
-                    strongThumb.image = RecentlyReadNoThumbnailPlaceholderImage(NO);
-                }
-                objc_setAssociatedObject(strongThumb, &kThumbTaskKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            });
-            return;
-        }
-
-        [cache setObject:image forKey:urlString];
+    __block NSURLSessionDataTask *task = nil;
+    // Single delivery path for every outcome (nil image -> placeholder)
+    void (^finish)(UIImage *) = ^(UIImage *image) {
         dispatch_async(dispatch_get_main_queue(), ^{
             UIImageView *strongThumb = weakThumb;
             if (!strongThumb) return;
             NSString *current = objc_getAssociatedObject(strongThumb, &kThumbURLKey);
             if ([current isEqualToString:urlString]) {
-                strongThumb.image = image;
+                strongThumb.image = image ?: RecentlyReadNoThumbnailPlaceholderImage(NO);
             }
-            objc_setAssociatedObject(strongThumb, &kThumbTaskKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            RecentlyReadClearThumbTask(strongThumb, task);
         });
+    };
+    task = [RecentlyReadThumbnailSession() dataTaskWithURL:thumbURL
+                                         completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        UIImage *image = (!error && data.length > 0) ? [UIImage imageWithData:data] : nil;
+        if (image) {
+            [cache setObject:image forKey:urlString];
+        }
+        finish(image);
     }];
     objc_setAssociatedObject(thumbnailView, &kThumbTaskKey, task, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     [task resume];
@@ -940,7 +1244,9 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
 }
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-    if (!self.hasMorePages || self.isFetchingPage || self.activePosts.count == 0) return;
+    // Gate on posts (not activePosts): when the NSFW filter hides an entire
+    // loaded page the visible list is empty but paging must continue.
+    if (!self.hasMorePages || self.isFetchingPage || self.posts.count == 0) return;
 
     CGFloat contentHeight = scrollView.contentSize.height;
     if (contentHeight <= 0) return;
@@ -963,16 +1269,26 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
     NSURL *url = [NSURL URLWithString:urlString];
     if (!url) return;
 
-    ApolloRouteResolvedURLViaApolloScheme(url);
+    if (ApolloRouteResolvedURLViaApolloScheme(url)) {
+        // Bump right here where the RDKLink is in hand - the CommentsVC opened
+        // via the URL scheme fetches its link asynchronously, so relying on it
+        // to mark is what made reordering miss refreshes (#609).
+        if (ApolloMarkPostIDAsRead(link.fullName)) {
+            ApolloLog(@"[RecentlyRead] Marked tapped post read: %@", link.fullName);
+        }
+    }
 }
 
 - (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.row >= (NSInteger)self.activePosts.count) return nil;
 
+    // Capture the link itself, not the index path - the table may have
+    // refreshed between the swipe opening and the action committing.
+    RDKLink *link = self.activePosts[indexPath.row];
     UIContextualAction *deleteAction = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleDestructive
         title:@""
         handler:^(UIContextualAction *action, UIView *sourceView, void (^completionHandler)(BOOL)) {
-            [self _deletePostAtIndexPath:indexPath];
+            [self _deletePost:link];
             completionHandler(YES);
         }];
     deleteAction.image = [UIImage systemImageNamed:@"trash.fill"];
@@ -983,20 +1299,28 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
     return config;
 }
 
-- (void)_deletePostAtIndexPath:(NSIndexPath *)indexPath {
-    NSArray *active = self.activePosts;
-    if (indexPath.row >= (NSInteger)active.count) return;
+- (void)_deletePost:(RDKLink *)link {
+    // Re-resolve the row at commit time
+    NSUInteger activeIdx = [self.activePosts indexOfObjectIdenticalTo:link];
+    if (activeIdx == NSNotFound) return;
 
-    RDKLink *link = active[indexPath.row];
+    // An in-flight page/replace fetch was computed against the pre-delete ID
+    // list: its completion would clobber the cursor adjustment below (or
+    // resurrect the deleted row on a pending replace). Supersede it and let
+    // scrolling or the next refresh refetch.
+    if (self.isFetchingPage) {
+        [self _invalidateInFlightFetches];
+    }
+
     NSString *fullName = link.fullName; // e.g. "t3_abc123"
-    NSString *bareID = [fullName hasPrefix:@"t3_"] ? [fullName substringFromIndex:3] : fullName;
+    NSString *bareID = ApolloBarePostID(fullName);
 
-    // Remove from tracker's in-memory ordered set (stores bare IDs)
-    NSMutableOrderedSet *trackerSet = getTrackerReadPostIDs();
-    if (trackerSet) {
+    // Remove from tracker's in-memory ordered set (stores bare IDs) with the
+    // same barrier discipline native writes use
+    ApolloMutateTrackerSet(^(NSMutableOrderedSet *trackerSet) {
         [trackerSet removeObject:fullName];
         [trackerSet removeObject:bareID];
-    }
+    });
 
     // Remove from NSUserDefaults fallback
     NSMutableArray *savedIDs = [[[NSUserDefaults standardUserDefaults] stringArrayForKey:@"ReadPostIDs"] mutableCopy];
@@ -1017,17 +1341,22 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
     }
     self.allPostFullNames = allNames;
 
-    // Remove from data arrays
-    [self.posts removeObject:link];
-    if ([self isSearchActive]) {
-        [self.filteredPosts removeObject:link];
-    }
+    // Remove from both data arrays unconditionally - activePosts serves
+    // filteredPosts whenever search OR the NSFW filter is active, and a stale
+    // filtered array desyncs the row count (crash on deleteRows).
+    [self.posts removeObjectIdenticalTo:link];
+    [self.filteredPosts removeObjectIdenticalTo:link];
 
     // Animate row removal
-    [self.tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+    [self.tableView deleteRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:activeIdx inSection:0]]
+                          withRowAnimation:UITableViewRowAnimationAutomatic];
 
     if (self.activePosts.count == 0) {
-        [self showEmptyState];
+        if (self.hasMorePages) {
+            // Don't dead-end on an empty page - pull the next one in.
+            [self fetchNextPageIfNeeded];
+        }
+        [self _updateBackgroundState];
     }
 }
 
@@ -1065,14 +1394,21 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
 
 // MARK: - Bump Recently Read on Revisit
 //
-// NSMutableOrderedSet.addObject: is a no-op for existing items — revisiting
+// NSMutableOrderedSet.addObject: is a no-op for existing items - revisiting
 // a post leaves it at its original position.  Hook it so that when the
 // ReadPostsTracker's readPostIDs set already contains the post ID, we remove
 // it first, causing addObject: to re-append at the end (most-recent slot).
+// Fires for every add regardless of caller: native feed taps, our marks, and
+// (caveat) Apollo Premium's "visited" re-adds during feed cell rendering,
+// which can reorder history for Premium accounts just by scrolling - those
+// adds are indistinguishable from real marks at this level, and gating them
+// out would also break feed-tap revisit bumps.
 
 %hook NSMutableOrderedSet
 
 - (void)addObject:(id)object {
+    // Runs for every ordered set in the app; getTrackerReadPostIDs() caches,
+    // so after first resolution this is a pointer compare.
     NSMutableOrderedSet *trackerSet = getTrackerReadPostIDs();
     if (trackerSet && self == trackerSet && object && [self containsObject:object]) {
         ApolloLog(@"[RecentlyRead] Bumping existing post to most-recent: %@", object);
@@ -1088,24 +1424,51 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
 // Native Apollo only marks posts as read through PostCellActionTaker (feed tap
 // path via sub_100324a84). Posts opened via apollo:// URL scheme (e.g. from
 // Safari, share links, or our Recently Read list) skip the read-tracking
-// entirely because CommentsViewController doesn't self-mark-as-read.
-// Fix: hook viewDidAppear: to mark the post as read once the RDKLink is
-// available on the CommentsViewController.
+// entirely because CommentsViewController never self-marks (confirmed in
+// Hopper). The RDKLink is fetched asynchronously on that path, so the old
+// single fixed-delay retry missed slow fetches and quick back-outs entirely
+// (#609). Instead, try to mark from several deterministic points:
+//  - viewDidAppear (link already present, e.g. re-appear after a deeper push)
+//  - viewDidLayoutSubviews (content laid out right after the async fetch)
+//  - viewWillDisappear (last chance, and early enough: a nav pop runs this
+//    BEFORE the underlying screen's viewWillAppear auto-refresh)
+//  - one timed retry as a fallback for "link loaded but nothing relaid out
+//    and the user backgrounded the app while reading"
+// The helper disarms itself via an associated flag after the first success.
 
 static const void *kCommentsVCMarkedReadKey = &kCommentsVCMarkedReadKey;
 
-static void markPostAsReadFromLink(id self_, id link) {
-    if (!link) return;
+static void ApolloCommentsVCTryMarkRead(id commentsVC, const char *trigger) {
+    if (!commentsVC) return;
+    if (objc_getAssociatedObject(commentsVC, kCommentsVCMarkedReadKey)) return;
+
+    // Respect the "Disable Marking Posts Read" setting (disarm - no point
+    // rechecking on every layout pass)
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DisableMarkingPostsRead"]) {
+        objc_setAssociatedObject(commentsVC, kCommentsVCMarkedReadKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return;
+    }
+
+    // Read the link ivar (RDKLink, nil until the URL-scheme fetch completes).
+    // Cache the Ivar - this runs on every layout pass while armed.
+    static Ivar sLinkIvar = NULL;
+    static BOOL sLinkIvarLookupDone = NO;
+    if (!sLinkIvarLookupDone) {
+        sLinkIvarLookupDone = YES;
+        sLinkIvar = class_getInstanceVariable([commentsVC class], "link");
+    }
+    if (!sLinkIvar) return;
+    id link = object_getIvar(commentsVC, sLinkIvar);
+    if (!link) return; // stay armed - a later trigger retries
 
     NSString *identifier = [link performSelector:@selector(identifier)];
-    if (!identifier || identifier.length == 0) return;
+    if (identifier.length == 0) return;
 
-    NSMutableOrderedSet *trackerSet = getTrackerReadPostIDs();
-    if (!trackerSet) return;
-
-    [trackerSet addObject:identifier];
-    objc_setAssociatedObject(self_, kCommentsVCMarkedReadKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    ApolloLog(@"[RecentlyRead] Marked post as read from CommentsVC: %@", identifier);
+    if (ApolloMarkPostIDAsRead(identifier)) {
+        objc_setAssociatedObject(commentsVC, kCommentsVCMarkedReadKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloLog(@"[RecentlyRead] Marked post read from CommentsVC (%s): %@", trigger, identifier);
+    }
+    // Tracker not captured yet: stay armed and let a later trigger retry.
 }
 
 %hook _TtC6Apollo22CommentsViewController
@@ -1113,44 +1476,30 @@ static void markPostAsReadFromLink(id self_, id link) {
 - (void)viewDidAppear:(BOOL)animated {
     %orig;
 
-    // Skip if already marked for this instance
-    if (objc_getAssociatedObject((id)self, kCommentsVCMarkedReadKey)) return;
+    ApolloCommentsVCTryMarkRead((id)self, "viewDidAppear");
 
-    // Respect the "Disable Marking Posts Read" setting
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DisableMarkingPostsRead"]) return;
-
-    // Read the link ivar (RDKLink, may be nil for URL scheme path)
-    id selfId = (id)self;
-    id link = nil;
-    Ivar linkIvar = class_getInstanceVariable([selfId class], "link");
-    if (linkIvar) {
-        link = object_getIvar(selfId, linkIvar);
-    }
-
-    if (link) {
-        // Feed path or link already available — mark immediately
-        ApolloLog(@"[RecentlyRead] Marking post as read from CommentsVC with available link");
-        markPostAsReadFromLink(selfId, link);
-    } else {
-        // URL scheme path: link is nil, fetched asynchronously from Reddit API.
-        // Retry after a delay to allow the API response to populate the ivar.
-        __weak id weakSelf = selfId;
+    if (!objc_getAssociatedObject((id)self, kCommentsVCMarkedReadKey)) {
+        __weak id weakSelf = (id)self;
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)),
                        dispatch_get_main_queue(), ^{
-            id strongSelf = weakSelf;
-            if (!strongSelf) return;
-            if (objc_getAssociatedObject(strongSelf, kCommentsVCMarkedReadKey)) return;
-
-            Ivar ivar = class_getInstanceVariable([strongSelf class], "link");
-            id fetchedLink = ivar ? object_getIvar(strongSelf, ivar) : nil;
-            if (fetchedLink) {
-                ApolloLog(@"[RecentlyRead] Fetched link on retry, marking as read");
-                markPostAsReadFromLink(strongSelf, fetchedLink);
-            } else {
-                ApolloLog(@"[RecentlyRead] CommentsVC link still nil after retry — skipping mark-as-read");
-            }
+            ApolloCommentsVCTryMarkRead(weakSelf, "timed retry");
         });
     }
+}
+
+- (void)viewDidLayoutSubviews {
+    %orig;
+    // ASDK can invoke viewDidLayoutSubviews off-main during deferred CA
+    // transaction flushes (same guard as ApolloInboxCommentScroll's hook).
+    if (![NSThread isMainThread]) return;
+    // One associated-object lookup once disarmed. Reads only - no layout
+    // inputs are written here (see the layoutSubviews rule in CLAUDE.md).
+    ApolloCommentsVCTryMarkRead((id)self, "layout");
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    %orig;
+    ApolloCommentsVCTryMarkRead((id)self, "viewWillDisappear");
 }
 
 %end


### PR DESCRIPTION
Fixes #609

This PR makes the Recently Read screen reorder reliably when a post is revisited, refresh itself automatically on return, and refresh in place instead of clearing to a spinner. It also fixes several latent bugs in the screen's data flow uncovered along the way.

### Issue

Reopening an already-read post was supposed to bump it to the top of Recently Read, but users reported it either taking two pull-to-refreshes or never reordering at all. Reverse engineering Apollo's `ReadPostsTracker` explained both symptoms:

- Posts opened from Recently Read go through the `apollo://` URL scheme, where `CommentsViewController` never self-marks and its `RDKLink` is fetched asynchronously. The tweak's only mark trigger was a single `dispatch_after` 2.0s retry holding a `__weak` reference.
- Backing out within ~2 seconds deallocated the controller, so the retry silently no-oped and the post was never marked - refreshing forever changed nothing (the "never reorders" case in the issue video).
- Returning and refreshing before the 2-second timer fired read the pre-mark order, so only a second refresh showed the bump (the "takes 2 refreshes" case).
- Separately, the tweak read and mutated the tracker's `NSMutableOrderedSet` directly from the main thread, while Apollo mutates it via async barrier blocks on a private concurrent queue (`com.christianselig.Apollo.ReadPostTrackerQueue`) - an unsynchronized read could miss an already-enqueued mark, and `-[NSOrderedSet array]` returns a live proxy rather than a snapshot, making the old reads a genuine data race.

### Deterministic read marking

Marking no longer depends on a timer racing a network fetch.

- Tapping a row in Recently Read marks and bumps the post immediately, right where the `RDKLink` is in hand, once routing succeeds.
- For posts opened via URL scheme elsewhere (Safari, shared links, cross-post links), the CommentsViewController hook now tries at several deterministic points: `viewDidAppear` (link already present), `viewDidLayoutSubviews` (fires when the fetched content lays out, with a main-thread guard since ASDK can call it off-main), and `viewWillDisappear` (last chance, and early enough to land before the underlying screen's auto-refresh in a nav pop).
- The old 2-second retry remains only as a fallback for the app being backgrounded mid-read, and the whole mechanism disarms itself after the first successful mark.

### Thread-safe tracker access

All tweak access to the tracker's in-memory set now mirrors Apollo's own queue discipline.

- Reads go through `dispatch_sync` on the tracker's captured private queue with the snapshot copied inside the block, so they are ordered after any pending native barrier mark - a refresh can no longer observe a stale order.
- Writes (mark, swipe-delete, Clear All) go through `dispatch_barrier_async`, eliminating the main-thread mutation race against native writers.
- The settings backup flush uses the same synchronized snapshot.

### Auto refresh on return

Returning to the screen now syncs it with the tracker automatically - no pull-to-refresh needed for reordering.

- `viewWillAppear` runs a soft refresh: a no-op when the ID order is unchanged, a purely local reorder when the revisited post is already loaded (instant, applied before the pop transition finishes), and a targeted fetch of only the missing IDs otherwise.
- Posts Reddit no longer returns (deleted/removed) are remembered per session so they are not re-requested on every return.

### Gentler refresh mechanics

Refreshing no longer blanks the list while it works.

- Pull-to-refresh restarts pagination against the new order but keeps the current content visible until the fresh first page arrives, then swaps it in; the center spinner only appears for an initial load of an empty list.
- A fetch generation counter invalidates superseded requests, fixing a latent bug where Clear All during an in-flight page fetch resurrected up to a page of "cleared" rows, and another where a pull during background pagination was silently swallowed.
- Swipe-deleting while a fetch is in flight now supersedes that fetch instead of letting its completion clobber the pagination cursor or resurrect the deleted row.
- The table's background view (spinner / empty label / "No matching posts") is derived in one place from current state instead of being written from scattered code paths.

### Other fixes

- Fixed a crash when swipe-deleting with "Filter NSFW" enabled: the filtered array was only updated during search, so the row count desynced and `deleteRowsAtIndexPaths` threw.
- Fixed stuck empty states: a page that surfaces zero visible rows (fully NSFW-filtered or all posts deleted on Reddit) now auto-chains up to a few more page fetches instead of dead-ending on "No recently read posts", and deleting the last visible rows pulls in the next page when more history remains.
- Fixed thumbnail flicker on refresh (cells reloading with the same image no longer reset to the placeholder) and a task-handle race where a cancelled request could orphan a newer in-flight one.
- Read IDs are deduped between bare and `t3_`-prefixed forms so a legacy twin can't produce duplicate rows, and the ID list is now built in a single backward pass since it runs on every screen return over a history of up to 5000 entries.

Known caveat: for Reddit Premium accounts, Apollo re-adds any link carrying the `visited` flag while rendering feed cells, and those re-adds are indistinguishable from real marks at the bump hook, so scrolling feeds can still reorder history for Premium users. This is pre-existing behavior and is now documented in the source.

### Testing

Verified via a clean device build and an adversarial multi-agent review of the diff, plus manual on-device validation.