### PR TITLE
Themes: fix code blocks and italic text under custom fonts

### DIFF
--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -3,6 +3,7 @@
 #import "ApolloThemeCompiler.h"
 #import "ApolloThemeGalleryCatalog.h"
 #import "ApolloCommon.h"
+#import <CoreText/CoreText.h>
 #import <mach-o/dyld.h>
 #import <mach-o/loader.h>
 #import <dlfcn.h>
@@ -207,11 +208,37 @@ static BOOL FontLooksLikeAppleSystemDesign(UIFont *font) {
     return NO;
 }
 
+// Apollo's markdown code faces do NOT come through fontWithName: as originally
+// assumed here — they're built with monospacedSystemFontOfSize:weight:, which
+// is itself a *system-design* font (name .AppleSystemUIFontMonospaced / family
+// prefixed .SFMono) and therefore matches FontLooksLikeAppleSystemDesign above.
+// Left unguarded, every sink/refresh path re-derives it into the active theme
+// design and strips the monospacing — reproducible under ANY custom theme,
+// including one whose font choice is plain SF Pro (the sink/refresh/attach
+// paths don't short-circuit on System the way ThemedFont() does; they still
+// call ApolloThemeFontApply(System, font), which rebuilds from a proportional
+// Body descriptor). Exempt anything already monospaced, independent of design.
+static BOOL FontIsMonospaced(UIFont *font) {
+    if (![font isKindOfClass:[UIFont class]]) return NO;
+    if (font.fontDescriptor.symbolicTraits & UIFontDescriptorTraitMonoSpace) return YES;
+    NSString *fontName = font.fontName ?: @"";
+    NSString *familyName = font.familyName ?: @"";
+    return [fontName localizedCaseInsensitiveContainsString:@"Mono"] ||
+           [familyName localizedCaseInsensitiveContainsString:@"Mono"];
+}
+
+// Single themeability gate used by every sink/refresh/attach path: a font must
+// look like a re-derivable Apple system design AND not already be monospaced
+// (code faces stay put no matter which design the theme is set to).
+static BOOL FontIsThemeable(UIFont *font) {
+    return FontLooksLikeAppleSystemDesign(font) && !FontIsMonospaced(font);
+}
+
 static UIFont *ThemedTextSinkFont(UIFont *font, id owner, uintptr_t caller) {
     if (!sEnabled || !font || sFontBypass) return font;
     if (FontPinned(owner)) return font;
     if (!TextSinkMayUseTheme(owner, caller)) return font;
-    if (!FontLooksLikeAppleSystemDesign(font)) return font;
+    if (!FontIsThemeable(font)) return font;
 
     sFontBypass++;
     UIFont *themed = ApolloThemeFontApply(sFontChoice, font);
@@ -449,7 +476,7 @@ static BOOL ChromeBarLooksApolloOwned(UIView *bar) {
 static void RefreshFontOnTextControl(UIView *view, ApolloThemeFont target) {
     if (FontPinned(view)) return;
     UIFont *font = ((UILabel *)view).font; // UILabel/UITextField/UITextView all expose `font`
-    if (![font isKindOfClass:[UIFont class]] || !FontLooksLikeAppleSystemDesign(font)) return;
+    if (![font isKindOfClass:[UIFont class]] || !FontIsThemeable(font)) return;
     sFontBypass++;
     UIFont *themed = ApolloThemeFontApply(target, font);
     if (themed && ![themed.fontName isEqualToString:font.fontName]) {
@@ -505,7 +532,7 @@ static void RethemeFontOnAttach(UIView *view) {
     if (!view.window) return;
     if (FontPinned(view)) return;
     UIFont *font = ((UILabel *)view).font; // UILabel/UITextField/UITextView all expose `font`
-    if (![font isKindOfClass:[UIFont class]] || !FontLooksLikeAppleSystemDesign(font)) return;
+    if (![font isKindOfClass:[UIFont class]] || !FontIsThemeable(font)) return;
     sFontBypass++;
     UIFont *themed = ApolloThemeFontApply(sFontChoice, font);
     if (themed && ![themed.fontName isEqualToString:font.fontName] && ObjectChainLooksApolloOwned(view)) {
@@ -1029,10 +1056,14 @@ void ApolloThemeRuntimeInvalidate(void) {
 // (ApolloThemeFontApply), preserving size/weight/traits/Dynamic Type. Apollo
 // is Swift, but UIFont.systemFont(ofSize:)/preferredFont(forTextStyle:)
 // compile down to these class methods, so Texture attributed strings are
-// covered. fontWithDescriptor:size: (our own re-derive path) and
-// fontWithName: (Apollo's markdown code blocks) are deliberately NOT hooked.
-// monospacedDigitSystemFontOfSize:weight: is also left alone — those callers
-// want column-aligned counters, which every design already honours there.
+// covered. fontWithDescriptor:size: (our own re-derive path) is deliberately
+// NOT hooked at the factory level, and neither is monospacedDigitSystemFontOfSize:
+// weight: (column-aligned counters, which every design already honours) nor
+// monospacedSystemFontOfSize:weight: (Apollo's markdown code blocks — NOT
+// fontWithName: as previously assumed here). The latter two are still system-
+// design fonts by name/family, so they DO reach the sink hooks below (setFont:,
+// attributed-string rewrites); FontIsThemeable()'s FontIsMonospaced() check is
+// what actually keeps code blocks monospaced, not an unhooked factory.
 
 %hook UIFont
 
@@ -1058,6 +1089,67 @@ void ApolloThemeRuntimeInvalidate(void) {
 
 + (UIFont *)preferredFontForTextStyle:(UIFontTextStyle)style compatibleWithTraitCollection:(UITraitCollection *)traitCollection {
     return ThemedFont(%orig, (uintptr_t)__builtin_return_address(0));
+}
+
+%end
+
+// SF Pro Rounded has no true italic face. CoreText doesn't fail an italic
+// request against it — it silently hands back an upright descriptor while
+// still reporting the trait as satisfied, so the caller has no way to detect
+// the failure after the fact. That caller isn't just this tweak's own code:
+// Apollo's OWN markdown-to-attributedstring conversion asks OUR factory hooks
+// above for a body font (getting back an already-Rounded one), then tries to
+// add italic to THAT font itself via fontDescriptorWithSymbolicTraits: — and
+// silently gets the same upright result, before ApolloThemeFontApply's own
+// per-run theming ever sees the text. By the time a per-run fixup could look
+// at it, the italic intent is already gone with no signal left to recover it.
+// Catch it at the one place both call sites actually go through: redirect the
+// WHOLE request to the DEFAULT (SF Pro) design at the same weight, which
+// always has a real italic face, whenever a Rounded-family descriptor is
+// asked for italic and doesn't already have it.
+%hook UIFontDescriptor
+
+- (UIFontDescriptor *)fontDescriptorWithSymbolicTraits:(UIFontDescriptorSymbolicTraits)symbolicTraits {
+    if (sEnabled && sFontChoice == ApolloThemeFontRounded &&
+        (symbolicTraits & UIFontDescriptorTraitItalic) &&
+        !(self.symbolicTraits & UIFontDescriptorTraitItalic) &&
+        [self.postscriptName localizedCaseInsensitiveContainsString:@"Rounded"] &&
+        CallerMayUseThemeRuntime((uintptr_t)__builtin_return_address(0))) {
+        // self.fontAttributes[UIFontDescriptorTraitsAttribute] isn't reliably
+        // populated once a descriptor is already concrete (which this one is
+        // — it came from an already-resolved .SFUIRounded-Bold-style font):
+        // the weight is baked into the postscript name at that point, not
+        // restated in the abstract traits dict. Resolving self into a font
+        // and reading CTFontCopyTraits (same technique ApolloThemeFontApply
+        // uses) is what actually reports the real weight — the traits-dict
+        // read silently defaulted every case to Regular, dropping bold.
+        CGFloat weight = UIFontWeightRegular;
+        UIFont *selfFont = [UIFont fontWithDescriptor:self size:(self.pointSize > 0 ? self.pointSize : 17.0)];
+        if (selfFont) {
+            NSDictionary *ctTraits = CFBridgingRelease(CTFontCopyTraits((__bridge CTFontRef)selfFont));
+            NSNumber *weightValue = ctTraits[(__bridge NSString *)kCTFontWeightTrait];
+            if ([weightValue isKindOfClass:[NSNumber class]]) weight = weightValue.doubleValue;
+        }
+        // Set weight and the caller's full requested symbolic traits (bold,
+        // italic, whatever else) TOGETHER in one combined traits dictionary.
+        // fontDescriptorWithSymbolicTraits: is documented as a FAMILY-MEMBER
+        // LOOKUP ("returns a new font descriptor reference in the same
+        // family with the given symbolic traits"), not an attribute merge —
+        // calling it after separately setting weight via
+        // fontDescriptorByAddingAttributes: silently discarded the weight
+        // (a bold Rounded header lost its boldness once italicized),
+        // because it replaces the descriptor with whichever family member
+        // matches the coarse symbolic bits, disregarding the fine-grained
+        // numeric weight set moments earlier.
+        UIFontDescriptor *fallback = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleBody];
+        return [fallback fontDescriptorByAddingAttributes:@{
+            UIFontDescriptorTraitsAttribute: @{
+                UIFontWeightTrait: @(weight),
+                UIFontSymbolicTrait: @(symbolicTraits),
+            },
+        }];
+    }
+    return %orig;
 }
 
 %end

--- a/src/ApolloThemeTokens.m
+++ b/src/ApolloThemeTokens.m
@@ -1,4 +1,5 @@
 #import "ApolloThemeTokens.h"
+#import "ApolloCommon.h"
 #import <math.h>
 
 #pragma mark - Token keys
@@ -196,6 +197,11 @@ UIFont *ApolloThemeFontApply(ApolloThemeFont font, UIFont *base) {
     // tile rendered in the live theme's design). The text-style descriptor is
     // the one public route to a system-family descriptor that does not pass
     // through the (runtime-hooked) UIFont factories.
+    //
+    // Deliberately does NOT carry an italic trait: an italic attempt is
+    // always built from a separate descriptor derived from this one (see
+    // below), so this stays a clean, reusable base for the upright
+    // resolution and (for Rounded) the SF Pro italic fallback alike.
     UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleBody];
     if (font != ApolloThemeFontSystem) {
         descriptor = [descriptor fontDescriptorWithDesign:design] ?: descriptor;
@@ -203,11 +209,7 @@ UIFont *ApolloThemeFontApply(ApolloThemeFont font, UIFont *base) {
     descriptor = [descriptor fontDescriptorByAddingAttributes:@{
         UIFontDescriptorTraitsAttribute: @{ UIFontWeightTrait: @(weight) },
     }];
-    if (italic) {
-        UIFontDescriptor *italicDescriptor =
-            [descriptor fontDescriptorWithSymbolicTraits:descriptor.symbolicTraits | UIFontDescriptorTraitItalic];
-        if (italicDescriptor) descriptor = italicDescriptor;
-    }
+
     // SF Mono's fixed-width glyphs are visibly wider than the proportional
     // system faces, so at an identical point size a monospaced theme reads as
     // "bigger" and eats more horizontal room. Nudge the effective size down a
@@ -221,8 +223,70 @@ UIFont *ApolloThemeFontApply(ApolloThemeFont font, UIFont *base) {
 
     // Explicit size wins over the descriptor's text-style size, preserving any
     // Dynamic Type scaling already applied to base.
-    UIFont *derived = [UIFont fontWithDescriptor:descriptor size:effectiveSize];
-    if (!derived) return base;
+    UIFont *upright = [UIFont fontWithDescriptor:descriptor size:effectiveSize];
+    if (!upright) return base;
+
+    UIFont *derived = upright;
+    if (italic) {
+        if (font == ApolloThemeFontRounded) {
+            // SF Pro Rounded ships no italic face, and CoreText doesn't fail
+            // the request when one is missing — it silently hands back the
+            // same upright font. Two different runtime-detection strategies
+            // were tried here (checking the resolved font's own symbolic
+            // traits, then comparing fontName against the upright
+            // resolution) and a shear-matrix UIFontDescriptor as the
+            // fallback in both cases — none of it produced visibly slanted
+            // text on-device. CoreText appears to just ignore custom
+            // matrices for Apple's .SFUI-* system-design fonts the way it
+            // doesn't for ordinary named fonts.
+            //
+            // Which designs have a real italic face is static platform
+            // knowledge, not something worth re-deriving at runtime: SF Pro,
+            // New York, and SF Mono all resolve genuine italics (confirmed by
+            // hands-on testing across all four theme fonts); Rounded is the
+            // one exception today. So italic runs under a Rounded theme fall
+            // back to the DEFAULT (SF Pro) design, which is guaranteed to
+            // have a real italic face — the rest of the paragraph keeps
+            // Rounded, only italic runs differ in roundedness. That reads far
+            // better than "italic" text that's indistinguishable from
+            // upright.
+            // Set weight and the italic symbolic trait TOGETHER in one
+            // combined traits dictionary rather than two chained calls.
+            // fontDescriptorWithSymbolicTraits: is documented as a FAMILY-
+            // MEMBER LOOKUP ("returns a new font descriptor reference in the
+            // same family with the given symbolic traits"), not an attribute
+            // merge — calling it after separately setting weight via
+            // fontDescriptorByAddingAttributes: silently discarded the
+            // weight (bold text under Rounded lost its boldness once
+            // italicized), because it replaces the descriptor with whichever
+            // family member matches the coarse symbolic bits, disregarding
+            // the fine-grained numeric weight set moments earlier.
+            UIFontDescriptor *fallback = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleBody];
+            fallback = [fallback fontDescriptorByAddingAttributes:@{
+                UIFontDescriptorTraitsAttribute: @{
+                    UIFontWeightTrait: @(weight),
+                    UIFontSymbolicTrait: @(fallback.symbolicTraits | UIFontDescriptorTraitItalic),
+                },
+            }];
+            UIFont *fallbackFont = [UIFont fontWithDescriptor:fallback size:effectiveSize];
+            derived = fallbackFont ?: upright;
+            ApolloLog(@"ThemeTokens: Rounded has no italic face, falling back to SF Pro italic (base=%@ -> %@)",
+                      base.fontName, derived.fontName);
+        } else {
+            // Same combined-dictionary fix as above: set weight and the
+            // italic symbolic trait together rather than via a separate
+            // fontDescriptorWithSymbolicTraits: call, which discards weight.
+            UIFontDescriptor *italicDescriptor = [descriptor fontDescriptorByAddingAttributes:@{
+                UIFontDescriptorTraitsAttribute: @{
+                    UIFontWeightTrait: @(weight),
+                    UIFontSymbolicTrait: @(descriptor.symbolicTraits | UIFontDescriptorTraitItalic),
+                },
+            }];
+            UIFont *italicFont = italicDescriptor ? [UIFont fontWithDescriptor:italicDescriptor size:effectiveSize] : nil;
+            derived = italicFont ?: upright;
+        }
+    }
+
     [FontApplyCache() setObject:derived forKey:cacheKey];
     return derived;
 }


### PR DESCRIPTION
## Summary
Fixes two font-rendering bugs affecting custom themes: markdown code blocks were losing their monospaced font under any active custom theme (including one set to the default "SF Pro" font), and using the SF Pro Rounded custom font breaks italics text (displays as regular text without slant).

## Impact
- Code blocks in posts/comments now stay monospaced under every custom theme font, matching stock Apollo's behavior.
- Italic markdown text (`*text*`) now renders visibly slanted under the SF Pro Rounded custom font, instead of appearing identical to regular text.

## Changes
- `ApolloThemeRuntime.xm`:
  - Added `FontIsMonospaced()` and a combined `FontIsThemeable()` gate, used by every font sink/refresh/attach path, so monospaced fonts (Apollo's code blocks, built via `monospacedSystemFontOfSize:weight:`) are exempted from theming regardless of the active design.
  - Added a `%hook` on `-[UIFontDescriptor fontDescriptorWithSymbolicTraits:]`: when a Rounded-family descriptor is asked for the italic trait it doesn't have, redirects the request to the default SF Pro design at the same weight (which has a real italic face), preserving both weight and italic together in one combined traits dictionary.
- `ApolloThemeTokens.m`:
  - `ApolloThemeFontApply` now falls back to the default SF Pro design for italic runs specifically when the active theme font is Rounded, since Rounded has no italic face.
  - Fixed a related weight-preservation bug in both the Rounded fallback and the plain (System/Serif/Mono) italic path: weight and the italic symbolic trait are now set together in one `UIFontDescriptorTraitsAttribute` dictionary instead of via two chained descriptor calls.

## Reasoning
- SF Pro Rounded is the one system font design with no true italic face. CoreText doesn't fail the request when italic is unavailable; it silently returns the same upright font while still reporting the trait as satisfied, so there's no reliable way to detect the failure by inspecting the resulting font alone.
- The actual fix location was non-obvious: the failure doesn't happen in this tweak's own font-derivation code at all. Apollo's own markdown-to-attributed-string conversion asks the theme runtime for a body font (correctly gets back Rounded), then tries to add italic to *that* font itself, hitting the same platform limitation before any of this tweak's per-run text theming ever sees the string. That's why the fix hooks the underlying UIKit API (`fontDescriptorWithSymbolicTraits:`) rather than just this tweak's own derivation logic, since it needs to correct Apollo's own font construction too, not only calls made by this tweak.
- `-[UIFontDescriptor fontDescriptorWithSymbolicTraits:]` is documented as a family-member lookup ("returns a new font descriptor reference in the same family with the given symbolic traits"), not an attribute merge. Calling it after separately setting a numeric weight discards that weight, since it replaces the descriptor with whichever family member matches the requested symbolic bits. Both fixed code paths now build weight and symbolic traits into one combined dictionary to avoid this.

## Testing
Manually verified on-device and in the iOS Simulator across all four theme fonts (SF Pro, SF Pro Rounded, New York, SF Mono): confirmed code blocks stay monospaced under each, confirmed italic text renders slanted under Rounded, and confirmed bold+italic combinations preserve both weight and slant — weight preservation was additionally confirmed numerically via diagnostic logging (`CTFontCopyTraits` weight values compared before/after, e.g. Semibold in → Semibold out).

## Screenshots
| Before | After |
|---|---|
| <img width="1206" height="859" alt="image" src="https://github.com/user-attachments/assets/5a37fbfc-16ca-46bb-b572-23beac4d89db" /> | <img width="1206" height="841" alt="image" src="https://github.com/user-attachments/assets/3deb45ea-8610-4343-a6b0-5b7b82e7872b" /> |