### PR TITLE
Fix inline comment images shrinking after collapse/expand + vote-time reload flicker loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 - Redesign **Detailed Profiles** with immersive banners, prominent avatars, glass stat cards, and improved Social Links (#655: @jordanearle)
 - Add modern **Reddit Chat** for API-Key-Free accounts, with an opt-in option for API-key accounts that preserves Apollo's legacy Direct Chat (#658: @icpryde)
 
+### Fixes
+
+- Fix **inline comment images** rendering tiny inside a full-height row after collapsing and re-expanding a comment (#675: @icpryde)
+
 ## [v3.4.1] - 2026-07-15
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
-- Fix **inline comment images** rendering tiny inside a full-height row after collapsing and re-expanding a comment (#675: @icpryde)
+- Fix **inline comment images** rendering tiny inside a full-height row after collapsing and re-expanding a comment, and the row flicker/reload loop when voting on a comment with an inline image (#675: @icpryde)
 
 ## [v3.4.1] - 2026-07-15
 

--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -74,6 +74,10 @@ typedef NS_ENUM(unsigned char, ApolloASStackLayoutAlignSelf) {
 - (UIView *)view;
 - (BOOL)isNodeLoaded;
 - (void)onDidLoad:(void(^)(__kindof ASDisplayNode *node))body;
+@property (nonatomic) CGRect bounds;
+- (void)layout;
+- (void)setNeedsDisplay;
+- (void)displayWillStartAsynchronously:(BOOL)asynchronously;
 @property (nonatomic) BOOL userInteractionEnabled;
 @property (nullable, nonatomic, copy) UIColor *backgroundColor;
 @end
@@ -147,6 +151,7 @@ static char kApolloImageURLKey;                // NSURL on the imageNode AND mir
 static char kApolloOriginalImageURLKey;        // NSURL for tap/long-press when different from the loaded URL (e.g. album URL)
 static char kApolloHostMarkdownNodeKey;        // ApolloWeakHostBox (zeroing-weak) to the host MarkdownNode/LinkButtonNode
 static char kApolloAspectRatioKey;             // NSNumber height/width — NIL if unknown (no URL params yet, no DIDLOAD yet)
+static char kApolloLastDisplayBoundsKey;       // NSValue CGSize — bounds when the last display pass started (#673 stale-backing heal)
 static char kApolloLongPressInstalledKey;      // NSNumber BOOL — gate for one-shot UIContextMenuInteraction install
 static char kApolloPlayOverlayViewKey;         // ApolloPlayOverlayContainer (play button OR pause badge), also used as install gate
 static char kApolloInlineAnimatedGIFKey;       // NSNumber BOOL — node loaded an animated GIF
@@ -194,6 +199,19 @@ static ASDisplayNode *ApolloInlineHostForNode(id node) {
 // call sites want: a hostless image node is no longer inline-hosted.
 static inline BOOL ApolloImageNodeHasInlineHost(id node) {
     return ApolloInlineHostForNode(node) != nil;
+}
+
+// "Is this one of OUR inline media leaves?" — for lifetime-scoped hooks that
+// must keep working after the host association is gone. The host box is wiped
+// by ApolloClearInlineGIFNodeState (which the clearImage hook runs when a
+// collapse drops the node out of the tree and Texture purges its image), but
+// the decomposition can hand the SAME node instance back on re-expand — so a
+// host-based check would skip exactly the nodes the #673 stale-backing heal
+// exists for. kApolloImageCacheKey is stamped once at creation and never
+// cleared; video-thumbnail leaves don't carry it, so fall back to the host.
+static inline BOOL ApolloIsInlineMediaLeafNode(id node) {
+    if (objc_getAssociatedObject(node, &kApolloImageCacheKey) != nil) return YES;
+    return ApolloImageNodeHasInlineHost(node);
 }
 
 static void ApolloApplyInlineGIFPlaybackPolicyWithCover(ASNetworkImageNode *imageNode, UIImage *cover, NSUInteger retryIndex);
@@ -2152,6 +2170,59 @@ static void ApolloGateNativeInlineAnimatedImageIfNeeded(ASDisplayNode *node) {
 %end
 
 %hook ASNetworkImageNode
+
+// Stale-backing-store heal (#673: inline image renders tiny after a comment
+// collapse/expand). When Apollo re-expands a collapsed comment it re-sets the
+// MarkdownNode's attributed text, which rebuilds the decomposition with a
+// fresh image node whose aspect ratio is still unknown. If PINRemoteImage
+// then delivers the (cached) image while the node is laid out at a transient
+// wrong size — measured in the sim as full-row-width x raw-image-height
+// (e.g. 372x1044) between the intrinsic-size measure and the debounced
+// ratio-wrap relayout — Texture renders the backing store for THOSE bounds.
+// When the ratio wrapper's correct bounds land a moment later, Texture does
+// NOT re-render existing contents on a bounds change (the backing layer has
+// needsDisplayOnBoundsChange == NO), and because inline images draw with
+// contentMode aspect-fit (layer contentsGravity resizeAspect), the stale
+// oversized bitmap letterboxes inside the new frame instead of stretching —
+// the image shows tiny and centered in a full-height row. Zero-height passes
+// are immune (nothing renders, so Texture re-displays once real bounds
+// arrive), which is why initial loads and plain scrolling never showed this.
+//
+// Invariant enforced here: an inline image node whose last display pass ran
+// under different bounds than its current layout must re-display. We snapshot
+// the bounds every time a display pass starts, and compare on every layout;
+// on mismatch, request a fresh display. The redundant re-display this causes
+// for the benign zero -> real transition is a no-op (Texture coalesces it
+// with the display it schedules anyway).
+
+- (void)displayWillStartAsynchronously:(BOOL)asynchronously {
+    if (ApolloIsInlineMediaLeafNode(self)) {
+        objc_setAssociatedObject(self, &kApolloLastDisplayBoundsKey,
+                                 [NSValue valueWithCGSize:[(ASDisplayNode *)self bounds].size],
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    %orig;
+}
+
+- (void)layout {
+    %orig;
+    if (!ApolloIsInlineMediaLeafNode(self)) return;
+    NSValue *lastVal = objc_getAssociatedObject(self, &kApolloLastDisplayBoundsKey);
+    if (!lastVal) return; // never displayed — the first display matches by construction
+    CGSize cur = [(ASDisplayNode *)self bounds].size;
+    if (cur.width < 1.0 || cur.height < 1.0) return; // hidden/zero-size pass — nothing visible to heal
+    CGSize last = [lastVal CGSizeValue];
+    if (fabs(cur.width - last.width) < 0.75 && fabs(cur.height - last.height) < 0.75) return;
+    // Record before the display actually runs so intermediate layout passes
+    // (the transition applies the same bounds several times) don't queue
+    // duplicate display requests.
+    objc_setAssociatedObject(self, &kApolloLastDisplayBoundsKey,
+                             [NSValue valueWithCGSize:cur],
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloLog(@"[InlineImages] re-display: backing store was rendered at %@ but node is now %@ (node=%p)",
+              NSStringFromCGSize(last), NSStringFromCGSize(cur), self);
+    [(ASDisplayNode *)self setNeedsDisplay];
+}
 
 - (void)setURL:(NSURL *)URL {
     if (ApolloImageNodeHasInlineHost(self) &&

--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -151,6 +151,24 @@ static char kApolloImageURLKey;                // NSURL on the imageNode AND mir
 static char kApolloOriginalImageURLKey;        // NSURL for tap/long-press when different from the loaded URL (e.g. album URL)
 static char kApolloHostMarkdownNodeKey;        // ApolloWeakHostBox (zeroing-weak) to the host MarkdownNode/LinkButtonNode
 static char kApolloAspectRatioKey;             // NSNumber height/width — NIL if unknown (no URL params yet, no DIDLOAD yet)
+
+// URL → known aspect ratio, surviving node recreation. The per-node
+// kApolloAspectRatioKey dies with its node, so every cell rebuild (vote
+// reconfigure, row reload, collapse/expand) re-measured the row with the
+// image OMITTED (nil ratio → hidden) and grew it post-hoc after DIDLOAD —
+// a visible hide→pop on content the app has already sized once. Keyed by
+// the node's stable cache-key URL string (normalized/album URL — NOT the
+// loaded URL, which changes for albums and proxies). NSCache: tiny values,
+// safe eviction under pressure.
+static NSCache<NSString *, NSNumber *> *ApolloKnownImageRatios(void) {
+    static NSCache<NSString *, NSNumber *> *cache;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        cache = [NSCache new];
+        cache.countLimit = 512;
+    });
+    return cache;
+}
 static char kApolloLastDisplayBoundsKey;       // NSValue CGSize — bounds when the last display pass started (#673 stale-backing heal)
 static char kApolloLongPressInstalledKey;      // NSNumber BOOL — gate for one-shot UIContextMenuInteraction install
 static char kApolloPlayOverlayViewKey;         // ApolloPlayOverlayContainer (play button OR pause badge), also used as install gate
@@ -1934,6 +1952,13 @@ static BOOL ApolloPresentOrResolveImageChestAlbumURL(NSURL *url, UIView *sourceV
 - (void)updateAspectRatioForImageNode:(id)imageNode imageSize:(CGSize)size {
     if (size.width <= 0 || size.height <= 0) return;
     CGFloat newRatio = size.height / size.width;
+    // Persist by stable URL so the NEXT node built for this image measures at
+    // the right height immediately instead of re-running the hide→grow dance
+    // on every cell rebuild.
+    NSString *stableKey = objc_getAssociatedObject(imageNode, &kApolloImageCacheKey);
+    if ([stableKey isKindOfClass:[NSString class]] && stableKey.length > 0) {
+        [ApolloKnownImageRatios() setObject:@(newRatio) forKey:stableKey];
+    }
     NSNumber *cur = objc_getAssociatedObject(imageNode, &kApolloAspectRatioKey);
     if (cur && fabs(newRatio - [cur doubleValue]) < 0.01) return;
     objc_setAssociatedObject(imageNode, &kApolloAspectRatioKey, @(newRatio), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -3491,9 +3516,18 @@ static ASNetworkImageNode *ApolloMakeInlineImageNode(NSURL *normalizedURL,
     [[imageNode style] setValue:@(ApolloASStackLayoutAlignSelfStretch) forKey:@"alignSelf"];
 
     CGFloat ratio = ApolloAspectRatioFromURL(normalizedURL);
+    if (ratio <= 0) {
+        // A previous node instance already loaded this image and recorded its
+        // real ratio — reuse it so a rebuilt cell measures the row
+        // correctly on the FIRST pass instead of hiding the image and growing
+        // the row post-DIDLOAD. Same trust level as didLoadImage: itself.
+        NSNumber *known = [ApolloKnownImageRatios() objectForKey:normalizedURL.absoluteString ?: @""];
+        if (known) ratio = known.doubleValue;
+    }
     // kApolloAspectRatioKey is only set when we have real ratio info (URL
-    // query params now, or didLoadImage later). Nil means "unknown" → the
-    // wrapper omits the image from layout to avoid wrong-ratio races.
+    // query params now, a prior load's cached ratio, or didLoadImage later).
+    // Nil means "unknown" → the wrapper omits the image from layout to avoid
+    // wrong-ratio races.
 
     // Stable cache key — the per-MarkdownNode reuse cache and the GC
     // both key on this. For Imgur albums the loaded URL changes when

--- a/src/ApolloInlineLinkPreviews.xm
+++ b/src/ApolloInlineLinkPreviews.xm
@@ -3604,6 +3604,25 @@ static void ApolloLPTriggerPlaceholderContextRelayout(ASDisplayNode *node, NSStr
 static void ApolloLPRunOverflowHeightCheck(ASDisplayNode *node, NSString *host, NSInteger remainingAttempts) {
     if (!node) return;
     @try {
+        // V26: only police rows whose height this module actually owns.
+        // A LinkButtonNode for an inline-media URL (i.imgur.com/*.jpeg etc.) is
+        // collapsed to a zero-size spec by ApolloInlineImages — its row height
+        // belongs to that module's aspect-ratio pipeline. But Apollo's native
+        // pill layout can still leave ~47pt of stale subview frames on the
+        // collapsed stub, and the union below would read them as a phantom
+        // "overflow=47pt" that a row reload can never fix (the reload rebuilds
+        // the same stub) — on a vote this looped reload → rebuild → reload
+        // forever, visibly flickering the comment. Bail by URL
+        // ownership, which is deterministic; genuine V18 subjects (twitter/
+        // bsky/site cards) are never inline-media URLs.
+        {
+            NSURL *ownURL = objc_getAssociatedObject(node, &kApolloLinkPreviewURLKey);
+            if (!ownURL) {
+                NSString *ownURLString = ApolloGetLinkButtonNodeURLString(node);
+                if (ownURLString.length > 0) ownURL = [NSURL URLWithString:ownURLString];
+            }
+            if (ownURL && ApolloLPShouldDeferToInlineMedia(ownURL)) return;
+        }
         BOOL loaded = [node respondsToSelector:@selector(isNodeLoaded)] && [node isNodeLoaded];
         UIView *nodeView = loaded ? ApolloLPViewForNode(node) : nil;
         UIView *cellView = nil;


### PR DESCRIPTION
Fixes #673 

Collapsing a top level comment with an embedded image and re-expanding it could leave the image rendering tiny inside a full height row. Took a while to track down because the layout is actually *fine* when it happens — I attached a debugger to a live broken cell and the image node's frame, the MarkdownNode frame, and the row height were all correct. The tiny thing you see is the **backing store**: Texture rendered the bitmap while the node was momentarily at the wrong size (full row width x the image's raw pixel height, e.g. 372x1044 — there's a window between the intrinsic-size measure and the debounced ratio-wrap relayout where the cached image arrives), and Texture never re-renders existing contents when bounds change. Since our inline images draw aspect-fit (`resizeAspect` contents gravity), the stale oversized bitmap letterboxes inside the corrected frame instead of stretching, so you get a mini image floating in a tall empty row.

That's also why it only regressed recently: before #627/#638 the collapse/expand always went through a full decomposition rebuild that happened to paper over this, and why GIFs never show it (their animation layer isn't the node backing store) and why fresh loads are immune (a zero-height display renders nothing, so Texture re-displays once real bounds arrive — only a *non-zero wrong-bounds* display gets stranded).

## In Action Gif

<img width="250" height="543" alt="grow shrink" src="https://github.com/user-attachments/assets/ac954ce6-cd55-4dee-af5c-cef6c5d09eea" />

The fix enforces the invariant directly: for our inline media leaves, snapshot the node bounds whenever a display pass starts, compare on every layout, and request a fresh display when they no longer match. The check is gated on a lifetime marker (the cache-key assoc with host assoc fallback) instead of just the host association, because `clearImage` wipes the host when a collapse drops the node out of the tree but the decomposition can hand the same instance back on re-expand.

Testing (sim, iOS 26 Liquid Glass, latest main): reproduced the bug reliably on the exact comment from the issue (second collapse/expand cycle broke it every time), then with the fix ran 4 collapse/expand cycles — image comes back full size every time. Also checked child comment images, sibling images, and scrolling through the media-heavy thread for regressions. The heal logs to ApolloLog when it fires so it's easy to spot in the wild.