### PR TITLE
Notifications: carry Reddit credentials in headers on account upserts

### DIFF
--- a/src/ApolloNotificationBackend.m
+++ b/src/ApolloNotificationBackend.m
@@ -149,6 +149,8 @@ static BOOL ApolloPathRequiresRegistrationToken(NSString *path) {
 // ApolloAccountCredentialsFor; missing/empty fields fall back to the global
 // default. This keeps backend push registration correct even when different
 // accounts use different Reddit API clients (see ApolloAccountCredentials.h).
+// A nil username returns the global defaults — used for the X-Apollo-Reddit-*
+// header channel, which is per-request and can't carry per-account overrides.
 static NSDictionary<NSString *, NSString *> *ApolloRedditCredentialsForRegistration(NSString *username) {
     ApolloAccountCredentialEntry *entry = username.length > 0 ? ApolloAccountCredentialsFor(username) : nil;
     NSString *clientId = (entry && entry.clientId.length > 0) ? entry.clientId : (sRedditClientId ?: @"");
@@ -294,7 +296,7 @@ NSURLRequest *ApolloRewriteRequestForNotificationBackend(NSURLRequest *request) 
         }
     }
 
-    // Body augmentation for the two account-upsert endpoints. The forked
+    // Credential injection for the two account-upsert endpoints. The forked
     // backend's accountRegistrationRequest requires four Reddit OAuth fields
     // that Apollo's wire format never carried; inject them from the tweak's
     // saved settings.
@@ -302,6 +304,29 @@ NSURLRequest *ApolloRewriteRequestForNotificationBackend(NSURLRequest *request) 
         BOOL singular = ApolloPathIsAccountUpsertSingular(path);
         BOOL bulk = !singular && ApolloPathIsAccountUpsertBulk(path);
         if (singular || bulk) {
+            // Headers are the reliable channel for the global-default
+            // credentials: like /v1/device below, Apollo can post these
+            // upserts as upload tasks whose body data rides outside the
+            // request object (`fromData:`), in which case the body rewrite
+            // below never reaches the wire and the backend sees Apollo's raw
+            // payload (no reddit_client_id -> 422). Headers set on the
+            // request always reach the wire. The backend fills missing
+            // fields body > header > env, so the per-account overrides
+            // (body-only) still win whenever the body rewrite does land.
+            NSDictionary<NSString *, NSString *> *globalCreds = ApolloRedditCredentialsForRegistration(nil);
+            NSDictionary<NSString *, NSString *> *headerForBodyKey = @{
+                @"reddit_client_id":     @"X-Apollo-Reddit-Client-Id",
+                @"reddit_client_secret": @"X-Apollo-Reddit-Client-Secret",
+                @"reddit_redirect_uri":  @"X-Apollo-Reddit-Redirect-Uri",
+                @"reddit_user_agent":    @"X-Apollo-Reddit-User-Agent",
+            };
+            for (NSString *bodyKey in headerForBodyKey) {
+                NSString *value = globalCreds[bodyKey];
+                if (value.length > 0) {
+                    [mutable setValue:value forHTTPHeaderField:headerForBodyKey[bodyKey]];
+                }
+            }
+
             NSData *augmented = ApolloAugmentAccountUpsertBody(mutable.HTTPBody, bulk);
             if (augmented) {
                 mutable.HTTPBody = augmented;
@@ -309,10 +334,10 @@ NSURLRequest *ApolloRewriteRequestForNotificationBackend(NSURLRequest *request) 
                 if ([mutable valueForHTTPHeaderField:@"Content-Type"] == nil) {
                     [mutable setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
                 }
-                ApolloLog(@"[NotifBackend] Augmented %@ body (+reddit_* fields, %lu bytes)",
-                          singular ? @"account" : @"accounts",
-                          (unsigned long)augmented.length);
             }
+            ApolloLog(@"[NotifBackend] %@ upsert: reddit_* creds in headers%@",
+                      singular ? @"account" : @"accounts",
+                      augmented ? @" + body augmented" : @" (body not reachable, header-only)");
         } else if (ApolloPathIsDeviceRegistration(path)) {
             // Headers are the authoritative channel: Apollo posts /v1/device
             // as an upload task whose body data is attached outside the


### PR DESCRIPTION
## Problem

Account registration against the notification backend can arrive with no `reddit_client_id`, failing with a 422 `missing required credentials` (`has_client_id: false`) even when the user has an API key configured. Hit in the wild by a user self-hosting the backend (debugged via chat today).

Root cause: Apollo posts the `/v1/device/<apns>/account(s)` upserts as upload tasks whose body data is attached **outside** the request object (`fromData:`), so `ApolloAugmentAccountUpsertBody`'s rewrite of `mutable.HTTPBody` never reaches the wire — the backend receives Apollo's raw payload, which never carried the four `reddit_*` fields. This is the exact gotcha `/v1/device` already works around by riding its transport info in `X-Apollo-Transport` headers; the account-upsert endpoints just never got the same treatment.

## Fix

- Send the tweak's global-default credentials as `X-Apollo-Reddit-Client-Id` / `-Client-Secret` / `-Redirect-Uri` / `-User-Agent` headers on every account-upsert POST — headers set on the request object reliably reach the wire (proven by `X-Registration-Token`).
- Keep the body augmentation: it's still the only channel for **per-account** credential overrides, and the backend's fill order (body > header > env) means it wins whenever it lands.
- Log line now reports which channel(s) carried the creds.

## Companion PR

Backend side (header backfill + singular-handler panic guard): Apollo-Reborn/apollo-backend — see the PR opened alongside this one.

## Testing

- Device `make package` builds clean.
- Backend companion tested with `go build ./...` + `go vet`.