### PR TITLE
User flair fixes: real per-sub emoji limits + over-limit warning on API-key-free accounts, and your own flair on a just-posted comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloSavedCategories.xm \
     $(SRC_DIR)/ApolloSwiftIvarBridge.swift \
     $(SRC_DIR)/ApolloUserFlair.xm \
+    $(SRC_DIR)/ApolloOwnCommentFlair.xm \
     $(SRC_DIR)/ApolloFlairColors.xm \
     $(SRC_DIR)/ApolloNativeActionMenus.xm \
     $(SRC_DIR)/ApolloHostedVideo.m \

--- a/src/ApolloFlairColors.xm
+++ b/src/ApolloFlairColors.xm
@@ -32,6 +32,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloState.h"
+#import "ApolloOwnCommentFlair.h"
 #import "UserDefaultConstants.h"
 #import <math.h>
 #import <objc/message.h>
@@ -498,20 +499,24 @@ static void ApolloFlairRecoverForModel(id model, NSDictionary *json) {
 + (id)modelOfClass:(Class)modelClass fromJSONDictionary:(NSDictionary *)JSONDictionary error:(NSError **)error {
     id model = %orig;
     ApolloFlairRecoverForModel(model, JSONDictionary);
+    ApolloOwnCommentFlairInspectModel(model);
     return model;
 }
 
 // Listing/array funnel — JSON array and model array are index-parallel.
 + (id)modelsOfClass:(Class)modelClass fromJSONArray:(NSArray *)JSONArray error:(NSError **)error {
     id models = %orig;
-    if ([models isKindOfClass:[NSArray class]] && [JSONArray isKindOfClass:[NSArray class]] &&
-        [(NSArray *)models count] == JSONArray.count) {
+    if ([models isKindOfClass:[NSArray class]]) {
         NSArray *modelArray = (NSArray *)models;
+        BOOL parallel = [JSONArray isKindOfClass:[NSArray class]] && modelArray.count == JSONArray.count;
         for (NSUInteger i = 0; i < modelArray.count; i++) {
-            id json = JSONArray[i];
-            if ([json isKindOfClass:[NSDictionary class]]) {
-                ApolloFlairRecoverForModel(modelArray[i], (NSDictionary *)json);
+            if (parallel) {
+                id json = JSONArray[i];
+                if ([json isKindOfClass:[NSDictionary class]])
+                    ApolloFlairRecoverForModel(modelArray[i], (NSDictionary *)json);
             }
+            // Reads the model itself, so it does not need the parallel JSON.
+            ApolloOwnCommentFlairInspectModel(modelArray[i]);
         }
     }
     return models;
@@ -520,6 +525,7 @@ static void ApolloFlairRecoverForModel(id model, NSDictionary *json) {
 - (id)modelFromJSONDictionary:(NSDictionary *)JSONDictionary error:(NSError **)error {
     id model = %orig;
     ApolloFlairRecoverForModel(model, JSONDictionary);
+    ApolloOwnCommentFlairInspectModel(model);
     return model;
 }
 

--- a/src/ApolloImageUploadHost.xm
+++ b/src/ApolloImageUploadHost.xm
@@ -299,6 +299,10 @@ void ApolloRedditCaptureBearerTokenFromAuthorization(NSString *authorization, NS
 void ApolloRedditCaptureBearerTokenFromAuthorizationForURL(NSString *authorization, NSURL *url, NSString *source) {
     if (!ApolloURLIsRedditOAuth(url)) return;
     if (ApolloURLIsAccountSpecificPoll(url)) return;
+    // WebJSON-internal fetches (flair rescue etc.) authenticate with the
+    // web-session account's token_v2 — a real-looking bearer that belongs to
+    // a DIFFERENT account than whoever Apollo is composing/uploading as.
+    if (ApolloWebJSONRequestIsInternal(url)) return;
     ApolloRedditCaptureBearerTokenFromAuthorization(authorization, source);
 }
 
@@ -306,6 +310,7 @@ void ApolloRedditCaptureBearerTokenFromRequest(NSURLRequest *request, NSString *
     if (![request isKindOfClass:[NSURLRequest class]]) return;
     if (!ApolloURLIsRedditOAuth(request.URL)) return;
     if (ApolloURLIsAccountSpecificPoll(request.URL)) return;
+    if (ApolloWebJSONRequestIsInternal(request.URL)) return;
     ApolloRedditCaptureBearerTokenFromAuthorization([request valueForHTTPHeaderField:@"Authorization"], source);
 }
 

--- a/src/ApolloOwnCommentFlair.h
+++ b/src/ApolloOwnCommentFlair.h
@@ -1,0 +1,31 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Restores the poster's own user flair on a comment they just submitted.
+//
+// Reddit's comment-create response (both oauth.reddit.com/api/comment and the
+// keyless www.reddit.com equivalent, whose legacy shape ApolloWebJSON.m
+// synthesizes into a modern dict) carries no author_flair_* fields, so the
+// RDKComment that Apollo splices into the open thread has an empty
+// authorFlairRichtext/authorFlairPlaintext and its cell renders no flair pill.
+// Everyone else's comments are fine because they arrive through a normal
+// listing, which does carry the fields — which is why a pull-to-refresh
+// "fixes" it. See ApolloOwnCommentFlair.xm for the full mechanism.
+
+// Called from the MTLJSONAdapter funnel in ApolloFlairColors.xm for every model
+// RedditKit deserializes. Harvests the active account's own flair per subreddit
+// and, when a submit is armed, backfills the just-posted comment.
+void ApolloOwnCommentFlairInspectModel(id model);
+
+// Write-through from the flair editor's save path, so the very next comment in
+// that subreddit renders correctly even with a cold cache. `text` of length 0
+// records an authoritative "no flair here".
+void ApolloOwnCommentFlairRecordSetFlair(NSString *subreddit, NSString *_Nullable text);
+
+// `-[RDKClient setShowUserFlair:subredditName:completion:]`: hiding flair is an
+// authoritative empty; showing it again invalidates so the next listing or
+// prefetch re-resolves the real value.
+void ApolloOwnCommentFlairRecordShowFlair(NSString *subreddit, BOOL show);
+
+NS_ASSUME_NONNULL_END

--- a/src/ApolloOwnCommentFlair.xm
+++ b/src/ApolloOwnCommentFlair.xm
@@ -1,0 +1,717 @@
+// Restore the poster's own user flair on a comment they just submitted.
+//
+// THE BUG
+// Post a comment and it appears instantly in the thread, but with no flair pill
+// next to your username; every other commenter's flair renders fine, and a
+// pull-to-refresh makes yours appear. Reported for both account modes.
+//
+// ROOT CAUSE (verified for keyless, inferred-then-confirmed-by-log for API key)
+// Reddit's comment-create response does not carry author_flair_* for the thing
+// it just created:
+//   * Keyless: www.reddit.com/api/comment answers in the legacy
+//     {parent, content:"<html>"} shape, which ApolloWebJSONSynthesizeModernThingData
+//     (ApolloWebJSON.m) rebuilds into a modern comment dict. That synthesis writes
+//     28 keys and no author_flair_* key at all — a hard, unconditional drop.
+//   * API key: oauth.reddit.com/api/comment goes through the exact same parser as
+//     a normal listing (RDKClient -objectsFromDataThingsListingResponse: ->
+//     +[RDKObjectBuilder objectFromJSON:] -> +[MTLJSONAdapter modelOfClass:...]),
+//     so Apollo cannot be losing the flair on the way in — the payload lacks it.
+// Either way the resulting RDKComment has empty authorFlairRichtext AND empty
+// authorFlairPlaintext, and the cell renders nothing.
+//
+// WHY THE CELL CAN'T BE FIXED AFTER THE FACT
+// -[RDKComment authorFlair] is a COMPUTED getter (it never reads its own
+// _authorFlair ivar, so -setAuthorFlair:/KVC on @"authorFlair" is a no-op for
+// display): it returns authorFlairRichtext when non-empty, else wraps
+// authorFlairPlaintext in a fresh RDKFlair, else nil. CommentCellNode's init
+// reads it exactly once and, when it is nil/empty, never allocates a FlairNode
+// at all — and FlairNode.flairs is a Swift `let` with no setter. So there is no
+// node to populate later: the flair has to be on the model BEFORE the cell is
+// built. That rules out any render-time repair and makes this a data-layer fix.
+//
+// THE FIX
+// Keep a small per-(account, subreddit) record of the user's own flair and use
+// it to backfill exactly the comment they just posted:
+//   1. LEARN, free: every model RedditKit parses passes through the MTLJSONAdapter
+//      funnel that ApolloFlairColors.xm already hooks. Any RDKComment/RDKLink
+//      authored by the active account teaches us that account's flair for that
+//      subreddit — including the authoritative negative "no flair here".
+//   2. LEARN, authoritative: the flair editor's save path writes through, so the
+//      very next comment is right even on a cold cache.
+//   3. PREFETCH: opening a thread parses its comments, which tells us the
+//      subreddit; if we have no record for it we resolve one in the background
+//      (once per subreddit per session). The user then spends seconds typing,
+//      which is what makes the record warm by the time they hit send.
+//   4. BACKFILL: -[RDKClient submitComment:...] arms a short-lived record. When
+//      the response parses into an RDKComment that is ours, in that subreddit,
+//      and has no flair, we write the cached pieces into authorFlairRichtext.
+//
+// The arm is what keeps this narrow: we only ever touch a comment the user just
+// submitted, never their comment history, and never anyone else's comments.
+
+#import "ApolloOwnCommentFlair.h"
+#import "ApolloUserFlair.h"
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+#import "ApolloWebJSON.h"
+#import "ApolloWebSessionStore.h"
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import <os/lock.h>
+
+static NSString *const kApolloOwnFlairGroupSuite = @"group.com.christianselig.apollo";
+static NSString *const kApolloOwnFlairDefaultsKey = @"ApolloOwnCommentFlairV1";
+
+// A record older than this is still used optimistically (the user's flair rarely
+// changes) but is refreshed in the background on next sight.
+static const NSTimeInterval kApolloOwnFlairStaleAfter = 24 * 60 * 60;
+// An armed submit must be consumed quickly; a slow post still lands well inside.
+static const NSTimeInterval kApolloOwnFlairArmTTL = 30.0;
+static const NSUInteger kApolloOwnFlairMaxEntries = 120;
+
+// Set on a comment we backfilled, so the harvester never mistakes our own
+// optimistic flair for evidence of what Reddit actually has.
+static char kApolloOwnFlairSynthesizedKey;
+
+#pragma mark - Active account identity (cheap)
+
+// ApolloActiveAccountUsername() unarchives RedditAccounts2 on every call, which
+// is far too heavy for a funnel that fires for every model in every listing.
+// RDKClient holds the same identity in memory; memoize it briefly on top of that.
+static NSString *ApolloOwnFlairActiveUsername(void) {
+    static NSString *cached = nil;
+    static NSTimeInterval cachedAt = 0;
+    static os_unfair_lock lock = OS_UNFAIR_LOCK_INIT;
+
+    NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
+    os_unfair_lock_lock(&lock);
+    NSString *hit = (now - cachedAt < 5.0) ? cached : nil;
+    os_unfair_lock_unlock(&lock);
+    if (hit) return hit;
+
+    NSString *username = nil;
+    @try {
+        Class clientClass = objc_getClass("RDKClient");
+        if (clientClass && [clientClass respondsToSelector:@selector(sharedClient)]) {
+            id client = ((id (*)(id, SEL))objc_msgSend)(clientClass, @selector(sharedClient));
+            if ([client respondsToSelector:@selector(currentUser)]) {
+                id user = ((id (*)(id, SEL))objc_msgSend)(client, @selector(currentUser));
+                if ([user respondsToSelector:@selector(username)]) {
+                    id name = ((id (*)(id, SEL))objc_msgSend)(user, @selector(username));
+                    if ([name isKindOfClass:[NSString class]] && [name length] > 0) username = name;
+                }
+            }
+        }
+    } @catch (__unused NSException *e) {}
+
+    // Keyless accounts are signed in through the web session, which may resolve
+    // before RDKClient's currentUser does.
+    if (username.length == 0) username = ApolloActiveWebSessionUsername();
+
+    os_unfair_lock_lock(&lock);
+    cached = [username copy];
+    cachedAt = now;
+    os_unfair_lock_unlock(&lock);
+    return username;
+}
+
+static BOOL ApolloOwnFlairIsActiveUser(NSString *author) {
+    if (author.length == 0) return NO;
+    NSString *me = ApolloOwnFlairActiveUsername();
+    if (me.length == 0) return NO;
+    return [author caseInsensitiveCompare:me] == NSOrderedSame;
+}
+
+#pragma mark - Record store
+
+// Keyed "<username-lowercase>|<subreddit-lowercase>" so switching accounts can
+// never show account A's flair on account B's comment. A record's `pieces` array
+// being empty is a positive answer ("known: no flair here"), distinct from having
+// no record at all ("unknown") — only the latter triggers a prefetch, and neither
+// an empty nor a missing record will ever backfill anything.
+static NSMutableDictionary<NSString *, NSDictionary *> *ApolloOwnFlairStore(void) {
+    static NSMutableDictionary *store = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        store = [NSMutableDictionary dictionary];
+        NSUserDefaults *group = [[NSUserDefaults alloc] initWithSuiteName:kApolloOwnFlairGroupSuite];
+        id saved = [group objectForKey:kApolloOwnFlairDefaultsKey];
+        if ([saved isKindOfClass:[NSDictionary class]]) {
+            [(NSDictionary *)saved enumerateKeysAndObjectsUsingBlock:^(id key, id value, __unused BOOL *stop) {
+                if ([key isKindOfClass:[NSString class]] && [value isKindOfClass:[NSDictionary class]])
+                    store[key] = value;
+            }];
+        }
+        ApolloLog(@"[OwnFlair] Loaded %lu cached own-flair record(s)", (unsigned long)store.count);
+    });
+    return store;
+}
+
+static NSString *ApolloOwnFlairKey(NSString *username, NSString *subreddit) {
+    if (username.length == 0 || subreddit.length == 0) return nil;
+    return [NSString stringWithFormat:@"%@|%@", username.lowercaseString, subreddit.lowercaseString];
+}
+
+static void ApolloOwnFlairPersist(void) {
+    NSDictionary *snapshot = nil;
+    @synchronized (ApolloOwnFlairStore()) {
+        NSMutableDictionary *store = ApolloOwnFlairStore();
+        // Cheap LRU: when over budget, drop the oldest records.
+        if (store.count > kApolloOwnFlairMaxEntries) {
+            NSArray *byAge = [store.allKeys sortedArrayUsingComparator:^NSComparisonResult(NSString *a, NSString *b) {
+                double ta = [store[a][@"updatedAt"] doubleValue], tb = [store[b][@"updatedAt"] doubleValue];
+                return ta < tb ? NSOrderedAscending : (ta > tb ? NSOrderedDescending : NSOrderedSame);
+            }];
+            for (NSUInteger i = 0; i + kApolloOwnFlairMaxEntries < byAge.count; i++) [store removeObjectForKey:byAge[i]];
+        }
+        snapshot = [store copy];
+    }
+    NSUserDefaults *group = [[NSUserDefaults alloc] initWithSuiteName:kApolloOwnFlairGroupSuite];
+    [group setObject:snapshot forKey:kApolloOwnFlairDefaultsKey];
+}
+
+// nil = unknown, @[] = known-and-empty, non-empty = the user's flair pieces as
+// plain JSON-safe dicts.
+static NSArray<NSDictionary *> *ApolloOwnFlairLookup(NSString *username, NSString *subreddit, BOOL *outStale) {
+    NSString *key = ApolloOwnFlairKey(username, subreddit);
+    if (!key) return nil;
+    NSDictionary *record = nil;
+    @synchronized (ApolloOwnFlairStore()) { record = ApolloOwnFlairStore()[key]; }
+    if (![record isKindOfClass:[NSDictionary class]]) return nil;
+    id pieces = record[@"pieces"];
+    if (![pieces isKindOfClass:[NSArray class]]) return nil;
+    if (outStale) {
+        NSTimeInterval updatedAt = [record[@"updatedAt"] doubleValue];
+        *outStale = ([NSDate timeIntervalSinceReferenceDate] - updatedAt) > kApolloOwnFlairStaleAfter;
+    }
+    return pieces;
+}
+
+static void ApolloOwnFlairStorePieces(NSString *username, NSString *subreddit, NSArray<NSDictionary *> *pieces) {
+    NSString *key = ApolloOwnFlairKey(username, subreddit);
+    if (!key) return;
+    NSArray *safe = [pieces isKindOfClass:[NSArray class]] ? pieces : @[];
+
+    BOOL changed = NO, refreshed = NO;
+    NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
+    @synchronized (ApolloOwnFlairStore()) {
+        NSDictionary *existing = ApolloOwnFlairStore()[key];
+        changed = !existing || ![existing[@"pieces"] isEqual:safe];
+        // Re-confirming the same value must still refresh the timestamp, or a
+        // stable flair would go permanently stale and re-prefetch every launch
+        // forever. Only persist when it actually matters, though: scrolling
+        // re-parses our own comments constantly and each persist is a defaults write.
+        refreshed = !changed && (now - [existing[@"updatedAt"] doubleValue]) > 3600.0;
+        if (!changed && !refreshed) return;
+        ApolloOwnFlairStore()[key] = @{ @"pieces": safe, @"updatedAt": @(now) };
+    }
+    ApolloOwnFlairPersist();
+    if (changed)
+        ApolloLog(@"[OwnFlair] Recorded own flair for r/%@: %lu piece(s)", subreddit, (unsigned long)safe.count);
+}
+
+// Subreddits already prefetched this launch, so a resolved miss doesn't re-ask on
+// every thread open. File-scope rather than function-static because invalidation
+// has to be able to clear it — otherwise the re-resolve it exists to trigger
+// would be permanently suppressed.
+static NSMutableSet<NSString *> *ApolloOwnFlairPrefetchAttempted(void) {
+    static NSMutableSet *set = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ set = [NSMutableSet set]; });
+    return set;
+}
+
+static void ApolloOwnFlairForget(NSString *username, NSString *subreddit) {
+    NSString *key = ApolloOwnFlairKey(username, subreddit);
+    if (!key) return;
+    @synchronized (ApolloOwnFlairStore()) { [ApolloOwnFlairStore() removeObjectForKey:key]; }
+    @synchronized (ApolloOwnFlairPrefetchAttempted()) { [ApolloOwnFlairPrefetchAttempted() removeObject:key]; }
+    ApolloOwnFlairPersist();
+    ApolloLog(@"[OwnFlair] Invalidated own-flair record for r/%@", subreddit);
+}
+
+#pragma mark - RDKFlair <-> plain dict
+
+// RDKFlair is a Mantle model with four properties. We persist plain dicts rather
+// than archived objects so the store stays inspectable and version-proof, and we
+// always hand the model FRESH RDKFlair instances: ApolloFlairColors.xm hangs
+// per-instance colour annotations off each RDKFlair, so sharing one instance
+// between cells would smear that state.
+static NSArray<NSDictionary *> *ApolloOwnFlairSerializePieces(NSArray *flairs) {
+    if (![flairs isKindOfClass:[NSArray class]] || flairs.count == 0) return @[];
+    NSMutableArray *out = [NSMutableArray array];
+    for (id flair in flairs) {
+        NSMutableDictionary *piece = [NSMutableDictionary dictionary];
+        for (NSString *prop in @[@"flairType", @"text", @"emojiLabel"]) {
+            @try {
+                id value = [flair valueForKey:prop];
+                if ([value isKindOfClass:[NSString class]]) piece[prop] = value;
+            } @catch (__unused NSException *e) {}
+        }
+        @try {
+            id url = [flair valueForKey:@"imageURL"];
+            if ([url isKindOfClass:[NSURL class]]) piece[@"imageURL"] = [(NSURL *)url absoluteString];
+            else if ([url isKindOfClass:[NSString class]]) piece[@"imageURL"] = url;
+        } @catch (__unused NSException *e) {}
+        if (piece.count > 0) [out addObject:piece];
+    }
+    return out;
+}
+
+static NSArray *ApolloOwnFlairMaterializePieces(NSArray<NSDictionary *> *pieces) {
+    if (![pieces isKindOfClass:[NSArray class]] || pieces.count == 0) return nil;
+    NSMutableArray *out = [NSMutableArray array];
+    for (NSDictionary *piece in pieces) {
+        if (![piece isKindOfClass:[NSDictionary class]]) continue;
+        NSString *imageURL = [piece[@"imageURL"] isKindOfClass:[NSString class]] ? piece[@"imageURL"] : nil;
+        NSString *text = [piece[@"text"] isKindOfClass:[NSString class]] ? piece[@"text"] : nil;
+        if (imageURL.length == 0 && text.length == 0) continue;  // nothing to draw
+        id flair = nil;
+        if (imageURL.length > 0) {
+            // Emoji run: text MUST stay nil or the native flair cell renders it as
+            // a text run instead of loading the image (see ApolloUserFlair.xm).
+            NSString *label = [piece[@"emojiLabel"] isKindOfClass:[NSString class]] ? piece[@"emojiLabel"] : @"";
+            flair = ApolloUserFlairBuildEmojiPiece(label, imageURL);
+        } else {
+            flair = ApolloUserFlairBuildTextPiece(text);
+        }
+        if (flair) [out addObject:flair];
+    }
+    return out.count > 0 ? out : nil;
+}
+
+#pragma mark - Submit arm
+
+// One entry per in-flight write. Matching on subreddit keeps concurrent posts to
+// different subreddits from crossing over.
+//
+// A matched arm is NOT removed, it is marked: `patched` caps the backfill at one
+// comment, while the arm itself stays alive for its full TTL so it keeps
+// suppressing the "no flair here" negative. That matters because RedditKit runs a
+// model through the Mantle funnel more than once, and because a write response is
+// never evidence about the account's real flair.
+@interface ApolloOwnFlairArm : NSObject
+@property (nonatomic, copy) NSString *subreddit;   // nil = wildcard
+@property (nonatomic, assign) NSTimeInterval armedAt;
+@property (nonatomic, assign) BOOL patched;
+@end
+@implementation ApolloOwnFlairArm
+@end
+
+static NSMutableArray<ApolloOwnFlairArm *> *ApolloOwnFlairArms(void) {
+    static NSMutableArray *arms = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ arms = [NSMutableArray array]; });
+    return arms;
+}
+
+static void ApolloOwnFlairPruneArms_locked(void) {
+    NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
+    NSMutableArray<ApolloOwnFlairArm *> *arms = ApolloOwnFlairArms();
+    for (NSInteger i = (NSInteger)arms.count - 1; i >= 0; i--)
+        if (now - arms[(NSUInteger)i].armedAt > kApolloOwnFlairArmTTL) [arms removeObjectAtIndex:(NSUInteger)i];
+}
+
+static void ApolloOwnFlairArmSubmit(NSString *subreddit) {
+    ApolloOwnFlairArm *arm = [ApolloOwnFlairArm new];
+    arm.subreddit = subreddit;
+    arm.armedAt = [NSDate timeIntervalSinceReferenceDate];
+    @synchronized (ApolloOwnFlairArms()) {
+        ApolloOwnFlairPruneArms_locked();
+        [ApolloOwnFlairArms() addObject:arm];
+    }
+    ApolloLog(@"[OwnFlair] Armed submit for r/%@", subreddit ?: @"<unknown>");
+}
+
+// The live arm covering this subreddit, if any. Never removes it — see the note
+// on ApolloOwnFlairArm.
+static ApolloOwnFlairArm *ApolloOwnFlairMatchArm(NSString *subreddit) {
+    @synchronized (ApolloOwnFlairArms()) {
+        ApolloOwnFlairPruneArms_locked();
+        for (ApolloOwnFlairArm *arm in ApolloOwnFlairArms()) {
+            NSString *armed = arm.subreddit;
+            if (armed.length == 0 || (subreddit.length > 0 && [armed caseInsensitiveCompare:subreddit] == NSOrderedSame))
+                return arm;
+        }
+    }
+    return nil;
+}
+
+// Claims the single backfill this arm is allowed. Returns NO if already used.
+static BOOL ApolloOwnFlairClaimArmPatch(ApolloOwnFlairArm *arm) {
+    if (!arm) return NO;
+    @synchronized (ApolloOwnFlairArms()) {
+        if (arm.patched) return NO;
+        arm.patched = YES;
+        return YES;
+    }
+}
+
+// submitComment:onLink: and submitComment:asReplyToComment: both tail-call
+// submitComment:onThingWithFullName: on the same thread, so this flag stops the
+// fullname variant from adding a second, subreddit-less wildcard arm on top of
+// the precise one we already have.
+static NSString *const kApolloOwnFlairTypedScopeKey = @"ApolloOwnFlairTypedSubmitScope";
+
+static void ApolloOwnFlairBeginTypedScope(void) {
+    [[NSThread currentThread] threadDictionary][kApolloOwnFlairTypedScopeKey] = @YES;
+}
+static void ApolloOwnFlairEndTypedScope(void) {
+    [[[NSThread currentThread] threadDictionary] removeObjectForKey:kApolloOwnFlairTypedScopeKey];
+}
+static BOOL ApolloOwnFlairInTypedScope(void) {
+    return [[[NSThread currentThread] threadDictionary][kApolloOwnFlairTypedScopeKey] boolValue];
+}
+
+#pragma mark - Prefetch
+
+// Resolving the user's own flair for a subreddit they have never commented in.
+// Both account modes use the SAME oauth endpoint; only the bearer differs — a
+// keyless account's token_v2 cookie is itself a valid OAuth bearer, which the
+// repo already relies on for /r/<sub>/api/user_flair_v2. ApolloWebJSONProbeURL
+// keeps the Web JSON transport from rewriting our own request back to www.
+static NSMutableSet<NSString *> *ApolloOwnFlairPrefetchesInFlight(void) {
+    static NSMutableSet *set = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ set = [NSMutableSet set]; });
+    return set;
+}
+
+static void ApolloOwnFlairPrefetch(NSString *username, NSString *subreddit) {
+    NSString *key = ApolloOwnFlairKey(username, subreddit);
+    if (!key) return;
+    @synchronized (ApolloOwnFlairPrefetchesInFlight()) {
+        if ([ApolloOwnFlairPrefetchesInFlight() containsObject:key]) return;
+        [ApolloOwnFlairPrefetchesInFlight() addObject:key];
+    }
+
+    void (^done)(void) = ^{
+        @synchronized (ApolloOwnFlairPrefetchesInFlight()) { [ApolloOwnFlairPrefetchesInFlight() removeObject:key]; }
+    };
+
+    // Everything below runs off the caller's thread. The thread-open hooks call us
+    // from the main thread, and resolving a keyless bearer can MINT a fresh token_v2
+    // — a synchronous, semaphore-gated HTML load documented as background-only that
+    // blocks for up to 12s. Nothing here is needed before %orig returns.
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        BOOL keyless = ApolloWebJSONHasUsableSession();
+        NSString *bearer = keyless ? ApolloWebJSONKeylessOAuthBearer(username) : sLatestRedditBearerToken;
+        if (bearer.length == 0) {
+            ApolloLog(@"[OwnFlair] Prefetch for r/%@ skipped: no usable bearer", subreddit);
+            done();
+            return;
+        }
+
+        NSString *encoded = [subreddit stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]] ?: subreddit;
+        NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://oauth.reddit.com/r/%@/api/flairselector?raw_json=1", encoded]];
+        if (!url) { done(); return; }
+
+        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:ApolloWebJSONProbeURL(url)];
+        request.HTTPMethod = @"POST";
+        request.HTTPBody = [[NSString stringWithFormat:@"name=%@", username] dataUsingEncoding:NSUTF8StringEncoding];
+        [request setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+        [request setValue:[@"Bearer " stringByAppendingString:bearer] forHTTPHeaderField:@"Authorization"];
+        request.timeoutInterval = 15.0;
+
+        ApolloLog(@"[OwnFlair] Prefetching own flair for r/%@ (%@ bearer)", subreddit,
+                  keyless ? @"keyless token_v2" : @"OAuth");
+
+        [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, __unused NSURLResponse *response, NSError *error) {
+        if (error || data.length == 0) {
+            ApolloLog(@"[OwnFlair] Prefetch for r/%@ failed: %@", subreddit, error.localizedDescription ?: @"empty response");
+            done();
+            return;
+        }
+        id json = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+        if (![json isKindOfClass:[NSDictionary class]]) { done(); return; }
+        id current = json[@"current"];
+        if (![current isKindOfClass:[NSDictionary class]]) { done(); return; }
+
+        id text = current[@"flair_text"];
+        NSString *flairText = [text isKindOfClass:[NSString class]] ? text : nil;
+        if (flairText.length == 0) {
+            // Authoritative: this account has no flair in this subreddit.
+            ApolloOwnFlairStorePieces(username, subreddit, @[]);
+            done();
+            return;
+        }
+
+        // Warm the subreddit's emoji catalogue first so ":token:" runs in the
+        // flair text resolve to image pieces rather than literal text.
+        ApolloUserFlairEnsureEmojisForSubreddit(subreddit, ^{
+            NSArray *pieces = ApolloUserFlairBuildPiecesForText(flairText, subreddit);
+            ApolloOwnFlairStorePieces(username, subreddit, ApolloOwnFlairSerializePieces(pieces));
+            done();
+        });
+        }] resume];
+    });
+}
+
+// Prefetching is deliberately tied to OPENING A THREAD, not to parsing a comment.
+// Comments are deserialized in bulk in places the user is not about to reply from
+// — the inbox alone parses comments from a dozen subreddits at launch — and
+// prefetching on each would fire a burst of pointless requests. RDKClient's
+// thread-open calls are the precise signal; the identifier-based variants don't
+// carry a subreddit, so they raise a short-lived flag that the first comment
+// parsed afterwards consumes.
+// Deliberately global rather than thread-local: the request is issued on the main
+// thread but its response parses on a network thread, so a thread dictionary
+// would never carry the flag across.
+static NSTimeInterval sApolloOwnFlairThreadOpenAt = 0;
+static os_unfair_lock sApolloOwnFlairThreadOpenLock = OS_UNFAIR_LOCK_INIT;
+
+static void ApolloOwnFlairMarkThreadOpening(void) {
+    os_unfair_lock_lock(&sApolloOwnFlairThreadOpenLock);
+    sApolloOwnFlairThreadOpenAt = [NSDate timeIntervalSinceReferenceDate];
+    os_unfair_lock_unlock(&sApolloOwnFlairThreadOpenLock);
+}
+
+// Consumes the flag, so one thread open prefetches at most one subreddit.
+static BOOL ApolloOwnFlairConsumeThreadOpening(void) {
+    os_unfair_lock_lock(&sApolloOwnFlairThreadOpenLock);
+    NSTimeInterval markedAt = sApolloOwnFlairThreadOpenAt;
+    sApolloOwnFlairThreadOpenAt = 0;
+    os_unfair_lock_unlock(&sApolloOwnFlairThreadOpenLock);
+    // An unconsumed flag must not arm a prefetch for an unrelated subreddit later.
+    return markedAt > 0 && ([NSDate timeIntervalSinceReferenceDate] - markedAt) < 20.0;
+}
+
+// Only ever one prefetch per subreddit per launch — a miss that resolves to
+// "no flair" must not re-ask on every thread open.
+static void ApolloOwnFlairMaybePrefetch(NSString *username, NSString *subreddit) {
+    NSString *key = ApolloOwnFlairKey(username, subreddit);
+    if (!key) return;
+
+    BOOL stale = NO;
+    NSArray *known = ApolloOwnFlairLookup(username, subreddit, &stale);
+    if (known && !stale) return;
+
+    @synchronized (ApolloOwnFlairPrefetchAttempted()) {
+        if ([ApolloOwnFlairPrefetchAttempted() containsObject:key]) return;
+        [ApolloOwnFlairPrefetchAttempted() addObject:key];
+    }
+    ApolloOwnFlairPrefetch(username, subreddit);
+}
+
+#pragma mark - Harvest + backfill
+
+static NSString *ApolloOwnFlairStringProperty(id model, SEL selector) {
+    if (![model respondsToSelector:selector]) return nil;
+    id value = nil;
+    @try { value = ((id (*)(id, SEL))objc_msgSend)(model, selector); }
+    @catch (__unused NSException *e) { return nil; }
+    return [value isKindOfClass:[NSString class]] ? value : nil;
+}
+
+// A comment the user just wrote is seconds old. Reddit stamps created/created_utc
+// at creation on both paths (the keyless synthesis in ApolloWebJSON.m uses "now"),
+// so this cheaply separates the write's own result from any older comment of ours
+// that happens to parse during the arm window.
+static BOOL ApolloOwnFlairIsRecent(id model) {
+    if (![model respondsToSelector:@selector(createdUTC)]) return NO;
+    id created = nil;
+    @try { created = ((id (*)(id, SEL))objc_msgSend)(model, @selector(createdUTC)); }
+    @catch (__unused NSException *e) { return NO; }
+    if (![created isKindOfClass:[NSDate class]]) return NO;
+    NSTimeInterval age = -[(NSDate *)created timeIntervalSinceNow];
+    return age >= -60.0 && age < kApolloOwnFlairArmTTL;   // tolerate mild clock skew
+}
+
+static NSArray *ApolloOwnFlairArrayProperty(id model, SEL selector) {
+    if (![model respondsToSelector:selector]) return nil;
+    id value = nil;
+    @try { value = ((id (*)(id, SEL))objc_msgSend)(model, selector); }
+    @catch (__unused NSException *e) { return nil; }
+    return [value isKindOfClass:[NSArray class]] ? value : nil;
+}
+
+void ApolloOwnCommentFlairInspectModel(id model) {
+    if (!model) return;
+
+    static Class commentClass = Nil, linkClass = Nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        commentClass = objc_getClass("RDKComment");
+        linkClass = objc_getClass("RDKLink");
+    });
+
+    BOOL isComment = commentClass && [model isKindOfClass:commentClass];
+    BOOL isLink = !isComment && linkClass && [model isKindOfClass:linkClass];
+    if (!isComment && !isLink) return;
+
+    NSString *subreddit = ApolloOwnFlairStringProperty(model, @selector(subreddit));
+    if (subreddit.length == 0) return;
+
+    // The first comment parsed after a thread-open call tells us which subreddit
+    // the user is now reading — and may reply in. At most one request per
+    // subreddit per launch.
+    NSString *username = ApolloOwnFlairActiveUsername();
+    if (isComment && username.length > 0 && ApolloOwnFlairConsumeThreadOpening())
+        ApolloOwnFlairMaybePrefetch(username, subreddit);
+
+    NSString *author = ApolloOwnFlairStringProperty(model, @selector(author));
+    if (!ApolloOwnFlairIsActiveUser(author)) return;
+
+    NSArray *richtext = ApolloOwnFlairArrayProperty(model, @selector(authorFlairRichtext));
+    NSString *plaintext = ApolloOwnFlairStringProperty(model, @selector(authorFlairPlaintext));
+    BOOL hasFlair = (richtext.count > 0) || (plaintext.length > 0);
+
+    if (hasFlair) {
+        // Never learn from a flair we ourselves invented.
+        if (objc_getAssociatedObject(model, &kApolloOwnFlairSynthesizedKey)) return;
+        if (richtext.count > 0) {
+            NSArray<NSDictionary *> *pieces = ApolloOwnFlairSerializePieces(richtext);
+            if (pieces.count > 0) ApolloOwnFlairStorePieces(username, subreddit, pieces);
+            return;
+        }
+        // Plaintext-only: ":token:" runs need the subreddit's emoji catalogue to
+        // become image pieces. Warming it first keeps a cold cache from persisting
+        // literal ":token:" text that would later be painted onto a real comment.
+        ApolloUserFlairEnsureEmojisForSubreddit(subreddit, ^{
+            NSArray<NSDictionary *> *pieces =
+                ApolloOwnFlairSerializePieces(ApolloUserFlairBuildPiecesForText(plaintext, subreddit));
+            if (pieces.count > 0) ApolloOwnFlairStorePieces(username, subreddit, pieces);
+        });
+        return;
+    }
+
+    // No flair on one of our own things. Two very different reasons:
+    //  * it came from a listing  -> authoritative "we have no flair here"
+    //  * it is the comment we just posted -> the payload simply omits flair, and
+    //    treating that as a negative would wipe the record we are about to use.
+    // The arm tells them apart.
+    ApolloOwnFlairArm *arm = isComment ? ApolloOwnFlairMatchArm(subreddit) : nil;
+    if (!arm) {
+        if (username.length > 0) ApolloOwnFlairStorePieces(username, subreddit, @[]);
+        return;
+    }
+
+    // An arm says "a write to this subreddit is in flight", not "this exact model
+    // is its result". Without a recency check, one of the user's OLD flairless
+    // comments parsed during the window could claim the backfill. A comment that
+    // was genuinely just written is seconds old.
+    if (!ApolloOwnFlairIsRecent(model)) return;
+
+    if (!ApolloOwnFlairClaimArmPatch(arm)) return;   // this write already backfilled
+
+    BOOL stale = NO;
+    NSArray<NSDictionary *> *cached = ApolloOwnFlairLookup(username, subreddit, &stale);
+    if (cached.count == 0) {
+        // Unknown, or known to be flairless here. Leave the comment blank — that
+        // is today's behaviour, and guessing would be worse than a blank pill.
+        ApolloLog(@"[OwnFlair] Fresh comment in r/%@ has no cached flair to restore — leaving blank", subreddit);
+        return;
+    }
+
+    NSArray *pieces = ApolloOwnFlairMaterializePieces(cached);
+    if (pieces.count == 0) return;
+    if (![model respondsToSelector:@selector(setAuthorFlairRichtext:)]) return;
+
+    // authorFlairRichtext, never authorFlair: -[RDKComment authorFlair] is a
+    // computed getter that ignores its own ivar, so setAuthorFlair: renders nothing.
+    @try {
+        ((void (*)(id, SEL, id))objc_msgSend)(model, @selector(setAuthorFlairRichtext:), pieces);
+    } @catch (__unused NSException *e) { return; }
+
+    objc_setAssociatedObject(model, &kApolloOwnFlairSynthesizedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloLog(@"[OwnFlair] Backfilled own flair on just-posted comment in r/%@ (%lu piece(s))",
+              subreddit, (unsigned long)pieces.count);
+}
+
+#pragma mark - Write-through from the flair editor
+
+void ApolloOwnCommentFlairRecordSetFlair(NSString *subreddit, NSString *text) {
+    NSString *username = ApolloOwnFlairActiveUsername();
+    if (username.length == 0 || subreddit.length == 0) return;
+    if (text.length == 0) {
+        ApolloOwnFlairStorePieces(username, subreddit, @[]);
+        return;
+    }
+    ApolloUserFlairEnsureEmojisForSubreddit(subreddit, ^{
+        NSArray *pieces = ApolloUserFlairBuildPiecesForText(text, subreddit);
+        ApolloOwnFlairStorePieces(username, subreddit, ApolloOwnFlairSerializePieces(pieces));
+    });
+}
+
+void ApolloOwnCommentFlairRecordShowFlair(NSString *subreddit, BOOL show) {
+    NSString *username = ApolloOwnFlairActiveUsername();
+    if (username.length == 0 || subreddit.length == 0) return;
+    if (show) ApolloOwnFlairForget(username, subreddit);       // re-resolve the real value
+    else ApolloOwnFlairStorePieces(username, subreddit, @[]);  // hidden flair renders as none
+}
+
+#pragma mark - Hooks
+
+// Arm around the submit so the backfill can only ever touch the comment the user
+// just posted. The response parses inside the completion, well within the arm TTL.
+%hook RDKClient
+
+- (id)submitComment:(id)comment onLink:(id)link completion:(id)completion {
+    ApolloOwnFlairArmSubmit(ApolloOwnFlairStringProperty(link, @selector(subreddit)));
+    ApolloOwnFlairBeginTypedScope();
+    id result = %orig;
+    ApolloOwnFlairEndTypedScope();
+    return result;
+}
+
+- (id)submitComment:(id)comment asReplyToComment:(id)parent completion:(id)completion {
+    ApolloOwnFlairArmSubmit(ApolloOwnFlairStringProperty(parent, @selector(subreddit)));
+    ApolloOwnFlairBeginTypedScope();
+    id result = %orig;
+    ApolloOwnFlairEndTypedScope();
+    return result;
+}
+
+- (id)submitComment:(id)comment onThingWithFullName:(id)fullName completion:(id)completion {
+    // Only when reached directly: the two typed entry points above already armed
+    // with a real subreddit and tail-call through here on the same thread.
+    if (!ApolloOwnFlairInTypedScope()) ApolloOwnFlairArmSubmit(nil);
+    return %orig;
+}
+
+// Editing has the same flair-less response shape as posting, so it needs the same
+// arm — otherwise the edited comment comes back with no flair, the harvester reads
+// that as "this account has no flair here", and it wipes the very record the fix
+// depends on. The arm only suppresses that false negative here: an edited comment
+// keeps its original createdUTC, so the recency gate declines to backfill it. That
+// is deliberate — relaxing recency to cover edits would reopen the hole where an
+// old flairless comment of ours claims the arm.
+- (id)editComment:(id)comment newText:(id)text completion:(id)completion {
+    ApolloOwnFlairArmSubmit(ApolloOwnFlairStringProperty(comment, @selector(subreddit)));
+    return %orig;
+}
+
+// Opening a thread is the cue to make sure we know the user's flair there before
+// they start typing a reply. The link-typed variant hands us the subreddit
+// outright; the identifier variants don't, so they defer to the first comment
+// parsed from the response.
+
+- (id)commentsForLink:(id)link completion:(id)completion {
+    NSString *subreddit = ApolloOwnFlairStringProperty(link, @selector(subreddit));
+    NSString *username = ApolloOwnFlairActiveUsername();
+    if (subreddit.length > 0 && username.length > 0) ApolloOwnFlairMaybePrefetch(username, subreddit);
+    else ApolloOwnFlairMarkThreadOpening();
+    return %orig;
+}
+
+- (id)commentsForLinkWithIdentifier:(id)identifier completion:(id)completion {
+    ApolloOwnFlairMarkThreadOpening();
+    return %orig;
+}
+
+- (id)commentsForLinkWithIdentifier:(id)identifier sort:(long long)sort limit:(long long)limit completion:(id)completion {
+    ApolloOwnFlairMarkThreadOpening();
+    return %orig;
+}
+
+- (id)linkAndCommentsForLinkWithIdentifier:(id)identifier completion:(id)completion {
+    ApolloOwnFlairMarkThreadOpening();
+    return %orig;
+}
+
+- (id)linkAndCommentsForLinkWithIdentifier:(id)identifier commentSort:(long long)sort pagination:(id)pagination completion:(id)completion {
+    ApolloOwnFlairMarkThreadOpening();
+    return %orig;
+}
+
+%end

