### PR TITLE
Fix crash deleting a Recently Read post with NSFW filter on

### DIFF
--- a/src/ApolloRecentlyRead.xm
+++ b/src/ApolloRecentlyRead.xm
@@ -1017,9 +1017,10 @@ static UIImage *RecentlyReadNSFWBadgeImage(CGFloat fontSize) {
     }
     self.allPostFullNames = allNames;
 
-    // Remove from data arrays
+    // Keep in sync with the activePosts getter's condition, or the table's
+    // row count won't actually shrink and deleteRowsAtIndexPaths: below crashes.
     [self.posts removeObject:link];
-    if ([self isSearchActive]) {
+    if ([self isSearchActive] || [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyFilterNSFWRecentlyRead]) {
         [self.filteredPosts removeObject:link];
     }
 


### PR DESCRIPTION
## Summary
- Fixes a crash when swipe-deleting a post from the Recently Read list while **Filter NSFW** is enabled (and search is not active).
- `activePosts` (which backs the table's row count) switches to `filteredPosts` whenever search **or** the NSFW filter is active, but `_deletePostAtIndexPath:` only kept `filteredPosts` in sync during search. With the filter on but not searching, the table's row count never actually shrank after `deleteRowsAtIndexPaths:`, so UIKit aborted with `Invalid Number Of Rows In Section`.

## Test plan
- [x] Reproduced on-device from a user-submitted crash log (`NSInternalInconsistencyException` / `Invalid Number Of Rows In Section` inside `UIContextualAction` → `_deletePostAtIndexPath:` → `deleteRowsAtIndexPaths:`).
- [x] Verified in the iOS Simulator: enabled `FilterNSFWRecentlyRead`, swiped to delete a Recently Read row — row deletes cleanly, no crash, app stays running.