### PR TITLE
Inline Media: fix layout-transition crashes and reduce scroll lag

### DIFF
--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -28,6 +28,10 @@ UIImage *ApolloRebornOptionsSettingsIcon(CGFloat size);
 // inject-deb-local.sh). Returns nil if no layout has the file.
 NSString *ApolloBundledResourcePath(NSString *baseName, NSString *extension);
 
+// Monotonic milliseconds (CACurrentMediaTime-based); ~ns-cheap. Used by the
+// trailing-debounce relayout schedulers (InlineImages, LinkPreviews).
+double ApolloPerfNowMs(void);
+
 // The build variant string sent with the anonymous usage heartbeat, e.g.
 // "glass", "deb-rootless". The source of truth is stamped at package time (IPA
 // variants set Info.plist "ARBuildVariant"; .deb installs drop an "ARVariant.txt"

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -1,5 +1,6 @@
 #import "ApolloCommon.h"
 #import "ApolloState.h"
+#import <QuartzCore/QuartzCore.h>
 #import <mach-o/dyld.h>
 #import <mach-o/loader.h>
 #import <objc/message.h>
@@ -778,4 +779,8 @@ void ApolloSetLinkPreviewCardColorHex(NSString *hex) {
     // Publish the render snapshot AFTER the string, so a background reader that
     // observes a non-zero packed value already has a consistent RGB to draw.
     sLinkPreviewCardColorPacked = color ? ApolloPackedColorFromHexString(sLinkPreviewCardColorHex) : 0;
+}
+
+double ApolloPerfNowMs(void) {
+    return CACurrentMediaTime() * 1000.0;
 }