--- a/src/ApolloOwnCommentFlair.xm
+++ b/src/ApolloOwnCommentFlair.xm
@@ -325,16 +325,26 @@ static void ApolloOwnFlairArmSubmit(NSString *subreddit) {
 
 // The live arm covering this subreddit, if any. Never removes it — see the note
 // on ApolloOwnFlairArm.
+//
+// Prefers an arm that has not spent its backfill: two comments posted into the
+// same subreddit within the TTL each append their own arm, and always returning
+// the first (by then patched) one would starve the second comment's claim. A
+// patched match is still returned when it is the only match — the caller relies
+// on arm != nil to keep suppressing the "no flair here" negative for the arm's
+// whole TTL, not just until its backfill is used.
 static ApolloOwnFlairArm *ApolloOwnFlairMatchArm(NSString *subreddit) {
     @synchronized (ApolloOwnFlairArms()) {
         ApolloOwnFlairPruneArms_locked();
+        ApolloOwnFlairArm *patchedMatch = nil;
         for (ApolloOwnFlairArm *arm in ApolloOwnFlairArms()) {
             NSString *armed = arm.subreddit;
-            if (armed.length == 0 || (subreddit.length > 0 && [armed caseInsensitiveCompare:subreddit] == NSOrderedSame))
-                return arm;
+            if (armed.length == 0 || (subreddit.length > 0 && [armed caseInsensitiveCompare:subreddit] == NSOrderedSame)) {
+                if (!arm.patched) return arm;
+                if (!patchedMatch) patchedMatch = arm;
+            }
         }
+        return patchedMatch;
     }
-    return nil;
 }
 
 // Claims the single backfill this arm is allowed. Returns NO if already used.

--- a/src/ApolloUserFlair.h
+++ b/src/ApolloUserFlair.h
@@ -1,0 +1,26 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Small export surface over ApolloUserFlair.xm's RDKFlair construction, so other
+// modules (currently ApolloOwnCommentFlair.xm) can build flair pieces without
+// duplicating the emoji-token parsing or the "emoji pieces must have a nil text"
+// rule. Everything else in that translation unit stays static.
+
+// One RDKFlair carrying `text`, via -[RDKFlair initWithRawText:].
+id _Nullable ApolloUserFlairBuildTextPiece(NSString *text);
+
+// One RDKFlair emoji run. `text` is deliberately left nil — the native flair cell
+// treats any non-nil text as a text run and renders it instead of the image.
+id _Nullable ApolloUserFlairBuildEmojiPiece(NSString *emojiLabel, NSString *imageURL);
+
+// Splits a flair_text string into RDKFlair pieces, turning ":token:" into emoji
+// runs using the subreddit's cached emoji catalogue. Synchronous and network-free;
+// unknown tokens stay as literal text (so a cold emoji cache degrades gracefully).
+NSArray *_Nullable ApolloUserFlairBuildPiecesForText(NSString *flairText, NSString *subreddit);
+
+// Ensures the subreddit's emoji catalogue is cached, then runs `completion` (on an
+// arbitrary queue). Fires immediately when the catalogue is already warm.
+void ApolloUserFlairEnsureEmojisForSubreddit(NSString *subreddit, void (^completion)(void));
+
+NS_ASSUME_NONNULL_END

--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -1,5 +1,7 @@
 #import "ApolloCommon.h"
+#import "ApolloOwnCommentFlair.h"
 #import "ApolloState.h"
+#import "ApolloUserFlair.h"
 #import "ApolloWebJSON.h"
 #import "ApolloWebSessionStore.h"
 #import <WebKit/WebKit.h>
@@ -1960,6 +1962,38 @@ static NSArray *ApolloUserFlairPiecesFromFlairText(NSString *flairText, NSString
     return ApolloUserFlairPiecesFromFlairTextWithEmojiMap(flairText, map);
 }
 
+#pragma mark - Exports for ApolloOwnCommentFlair
+
+// Thin wrappers over the static builders above. ApolloOwnCommentFlair.xm restores
+// the poster's own flair on a just-posted comment and needs to turn a stored
+// flair_text back into RDKFlair pieces; everything else in this file stays static.
+
+id ApolloUserFlairBuildTextPiece(NSString *text) {
+    return ApolloUserFlairMakeTextFlair(text);
+}
+
+id ApolloUserFlairBuildEmojiPiece(NSString *emojiLabel, NSString *imageURL) {
+    return ApolloUserFlairMakeEmojiFlair(emojiLabel, imageURL);
+}
+
+NSArray *ApolloUserFlairBuildPiecesForText(NSString *flairText, NSString *subreddit) {
+    return ApolloUserFlairPiecesFromFlairText(flairText, subreddit.lowercaseString);
+}
+
+void ApolloUserFlairEnsureEmojisForSubreddit(NSString *subreddit, void (^completion)(void)) {
+    if (!completion) return;
+    if (subreddit.length == 0) { completion(); return; }
+
+    NSString *key = subreddit.lowercaseString;
+    NSArray *cached = nil;
+    BOOL partial = NO;
+    @synchronized (ApolloUserFlairEmojiListCache()) { cached = ApolloUserFlairEmojiListCache()[key]; }
+    @synchronized (ApolloUserFlairPartialEmojiCacheKeys()) { partial = [ApolloUserFlairPartialEmojiCacheKeys() containsObject:key]; }
+    if (cached && !partial) { completion(); return; }
+
+    ApolloUserFlairFetchEmojis(subreddit, ^(__unused NSArray *emojis) { completion(); });
+}
+
 #pragma mark - API-key-free old-Reddit flair bridge
 
 // Reddit's OAuth-only GET /r/<sub>/api/user_flair_v2 is what Apollo normally
@@ -2896,18 +2930,34 @@ static BOOL ApolloUserFlairPresenterHasFlairSelector(UIViewController *presenter
                                   text:(NSString *)text
                             templateID:(NSString *)templateID
                             completion:(id)completion {
-    if (!ApolloWebJSONHasUsableSession()) return %orig;
+    // Remember what the user just applied, so the next comment they post in this
+    // subreddit renders it immediately — Reddit's comment-create response never
+    // carries author_flair_* (see ApolloOwnCommentFlair.xm). Recorded from inside
+    // the completion, and only on success: a rejected save must not leave us
+    // believing in a flair the account doesn't actually have. Wrapping is safe on
+    // both branches because both take the same void (^)(NSError *) completion.
+    void (^originalCompletion)(NSError *) = completion;
+    id wrapped = ^(NSError *error) {
+        if (!error) ApolloOwnCommentFlairRecordSetFlair(subreddit, text);
+        if (originalCompletion) originalCompletion(error);
+    };
+    if (!ApolloWebJSONHasUsableSession()) return %orig(subreddit, text, templateID, wrapped);
     return ApolloUserFlairPerformWebUpdate(@"/api/selectflair", subreddit, @{
         @"flair_template_id": templateID ?: @"",
         @"text": text ?: @"",
-    }, completion);
+    }, wrapped);
 }
 
 - (id)setShowUserFlair:(BOOL)show subredditName:(NSString *)subreddit completion:(id)completion {
-    if (!ApolloWebJSONHasUsableSession()) return %orig;
+    void (^originalCompletion)(NSError *) = completion;
+    id wrapped = ^(NSError *error) {
+        if (!error) ApolloOwnCommentFlairRecordShowFlair(subreddit, show);
+        if (originalCompletion) originalCompletion(error);
+    };
+    if (!ApolloWebJSONHasUsableSession()) return %orig(show, subreddit, wrapped);
     return ApolloUserFlairPerformWebUpdate(@"/api/setflairenabled", subreddit, @{
         @"flair_enabled": show ? @"true" : @"false",
-    }, completion);
+    }, wrapped);
 }
 
 %end

