### PR TITLE
Speed up full Community Highlights loading

### DIFF
--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -57,14 +57,15 @@ extern BOOL sUseProfileAvatarTabIcon;
 // registerDefaults. See ApolloUserAvatars.xm and ApolloProfileSocialLinks.{h,m}.
 extern BOOL sShowDetailedProfiles;
 extern BOOL sShowSubredditHeaders;
-// When ON, a horizontally-scrolling "Community Highlights" carousel of the
-// subreddit's pinned/stickied posts is shown at the top of the feed (mirrors
-// new-Reddit / the official app). See ApolloSubredditHighlights.xm.
+// Backing booleans for the single Community Highlights mode picker:
+//   Off     = both NO
+//   Partial = sCommunityHighlights YES, sCommunityHighlightsWeb NO
+//   Full    = both YES
+// Kept as booleans so existing preferences/backups migrate without conversion.
+// The carousel shows the subreddit's pinned posts at the top of the feed.
 extern BOOL sCommunityHighlights;
-// When ON (and sCommunityHighlights ON), a hidden WKWebView loads the subreddit's
-// new-Reddit page to harvest the FULL highlights set (up to 6), beyond the 2 the
-// REST API exposes. Heavier (loads the web page per sub); opt-in. See
-// ApolloSubredditHighlights.xm (ApolloHLWebFetch).
+// Full mode uses a hidden WKWebView to harvest up to 6 highlights beyond the 2
+// Reddit's REST API exposes. See ApolloSubredditHighlights.xm (ApolloHLWebFetch).
 extern BOOL sCommunityHighlightsWeb;
 extern BOOL sAutoHideTabBarShowOnIdle;
 // Which side the iOS 26 minimized (Liquid Glass) tab bar pill docks on:

--- a/src/ApolloSubredditHighlights.xm
+++ b/src/ApolloSubredditHighlights.xm
@@ -21,8 +21,8 @@
 // it is OFF the slot is free and we own it with zero conflict. Coexistence with
 // that feature (both ON) is handled separately; here we defer to it.
 //
-// Gated behind sCommunityHighlights (Settings → Subreddits → Community
-// Highlights).
+// Gated behind the Settings → Subreddits → Community Highlights mode: Off
+// disables it, Partial uses only the REST result, and Full adds the web upgrade.
 
 #import <UIKit/UIKit.h>
 #import <WebKit/WebKit.h>
@@ -258,6 +258,14 @@ static NSMutableDictionary<NSString *, NSArray<ApolloHLItem *> *> *ApolloHLCache
     dispatch_once(&once, ^{ cache = [NSMutableDictionary dictionary]; });
     return cache;
 }
+// The displayed cache can be upgraded to the full web set. Keep the latest pure
+// REST result separately so changing the setting from Full to Partial can remove
+// the extra cards immediately without another request or app restart.
+static NSMutableDictionary<NSString *, NSArray<ApolloHLItem *> *> *ApolloHLRestCache(void) {
+    static NSMutableDictionary *cache; static dispatch_once_t once;
+    dispatch_once(&once, ^{ cache = [NSMutableDictionary dictionary]; });
+    return cache;
+}
 static NSMutableSet<NSString *> *ApolloHLInFlight(void) {
     static NSMutableSet *set; static dispatch_once_t once;
     dispatch_once(&once, ^{ set = [NSMutableSet set]; });
@@ -481,7 +489,8 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
 // new-Reddit subreddit page (logged out — highlights are public), waits for the
 // challenge to clear + the carousel to render, then scrapes title/permalink/
 // thumbnail from the DOM. Calls `done` on the main queue (empty array on
-// fail/timeout). Heavy — callers must cache + gate behind sCommunityHighlightsWeb.
+// fail/timeout). Used only by the Full setting; callers cache the result and gate
+// it behind sCommunityHighlightsWeb.
 @interface ApolloHLWebFetch : NSObject <WKNavigationDelegate>
 @property (nonatomic, strong) WKWebView *web;
 @property (nonatomic, copy) NSString *sub;
@@ -624,6 +633,16 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
     void (^d)(NSArray *) = self.done; self.done = nil;
     if (d) d(items ?: @[]);
 }