--- a/src/ApolloImageUploadHost.xm
+++ b/src/ApolloImageUploadHost.xm
@@ -3703,7 +3703,6 @@ static CGImageRef hooked_CGImageSourceCreateThumbnailAtIndex(CGImageSourceRef is
     CFDictionaryRef newOptions = ApolloCopyOptionsWithReplacement(options, kCGImageSourceThumbnailMaxPixelSize, largeMaxRef);
     CFRelease(largeMaxRef);
 
-    ApolloLog(@"[ImageUploadHost] Bypassing Apollo's 2000px image-prep cap for full-resolution upload");
     CGImageRef result = orig_CGImageSourceCreateThumbnailAtIndex(isrc, index, newOptions);
     if (newOptions) CFRelease(newOptions);
     return result;

--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -201,6 +201,7 @@ static void ApolloStartInlineGIFPlayback(ASNetworkImageNode *imageNode);
 static void ApolloStopInlineGIFPlayback(ASNetworkImageNode *imageNode);
 static BOOL ApolloResumeInlineGIFPlaybackIfPossible(ASNetworkImageNode *imageNode);
 static void ApolloClearInlineGIFNodeState(ASNetworkImageNode *node);
+static void ApolloScheduleCoalescedHostRelayout(ASNetworkImageNode *imageNode);
 static NSUInteger ApolloInlineGIFGenerationForNode(id node);
 static NSUInteger ApolloInlineGIFBumpGeneration(id node);
 static BOOL ApolloInlineGIFGenerationMatches(id node, NSUInteger generation);
@@ -1921,8 +1922,14 @@ static BOOL ApolloPresentOrResolveImageChestAlbumURL(NSURL *url, UIView *sourceV
     ApolloLog(@"[InlineImages] ratio set imageNode=%p ratio=%.3f size=%@",
               imageNode, newRatio, NSStringFromCGSize(size));
 
-    // Texture's internal "intrinsic size changed" hook; walks up to the
-    // root signaling the table/collection to re-measure the row.
+    // Surface the new size. Prefer the debounced per-host scheduler (one
+    // re-measure per burst); fall back to Texture's direct "intrinsic size
+    // changed" climb only when the node has no live inline host.
+    if ([imageNode isKindOfClass:[ApolloASNetworkImageNodeClass() class]] &&
+        ApolloInlineHostForNode(imageNode)) {
+        ApolloScheduleCoalescedHostRelayout((ASNetworkImageNode *)imageNode);
+        return;
+    }
     SEL sel = NSSelectorFromString(@"_u_setNeedsLayoutFromAbove");
     if (![imageNode respondsToSelector:sel]) return;
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -2283,60 +2290,92 @@ static BOOL ApolloApplyResolvedAlbumImageContent(ASNetworkImageNode *imageNode, 
     return YES;
 }
 
-// Relayout-from-above of the image node's host cell, coalesced per host: N
-// album resolutions landing together (a body with many albums) queue ONE
-// invalidate+re-measure of the cell instead of N. Each doRelayout would
-// otherwise invalidate the just-recomputed layout again — up to N full
-// re-measures of a 30-child header row on the main thread.
-static char kApolloHostRelayoutPendingKey;
+// Relayout-from-above of the image node's host cell, debounced per host.
+// Cold-cache opens land N album resolutions 50-500ms apart; per-main-drain
+// coalescing alone still produced up to N full re-measures of a 30-child
+// header row on the main thread (one per resolve). A trailing debounce
+// collapses a burst into one re-measure ~QUIET ms after the last resolve,
+// with a MAX cap so a slow trickle can't starve the row of its first grow.
+static char kApolloHostRelayoutArmedKey;      // NSNumber BOOL — debounce timer armed for this host
+static char kApolloHostRelayoutLastMsKey;     // NSNumber double — ApolloPerfNowMs of latest schedule request
+static char kApolloHostRelayoutFirstMsKey;    // NSNumber double — first request of the current burst
+static char kApolloHostRelayoutOnDidLoadKey;  // NSNumber BOOL — onDidLoad fallback registered (once per host)
+
+static const double kApolloHostRelayoutQuietMs = 180.0;  // fire after this much quiet
+static const double kApolloHostRelayoutMaxMs   = 450.0;  // ...but never later than this after the burst began
+
+// The actual invalidate + re-measure climb. Main thread only.
+static void ApolloHostRelayoutPerform(ASDisplayNode *host) {
+    if (!host) return;
+    ASDisplayNode *n = host;
+    ASDisplayNode *cellNode = nil;
+    while (n) {
+        NSString *cls = NSStringFromClass([n class]);
+        if ([n respondsToSelector:@selector(invalidateCalculatedLayout)]) {
+            [n invalidateCalculatedLayout];
+        }
+        if ([n respondsToSelector:@selector(setNeedsLayout)]) {
+            [n setNeedsLayout];
+        }
+        if ([cls containsString:@"CellNode"]) cellNode = n;
+        n = n.supernode;
+    }
+    SEL relayoutSel = NSSelectorFromString(@"_u_setNeedsLayoutFromAbove");
+    id target = cellNode ?: host;
+    if ([target respondsToSelector:relayoutSel]) {
+        ((void (*)(id, SEL))objc_msgSend)(target, relayoutSel);
+    }
+
+    // The host MarkdownNode may not be view-loaded yet (Profile pre-builds
+    // cells off-screen before mounting) — the climb above can't resize an
+    // unloaded row, so re-run once when it loads. Registered at most once per
+    // host, and only when genuinely not loaded: onDidLoad on a loaded-but-
+    // detached node executes immediately, which used to double the relayout.
+    if (![host isNodeLoaded]
+        && ![objc_getAssociatedObject(host, &kApolloHostRelayoutOnDidLoadKey) boolValue]
+        && [host respondsToSelector:@selector(onDidLoad:)]) {
+        objc_setAssociatedObject(host, &kApolloHostRelayoutOnDidLoadKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        [host onDidLoad:^(__kindof ASDisplayNode *node) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                ApolloHostRelayoutPerform(node);
+            });
+        }];
+    }
+}
+
+// Debounce timer: re-arms while schedule requests keep arriving, fires the
+// climb once the burst quiets down (or the max wait elapses).
+static void ApolloHostRelayoutArm(ASDisplayNode *host, double delayMs) {
+    __weak ASDisplayNode *weakHost = host;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayMs * NSEC_PER_MSEC)),
+                   dispatch_get_main_queue(), ^{
+        ASDisplayNode *h = weakHost;
+        if (!h) return;
+        double now = ApolloPerfNowMs();
+        double last = [objc_getAssociatedObject(h, &kApolloHostRelayoutLastMsKey) doubleValue];
+        double first = [objc_getAssociatedObject(h, &kApolloHostRelayoutFirstMsKey) doubleValue];
+        double sinceLast = now - last;
+        if (sinceLast < kApolloHostRelayoutQuietMs - 10.0 && now - first < kApolloHostRelayoutMaxMs) {
+            ApolloHostRelayoutArm(h, kApolloHostRelayoutQuietMs - sinceLast);
+            return;
+        }
+        objc_setAssociatedObject(h, &kApolloHostRelayoutArmedKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(h, &kApolloHostRelayoutFirstMsKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloHostRelayoutPerform(h);
+    });
+}
 
 static void ApolloScheduleCoalescedHostRelayout(ASNetworkImageNode *imageNode) {
     ASDisplayNode *host = ApolloInlineHostForNode(imageNode);
     if (!host) return;
-    if ([objc_getAssociatedObject(host, &kApolloHostRelayoutPendingKey) boolValue]) return;
-    objc_setAssociatedObject(host, &kApolloHostRelayoutPendingKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-
-    // Walk up to the enclosing CellNode and trigger relayout. The host
-    // MarkdownNode may not be attached to its supernodes yet (Profile
-    // pre-builds cells off-screen before mounting), so we also defer a
-    // relayout to onDidLoad which fires when the node is added to its
-    // parent view hierarchy.
-    __weak ASDisplayNode *weakHost = host;
-    void (^doRelayout)(void) = ^{
-        ASDisplayNode *strongHost = weakHost;
-        if (!strongHost) return;
-        ASDisplayNode *n = strongHost;
-        ASDisplayNode *cellNode = nil;
-        while (n) {
-            NSString *cls = NSStringFromClass([n class]);
-            if ([n respondsToSelector:@selector(invalidateCalculatedLayout)]) {
-                [n invalidateCalculatedLayout];
-            }
-            if ([n respondsToSelector:@selector(setNeedsLayout)]) {
-                [n setNeedsLayout];
-            }
-            if ([cls containsString:@"CellNode"]) cellNode = n;
-            n = n.supernode;
-        }
-        SEL relayoutSel = NSSelectorFromString(@"_u_setNeedsLayoutFromAbove");
-        id target = cellNode ?: strongHost;
-        if ([target respondsToSelector:relayoutSel]) {
-            ((void (*)(id, SEL))objc_msgSend)(target, relayoutSel);
-        }
-    };
-
+    // Bookkeeping on main so the timestamp/armed associations never race.
     dispatch_async(dispatch_get_main_queue(), ^{
-        ASDisplayNode *strongHost = weakHost;
-        if (!strongHost) return;
-        objc_setAssociatedObject(strongHost, &kApolloHostRelayoutPendingKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        doRelayout();
-        BOOL hostMounted = [strongHost respondsToSelector:@selector(isNodeLoaded)]
-                          && [strongHost isNodeLoaded] && strongHost.supernode != nil;
-        if (!hostMounted && [strongHost respondsToSelector:@selector(onDidLoad:)]) {
-            [strongHost onDidLoad:^(__kindof ASDisplayNode *node) {
-                dispatch_async(dispatch_get_main_queue(), doRelayout);
-            }];
-        }
+        double now = ApolloPerfNowMs();
+        objc_setAssociatedObject(host, &kApolloHostRelayoutLastMsKey, @(now), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        if ([objc_getAssociatedObject(host, &kApolloHostRelayoutArmedKey) boolValue]) return;
+        objc_setAssociatedObject(host, &kApolloHostRelayoutArmedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(host, &kApolloHostRelayoutFirstMsKey, @(now), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloHostRelayoutArm(host, kApolloHostRelayoutQuietMs);
     });
 }
 

--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -145,7 +145,7 @@ static char kApolloImageNodesByURLKey;         // NSMutableDictionary<NSString U
 static char kApolloImageCacheKey;              // NSString stable cache key (set even before deferred image URLs resolve)
 static char kApolloImageURLKey;                // NSURL on the imageNode AND mirrored on the imageNode's view
 static char kApolloOriginalImageURLKey;        // NSURL for tap/long-press when different from the loaded URL (e.g. album URL)
-static char kApolloHostMarkdownNodeKey;        // weak ref (assign association) to the host MarkdownNode
+static char kApolloHostMarkdownNodeKey;        // ApolloWeakHostBox (zeroing-weak) to the host MarkdownNode/LinkButtonNode
 static char kApolloAspectRatioKey;             // NSNumber height/width — NIL if unknown (no URL params yet, no DIDLOAD yet)
 static char kApolloLongPressInstalledKey;      // NSNumber BOOL — gate for one-shot UIContextMenuInteraction install
 static char kApolloPlayOverlayViewKey;         // ApolloPlayOverlayContainer (play button OR pause badge), also used as install gate
@@ -160,16 +160,40 @@ static char kApolloInlineGIFOverlayReassertKey; // NSNumber BOOL — a play-over
 static char kApolloStackedCardSyncerKey;       // ApolloStackedCardSyncer — keeps the multi-image card peeking behind imageNode
 static char kApolloImageChestItemsKey;         // NSArray<NSDictionary *> direct ImageChest CDN image entries for album pager
 
-// kApolloHostMarkdownNodeKey is an OBJC_ASSOCIATION_ASSIGN (unsafe unretained)
-// reference to the host MarkdownNode. The host can be deallocated before the
-// image node (e.g. during comments table teardown), leaving the association
-// slot pointing at freed memory. Reading it as an `id` lets ARC retain the
-// result, which crashes in objc_retain on the dangling pointer. Bridge-cast to
-// a raw void* so ARC performs no retain/release; we only ever need to know
-// whether the node is an inline-hosted image node, not to message the host.
+// Zeroing-weak holder for the host association. This used to be an
+// OBJC_ASSOCIATION_ASSIGN raw pointer, but the host can be deallocated before
+// the image node (comments table teardown / cell rebuild while an album
+// resolve is still in flight), and any `id`-typed read of a dangling ASSIGN
+// slot crashes in objc_retain. A retained box holding a weak reference reads
+// back as nil instead, from any thread, at any time.
+@interface ApolloWeakHostBox : NSObject
+@property (nonatomic, weak) ASDisplayNode *host;
+@end
+@implementation ApolloWeakHostBox
+@end
+
+static void ApolloSetInlineHostForNode(id node, ASDisplayNode *host) {
+    if (!node) return;
+    if (!host) {
+        objc_setAssociatedObject(node, &kApolloHostMarkdownNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return;
+    }
+    ApolloWeakHostBox *box = [ApolloWeakHostBox new];
+    box.host = host;
+    objc_setAssociatedObject(node, &kApolloHostMarkdownNodeKey, box, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static ASDisplayNode *ApolloInlineHostForNode(id node) {
+    if (!node) return nil;
+    ApolloWeakHostBox *box = objc_getAssociatedObject(node, &kApolloHostMarkdownNodeKey);
+    return [box isKindOfClass:[ApolloWeakHostBox class]] ? box.host : nil;
+}
+
+// NOTE: with the weak box this flips to NO once the host deallocates (the
+// ASSIGN version stayed "YES" on a dangling slot). That's the semantics the
+// call sites want: a hostless image node is no longer inline-hosted.
 static inline BOOL ApolloImageNodeHasInlineHost(id node) {
-    if (!node) return NO;
-    return ((__bridge void *)objc_getAssociatedObject(node, &kApolloHostMarkdownNodeKey)) != NULL;
+    return ApolloInlineHostForNode(node) != nil;
 }
 
 static void ApolloApplyInlineGIFPlaybackPolicyWithCover(ASNetworkImageNode *imageNode, UIImage *cover, NSUInteger retryIndex);
@@ -1747,7 +1771,7 @@ static id ApolloFindResponderForSelector(SEL sel, id imageNode) {
         if (ApolloPresentImageChestItems(@[@{ @"url": url }], view, 0)) return;
     }
 
-    ASDisplayNode *host = objc_getAssociatedObject(imageNode, &kApolloHostMarkdownNodeKey);
+    ASDisplayNode *host = ApolloInlineHostForNode(imageNode);
     SEL sel = @selector(textNode:tappedLinkAttribute:value:atPoint:textRange:);
     id target = ApolloFindResponderForSelector(sel, imageNode) ?: ([host respondsToSelector:sel] ? host : nil);
     if (!target) {
@@ -2200,10 +2224,17 @@ static void ApolloSetOriginalImageURL(ASNetworkImageNode *imageNode, NSURL *orig
 // URL, captures aspect ratio if available, and triggers cell relayout.
 // Preserves kApolloOriginalImageURLKey so copy/share still use the user
 // posted album URL instead of only the resolved cover image.
-static void ApolloApplyResolvedAlbumImage(ASNetworkImageNode *imageNode, NSDictionary *result) {
-    if (![result isKindOfClass:[NSDictionary class]]) return;
+// Applies a resolved album result to the node (load URL, tap-routing keys,
+// aspect ratio, stacked card) WITHOUT scheduling any relayout. Use directly
+// when the resolution comes from cache during the same layout pass that is
+// creating the node — that pass consumes the ratio immediately, so a
+// relayout-from-above would only re-measure the whole cell again for nothing
+// (9 cached albums × every header-cell rebuild during comments pagination was
+// a visible scroll hitch). Returns YES when the result was applied.
+static BOOL ApolloApplyResolvedAlbumImageContent(ASNetworkImageNode *imageNode, NSDictionary *result) {
+    if (![result isKindOfClass:[NSDictionary class]]) return NO;
     NSURL *imageURL = [result[@"url"] isKindOfClass:[NSURL class]] ? result[@"url"] : nil;
-    if (![imageURL isKindOfClass:[NSURL class]]) return;
+    if (![imageURL isKindOfClass:[NSURL class]]) return NO;
 
     imageNode.URL = imageURL;
     NSArray *images = [result[@"images"] isKindOfClass:[NSArray class]] ? result[@"images"] : nil;
@@ -2225,44 +2256,6 @@ static void ApolloApplyResolvedAlbumImage(ASNetworkImageNode *imageNode, NSDicti
     } else {
         objc_setAssociatedObject(imageNode, &kApolloAspectRatioKey, @(1.0), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
-
-    // Walk up to the enclosing CellNode and trigger relayout. The host
-    // MarkdownNode may not be attached to its supernodes yet (Profile
-    // pre-builds cells off-screen before mounting), so we also defer a
-    // relayout to onDidLoad which fires when the node is added to its
-    // parent view hierarchy.
-    ASDisplayNode *host = objc_getAssociatedObject(imageNode, &kApolloHostMarkdownNodeKey);
-    void (^doRelayout)(void) = ^{
-        ASDisplayNode *n = host;
-        ASDisplayNode *cellNode = nil;
-        while (n) {
-            NSString *cls = NSStringFromClass([n class]);
-            if ([n respondsToSelector:@selector(invalidateCalculatedLayout)]) {
-                [n invalidateCalculatedLayout];
-            }
-            if ([n respondsToSelector:@selector(setNeedsLayout)]) {
-                [n setNeedsLayout];
-            }
-            if ([cls containsString:@"CellNode"]) cellNode = n;
-            n = n.supernode;
-        }
-        SEL relayoutSel = NSSelectorFromString(@"_u_setNeedsLayoutFromAbove");
-        id target = cellNode ?: host;
-        if ([target respondsToSelector:relayoutSel]) {
-            ((void (*)(id, SEL))objc_msgSend)(target, relayoutSel);
-        }
-    };
-
-    dispatch_async(dispatch_get_main_queue(), ^{
-        doRelayout();
-        BOOL hostMounted = [host respondsToSelector:@selector(isNodeLoaded)]
-                          && [host isNodeLoaded] && host.supernode != nil;
-        if (!hostMounted && [host respondsToSelector:@selector(onDidLoad:)]) {
-            [host onDidLoad:^(__kindof ASDisplayNode *node) {
-                dispatch_async(dispatch_get_main_queue(), doRelayout);
-            }];
-        }
-    });
 
     // Multi-image albums get a "stacked card" peeking out bottom-right to
     // signal "more than one image". Installed on imageNode's view's
@@ -2287,6 +2280,71 @@ static void ApolloApplyResolvedAlbumImage(ASNetworkImageNode *imageNode, NSDicti
             }
         });
     }
+    return YES;
+}
+
+// Relayout-from-above of the image node's host cell, coalesced per host: N
+// album resolutions landing together (a body with many albums) queue ONE
+// invalidate+re-measure of the cell instead of N. Each doRelayout would
+// otherwise invalidate the just-recomputed layout again — up to N full
+// re-measures of a 30-child header row on the main thread.
+static char kApolloHostRelayoutPendingKey;
+
+static void ApolloScheduleCoalescedHostRelayout(ASNetworkImageNode *imageNode) {
+    ASDisplayNode *host = ApolloInlineHostForNode(imageNode);
+    if (!host) return;
+    if ([objc_getAssociatedObject(host, &kApolloHostRelayoutPendingKey) boolValue]) return;
+    objc_setAssociatedObject(host, &kApolloHostRelayoutPendingKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    // Walk up to the enclosing CellNode and trigger relayout. The host
+    // MarkdownNode may not be attached to its supernodes yet (Profile
+    // pre-builds cells off-screen before mounting), so we also defer a
+    // relayout to onDidLoad which fires when the node is added to its
+    // parent view hierarchy.
+    __weak ASDisplayNode *weakHost = host;
+    void (^doRelayout)(void) = ^{
+        ASDisplayNode *strongHost = weakHost;
+        if (!strongHost) return;
+        ASDisplayNode *n = strongHost;
+        ASDisplayNode *cellNode = nil;
+        while (n) {
+            NSString *cls = NSStringFromClass([n class]);
+            if ([n respondsToSelector:@selector(invalidateCalculatedLayout)]) {
+                [n invalidateCalculatedLayout];
+            }
+            if ([n respondsToSelector:@selector(setNeedsLayout)]) {
+                [n setNeedsLayout];
+            }
+            if ([cls containsString:@"CellNode"]) cellNode = n;
+            n = n.supernode;
+        }
+        SEL relayoutSel = NSSelectorFromString(@"_u_setNeedsLayoutFromAbove");
+        id target = cellNode ?: strongHost;
+        if ([target respondsToSelector:relayoutSel]) {
+            ((void (*)(id, SEL))objc_msgSend)(target, relayoutSel);
+        }
+    };
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ASDisplayNode *strongHost = weakHost;
+        if (!strongHost) return;
+        objc_setAssociatedObject(strongHost, &kApolloHostRelayoutPendingKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        doRelayout();
+        BOOL hostMounted = [strongHost respondsToSelector:@selector(isNodeLoaded)]
+                          && [strongHost isNodeLoaded] && strongHost.supernode != nil;
+        if (!hostMounted && [strongHost respondsToSelector:@selector(onDidLoad:)]) {
+            [strongHost onDidLoad:^(__kindof ASDisplayNode *node) {
+                dispatch_async(dispatch_get_main_queue(), doRelayout);
+            }];
+        }
+    });
+}
+
+// Async-resolution entry point (network completion, reuse-path re-resolve):
+// apply the content, then surface it with one coalesced host relayout.
+static void ApolloApplyResolvedAlbumImage(ASNetworkImageNode *imageNode, NSDictionary *result) {
+    if (!ApolloApplyResolvedAlbumImageContent(imageNode, result)) return;
+    ApolloScheduleCoalescedHostRelayout(imageNode);
 }
 
 // Standalone play-circle glyph (transparent background) drawn into a
@@ -2553,12 +2611,10 @@ static void ApolloClearInlineGIFNodeState(ASNetworkImageNode *node) {
     objc_setAssociatedObject(node, &kApolloInlineAnimatedGIFKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(node, &kApolloInlineGIFUserForcedPlayKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(node, &kApolloInlineGIFOverlayReassertKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    objc_setAssociatedObject(node, &kApolloHostMarkdownNodeKey, nil, OBJC_ASSOCIATION_ASSIGN);
+    ApolloSetInlineHostForNode(node, nil);
     ApolloUnregisterInlineGIFNode(node);
 }
 
-// kApolloHostMarkdownNodeKey uses OBJC_ASSOCIATION_ASSIGN — never read that host
-// pointer during settings refresh; it can dangle after cell reuse while the slot stays non-nil.
 static BOOL ApolloInlineGIFImageNodeIsLiveForRefresh(ASNetworkImageNode *node) {
     if (!ApolloInlineGIFNodeIsRegistryEligible(node)) {
         if (node) ApolloUnregisterInlineGIFNode(node);
@@ -3206,7 +3262,7 @@ static ASNetworkImageNode *ApolloMakeInlineVideoThumbnailNode(NSURL *videoURL,
     // ratio so the layout reserves space immediately; DIDLOAD refines it
     // once the real poster loads.
     objc_setAssociatedObject(imageNode, &kApolloImageURLKey, videoURL, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    objc_setAssociatedObject(imageNode, &kApolloHostMarkdownNodeKey, hostMarkdownNode, OBJC_ASSOCIATION_ASSIGN);
+    ApolloSetInlineHostForNode(imageNode, hostMarkdownNode);
     objc_setAssociatedObject(imageNode, &kApolloAspectRatioKey, @(9.0 / 16.0), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
     __weak ASNetworkImageNode *weakImage = imageNode;
@@ -3221,7 +3277,7 @@ static ASNetworkImageNode *ApolloMakeInlineVideoThumbnailNode(NSURL *videoURL,
         // (RedditVideo entries have no p[]), fall back to DASH manifest
         // + AVAssetImageGenerator to extract a frame at t=0.
         if (!img.URL && !img.image) {
-            ASDisplayNode *host = objc_getAssociatedObject(img, &kApolloHostMarkdownNodeKey);
+            ASDisplayNode *host = ApolloInlineHostForNode(img);
             NSDictionary *mm = ApolloMediaMetadataForHost(host);
             NSURL *posterURL = mm ? ApolloPosterURLFromMediaMetadata(mm, videoURL) : nil;
             if (posterURL) {
@@ -3340,25 +3396,33 @@ static ASNetworkImageNode *ApolloMakeInlineImageNode(NSURL *normalizedURL,
         // copy/share/open actions keep what the user posted.
         objc_setAssociatedObject(imageNode, &kApolloOriginalImageURLKey, normalizedURL, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
-    objc_setAssociatedObject(imageNode, &kApolloHostMarkdownNodeKey, hostMarkdownNode, OBJC_ASSOCIATION_ASSIGN);
+    ApolloSetInlineHostForNode(imageNode, hostMarkdownNode);
     if (ratio > 0) {
         objc_setAssociatedObject(imageNode, &kApolloAspectRatioKey, @(ratio), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
 
-    // Kick off Imgur/ImageChest album resolution. Result is applied
-    // asynchronously via ApolloApplyResolvedAlbumImage, which sets the
-    // load URL, captures aspect ratio, and triggers cell relayout.
+    // Album resolution. Cached results are applied synchronously WITHOUT a
+    // relayout: this runs inside the host's layoutSpecThatFits pass, which
+    // picks up the ratio directly — scheduling relayout-from-above here made
+    // every header-cell rebuild (comments pagination recreates the cell)
+    // re-measure the row once per album. Only a genuinely async resolution
+    // needs the coalesced relayout to surface the image afterwards.
     __weak ASNetworkImageNode *weakImage = imageNode;
     if (deferredImgur) {
-        ApolloResolveImgurURL(normalizedURL, ^(NSDictionary *result) {
-            ASNetworkImageNode *strong = weakImage;
-            if (!strong || !result) return;
-            ApolloApplyResolvedAlbumImage(strong, result);
-        });
+        NSDictionary *cachedImgur = ApolloCachedImgurResolution(normalizedURL);
+        if (cachedImgur) {
+            ApolloApplyResolvedAlbumImageContent(imageNode, cachedImgur);
+        } else {
+            ApolloResolveImgurURL(normalizedURL, ^(NSDictionary *result) {
+                ASNetworkImageNode *strong = weakImage;
+                if (!strong || !result) return;
+                ApolloApplyResolvedAlbumImage(strong, result);
+            });
+        }
     } else if (deferredImageChest) {
         NSDictionary *cached = ApolloImageChestCachedResolution(normalizedURL);
         if (cached) {
-            ApolloApplyResolvedAlbumImage(imageNode, cached);
+            ApolloApplyResolvedAlbumImageContent(imageNode, cached);
         } else {
             ApolloImageChestResolveURL(normalizedURL, ^(NSDictionary *result) {
                 ASNetworkImageNode *strong = weakImage;
@@ -3462,9 +3526,11 @@ static ASLayoutSpec *ApolloWrapImageNodeForLayout(ASNetworkImageNode *imageNode,
     ApolloRegisterInlineMediaLayoutNode((ASDisplayNode *)imageNode);
     NSNumber *ratioNum = objc_getAssociatedObject(imageNode, &kApolloAspectRatioKey);
     if (!ratioNum) {
-        // Unknown ratio → omit from layout. Including with a guessed ratio
-        // would cause cell measurement to capture the wrong size and race
-        // with the post-load relayout-from-above.
+        // Unknown ratio → no visible wrapper yet. Including with a guessed
+        // ratio would cause cell measurement to capture the wrong size and
+        // race with the post-load relayout-from-above. Callers that need the
+        // node in the tree anyway (MarkdownNode decomposition) wrap it in
+        // ApolloHiddenInlineLeafSpec instead.
         return nil;
     }
     CGFloat naturalRatio = [ratioNum doubleValue];
@@ -3553,6 +3619,30 @@ static ASLayoutSpec *ApolloWrapImageNodeForLayout(ASNetworkImageNode *imageNode,
     ASInsetLayoutSpec *insetSpec = [ApolloASInsetLayoutSpecClass() insetLayoutSpecWithInsets:insets child:ratioSpec];
     [[insetSpec style] setValue:@(ApolloASStackLayoutAlignSelfStretch) forKey:@"alignSelf"];
     return insetSpec;
+}
+
+// Zero-size wrapper for a media leaf whose aspect ratio is still unknown.
+//
+// INVARIANT (crash fix): MarkdownNode and LinkButtonNode both enable
+// automaticallyManagesSubnodes, so their subnode arrays are owned exclusively
+// by ASLayoutTransition — it diffs the previous vs pending layout and applies
+// insertSubnode:atIndex: with indexes that are only valid against an array it
+// alone has mutated. Manually calling addSubnode:/removeFromSupernode on these
+// hosts (as this module used to) desyncs that array; with many images
+// resolving at once (e.g. a post with 9 imgur albums) an insertion lands past
+// the end of _subnodes → NSRangeException → abort. Hierarchy membership must
+// therefore come from the returned layout spec, and ONLY from it.
+//
+// That rule is why this wrapper exists: an ASNetworkImageNode only starts
+// loading once it's in the node tree (interface state), and for direct image
+// URLs the aspect ratio is only known after the image loads. So an
+// unknown-ratio leaf is included in the layout at zero size — in the tree and
+// loading, but reserving no space — which preserves the old "appears once the
+// ratio is known" behavior via the didLoadImage → relayout-from-above pass.
+static ASLayoutSpec *ApolloHiddenInlineLeafSpec(ASDisplayNode *leaf) {
+    ASInsetLayoutSpec *spec = [ApolloASInsetLayoutSpecClass() insetLayoutSpecWithInsets:UIEdgeInsetsZero child:leaf];
+    [[spec style] setValue:[NSValue valueWithCGSize:CGSizeZero] forKey:@"preferredSize"];
+    return spec;
 }
 
 // MARK: - Text-splitting
@@ -3673,9 +3763,18 @@ static NSUInteger ApolloUniqueImageChestPostLinkCount(NSAttributedString *attr);
 // Returns an array of leaf nodes (ASTextNode + ASNetworkImageNode instances)
 // in the order they should appear in the augmented stack, replacing the
 // original text node. Returns nil if the text node has no inline media URLs.
-// Side effects: each new leaf is added as a subnode of `hostMarkdownNode`.
+//
+// `seenAbs` (normalized URL absoluteStrings, the imageNode cache key) MUST be
+// shared across every text child of one host rebuild, not per-child: the
+// per-host node cache returns the SAME node instance for a repeated URL, and
+// one node instance appearing at two positions in a single layout is fatal —
+// a node occupies only one _subnodes slot, so ASLayoutTransition's diffed
+// insert indexes overrun the array (NSRangeException). A post linking the
+// same imgur album twice in different paragraphs (separate text children)
+// reproduced this. Later occurrences stay ordinary tappable links.
 static NSArray *ApolloBuildLeavesForTextNode(ASTextNode *textNode,
-                                              ASDisplayNode *hostMarkdownNode) {
+                                              ASDisplayNode *hostMarkdownNode,
+                                              NSMutableSet<NSString *> *seenAbs) {
     NSAttributedString *attr = textNode.attributedText;
     if (attr.length == 0) return nil;
 
@@ -3691,7 +3790,6 @@ static NSArray *ApolloBuildLeavesForTextNode(ASTextNode *textNode,
     // Issue #392: the link/alt text is just the default word "gif" — drop the
     // redundant label beneath the inline GIF (custom alt text stays visible).
     NSMutableArray<NSNumber *> *isDefaultGifLabel = [NSMutableArray array];
-    NSMutableSet<NSString *> *seenAbs = [NSMutableSet set];
     NSUInteger imageChestPostLinkCount = ApolloUniqueImageChestPostLinkCount(attr);
     NSDictionary *hostMediaMetadata = ApolloMediaMetadataForHost(hostMarkdownNode);
     // Original /player URLs classified as video while metadata was unavailable;
@@ -3852,8 +3950,10 @@ static NSArray *ApolloBuildLeavesForTextNode(ASTextNode *textNode,
         if (trimmed.length > 0) {
             ASTextNode *tn = ApolloMakeTextSegmentNode(textNode, trimmed);
             if (tn) {
+                // No manual addSubnode: — the host uses automaticallyManagesSubnodes,
+                // so returning the leaf in the layout spec is what inserts it (see
+                // ApolloHiddenInlineLeafSpec for the full invariant).
                 [leaves addObject:tn];
-                [hostMarkdownNode addSubnode:tn];
             }
         }
 
@@ -3888,7 +3988,7 @@ static ASNetworkImageNode *ApolloImageNodeForURL(NSURL *normalizedURL,
     if (existing) {
         // Reuse: ensure the host association is still up to date in case
         // (somehow) it pointed elsewhere previously.
-        objc_setAssociatedObject(existing, &kApolloHostMarkdownNodeKey, hostMarkdownNode, OBJC_ASSOCIATION_ASSIGN);
+        ApolloSetInlineHostForNode(existing, hostMarkdownNode);
         // If this is a cached album/gallery node whose resolution never
         // completed (e.g. previous host was deallocated mid-fetch), kick
         // off another resolve attempt — the resolver dedupes on cacheKey.
@@ -3912,7 +4012,8 @@ static ASNetworkImageNode *ApolloImageNodeForURL(NSURL *normalizedURL,
 
     ASNetworkImageNode *imageNode = ApolloMakeInlineImageNode(normalizedURL, hostMarkdownNode);
     if (!imageNode) return nil;
-    [hostMarkdownNode addSubnode:imageNode];
+    // No manual addSubnode: — both host classes (MarkdownNode, LinkButtonNode)
+    // use automaticallyManagesSubnodes; layout membership inserts the node.
     if (key) cache[key] = imageNode;
     return imageNode;
 }
@@ -3928,13 +4029,13 @@ static ASNetworkImageNode *ApolloVideoThumbnailNodeForURL(NSURL *normalizedURL,
     NSString *key = [normalizedURL absoluteString];
     ASNetworkImageNode *existing = key ? cache[key] : nil;
     if (existing) {
-        objc_setAssociatedObject(existing, &kApolloHostMarkdownNodeKey, hostMarkdownNode, OBJC_ASSOCIATION_ASSIGN);
+        ApolloSetInlineHostForNode(existing, hostMarkdownNode);
         return existing;
     }
 
     ASNetworkImageNode *videoNode = ApolloMakeInlineVideoThumbnailNode(normalizedURL, hostMarkdownNode);
     if (!videoNode) return nil;
-    [hostMarkdownNode addSubnode:videoNode];
+    // No manual addSubnode: — see ApolloHiddenInlineLeafSpec for the ASM invariant.
     if (key) cache[key] = videoNode;
     return videoNode;
 }
@@ -4049,11 +4150,16 @@ static BOOL ApolloLinkButtonHasInlineHost(ASDisplayNode *linkButtonNode) {
         objc_setAssociatedObject(self, &kApolloProvisionalDecompKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         NSMutableDictionary *newDecomp = [NSMutableDictionary dictionary];
         NSMutableSet<NSString *> *referencedURLs = [NSMutableSet set];
+        // One shared URL-dedupe set for the WHOLE rebuild: a URL repeated in
+        // different text children would otherwise resolve to the same cached
+        // node instance twice in one layout, which crashes the layout
+        // transition (see ApolloBuildLeavesForTextNode).
+        NSMutableSet<NSString *> *seenAbs = [NSMutableSet set];
         Class textNodeCls = ApolloASTextNodeClass();
         Class imageNodeCls = ApolloASNetworkImageNodeClass();
         for (id child in origChildren) {
             if (![child isKindOfClass:textNodeCls]) continue;
-            NSArray *leaves = ApolloBuildLeavesForTextNode((ASTextNode *)child, (ASDisplayNode *)self);
+            NSArray *leaves = ApolloBuildLeavesForTextNode((ASTextNode *)child, (ASDisplayNode *)self, seenAbs);
             if (leaves.count > 0) {
                 NSValue *k = [NSValue valueWithNonretainedObject:child];
                 newDecomp[k] = leaves;
@@ -4073,6 +4179,9 @@ static BOOL ApolloLinkButtonHasInlineHost(ASDisplayNode *linkButtonNode) {
 
         // Garbage-collect imageNodes whose URL no longer appears in the new
         // decomposition (e.g., the comment was edited and the URL removed).
+        // Cache eviction only — no removeFromSupernode: MarkdownNode uses
+        // automaticallyManagesSubnodes, so once the node stops appearing in
+        // the returned layout spec the layout transition removes it itself.
         NSMutableDictionary *imageCache = objc_getAssociatedObject(self, &kApolloImageNodesByURLKey);
         if (imageCache.count > 0) {
             NSArray *cachedURLs = [imageCache.allKeys copy];
@@ -4082,7 +4191,6 @@ static BOOL ApolloLinkButtonHasInlineHost(ASDisplayNode *linkButtonNode) {
                     if ([staleNode isKindOfClass:[ApolloASNetworkImageNodeClass() class]]) {
                         ApolloClearInlineGIFNodeState(staleNode);
                     }
-                    [staleNode removeFromSupernode];
                     [imageCache removeObjectForKey:cachedURL];
                 }
             }
@@ -4106,11 +4214,18 @@ static BOOL ApolloLinkButtonHasInlineHost(ASDisplayNode *linkButtonNode) {
     if (decomp.count == 0) return origSpec;
 
     // Replace each decomposed text node with its leaves. Image nodes whose
-    // ratio is still unknown are omitted — DIDLOAD will trigger a layout-
-    // from-above and they'll appear on the next pass.
+    // ratio is still unknown are included at zero size (ApolloHiddenInlineLeafSpec)
+    // so ASM inserts them into the tree and they start loading; DIDLOAD then
+    // triggers a layout-from-above and they get their real size on that pass.
     NSMutableArray *augmented = [NSMutableArray arrayWithCapacity:origChildren.count];
     Class imageNodeCls = ApolloASNetworkImageNodeClass();
     CGFloat rowMaxWidth = constrainedSize.max.width;
+    // Invariant: no node instance may appear twice in one layout — a node
+    // occupies a single _subnodes slot, so a duplicate desyncs the layout
+    // transition's insert indexes and crashes (NSRangeException). The rebuild
+    // dedupes by URL, but a duplicated instance is fatal enough to enforce
+    // here at assembly too.
+    NSHashTable *usedLeaves = [NSHashTable hashTableWithOptions:NSPointerFunctionsObjectPointerPersonality];
     for (id child in origChildren) {
         NSArray *leaves = decomp[[NSValue valueWithNonretainedObject:child]];
         if (!leaves) {
@@ -4118,9 +4233,15 @@ static BOOL ApolloLinkButtonHasInlineHost(ASDisplayNode *linkButtonNode) {
             continue;
         }
         for (id leaf in leaves) {
+            if ([usedLeaves containsObject:leaf]) {
+                ApolloLog(@"[InlineImages] skipping duplicate leaf instance %p in one layout pass (host=%p)", leaf, self);
+                continue;
+            }
+            [usedLeaves addObject:leaf];
             if ([leaf isKindOfClass:imageNodeCls]) {
-                ASLayoutSpec *wrapped = ApolloWrapImageNodeForLayout((ASNetworkImageNode *)leaf, rowMaxWidth);
-                if (wrapped) [augmented addObject:wrapped];
+                ASLayoutSpec *wrapped = ApolloWrapImageNodeForLayout((ASNetworkImageNode *)leaf, rowMaxWidth)
+                                        ?: ApolloHiddenInlineLeafSpec((ASDisplayNode *)leaf);
+                [augmented addObject:wrapped];
             } else {
                 [augmented addObject:leaf];
             }

--- a/src/ApolloInlineLinkPreviews.xm
+++ b/src/ApolloInlineLinkPreviews.xm
@@ -134,7 +134,6 @@ static char kApolloLinkPreviewImageFallbackScheduledKey;
 static char kApolloLinkPreviewImageFallbackInFlightKey;
 static char kApolloLinkPreviewImageFallbackAppliedURLKey;
 static char kApolloLinkPreviewRenderSignaturesKey;
-static char kApolloLinkPreviewV17LogCountKey;
 static char kApolloLinkPreviewCropContextKey;
 
 static NSHashTable<id> *sApolloLPRegisteredLinkNodes = nil;
@@ -1768,19 +1767,59 @@ static BOOL ApolloLPSetTextNodeAttributedTextIfChanged(ASTextNode *textNode, NSA
     return YES;
 }
 
+// Regexes compiled once — NSRegularExpression is immutable and thread-safe.
+// Compiling them per clean call was the hottest allocation in the card render
+// path: several cleans per measure, several measures per card, per scroll.
+static NSRegularExpression *ApolloLPTagRegex(void) {
+    static NSRegularExpression *r; static dispatch_once_t once;
+    dispatch_once(&once, ^{ r = [NSRegularExpression regularExpressionWithPattern:@"<[^>]+>" options:0 error:nil]; });
+    return r;
+}
+static NSRegularExpression *ApolloLPWhitespaceRunRegex(void) {
+    static NSRegularExpression *r; static dispatch_once_t once;
+    dispatch_once(&once, ^{ r = [NSRegularExpression regularExpressionWithPattern:@"\\s+" options:0 error:nil]; });
+    return r;
+}
+static NSRegularExpression *ApolloLPInlineWhitespaceRegex(void) {
+    static NSRegularExpression *r; static dispatch_once_t once;
+    // \x0B (vertical tab), NOT \v: in ICU regex \v is a class shorthand for
+    // ALL vertical whitespace including \n — it silently ate the very line
+    // breaks the multiline variant exists to preserve.
+    dispatch_once(&once, ^{ r = [NSRegularExpression regularExpressionWithPattern:@"[\\t\\f\\x0B ]+" options:0 error:nil]; });
+    return r;
+}
+static NSRegularExpression *ApolloLPBlankRunRegex(void) {
+    static NSRegularExpression *r; static dispatch_once_t once;
+    dispatch_once(&once, ^{ r = [NSRegularExpression regularExpressionWithPattern:@"\\n{3,}" options:0 error:nil]; });
+    return r;
+}
+
+// Cleaned-text memo: the SAME titles/descriptions are re-cleaned on every
+// measure of every card (and again by the render-signature path). Keyed by
+// the source string with an "s|"/"m|" prefix so the single-line and multiline
+// variants of the same source never collide. NSCache: thread-safe + bounded.
+static NSCache<NSString *, NSString *> *ApolloLPCleanMemo(void) {
+    static NSCache *c; static dispatch_once_t once;
+    dispatch_once(&once, ^{ c = [NSCache new]; c.countLimit = 512; });
+    return c;
+}
+
 static NSString *ApolloLPCleanDisplayText(NSString *text) {
     if (![text isKindOfClass:[NSString class]] || text.length == 0) return text;
+    NSString *memoKey = [@"s|" stringByAppendingString:text];
+    NSString *memo = [ApolloLPCleanMemo() objectForKey:memoKey];
+    if (memo) return memo;
     // Decode HTML entities FIRST (named + numeric, incl. « » ° €) — the fetcher
     // decodes freshly-stored metadata, but cached and *translated* card text reach
     // this render choke point raw and would otherwise show literal "&laquo;".
     // Decoding before tag-stripping also lets an encoded "&lt;b&gt;" collapse out.
     NSString *clean = ApolloLinkPreviewDecodeEntities(text) ?: text;
-    NSRegularExpression *tagRegex = [NSRegularExpression regularExpressionWithPattern:@"<[^>]+>" options:0 error:nil];
-    clean = [tagRegex stringByReplacingMatchesInString:clean options:0 range:NSMakeRange(0, clean.length) withTemplate:@" "];
-    NSRegularExpression *whitespace = [NSRegularExpression regularExpressionWithPattern:@"\\s+" options:0 error:nil];
-    clean = [whitespace stringByReplacingMatchesInString:clean options:0 range:NSMakeRange(0, clean.length) withTemplate:@" "];
+    clean = [ApolloLPTagRegex() stringByReplacingMatchesInString:clean options:0 range:NSMakeRange(0, clean.length) withTemplate:@" "];
+    clean = [ApolloLPWhitespaceRunRegex() stringByReplacingMatchesInString:clean options:0 range:NSMakeRange(0, clean.length) withTemplate:@" "];
     clean = [clean stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    return clean.length > 0 ? clean : text;
+    NSString *result = clean.length > 0 ? clean : text;
+    [ApolloLPCleanMemo() setObject:result forKey:memoKey];
+    return result;
 }
 
 // Like ApolloLPCleanDisplayText, but preserves the text's line structure —
@@ -1789,20 +1828,19 @@ static NSString *ApolloLPCleanDisplayText(NSString *text) {
 // a multi-paragraph post into one run-on blob.
 static NSString *ApolloLPCleanMultilineDisplayText(NSString *text) {
     if (![text isKindOfClass:[NSString class]] || text.length == 0) return text;
+    NSString *memoKey = [@"m|" stringByAppendingString:text];
+    NSString *memo = [ApolloLPCleanMemo() objectForKey:memoKey];
+    if (memo) return memo;
     // Decode entities first (see ApolloLPCleanDisplayText) — keeps numeric/named
     // entities out of cached/translated multiline bodies (e.g. Bluesky posts).
     NSString *clean = ApolloLinkPreviewDecodeEntities(text) ?: text;
-    NSRegularExpression *tagRegex = [NSRegularExpression regularExpressionWithPattern:@"<[^>]+>" options:0 error:nil];
-    clean = [tagRegex stringByReplacingMatchesInString:clean options:0 range:NSMakeRange(0, clean.length) withTemplate:@" "];
-    // \x0B (vertical tab), NOT \v: in ICU regex \v is a class shorthand for
-    // ALL vertical whitespace including \n — it silently ate the very line
-    // breaks this function exists to preserve.
-    NSRegularExpression *inlineWhitespace = [NSRegularExpression regularExpressionWithPattern:@"[\\t\\f\\x0B ]+" options:0 error:nil];
-    clean = [inlineWhitespace stringByReplacingMatchesInString:clean options:0 range:NSMakeRange(0, clean.length) withTemplate:@" "];
-    NSRegularExpression *blankRuns = [NSRegularExpression regularExpressionWithPattern:@"\\n{3,}" options:0 error:nil];
-    clean = [blankRuns stringByReplacingMatchesInString:clean options:0 range:NSMakeRange(0, clean.length) withTemplate:@"\n\n"];
+    clean = [ApolloLPTagRegex() stringByReplacingMatchesInString:clean options:0 range:NSMakeRange(0, clean.length) withTemplate:@" "];
+    clean = [ApolloLPInlineWhitespaceRegex() stringByReplacingMatchesInString:clean options:0 range:NSMakeRange(0, clean.length) withTemplate:@" "];
+    clean = [ApolloLPBlankRunRegex() stringByReplacingMatchesInString:clean options:0 range:NSMakeRange(0, clean.length) withTemplate:@"\n\n"];
     clean = [clean stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    return clean.length > 0 ? clean : text;
+    NSString *result = clean.length > 0 ? clean : text;
+    [ApolloLPCleanMemo() setObject:result forKey:memoKey];
+    return result;
 }
 
 static NSString *ApolloLPDisplayTitleForPreview(ApolloLinkPreview *preview) {
@@ -3261,42 +3299,92 @@ static void ApolloLPInvokeContainerRelayoutIfPossible(ASDisplayNode *node, ASDis
     }
 }
 
-static void ApolloLPTriggerRelayoutInternal(ASDisplayNode *node, BOOL scheduleDelayed, NSString *host) {
-    ASDisplayNode *cellNode = ApolloLPFindOwningCellNode(node);
+// Cheap synchronous part of a relayout trigger: dirty the ancestor chain's
+// cached layouts. Flag flips only — the expensive re-measure happens in the
+// single escalation below. Every card must dirty its own path (several cards
+// can share one cell), so this always runs at trigger time.
+static void ApolloLPInvalidateAncestorChain(ASDisplayNode *node) {
     NSUInteger depth = 0;
     for (ASDisplayNode *current = node; current && depth < 32; current = current.supernode, depth++) {
-        SEL invalidate = @selector(invalidateCalculatedLayout);
-        if ([current respondsToSelector:invalidate]) {
-            ((void (*)(id, SEL))objc_msgSend)(current, invalidate);
+        if ([current respondsToSelector:@selector(invalidateCalculatedLayout)]) {
+            ((void (*)(id, SEL))objc_msgSend)(current, @selector(invalidateCalculatedLayout));
         }
-
-        SEL relayout = NSSelectorFromString(@"_u_setNeedsLayoutFromAbove");
-        if ([current respondsToSelector:relayout]) {
-            ((void (*)(id, SEL))objc_msgSend)(current, relayout);
-        }
-
-        SEL setNeedsLayout = @selector(setNeedsLayout);
-        if ([current respondsToSelector:setNeedsLayout]) {
-            ((void (*)(id, SEL))objc_msgSend)(current, setNeedsLayout);
+        if ([current respondsToSelector:@selector(setNeedsLayout)]) {
+            ((void (*)(id, SEL))objc_msgSend)(current, @selector(setNeedsLayout));
         }
     }
+}
 
+// The expensive part: ONE _u_setNeedsLayoutFromAbove escalation at the cell
+// (Texture re-measures the whole ancestor chain itself — the old shape called
+// it at EVERY level, an O(depth²) climb per preview resolution), plus the
+// cell transition and container relayout.
+static void ApolloLPPerformRelayoutClimb(ASDisplayNode *node, ASDisplayNode *cellNode, NSString *host) {
+    ASDisplayNode *target = cellNode ?: node;
+    SEL relayout = NSSelectorFromString(@"_u_setNeedsLayoutFromAbove");
+    if ([target respondsToSelector:relayout]) {
+        ((void (*)(id, SEL))objc_msgSend)(target, relayout);
+    }
     if (cellNode) {
         ApolloLPInvokeTransitionLayoutIfPossible(cellNode);
     }
+    ApolloLPInvokeContainerRelayoutIfPossible(node, cellNode, host);
+}
 
+// Debounce state lives on the climb TARGET (the owning cell when found), so
+// every card in a cell shares one pending climb. ~50 staggered cold preview
+// resolutions used to mean ~50 synchronous full-cell re-measures; now a burst
+// collapses to one climb ~QUIET ms after its last trigger (MAX-capped).
+static char kApolloLPClimbArmedKey;
+static char kApolloLPClimbLastMsKey;
+static char kApolloLPClimbFirstMsKey;
+static const double kApolloLPClimbQuietMs = 150.0;
+static const double kApolloLPClimbMaxMs   = 400.0;
+
+static void ApolloLPArmRelayoutClimb(ASDisplayNode *node, ASDisplayNode *cellNode, NSString *host, double delayMs) {
+    __weak ASDisplayNode *weakNode = node;
+    __weak ASDisplayNode *weakCell = cellNode;
+    NSString *hostCopy = [host copy];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayMs * NSEC_PER_MSEC)),
+                   dispatch_get_main_queue(), ^{
+        ASDisplayNode *n = weakNode;
+        ASDisplayNode *cell = weakCell;
+        ASDisplayNode *target = cell ?: n;
+        if (!n || !target) return;
+        double now = ApolloPerfNowMs();
+        double last = [objc_getAssociatedObject(target, &kApolloLPClimbLastMsKey) doubleValue];
+        double first = [objc_getAssociatedObject(target, &kApolloLPClimbFirstMsKey) doubleValue];
+        double sinceLast = now - last;
+        if (sinceLast < kApolloLPClimbQuietMs - 10.0 && now - first < kApolloLPClimbMaxMs) {
+            ApolloLPArmRelayoutClimb(n, cell, hostCopy, kApolloLPClimbQuietMs - sinceLast);
+            return;
+        }
+        objc_setAssociatedObject(target, &kApolloLPClimbArmedKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(target, &kApolloLPClimbFirstMsKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloLPPerformRelayoutClimb(n, cell, hostCopy);
+    });
+}
+
+static void ApolloLPTriggerRelayoutInternal(ASDisplayNode *node, BOOL scheduleDelayed, NSString *host) {
+    if (!node) return;
+    ASDisplayNode *cellNode = ApolloLPFindOwningCellNode(node);
+    ApolloLPInvalidateAncestorChain(node);
+
+    // scheduleDelayed == NO is the immediate path (placeholder-context shrink
+    // checks row-reload right after; it needs the climb done synchronously).
     if (!scheduleDelayed) {
-        ApolloLPInvokeContainerRelayoutIfPossible(node, cellNode, host);
+        ApolloLPPerformRelayoutClimb(node, cellNode, host);
+        return;
     }
 
-    if (scheduleDelayed) {
-        __weak ASDisplayNode *weakNode = node;
-        NSString *hostCopy = [host copy];
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(80 * NSEC_PER_MSEC)), dispatch_get_main_queue(), ^{
-            ASDisplayNode *strongNode = weakNode;
-            if (strongNode) ApolloLPTriggerRelayoutInternal(strongNode, NO, hostCopy);
-        });
-    }
+    // Per-resolution path: debounced.
+    ASDisplayNode *target = cellNode ?: node;
+    double now = ApolloPerfNowMs();
+    objc_setAssociatedObject(target, &kApolloLPClimbLastMsKey, @(now), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if ([objc_getAssociatedObject(target, &kApolloLPClimbArmedKey) boolValue]) return;
+    objc_setAssociatedObject(target, &kApolloLPClimbArmedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(target, &kApolloLPClimbFirstMsKey, @(now), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloLPArmRelayoutClimb(node, cellNode, host, kApolloLPClimbQuietMs);
 }
 
 static void ApolloLPTriggerRelayoutForHost(ASDisplayNode *node, NSString *host) {
@@ -3952,25 +4040,11 @@ static id ApolloLPNativeLinkSpecWithBannedHintIfNeeded(id linkButtonNode, NSURL 
     NSString *host = ApolloLPHost(url);
     ApolloLPArea area = ApolloLPAreaForLinkButton((ASDisplayNode *)self);
 
-    // V17 diagnostic logging: per-node rate-limited (max 6 calls) snapshot of
-    // area resolution + supernode chain depth to identify the vote-time
-    // compact→hero flip. Always-on; gated by per-node counter to bound noise.
-    {
-        NSNumber *countObj = objc_getAssociatedObject(self, &kApolloLinkPreviewV17LogCountKey);
-        NSUInteger count = [countObj isKindOfClass:[NSNumber class]] ? countObj.unsignedIntegerValue : 0;
-        if (count < 6) {
-            NSUInteger walkDepth = 0;
-            ApolloLPArea walkArea = ApolloLPAreaBody;
-            BOOL walkResolved = ApolloLPResolveAreaByWalk((ASDisplayNode *)self, &walkArea, &walkDepth);
-            NSNumber *cached = objc_getAssociatedObject(self, &kApolloLinkPreviewAreaKey);
-            ASDisplayNode *sup = [(id)self respondsToSelector:@selector(supernode)] ? [(id)self supernode] : nil;
-            ApolloLog(@"[LinkPreviews] V17 layout host=%@ area=%lu cached=%@ walk=%d walkArea=%lu depth=%lu super=%@ bodyMode=%ld commentsMode=%ld n=%lu",
-                      host, (unsigned long)area, cached, walkResolved, (unsigned long)walkArea, (unsigned long)walkDepth,
-                      sup ? NSStringFromClass([sup class]) : @"(nil)",
-                      (long)sLinkPreviewBodyMode, (long)sLinkPreviewCommentsMode, (unsigned long)count);
-            objc_setAssociatedObject(self, &kApolloLinkPreviewV17LogCountKey, @(count + 1), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        }
-    }
+    // (The old V17 per-measure diagnostic block lived here. It ran a supernode
+    // walk + os_log on virtually every LinkButtonNode measure — its 6-per-node
+    // cap reset constantly because scrolling recreates nodes — which was
+    // measurable overhead in link-dense comment threads. The vote-time
+    // compact→hero flip it was added to diagnose is long since fixed.)
     if (ApolloLPIsImageChestAlbumURL(url)) {
         // #552: defer to the inline-image album renderer (ApolloInlineImages'
         // LinkButtonNode hook) instead of suppressing to empty. Suppressing left

--- a/src/ApolloPictureInPicture.xm
+++ b/src/ApolloPictureInPicture.xm
@@ -3245,6 +3245,16 @@ static BOOL PiPPagerLinkNeverAutoplays(id pageVC) {
         && ((BOOL (*)(id, SEL))objc_msgSend)(link, nsfwSel);
 }
 
+// URL-opened viewers (markdown/inline-media links via the URL router
+// sub_100078db0, plus tip jar/SPCA-album easter eggs) carry no RDKLink —
+// every post-media entry passes one (verified across all pager-init call
+// sites). No link means no inline player home, so an owned player is as
+// PiP-safe as autoplay-off. Image-only nil-link viewers are filtered by the
+// owned-player check.
+static BOOL PiPPagerIsURLOpened(id pageVC) {
+    return pageVC && PiPGetIvar(pageVC, "link") == nil;
+}
+
 // Restore the user's fullscreen playback state on the card after the native
 // dismissal's mute dance settles (T+0 force-mute, T+50ms Ambient downgrade,
 // T+100ms setMuted:YES — relative to viewDidDisappear).
@@ -3377,13 +3387,15 @@ static void PiPRefreshFullscreenPiPButton(id pageVC) {
                                  closeFrame.origin.y,
                                  closeFrame.size.width, closeFrame.size.height);
     pipButton.alpha = closeButton.alpha;
-    // Only when the video can't be autoplaying inline (setting off, or a
-    // spoiler/NSFW post — those never autoplay) AND the page has a fullscreen-
-    // OWNED player (image pages and adopted shared-layer pages keep the X
-    // alone). Live checks — every layout/page-swipe pass re-evaluates.
+    // Only when the video can't be autoplaying inline (setting off, a
+    // spoiler/NSFW post — those never autoplay — or a URL-opened viewer,
+    // which has no inline home at all) AND the page has a fullscreen-OWNED
+    // player (image pages and adopted shared-layer pages keep the X alone).
+    // Live checks — every layout/page-swipe pass re-evaluates.
     pipButton.hidden = closeButton.hidden
         || (PiPOwnedPlayerFromMediaPageVC(pageVC) == nil)
-        || !(ApolloNativeAutoplayEffectivelyOff() || PiPPagerLinkNeverAutoplays(pageVC));
+        || !(ApolloNativeAutoplayEffectivelyOff() || PiPPagerIsURLOpened(pageVC)
+             || PiPPagerLinkNeverAutoplays(pageVC));
 }
 
 // Consulted by ApolloVideoUnmute.xm's MediaPageViewController.viewDidDisappear
@@ -3557,6 +3569,17 @@ BOOL ApolloPiP_WillHandleFullscreenDismiss(void) {
             controller.sessionClaimedAudibly = NO;
             [controller teardownKeepPlaying:NO];
         }
+    } else if (controller.active) {
+        // Nil-link card (URL-opened inline video): no link to dedupe on, so
+        // match the fresh fullscreen player's asset URL against the card's.
+        // Same two-live-players situation and session-handback hazard as the
+        // link-match branch above.
+        NSURL *cardURL = PiPAssetURLForNode(nil, controller.player);
+        if (cardURL && [cardURL isEqual:PiPAssetURLForNode(nil, fullscreenPlayer)]) {
+            ApolloLog(@"[PiP] Fullscreen re-opened our video (asset URL match) — closing card");
+            controller.sessionClaimedAudibly = NO;
+            [controller teardownKeepPlaying:NO];
+        }
     }
     // Fullscreen creates its own (dormant) AVPictureInPictureController on the
     // shared layer — retire our inline one to avoid two controllers on it.
@@ -3599,7 +3622,8 @@ BOOL ApolloPiP_WillHandleFullscreenDismiss(void) {
     // Re-check the gate at tap time: visibility only re-evaluates on layout
     // passes, so a reachability flip while the viewer sits open can leave the
     // button stale-visible. Hide and stand down instead of acting.
-    if (!ApolloNativeAutoplayEffectivelyOff() && !PiPPagerLinkNeverAutoplays(self)) {
+    if (!ApolloNativeAutoplayEffectivelyOff() && !PiPPagerIsURLOpened(self)
+        && !PiPPagerLinkNeverAutoplays(self)) {
         ApolloLog(@"[PiP] Fullscreen PiP tapped but the gate closed — hiding button");
         PiPRefreshFullscreenPiPButton(self);
         return;

--- a/src/ApolloTagFilters.xm
+++ b/src/ApolloTagFilters.xm
@@ -199,14 +199,66 @@ static BOOL ApolloTagMediaIsVideo(id richMediaNode) {
     return vn != nil;
 }
 
-// Captured Reddit account pref "Blur mature (18+) images and media": Apollo
-// parses pref_no_profanity from /me.json (self /about.json too) into
-// RDKUser.noProfanity via Mantle — only self responses carry the field, so
-// the setter hook below fires only for the signed-in account. -1 until the
-// first parse. Some sessions never parse it at all (web-JSON/cookie identity
-// synthesizes the account without a /me fetch), leaving Apollo's own
-// noProfanity NO — so unknown must NOT suppress our cover (see below).
-static NSInteger sTagRedditNoProfanity = -1;
+// Captured Reddit account pref "Blur mature (18+) images and media",
+// PER ACCOUNT. Apollo parses pref_no_profanity from self /me.json (and self
+// /about.json) into RDKUser.noProfanity via Mantle. With multiple accounts
+// added, Apollo materializes an RDKUser for EVERY stored account (switcher
+// refreshes, session restores) — a single last-writer-wins global held
+// whichever account happened to parse most recently, which is wrong for the
+// signed-in account whenever two accounts' prefs disagree, and the 0↔1
+// ping-pong re-ran the visible-cell refresh once per parse. Captures are
+// keyed by lowercased username and decisions resolve against the ACTIVE
+// account. Effective value is -1 (unknown) until the active account's pref
+// is captured; some sessions never capture it at all (web-JSON/cookie
+// identity synthesizes the account without a /me fetch), so unknown must NOT
+// suppress our cover (see below). All state is main-thread confined: the
+// Mantle setter can fire on background parse queues mid-init, so captures
+// hop to main (where the parsed object is fully populated); decisions run
+// from cell didLoad/layout on main.
+static NSMutableDictionary<NSString *, NSNumber *> *sTagNoProfanityByUser = nil;
+static NSString *sTagActiveUsername = nil;
+static NSInteger sTagEffectiveNoProfanity = -1;
+
+static void ApolloTagRefreshAllVisibleCells(void);
+
+static NSString *ApolloTagNormalizedUsername(id userObject) {
+    NSString *name = nil;
+    if ([userObject respondsToSelector:@selector(username)]) {
+        id v = ((id (*)(id, SEL))objc_msgSend)(userObject, @selector(username));
+        if ([v isKindOfClass:[NSString class]]) name = v;
+    }
+    if (name.length == 0 && [userObject respondsToSelector:@selector(name)]) {
+        id v = ((id (*)(id, SEL))objc_msgSend)(userObject, @selector(name));
+        if ([v isKindOfClass:[NSString class]]) name = v;
+    }
+    return name.length > 0 ? [name lowercaseString] : nil;
+}
+
+// Live lookup for sessions restored with a signed-in user before any
+// -[RDKClient setCurrentUser:] fires under our hook.
+static NSString *ApolloTagLiveActiveUsername(void) {
+    Class clientClass = objc_getClass("RDKClient");
+    if (!clientClass || ![clientClass respondsToSelector:@selector(sharedClient)]) return nil;
+    id client = ((id (*)(id, SEL))objc_msgSend)(clientClass, @selector(sharedClient));
+    if (!client || ![client respondsToSelector:@selector(currentUser)]) return nil;
+    id currentUser = ((id (*)(id, SEL))objc_msgSend)(client, @selector(currentUser));
+    return currentUser ? ApolloTagNormalizedUsername(currentUser) : nil;
+}
+
+// Main thread only. Re-resolves the active account's captured pref; on an
+// EFFECTIVE change (capture for the active account, or an account switch)
+// re-evaluates visible cells — a statically-visible feed gets no layout pass
+// of its own when /me lands or the account flips.
+static void ApolloTagRecomputeEffectiveNoProfanity(void) {
+    if (sTagActiveUsername.length == 0) sTagActiveUsername = ApolloTagLiveActiveUsername();
+    NSNumber *captured = sTagActiveUsername.length > 0 ? sTagNoProfanityByUser[sTagActiveUsername] : nil;
+    NSInteger effective = captured ? (captured.boolValue ? 1 : 0) : -1;
+    if (effective == sTagEffectiveNoProfanity) return;
+    sTagEffectiveNoProfanity = effective;
+    ApolloLog(@"[TagFilters] Effective pref_no_profanity=%ld for u/%@ (blur mature media)",
+              (long)effective, sTagActiveUsername ?: @"(unknown)");
+    ApolloTagRefreshAllVisibleCells();
+}
 
 // Predicts Apollo's native NSFW obscuring for a link, so the tweak's overlay
 // can stay out of the way from the FIRST layout pass (the native overlay node
@@ -216,7 +268,7 @@ static NSInteger sTagRedditNoProfanity = -1;
 // object exists with noProfanity NO, so no native overlay ever appears. The
 // conservative default costs only a brief launch-window double-blur.
 static BOOL ApolloTagNativeWillBlurNSFW(BOOL isNSFW) {
-    return isNSFW && sTagRedditNoProfanity == 1;
+    return isNSFW && sTagEffectiveNoProfanity == 1;
 }
 
 // Apollo's native obscured overlay ("NSFW / Spoiler — tap to view") lives on
@@ -322,7 +374,7 @@ static NSArray<NSDictionary *> *ApolloTagBlurEntriesForCell(id cell, RDKLink *li
     // heuristic for configurations where the ivar isn't observable yet.
     // Square corners — the media area runs edge-to-edge and any rounding
     // leaves a sliver of the underlying image visible in the corners.
-    BOOL latchTrusted = isSpoiler || sTagRedditNoProfanity != 0;
+    BOOL latchTrusted = isSpoiler || sTagEffectiveNoProfanity != 0;
     BOOL skipMedia = ApolloTagMediaNativelyObscured(cell, richMediaNode, latchTrusted)
         || (richMediaNode && ApolloTagNativeWillBlurNSFW(isNSFW))
         || (!isNSFW && isSpoiler && ApolloTagMediaIsVideo(richMediaNode));
@@ -605,21 +657,45 @@ static void ApolloTagRefreshAllVisibleCells(void) {
 
 // MARK: - Cell hooks
 
-// Captures the account's blur-mature pref as Apollo parses it from /me.json
+// Captures a per-account blur-mature pref as Apollo parses it from /me.json
 // (Mantle key path data.pref_no_profanity → this setter). A pref change made
-// on Reddit's side flows in on the next /me refresh. On any change, visible
-// cells are re-evaluated — a statically-visible feed gets no layout pass of
-// its own when /me lands, so overlays computed under the unknown/-1 default
-// would otherwise stay wrong until the user scrolls.
+// on Reddit's side flows in on the next /me refresh. The capture hops to
+// main because Mantle can call this setter mid-init on a background parse
+// queue — on main the object's username is populated and all TagFilters
+// state is main-confined (the old direct call also walked UIWindows from the
+// parse thread). Cell refresh happens only when the ACTIVE account's
+// effective value changes, inside the recompute.
 %hook RDKUser
 
 - (void)setNoProfanity:(BOOL)value {
     %orig;
-    if (sTagRedditNoProfanity != (value ? 1 : 0)) {
-        sTagRedditNoProfanity = value ? 1 : 0;
-        ApolloLog(@"[TagFilters] Captured pref_no_profanity=%d (blur mature media)", value);
-        ApolloTagRefreshAllVisibleCells();
-    }
+    id parsedUser = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSString *username = ApolloTagNormalizedUsername(parsedUser);
+        if (username.length == 0) return;  // uncaptured stays conservative (-1)
+        if (!sTagNoProfanityByUser) sTagNoProfanityByUser = [NSMutableDictionary dictionary];
+        NSNumber *previous = sTagNoProfanityByUser[username];
+        if (!previous || previous.boolValue != value) {
+            sTagNoProfanityByUser[username] = @(value);
+            ApolloLog(@"[TagFilters] Captured pref_no_profanity=%d for u/%@ (blur mature media)", value, username);
+        }
+        ApolloTagRecomputeEffectiveNoProfanity();
+    });
+}
+
+%end
+
+// Account switches move the effective pref to the new account's captured
+// value (or back to unknown if it was never captured for them).
+%hook RDKClient
+
+- (void)setCurrentUser:(id)user {
+    %orig;
+    id newUser = user;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        sTagActiveUsername = newUser ? ApolloTagNormalizedUsername(newUser) : nil;
+        ApolloTagRecomputeEffectiveNoProfanity();
+    });
 }
 
 %end

--- a/src/ApolloUserProfileCache.m
+++ b/src/ApolloUserProfileCache.m
@@ -489,6 +489,24 @@ static NSTimeInterval ApolloUserProfileRetryBackoffForAttempt(NSInteger attempt)
     [self startInfoFetchForKey:key bypassingCache:bypassingCache attempt:0];
 }
 
+// Negative-cache a permanent miss (404 nonexistent/deleted user, unparseable
+// body) so repeated lookups short-circuit for the cache TTL. Without this,
+// every layout pass of any cell referencing the user (inline avatar path,
+// u/ link-preview prefetch) refires the fetch — one network round trip per
+// ~200ms for as long as the cell is near the viewport, which lags comment
+// scrolling. The sentinel has fetchedAt=now + suspensionChecked=YES so
+// requestInfoForUsername's freshness short-circuit skips the network, and a
+// nil username so display fallbacks keep the author's original casing.
+// Memory-only (never diskInfo): a transient upstream 404 must not persist
+// across launches.
+- (void)cacheNotFoundInfoForKey:(NSString *)key {
+    if (!key) return;
+    ApolloUserProfileInfo *sentinel = [ApolloUserProfileInfo new];
+    sentinel.fetchedAt = [NSDate date];
+    sentinel.suspensionChecked = YES;
+    [self.infoCache setObject:sentinel forKey:key];
+}
+
 - (void)startInfoFetchForKey:(NSString *)key bypassingCache:(BOOL)bypassingCache attempt:(NSInteger)attempt {
     NSMutableURLRequest *request = [[self profileRequestForUsername:key] mutableCopy];
     if (bypassingCache) {
@@ -537,12 +555,14 @@ static NSTimeInterval ApolloUserProfileRetryBackoffForAttempt(NSInteger attempt)
         if (statusCode < 200 || statusCode >= 300) {
             // Permanent (404 not found, 403 forbidden, etc.) — no retry.
             ApolloLog(@"[UserAvatars] Profile fetch for u/%@ returned HTTP %ld", key, (long)statusCode);
+            [self cacheNotFoundInfoForKey:key];
             [self finishInfoRequestForKey:key info:nil];
             return;
         }
 
         ApolloUserProfileInfo *info = [self profileInfoFromResponseData:data fallbackUsername:key];
         if (!info) {
+            [self cacheNotFoundInfoForKey:key];
             [self finishInfoRequestForKey:key info:nil];
             return;
         }


### PR DESCRIPTION
This PR fixes a reproducible crash when opening a post whose body links the same imgur album twice, a follow-up use-after-free when leaving the post mid-resolve, and a set of scroll-performance hotspots in the same code paths that the crash investigation surfaced. It also extends the fullscreen PiP button to inline videos.

### Crash: Inline Media on nodes with automatic subnode management

Apollo's `MarkdownNode` and `LinkButtonNode` enable `automaticallyManagesSubnodes` (confirmed in Hopper), so their subnode arrays are owned exclusively by `ASLayoutTransition` - the diffed insert indexes are only valid against an array nothing else has mutated. The Inline Media module violated that in three independent ways, each ending in an abort like:

- `*** -[__NSArrayM insertObject:atIndex:]: index 29 beyond bounds [0 .. 27]`

Fixes, all in `ApolloInlineImages.xm`:

- Injected leaves (text segments, image nodes, video thumbnails) now enter and leave the node tree only via the returned layout spec; all manual `addSubnode:`/`removeFromSupernode` calls are gone. Unknown-ratio images are included at zero size instead of omitted, so they still start loading and appear once their ratio arrives.
- A body linking the same imgur album twice put one node instance at two layout positions (the per-host node cache reuses by URL, but the URL dedupe was per text child). The dedupe now spans the whole rebuild, and an identity guard at spec assembly enforces the one-slot-per-node invariant outright.
- The image node's host reference was an `OBJC_ASSOCIATION_ASSIGN` raw pointer; async album-resolve completions read it after the host deallocated (cell rebuilds while a resolve was in flight), crashing in `objc_retain`. It is now a retained box holding a zeroing-weak reference.

### Relayout storms

Cold opens of album-heavy posts re-measured the header row once per event instead of once per burst.

- Album-resolve relayouts are debounced per host (180ms quiet / 450ms cap): nine staggered cold resolves now cost one re-measure instead of up to nine, cached resolves apply synchronously during the creating layout pass with no relayout at all, and the `onDidLoad` fallback registers once per host instead of once per resolve.
- `ApolloInlineLinkPreviews`' relayout trigger called `_u_setNeedsLayoutFromAbove` at every ancestor level per preview resolution (each call itself climbs to the root), plus a synchronous cell transition and an 80ms full repeat. It now does a cheap invalidate-only walk synchronously and one debounced escalation per cell; the immediate path is preserved for the placeholder-shrink flow that needs a synchronous climb.
- `DIDLOAD` aspect-ratio changes route through the same debounced scheduler instead of issuing their own climbs.

### Per-measure overhead

- `ApolloLPCleanDisplayText` compiled two fresh `NSRegularExpression`s per call, with several cleans per card measure; all regexes are now `dispatch_once` singletons and cleaned strings are memoized in a bounded `NSCache`.
- Removed the leftover V17 diagnostic block from the `LinkButtonNode` layout hook (a supernode walk plus os_log on effectively every card measure - its per-node cap reset constantly because scrolling recreates nodes).
- 404'd user profiles are now negative-cached in `ApolloUserProfileCache` (memory-only, TTL'd): a comment linking a nonexistent user previously refired a network fetch on every layout pass, one round trip per ~200ms for as long as the cell was near the viewport.
- Silenced the `[ImageUploadHost]` 2000px bypass log, which fires on Apollo display-path thumbnail calls and spammed during scrolling.

### Blur-mature pref: per-account capture

The `pref_no_profanity` capture assumed `-[RDKUser setNoProfanity:]` fires only for the signed-in account, but with multiple accounts added Apollo materializes an `RDKUser` for every stored account, so a single last-writer-wins global ping-ponged whenever two accounts' prefs disagreed - mispredicting Apollo's native NSFW blur and re-running the visible-cell refresh on every flip.

- Captures are now stored per username, decisions resolve against the active account (tracked via `RDKClient setCurrentUser:` with a live `sharedClient.currentUser` fallback), and the visible-cell refresh fires only when the effective value changes.
- Captures hop to the main thread, which also fixes a pre-existing off-main `UIWindow` walk from Mantle's parse thread; the conservative unknown-means-keep-cover semantics are unchanged.

### Fullscreen PiP for inline videos

Videos opened from inline media (or any markdown link) now offer the fullscreen PiP button even with autoplay on.

### Testing

Manually validated on device: the previously crashing post now opens, scrolls, and re-enters cleanly with inline media enabled; cold-cache opens show a single coalesced header re-measure instead of a storm; device logs confirm one 404 per dead user per session and no repeated capture/refresh churn when switching between accounts with differing blur prefs; full-resolution image upload still works.