--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -1102,7 +1102,14 @@ static NSDictionary *ApolloUserFlairParseTemplateLimits(id templates) {
 static void ApolloUserFlairStoreTemplateLimits(NSString *subreddit, NSDictionary *byTemplate) {
     NSString *key = subreddit.lowercaseString;
     if (key.length == 0 || !byTemplate) return;
-    @synchronized (ApolloUserFlairTemplateLimitsCache()) { ApolloUserFlairTemplateLimitsCache()[key] = byTemplate; }
+    @synchronized (ApolloUserFlairTemplateLimitsCache()) {
+        // Never downgrade real limits to the empty marker: concurrent editor opens can
+        // race a slow no-answer fetch against one that found templates, and last-write-
+        // wins would pin the /10 default for the rest of the session.
+        NSDictionary *existing = ApolloUserFlairTemplateLimitsCache()[key];
+        if (byTemplate.count == 0 && existing.count > 0) return;
+        ApolloUserFlairTemplateLimitsCache()[key] = byTemplate;
+    }
 }
 
 static BOOL ApolloUserFlairHasTemplateLimits(NSString *subreddit) {
@@ -1126,10 +1133,60 @@ static NSUInteger ApolloUserFlairMaxEmojisForTemplate(NSString *subreddit, NSStr
     return kApolloUserFlairMaxEmojis;
 }
 
+// One synchronous GET of `url` with `bearer`, parsed into templateID -> limits (nil on
+// any failure). `outDefinitive` reports whether Reddit itself answered the flair
+// question — i.e. whether an empty result may be cached as "asked, nothing usable".
+// That requires the answer to have come from oauth.reddit.com (on a keyless account
+// the transport layer can reroute this request to cookie auth on www, whose 403/HTML
+// answers are transport artifacts, not flair config — see ApolloWebJSONNoteResponse's
+// block-page handling) AND to look like a real API answer: a JSON array for 200, or a
+// JSON body for 403 ("flair self-assign off"; Reddit's transient rate-limit block
+// pages are text/html). Background queues only — bounded by the request timeout.
+static NSDictionary *ApolloUserFlairFetchTemplateLimits(NSURL *url, NSString *bearer, NSInteger *outStatus, BOOL *outDefinitive) {
+    if (outStatus) *outStatus = 0;
+    if (outDefinitive) *outDefinitive = NO;
+    if (!url || bearer.length == 0) return nil;
+    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url];
+    [req setValue:[@"Bearer " stringByAppendingString:bearer] forHTTPHeaderField:@"Authorization"];
+    [req setValue:@"Apollo iOS" forHTTPHeaderField:@"User-Agent"];
+    req.HTTPShouldHandleCookies = NO;
+    req.timeoutInterval = 15;
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    __block NSData *body = nil;
+    __block NSHTTPURLResponse *http = nil;
+    [[[NSURLSession sharedSession] dataTaskWithRequest:req completionHandler:^(NSData *data, NSURLResponse *resp, NSError *error) {
+        body = data;
+        if ([resp isKindOfClass:[NSHTTPURLResponse class]]) http = (NSHTTPURLResponse *)resp;
+        dispatch_semaphore_signal(sema);
+    }] resume];
+    if (dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 18 * NSEC_PER_SEC)) != 0) return nil;
+    NSInteger status = http.statusCode;
+    if (outStatus) *outStatus = status;
+    // http.URL reflects any pre-flight rewrite, so this is the host that ANSWERED.
+    BOOL fromOAuth = [http.URL.host.lowercaseString isEqualToString:@"oauth.reddit.com"];
+    if (status == 403 && fromOAuth) {
+        NSString *contentType = [http.allHeaderFields[@"Content-Type"] description].lowercaseString;
+        if (outDefinitive) *outDefinitive = [contentType containsString:@"json"];
+        return nil;
+    }
+    if (status != 200 || body.length == 0) return nil;
+    id json = [NSJSONSerialization JSONObjectWithData:body options:0 error:NULL];
+    if (outDefinitive) *outDefinitive = fromOAuth && [json isKindOfClass:[NSArray class]];
+    return ApolloUserFlairParseTemplateLimits(json);
+}
+
 // Ensure the per-template limits for a subreddit are cached, fetching user_flair_v2 once
 // if needed. Lazy: the editor calls this on open. `completion` always runs on the main
