### PR TITLE
Performance: reduce feed scrolling hot-path work

### DIFF
--- a/src/ApolloFlairColors.xm
+++ b/src/ApolloFlairColors.xm
@@ -37,6 +37,10 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 
+#ifndef APOLLO_FLAIR_VERBOSE_LOGS
+#define APOLLO_FLAIR_VERBOSE_LOGS 0
+#endif
+
 // ASSizeRange is { CGSize min; CGSize max; }. Match the class-dumped
 // layoutSpecThatFits: ABI used elsewhere in the tweak.
 struct CDStruct_90e057aa { CGSize min; CGSize max; };
@@ -223,7 +227,9 @@ static void ApolloFlairAnnotate(NSArray *flairs, UIColor *background, UIColor *t
     }
 }
 
+#if APOLLO_FLAIR_VERBOSE_LOGS
 static NSUInteger sApolloFlairRecoverLogCount = 0;
+#endif
 
 // Reddit sometimes nests the link/comment fields under a "data" sub-dictionary
 // (the t3 / t1 "thing" wrapper). Pick whichever dict actually carries the flair
@@ -258,10 +264,12 @@ static void ApolloFlairRecoverColors(id model, NSDictionary *rawJson, BOOL isLin
             ApolloFlairAnnotate(ApolloFlairArrayProperty(model, @selector(linkFlair)), linkBG, linkText);
             ApolloFlairAnnotate(ApolloFlairArrayProperty(model, @selector(linkFlairRichText)), linkBG, linkText);
             ApolloFlairCacheColors(ApolloFlairStringProperty(model, @selector(linkFlairText)), linkBG, linkText);
+#if APOLLO_FLAIR_VERBOSE_LOGS
             if (sApolloFlairRecoverLogCount < 30) {
                 sApolloFlairRecoverLogCount++;
                 ApolloLog(@"[FlairColors] recovered link flair bg=%@ textMode=%@", json[@"link_flair_background_color"], json[@"link_flair_text_color"]);
             }
+#endif
         }
     }
 
@@ -271,10 +279,12 @@ static void ApolloFlairRecoverColors(id model, NSDictionary *rawJson, BOOL isLin
         ApolloFlairAnnotate(ApolloFlairArrayProperty(model, @selector(authorFlair)), authorBG, authorText);
         ApolloFlairAnnotate(ApolloFlairArrayProperty(model, @selector(authorFlairRichtext)), authorBG, authorText);
         ApolloFlairCacheColors(ApolloFlairStringProperty(model, @selector(authorFlairPlaintext)), authorBG, authorText);
+#if APOLLO_FLAIR_VERBOSE_LOGS
         if (sApolloFlairRecoverLogCount < 30) {
             sApolloFlairRecoverLogCount++;
             ApolloLog(@"[FlairColors] recovered author flair bg=%@ textMode=%@", json[@"author_flair_background_color"], json[@"author_flair_text_color"]);
         }
+#endif
     }
 }
 