+- (void)cancel {
+    self.done = nil;
+    if (self.web) {
+        self.web.navigationDelegate = nil;
+        [self.web stopLoading];
+        [self.web removeFromSuperview];
+        self.web = nil;
+    }
+    self.pollScheduled = NO; self.evaluationInFlight = NO; self.startedAt = nil; self.bestItems = nil;
+}
 - (void)webView:(WKWebView *)wv didFinishNavigation:(WKNavigation *)nav {
     // On a warm WebKit process the full carousel is often present immediately.
     // Probe now instead of waiting for the fallback timer; if Reddit still has
@@ -683,12 +702,13 @@ static void ApolloHLFetchHighlights(NSString *subredditName, BOOL force, void (^
                 // If it wins the race and has already installed the full set, do not
                 // let this slower REST response downgrade the cache/carousel to two.
                 NSArray<ApolloHLItem *> *displayed = ApolloHLCache()[key];
-                if (!displayed || displayed.count <= items.count) ApolloHLCache()[key] = items;
+                if (!displayed || !sCommunityHighlightsWeb || displayed.count <= items.count) ApolloHLCache()[key] = items;
                 completionItems = ApolloHLCache()[key] ?: items;
             }
             // Record the inline-sticky count (REST only) for the breaker rule + the
             // freshness timestamp/signature for the stale-while-revalidate re-poll.
             if (status == 200) {
+                ApolloHLRestCache()[key] = items;
                 ApolloHLStickyCount()[key] = @(items.count);
                 ApolloHLFetchTime()[key] = [NSDate date];
                 ApolloHLRestSig()[key] = ApolloHLItemsContentSig(items);
@@ -1586,8 +1606,11 @@ static void ApolloHLMaybeWebUpgrade(NSString *subreddit) {
     ApolloHLWebFetchers()[sub] = fetch;
     [fetch startForSub:sub completion:^(NSArray<ApolloHLItem *> *items) {
         [ApolloHLWebFetchers() removeObjectForKey:sub];
+        // The user may have changed Full to Partial/Off while WebKit was still
+        // rendering. Never let that stale completion restore the full set.
+        if (!sCommunityHighlights || !sCommunityHighlightsWeb) return;
         [ApolloHLWebDone() addObject:sub];
-        NSArray<ApolloHLItem *> *apiItems = ApolloHLCache()[sub];
+        NSArray<ApolloHLItem *> *apiItems = ApolloHLRestCache()[sub] ?: ApolloHLCache()[sub];
         if (items.count == 0) return; // web found nothing
 
         // The DOM already has the authoritative order, titles, and links. Merge
@@ -1608,6 +1631,7 @@ static void ApolloHLMaybeWebUpgrade(NSString *subreddit) {
         // presentation-signature change rebuilds the cards, while an identical
         // response is a no-op and cannot cause a visible flash.
         ApolloHLEnrichViaInfo(items, apiItems, ^(NSArray<ApolloHLItem *> *enriched) {
+            if (!sCommunityHighlights || !sCommunityHighlightsWeb) return;
             BOOL metadataChanged = ![ApolloHLItemsPresentationSig(enriched) isEqualToString:preEnrichmentSig];
             NSArray<ApolloHLItem *> *shown = ApolloHLCache()[sub];
             BOOL setChanged = ![ApolloHLItemsContentSig(enriched) isEqualToString:ApolloHLItemsContentSig(shown)];
@@ -2200,9 +2224,56 @@ static void ApolloHLCollapseOrphanSeparators(UIViewController *vc) {
                                                       object:nil
                                                        queue:[NSOperationQueue mainQueue]
                                                   usingBlock:^(__unused NSNotification *note) {
-        // Install/teardown + re-layout every feed controller so the carousel and
-        // the inline de-dup both update live (cells already laid out under the old
-        // state need a reload to collapse/restore).
+        NSMutableSet<NSString *> *visibleSubs = [NSMutableSet set];
+        ApolloHLForEachPostsVC(^(UIViewController *postsVC) {
+            NSString *sub = ApolloHLSubredditName(postsVC);
+            if (sub.length) [visibleSubs addObject:sub];
+        });
+
+        if (!sCommunityHighlightsWeb) {
+            // Partial and Off must stop a Full-mode scrape already in progress.
+            // cancel deliberately drops its completion so it cannot repopulate
+            // the carousel after the mode changed.
+            NSArray<ApolloHLWebFetch *> *fetches = ApolloHLWebFetchers().allValues;
+            [ApolloHLWebFetchers() removeAllObjects];
+            for (ApolloHLWebFetch *fetch in fetches) [fetch cancel];
+            [ApolloHLWebDone() removeAllObjects];
+        } else {
+            // Full selected after Partial: allow each visible subreddit to run a
+            // fresh web upgrade even if it completed earlier in this app session.
+            for (NSString *sub in visibleSubs) [ApolloHLWebDone() removeObject:sub];
+        }
+
+        if (sCommunityHighlights && !sCommunityHighlightsWeb) {
+            // Downgrade a live Full carousel to the saved REST-only set at once.
+            // Every Full load begins with the same REST request Partial uses.
+            for (NSString *sub in visibleSubs) {
+                NSArray<ApolloHLItem *> *restItems = ApolloHLRestCache()[sub];
+                if (restItems) {
+                    ApolloHLCache()[sub] = restItems;
+                    if (restItems.count > 0) ApolloHLApplyItems(sub, restItems);
+                    else ApolloHLClearDeDup(sub);
+                    continue;
+                }
+
+                // An extremely early change can beat the first REST response.
+                // Force one if needed; the in-flight guard prevents duplicates.
+                ApolloHLFetchHighlights(sub, YES, ^(NSArray<ApolloHLItem *> *freshREST) {
+                    if (!freshREST || !sCommunityHighlights || sCommunityHighlightsWeb) return;
+                    ApolloHLCache()[sub] = freshREST;
+                    if (freshREST.count > 0) ApolloHLApplyItems(sub, freshREST);
+                    else ApolloHLClearDeDup(sub);
+                    ApolloHLForEachPostsVC(^(UIViewController *liveVC) {
+                        if (![ApolloHLSubredditName(liveVC) isEqualToString:sub]) return;
+                        ApolloHLInstall(liveVC);
+                        ApolloHLReloadFeed(liveVC);
+                    });
+                });
+            }
+        }
+
+        // Install/teardown + re-layout every feed controller so all three modes
+        // apply live (cells laid out under the old mode need remeasurement too).
         ApolloHLForEachPostsVC(^(UIViewController *postsVC) {
             ApolloHLInstall(postsVC);
             ApolloHLReloadFeed(postsVC);

--- a/src/ApolloSubredditHighlights.xm
+++ b/src/ApolloSubredditHighlights.xm
@@ -500,6 +500,10 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
 @property (nonatomic, strong) NSArray<ApolloHLItem *> *bestItems;
 @property (nonatomic) BOOL pollScheduled;
 @property (nonatomic) BOOL evaluationInFlight;
+// Reddit can hydrate a larger carousel progressively. Once a probe first sees
+// more than the REST-sized two cards, take one confirming probe before finishing
+// so bestItems can grow to the complete set without restoring the old 3s delay.
+@property (nonatomic) BOOL awaitingLargeSetConfirmation;
 @end
 @implementation ApolloHLWebFetch
 
@@ -535,6 +539,7 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
 - (void)startForSub:(NSString *)sub completion:(void (^)(NSArray<ApolloHLItem *> *))done {
     self.sub = sub; self.done = done; self.polls = 0;
     self.startedAt = [NSDate date]; self.bestItems = nil; self.pollScheduled = NO; self.evaluationInFlight = NO;
+    self.awaitingLargeSetConfirmation = NO;
     UIWindow *win = nil;
     for (UIScene *s in UIApplication.sharedApplication.connectedScenes) {
         if (![s isKindOfClass:[UIWindowScene class]]) continue;
@@ -593,7 +598,12 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
         NSArray<ApolloHLItem *> *items = [ApolloHLWebFetch parseItems:res];
         if (items.count > ss.bestItems.count) ss.bestItems = items;
         NSTimeInterval now = ss.startedAt ? -ss.startedAt.timeIntervalSinceNow : 0.0;
-        if (ss.bestItems.count > 2 || (ss.bestItems.count > 0 && now >= kApolloHLWebSmallSetSettleDelay)) {
+        if (ss.bestItems.count > 2 && !ss.awaitingLargeSetConfirmation && now < kApolloHLWebTimeout) {
+            ss.awaitingLargeSetConfirmation = YES;
+            ApolloLog(@"[Highlights][web] r/%@ found %lu highlights in %.2fs; confirming once for progressive hydration",
+                      ss.sub, (unsigned long)ss.bestItems.count, now);
+            [ss pollAfter:kApolloHLWebPollInterval];
+        } else if (ss.bestItems.count > 2 || (ss.bestItems.count > 0 && now >= kApolloHLWebSmallSetSettleDelay)) {
             ApolloLog(@"[Highlights][web] r/%@ extracted %lu highlights in %.2fs (probe#%d)", ss.sub, (unsigned long)ss.bestItems.count, now, ss.polls);
             [ss finish:ss.bestItems];
         } else if (now >= kApolloHLWebTimeout) {
@@ -629,7 +639,8 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
 }
 - (void)finish:(NSArray<ApolloHLItem *> *)items {
     if (self.web) { self.web.navigationDelegate = nil; [self.web removeFromSuperview]; self.web = nil; }
-    self.pollScheduled = NO; self.evaluationInFlight = NO; self.startedAt = nil; self.bestItems = nil;
+    self.pollScheduled = NO; self.evaluationInFlight = NO; self.awaitingLargeSetConfirmation = NO;
+    self.startedAt = nil; self.bestItems = nil;
     void (^d)(NSArray *) = self.done; self.done = nil;
     if (d) d(items ?: @[]);
 }
@@ -641,7 +652,8 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
         [self.web removeFromSuperview];
         self.web = nil;
     }
-    self.pollScheduled = NO; self.evaluationInFlight = NO; self.startedAt = nil; self.bestItems = nil;
+    self.pollScheduled = NO; self.evaluationInFlight = NO; self.awaitingLargeSetConfirmation = NO;
+    self.startedAt = nil; self.bestItems = nil;
 }
 - (void)webView:(WKWebView *)wv didFinishNavigation:(WKNavigation *)nav {
     // On a warm WebKit process the full carousel is often present immediately.
@@ -2245,12 +2257,20 @@ static void ApolloHLCollapseOrphanSeparators(UIViewController *vc) {
         }
 
         if (sCommunityHighlights && !sCommunityHighlightsWeb) {
-            // Downgrade a live Full carousel to the saved REST-only set at once.
-            // Every Full load begins with the same REST request Partial uses.
+            // The display cache outlives its feed controller. Reset every cached
+            // subreddit, not just the currently visible ones, so revisiting a sub
+            // after Full → Partial cannot reinstall its session-old web set.
+            for (NSString *sub in ApolloHLCache().allKeys) {
+                NSArray<ApolloHLItem *> *restItems = ApolloHLRestCache()[sub];
+                if (restItems) ApolloHLCache()[sub] = restItems;
+                else [ApolloHLCache() removeObjectForKey:sub];
+            }
+
+            // Apply/fetch only for live feeds. Every Full load begins with the
+            // same REST request Partial uses, so most visible subs update at once.
             for (NSString *sub in visibleSubs) {
                 NSArray<ApolloHLItem *> *restItems = ApolloHLRestCache()[sub];
                 if (restItems) {
-                    ApolloHLCache()[sub] = restItems;
                     if (restItems.count > 0) ApolloHLApplyItems(sub, restItems);
                     else ApolloHLClearDeDup(sub);
                     continue;
@@ -2260,9 +2280,15 @@ static void ApolloHLCollapseOrphanSeparators(UIViewController *vc) {
                 // Force one if needed; the in-flight guard prevents duplicates.
                 ApolloHLFetchHighlights(sub, YES, ^(NSArray<ApolloHLItem *> *freshREST) {
                     if (!freshREST || !sCommunityHighlights || sCommunityHighlightsWeb) return;
-                    ApolloHLCache()[sub] = freshREST;
-                    if (freshREST.count > 0) ApolloHLApplyItems(sub, freshREST);
-                    else ApolloHLClearDeDup(sub);
+                    // Preserve the fetcher's failure semantics: an empty result
+                    // stays uncached so a transient error can retry later instead
+                    // of becoming a session-long "nothing pinned" negative cache.
+                    if (freshREST.count > 0) {
+                        ApolloHLCache()[sub] = freshREST;
+                        ApolloHLApplyItems(sub, freshREST);
+                    } else {
+                        ApolloHLClearDeDup(sub);
+                    }
                     ApolloHLForEachPostsVC(^(UIViewController *liveVC) {
                         if (![ApolloHLSubredditName(liveVC) isEqualToString:sub]) return;
                         ApolloHLInstall(liveVC);

--- a/src/ApolloSubredditHighlights.xm
+++ b/src/ApolloSubredditHighlights.xm
@@ -74,6 +74,19 @@ static CGFloat const kApolloHLTopPadding = 6.0;
 // room. Mirrors the carousel's top padding for symmetry.
 static CGFloat const kApolloHLBottomPadding = 6.0;
 static NSInteger const kApolloHLFetchLimit = 15;
+// The full set comes from a rendered Reddit page, but there is no reason to leave
+// the rendered DOM sitting idle for a fixed three seconds before looking at it.
+// Probe as soon as navigation finishes (plus this short fallback timer for pages
+// whose navigation delegate callback races their client-side render), then poll
+// cheaply until the same overall timeout the old 3s + 8x2s loop allowed.
+static NSTimeInterval const kApolloHLWebInitialPollDelay = 0.20;
+static NSTimeInterval const kApolloHLWebPollInterval = 0.50;
+// A just-finished page can briefly expose only its first couple of cards before
+// the client render fills the carousel. More than two proves the upgrade is ready;
+// for a genuinely small set, keep the old three-second settling window so an early
+// partial DOM can never make us miss later cards.
+static NSTimeInterval const kApolloHLWebSmallSetSettleDelay = 3.0;
+static NSTimeInterval const kApolloHLWebTimeout = 18.0;
 // Freshness window: a cached carousel is reused as-is for this long. Returning to a
 // subreddit after the window elapses kicks a quiet background re-poll (stale-while-
 // revalidate) that rebuilds ONLY if the pinned set actually changed. Keeps navigation
@@ -474,6 +487,10 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
 @property (nonatomic, copy) NSString *sub;
 @property (nonatomic, copy) void (^done)(NSArray<ApolloHLItem *> *items);
 @property (nonatomic) int polls;
+@property (nonatomic, strong) NSDate *startedAt;
+@property (nonatomic, strong) NSArray<ApolloHLItem *> *bestItems;
+@property (nonatomic) BOOL pollScheduled;
+@property (nonatomic) BOOL evaluationInFlight;
 @end
 @implementation ApolloHLWebFetch
 
@@ -508,6 +525,7 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
 
 - (void)startForSub:(NSString *)sub completion:(void (^)(NSArray<ApolloHLItem *> *))done {
     self.sub = sub; self.done = done; self.polls = 0;
+    self.startedAt = [NSDate date]; self.bestItems = nil; self.pollScheduled = NO; self.evaluationInFlight = NO;
     UIWindow *win = nil;
     for (UIScene *s in UIApplication.sharedApplication.connectedScenes) {
         if (![s isKindOfClass:[UIWindowScene class]]) continue;
@@ -523,14 +541,29 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
     [win insertSubview:self.web atIndex:0];
     [self.web loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://www.reddit.com/r/%@/", sub]]]];
     ApolloLog(@"[Highlights][web] loading r/%@ for full highlights", sub);
-    [self pollAfter:3.0];
+    [self pollAfter:kApolloHLWebInitialPollDelay];
 }
 - (void)pollAfter:(double)delay {
+    // didFinishNavigation and the fallback timer can both ask for a probe. Keep
+    // exactly one scheduled probe and one evaluateJavaScript call at a time so
+    // faster polling never stacks work in WebKit.
+    if (!self.web || self.pollScheduled) return;
+    self.pollScheduled = YES;
     __weak typeof(self) ws = self;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay*NSEC_PER_SEC)), dispatch_get_main_queue(), ^{ [ws poll]; });
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay*NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        ws.pollScheduled = NO;
+        [ws poll];
+    });
 }
 - (void)poll {
-    if (!self.web) return;
+    if (!self.web || self.evaluationInFlight) return;
+    NSTimeInterval elapsed = self.startedAt ? -self.startedAt.timeIntervalSinceNow : 0.0;
+    if (elapsed >= kApolloHLWebTimeout) {
+        ApolloLog(@"[Highlights][web] r/%@ timed out after %.1fs (%d probes)", self.sub, elapsed, self.polls);
+        [self finish:self.bestItems ?: @[]];
+        return;
+    }
+    self.evaluationInFlight = YES;
     self.polls++;
     NSString *js = @"(function(){"
         "var all=document.querySelectorAll('*'),heading=null;"
@@ -544,10 +577,22 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
         "return JSON.stringify({n:out.length,items:out});})()";
     __weak typeof(self) ws = self;
     [self.web evaluateJavaScript:js completionHandler:^(id res, NSError *e) {
+        ApolloHLWebFetch *ss = ws;
+        if (!ss) return;
+        ss.evaluationInFlight = NO;
+        if (!ss.web) return;
         NSArray<ApolloHLItem *> *items = [ApolloHLWebFetch parseItems:res];
-        if (items.count > 0) { ApolloLog(@"[Highlights][web] r/%@ extracted %lu highlights (poll#%d)", ws.sub, (unsigned long)items.count, ws.polls); [ws finish:items]; }
-        else if (ws.polls >= 8) { ApolloLog(@"[Highlights][web] r/%@ timed out", ws.sub); [ws finish:@[]]; }
-        else [ws pollAfter:2.0];
+        if (items.count > ss.bestItems.count) ss.bestItems = items;
+        NSTimeInterval now = ss.startedAt ? -ss.startedAt.timeIntervalSinceNow : 0.0;
+        if (ss.bestItems.count > 2 || (ss.bestItems.count > 0 && now >= kApolloHLWebSmallSetSettleDelay)) {
+            ApolloLog(@"[Highlights][web] r/%@ extracted %lu highlights in %.2fs (probe#%d)", ss.sub, (unsigned long)ss.bestItems.count, now, ss.polls);
+            [ss finish:ss.bestItems];
+        } else if (now >= kApolloHLWebTimeout) {
+            ApolloLog(@"[Highlights][web] r/%@ timed out after %.1fs (%d probes, last error=%@)", ss.sub, now, ss.polls, e.localizedDescription ?: @"nil");
+            [ss finish:ss.bestItems ?: @[]];
+        } else {
+            [ss pollAfter:kApolloHLWebPollInterval];
+        }
     }];
 }
 + (NSArray<ApolloHLItem *> *)parseItems:(id)res {
@@ -575,10 +620,16 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
 }
 - (void)finish:(NSArray<ApolloHLItem *> *)items {
     if (self.web) { self.web.navigationDelegate = nil; [self.web removeFromSuperview]; self.web = nil; }
+    self.pollScheduled = NO; self.evaluationInFlight = NO; self.startedAt = nil; self.bestItems = nil;
     void (^d)(NSArray *) = self.done; self.done = nil;
     if (d) d(items ?: @[]);
 }
-- (void)webView:(WKWebView *)wv didFinishNavigation:(WKNavigation *)nav {}
+- (void)webView:(WKWebView *)wv didFinishNavigation:(WKNavigation *)nav {
+    // On a warm WebKit process the full carousel is often present immediately.
+    // Probe now instead of waiting for the fallback timer; if Reddit still has
+    // client-side work to do, the regular poll loop continues unchanged.
+    if (wv == self.web) [self poll];
+}
 @end
 
 static NSString *ApolloHLItemsContentSig(NSArray<ApolloHLItem *> *items); // defined with ApolloHLSignature
@@ -626,7 +677,15 @@ static void ApolloHLFetchHighlights(NSString *subredditName, BOOL force, void (^
             // re-poll) must NOT overwrite it — the cache holds the possibly web-upgraded
             // set on display; the refresh caller rebuilds via ApplyItems only on a real
             // change, so a failed web re-run can't silently downgrade the carousel.
-            if (!force && (status == 200 || items.count > 0)) ApolloHLCache()[key] = items;
+            NSArray<ApolloHLItem *> *completionItems = items;
+            if (!force && (status == 200 || items.count > 0)) {
+                // The web page can now finish very quickly on a warm WebKit process.
+                // If it wins the race and has already installed the full set, do not
+                // let this slower REST response downgrade the cache/carousel to two.
+                NSArray<ApolloHLItem *> *displayed = ApolloHLCache()[key];
+                if (!displayed || displayed.count <= items.count) ApolloHLCache()[key] = items;
+                completionItems = ApolloHLCache()[key] ?: items;
+            }
             // Record the inline-sticky count (REST only) for the breaker rule + the
             // freshness timestamp/signature for the stale-while-revalidate re-poll.
             if (status == 200) {
@@ -634,7 +693,7 @@ static void ApolloHLFetchHighlights(NSString *subredditName, BOOL force, void (^
                 ApolloHLFetchTime()[key] = [NSDate date];
                 ApolloHLRestSig()[key] = ApolloHLItemsContentSig(items);
             }
-            if (completion) completion(items);
+            if (completion) completion(completionItems);
         });
     }] resume];
 }
@@ -976,13 +1035,29 @@ static void ApolloHLToggleCollapsed(NSString *sub); // fwd (defined after ApplyI
 }
 @end
 
+// Presentation signature includes metadata as well as post identity. The fast web
+// path intentionally paints titles/links before /api/info enrichment returns; once
+// thumbnails/flair/comment counts arrive, this signature makes the second ApplyItems
+// call rebuild those same cards with their richer presentation.
+static NSString *ApolloHLItemsPresentationSig(NSArray<ApolloHLItem *> *items) {
+    NSMutableArray<NSString *> *parts = [NSMutableArray array];
+    for (ApolloHLItem *it in items) {
+        [parts addObject:[NSString stringWithFormat:@"%@\x1F%@\x1F%@\x1F%@\x1F%lld\x1F%d",
+                          it.fullName ?: it.permalink ?: @"?",
+                          it.title ?: @"",
+                          it.thumbnailURL.absoluteString ?: @"",
+                          it.flairText ?: @"",
+                          it.numComments,
+                          it.isSpoiler]];
+    }
+    return [parts componentsJoinedByString:@"\x1E"];
+}
+
 // A stable signature for a set of items PLUS the collapse state, so we rebuild
-// when either the content or the collapsed/expanded state changes.
+// when either the content, its presentation metadata, or collapsed state changes.
 static NSString *ApolloHLSignature(NSString *sub, NSArray<ApolloHLItem *> *items) {
-    NSMutableArray *ids = [NSMutableArray array];
-    for (ApolloHLItem *it in items) [ids addObject:(it.fullName ?: it.permalink ?: @"?")];
     NSString *state = ApolloHLIsCollapsed(sub) ? @"C|" : @"E|";
-    return [state stringByAppendingString:[ids componentsJoinedByString:@"|"]];
+    return [state stringByAppendingString:ApolloHLItemsPresentationSig(items)];
 }
 
 // Content-only signature (no collapse-state prefix) used to detect when a subreddit's
@@ -1446,34 +1521,40 @@ static void ApolloHLToggleCollapsed(NSString *sub) {
 // reliable source that gives the first 2 their crisp thumbnails. Thumbnail/flair/
 // comment-count are filled from /api/info, then the API stickied cache, then the
 // web DOM as a last resort. Web order is preserved. `completion` runs on main.
-static void ApolloHLEnrichViaInfo(NSArray<ApolloHLItem *> *webItems, NSArray<ApolloHLItem *> *apiItems, void (^completion)(NSArray<ApolloHLItem *> *)) {
+static void ApolloHLMergeMetadata(NSArray<ApolloHLItem *> *webItems,
+                                  NSArray<ApolloHLItem *> *apiItems,
+                                  NSDictionary<NSString *, ApolloHLItem *> *infoMap) {
     NSMutableDictionary<NSString *, ApolloHLItem *> *apiByID = [NSMutableDictionary dictionary];
     for (ApolloHLItem *a in apiItems) {
         NSString *pid = ApolloHLPostIDFromPermalink(a.permalink);
         if (pid.length) apiByID[pid] = a;
     }
-    NSMutableArray<NSString *> *pidsInOrder = [NSMutableArray array];
+    for (ApolloHLItem *w in webItems) {
+        NSString *pid = ApolloHLPostIDFromPermalink(w.permalink);
+        ApolloHLItem *info = pid.length ? infoMap[[@"t3_" stringByAppendingString:pid]] : nil;
+        ApolloHLItem *api = pid.length ? apiByID[pid] : nil;
+        if (!w.fullName.length) w.fullName = info.fullName ?: api.fullName;
+        if (!w.thumbnailURL) w.thumbnailURL = info.thumbnailURL ?: api.thumbnailURL;
+        if (!w.flairText.length) w.flairText = info.flairText ?: api.flairText;
+        if (w.numComments == 0) w.numComments = info ? info.numComments : (api ? api.numComments : 0);
+        if (!w.isSpoiler) w.isSpoiler = info ? info.isSpoiler : (api ? api.isSpoiler : NO);
+    }
+}
+
+static void ApolloHLEnrichViaInfo(NSArray<ApolloHLItem *> *webItems, NSArray<ApolloHLItem *> *apiItems, void (^completion)(NSArray<ApolloHLItem *> *)) {
     NSMutableArray<NSString *> *fullnames = [NSMutableArray array];
     for (ApolloHLItem *w in webItems) {
-        NSString *pid = ApolloHLPostIDFromPermalink(w.permalink) ?: @"";
-        [pidsInOrder addObject:pid];
+        NSString *pid = ApolloHLPostIDFromPermalink(w.permalink);
         if (pid.length) [fullnames addObject:[@"t3_" stringByAppendingString:pid]];
     }
 
     void (^finish)(NSDictionary<NSString *, ApolloHLItem *> *) = ^(NSDictionary<NSString *, ApolloHLItem *> *infoMap) {
-        NSMutableArray<ApolloHLItem *> *out = [NSMutableArray array];
-        for (NSUInteger i = 0; i < webItems.count; i++) {
-            ApolloHLItem *w = webItems[i];
-            NSString *pid = pidsInOrder[i];
-            ApolloHLItem *info = pid.length ? infoMap[[@"t3_" stringByAppendingString:pid]] : nil;
-            ApolloHLItem *api = pid.length ? apiByID[pid] : nil;
-            if (!w.thumbnailURL) w.thumbnailURL = info.thumbnailURL ?: api.thumbnailURL;
-            if (!w.flairText.length) w.flairText = info.flairText ?: api.flairText;
-            if (w.numComments == 0) w.numComments = info ? info.numComments : (api ? api.numComments : 0);
-            if (!w.isSpoiler) w.isSpoiler = info ? info.isSpoiler : (api ? api.isSpoiler : NO);
-            [out addObject:w];
-        }
-        dispatch_async(dispatch_get_main_queue(), ^{ completion(out); });
+        // `items` may already be the live main-queue cache because the fast path
+        // paints it before enrichment. Keep both mutation and callback on main.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            ApolloHLMergeMetadata(webItems, apiItems, infoMap);
+            completion(webItems);
+        });
     };
 
     if (fullnames.count == 0) { finish(@{}); return; }
@@ -1508,15 +1589,30 @@ static void ApolloHLMaybeWebUpgrade(NSString *subreddit) {
         [ApolloHLWebDone() addObject:sub];
         NSArray<ApolloHLItem *> *apiItems = ApolloHLCache()[sub];
         if (items.count == 0) return; // web found nothing
-        // Enrich the web list with reliable /api/info thumbnails before applying.
+
+        // The DOM already has the authoritative order, titles, and links. Merge
+        // whatever metadata the fast REST result already knows, then show the full
+        // list immediately instead of blocking all extra cards on another network
+        // round trip. Missing off-screen thumbnails/details arrive just below.
+        ApolloHLMergeMetadata(items, apiItems, @{});
+        NSArray<ApolloHLItem *> *cur = ApolloHLCache()[sub];
+        BOOL grew = items.count > cur.count;
+        BOOL differs = ![ApolloHLItemsContentSig(items) isEqualToString:ApolloHLItemsContentSig(cur)];
+        if (grew || differs) {
+            ApolloLog(@"[Highlights] fast web upgrade r/%@: %lu → %lu (enriching asynchronously)", sub, (unsigned long)cur.count, (unsigned long)items.count);
+            ApolloHLApplyItems(sub, items);
+        }
+
+        NSString *preEnrichmentSig = ApolloHLItemsPresentationSig(items);
+        // Enrich the already-visible list with reliable /api/info thumbnails. A
+        // presentation-signature change rebuilds the cards, while an identical
+        // response is a no-op and cannot cause a visible flash.
         ApolloHLEnrichViaInfo(items, apiItems, ^(NSArray<ApolloHLItem *> *enriched) {
-            NSArray<ApolloHLItem *> *cur = ApolloHLCache()[sub];
-            // Apply when the web set adds to OR differs from what's shown — the latter
-            // matters on a refresh where a highlight was swapped (same count, new posts).
-            BOOL grew = enriched.count > cur.count;
-            BOOL differs = ![ApolloHLItemsContentSig(enriched) isEqualToString:ApolloHLItemsContentSig(cur)];
-            if (grew || differs) {
-                ApolloLog(@"[Highlights] web upgrade r/%@: %lu → %lu", sub, (unsigned long)cur.count, (unsigned long)enriched.count);
+            BOOL metadataChanged = ![ApolloHLItemsPresentationSig(enriched) isEqualToString:preEnrichmentSig];
+            NSArray<ApolloHLItem *> *shown = ApolloHLCache()[sub];
+            BOOL setChanged = ![ApolloHLItemsContentSig(enriched) isEqualToString:ApolloHLItemsContentSig(shown)];
+            if (metadataChanged || setChanged) {
+                ApolloLog(@"[Highlights] web enrichment r/%@ applied (metadataChanged=%d setChanged=%d)", sub, metadataChanged, setChanged);
                 ApolloHLApplyItems(sub, enriched);
             }
         });

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -48,6 +48,15 @@ typedef NS_ENUM(NSInteger, SectionIndex) {
     SectionCount
 };
 
+// The settings UI presents Community Highlights as one three-way choice while
+// the runtime keeps the two existing booleans for compatibility with backups
+// and preferences from builds that exposed separate switches.
+typedef NS_ENUM(NSInteger, ApolloCommunityHighlightsMode) {
+    ApolloCommunityHighlightsModeOff = 0,
+    ApolloCommunityHighlightsModePartial,
+    ApolloCommunityHighlightsModeFull,
+};
+
 // Row indices within SectionNotificationBackend. The Bark rows are always
 // visible: on builds without a push entitlement Bark is the only delivery
 // path, and on entitled builds it's an optional alternative transport (the
@@ -370,6 +379,83 @@ typedef NS_ENUM(NSInteger, Tag) {
 
 - (NSString *)preferredGIFFallbackFormatText {
     return (sPreferredGIFFallbackFormat == 0) ? @"GIF" : @"MP4";
+}
+
+- (ApolloCommunityHighlightsMode)communityHighlightsMode {
+    if (!sCommunityHighlights) return ApolloCommunityHighlightsModeOff;
+    return sCommunityHighlightsWeb ? ApolloCommunityHighlightsModeFull : ApolloCommunityHighlightsModePartial;
+}
+
+- (NSString *)communityHighlightsModeText {
+    switch ([self communityHighlightsMode]) {
+        case ApolloCommunityHighlightsModeFull:    return @"Full";
+        case ApolloCommunityHighlightsModePartial: return @"Partial";
+        case ApolloCommunityHighlightsModeOff:
+        default:                                   return @"Off";
+    }
+}
+
+- (NSInteger)subredditLogicalRowForVisibleRow:(NSInteger)row {
+    // Modern Dividers (logical row 1) is the only conditional row now. When it
+    // is hidden, every later visible row is shifted up by one.
+    return (!sSubredditListEnhancements && row >= 1) ? row + 1 : row;
+}
+
+- (NSInteger)visibleSubredditRowForLogicalRow:(NSInteger)row {
+    return (!sSubredditListEnhancements && row > 1) ? row - 1 : row;
+}
+
+- (void)setCommunityHighlightsMode:(ApolloCommunityHighlightsMode)mode {
+    if (mode < ApolloCommunityHighlightsModeOff || mode > ApolloCommunityHighlightsModeFull) {
+        mode = ApolloCommunityHighlightsModeOff;
+    }
+
+    BOOL enabled = (mode != ApolloCommunityHighlightsModeOff);
+    BOOL full = (mode == ApolloCommunityHighlightsModeFull);
+    if (sCommunityHighlights == enabled && sCommunityHighlightsWeb == full) return;
+
+    sCommunityHighlights = enabled;
+    sCommunityHighlightsWeb = full;
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setBool:enabled forKey:UDKeyCommunityHighlights];
+    [defaults setBool:full forKey:UDKeyCommunityHighlightsWeb];
+
+    NSInteger visibleRow = [self visibleSubredditRowForLogicalRow:3];
+    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:visibleRow inSection:SectionSubreddits];
+    if ([[self.tableView indexPathsForVisibleRows] containsObject:indexPath]) {
+        [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
+    }
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloCommunityHighlightsToggleChangedNotification" object:nil];
+}
+
+- (void)presentCommunityHighlightsModeSheetFromSourceView:(UIView *)sourceView {
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Community Highlights"
+                                                                   message:@"Full loads every available highlight. Partial uses Reddit's API and shows up to two."
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+    ApolloCommunityHighlightsMode current = [self communityHighlightsMode];
+
+    NSString *fullTitle = (current == ApolloCommunityHighlightsModeFull) ? @"Full (Current)" : @"Full";
+    NSString *partialTitle = (current == ApolloCommunityHighlightsModePartial) ? @"Partial (Current)" : @"Partial";
+    NSString *offTitle = (current == ApolloCommunityHighlightsModeOff) ? @"Off (Current)" : @"Off";
+
+    [sheet addAction:[UIAlertAction actionWithTitle:fullTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self setCommunityHighlightsMode:ApolloCommunityHighlightsModeFull];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:partialTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self setCommunityHighlightsMode:ApolloCommunityHighlightsModePartial];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:offTitle style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [self setCommunityHighlightsMode:ApolloCommunityHighlightsModeOff];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    if (popover && sourceView) {
+        popover.sourceView = sourceView;
+        popover.sourceRect = sourceView.bounds;
+    }
+    [self presentViewController:sheet animated:YES completion:nil];
 }
 
 - (BOOL)apollo_supportsAutoHideTabBarIdleSetting {
@@ -881,7 +967,9 @@ typedef NS_ENUM(NSInteger, Tag) {
         // Play Inline" toggle. The hold-speed picker (row 11) shows only while its
         // toggle is on.
         case SectionMedia: return 11 + (sVideoHoldSpeedEnabled ? 1 : 0);
-        case SectionSubreddits: return 10 - (sSubredditListEnhancements ? 0 : 1) - (sCommunityHighlights ? 0 : 1);
+        // One Community Highlights picker replaces the old master + web switches.
+        // Modern Dividers remains the only conditional row in this section.
+        case SectionSubreddits: return 9 - (sSubredditListEnhancements ? 0 : 1);
         case SectionNotificationBackend: return kNotifBackendRowCount;
         case SectionPrivacy: return 1; // Anonymous Install Count toggle
         case SectionAbout: return 6; // GitHub + Reddit + Thanks To + Export Logs + Privacy Policy + Version
@@ -1544,17 +1632,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 }
 
 - (UITableViewCell *)subredditCellForRow:(NSInteger)row tableView:(UITableView *)tableView {
-    // Sub-options are hidden when their parent toggle is off: Modern Dividers (logical 1)
-    // under "Subreddit List Enhancements", and "Load All Highlights (Web)" (logical 4)
-    // under "Community Highlights". Map the display row to its logical case by walking the
-    // logical rows in order and skipping any that are currently hidden.
-    BOOL hideDividers = !sSubredditListEnhancements;
-    BOOL hideWeb = !sCommunityHighlights;
-    NSInteger logicalRow = -1;
-    for (NSInteger visible = -1; visible < row; ) {
-        logicalRow++;
-        if (!((logicalRow == 1 && hideDividers) || (logicalRow == 4 && hideWeb))) visible++;
-    }
+    NSInteger logicalRow = [self subredditLogicalRowForVisibleRow:row];
     switch (logicalRow) {
         case 0:
             return [self switchCellWithIdentifier:@"Cell_Sub_Enhancements"
@@ -1571,41 +1649,43 @@ typedef NS_ENUM(NSInteger, Tag) {
                                             label:@"Show Subreddit Headers"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowSubredditHeaders]
                                            action:@selector(subredditHeadersSwitchToggled:)];
-        case 3:
-            return [self switchCellWithIdentifier:@"Cell_Sub_Highlights"
-                                            label:@"Community Highlights"
-                                               on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyCommunityHighlights]
-                                           action:@selector(communityHighlightsSwitchToggled:)];
+        case 3: {
+            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell_Sub_HighlightsMode"];
+            if (!cell) {
+                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"Cell_Sub_HighlightsMode"];
+                cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+            }
+            cell.textLabel.text = @"Community Highlights";
+            cell.detailTextLabel.text = [self communityHighlightsModeText];
+            cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+            return cell;
+        }
         case 4:
-            return [self switchCellWithIdentifier:@"Cell_Sub_HighlightsWeb"
-                                            label:@"Load All Highlights (Web)"
-                                               on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyCommunityHighlightsWeb]
-                                           action:@selector(communityHighlightsWebSwitchToggled:)];
-        case 5:
             return [self textFieldCellWithIdentifier:@"Cell_Sub_TrendLimit"
                                                label:@"Trending Subreddits Limit"
                                          placeholder:@"(unlimited)"
                                                 text:sTrendingSubredditsLimit
                                                  tag:TagTrendingLimit
                                            numerical:YES];
-        case 6:
+        case 5:
             return [self stackedTextFieldCellWithIdentifier:@"Cell_Sub_Trending"
                                                       label:@"Trending Source"
                                                 placeholder:defaultTrendingSubredditsSource
                                                        text:sTrendingSubredditsSource
                                                         tag:TagTrendingSubredditsSource];
-        case 7:
+        case 6:
             return [self stackedTextFieldCellWithIdentifier:@"Cell_Sub_Random"
                                                       label:@"Random Source"
                                                 placeholder:defaultRandomSubredditsSource
                                                        text:sRandomSubredditsSource
                                                         tag:TagRandomSubredditsSource];
-        case 8:
+        case 7:
             return [self switchCellWithIdentifier:@"Cell_Sub_RandNSFW"
                                             label:@"Show RandNSFW in Search"
                                                on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowRandNsfw]
                                            action:@selector(randNsfwSwitchToggled:)];
-        case 9:
+        case 8:
             return [self stackedTextFieldCellWithIdentifier:@"Cell_Sub_RandNSFW_Source"
                                                       label:@"RandNSFW Source"
                                                 placeholder:@"(empty)"
@@ -2103,6 +2183,12 @@ typedef NS_ENUM(NSInteger, Tag) {
         } else if (indexPath.row == 11) {
             [self presentVideoHoldSpeedSheetFromSourceView:cell];
         }
+    } else if (indexPath.section == SectionSubreddits) {
+        NSInteger logicalRow = [self subredditLogicalRowForVisibleRow:indexPath.row];
+        if (logicalRow == 3) {
+            UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+            [self presentCommunityHighlightsModeSheetFromSourceView:cell];
+        }
     } else if (indexPath.section == SectionNotificationBackend) {
         NSInteger row = indexPath.row;
         if (row == kNotifBackendRowTestConnection) {
@@ -2225,6 +2311,9 @@ typedef NS_ENUM(NSInteger, Tag) {
     if (indexPath.section == SectionMedia) {
         return (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 ||
                 indexPath.row == 3 || indexPath.row == 11);
+    }
+    if (indexPath.section == SectionSubreddits) {
+        return [self subredditLogicalRowForVisibleRow:indexPath.row] == 3;
     }
     if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 || indexPath.row == 3 || indexPath.row == 4)) return YES;
     if (indexPath.section == SectionNotificationBackend) {
@@ -2761,30 +2850,6 @@ typedef NS_ENUM(NSInteger, Tag) {
     sShowSubredditHeaders = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sShowSubredditHeaders forKey:UDKeyShowSubredditHeaders];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloSubredditHeaderToggleChangedNotification" object:nil];
-}
-
-- (void)communityHighlightsSwitchToggled:(UISwitch *)sender {
-    BOOL wasOn = sCommunityHighlights;
-    sCommunityHighlights = sender.isOn;
-    [[NSUserDefaults standardUserDefaults] setBool:sCommunityHighlights forKey:UDKeyCommunityHighlights];
-    if (sCommunityHighlights != wasOn) {
-        // The "Load All Highlights (Web)" sub-row (logical 4) only exists while this master
-        // toggle is on; its display index drops by 1 when the Modern Dividers row (logical 1)
-        // is itself hidden (enhancements off). Mirrors the Enhancements toggle's row anim.
-        NSArray<NSIndexPath *> *webPaths = @[[NSIndexPath indexPathForRow:(sSubredditListEnhancements ? 4 : 3) inSection:SectionSubreddits]];
-        if (sCommunityHighlights) {
-            [self.tableView insertRowsAtIndexPaths:webPaths withRowAnimation:UITableViewRowAnimationFade];
-        } else {
-            [self.tableView deleteRowsAtIndexPaths:webPaths withRowAnimation:UITableViewRowAnimationFade];
-        }
-    }
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloCommunityHighlightsToggleChangedNotification" object:nil];
-}
-
-- (void)communityHighlightsWebSwitchToggled:(UISwitch *)sender {
-    sCommunityHighlightsWeb = sender.isOn;
-    [[NSUserDefaults standardUserDefaults] setBool:sCommunityHighlightsWeb forKey:UDKeyCommunityHighlightsWeb];
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloCommunityHighlightsToggleChangedNotification" object:nil];
 }
 
 - (void)textPostThumbnailsSwitchToggled:(UISwitch *)sender {

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -87,6 +87,9 @@ static NSString *const UDKeyUseProfileAvatarTabIcon = @"UseProfileAvatarTabIcon"
 // See ApolloUserAvatars.xm and ApolloProfileSocialLinks.m. Default YES.
 static NSString *const UDKeyShowDetailedProfiles = @"ShowDetailedProfiles";
 static NSString *const UDKeyShowSubredditHeaders = @"ShowSubredditHeaders";
+// Backing values for the single Community Highlights picker. Keeping the old
+// keys maps existing settings naturally: both YES = Full, master only = Partial,
+// master NO = Off.
 static NSString *const UDKeyCommunityHighlights = @"CommunityHighlights";
 static NSString *const UDKeyCommunityHighlightsWeb = @"CommunityHighlightsWeb";
 static NSString *const UDKeyAutoHideTabBarShowOnIdle = @"AutoHideTabBarShowOnIdle";


### PR DESCRIPTION
## Summary

- probe the hidden Reddit web view as soon as navigation finishes instead of waiting a fixed three seconds
- take one confirming probe after the first larger-than-REST result so progressively hydrated carousels are not truncated
- show the full Community Highlights set before optional API metadata enrichment finishes
- prevent the faster full web result from being overwritten by the two-item REST response
- replace the two Community Highlights switches with one clean **Full / Partial / Off** setting
  - **Full** loads every available highlight using the fast API result followed by the web upgrade
  - **Partial** uses Reddit's API and shows up to two highlights
  - **Off** disables Community Highlights
- apply mode changes immediately, including cancelling stale web work and downgrading every session-cached Full result when Partial is selected
- keep transient fallback-fetch failures uncached so a later pass can retry
- keep the existing preference keys so current settings and backups migrate automatically
- preserve the existing freshness and pull-to-refresh paths so new or changed highlights still replace the carousel

## In Action

<table>
  <tr>
    <th>Faster loading</th>
    <th>One clean settings row</th>
  </tr>
  <tr>
    <td width="50%" align="center">
      <img width="360" alt="Improved Community Highlights loading speed" src="https://github.com/user-attachments/assets/aea00879-0ebb-49b9-86b4-2a23f689c2e4" />
    </td>
    <td width="50%" align="center">
      <img width="360" alt="Community Highlights Full Partial Off setting" src="https://github.com/user-attachments/assets/f7f2c2f1-bec1-4cd3-ad55-a53e6c1235c7" />
    </td>
  </tr>
</table>

## Testing

- `make package`
- Apollo-Sim2 on r/soccer after review fixes: REST two-card result at 0.69 seconds, first three-card web result at 1.59 seconds, full set finalized after exactly one confirming probe at 2.09 seconds, enrichment complete at 2.40 seconds
- Apollo-Sim2: verified the single settings row, the Full / Partial / Off picker, all three saved-value mappings, relaunch persistence, and the conditional-row layout
- visually verified the carousel and settings UI under Liquid Glass