-// queue. The result is cached (including an empty marker for 403/none) so reopening the
-// editor doesn't refetch; a pure network failure is left uncached so it can retry.
+// queue. The result is cached (including an empty marker when Reddit answered but had
+// nothing usable) so reopening the editor doesn't refetch; a pure network failure is
+// left uncached so it can retry.
+//
+// Two transports, because the endpoint is OAuth-only: Apollo's own bearer works
+// directly for API-key accounts, but on a keyless (web-session) account the WebJSON
+// layer reroutes that first request to cookie auth on www — which user_flair_v2
+// rejects — so we rescue with the session's token_v2 cookie, itself a valid OAuth
+// bearer on oauth.reddit.com (same trick as ApolloWebJSONRescueFlairList). The rescue
+// request is probe-marked so the transport hooks don't reroute it again.
 static void ApolloUserFlairEnsureTemplateLimits(NSString *subreddit, void (^completion)(void)) {
     void (^done)(void) = ^{
         if (!completion) return;
@@ -1137,25 +1194,42 @@ static void ApolloUserFlairEnsureTemplateLimits(NSString *subreddit, void (^comp
         else dispatch_async(dispatch_get_main_queue(), completion);
     };
     if (ApolloUserFlairHasTemplateLimits(subreddit)) { done(); return; }
-    NSString *token = [sLatestRedditBearerToken copy];
     NSString *enc = [subreddit stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]] ?: subreddit;
-    if (token.length == 0 || enc.length == 0) { done(); return; }
-    NSString *urlStr = [NSString stringWithFormat:@"https://oauth.reddit.com/r/%@/api/user_flair_v2?raw_json=1", enc];
-    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlStr]];
-    [req setValue:[@"Bearer " stringByAppendingString:token] forHTTPHeaderField:@"Authorization"];
-    [req setValue:@"Apollo iOS" forHTTPHeaderField:@"User-Agent"];
-    req.timeoutInterval = 20;
-    [[[NSURLSession sharedSession] dataTaskWithRequest:req completionHandler:^(NSData *data, NSURLResponse *resp, NSError *error) {
-        id json = data ? [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL] : nil;
-        NSDictionary *byTemplate = ApolloUserFlairParseTemplateLimits(json);
+    if (enc.length == 0) { done(); return; }
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"https://oauth.reddit.com/r/%@/api/user_flair_v2?raw_json=1", enc]];
+    // Everything below blocks on semaphores (fetches, and possibly a token_v2 mint
+    // inside ApolloWebJSONKeylessOAuthBearer) — keep it off the main thread and off
+    // NSURLSession's own serial delegate queue.
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        NSInteger status = 0;
+        BOOL definitive = NO;
+        NSDictionary *byTemplate = nil;
+        NSString *apolloBearer = [sLatestRedditBearerToken copy];
+        if (apolloBearer.length) {
+            byTemplate = ApolloUserFlairFetchTemplateLimits(url, apolloBearer, &status, &definitive);
+            if (!byTemplate.count) {
+                ApolloLog(@"[UserFlair] limits fetch r/%@ primary HTTP %ld — %@", subreddit, (long)status,
+                    definitive ? @"no usable templates" : @"trying token_v2 rescue");
+            }
+        }
+        if (!byTemplate.count) {
+            NSString *webBearer = ApolloWebJSONKeylessOAuthBearer(nil);
+            if (webBearer.length) {
+                // The rescue's verdict supersedes the primary's: if it errors out
+                // (definitive becomes NO), the sub stays uncached and retries later.
+                byTemplate = ApolloUserFlairFetchTemplateLimits(ApolloWebJSONProbeURL(url), webBearer, &status, &definitive);
+                ApolloLog(@"[UserFlair] limits rescue r/%@ HTTP %ld templates=%lu (token_v2 bearer)",
+                    subreddit, (long)status, (unsigned long)byTemplate.count);
+            }
+        }
         if (byTemplate.count) {
             ApolloUserFlairStoreTemplateLimits(subreddit, byTemplate);
             ApolloLog(@"[UserFlair] template emoji limits r/%@: %lu templates", subreddit, (unsigned long)byTemplate.count);
-        } else if (resp) {
+        } else if (definitive) {
             ApolloUserFlairStoreTemplateLimits(subreddit, @{}); // definitive: no usable limits
         }
         done();
-    }] resume];
+    });
 }
 
 #pragma mark Emoji grid cell