@@ -493,6 +503,7 @@ static void ApolloFlairRecoverForModel(id model, NSDictionary *json) {
         Class linkClass = objc_getClass("RDKLink");
         Class commentClass = objc_getClass("RDKComment");
         if (linkClass && [model isKindOfClass:linkClass]) {
+#if APOLLO_FLAIR_VERBOSE_LOGS
             static NSUInteger sLinkLog = 0;
             if (sLinkLog < 10) {
                 sLinkLog++;
@@ -501,6 +512,7 @@ static void ApolloFlairRecoverForModel(id model, NSDictionary *json) {
                           json[@"link_flair_background_color"],
                           json[@"link_flair_richtext"] ? @"richtext" : (json[@"link_flair_text"] ? @"text" : @"none"));
             }
+#endif
             ApolloFlairRecoverColors(model, json, YES);
         } else if (commentClass && [model isKindOfClass:commentClass]) {
             ApolloFlairRecoverColors(model, json, NO);
@@ -515,11 +527,13 @@ static void ApolloFlairRecoverForModel(id model, NSDictionary *json) {
 // methods directly (not the instance method), so we must hook here.
 + (id)modelOfClass:(Class)modelClass fromJSONDictionary:(NSDictionary *)JSONDictionary error:(NSError **)error {
     id model = %orig;
+#if APOLLO_FLAIR_VERBOSE_LOGS
     static NSUInteger sClassLog = 0;
     if (sClassLog < 5) {
         sClassLog++;
         ApolloLog(@"[FlairColors] +modelOfClass:%@ fromJSONDictionary fired", NSStringFromClass(modelClass));
     }
+#endif
     ApolloFlairRecoverForModel(model, JSONDictionary);
     return model;
 }
@@ -527,12 +541,14 @@ static void ApolloFlairRecoverForModel(id model, NSDictionary *json) {
 // Listing/array funnel — JSON array and model array are index-parallel.
 + (id)modelsOfClass:(Class)modelClass fromJSONArray:(NSArray *)JSONArray error:(NSError **)error {
     id models = %orig;
+#if APOLLO_FLAIR_VERBOSE_LOGS
     static NSUInteger sArrayLog = 0;
     if (sArrayLog < 5) {
         sArrayLog++;
         ApolloLog(@"[FlairColors] +modelsOfClass:%@ fromJSONArray count=%lu fired",
                   NSStringFromClass(modelClass), (unsigned long)([JSONArray isKindOfClass:[NSArray class]] ? JSONArray.count : 0));
     }
+#endif
     if ([models isKindOfClass:[NSArray class]] && [JSONArray isKindOfClass:[NSArray class]] &&
         [(NSArray *)models count] == JSONArray.count) {
         NSArray *modelArray = (NSArray *)models;
@@ -564,6 +580,7 @@ static void ApolloFlairRecoverForModel(id model, NSDictionary *json) {
 
 - (void)didLoad {
     %orig;
+#if APOLLO_FLAIR_VERBOSE_LOGS
     static NSUInteger sDidLoadLogCount = 0;
     if (sDidLoadLogCount < 20) {
         sDidLoadLogCount++;
@@ -574,6 +591,7 @@ static void ApolloFlairRecoverForModel(id model, NSDictionary *json) {
                   (int)sEnableFlairColors, (unsigned long)flairs.count,
                   flairs.count ? ApolloFlairText(flairs.firstObject) : @"(none)", (int)resolved, bg);
     }
+#endif
     ApolloFlairApply(self, YES);
 }
 
@@ -599,11 +617,13 @@ static void ApolloFlairRecoverForModel(id model, NSDictionary *json) {
     // reapply cannot reliably win the race. The real guarantee is the write-time
     // setBackgroundColor: chokepoint below (mirroring the text chokepoint). We keep
     // this reapply because it's cheap and idempotent and covers the non-race paths.
+#if APOLLO_FLAIR_VERBOSE_LOGS
     static NSUInteger sVisibleLogCount = 0;
     if (sVisibleLogCount < 20) {
         sVisibleLogCount++;
         ApolloLog(@"[FlairColors] FlairNode.didEnterVisibleState enabled=%d reapplying", (int)sEnableFlairColors);
     }
+#endif
     ApolloFlairApply(self, YES);
 }
 
@@ -633,11 +653,13 @@ static void ApolloFlairRecoverForModel(id model, NSDictionary *json) {
     // redundant corner-radius/text work below on our own writes.)
     if ([color isEqual:memo]) { %orig; return; }
 
+#if APOLLO_FLAIR_VERBOSE_LOGS
     static NSUInteger sBGChokeLog = 0;
     if (sBGChokeLog < 20) {
         sBGChokeLog++;
         ApolloLog(@"[FlairColors] setBackgroundColor: re-imposing memoized flair color over %@", color);
     }
+#endif
 
     // Apollo tried to paint grey — re-impose our color and restore the pill
     // geometry ApolloFlairSetBackground normally sets.

--- a/src/ApolloInlineLinkPreviews.xm
+++ b/src/ApolloInlineLinkPreviews.xm
@@ -24,6 +24,16 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 
+#ifndef APOLLO_LINKPREVIEW_VERBOSE_LOGS
+#define APOLLO_LINKPREVIEW_VERBOSE_LOGS 0
+#endif
+
+#if APOLLO_LINKPREVIEW_VERBOSE_LOGS
+#define ApolloLPVerboseLog(fmt, ...) ApolloLog(fmt, ##__VA_ARGS__)
+#else
+#define ApolloLPVerboseLog(fmt, ...) do {} while (0)
+#endif
+
 typedef NS_ENUM(unsigned char, ApolloLinkPreviewStackDirection) {
     ApolloLinkPreviewStackDirectionVertical = 0,
     ApolloLinkPreviewStackDirectionHorizontal = 1,
@@ -144,7 +154,15 @@ typedef struct {
     NSUInteger recolored;
 } ApolloLPRegisteredRecolorResult;
 
+#if APOLLO_LINKPREVIEW_VERBOSE_LOGS
 static void ApolloLPLogOncePerHost(NSString *host, NSString *event);
+#else
+// Macros intentionally discard their arguments before compilation. Several
+// call sites build diagnostic strings in layout callbacks, so a no-op function
+// would still pay the formatting/allocation cost during a scroll.
+#define ApolloLPLogOncePerHost(...) do {} while (0)
+#define ApolloLPLogMetadataOnce(...) do {} while (0)
+#endif
 static void ApolloLPTriggerRelayoutForHost(ASDisplayNode *node, NSString *host);
 static BOOL ApolloLPInvokeRowReloadIfPossible(ASDisplayNode *startNode, NSString *host);
 static ASDisplayNode *ApolloLPFindOwningCellNode(ASDisplayNode *node);
@@ -1040,7 +1058,7 @@ static void ApolloLPStartFallbackImageFetch(ASNetworkImageNode *imageNode, NSURL
                     hostNode = hostNode.supernode;
                 }
                 if (hostNode) {
-                    ApolloLog(@"[LinkPreviews] V21-dead-image-compact-reflow host=%@", hostCopy ?: ApolloLPHost(imageURL));
+                    ApolloLPVerboseLog(@"[LinkPreviews] V21-dead-image-compact-reflow host=%@", hostCopy ?: ApolloLPHost(imageURL));
                     ApolloLPTriggerRelayoutForHost(hostNode, hostCopy);
                     ASDisplayNode *cellNode = ApolloLPFindOwningCellNode(hostNode);
                     if (!ApolloLPInvokeRowReloadIfPossible(cellNode ?: hostNode, hostCopy)) {
@@ -1299,7 +1317,11 @@ static void ApolloLPStartFaceScanIfNeeded(NSString *key, UIImage *image, NSStrin
         if ([pending containsObject:key]) return;
         [pending addObject:key];
     }
+#if APOLLO_LINKPREVIEW_VERBOSE_LOGS
     NSString *hostCopy = [host copy];
+#else
+    (void)host;
+#endif
     // Deliberately do NOT capture the UIImage: a fast scroll can queue many
     // scans, and blocks pinning full decoded bitmaps would hold megabytes
     // NSCache couldn't evict under pressure. Re-fetch from the fallback cache
@@ -1307,7 +1329,9 @@ static void ApolloLPStartFaceScanIfNeeded(NSString *key, UIImage *image, NSStrin
     // it got evicted meanwhile, drop without caching a verdict so a later
     // arrival can re-kick.
     dispatch_async(ApolloLPFaceScanQueue(), ^{
+#if APOLLO_LINKPREVIEW_VERBOSE_LOGS
         CFTimeInterval started = CACurrentMediaTime();
+#endif
         UIImage *scanUIImage = [ApolloLPFallbackImageCache() objectForKey:key];
         CGImageRef scanImage = scanUIImage.CGImage;
         if (!scanImage) {
@@ -1322,7 +1346,9 @@ static void ApolloLPStartFaceScanIfNeeded(NSString *key, UIImage *image, NSStrin
             return;
         }
         CGRect region = CGRectNull;
+#if APOLLO_LINKPREVIEW_VERBOSE_LOGS
         NSUInteger faceCount = 0;
+#endif
         @try {
             CGFloat width = (CGFloat)CGImageGetWidth(scanImage);
             CGFloat height = (CGFloat)CGImageGetHeight(scanImage);
@@ -1338,7 +1364,9 @@ static void ApolloLPStartFaceScanIfNeeded(NSString *key, UIImage *image, NSStrin
                                                    bounds.size.width / width,
                                                    bounds.size.height / height);
                     region = CGRectIsNull(region) ? normalized : CGRectUnion(region, normalized);
+#if APOLLO_LINKPREVIEW_VERBOSE_LOGS
                     faceCount++;
+#endif
                 }
             }
         } @catch (NSException *exception) {
@@ -1346,10 +1374,12 @@ static void ApolloLPStartFaceScanIfNeeded(NSString *key, UIImage *image, NSStrin
         }
         [ApolloLPFaceRegionCache() setObject:[NSValue valueWithCGRect:region] forKey:key];
         @synchronized (pending) { [pending removeObject:key]; }
+#if APOLLO_LINKPREVIEW_VERBOSE_LOGS
         ApolloLog(@"[LinkPreviews] V22-face-scan host=%@ faces=%lu top=%.2f ms=%.0f",
                   hostCopy ?: @"?", (unsigned long)faceCount,
                   CGRectIsNull(region) ? -1.0 : region.origin.y,
                   (CACurrentMediaTime() - started) * 1000.0);
+#endif
         dispatch_async(dispatch_get_main_queue(), ^{ ApolloLPRefineCropAnchorsForKey(key); });
     });
 }
@@ -1431,6 +1461,7 @@ static void ApolloLPApplyVerticalCropAnchor(ASNetworkImageNode *imageNode, Apoll
         ApolloLPStartFaceScanIfNeeded(key, availableImage, host);
     }
     ApolloLPSetCropAnchorY(imageNode, anchorY, NO);
+#if APOLLO_LINKPREVIEW_VERBOSE_LOGS
     // Stable dedup key (no per-image numbers — those would degrade the
     // once-per-host set to once-per-geometry). Numeric detail lives in the
     // per-scan V22-face-scan log line.
@@ -1438,6 +1469,7 @@ static void ApolloLPApplyVerticalCropAnchor(ASNetworkImageNode *imageNode, Apoll
         ? (CGRectIsNull([region CGRectValue]) ? (defaultAnchorY <= 0.0 ? @"top" : @"center") : @"face")
         : (visibleFrac <= 0.0 ? @"unknown-size" : (defaultAnchorY <= 0.0 ? @"top" : @"center"));
     ApolloLPLogOncePerHost(host, [NSString stringWithFormat:@"V22-crop-anchor kind=%@", kind]);
+#endif
 }
 
 static UIColor *ApolloLPBlendColor(UIColor *foreground, UIColor *background, CGFloat foregroundAlpha, UITraitCollection *traitCollection) {
@@ -1611,7 +1643,7 @@ static void ApolloLPRunCrossNodeRowReloadPoll(void) {
         NSString *host = ApolloLPHost([NSURL URLWithString:urlString]);
         if (ApolloLPFireRowReloadFromAttachedNodesForURL(urlString, host)) {
             [pending removeObjectForKey:urlString];
-            ApolloLog(@"[LinkPreviews] V23-cross-node-row-reload host=%@", host ?: @"?");
+            ApolloLPVerboseLog(@"[LinkPreviews] V23-cross-node-row-reload host=%@", host ?: @"?");
         }
     }
     if (pending.count > 0) {
@@ -1632,7 +1664,7 @@ static void ApolloLPNoteRowReloadMissForNode(ASDisplayNode *node, NSString *host
     NSString *urlString = url.absoluteString;
     if (urlString.length == 0) return;
     if (ApolloLPFireRowReloadFromAttachedNodesForURL(urlString, host)) {
-        ApolloLog(@"[LinkPreviews] V23-cross-node-row-reload host=%@", host ?: @"?");
+        ApolloLPVerboseLog(@"[LinkPreviews] V23-cross-node-row-reload host=%@", host ?: @"?");
         return;
     }
     ApolloLPPendingCrossNodeRowReloads()[urlString] = [NSDate date];
@@ -2039,9 +2071,11 @@ static void ApolloLPRememberCompactPlaceholderHost(NSURL *url) {
     }
 }
 
+#if APOLLO_LINKPREVIEW_VERBOSE_LOGS
 static NSString *ApolloLPContextLogName(ApolloLPContext context) {
     return context == ApolloLPContextSelfText ? @"hero" : @"compact";
 }
+#endif
 
 static id ApolloLPModelFromNodeIvar(ASDisplayNode *node, const char *ivarName) {
     if (!node || !ivarName) return nil;
@@ -2215,7 +2249,7 @@ static ApolloLPArea ApolloLPAreaForLinkButton(ASDisplayNode *linkButtonNode) {
                 [(id)cell setNeedsLayout];
             }
         }
-        ApolloLog(@"[LinkPreviews] V18 deferred-upgrade fallback=%ld→resolved=%ld cell=%@",
+        ApolloLPVerboseLog(@"[LinkPreviews] V18 deferred-upgrade fallback=%ld→resolved=%ld cell=%@",
                   (long)fallbackMode, (long)resolvedMode,
                   cell ? NSStringFromClass([cell class]) : @"(no-cell)");
     });
@@ -2684,12 +2718,14 @@ static id ApolloLPBuildBlueskyPostCardSpec(ASDisplayNode *hostNode, NSURL *url, 
     // for multi-line posts. Bluesky posts are capped at ~300 chars, so the
     // body is naturally bounded even without a line limit.
     NSString *postText = preview.postText.length > 0 ? ApolloLPCleanMultilineDisplayText(preview.postText) : ApolloLPCleanMultilineDisplayText(preview.desc);
+#if APOLLO_LINKPREVIEW_VERBOSE_LOGS
     NSUInteger bodyNewlines = postText.length > 0 ? [postText componentsSeparatedByString:@"\n"].count - 1 : 0;
     NSUInteger rawNewlines = preview.postText.length > 0 ? [preview.postText componentsSeparatedByString:@"\n"].count - 1 : 0;
     ApolloLPLogOncePerHost(ApolloLPHost(url),
         [NSString stringWithFormat:@"V19-bluesky-body source=%@ len=%lu newlines=%lu rawNewlines=%lu",
          preview.postText.length > 0 ? @"postText" : @"desc",
          (unsigned long)postText.length, (unsigned long)bodyNewlines, (unsigned long)rawNewlines]);
+#endif
     BOOL imageIsAvatar = preview.avatarURL.absoluteString.length > 0
         && [preview.imageURL.absoluteString isEqualToString:preview.avatarURL.absoluteString];
     BOOL hasPostImage = preview.imageURL.absoluteString.length > 0 && !imageIsAvatar && !preview.imageIsFallbackIcon;
@@ -3201,6 +3237,7 @@ static BOOL ApolloLPInvokeTextureScrollRelayoutIfPossible(UIView *scrollView, NS
 // chains so a miss log pinpoints which container class the walk failed to
 // recognize (e.g. the search results VC's cell tree).
 static void ApolloLPLogRowReloadMissAncestry(ASDisplayNode *startNode, UIView *cellView, NSString *host) {
+#if APOLLO_LINKPREVIEW_VERBOSE_LOGS
     NSMutableArray<NSString *> *viewChain = [NSMutableArray array];
     NSUInteger depth = 0;
     for (UIView *current = cellView; current && depth < 40; current = current.superview, depth++) {
@@ -3213,6 +3250,9 @@ static void ApolloLPLogRowReloadMissAncestry(ASDisplayNode *startNode, UIView *c
     }
     ApolloLPLogOncePerHost(host, [NSString stringWithFormat:@"V23-miss-view-chain %@", [viewChain componentsJoinedByString:@" > "]]);
     ApolloLPLogOncePerHost(host, [NSString stringWithFormat:@"V23-miss-node-chain %@", [nodeChain componentsJoinedByString:@" > "]]);
+#else
+    (void)startNode; (void)cellView; (void)host;
+#endif
 }
 
 static BOOL ApolloLPInvokeRowReloadIfPossible(ASDisplayNode *startNode, NSString *host) {
@@ -3402,7 +3442,7 @@ static void ApolloLPTriggerRelayoutForHost(ASDisplayNode *node, NSString *host) 
 static void ApolloLPTriggerPlaceholderContextRelayout(ASDisplayNode *node, NSString *host, ApolloLPContext fromContext, ApolloLPContext toContext) {
     if (!node) return;
 
-    ApolloLog(@"[LinkPreviews] V12-placeholder-context-shrink-refresh host=%@ from=%@ to=%@",
+    ApolloLPVerboseLog(@"[LinkPreviews] V12-placeholder-context-shrink-refresh host=%@ from=%@ to=%@",
               host ?: @"(nohost)", ApolloLPContextLogName(fromContext), ApolloLPContextLogName(toContext));
     ApolloLPTriggerRelayoutInternal(node, NO, host);
     ASDisplayNode *cellNode = ApolloLPFindOwningCellNode(node);
@@ -3477,7 +3517,7 @@ static void ApolloLPRunOverflowHeightCheck(ASDisplayNode *node, NSString *host, 
         CGRect frameInCell = [nodeView convertRect:content toView:cellView];
         CGFloat overflow = CGRectGetMaxY(frameInCell) - CGRectGetHeight(cellView.bounds);
         if (overflow > 8.0) {
-            ApolloLog(@"[LinkPreviews] V18-stale-row-height host=%@ overflow=%.0fpt -> reloading row",
+            ApolloLPVerboseLog(@"[LinkPreviews] V18-stale-row-height host=%@ overflow=%.0fpt -> reloading row",
                       host ?: @"?", overflow);
             ApolloLPInvokeRowReloadIfPossible(node, host);
         }
@@ -3766,7 +3806,7 @@ static void ApolloLPRefreshVisibleLayoutsForModeChange(NSString *areaName) {
         }
 
         if (cardColorRefresh) {
-            ApolloLog(@"[LinkPreviews] V14-card-color-global-refresh area=%@ scrollViews=%lu linkNodes=%lu registeredNodes=%lu registeredRecolored=%lu visibleRecolored=%lu",
+            ApolloLPVerboseLog(@"[LinkPreviews] V14-card-color-global-refresh area=%@ scrollViews=%lu linkNodes=%lu registeredNodes=%lu registeredRecolored=%lu visibleRecolored=%lu",
                       areaName ?: @"unknown",
                       (unsigned long)refreshCount,
                       (unsigned long)invalidatedNodes,
@@ -3774,9 +3814,13 @@ static void ApolloLPRefreshVisibleLayoutsForModeChange(NSString *areaName) {
                       (unsigned long)registeredResult.recolored,
                       (unsigned long)visibleRecolored);
         } else {
-            ApolloLog(@"[LinkPreviews] V14-mode-change-layout-refresh area=%@ scrollViews=%lu linkNodes=%lu registeredNodes=%lu",
+            ApolloLPVerboseLog(@"[LinkPreviews] V14-mode-change-layout-refresh area=%@ scrollViews=%lu linkNodes=%lu registeredNodes=%lu",
                       areaName ?: @"unknown", (unsigned long)refreshCount, (unsigned long)invalidatedNodes, (unsigned long)registeredInvalidated);
         }
+        (void)registeredInvalidated;
+        (void)visibleRecolored;
+        (void)invalidatedNodes;
+        (void)refreshCount;
     });
 }
 
@@ -3838,9 +3882,10 @@ static void ApolloLPArmTranslationLayoutRefreshForURL(NSURL *url, NSString *urlK
 
 static void ApolloLPFireTranslationLayoutRefreshForURL(NSURL *url, NSString *urlKey) {
     NSUInteger invalidated = ApolloLPInvalidateRegisteredLinkPreviewNodesForURL(url, @"translation-update-url");
-    ApolloLog(@"[LinkPreviews] V15-translation-url-refresh host=%@ invalidated=%lu",
+    ApolloLPVerboseLog(@"[LinkPreviews] V15-translation-url-refresh host=%@ invalidated=%lu",
               ApolloLPHost(url) ?: @"(nohost)",
               (unsigned long)invalidated);
+    (void)invalidated;
 }
 
 static void ApolloLPScheduleTranslationLayoutRefreshForURL(NSURL *url) {
@@ -3882,6 +3927,7 @@ static void ApolloLPScheduleTranslationLayoutRefreshForURL(NSURL *url) {
 // doesn't spam OSLog with the same host hundreds of times. We still want one
 // entry per unique host per session so we can correlate hook activity with
 // the user's screenshots.
+#if APOLLO_LINKPREVIEW_VERBOSE_LOGS
 static NSMutableSet<NSString *> *ApolloLPLoggedHosts(void) {
     static NSMutableSet *set;
     static dispatch_once_t once;
@@ -3922,6 +3968,7 @@ static void ApolloLPLogMetadataOnce(NSString *host, ApolloLinkPreview *preview, 
               (unsigned long)preview.title.length,
               (unsigned long)preview.desc.length);
 }
+#endif
 
 static NSString *ApolloLPVariant(ApolloLPArea area, NSInteger mode, ApolloLPContext context, BOOL placeholder) {
     NSString *areaName = (area == ApolloLPAreaComments) ? @"comments" : @"body";
@@ -4123,7 +4170,7 @@ static id ApolloLPNativeLinkSpecWithBannedHintIfNeeded(id linkButtonNode, NSURL 
                     objc_setAssociatedObject(strongSelf, &kApolloLinkPreviewFetchInFlightKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
                     if (preview) {
                         NSUInteger invalidated = ApolloLPInvalidateRegisteredLinkPreviewNodesForURL(url, @"cache-update-url");
-                        ApolloLog(@"[LinkPreviews] V16-cache-url-refresh host=%@ invalidated=%lu",
+                        ApolloLPVerboseLog(@"[LinkPreviews] V16-cache-url-refresh host=%@ invalidated=%lu",
                                   host ?: @"(nohost)",
                                   (unsigned long)invalidated);
                         if (invalidated == 0) {
@@ -4279,7 +4326,7 @@ static id ApolloLPNativeLinkSpecWithBannedHintIfNeeded(id linkButtonNode, NSURL 
     NSString *pendingHost = objc_getAssociatedObject(self, &kApolloLPPendingRowReloadHostKey);
     if (pendingHost) {
         objc_setAssociatedObject(self, &kApolloLPPendingRowReloadHostKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
-        ApolloLog(@"[LinkPreviews] V20-deferred-row-reload host=%@", pendingHost);
+        ApolloLPVerboseLog(@"[LinkPreviews] V20-deferred-row-reload host=%@", pendingHost);
         __weak ASDisplayNode *weakSelf = (ASDisplayNode *)self;
         // Let the cell finish attaching before resolving its index path.
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(50 * NSEC_PER_MSEC)), dispatch_get_main_queue(), ^{
@@ -4362,7 +4409,7 @@ static id ApolloLPNativeLinkSpecWithBannedHintIfNeeded(id linkButtonNode, NSURL 
         } else if ([reason isEqualToString:@"settings-change"] || [reason isEqualToString:@"mode-toggle"]) {
             ApolloLPScheduleTranslationLayoutRefreshForURL(nil);
         } else {
-            ApolloLog(@"[LinkPreviews] V15-translation-refresh-ignored reason=%@", reason ?: @"unknown");
+            ApolloLPVerboseLog(@"[LinkPreviews] V15-translation-refresh-ignored reason=%@", reason ?: @"unknown");
         }
     }];
 

--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -1192,7 +1192,7 @@ void ApolloThemeRuntimeInvalidate(void) {
 %hook UIFontDescriptor
 
 - (UIFontDescriptor *)fontDescriptorWithSymbolicTraits:(UIFontDescriptorSymbolicTraits)symbolicTraits {
-    if (sEnabled && sFontChoice == ApolloThemeFontRounded &&
+    if (sEnabled && CurrentFontChoice() == ApolloThemeFontRounded &&
         (symbolicTraits & UIFontDescriptorTraitItalic) &&
         !(self.symbolicTraits & UIFontDescriptorTraitItalic) &&
         [self.postscriptName localizedCaseInsensitiveContainsString:@"Rounded"] &&

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -4,6 +4,7 @@
 #import <objc/runtime.h>
 #import <objc/message.h>
 #include <dlfcn.h>
+#include <float.h>
 #include <string.h>
 
 #import "ApolloCommon.h"
@@ -80,6 +81,7 @@ static const CGFloat kApolloGlobeMergeSlotWidth = 34.0;
 // 44pt mod-badge slot's leading padding so the globe→badge gap looks even).
 static const CGFloat kApolloGlobeMergeGlyphNudge = 3.0;
 static const void *kApolloFeedSettledTitleRefreshScheduledKey = &kApolloFeedSettledTitleRefreshScheduledKey;
+static const void *kApolloPostTitleTranslationScheduledKey = &kApolloPostTitleTranslationScheduledKey;
 static const void *kApolloReapplyScheduledKey = &kApolloReapplyScheduledKey;
 // Phase C — post selftext translation.
 static const void *kApolloAppliedHeaderTranslationFullNameKey = &kApolloAppliedHeaderTranslationFullNameKey;
@@ -114,6 +116,14 @@ static const void *kApolloReconcileGenerationKey = &kApolloReconcileGenerationKe
 static NSString *const kApolloDefaultLibreTranslateURL = @"https://libretranslate.de/translate";
 
 static NSCache<NSString *, NSString *> *sTranslationCache;
+// Language recognition is CPU-heavy enough to show up while rows enter the
+// viewport. Cache both successful and inconclusive detections for the session.
+static NSCache<NSString *, NSString *> *sDetectedLanguageCache;
+static NSString *const kApolloNoDetectedLanguage = @"<none>";
+// Avoid immediately repeating provider setup/network work for the same text
+// after an expected transient failure. Bounded and cleared on lifecycle edges.
+static NSMutableDictionary<NSString *, NSDictionary *> *sTranslationFailureCooldowns;
+static const NSTimeInterval kApolloTranslationFailureRetryDelay = 15.0;
 // fullName ("t1_xxxxx") -> translated body text. Survives cell reuse / collapse.
 static NSCache<NSString *, NSString *> *sCommentTranslationByFullName;
 // fullName ("t3_xxxxx") -> translated post selftext. Same idea, for posts.
@@ -2699,7 +2709,18 @@ static NSString *ApolloDominantLanguageWithConfidence(NSString *text, double *ou
 }
 
 static NSString *ApolloDetectDominantLanguage(NSString *text) {
-    return ApolloDominantLanguageWithConfidence(text, NULL);
+    if (![text isKindOfClass:[NSString class]]) return nil;
+    NSString *trimmed = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (trimmed.length < 8) return nil;
+
+    NSString *cached = [sDetectedLanguageCache objectForKey:trimmed];
+    if (cached) {
+        return [cached isEqualToString:kApolloNoDetectedLanguage] ? nil : cached;
+    }
+
+    NSString *detected = ApolloDominantLanguageWithConfidence(trimmed, NULL);
+    [sDetectedLanguageCache setObject:(detected ?: kApolloNoDetectedLanguage) forKey:trimmed];
+    return detected;
 }
 
 // Returns YES if the user has asked us not to translate text in `detectedLang`.
@@ -2875,6 +2896,57 @@ static void ApolloTranslateTextWithFallback(NSString *text,
     });
 }
 
+static NSString *ApolloTranslationFailureCooldownKey(NSString *cacheKey) {
+    NSString *provider = sTranslationProvider.length > 0 ? sTranslationProvider : @"google";
+    return [NSString stringWithFormat:@"%@|%@", provider, cacheKey ?: @""];
+}
+
+static NSError *ApolloRecentTranslationFailure(NSString *cacheKey) {
+    if (cacheKey.length == 0 || !sTranslationFailureCooldowns) return nil;
+    NSString *failureKey = ApolloTranslationFailureCooldownKey(cacheKey);
+    NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
+    @synchronized (sTranslationFailureCooldowns) {
+        NSDictionary *record = sTranslationFailureCooldowns[failureKey];
+        NSNumber *timestamp = [record[@"timestamp"] isKindOfClass:[NSNumber class]] ? record[@"timestamp"] : nil;
+        NSError *error = [record[@"error"] isKindOfClass:[NSError class]] ? record[@"error"] : nil;
+        if (timestamp && error && now - timestamp.doubleValue < kApolloTranslationFailureRetryDelay) {
+            return error;
+        }
+        if (record) [sTranslationFailureCooldowns removeObjectForKey:failureKey];
+    }
+    return nil;
+}
+
+static void ApolloRecordTranslationFailure(NSString *cacheKey, NSError *error) {
+    if (cacheKey.length == 0 || !error || !sTranslationFailureCooldowns) return;
+    NSString *failureKey = ApolloTranslationFailureCooldownKey(cacheKey);
+    @synchronized (sTranslationFailureCooldowns) {
+        if (sTranslationFailureCooldowns.count >= 512 && !sTranslationFailureCooldowns[failureKey]) {
+            __block NSString *oldestKey = nil;
+            __block NSTimeInterval oldest = DBL_MAX;
+            [sTranslationFailureCooldowns enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSDictionary *record, BOOL *stop) {
+                (void)stop;
+                NSNumber *timestamp = [record[@"timestamp"] isKindOfClass:[NSNumber class]] ? record[@"timestamp"] : nil;
+                if (!timestamp || timestamp.doubleValue < oldest) {
+                    oldest = timestamp ? timestamp.doubleValue : 0.0;
+                    oldestKey = key;
+                }
+            }];
+            if (oldestKey) [sTranslationFailureCooldowns removeObjectForKey:oldestKey];
+        }
+        sTranslationFailureCooldowns[failureKey] = @{
+            @"timestamp": @([NSDate timeIntervalSinceReferenceDate]),
+            @"error": error,
+        };
+    }
+}
+
+static void ApolloClearTranslationFailureCooldowns(void) {
+    @synchronized (sTranslationFailureCooldowns) {
+        [sTranslationFailureCooldowns removeAllObjects];
+    }
+}
+
 static void ApolloRequestTranslation(NSString *cacheKey,
                                      NSString *sourceText,
                                      NSString *targetLanguage,
@@ -2882,6 +2954,12 @@ static void ApolloRequestTranslation(NSString *cacheKey,
     NSString *cached = [sTranslationCache objectForKey:cacheKey];
     if (cached.length > 0) {
         completion(cached, nil);
+        return;
+    }
+
+    NSError *recentFailure = ApolloRecentTranslationFailure(cacheKey);
+    if (recentFailure) {
+        completion(nil, recentFailure);
         return;
     }
 
@@ -2918,6 +2996,11 @@ static void ApolloRequestTranslation(NSString *cacheKey,
 
         if ([restoredTranslation isKindOfClass:[NSString class]] && restoredTranslation.length > 0) {
             [sTranslationCache setObject:restoredTranslation forKey:cacheKey];
+            @synchronized (sTranslationFailureCooldowns) {
+                [sTranslationFailureCooldowns removeObjectForKey:ApolloTranslationFailureCooldownKey(cacheKey)];
+            }
+        } else if (error) {
+            ApolloRecordTranslationFailure(cacheKey, error);
         }
 
         for (id callbackObj in callbacks) {
@@ -6578,27 +6661,48 @@ static void ApolloMaybeTranslateFeedPostBodyNode(id feedCellNode, id excludeTitl
     });
 }
 
+// didLoad, preload, and display commonly arrive in the same main-queue turn.
+// Keep all three recovery hooks, but collapse them into one title/body scan so
+// a newly visible row does not traverse its node tree three times.
+static void ApolloSchedulePostTitleTranslation(id titleNode) {
+    if (!titleNode || !sEnableBulkTranslation || !sTranslatePostTitles) return;
+    @synchronized (titleNode) {
+        if ([objc_getAssociatedObject(titleNode, kApolloPostTitleTranslationScheduledKey) boolValue]) return;
+        objc_setAssociatedObject(titleNode,
+                                 kApolloPostTitleTranslationScheduledKey,
+                                 @YES,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    __weak id weakTitleNode = titleNode;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        id strongTitleNode = weakTitleNode;
+        if (!strongTitleNode) return;
+        @synchronized (strongTitleNode) {
+            objc_setAssociatedObject(strongTitleNode,
+                                     kApolloPostTitleTranslationScheduledKey,
+                                     nil,
+                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+        ApolloMaybeTranslatePostTitleNode(strongTitleNode);
+    });
+}
+
 %hook _TtC6Apollo13PostTitleNode
 
 - (void)didLoad {
     %orig;
-    if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
-    __weak id weakSelf = self;
-    dispatch_async(dispatch_get_main_queue(), ^{ ApolloMaybeTranslatePostTitleNode(weakSelf); });
+    ApolloSchedulePostTitleTranslation(self);
 }
 
 - (void)didEnterPreloadState {
     %orig;
-    if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
-    __weak id weakSelf = self;
-    dispatch_async(dispatch_get_main_queue(), ^{ ApolloMaybeTranslatePostTitleNode(weakSelf); });
+    ApolloSchedulePostTitleTranslation(self);
 }
 
 - (void)didEnterDisplayState {
     %orig;
-    if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
-    __weak id weakSelf = self;
-    dispatch_async(dispatch_get_main_queue(), ^{ ApolloMaybeTranslatePostTitleNode(weakSelf); });
+    ApolloSchedulePostTitleTranslation(self);
 }
 
 %end
@@ -6622,23 +6726,17 @@ static void ApolloMaybeTranslateFeedPostBodyNode(id feedCellNode, id excludeTitl
 
 - (void)didLoad {
     %orig;
-    if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
-    __weak id weakSelf = self;
-    dispatch_async(dispatch_get_main_queue(), ^{ ApolloMaybeTranslatePostTitleNode(weakSelf); });
+    ApolloSchedulePostTitleTranslation(self);
 }
 
 - (void)didEnterPreloadState {
     %orig;
-    if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
-    __weak id weakSelf = self;
-    dispatch_async(dispatch_get_main_queue(), ^{ ApolloMaybeTranslatePostTitleNode(weakSelf); });
+    ApolloSchedulePostTitleTranslation(self);
 }
 
 - (void)didEnterDisplayState {
     %orig;
-    if (!sEnableBulkTranslation || !sTranslatePostTitles) return;
-    __weak id weakSelf = self;
-    dispatch_async(dispatch_get_main_queue(), ^{ ApolloMaybeTranslatePostTitleNode(weakSelf); });
+    ApolloSchedulePostTitleTranslation(self);
 }
 
 %end
@@ -7462,6 +7560,9 @@ static void ApolloDbgOpenFirstPost(CFNotificationCenterRef c, void *o, CFStringR
 
 %ctor {
     sTranslationCache = [NSCache new];
+    sDetectedLanguageCache = [NSCache new];
+    sDetectedLanguageCache.countLimit = 2048;
+    sTranslationFailureCooldowns = [NSMutableDictionary dictionary];
     sCommentTranslationByFullName = [NSCache new];
     sCommentTranslationByFullName.countLimit = 2048;
     sLinkTranslationByFullName = [NSCache new];
@@ -7550,6 +7651,8 @@ static void ApolloDbgOpenFirstPost(CFNotificationCenterRef c, void *o, CFStringR
                                                        queue:[NSOperationQueue mainQueue]
                                                   usingBlock:^(__unused NSNotification *note) {
         [sTranslationCache removeAllObjects];
+        [sDetectedLanguageCache removeAllObjects];
+        ApolloClearTranslationFailureCooldowns();
     }];
 
     // App lifecycle: snapshot caches when going to background; re-apply the
@@ -7564,6 +7667,8 @@ static void ApolloDbgOpenFirstPost(CFNotificationCenterRef c, void *o, CFStringR
                                                       object:nil
                                                        queue:[NSOperationQueue mainQueue]
                                                   usingBlock:^(__unused NSNotification *note) {
+        // Language packs or network state may have changed in the background.
+        ApolloClearTranslationFailureCooldowns();
         ApolloReapplyTranslationOnAppResume();
         [[NSNotificationCenter defaultCenter] postNotificationName:ApolloRichPreviewTranslationDidUpdateNotification
                                                             object:nil
@@ -7573,6 +7678,7 @@ static void ApolloDbgOpenFirstPost(CFNotificationCenterRef c, void *o, CFStringR
                                                       object:nil
                                                        queue:[NSOperationQueue mainQueue]
                                                   usingBlock:^(__unused NSNotification *note) {
+        ApolloClearTranslationFailureCooldowns();
         ApolloReapplyTranslationOnAppResume();
         [[NSNotificationCenter defaultCenter] postNotificationName:ApolloRichPreviewTranslationDidUpdateNotification
                                                             object:nil
@@ -7587,6 +7693,8 @@ static void ApolloDbgOpenFirstPost(CFNotificationCenterRef c, void *o, CFStringR
                                                        queue:[NSOperationQueue mainQueue]
                                                   usingBlock:^(__unused NSNotification *note) {
         [sTranslationCache removeAllObjects];
+        [sDetectedLanguageCache removeAllObjects];
+        ApolloClearTranslationFailureCooldowns();
         [sCommentTranslationByFullName removeAllObjects];
         [sLinkTranslationByFullName removeAllObjects];
         @synchronized (sLoggedSkippedCommentFullNames) {


### PR DESCRIPTION
## Summary

- cache positive and negative Natural Language detections used while feed rows enter the viewport
- coalesce the `didLoad` / preload / display callbacks for post titles into one translation/body scan per main-queue turn
- add a bounded 15-second cooldown for repeated translation-provider failures, cleared when lifecycle or language settings make a retry useful
- compile verbose Link Preview and Flair diagnostics out by default, including diagnostic-only string formatting, ancestry walks, counters, and face-scan timing
- retain real Link Preview error logs and all existing rendering, translation, flair, and recovery behavior

## Why

A supplied 60 fps screen recording contained an approximately 100 ms motion freeze while scrolling. The matching `apollofix` log interval contained a burst of Link Preview layout messages. The larger log capture also showed translation discovery/retry work repeatedly entering through all three Texture title lifecycle callbacks as rows appeared.

This keeps those recovery hooks and features intact while removing duplicate work from the scrolling hot path.

## Validation

- reproduced and quantified the pause from the supplied recording and correlated it with the supplied logs
- tested the full main + open-PR integration with PR #633 removed, Liquid Glass enabled, and repeated simulator feed swipes
- the post-change stress recording had continuous motion through the equivalent scrolling interval and no matching 100 ms freeze
- Link Preview diagnostics dropped from 115 entries in the earlier stress window to startup/error-level entries
- smoke-tested feed navigation, translations, link cards, flair, avatars, media, settings, and Liquid Glass
- clean current-main branch completed a full simulator link
- `make package FINALPACKAGE=1` completed successfully and produced the device `.deb`
- includes the one-line `sFontChoice` → `CurrentFontChoice()` correction required after #651 introduced per-mode font storage; without it current `main` and this PR both fail to compile
- `git diff --check` passes