@@ -1379,7 +1453,8 @@ static void ApolloUserFlairEnsureTemplateLimits(NSString *subreddit, void (^comp
             (unsigned long)emojiCount, (unsigned long)self.maxEmojis];
     }
     self.counterLabel.textColor = (overText || overEmoji) ? [UIColor systemRedColor] : [UIColor secondaryLabelColor];
-    self.saveItem.enabled = !overText && !overEmoji;
+    // Save stays tappable while over a limit — a greyed-out button doesn't tell the
+    // user WHY they can't save; saveTapped explains the community's rule instead.
     [self refreshPreview];
 }
 
@@ -1458,6 +1533,48 @@ static void ApolloUserFlairEnsureTemplateLimits(NSString *subreddit, void (^comp
 - (void)cancelTapped { [self finishAndDismiss]; }
 
 - (void)saveTapped {
+    NSString *text = self.textField.text ?: @"";
+    // Saving past a limit is legal but useless-to-misleading: Reddit silently won't
+    // display emoji beyond the community's cap, and rejects text past 64 chars. The
+    // counter already went red — this explains WHY before anything is committed.
+    NSUInteger textLen = 0;
+    NSUInteger emojiCount = [self emojiCountInText:text textLength:&textLen];
+    BOOL overText = textLen > kApolloUserFlairMaxLength;
+    BOOL overEmoji = emojiCount > self.maxEmojis;
+    if (overText || overEmoji) {
+        NSMutableArray<NSString *> *reasons = [NSMutableArray array];
+        if (overEmoji && self.maxEmojis == 0) {
+            [reasons addObject:[NSString stringWithFormat:
+                @"r/%@ only allows plain text in user flair — emoji won't be displayed.", self.subreddit]];
+        } else if (overEmoji) {
+            [reasons addObject:[NSString stringWithFormat:
+                @"r/%@ allows up to %lu emoji in user flair, and this flair uses %lu. Reddit won't display the extra emoji.",
+                self.subreddit, (unsigned long)self.maxEmojis, (unsigned long)emojiCount]];
+        }
+        if (overText) {
+            [reasons addObject:[NSString stringWithFormat:
+                @"Flair text is limited to %lu characters, and this flair uses %lu. Reddit may reject the save.",
+                (unsigned long)kApolloUserFlairMaxLength, (unsigned long)textLen]];
+        }
+        ApolloLog(@"[UserFlair] save over-limit prompt subreddit=%@ emoji=%lu/%lu textLen=%lu",
+            self.subreddit, (unsigned long)emojiCount, (unsigned long)self.maxEmojis, (unsigned long)textLen);
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Over This Community's Flair Limit"
+                                                                       message:[reasons componentsJoinedByString:@"\n\n"]
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+        __weak typeof(self) weakSelf = self;
+        [alert addAction:[UIAlertAction actionWithTitle:@"Save Anyway" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *a) {
+            [weakSelf commitAndDismiss];
+        }]];
+        UIAlertAction *keepEditing = [UIAlertAction actionWithTitle:@"Keep Editing" style:UIAlertActionStyleCancel handler:nil];
+        [alert addAction:keepEditing];
+        alert.preferredAction = keepEditing;
+        [self presentViewController:alert animated:YES completion:nil];
+        return;
+    }
+    [self commitAndDismiss];
+}
+
+- (void)commitAndDismiss {
     NSString *text = self.textField.text ?: @"";
     ApolloUserFlairEditSession *session = self.session;
     ApolloLog(@"[UserFlair] save tapped subreddit=%@ templateID=%@ textLen=%lu",

--- a/src/ApolloWebJSON.h
+++ b/src/ApolloWebJSON.h
@@ -101,6 +101,15 @@ NSArray *ApolloWebJSONRescueFlairList(NSHTTPURLResponse *response);
 // the web-session account's token_v2, not Apollo's own OAuth credential.
 BOOL ApolloWebJSONRequestIsInternal(NSURL *url);
 
+// A token_v2-derived OAuth bearer for `username` (or the active web-session
+// account when nil/empty), minting a fresh token when the stored one is stale
+// (see ApolloWebJSONRescueFlairList above for why token_v2 works there).
+// Returns nil when the account has no stored web session — i.e. for API-key
+// accounts, which authenticate with Apollo's own bearer instead. Synchronous,
+// bounded by short timeouts — background queues only. Callers must mark their
+// request with ApolloWebJSONProbeURL so the transport hooks leave it alone.
+NSString *ApolloWebJSONKeylessOAuthBearer(NSString *username);
+
 // Hydrates the legacy single-session globals from the keychain, migrating any
 // legacy NSUserDefaults cookie value, then any legacy single-global session,
 // into the per-account ApolloWebSessionStore (see that file's harvest path for

--- a/src/ApolloWebJSON.h
+++ b/src/ApolloWebJSON.h
@@ -82,6 +82,25 @@ BOOL ApolloWebJSONShouldStubInvitedModerators(NSURLResponse *response);
 // RDKResponseSerializer hook.
 BOOL ApolloWebJSONShouldStubFlairList(NSURLResponse *response);
 
+// Recovers the real flair-template list after a cookie-routed flair fetch
+// failed (see ApolloWebJSONShouldStubFlairList): refetches the same path+query
+// from oauth.reddit.com using the session's token_v2 cookie as an OAuth
+// bearer, minting a fresh token via a cookie-authed HTML page load when the
+// stored one has aged out (Reddit only rotates token_v2 on HTML responses).
+// Returns the template array Apollo natively parses, or nil when no usable
+// bearer/response could be produced (caller falls back to the empty stub).
+// Synchronous, bounded by short timeouts — background queues only; in
+// practice it runs on AFNetworking's response-processing queue via the
+// RDKResponseSerializer hook.
+NSArray *ApolloWebJSONRescueFlairList(NSHTTPURLResponse *response);
+
+// YES for requests the WebJSON layer authors itself (session probes, token_v2
+// mints, flair rescue fetches), marked by an internal URL fragment that never
+// reaches the wire. Transport-level observers — in particular the bearer
+// capture feeding sLatestRedditBearerToken — must skip these: their bearer is
+// the web-session account's token_v2, not Apollo's own OAuth credential.
+BOOL ApolloWebJSONRequestIsInternal(NSURL *url);
+
 // Hydrates the legacy single-session globals from the keychain, migrating any
 // legacy NSUserDefaults cookie value, then any legacy single-global session,
 // into the per-account ApolloWebSessionStore (see that file's harvest path for

--- a/src/ApolloWebJSON.m
+++ b/src/ApolloWebJSON.m
@@ -1506,13 +1506,15 @@ BOOL ApolloWebJSONShouldStubInvitedModerators(NSURLResponse *response) {
 }
 
 // GET /r/<sub>/api/link_flair(_v2) — the post composer's flair-template list —
-// is OAuth-only: the www mirror 404s for cookie auth (verified live; old
-// reddit picks flair via a different POST flow the app can't use). The rewrite
-// still routes it to www so it draws a definitive 404 instead of the oauth
-// 401→refresh→retry loop (see the classifier note), and this override turns
-// that 404 into an empty flair list so the Submit drawer loads normally — no
-// flair choices, a missing feature rather than a hang. user_flair(_v2) gets
-// the same treatment for symmetry. OAuth accounts untouched (session gate).
+// rejects cookie auth: the www mirror 404s for it (verified live; old reddit
+// picks flair via a different POST flow the app can't use). The rewrite still
+// routes it to www so it draws a definitive 404 instead of the oauth
+// 401→refresh→retry loop (see the classifier note), and the serializer then
+// recovers the real list from oauth.reddit.com with the session's token_v2
+// bearer (ApolloWebJSONRescueFlairList below), stubbing an empty list only
+// when no usable bearer exists — no flair choices, but the Submit drawer
+// still loads instead of hanging. user_flair(_v2) gets the same treatment
+// for symmetry. OAuth accounts untouched (session gate).
 BOOL ApolloWebJSONShouldStubFlairList(NSURLResponse *response) {
     if (!ApolloWebJSONHasUsableSession()) return NO;
     if (![response isKindOfClass:[NSHTTPURLResponse class]]) return NO;
@@ -1526,6 +1528,156 @@ BOOL ApolloWebJSONShouldStubFlairList(NSURLResponse *response) {
                                                          options:0 error:NULL];
     });
     return [re firstMatchInString:path options:0 range:NSMakeRange(0, path.length)] != nil;
+}
+
+#pragma mark - Keyless flair rescue (token_v2 bearer)
+
+// The flair-template endpoints reject cookie auth on www, but the web
+// session's own token_v2 cookie is a valid OAuth bearer that oauth.reddit.com
+// accepts for them (verified live 2026-07-16, full native response shape).
+// The rescue below refetches the failed flair list that way, so keyless
+// accounts get real flair options in the composer instead of the empty stub.
+
+BOOL ApolloWebJSONRequestIsInternal(NSURL *url) {
+    return ApolloWebJSONURLIsProbe(url);
+}
+
+// Unix expiry of a JWT's `exp` claim, or 0 when unparseable (treated as
+// expired). token_v2 is a standard three-segment JWT.
+static NSTimeInterval ApolloWebJSONJWTExpiry(NSString *jwt) {
+    NSArray<NSString *> *parts = [jwt componentsSeparatedByString:@"."];
+    if (parts.count < 2) return 0;
+    NSString *payload = [[parts[1] stringByReplacingOccurrencesOfString:@"-" withString:@"+"]
+                         stringByReplacingOccurrencesOfString:@"_" withString:@"/"];
+    while (payload.length % 4 != 0) payload = [payload stringByAppendingString:@"="];
+    NSData *data = [[NSData alloc] initWithBase64EncodedString:payload options:0];
+    if (!data) return 0;
+    NSDictionary *claims = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+    if (![claims isKindOfClass:[NSDictionary class]]) return 0;
+    id exp = claims[@"exp"];
+    return [exp respondsToSelector:@selector(doubleValue)] ? [exp doubleValue] : 0;
+}
+
+static NSString *ApolloWebJSONCookieValueFromHeader(NSString *header, NSString *name) {
+    for (NSString *pair in [header componentsSeparatedByString:@";"]) {
+        NSString *trimmed = [pair stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        NSRange eq = [trimmed rangeOfString:@"="];
+        if (eq.location == NSNotFound || eq.location == 0) continue;
+        if ([[trimmed substringToIndex:eq.location] isEqualToString:name]) {
+            return [trimmed substringFromIndex:eq.location + 1];
+        }
+    }
+    return nil;
+}
+
+// The session's token_v2 when it's still comfortably valid (5-minute margin
+// against mid-flight expiry), else nil.
+static NSString *ApolloWebJSONUsableTokenV2ForSession(ApolloWebSessionEntry *session) {
+    NSString *token = ApolloWebJSONCookieValueFromHeader(session.cookieHeader ?: @"", @"token_v2");
+    if (token.length == 0) return nil;
+    if (ApolloWebJSONJWTExpiry(token) <= [[NSDate date] timeIntervalSince1970] + 300) return nil;
+    return token;
+}
+
+// Reddit rotates token_v2 (~24h JWT) via Set-Cookie only on HTML page loads —
+// Apollo's .json traffic never triggers one, so the stored token routinely
+// ages out while reddit_session stays perfectly valid. Fetch one HTML page
+// with the session cookie and persist the rotated cookies through the same
+// Set-Cookie merge live traffic uses. Serialized behind a lock; losers of the
+// race see the winner's fresh token on the re-check. Synchronous (bounded by
+// the request timeout) — background queues only.
+static NSString *ApolloWebJSONMintTokenV2ForAccount(NSString *username) {
+    static NSObject *mintLock;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ mintLock = [NSObject new]; });
+    @synchronized (mintLock) {
+        ApolloWebSessionEntry *session = ApolloWebSessionFor(username);
+        if (session.cookieHeader.length == 0) return nil;
+        NSString *existing = ApolloWebJSONUsableTokenV2ForSession(session);
+        if (existing) return existing; // a concurrent rescuer already minted
+
+        // The probe fragment keeps the transport hooks' hands off this request
+        // (no rewrite, no expiry accounting, no bearer capture); it never
+        // reaches the wire.
+        NSURL *mintURL = ApolloWebJSONProbeURL([NSURL URLWithString:@"https://www.reddit.com/"]);
+        NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:mintURL];
+        [req setValue:session.cookieHeader forHTTPHeaderField:@"Cookie"];
+        [req setValue:([sUserAgent length] > 0 ? sUserAgent : defaultUserAgent) forHTTPHeaderField:@"User-Agent"];
+        req.HTTPShouldHandleCookies = NO;
+        req.timeoutInterval = 10;
+
+        dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+        __block NSHTTPURLResponse *http = nil;
+        [[[NSURLSession sharedSession] dataTaskWithRequest:req
+                                         completionHandler:^(NSData *data, NSURLResponse *resp, NSError *err) {
+            if ([resp isKindOfClass:[NSHTTPURLResponse class]]) http = (NSHTTPURLResponse *)resp;
+            dispatch_semaphore_signal(sema);
+        }] resume];
+        if (dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 12 * NSEC_PER_SEC)) != 0) {
+            ApolloLog(@"[WebJSON] token_v2 mint timed out for u/%@", username);
+            return nil;
+        }
+        if (!http || http.statusCode < 200 || http.statusCode >= 400) {
+            ApolloLog(@"[WebJSON] token_v2 mint failed for u/%@ (HTTP %ld)", username, (long)http.statusCode);
+            return nil;
+        }
+        ApolloWebJSONMergeSetCookiesFromResponse(username, http);
+        NSString *minted = ApolloWebJSONUsableTokenV2ForSession(ApolloWebSessionFor(username));
+        ApolloLog(@"[WebJSON] token_v2 mint for u/%@ %@", username, minted ? @"succeeded" : @"produced no usable token");
+        return minted;
+    }
+}
+
+NSArray *ApolloWebJSONRescueFlairList(NSHTTPURLResponse *response) {
+    NSURL *failedURL = response.URL;
+    if (!failedURL) return nil;
+    // The account marker was stamped by the rewrite that authenticated the
+    // failed request; fall back to the active session for safety.
+    NSString *username = ApolloWebJSONAccountFromURL(failedURL) ?: ApolloActiveWebSessionUsername();
+    if (username.length == 0) return nil;
+    ApolloWebSessionEntry *session = ApolloWebSessionFor(username);
+    if (session.cookieHeader.length == 0) return nil;
+
+    NSString *token = ApolloWebJSONUsableTokenV2ForSession(session) ?: ApolloWebJSONMintTokenV2ForAccount(username);
+    if (token.length == 0) return nil;
+
+    // Same path + query as the failed www request, back on the oauth host.
+    NSURLComponents *components = [NSURLComponents componentsWithURL:failedURL resolvingAgainstBaseURL:NO];
+    if (!components) return nil;
+    components.host = @"oauth.reddit.com";
+    components.fragment = nil;
+    NSURL *oauthURL = components.URL ? ApolloWebJSONProbeURL(components.URL) : nil;
+    if (!oauthURL) return nil;
+
+    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:oauthURL];
+    [req setValue:[@"Bearer " stringByAppendingString:token] forHTTPHeaderField:@"Authorization"];
+    [req setValue:([sUserAgent length] > 0 ? sUserAgent : defaultUserAgent) forHTTPHeaderField:@"User-Agent"];
+    req.HTTPShouldHandleCookies = NO;
+    req.timeoutInterval = 10;
+
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    __block NSData *body = nil;
+    __block NSInteger status = 0;
+    [[[NSURLSession sharedSession] dataTaskWithRequest:req
+                                     completionHandler:^(NSData *data, NSURLResponse *resp, NSError *err) {
+        body = data;
+        if ([resp isKindOfClass:[NSHTTPURLResponse class]]) status = ((NSHTTPURLResponse *)resp).statusCode;
+        dispatch_semaphore_signal(sema);
+    }] resume];
+    if (dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 12 * NSEC_PER_SEC)) != 0) {
+        ApolloLog(@"[WebJSON] Flair rescue timed out for %@", failedURL.path);
+        return nil;
+    }
+    if (status != 200 || body.length == 0) {
+        ApolloLog(@"[WebJSON] Flair rescue got HTTP %ld for %@", (long)status, failedURL.path);
+        return nil;
+    }
+    id json = [NSJSONSerialization JSONObjectWithData:body options:0 error:NULL];
+    if (![json isKindOfClass:[NSArray class]]) {
+        ApolloLog(@"[WebJSON] Flair rescue got a non-array payload for %@", failedURL.path);
+        return nil;
+    }
+    return json;
 }
 
 #pragma mark - Credential hydration

--- a/src/ApolloWebJSON.m
+++ b/src/ApolloWebJSON.m
@@ -1628,6 +1628,14 @@ static NSString *ApolloWebJSONMintTokenV2ForAccount(NSString *username) {
     }
 }
 
+NSString *ApolloWebJSONKeylessOAuthBearer(NSString *username) {
+    NSString *user = username.length ? username : ApolloActiveWebSessionUsername();
+    if (user.length == 0) return nil;
+    ApolloWebSessionEntry *session = ApolloWebSessionFor(user);
+    if (session.cookieHeader.length == 0) return nil;
+    return ApolloWebJSONUsableTokenV2ForSession(session) ?: ApolloWebJSONMintTokenV2ForAccount(user);
+}
+
 NSArray *ApolloWebJSONRescueFlairList(NSHTTPURLResponse *response) {
     NSURL *failedURL = response.URL;
     if (!failedURL) return nil;

--- a/src/ApolloWebJSONIdentity.xm
+++ b/src/ApolloWebJSONIdentity.xm
@@ -789,14 +789,28 @@ void ApolloWebJSONRepairPoisonedAccountBlobs(void) {
                 ApolloLog(@"[WebJSON] Stubbed empty invited-moderators list (no cookie-compatible endpoint)");
             }
         } @catch (NSException *e) { ApolloLog(@"[WebJSON] invited-moderators stub failed: %@", e); }
-        // Flair-template lists are OAuth-only (www 404s for cookie auth) — see
-        // ApolloWebJSONShouldStubFlairList. Empty list = no flair options in
-        // the composer, instead of a hung Submit drawer.
+        // Flair-template lists reject cookie auth on www (404) — but the
+        // session's own token_v2 cookie is a valid OAuth bearer for them, so
+        // recover the real list from oauth.reddit.com before falling back to
+        // an empty one (no flair options, but the Submit drawer still loads
+        // instead of hanging). Either way the 404's validation error is
+        // cleared, which is also what keeps RDK's 401/404 retry machinery out
+        // of the picture. This serializer runs on AFNetworking's background
+        // processing queue, so the rescue's bounded synchronous fetches are
+        // safe here. See ApolloWebJSONRescueFlairList.
         @try {
-            if (ApolloWebJSONShouldStubFlairList(response)) {
-                obj = @[];
+            if (ApolloWebJSONShouldStubFlairList(response) && ![obj isKindOfClass:[NSArray class]]) {
+                NSArray *rescued = nil;
+                @try { rescued = ApolloWebJSONRescueFlairList((NSHTTPURLResponse *)response); }
+                @catch (NSException *e) { ApolloLog(@"[WebJSON] flair rescue failed: %@", e); }
+                obj = rescued ?: @[];
                 if (error) *error = nil;
-                ApolloLog(@"[WebJSON] Stubbed empty flair list for %@ (OAuth-only endpoint)", ((NSHTTPURLResponse *)response).URL.path);
+                if (rescued) {
+                    ApolloLog(@"[WebJSON] Recovered %lu flair template(s) for %@ via web-session bearer",
+                              (unsigned long)rescued.count, ((NSHTTPURLResponse *)response).URL.path);
+                } else {
+                    ApolloLog(@"[WebJSON] Stubbed empty flair list for %@ (no usable web bearer)", ((NSHTTPURLResponse *)response).URL.path);
+                }
             }
         } @catch (NSException *e) { ApolloLog(@"[WebJSON] flair-list stub failed: %@", e); }
     }


### PR DESCRIPTION
Follow-up to #533 and **stacked on #669** (first commit here is that PR — it reuses its token_v2-bearer helpers, so merge #669 first and this diff shrinks).

Three user-flair fixes, all of them things that only bite on API-key-free accounts or that nobody noticed until now.

## 1. Real per-sub emoji limits on API-key-free accounts

**Bug:** on API-key-free accounts the flair editor still showed the flat /10 emoji cap, so on a sub like r/ApolloReborn (3 emoji max) you could stack 10 emoji, save, and never find out why most of them don't show up on Reddit. The user_flair_v2 limits fetch from #533 rides Apollo's bearer to oauth.reddit.com, but on a web-session account the WebJSON transport reroutes it to cookie auth on www.reddit.com — which rejects the flair endpoints — and that failure got cached as "no limits" for the rest of the session.

**Fixes:**
- the limits fetch now rescues with the web session's token_v2 cookie as an OAuth bearer on oauth.reddit.com (same trick #669 proved for link_flair), probe-marked so the transport hooks leave it alone
- the empty "asked, nothing usable" marker is only cached when oauth.reddit.com actually answered (JSON array for 200 / JSON 403) — transient rate-limit block pages and rerouted www junk can't poison the session anymore, and a racing empty result can't clobber real limits
- going over the community's limit still turns the counter red, but Save no longer silently greys out — it stays tappable and pops an alert ("r/ApolloReborn allows up to 3 emoji in user flair, and this flair uses 4. Reddit won't display the extra emoji.") with Keep Editing / Save Anyway

### Screenshot of it working without API Key

<img width="596" height="640" alt="Simulator Screenshot - Apollo-Sim3 - 2026-07-16 at 13 30 45 Medium" src="https://github.com/user-attachments/assets/a3cbb3c0-a987-4c78-b17b-097f1a369e9f" />

Sim-verified on a web-session account: r/ApolloReborn shows 3/3 (was 3/10), forced the rescue path and got `limits rescue r/ApolloReborn HTTP 200 (token_v2 bearer)`, 4/3 goes red, Save pops the alert, Keep Editing returns to the editor, and nothing was committed to the live flair during testing. Not device-tested.

## 2. Your own flair on a comment you just posted

**Bug:** post a comment and it shows up in the thread instantly but with no flair pill next to your username. Everyone else's flair renders fine. Pull to refresh and yours finally appears. Happens on both API-key and API-key-free accounts.

Reddit's comment-create response just doesn't carry `author_flair_*` for the thing it made. Keyless is the provable half — `ApolloWebJSONSynthesizeModernThingData` rebuilds the legacy `{parent, content:"<html>"}` reply into a modern comment dict with 28 keys and not one flair key. The OAuth response goes through the identical `RDKObjectBuilder` -> `MTLJSONAdapter` chain as a normal listing, so Apollo isn't losing it on the way in either, the payload just doesn't have it. Either way you end up with an RDKComment whose `authorFlairRichtext` and `authorFlairPlaintext` are both empty. Everyone else looks right because their comments came in through a listing, which is also why refreshing "fixes" it.

**Worth knowing if you ever touch flair code:** `-[RDKComment authorFlair]` is a *computed* getter — it returns `authorFlairRichtext` if non-empty, else wraps `authorFlairPlaintext` in a fresh RDKFlair, and it never reads its own `_authorFlair` ivar. So `setAuthorFlair:` writes memory nothing ever reads. And `CommentCellNode.init` reads `authorFlair` exactly once and skips allocating a FlairNode at all when it's empty, with `FlairNode.flairs` being a Swift `let`. So there's no node to fill in later — the flair has to be on the model before the cell gets built, which rules out fixing this at render time.

**Fix:** keep a small per-(account, subreddit) record of your own flair and use it to backfill exactly the comment you just wrote.
- learns for free off the MTLJSONAdapter funnel ApolloFlairColors.xm already hooks — your own comments teach it your flair, and your own comments in a listing with no flair record an authoritative "none here"
- learns authoritatively when the flair editor saves, recorded from inside the completion and only on success, so a rejected save doesn't cache a flair you don't actually have
- prefetches on thread open (one request per sub per launch, off the main thread — resolving a keyless bearer can mint a token_v2, which blocks for a while)
- backfills when `submitComment:` armed that sub and the parsed comment is yours, seconds old, and flairless

Both account modes share one path, only the bearer differs. Guards, since a wrong flair is worse than no flair: records are keyed by account so switching accounts can't cross over, "unknown" and "known to have no flair" both refuse to backfill, a recency check stops an older flairless comment of yours from claiming the slot, an arm backfills at most once but stays alive its full TTL so a write response is never mistaken for evidence about your real flair, and edits are armed too so editing a comment can't record a false negative that wipes a good record.

Device-tested, works. Known gap: on the API-key path an *edited* comment still won't show flair until a refresh — backfilling edits would mean loosening the recency check, which reopens the old-comment case, and that one's pre-existing behaviour anyway.

## 3. Composer Set Flair on API-key-free accounts

First commit, from #669 — Set Flair in the post composer opened nothing on keyless accounts.
