### PR TITLE
Fix translated-comment vote flicker and vote-time row shifts

### DIFF
--- a/src/ApolloCommentVoteFlicker.xm
+++ b/src/ApolloCommentVoteFlicker.xm
@@ -187,28 +187,68 @@ static void ApolloVFRealizeUpdatedCommentsInfo(id postInfo, const char *stage) {
 // crowd-controlled threads (reported against translated threads because
 // foreign-language subs are where both crowd control and translation are on).
 //
-// Neutralize the flag on the incoming copy when it is merely CARRIED OVER
-// (old model and copy both say collapsed) rather than deliberately flipped:
-// Apollo's own collapse toggle never routes through this notification (it
-// splices + rebuilds directly), so a carried-over YES here can only be stale
-// server state the visible row never rendered. The write goes straight to the
-// ivar so no setCollapsed: hooks (cover views, settle windows) fire for what
-// is a pure metadata correction.
+// Neutralize the flag on the incoming copy ONLY when the visible row is
+// actually RENDERED EXPANDED: an expanded row whose replacement model says
+// collapsed can only be latent server state (or our own setStickied: hook
+// re-asserting on the copy) — Apollo's own collapse toggle never routes
+// through this notification (it splices + rebuilds directly). A row that is
+// rendered collapsed, on the other hand, is a DELIBERATE collapse — the user's
+// manual toggle, a blocked/AutoMod collapse, or the tweak's own Collapse
+// Pinned Comments feature (ApolloCommentsCollapse.xm forces _collapsed on
+// stickied comments) — and clearing the copy's flag there would pop the row
+// open on vote. Gate on the rendered presentation, not the model flags.
+//
+// The rendered state is probed structurally: CommentCellNode's byline layout
+// switches its trailing accessories on comment.collapsed — the collapsed
+// presentation carries totalCollapsedChildrenIndicator (the child-count
+// badge) and collapseDisclosureIndicator, the expanded one carries the
+// age/more-options cluster instead. Either indicator live in the hierarchy ⇒
+// the row is rendered collapsed. The write goes straight to the ivar so no
+// setCollapsed: hooks (cover views, settle windows) fire for what is a pure
+// metadata correction.
+static BOOL ApolloVFAccessoryNodeIsLive(id node) {
+    if (!node) return NO;
+    @try {
+        if (![node respondsToSelector:@selector(isNodeLoaded)] ||
+            !((BOOL (*)(id, SEL))objc_msgSend)(node, @selector(isNodeLoaded))) return NO;
+        // Probe at the LAYER level: these indicator nodes are layer-backed
+        // (no UIView — -view returns nil for them), and a layer probe also
+        // covers view-backed nodes uniformly.
+        CALayer *layer = [node respondsToSelector:@selector(layer)]
+            ? ((CALayer *(*)(id, SEL))objc_msgSend)(node, @selector(layer)) : nil;
+        if (!layer.superlayer || layer.hidden) return NO;
+        CGRect f = layer.frame;
+        return f.size.width > 0.5 && f.size.height > 0.5;
+    } @catch (__unused NSException *e) { return NO; }
+}
+
+static BOOL ApolloVFCellRendersCollapsed(id cell) {
+    return ApolloVFAccessoryNodeIsLive(ApolloVFIvar(cell, "totalCollapsedChildrenIndicator")) ||
+           ApolloVFAccessoryNodeIsLive(ApolloVFIvar(cell, "collapseDisclosureIndicator"));
+}
+
 static void ApolloVFNeutralizeCarriedOverCollapse(id note) {
     @try {
         id oldModel = [note isKindOfClass:[NSNotification class]] ? [(NSNotification *)note object] : nil;
         id newModel = [note isKindOfClass:[NSNotification class]] ? [(NSNotification *)note userInfo][@"newModel"] : nil;
         Class commentClass = objc_getClass("RDKComment");
         if (!commentClass || ![oldModel isKindOfClass:commentClass] || ![newModel isKindOfClass:commentClass]) return;
-        if (![oldModel respondsToSelector:@selector(collapsed)] ||
-            ![newModel respondsToSelector:@selector(collapsed)]) return;
-        BOOL oldCollapsed = ((BOOL (*)(id, SEL))objc_msgSend)(oldModel, @selector(collapsed));
+        if (![newModel respondsToSelector:@selector(collapsed)]) return;
         BOOL newCollapsed = ((BOOL (*)(id, SEL))objc_msgSend)(newModel, @selector(collapsed));
-        if (!newCollapsed || !oldCollapsed) return; // absent, or a deliberate flip — leave it alone
+        if (!newCollapsed) return; // nothing to neutralize
+        NSArray *cells = ApolloVFCellsForUpdatedModel(note);
+        if (cells.count == 0) return; // no visible row — nothing can flicker, and an
+                                      // off-screen pinned/collapsed comment keeps its flag
+        for (id cell in cells) {
+            if (ApolloVFCellRendersCollapsed(cell)) {
+                ApolloLog(@"[VoteFlicker] kept collapse on updated comment — row is rendered collapsed (deliberate)");
+                return;
+            }
+        }
         Ivar collapsedIvar = class_getInstanceVariable([newModel class], "_collapsed");
         if (!collapsedIvar) return;
         *(BOOL *)((uint8_t *)(__bridge void *)newModel + ivar_getOffset(collapsedIvar)) = NO;
-        ApolloLog(@"[VoteFlicker] cleared carried-over server collapse on updated comment (crowd-control flag)");
+        ApolloLog(@"[VoteFlicker] cleared carried-over server collapse on updated comment (row renders expanded)");
     } @catch (__unused NSException *e) {}
 }
 

--- a/src/ApolloCommentVoteFlicker.xm
+++ b/src/ApolloCommentVoteFlicker.xm
@@ -318,7 +318,9 @@ static void ApolloVFHandleModelUpdate(id note, void (^origCall)(void)) {
     // cell has settled so that fast path also has a ready vote cover.
     __weak id weakCell = self;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.35 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        ApolloTranslationPrimeVoteBodySnapshot(weakCell);
+        id strongCell = weakCell;
+        if (!strongCell || ![sApolloVFVisibleCells containsObject:strongCell]) return;
+        ApolloTranslationPrimeVoteBodySnapshot(strongCell);
     });
 }
 - (void)didExitVisibleState {

--- a/src/ApolloCommentVoteFlicker.xm
+++ b/src/ApolloCommentVoteFlicker.xm
@@ -45,6 +45,7 @@
 #import <objc/message.h>
 
 #import "ApolloCommon.h"
+#import "ApolloTranslation.h"
 
 @interface ASDisplayNode : NSObject
 @property (nonatomic) BOOL neverShowPlaceholders;
@@ -269,17 +270,26 @@ static void ApolloVFHandleModelUpdate(id note, void (^origCall)(void)) {
     }
     origCall();
     if (cells.count == 0) return;
-    // NOTE: do NOT reapply the cached translation synchronously here. The
-    // reconfigure resets the body to the untranslated original ~15ms LATER
-    // (async), and an early reapply stamps the translation module's
-    // recently-applied guard — which then blocks the scheduled reapply that
-    // would restore the text after that reset, leaving the original language
-    // on screen and its (shorter) row height to be committed for real. The
-    // module's own +10ms scheduled reapply lands after the reset and restores
-    // cleanly; the height quiesce above keeps the interim measure from ever
-    // being committed.
+    // Settle the translation right before EACH flush: these synchronous
+    // flushes exist to kill the blank frame, but they paint whatever the body
+    // holds — and a vote rebuilds the body node with the untranslated
+    // original ~a turn later, which the detached-node preempt can only
+    // correct after attach. A flush landing inside that gap painted the
+    // original language for a frame or two ("sometimes it flickers"). The
+    // settle call is an exact-gate no-op when the text is already right, so
+    // the usual pre-reset flush stays write-free — and the module's
+    // recently-applied guard is content-scoped now, so even a pre-reset
+    // write cannot strand the post-reset restore (the round-2 failure mode).
+    for (ASDisplayNode *cell in cells) {
+        @try { ApolloTranslationReapplySynchronouslyForVoteReconfigure(cell); }
+        @catch (__unused NSException *e) {}
+    }
     ApolloVFEnsureSynchronousDisplay(cells, "post-reconfigure");
     dispatch_async(dispatch_get_main_queue(), ^{
+        for (ASDisplayNode *cell in cells) {
+            @try { ApolloTranslationReapplySynchronouslyForVoteReconfigure(cell); }
+            @catch (__unused NSException *e) {}
+        }
         ApolloVFEnsureSynchronousDisplay(cells, "next-turn");
     });
 }

--- a/src/ApolloCommentVoteFlicker.xm
+++ b/src/ApolloCommentVoteFlicker.xm
@@ -258,11 +258,14 @@ static void ApolloVFRequeryNodeHeights(id self, SEL _cmd) {
 static void ApolloVFHandleModelUpdate(id note, void (^origCall)(void)) {
     ApolloVFNeutralizeCarriedOverCollapse(note);
     NSArray *cells = ApolloVFCellsForUpdatedModel(note);
+    NSMutableArray *translatedBodyCovers = [NSMutableArray array];
     for (ASDisplayNode *cell in cells) {
         @try {
             if ([cell respondsToSelector:@selector(setNeverShowPlaceholders:)]) {
                 cell.neverShowPlaceholders = YES;
             }
+            id cover = ApolloTranslationInstallVoteBodyCover(cell);
+            if (cover) [translatedBodyCovers addObject:cover];
         } @catch (__unused NSException *e) {}
     }
     if (cells.count > 0) {
@@ -292,11 +295,37 @@ static void ApolloVFHandleModelUpdate(id note, void (^origCall)(void)) {
         }
         ApolloVFEnsureSynchronousDisplay(cells, "next-turn");
     });
+    // The deferred translation preempt lands on the next main turn and the
+    // replacement body's synchronous flush is complete by the following
+    // frame. Keep the exact old translated pixels over the BODY ONLY for a
+    // few extra frames, then remove them without animation. Score/byline
+    // changes remain visible throughout because they sit outside the cover.
+    if (translatedBodyCovers.count > 0) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.60 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            for (id cover in translatedBodyCovers) {
+                ApolloTranslationRemoveVoteBodyCover(cover);
+            }
+        });
+    }
 }
 
 %hook _TtC6Apollo15CommentCellNode
-- (void)didEnterVisibleState { %orig; ApolloVFTrackCell(self, YES); }
-- (void)didExitVisibleState  { %orig; ApolloVFTrackCell(self, NO);  }
+- (void)didEnterVisibleState {
+    %orig;
+    ApolloVFTrackCell(self, YES);
+    // Cached translations can be installed by the global text-node preempt
+    // before the normal translation apply function ever runs. Prime after the
+    // cell has settled so that fast path also has a ready vote cover.
+    __weak id weakCell = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.35 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        ApolloTranslationPrimeVoteBodySnapshot(weakCell);
+    });
+}
+- (void)didExitVisibleState {
+    %orig;
+    ApolloVFTrackCell(self, NO);
+    ApolloTranslationDiscardVoteBodySnapshot(self);
+}
 %end
 
 %hook _TtC6Apollo22CommentsHeaderCellNode

--- a/src/ApolloCommentVoteFlicker.xm
+++ b/src/ApolloCommentVoteFlicker.xm
@@ -173,11 +173,50 @@ static void ApolloVFRealizeUpdatedCommentsInfo(id postInfo, const char *stage) {
     } @catch (__unused NSException *e) {}
 }
 
+// A vote (or any in-place model update) makes Apollo splice a Mantle COPY of
+// the comment into the tree, and Mantle's copy re-runs every property setter —
+// including setCollapsed: with whatever the model last parsed from the server.
+// Reddit marks crowd-controlled comments `collapsed: true` in the listing JSON,
+// but Apollo's initial cell build renders them EXPANDED (the flatten only
+// collapses tracker/blocked/AutoMod comments), so the flag sits latent in the
+// model. The vote-time reconfigure (unlike the initial build) DOES honor
+// comment.collapsed, so the row the user just voted on snaps into the
+// collapsed presentation (body hidden, child-count badge) and then bounces
+// back when the next update lands — the "flicker" on every vote in
+// crowd-controlled threads (reported against translated threads because
+// foreign-language subs are where both crowd control and translation are on).
+//
+// Neutralize the flag on the incoming copy when it is merely CARRIED OVER
+// (old model and copy both say collapsed) rather than deliberately flipped:
+// Apollo's own collapse toggle never routes through this notification (it
+// splices + rebuilds directly), so a carried-over YES here can only be stale
+// server state the visible row never rendered. The write goes straight to the
+// ivar so no setCollapsed: hooks (cover views, settle windows) fire for what
+// is a pure metadata correction.
+static void ApolloVFNeutralizeCarriedOverCollapse(id note) {
+    @try {
+        id oldModel = [note isKindOfClass:[NSNotification class]] ? [(NSNotification *)note object] : nil;
+        id newModel = [note isKindOfClass:[NSNotification class]] ? [(NSNotification *)note userInfo][@"newModel"] : nil;
+        Class commentClass = objc_getClass("RDKComment");
+        if (!commentClass || ![oldModel isKindOfClass:commentClass] || ![newModel isKindOfClass:commentClass]) return;
+        if (![oldModel respondsToSelector:@selector(collapsed)] ||
+            ![newModel respondsToSelector:@selector(collapsed)]) return;
+        BOOL oldCollapsed = ((BOOL (*)(id, SEL))objc_msgSend)(oldModel, @selector(collapsed));
+        BOOL newCollapsed = ((BOOL (*)(id, SEL))objc_msgSend)(newModel, @selector(collapsed));
+        if (!newCollapsed || !oldCollapsed) return; // absent, or a deliberate flip — leave it alone
+        Ivar collapsedIvar = class_getInstanceVariable([newModel class], "_collapsed");
+        if (!collapsedIvar) return;
+        *(BOOL *)((uint8_t *)(__bridge void *)newModel + ivar_getOffset(collapsedIvar)) = NO;
+        ApolloLog(@"[VoteFlicker] cleared carried-over server collapse on updated comment (crowd-control flag)");
+    } @catch (__unused NSException *e) {}
+}
+
 // Shared handler body for both section-controller hooks: arm the matching
 // visible cell(s) before the reconfigure, flush the display wave right after,
 // and once more on the next runloop turn (the -setNeedsLayout relayout lands
 // there; its re-displays are what commit blank without this).
 static void ApolloVFHandleModelUpdate(id note, void (^origCall)(void)) {
+    ApolloVFNeutralizeCarriedOverCollapse(note);
     NSArray *cells = ApolloVFCellsForUpdatedModel(note);
     for (ASDisplayNode *cell in cells) {
         @try {

--- a/src/ApolloCommentVoteFlicker.xm
+++ b/src/ApolloCommentVoteFlicker.xm
@@ -242,7 +242,13 @@ static void ApolloVFRequeryNodeHeights(id self, SEL _cmd) {
                 UIView *strongSelf = weakSelf;
                 if (!strongSelf) return;
                 objc_setAssociatedObject(strongSelf, &kApolloVFRequeryDeferredKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-                if (!strongSelf.window) return;
+                // Run the deferred requery even off-window: dropping it
+                // left the table's committed row heights permanently stale —
+                // any row that grew during the quiesce (e.g. an inline image
+                // getting its ratio) stayed short until something else happened
+                // to re-query. requeryNodeHeights is a pure recompute and safe
+                // off-window; the quiesce's only job is to SKIP the mid-vote
+                // intermediate measure, never to lose the final one.
                 @try { orig_ApolloVFRequeryNodeHeights(strongSelf, _cmd); } @catch (__unused NSException *e) {}
             });
         }

--- a/src/ApolloCommentVoteFlicker.xm
+++ b/src/ApolloCommentVoteFlicker.xm
@@ -45,7 +45,6 @@
 #import <objc/message.h>
 
 #import "ApolloCommon.h"
-#import "ApolloTranslation.h"
 
 @interface ASDisplayNode : NSObject
 @property (nonatomic) BOOL neverShowPlaceholders;
@@ -270,17 +269,15 @@ static void ApolloVFHandleModelUpdate(id note, void (^origCall)(void)) {
     }
     origCall();
     if (cells.count == 0) return;
-    // Restore the cached translation BEFORE flushing display: the reconfigure
-    // above resets a translated body to the untranslated original (bypassing
-    // the text-setter hooks), and flushing that state would measure the row
-    // one marker line shorter — an animated height commit that visibly nudges
-    // the comment's bottom divider until the scheduled reapply restores the
-    // text. Reapplying here keeps the original-language state from ever being
-    // measured or painted; the flush below then realizes the final text.
-    for (ASDisplayNode *cell in cells) {
-        @try { ApolloTranslationReapplySynchronouslyForVoteReconfigure(cell); }
-        @catch (__unused NSException *e) {}
-    }
+    // NOTE: do NOT reapply the cached translation synchronously here. The
+    // reconfigure resets the body to the untranslated original ~15ms LATER
+    // (async), and an early reapply stamps the translation module's
+    // recently-applied guard — which then blocks the scheduled reapply that
+    // would restore the text after that reset, leaving the original language
+    // on screen and its (shorter) row height to be committed for real. The
+    // module's own +10ms scheduled reapply lands after the reset and restores
+    // cleanly; the height quiesce above keeps the interim measure from ever
+    // being committed.
     ApolloVFEnsureSynchronousDisplay(cells, "post-reconfigure");
     dispatch_async(dispatch_get_main_queue(), ^{
         ApolloVFEnsureSynchronousDisplay(cells, "next-turn");

--- a/src/ApolloCommentVoteFlicker.xm
+++ b/src/ApolloCommentVoteFlicker.xm
@@ -45,6 +45,7 @@
 #import <objc/message.h>
 
 #import "ApolloCommon.h"
+#import "ApolloTranslation.h"
 
 @interface ASDisplayNode : NSObject
 @property (nonatomic) BOOL neverShowPlaceholders;
@@ -211,6 +212,45 @@ static void ApolloVFNeutralizeCarriedOverCollapse(id note) {
     } @catch (__unused NSException *e) {}
 }
 
+// ── Vote-window row-height quiesce ──────────────────────────────────────────
+// A vote's reconfigure rebuilds the comment's body text node and the fresh
+// node briefly holds the UNTRANSLATED original — one "Translated from X"
+// marker line shorter than what's on screen. The rebuilt node is still
+// detached when its text is set, so the translation module's identity-checked
+// preempt must decline (an identical body could otherwise borrow another
+// comment's translation), and the scheduled reapply restores the text ~10ms
+// later. The text race is invisible (the reapply's synchronous heal wins),
+// but ASTableView's requeryNodeHeights runs in between: it commits the
+// one-line-shorter measure as an ANIMATED row update and then a second
+// animated update restores it — the comment's bottom divider visibly nudges
+// up and springs back on every vote. Suppress height re-queries for a short
+// window around the reconfigure and re-run once after it: the intermediate
+// measure is never committed, and the deferred re-query commits the (by then
+// unchanged) final height.
+static CFAbsoluteTime sApolloVFHeightQuiesceUntil = 0;
+static char kApolloVFRequeryDeferredKey;
+
+static void (*orig_ApolloVFRequeryNodeHeights)(id, SEL);
+static void ApolloVFRequeryNodeHeights(id self, SEL _cmd) {
+    CFAbsoluteTime now = CFAbsoluteTimeGetCurrent();
+    if (now < sApolloVFHeightQuiesceUntil) {
+        if (!objc_getAssociatedObject(self, &kApolloVFRequeryDeferredKey)) {
+            objc_setAssociatedObject(self, &kApolloVFRequeryDeferredKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            NSTimeInterval delay = MAX(0.02, (sApolloVFHeightQuiesceUntil - now) + 0.02);
+            __weak UIView *weakSelf = (UIView *)self;
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                UIView *strongSelf = weakSelf;
+                if (!strongSelf) return;
+                objc_setAssociatedObject(strongSelf, &kApolloVFRequeryDeferredKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                if (!strongSelf.window) return;
+                @try { orig_ApolloVFRequeryNodeHeights(strongSelf, _cmd); } @catch (__unused NSException *e) {}
+            });
+        }
+        return;
+    }
+    orig_ApolloVFRequeryNodeHeights(self, _cmd);
+}
+
 // Shared handler body for both section-controller hooks: arm the matching
 // visible cell(s) before the reconfigure, flush the display wave right after,
 // and once more on the next runloop turn (the -setNeedsLayout relayout lands
@@ -225,8 +265,22 @@ static void ApolloVFHandleModelUpdate(id note, void (^origCall)(void)) {
             }
         } @catch (__unused NSException *e) {}
     }
+    if (cells.count > 0) {
+        sApolloVFHeightQuiesceUntil = CFAbsoluteTimeGetCurrent() + 0.12;
+    }
     origCall();
     if (cells.count == 0) return;
+    // Restore the cached translation BEFORE flushing display: the reconfigure
+    // above resets a translated body to the untranslated original (bypassing
+    // the text-setter hooks), and flushing that state would measure the row
+    // one marker line shorter — an animated height commit that visibly nudges
+    // the comment's bottom divider until the scheduled reapply restores the
+    // text. Reapplying here keeps the original-language state from ever being
+    // measured or painted; the flush below then realizes the final text.
+    for (ASDisplayNode *cell in cells) {
+        @try { ApolloTranslationReapplySynchronouslyForVoteReconfigure(cell); }
+        @catch (__unused NSException *e) {}
+    }
     ApolloVFEnsureSynchronousDisplay(cells, "post-reconfigure");
     dispatch_async(dispatch_get_main_queue(), ^{
         ApolloVFEnsureSynchronousDisplay(cells, "next-turn");
@@ -317,6 +371,18 @@ static void ApolloVFForegroundHeal(const char *stage) {
 
 %ctor {
     %init;
+
+    // Vote-window height quiesce (see sApolloVFHeightQuiesceUntil above).
+    // Manual swizzle with an existence guard: requeryNodeHeights is a Texture
+    // internal — if a future Apollo binary ships without it, the quiesce
+    // silently disarms and the rest of the module is unaffected.
+    Class tableClass = objc_getClass("ASTableView");
+    Method requeryMethod = tableClass ? class_getInstanceMethod(tableClass, NSSelectorFromString(@"requeryNodeHeights")) : NULL;
+    if (requeryMethod) {
+        orig_ApolloVFRequeryNodeHeights = (void (*)(id, SEL))method_getImplementation(requeryMethod);
+        method_setImplementation(requeryMethod, (IMP)ApolloVFRequeryNodeHeights);
+    }
+
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     void (^heal)(NSNotification *) = ^(__unused NSNotification *n) {
         ApolloVFForegroundHeal("now");

--- a/src/ApolloTranslation.h
+++ b/src/ApolloTranslation.h
@@ -4,10 +4,3 @@ FOUNDATION_EXPORT NSString * const ApolloRichPreviewTranslationDidUpdateNotifica
 
 BOOL ApolloRichPreviewTranslationShouldTranslateForNode(id node);
 NSString *ApolloRichPreviewTranslatedTextIfAvailable(NSURL *url, NSString *field, NSString *sourceText, id ownerNode);
-
-// Restores a comment/header cell's cached translation synchronously; called by
-// the vote-flicker module between Apollo's vote reconfigure (which resets the
-// body to the untranslated original) and its synchronous display flush, so the
-// original-language text is never measured or painted. Returns YES if a cached
-// translation was applied.
-BOOL ApolloTranslationReapplySynchronouslyForVoteReconfigure(id cellNode);

--- a/src/ApolloTranslation.h
+++ b/src/ApolloTranslation.h
@@ -4,3 +4,10 @@ FOUNDATION_EXPORT NSString * const ApolloRichPreviewTranslationDidUpdateNotifica
 
 BOOL ApolloRichPreviewTranslationShouldTranslateForNode(id node);
 NSString *ApolloRichPreviewTranslatedTextIfAvailable(NSURL *url, NSString *field, NSString *sourceText, id ownerNode);
+
+// Settles a vote-reconfigured comment/header cell's body back to its cached
+// translation. Called by the vote-flicker module immediately before each of
+// its synchronous display flushes, so a flush can never paint the
+// untranslated text a vote's node rebuild briefly leaves behind. Exact-gate
+// no-op when the body already shows the translation.
+BOOL ApolloTranslationReapplySynchronouslyForVoteReconfigure(id cellNode);

--- a/src/ApolloTranslation.h
+++ b/src/ApolloTranslation.h
@@ -4,3 +4,10 @@ FOUNDATION_EXPORT NSString * const ApolloRichPreviewTranslationDidUpdateNotifica
 
 BOOL ApolloRichPreviewTranslationShouldTranslateForNode(id node);
 NSString *ApolloRichPreviewTranslatedTextIfAvailable(NSURL *url, NSString *field, NSString *sourceText, id ownerNode);
+
+// Restores a comment/header cell's cached translation synchronously; called by
+// the vote-flicker module between Apollo's vote reconfigure (which resets the
+// body to the untranslated original) and its synchronous display flush, so the
+// original-language text is never measured or painted. Returns YES if a cached
+// translation was applied.
+BOOL ApolloTranslationReapplySynchronouslyForVoteReconfigure(id cellNode);

--- a/src/ApolloTranslation.h
+++ b/src/ApolloTranslation.h
@@ -17,8 +17,9 @@ BOOL ApolloTranslationReapplySynchronouslyForVoteReconfigure(id cellNode);
 // with ApolloTranslationRemoveVoteBodyCover after the replacement settles.
 id ApolloTranslationInstallVoteBodyCover(id cellNode);
 void ApolloTranslationRemoveVoteBodyCover(id coverToken);
-// Warms the same snapshot cache without presenting a cover. Safe to call for
-// every visible comment; it is an exact no-op outside translated mode or when
-// this cell/fullname already has a snapshot.
+// Warms the same snapshot cache and briefly presents the identical cover so
+// Core Animation commits its layer before a vote. Safe to call for every
+// visible comment; it is an exact no-op outside translated mode or when this
+// cell/fullname already has a ready cover.
 void ApolloTranslationPrimeVoteBodySnapshot(id cellNode);
 void ApolloTranslationDiscardVoteBodySnapshot(id cellNode);

--- a/src/ApolloTranslation.h
+++ b/src/ApolloTranslation.h
@@ -11,3 +11,14 @@ NSString *ApolloRichPreviewTranslatedTextIfAvailable(NSURL *url, NSString *field
 // untranslated text a vote's node rebuild briefly leaves behind. Exact-gate
 // no-op when the body already shows the translation.
 BOOL ApolloTranslationReapplySynchronouslyForVoteReconfigure(id cellNode);
+
+// Preserves the exact on-screen translated comment body while Apollo replaces
+// its Texture node during a vote. The returned opaque token must be removed
+// with ApolloTranslationRemoveVoteBodyCover after the replacement settles.
+id ApolloTranslationInstallVoteBodyCover(id cellNode);
+void ApolloTranslationRemoveVoteBodyCover(id coverToken);
+// Warms the same snapshot cache without presenting a cover. Safe to call for
+// every visible comment; it is an exact no-op outside translated mode or when
+// this cell/fullname already has a snapshot.
+void ApolloTranslationPrimeVoteBodySnapshot(id cellNode);
+void ApolloTranslationDiscardVoteBodySnapshot(id cellNode);

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -3977,6 +3977,8 @@ static BOOL ApolloCellNodeStillShowsCachedTranslation(id commentCellNode) {
     return ApolloTextMatchesSourceOrVisualDisplay(current.string, ApolloStripInlineMediaTokens(translated));
 }
 
+static BOOL ApolloCommentCellNodeIsBackedByActiveCommentsTable(id commentCellNode, UIViewController *commentsVC);
+
 static void ApolloScheduleCachedTranslationReapplyForCellNode(id commentCellNode) {
     if (!commentCellNode || !sEnableBulkTranslation) return;
     if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) return;
@@ -3996,6 +3998,15 @@ static void ApolloScheduleCachedTranslationReapplyForCellNode(id commentCellNode
             return;
         }
         objc_setAssociatedObject(strong, kApolloReapplyScheduledKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        // Context-menu previews use freshly-built CommentCellNodes outside the
+        // comments table. Reapplying a cached translation after UIKit measured
+        // one of those detached nodes changes its height mid-presentation and
+        // creates the overlapping/jumping copy reported in #676. Vote rebuilds
+        // are attached to the real visible table cell before this block fires.
+        if (!ApolloCommentCellNodeIsBackedByActiveCommentsTable(strong, sVisibleCommentsViewController)) {
+            ApolloTranslationVerboseLog(@"[Translation/vote] commentReapply: skipping non-table cellNode=%p", strong);
+            return;
+        }
         ApolloReapplyCachedTranslationForCellNode(strong);
     });
 }

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -4038,6 +4038,33 @@ static void ApolloScheduleCachedTranslationReapplyForHeaderCellNode(id headerCel
     });
 }
 
+// Synchronous vote-path reapply, called by the vote-flicker module right
+// BEFORE each of its synchronous display flushes for a vote-reconfigured
+// cell. Those flushes exist to kill the #627 blank frame, but they also
+// faithfully paint whatever the body node holds at that instant — and a
+// vote rebuilds the body node with the UNTRANSLATED original, which the
+// detached-node preempt can only correct one runloop turn later. When a
+// flush lands inside that gap, the original language gets painted for a
+// frame or two. Settling the text here first closes the gap: if the body
+// already shows the translation this is a cheap exact-gate no-op (so the
+// usual pre-reset flush never writes and never arms the recently-applied
+// guard — and since that guard is content-scoped now, even an early write
+// cannot strand a later reset the way the first version of this call did).
+BOOL ApolloTranslationReapplySynchronouslyForVoteReconfigure(id cellNode) {
+    if (!cellNode || !sEnableBulkTranslation) return NO;
+    if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) return NO;
+    NSString *className = NSStringFromClass([cellNode class]);
+    @try {
+        if ([className containsString:@"CommentsHeaderCellNode"]) {
+            return ApolloReapplyCachedTranslationForHeaderCellNode(cellNode);
+        }
+        if ([className containsString:@"CommentCellNode"]) {
+            return ApolloReapplyCachedTranslationForCellNode(cellNode);
+        }
+    } @catch (__unused NSException *e) {}
+    return NO;
+}
+
 #pragma mark - Phase C: post selftext translation driver
 
 static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *fallbackLink, BOOL forceTranslation) {

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #import "ApolloCommon.h"
+#import "ApolloDeletedCommentsData.h"
 #import "ApolloState.h"
 #import "ApolloThemeRuntime.h"
 #import "ApolloTranslation.h"
@@ -1691,8 +1692,34 @@ static id ApolloBestCommentTextNode(id commentCellNode, RDKComment *comment) {
 
 // One deferred, per-table-coalesced empty begin/endUpdates: re-queries row heights and
 // re-measures only nodes whose calculated layout was invalidated. Mirrors the
-// link-preview module's coalesced height refresh (#630 rounds 6-7).
+// link-preview module's coalesced height refresh (#630 rounds 6-7), including its
+// collapse-settle gate: an empty begin/endUpdates fired while a comment
+// collapse/expand row animation is running re-queries every row height
+// mid-animation and restarts the native delete/insert animations (#620 round 2's
+// wrong-way glide). Defer to the window's end, bounded like the LP refresher so
+// a collapse storm can't postpone the height commit forever.
 static char kApolloTranslationHeightCommitPendingKey;
+static void ApolloTranslationRunHostHeightCommit(UITableView *tableView, NSInteger attemptsLeft) {
+    NSTimeInterval settleDelay = ApolloDeletedCommentsCollapseSettleDelayRemaining();
+    if (settleDelay > 0 && attemptsLeft > 0) {
+        __weak UITableView *weakTableView = tableView;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)((settleDelay + 0.03) * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            UITableView *strongTableView = weakTableView;
+            if (!strongTableView) return;
+            ApolloTranslationRunHostHeightCommit(strongTableView, attemptsLeft - 1);
+        });
+        return;
+    }
+    objc_setAssociatedObject(tableView, &kApolloTranslationHeightCommitPendingKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (!tableView.window) return;
+    @try {
+        [UIView performWithoutAnimation:^{
+            [tableView beginUpdates];
+            [tableView endUpdates];
+        }];
+    } @catch (__unused NSException *e) {}
+}
+
 static void ApolloTranslationScheduleHostHeightCommit(id cellNode) {
     if (!cellNode) return;
     UIView *cellView = nil;
@@ -1720,14 +1747,7 @@ static void ApolloTranslationScheduleHostHeightCommit(id cellNode) {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         UITableView *strongTableView = weakTableView;
         if (!strongTableView) return;
-        objc_setAssociatedObject(strongTableView, &kApolloTranslationHeightCommitPendingKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        if (!strongTableView.window) return;
-        @try {
-            [UIView performWithoutAnimation:^{
-                [strongTableView beginUpdates];
-                [strongTableView endUpdates];
-            }];
-        } @catch (__unused NSException *e) {}
+        ApolloTranslationRunHostHeightCommit(strongTableView, 6);
     });
 }
 

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -3895,13 +3895,39 @@ static BOOL ApolloReapplyCachedTranslationForCellNode(id commentCellNode) {
     return YES;
 }
 
+// Rapid consecutive votes can reset a comment's body back to the original
+// WHILE the recently-applied re-entrancy guard from the previous vote's
+// restore is still hot (~150ms). The guard exists to break the harmless
+// apply → layout-invalidate → schedule loop on ALREADY-translated text, so
+// honoring it when the on-screen text has genuinely regressed leaves the
+// original language (one marker line shorter) on screen until something else
+// re-triggers a pass — the "flickers again after a few rapid votes" report.
+// Bypass the guard only when the body no longer shows the cached translation.
+static BOOL ApolloTextMatchesSourceOrVisualDisplay(NSString *incomingText, NSString *targetText);
+static BOOL ApolloCellNodeStillShowsCachedTranslation(id commentCellNode) {
+    RDKComment *comment = ApolloCommentFromCellNode(commentCellNode);
+    if (!comment) return YES; // can't tell — keep the guard
+    NSString *fullName = ApolloCommentFullName(comment);
+    NSString *translated = fullName.length > 0 ? ApolloCachedCommentTranslationForFullName(fullName) : nil;
+    if (translated.length == 0) return YES; // nothing to restore anyway
+    id textNode = ApolloBestCommentTextNode(commentCellNode, comment);
+    if (!textNode) return YES;
+    NSAttributedString *current = nil;
+    @try { current = ((id (*)(id, SEL))objc_msgSend)(textNode, @selector(attributedText)); }
+    @catch (__unused NSException *e) { return YES; }
+    if (![current isKindOfClass:[NSAttributedString class]] || current.length == 0) return YES;
+    return ApolloTextMatchesSourceOrVisualDisplay(current.string, ApolloStripInlineMediaTokens(translated));
+}
+
 static void ApolloScheduleCachedTranslationReapplyForCellNode(id commentCellNode) {
     if (!commentCellNode || !sEnableBulkTranslation) return;
     if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) return;
     if ([objc_getAssociatedObject(commentCellNode, kApolloReapplyScheduledKey) boolValue]) return;
     // Re-entrancy guard: skip if we just applied translation here. Breaks
-    // the apply -> ASDK invalidates layout -> hook -> schedule loop.
-    if ([objc_getAssociatedObject(commentCellNode, kApolloRecentlyAppliedKey) boolValue]) return;
+    // the apply -> ASDK invalidates layout -> hook -> schedule loop — but
+    // only while the body still SHOWS the translation (see above).
+    if ([objc_getAssociatedObject(commentCellNode, kApolloRecentlyAppliedKey) boolValue] &&
+        ApolloCellNodeStillShowsCachedTranslation(commentCellNode)) return;
     objc_setAssociatedObject(commentCellNode, kApolloReapplyScheduledKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloTranslationVerboseLog(@"[Translation/vote] commentReapply: SCHEDULED cellNode=%p", commentCellNode);
     __weak id weakNode = commentCellNode;

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -5,6 +5,7 @@
 #import <objc/message.h>
 #include <dlfcn.h>
 #include <float.h>
+#include <math.h>
 #include <string.h>
 
 #import "ApolloCommon.h"
@@ -36,6 +37,18 @@
 
 static const void *kApolloOriginalAttributedTextKey = &kApolloOriginalAttributedTextKey;
 static const void *kApolloTranslatedTextNodeKey = &kApolloTranslatedTextNodeKey;
+// Last fully-composited translated body bitmap + cell-relative frame. Apollo
+// can leave the replacement body's logical text and visible backing image out
+// of sync after repeated votes, so later vote windows need a known-good visual
+// fallback rather than depending on whichever body node currently wins lookup.
+static const void *kApolloVoteBodySnapshotKey = &kApolloVoteBodySnapshotKey;
+static const void *kApolloVoteBodySnapshotPrimeScheduledKey = &kApolloVoteBodySnapshotPrimeScheduledKey;
+static const void *kApolloVoteBodyCoverViewKey = &kApolloVoteBodyCoverViewKey;
+static const void *kApolloPersistentVoteBodyCoverKey = &kApolloPersistentVoteBodyCoverKey;
+// Counts overlapping vote windows separately from the brief invisible-layer
+// warm-up. A rapid second vote can begin before the first delayed removal; the
+// first completion must not hide the cover while the second rebuild is active.
+static const void *kApolloVoteBodyCoverActiveCountKey = &kApolloVoteBodyCoverActiveCountKey;
 static const void *kApolloCellTranslationKeyKey = &kApolloCellTranslationKeyKey;
 static const void *kApolloThreadTranslatedModeKey = &kApolloThreadTranslatedModeKey;
 // Set when the user explicitly toggled away from a translated thread (so we
@@ -296,6 +309,29 @@ static void ApolloAppendTranslateAffordanceForCellNode(id cellNode, RDKComment *
 static void ApolloShowOriginalWithRetranslateAffordanceForCellNode(id cellNode, RDKComment *comment, id textNode);
 static BOOL ApolloAttributedStringEndsWithMarker(NSAttributedString *attr);
 static void ApolloApplyTranslationToTitleNode(id titleNode, id textNode, NSString *sourceText, NSString *translatedText);
+// Main-thread-only flag used to reuse the normal snapshot builder without
+// briefly installing its cover while warming the cache after translation.
+static BOOL sApolloPrimingVoteBodySnapshot = NO;
+static void ApolloScheduleVoteBodySnapshotPrime(id commentCellNode) {
+    if (!commentCellNode || objc_getAssociatedObject(commentCellNode, kApolloVoteBodySnapshotPrimeScheduledKey)) return;
+    objc_setAssociatedObject(commentCellNode, kApolloVoteBodySnapshotPrimeScheduledKey,
+                             @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    __weak id weakCell = commentCellNode;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.10 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        id strongCell = weakCell;
+        if (!strongCell) return;
+        objc_setAssociatedObject(strongCell, kApolloVoteBodySnapshotPrimeScheduledKey,
+                                 nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        // A real translation/style write supersedes any snapshot previously
+        // cached for this cell, even when it happens to have the same fullname.
+        objc_setAssociatedObject(strongCell, kApolloVoteBodySnapshotKey,
+                                 nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        sApolloPrimingVoteBodySnapshot = YES;
+        @try { ApolloTranslationInstallVoteBodyCover(strongCell); }
+        @catch (__unused NSException *e) {}
+        sApolloPrimingVoteBodySnapshot = NO;
+    });
+}
 // A feed post title the user tapped to pin back to ORIGINAL; gates the title
 // apply path so a re-translation pass won't swap it back until they toggle again.
 static const void *kApolloTitlePinnedOriginalKey = &kApolloTitlePinnedOriginalKey;
@@ -1919,6 +1955,12 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
     }
     // Already showing the translation? No-op.
     if (textMatchesTranslation && !textMatchesBody) {
+        NSDictionary *snapshot = objc_getAssociatedObject(commentCellNode, kApolloVoteBodySnapshotKey);
+        NSString *snapshotFullName = [snapshot objectForKey:@"fullName"];
+        NSString *commentFullName = ApolloCommentFullName(comment);
+        if (commentFullName.length > 0 && ![snapshotFullName isEqualToString:commentFullName]) {
+            ApolloScheduleVoteBodySnapshotPrime(commentCellNode);
+        }
         return;
     }
 
@@ -1956,6 +1998,12 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
     // nothing to do.
     if ([current.string isEqualToString:displayAttr.string]) {
         ApolloTranslationVerboseLog(@"[Translation/vote] apply: display identical — exact no-op cell=%p", commentCellNode);
+        NSDictionary *snapshot = objc_getAssociatedObject(commentCellNode, kApolloVoteBodySnapshotKey);
+        NSString *snapshotFullName = [snapshot objectForKey:@"fullName"];
+        NSString *commentFullName = ApolloCommentFullName(comment);
+        if (commentFullName.length > 0 && ![snapshotFullName isEqualToString:commentFullName]) {
+            ApolloScheduleVoteBodySnapshotPrime(commentCellNode);
+        }
         return;
     }
 
@@ -2006,6 +2054,10 @@ static void ApolloApplyTranslationToCellNode(id commentCellNode, RDKComment *com
         if (textMatchesBody) ApolloIndexTranslatedCommentBody(current.string, fullName);
     }
     ApolloMarkVisibleTranslationApplied(comment.body, translatedText);
+    // Warm a fully-independent body bitmap after Texture has committed this
+    // translation. The vote handler can then install it without rasterizing
+    // from a surface that Apollo is about to clear in the same frame.
+    ApolloScheduleVoteBodySnapshotPrime(commentCellNode);
 }
 
 static void ApolloRestoreOriginalForCellNode(id commentCellNode, RDKComment *comment) {
@@ -4036,6 +4088,259 @@ static void ApolloScheduleCachedTranslationReapplyForHeaderCellNode(id headerCel
         objc_setAssociatedObject(strong, kApolloHeaderReapplyScheduledKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         ApolloReapplyCachedTranslationForHeaderCellNode(strong);
     });
+}
+
+// Texture can commit a stale original-language backing image even while the
+// rebuilt node's attributedText already contains the translation. Preserve
+// the exact translated pixels that are on screen before Apollo starts the
+// rebuild, then let the vote module remove this body-only cover after its
+// settle window. The byline/score is outside this view, so it remains live.
+id ApolloTranslationInstallVoteBodyCover(id commentCellNode) {
+    if (!commentCellNode || !sEnableBulkTranslation ||
+        !ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) return nil;
+    RDKComment *comment = nil;
+    NSString *fullName = nil;
+    NSString *translated = nil;
+    UIView *cellView = nil;
+    UIWindow *window = nil;
+    @try {
+        comment = ApolloCommentFromCellNode(commentCellNode);
+        fullName = ApolloCommentFullName(comment);
+        translated = fullName.length > 0 ? ApolloCachedCommentTranslationForFullName(fullName) : nil;
+        if ([commentCellNode respondsToSelector:@selector(isNodeLoaded)] &&
+            ((BOOL (*)(id, SEL))objc_msgSend)(commentCellNode, @selector(isNodeLoaded)) &&
+            [commentCellNode respondsToSelector:@selector(view)]) {
+            cellView = ((id (*)(id, SEL))objc_msgSend)(commentCellNode, @selector(view));
+            window = cellView.window;
+        }
+    } @catch (NSException *e) {
+        ApolloTranslationVerboseLog(@"[Translation/vote] body cover setup failed cell=%p exception=%@", commentCellNode, e.name);
+    }
+    if (!comment || fullName.length == 0 || translated.length == 0 || !cellView || !window) return nil;
+
+    NSDictionary *cachedSnapshot = objc_getAssociatedObject(commentCellNode, kApolloVoteBodySnapshotKey);
+    CGFloat cachedCellWidth = [[cachedSnapshot objectForKey:@"cellWidth"] doubleValue];
+    if (![[cachedSnapshot objectForKey:@"fullName"] isEqualToString:fullName] ||
+        fabs(cachedCellWidth - CGRectGetWidth(cellView.bounds)) > 0.5) {
+        cachedSnapshot = nil;
+    }
+
+    UIImage *frozenImage = nil;
+    UIColor *frozenBackgroundColor = nil;
+    CGRect bodyFrameInCell = CGRectNull;
+    id textNode = nil;
+    BOOL usedCachedSnapshot = NO;
+    if (cachedSnapshot) {
+        frozenImage = [cachedSnapshot objectForKey:@"image"];
+        bodyFrameInCell = [[cachedSnapshot objectForKey:@"frame"] CGRectValue];
+        frozenBackgroundColor = [cachedSnapshot objectForKey:@"backgroundColor"];
+        usedCachedSnapshot = frozenImage != nil && !CGRectIsEmpty(bodyFrameInCell) && !CGRectIsNull(bodyFrameInCell);
+    }
+    // The normal vote path should only attach the snapshot primed after the
+    // translation settled. Live capture remains as a first-vote fallback for
+    // the narrow window before that prime has fired.
+    if (!usedCachedSnapshot) @try {
+        // Resolve the current body first. Apollo replaces this node on every
+        // vote; the associated node is retained only as a detached fallback.
+        textNode = ApolloBestCommentTextNode(commentCellNode, comment);
+        id associatedNode = objc_getAssociatedObject(commentCellNode, kApolloTranslatedTextNodeKey);
+        NSArray *candidates = textNode
+            ? (associatedNode && associatedNode != textNode ? @[textNode, associatedNode] : @[textNode])
+            : (associatedNode ? @[associatedNode] : @[]);
+        UIView *bodyView = nil;
+        for (id candidate in candidates) {
+            if (![candidate respondsToSelector:@selector(isNodeLoaded)] ||
+                !((BOOL (*)(id, SEL))objc_msgSend)(candidate, @selector(isNodeLoaded)) ||
+                ![candidate respondsToSelector:@selector(view)]) continue;
+            UIView *candidateView = ((id (*)(id, SEL))objc_msgSend)(candidate, @selector(view));
+            if (!candidateView || candidateView.window != window || CGRectIsEmpty(candidateView.bounds) ||
+                ![candidateView isDescendantOfView:cellView]) continue;
+            NSAttributedString *shown = [candidate respondsToSelector:@selector(attributedText)]
+                ? ((id (*)(id, SEL))objc_msgSend)(candidate, @selector(attributedText)) : nil;
+            BOOL isBody = [shown isKindOfClass:[NSAttributedString class]] &&
+                (ApolloTextQualifiesAsBodyCandidate(shown.string, comment.body) ||
+                 ApolloTextQualifiesAsBodyCandidate(shown.string, translated));
+            BOOL isTranslatedBody = [shown isKindOfClass:[NSAttributedString class]] &&
+                ApolloTextQualifiesAsBodyCandidate(shown.string, translated);
+            // Never prime from Apollo's original-language replacement. A vote
+            // in the small window before translation settles is better left
+            // uncovered than deliberately frozen in the wrong language.
+            if (!isBody || !isTranslatedBody) continue;
+            textNode = candidate;
+            bodyView = candidateView;
+            break;
+        }
+
+        if (bodyView) {
+            CGRect bodyFrameInWindow = [bodyView convertRect:bodyView.bounds toView:window];
+            bodyFrameInCell = [bodyView convertRect:bodyView.bounds toView:cellView];
+            if (!CGRectIsEmpty(bodyFrameInWindow) && !CGRectIsEmpty(bodyFrameInCell)) {
+                // Texture has already committed the correct translated body
+                // backing image before the vote. Do not use
+                // drawViewHierarchyInRect: here: it asks Texture/UIKit to
+                // render again and can itself capture half-finished glyph tiles.
+                id contents = bodyView.layer.contents;
+                // ASTextNode's backing image is intentionally transparent.
+                // Resolve the first real ancestor background so the cover is
+                // opaque; otherwise the stale Portuguese glyphs underneath
+                // remain visible through its clear pixels.
+                for (UIView *ancestor = bodyView; ancestor; ancestor = ancestor.superview) {
+                    UIColor *candidate = ancestor.backgroundColor;
+                    if (!candidate) continue;
+                    candidate = [candidate resolvedColorWithTraitCollection:bodyView.traitCollection];
+                    if (CGColorGetAlpha(candidate.CGColor) >= 0.99) {
+                        frozenBackgroundColor = candidate;
+                        break;
+                    }
+                }
+                if (!frozenBackgroundColor) {
+                    frozenBackgroundColor = [[UIColor systemBackgroundColor]
+                        resolvedColorWithTraitCollection:bodyView.traitCollection];
+                }
+                if (contents && CFGetTypeID((__bridge CFTypeRef)contents) == CGImageGetTypeID()) {
+                    CGImageRef contentsImage = (__bridge CGImageRef)contents;
+                    // Texture's layer.contentsScale is not reliable here (it
+                    // is often 1 while the backing image is screen-scale).
+                    // Derive scale from actual pixels to avoid a visibly soft
+                    // cover caused by a 3x downsample followed by a 3x upscale.
+                    CGFloat pixelScaleX = (CGFloat)CGImageGetWidth(contentsImage) / CGRectGetWidth(bodyView.bounds);
+                    CGFloat pixelScaleY = (CGFloat)CGImageGetHeight(contentsImage) / CGRectGetHeight(bodyView.bounds);
+                    CGFloat contentsScale = MIN(pixelScaleX, pixelScaleY);
+                    if (!isfinite(contentsScale) || contentsScale <= 0.0) contentsScale = window.screen.scale;
+                    UIImage *backingImage = [UIImage imageWithCGImage:(__bridge CGImageRef)contents
+                                                                 scale:contentsScale
+                                                           orientation:UIImageOrientationUp];
+                    // A retained Texture CGImage can still reference a backing
+                    // surface that Texture clears/reuses during the rebuild.
+                    // Rasterizing it into our own bitmap severs that lifetime:
+                    // every cached cover owns stable pixels thereafter.
+                    UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
+                    format.scale = contentsScale;
+                    format.opaque = YES;
+                    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc]
+                        initWithSize:bodyView.bounds.size format:format];
+                    frozenImage = [renderer imageWithActions:^(__unused UIGraphicsImageRendererContext *context) {
+                        [frozenBackgroundColor setFill];
+                        UIRectFill(bodyView.bounds);
+                        [backingImage drawInRect:bodyView.bounds];
+                    }];
+                }
+                if (frozenImage) {
+                    cachedSnapshot = @{
+                        @"fullName": fullName,
+                        @"image": frozenImage,
+                        @"frame": [NSValue valueWithCGRect:bodyFrameInCell],
+                        @"backgroundColor": frozenBackgroundColor,
+                        @"cellWidth": @(CGRectGetWidth(cellView.bounds)),
+                    };
+                    objc_setAssociatedObject(commentCellNode, kApolloVoteBodySnapshotKey,
+                                             cachedSnapshot, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                }
+            }
+        }
+    } @catch (NSException *e) {
+        ApolloTranslationVerboseLog(@"[Translation/vote] live body capture failed cell=%p exception=%@", commentCellNode, e.name);
+    }
+
+    if (!frozenImage || CGRectIsEmpty(bodyFrameInCell) || CGRectIsNull(bodyFrameInCell)) {
+        ApolloTranslationVerboseLog(@"[Translation/vote] body cover skipped: no live or cached snapshot cell=%p", commentCellNode);
+        return nil;
+    }
+    UIImageView *cover = objc_getAssociatedObject(commentCellNode, kApolloVoteBodyCoverViewKey);
+    if (![cover isKindOfClass:[UIImageView class]]) {
+        cover = [[UIImageView alloc] initWithImage:frozenImage];
+        objc_setAssociatedObject(cover, kApolloPersistentVoteBodyCoverKey,
+                                 @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(commentCellNode, kApolloVoteBodyCoverViewKey,
+                                 cover, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    } else {
+        cover.image = frozenImage;
+    }
+    cover.frame = [cellView convertRect:bodyFrameInCell toView:window];
+    cover.backgroundColor = frozenBackgroundColor;
+    cover.opaque = YES;
+    cover.userInteractionEnabled = NO;
+    cover.accessibilityElementsHidden = YES;
+    // Window child order normally suffices; the explicit z-position also
+    // keeps Texture's asynchronously-created backing layers below the cover.
+    cover.layer.zPosition = CGFLOAT_MAX / 4.0;
+    [UIView performWithoutAnimation:^{
+        if (cover.superview != window) [window addSubview:cover];
+        cover.alpha = 1.0;
+    }];
+    if (sApolloPrimingVoteBodySnapshot) {
+        // Commit the already-correct cover while the real body is stable, so
+        // Core Animation uploads its bitmap before any vote. Keeping the view
+        // attached at alpha zero means the vote only flips opacity on an
+        // existing layer; no first-frame view/layer/image commit remains.
+        __weak UIImageView *weakCover = cover;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.12 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            UIImageView *strongCover = weakCover;
+            if (!strongCover || [objc_getAssociatedObject(strongCover, kApolloVoteBodyCoverActiveCountKey) unsignedIntegerValue] > 0) return;
+            [UIView performWithoutAnimation:^{ strongCover.alpha = 0.0; }];
+        });
+        ApolloTranslationVerboseLog(@"[Translation/vote] primed translated body snapshot cell=%p frame=%@",
+                                    commentCellNode, NSStringFromCGRect(bodyFrameInCell));
+        return nil;
+    }
+    NSUInteger activeCount = [objc_getAssociatedObject(cover, kApolloVoteBodyCoverActiveCountKey) unsignedIntegerValue];
+    objc_setAssociatedObject(cover, kApolloVoteBodyCoverActiveCountKey,
+                             @(activeCount + 1), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloTranslationVerboseLog(@"[Translation/vote] installed %@ translated body cover cell=%p node=%p frame=%@",
+                                usedCachedSnapshot ? @"cached" : @"live", commentCellNode, textNode,
+                                NSStringFromCGRect(cover.frame));
+    return cover;
+}
+
+void ApolloTranslationRemoveVoteBodyCover(id coverToken) {
+    if (![coverToken isKindOfClass:[UIView class]]) return;
+    UIView *cover = (UIView *)coverToken;
+    NSUInteger activeCount = [objc_getAssociatedObject(cover, kApolloVoteBodyCoverActiveCountKey) unsignedIntegerValue];
+    if (activeCount > 1) {
+        objc_setAssociatedObject(cover, kApolloVoteBodyCoverActiveCountKey,
+                                 @(activeCount - 1), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return;
+    }
+    objc_setAssociatedObject(cover, kApolloVoteBodyCoverActiveCountKey,
+                             nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if ([objc_getAssociatedObject(cover, kApolloPersistentVoteBodyCoverKey) boolValue]) {
+        [UIView performWithoutAnimation:^{ cover.alpha = 0.0; }];
+    } else {
+        [cover removeFromSuperview];
+    }
+}
+
+void ApolloTranslationPrimeVoteBodySnapshot(id commentCellNode) {
+    if (!commentCellNode) return;
+    if (![NSThread isMainThread]) {
+        __weak id weakCell = commentCellNode;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            ApolloTranslationPrimeVoteBodySnapshot(weakCell);
+        });
+        return;
+    }
+    @try {
+        RDKComment *comment = ApolloCommentFromCellNode(commentCellNode);
+        NSString *fullName = ApolloCommentFullName(comment);
+        NSDictionary *snapshot = objc_getAssociatedObject(commentCellNode, kApolloVoteBodySnapshotKey);
+        UIView *cover = objc_getAssociatedObject(commentCellNode, kApolloVoteBodyCoverViewKey);
+        if (fullName.length > 0 && [[snapshot objectForKey:@"fullName"] isEqualToString:fullName] && cover.superview) return;
+        sApolloPrimingVoteBodySnapshot = YES;
+        ApolloTranslationInstallVoteBodyCover(commentCellNode);
+        sApolloPrimingVoteBodySnapshot = NO;
+    } @catch (__unused NSException *e) {
+        sApolloPrimingVoteBodySnapshot = NO;
+    }
+}
+
+void ApolloTranslationDiscardVoteBodySnapshot(id commentCellNode) {
+    if (!commentCellNode) return;
+    UIView *cover = objc_getAssociatedObject(commentCellNode, kApolloVoteBodyCoverViewKey);
+    [cover removeFromSuperview];
+    objc_setAssociatedObject(commentCellNode, kApolloVoteBodyCoverViewKey,
+                             nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(commentCellNode, kApolloVoteBodySnapshotKey,
+                             nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 // Synchronous vote-path reapply, called by the vote-flicker module right

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -4011,33 +4011,6 @@ static void ApolloScheduleCachedTranslationReapplyForHeaderCellNode(id headerCel
     });
 }
 
-// Synchronous vote-path reapply, called by the vote-flicker module BETWEEN
-// Apollo's model-update reconfigure and its synchronous display flush. The
-// reconfigure resets the body back to the untranslated original through a
-// path that never crosses the setAttributedText: hook, so the row measures
-// one marker line shorter and the flush commits that height as an ANIMATED
-// table update; the scheduled +10ms reapply then restores the translation
-// with a second animated commit — the comment's bottom divider visibly
-// nudges up and springs back on every vote of a translated comment (and on
-// device the untranslated text itself is on screen for those frames).
-// Restoring the translation here, in the same runloop turn as the
-// reconfigure, means the original-language state is never measured or
-// painted: the flush sees the final text and the row height never changes.
-BOOL ApolloTranslationReapplySynchronouslyForVoteReconfigure(id cellNode) {
-    if (!cellNode || !sEnableBulkTranslation) return NO;
-    if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) return NO;
-    NSString *className = NSStringFromClass([cellNode class]);
-    @try {
-        if ([className containsString:@"CommentsHeaderCellNode"]) {
-            return ApolloReapplyCachedTranslationForHeaderCellNode(cellNode);
-        }
-        if ([className containsString:@"CommentCellNode"]) {
-            return ApolloReapplyCachedTranslationForCellNode(cellNode);
-        }
-    } @catch (__unused NSException *e) {}
-    return NO;
-}
-
 #pragma mark - Phase C: post selftext translation driver
 
 static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *fallbackLink, BOOL forceTranslation) {

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -309,8 +309,8 @@ static void ApolloAppendTranslateAffordanceForCellNode(id cellNode, RDKComment *
 static void ApolloShowOriginalWithRetranslateAffordanceForCellNode(id cellNode, RDKComment *comment, id textNode);
 static BOOL ApolloAttributedStringEndsWithMarker(NSAttributedString *attr);
 static void ApolloApplyTranslationToTitleNode(id titleNode, id textNode, NSString *sourceText, NSString *translatedText);
-// Main-thread-only flag used to reuse the normal snapshot builder without
-// briefly installing its cover while warming the cache after translation.
+// Main-thread-only flag used to reuse the normal snapshot builder while
+// briefly presenting an identical body-only cover to precommit its layer.
 static BOOL sApolloPrimingVoteBodySnapshot = NO;
 static void ApolloScheduleVoteBodySnapshotPrime(id commentCellNode) {
     if (!commentCellNode || objc_getAssociatedObject(commentCellNode, kApolloVoteBodySnapshotPrimeScheduledKey)) return;
@@ -4103,6 +4103,7 @@ id ApolloTranslationInstallVoteBodyCover(id commentCellNode) {
     NSString *translated = nil;
     UIView *cellView = nil;
     UIWindow *window = nil;
+    UIScrollView *scrollContainer = nil;
     @try {
         comment = ApolloCommentFromCellNode(commentCellNode);
         fullName = ApolloCommentFullName(comment);
@@ -4112,11 +4113,20 @@ id ApolloTranslationInstallVoteBodyCover(id commentCellNode) {
             [commentCellNode respondsToSelector:@selector(view)]) {
             cellView = ((id (*)(id, SEL))objc_msgSend)(commentCellNode, @selector(view));
             window = cellView.window;
+            UIView *ancestor = cellView.superview;
+            while (ancestor && ancestor != window) {
+                if ([ancestor isKindOfClass:[UIScrollView class]]) {
+                    scrollContainer = (UIScrollView *)ancestor;
+                    break;
+                }
+                ancestor = ancestor.superview;
+            }
         }
     } @catch (NSException *e) {
         ApolloTranslationVerboseLog(@"[Translation/vote] body cover setup failed cell=%p exception=%@", commentCellNode, e.name);
     }
-    if (!comment || fullName.length == 0 || translated.length == 0 || !cellView || !window) return nil;
+    if (!comment || fullName.length == 0 || translated.length == 0 ||
+        !cellView || !window || !scrollContainer) return nil;
 
     NSDictionary *cachedSnapshot = objc_getAssociatedObject(commentCellNode, kApolloVoteBodySnapshotKey);
     CGFloat cachedCellWidth = [[cachedSnapshot objectForKey:@"cellWidth"] doubleValue];
@@ -4172,9 +4182,8 @@ id ApolloTranslationInstallVoteBodyCover(id commentCellNode) {
         }
 
         if (bodyView) {
-            CGRect bodyFrameInWindow = [bodyView convertRect:bodyView.bounds toView:window];
             bodyFrameInCell = [bodyView convertRect:bodyView.bounds toView:cellView];
-            if (!CGRectIsEmpty(bodyFrameInWindow) && !CGRectIsEmpty(bodyFrameInCell)) {
+            if (!CGRectIsEmpty(bodyFrameInCell)) {
                 // Texture has already committed the correct translated body
                 // backing image before the vote. Do not use
                 // drawViewHierarchyInRect: here: it asks Texture/UIKit to
@@ -4256,16 +4265,22 @@ id ApolloTranslationInstallVoteBodyCover(id commentCellNode) {
     } else {
         cover.image = frozenImage;
     }
-    cover.frame = [cellView convertRect:bodyFrameInCell toView:window];
+    // Keep the cover in the table's scrolling coordinate space, not the
+    // window. A window-level cover stayed fixed on screen while the cell
+    // moved, producing a duplicated "stuck" comment. The cell itself is not
+    // a safe container either: Apollo briefly shrinks its bounds during the
+    // vote reconfigure, which clips the bottom of a tall translated body.
+    // The scroll view follows scrolling while remaining stable through both
+    // the body-node replacement and that transient cell resize.
+    cover.frame = [cellView convertRect:bodyFrameInCell toView:scrollContainer];
     cover.backgroundColor = frozenBackgroundColor;
     cover.opaque = YES;
     cover.userInteractionEnabled = NO;
     cover.accessibilityElementsHidden = YES;
-    // Window child order normally suffices; the explicit z-position also
-    // keeps Texture's asynchronously-created backing layers below the cover.
+    // Keep Texture's asynchronously-created replacement body below the cover.
     cover.layer.zPosition = CGFLOAT_MAX / 4.0;
     [UIView performWithoutAnimation:^{
-        if (cover.superview != window) [window addSubview:cover];
+        if (cover.superview != scrollContainer) [scrollContainer addSubview:cover];
         cover.alpha = 1.0;
     }];
     if (sApolloPrimingVoteBodySnapshot) {

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -3567,6 +3567,12 @@ static NSString *ApolloTranslationFailureCooldownKey(NSString *cacheKey) {
     return [NSString stringWithFormat:@"%@|%@", provider, cacheKey ?: @""];
 }
 
+// userInfo marker on errors replayed from the cooldown cache, so downstream
+// logging can tell "the provider just failed" from "the cached failure was
+// handed back to yet another rebuilt cell" — inside a cell-rebuild storm the
+// latter fired the same failure log several times a second.
+static NSString *const kApolloTranslationCooldownReplayKey = @"ApolloTranslationCooldownReplay";
+
 static NSError *ApolloRecentTranslationFailure(NSString *cacheKey) {
     if (cacheKey.length == 0 || !sTranslationFailureCooldowns) return nil;
     NSString *failureKey = ApolloTranslationFailureCooldownKey(cacheKey);
@@ -3576,7 +3582,9 @@ static NSError *ApolloRecentTranslationFailure(NSString *cacheKey) {
         NSNumber *timestamp = [record[@"timestamp"] isKindOfClass:[NSNumber class]] ? record[@"timestamp"] : nil;
         NSError *error = [record[@"error"] isKindOfClass:[NSError class]] ? record[@"error"] : nil;
         if (timestamp && error && now - timestamp.doubleValue < kApolloTranslationFailureRetryDelay) {
-            return error;
+            NSMutableDictionary *info = [error.userInfo mutableCopy] ?: [NSMutableDictionary dictionary];
+            info[kApolloTranslationCooldownReplayKey] = @YES;
+            return [NSError errorWithDomain:error.domain code:error.code userInfo:info];
         }
         if (record) [sTranslationFailureCooldowns removeObjectForKey:failureKey];
     }
@@ -3906,7 +3914,10 @@ static void ApolloMaybeTranslateCommentCellNode(id commentCellNode, BOOL forceTr
         if (![currentKey isEqualToString:cacheKey]) return;
 
         if (![translated isKindOfClass:[NSString class]] || translated.length == 0) {
-            if (error) {
+            // Log fresh provider failures once; cooldown replays (the cached
+            // error handed to every rebuilt cell for the next 15s) are noise
+            // that floods the log inside cell-rebuild storms.
+            if (error && ![error.userInfo[kApolloTranslationCooldownReplayKey] boolValue]) {
                 ApolloLog(@"[Translation] Failed to translate comment: %@", error.localizedDescription ?: @"unknown error");
             }
             return;

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -52,6 +52,7 @@ static const void *kApolloTranslationOwnedTextNodeKey = &kApolloTranslationOwned
 static const void *kApolloOwnedNodeOriginalBodyKey = &kApolloOwnedNodeOriginalBodyKey;
 static const void *kApolloOwnedNodeTranslatedTextKey = &kApolloOwnedNodeTranslatedTextKey;
 static const void *kApolloOwnedNodeReentrancyKey = &kApolloOwnedNodeReentrancyKey;
+static const void *kApolloDeferredPreemptScheduledKey = &kApolloDeferredPreemptScheduledKey;
 // Marker for title text nodes. Title nodes live outside the comments view
 // controller (feeds, search, profiles) so they must bypass the
 // `ApolloControllerIsInTranslatedMode` check used by the comment-thread
@@ -6666,6 +6667,56 @@ static BOOL ApolloPreemptUnownedCommentTextNode(id textNode, NSAttributedString 
     return YES;
 }
 
+// The comment preempt above must resolve the node's enclosing cell for
+// identity, but a vote's rebuilt body node receives its first write while
+// still DETACHED — the preempt declines, Apollo's original-language text goes
+// through, and the ~10ms scheduled reapply usually overwrites it before its
+// async render commits. Usually: when the render wins that race, the comment
+// visibly flashes the original language for a frame or two on the vote (the
+// row height no longer moves — the vote-flicker module holds it — but the
+// text itself repaints). Close the race: when a DECLINED unowned write looks
+// like one of this thread's translated bodies (candidate set exists in the
+// body index — a cheap dictionary hit), retry the preempt one runloop turn
+// later. The node is attached by then, so the preempt can resolve the real
+// comment and swap; the synchronous heal then flushes the swap before the
+// original's async render can commit.
+static void ApolloScheduleDeferredCommentPreempt(id textNode, NSAttributedString *incomingAttributedText) {
+    NSString *incomingText = [incomingAttributedText isKindOfClass:[NSAttributedString class]] ? incomingAttributedText.string : nil;
+    if (!textNode || incomingText.length == 0) return;
+    UIViewController *vc = sVisibleCommentsViewController;
+    if (!vc || !ApolloControllerIsInTranslatedMode(vc)) return;
+    BOOL hasCandidates = NO;
+    @synchronized (ApolloTranslatedBodyIndexLock()) {
+        ApolloScopeTranslatedBodyIndexLocked(vc);
+        hasCandidates = ((NSSet *)sApolloTranslatedBodyIndex[incomingText]).count > 0;
+    }
+    if (!hasCandidates) return;
+    if ([objc_getAssociatedObject(textNode, kApolloDeferredPreemptScheduledKey) boolValue]) return;
+    objc_setAssociatedObject(textNode, kApolloDeferredPreemptScheduledKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    __weak id weakNode = textNode;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        id node = weakNode;
+        if (!node) return;
+        objc_setAssociatedObject(node, kApolloDeferredPreemptScheduledKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        // Adopted by a preempt/apply in the meantime — nothing to do.
+        if ([objc_getAssociatedObject(node, kApolloTranslationOwnedTextNodeKey) boolValue]) return;
+        NSAttributedString *current = nil;
+        @try { current = ((id (*)(id, SEL))objc_msgSend)(node, @selector(attributedText)); }
+        @catch (__unused NSException *e) { return; }
+        if (![current isKindOfClass:[NSAttributedString class]] ||
+            ![current.string isEqualToString:incomingText]) return; // text moved on
+        NSAttributedString *swap = nil;
+        if (!ApolloPreemptUnownedCommentTextNode(node, current, &swap) || !swap) return;
+        objc_setAssociatedObject(node, kApolloOwnedNodeReentrancyKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        @try { ((void (*)(id, SEL, id))objc_msgSend)(node, @selector(setAttributedText:), swap); }
+        @catch (__unused NSException *e) {}
+        objc_setAssociatedObject(node, kApolloOwnedNodeReentrancyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        id cellNode = ApolloCommentCellNodeForTextNode(node);
+        if (cellNode) ApolloTranslationHealCellDisplaySync(cellNode);
+        ApolloTranslationVerboseLog(@"[Translation/vote] deferred preempt: rebuilt node=%p swapped after attach", node);
+    });
+}
+
 // Vote-flash mitigation: when the comments header is rebuilt after a vote
 // tap, the new post-body text node has NO ownership markers yet. The
 // scheduler-based reapply path takes ~80-100ms, during which the original
@@ -6755,6 +6806,10 @@ static BOOL ApolloPreemptUnownedTextNodeFromVCStash(id textNode, NSAttributedStr
             objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
             return;
         }
+        // Preempt declined (typically: rebuilt node still detached, identity
+        // unresolvable). If this looks like a translated body, retry next
+        // turn once the node is attached — see the deferred preempt above.
+        ApolloScheduleDeferredCommentPreempt(self, attributedText);
         %orig;
         return;
     }
@@ -6829,6 +6884,10 @@ static BOOL ApolloPreemptUnownedTextNodeFromVCStash(id textNode, NSAttributedStr
             objc_setAssociatedObject(self, kApolloOwnedNodeReentrancyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
             return;
         }
+        // Preempt declined (typically: rebuilt node still detached, identity
+        // unresolvable). If this looks like a translated body, retry next
+        // turn once the node is attached — see the deferred preempt above.
+        ApolloScheduleDeferredCommentPreempt(self, attributedText);
         %orig;
         return;
     }

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -4011,6 +4011,33 @@ static void ApolloScheduleCachedTranslationReapplyForHeaderCellNode(id headerCel
     });
 }
 
+// Synchronous vote-path reapply, called by the vote-flicker module BETWEEN
+// Apollo's model-update reconfigure and its synchronous display flush. The
+// reconfigure resets the body back to the untranslated original through a
+// path that never crosses the setAttributedText: hook, so the row measures
+// one marker line shorter and the flush commits that height as an ANIMATED
+// table update; the scheduled +10ms reapply then restores the translation
+// with a second animated commit — the comment's bottom divider visibly
+// nudges up and springs back on every vote of a translated comment (and on
+// device the untranslated text itself is on screen for those frames).
+// Restoring the translation here, in the same runloop turn as the
+// reconfigure, means the original-language state is never measured or
+// painted: the flush sees the final text and the row height never changes.
+BOOL ApolloTranslationReapplySynchronouslyForVoteReconfigure(id cellNode) {
+    if (!cellNode || !sEnableBulkTranslation) return NO;
+    if (!ApolloControllerIsInTranslatedMode(sVisibleCommentsViewController)) return NO;
+    NSString *className = NSStringFromClass([cellNode class]);
+    @try {
+        if ([className containsString:@"CommentsHeaderCellNode"]) {
+            return ApolloReapplyCachedTranslationForHeaderCellNode(cellNode);
+        }
+        if ([className containsString:@"CommentCellNode"]) {
+            return ApolloReapplyCachedTranslationForCellNode(cellNode);
+        }
+    } @catch (__unused NSException *e) {}
+    return NO;
+}
+
 #pragma mark - Phase C: post selftext translation driver
 
 static void ApolloMaybeTranslatePostHeaderCellNode(id headerCellNode, RDKLink *fallbackLink, BOOL forceTranslation) {
@@ -6452,6 +6479,31 @@ static BOOL ApolloPrepareTranslatedSwapForTextNode(id textNode,
 
     NSString *incomingText = incomingAttributedText.string;
     if (ApolloTextMatchesSourceOrVisualDisplay(incomingText, translatedText)) {
+        // Marker parity for the pass-through branch too: Apollo's vote-time
+        // rewrite can hand this hook the CLEAN translation (no "Translated
+        // from <Language>" line). Letting it through unchanged measures the
+        // row one marker line shorter until the scheduled reapply re-appends
+        // the marker ~10ms later — and BOTH height commits run as animated
+        // table updates, so the comment's bottom divider visibly nudges up
+        // and springs back on every vote. Same rule as the incoming==original
+        // rebuild below (round 4's fix), applied here: swap in incoming +
+        // marker. Guarded on the incoming being EXACTLY the clean translation:
+        // the surrounding matcher tolerates marker-bearing variants (which
+        // must pass through untouched — appending blindly doubled the line on
+        // every initial render), so only the character-identical marker-less
+        // form takes this branch.
+        if (swapOut && [incomingText isEqualToString:translatedText] &&
+            [objc_getAssociatedObject(textNode, kApolloCommentOwnedTextNodeKey) boolValue]) {
+            NSAttributedString *withMarker = ApolloAttributedStringByAppendingTranslationMarker(incomingAttributedText, originalBody);
+            if ([withMarker isKindOfClass:[NSAttributedString class]] &&
+                withMarker != incomingAttributedText &&
+                ![withMarker.string isEqualToString:incomingText]) {
+                ApolloTranslationVerboseLog(@"[Translation/vote] prepareSwap: incoming==translated but marker-less → appending marker node=%p", textNode);
+                ApolloEnsureMarkerTappableOnNode(textNode);
+                *swapOut = withMarker;
+                return YES;
+            }
+        }
         ApolloTranslationVerboseLog(@"[Translation/vote] prepareSwap: incoming==translated, no-op node=%p", textNode);
         return NO;
     }

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -314,12 +314,17 @@ static void ApolloApplyTranslationToTitleNode(id titleNode, id textNode, NSStrin
 static BOOL sApolloPrimingVoteBodySnapshot = NO;
 static void ApolloScheduleVoteBodySnapshotPrime(id commentCellNode) {
     if (!commentCellNode || objc_getAssociatedObject(commentCellNode, kApolloVoteBodySnapshotPrimeScheduledKey)) return;
+    NSObject *primeToken = [NSObject new];
     objc_setAssociatedObject(commentCellNode, kApolloVoteBodySnapshotPrimeScheduledKey,
-                             @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                             primeToken, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     __weak id weakCell = commentCellNode;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.10 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         id strongCell = weakCell;
         if (!strongCell) return;
+        // didExitVisibleState/discard cancels this token. Identity (rather
+        // than a BOOL) also prevents an older block from consuming a newer
+        // schedule after a rapid exit/re-entry or cell reuse.
+        if (objc_getAssociatedObject(strongCell, kApolloVoteBodySnapshotPrimeScheduledKey) != primeToken) return;
         objc_setAssociatedObject(strongCell, kApolloVoteBodySnapshotPrimeScheduledKey,
                                  nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         // A real translation/style write supersedes any snapshot previously
@@ -4103,7 +4108,7 @@ id ApolloTranslationInstallVoteBodyCover(id commentCellNode) {
     NSString *translated = nil;
     UIView *cellView = nil;
     UIWindow *window = nil;
-    UIScrollView *scrollContainer = nil;
+    UIView *coverContainer = nil;
     @try {
         comment = ApolloCommentFromCellNode(commentCellNode);
         fullName = ApolloCommentFullName(comment);
@@ -4115,8 +4120,9 @@ id ApolloTranslationInstallVoteBodyCover(id commentCellNode) {
             window = cellView.window;
             UIView *ancestor = cellView.superview;
             while (ancestor && ancestor != window) {
-                if ([ancestor isKindOfClass:[UIScrollView class]]) {
-                    scrollContainer = (UIScrollView *)ancestor;
+                if ([ancestor isKindOfClass:[UITableViewCell class]]) {
+                    UITableViewCell *tableCell = (UITableViewCell *)ancestor;
+                    coverContainer = tableCell.contentView ?: tableCell;
                     break;
                 }
                 ancestor = ancestor.superview;
@@ -4126,7 +4132,7 @@ id ApolloTranslationInstallVoteBodyCover(id commentCellNode) {
         ApolloTranslationVerboseLog(@"[Translation/vote] body cover setup failed cell=%p exception=%@", commentCellNode, e.name);
     }
     if (!comment || fullName.length == 0 || translated.length == 0 ||
-        !cellView || !window || !scrollContainer) return nil;
+        !cellView || !window || !coverContainer) return nil;
 
     NSDictionary *cachedSnapshot = objc_getAssociatedObject(commentCellNode, kApolloVoteBodySnapshotKey);
     CGFloat cachedCellWidth = [[cachedSnapshot objectForKey:@"cellWidth"] doubleValue];
@@ -4265,22 +4271,21 @@ id ApolloTranslationInstallVoteBodyCover(id commentCellNode) {
     } else {
         cover.image = frozenImage;
     }
-    // Keep the cover in the table's scrolling coordinate space, not the
-    // window. A window-level cover stayed fixed on screen while the cell
-    // moved, producing a duplicated "stuck" comment. The cell itself is not
-    // a safe container either: Apollo briefly shrinks its bounds during the
-    // vote reconfigure, which clips the bottom of a tall translated body.
-    // The scroll view follows scrolling while remaining stable through both
-    // the body-node replacement and that transient cell resize.
-    cover.frame = [cellView convertRect:bodyFrameInCell toView:scrollContainer];
+    // Host the cover in Texture's stable UITableViewCell wrapper. It follows
+    // scrolling and UIKit's context-menu lift, remains below the nav bar's
+    // scroll-edge glass, and stays full-height while Apollo briefly resizes
+    // the inner CommentCellNode view during a vote rebuild.
+    cover.frame = [cellView convertRect:bodyFrameInCell toView:coverContainer];
     cover.backgroundColor = frozenBackgroundColor;
     cover.opaque = YES;
     cover.userInteractionEnabled = NO;
     cover.accessibilityElementsHidden = YES;
-    // Keep Texture's asynchronously-created replacement body below the cover.
-    cover.layer.zPosition = CGFLOAT_MAX / 4.0;
+    // Normal sibling order is sufficient inside this cell-only container.
+    // An extreme z-position here can outrank iOS 26's scroll-edge glass.
+    cover.layer.zPosition = 0.0;
     [UIView performWithoutAnimation:^{
-        if (cover.superview != scrollContainer) [scrollContainer addSubview:cover];
+        if (cover.superview != coverContainer) [coverContainer addSubview:cover];
+        else [coverContainer bringSubviewToFront:cover];
         cover.alpha = 1.0;
     }];
     if (sApolloPrimingVoteBodySnapshot) {
@@ -4350,6 +4355,10 @@ void ApolloTranslationPrimeVoteBodySnapshot(id commentCellNode) {
 
 void ApolloTranslationDiscardVoteBodySnapshot(id commentCellNode) {
     if (!commentCellNode) return;
+    // Cancel a translation-write prime that has not fired yet. Without this,
+    // its delayed block can recreate an offscreen cover after cleanup.
+    objc_setAssociatedObject(commentCellNode, kApolloVoteBodySnapshotPrimeScheduledKey,
+                             nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     UIView *cover = objc_getAssociatedObject(commentCellNode, kApolloVoteBodyCoverViewKey);
     [cover removeFromSuperview];
     objc_setAssociatedObject(commentCellNode, kApolloVoteBodyCoverViewKey,
@@ -5107,6 +5116,36 @@ static id ApolloCommentCellNodeForTextNode(id textNode) {
         @catch (__unused NSException *e) { break; }
     }
     return nil;
+}
+
+// Vote rebuilds attach their fresh body node back to the real table-backed
+// CommentCellNode before the deferred preempt runs. Apollo also builds
+// temporary CommentCellNode copies for context-menu previews, but those live
+// in a window transition container instead of a UITableViewCell. Translating
+// those copies after UIKit has measured the preview at the original-language
+// height makes the preview overflow and appear to jump up the screen.
+static BOOL ApolloCommentCellNodeIsBackedByActiveCommentsTable(id commentCellNode, UIViewController *commentsVC) {
+    if (!commentCellNode || !commentsVC || ![NSThread isMainThread]) return NO;
+    @try {
+        UITableView *commentsTable = GetCommentsTableView(commentsVC);
+        if (!commentsTable) return NO;
+        if ([commentCellNode respondsToSelector:@selector(isNodeLoaded)] &&
+            !((BOOL (*)(id, SEL))objc_msgSend)(commentCellNode, @selector(isNodeLoaded))) return NO;
+        UIView *view = [commentCellNode respondsToSelector:@selector(view)]
+            ? ((UIView *(*)(id, SEL))objc_msgSend)(commentCellNode, @selector(view)) : nil;
+        UITableViewCell *tableCell = nil;
+        for (UIView *ancestor = view; ancestor; ancestor = ancestor.superview) {
+            if (!tableCell && [ancestor isKindOfClass:[UITableViewCell class]]) {
+                tableCell = (UITableViewCell *)ancestor;
+            }
+            if ([ancestor isKindOfClass:[UITableView class]]) {
+                UITableView *table = (UITableView *)ancestor;
+                return tableCell && table == commentsTable && tableCell.window == commentsTable.window &&
+                    [commentsTable indexPathForCell:tableCell] != nil;
+            }
+        }
+    } @catch (__unused NSException *e) {}
+    return NO;
 }
 
 // Compact "🌐 Show translation" affordance appended under the ORIGINAL text when
@@ -6974,6 +7013,12 @@ static BOOL ApolloPreemptUnownedCommentTextNode(id textNode, NSAttributedString 
     // the owning model from this fresh node so identical bodies cannot borrow
     // another comment's translation cache or per-item pin state.
     id cellNode = ApolloCommentCellNodeForTextNode(textNode);
+    // Fresh body nodes also exist in Apollo's separately-measured context-menu
+    // preview controller. Only adopt a node in the active comments table. A
+    // detached vote replacement falls through to the deferred retry below and
+    // passes this check once Apollo attaches it to the real row; a preview
+    // clone never does, so its already-measured height stays coherent.
+    if (!ApolloCommentCellNodeIsBackedByActiveCommentsTable(cellNode, vc)) return NO;
     RDKComment *comment = cellNode ? ApolloCommentFromCellNode(cellNode) : nil;
     NSString *fullName = comment ? ApolloCommentFullName(comment) : nil;
     if (fullName.length == 0) return NO;
@@ -7052,13 +7097,17 @@ static void ApolloScheduleDeferredCommentPreempt(id textNode, NSAttributedString
         @catch (__unused NSException *e) { return; }
         if (![current isKindOfClass:[NSAttributedString class]] ||
             ![current.string isEqualToString:incomingText]) return; // text moved on
+        id cellNode = ApolloCommentCellNodeForTextNode(node);
+        if (!ApolloCommentCellNodeIsBackedByActiveCommentsTable(cellNode, vc)) {
+            ApolloTranslationVerboseLog(@"[Translation/vote] deferred preempt: skipping non-table comment clone node=%p", node);
+            return;
+        }
         NSAttributedString *swap = nil;
         if (!ApolloPreemptUnownedCommentTextNode(node, current, &swap) || !swap) return;
         objc_setAssociatedObject(node, kApolloOwnedNodeReentrancyKey, (id)kCFBooleanTrue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         @try { ((void (*)(id, SEL, id))objc_msgSend)(node, @selector(setAttributedText:), swap); }
         @catch (__unused NSException *e) {}
         objc_setAssociatedObject(node, kApolloOwnedNodeReentrancyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        id cellNode = ApolloCommentCellNodeForTextNode(node);
         if (cellNode) ApolloTranslationHealCellDisplaySync(cellNode);
         ApolloTranslationVerboseLog(@"[Translation/vote] deferred preempt: rebuilt node=%p swapped after attach", node);
     });

--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -2782,8 +2782,71 @@ static void ApolloPinAccountToCurrentDefaultCredentialsIfNeeded(id currentUser) 
 
 %end
 
+// A vote's model-update reconfigure can REBUILD the author byline text node.
+// The fresh node carries no avatar ownership, so the rewrite-preserve hook
+// (owned nodes only) can't keep the avatar attachment — the byline renders
+// text-only, one avatar line-height (~10pt) shorter, until the profile batch
+// fetch re-applies it seconds later: the comment's row visibly dips and
+// springs back on every vote of a comment whose author avatar has fallen out
+// of the image cache. Re-run the normal cell apply shortly after the update
+// settles: the rebuilt node is attached by then, the apply is idempotent
+// (applied-token + prepended-marker check), and the immediate placeholder
+// render is diameter-identical to the eventual image, so the row height never
+// moves while the real avatar loads.
+static void ApolloInlineAvatarReapplyAfterModelUpdate(NSString *fullName) {
+    if (fullName.length == 0) return;
+    UITableView *tableView = nil;
+    for (UIWindow *window in [UIApplication sharedApplication].windows) {
+        if (window.hidden) continue;
+        NSMutableArray *stack = [NSMutableArray arrayWithObject:window];
+        while (stack.count && !tableView) {
+            UIView *view = stack.lastObject; [stack removeLastObject];
+            if ([view isKindOfClass:[UITableView class]]) {
+                for (UITableViewCell *cell in ((UITableView *)view).visibleCells) {
+                    if (![cell respondsToSelector:@selector(node)]) continue;
+                    id node = ((id (*)(id, SEL))objc_msgSend)(cell, @selector(node));
+                    if (node && [NSStringFromClass([node class]) containsString:@"CommentCellNode"]) {
+                        tableView = (UITableView *)view;
+                        break;
+                    }
+                }
+            }
+            [stack addObjectsFromArray:view.subviews];
+        }
+        if (tableView) break;
+    }
+    if (!tableView) return;
+    for (UITableViewCell *cell in tableView.visibleCells) {
+        if (![cell respondsToSelector:@selector(node)]) continue;
+        id node = ((id (*)(id, SEL))objc_msgSend)(cell, @selector(node));
+        if (!node || ![NSStringFromClass([node class]) containsString:@"CommentCellNode"]) continue;
+        id comment = nil;
+        Ivar ivar = class_getInstanceVariable([node class], "comment");
+        if (ivar) comment = object_getIvar(node, ivar);
+        if (!comment || ![comment respondsToSelector:@selector(fullName)]) continue;
+        NSString *cellFullName = ((id (*)(id, SEL))objc_msgSend)(comment, @selector(fullName));
+        if (![cellFullName isKindOfClass:[NSString class]] || ![cellFullName isEqualToString:fullName]) continue;
+        ApolloApplyAvatarToCellWithDiameter(node, ApolloUsernameFromCell(node, @"comment"), ApolloCommentInlineAvatarDiameter);
+        return;
+    }
+}
+
 %ctor {
     %init;
+    [[NSNotificationCenter defaultCenter] addObserverForName:@"com.christianselig.ModelObjectUpdated"
+                                                      object:nil
+                                                       queue:nil
+                                                  usingBlock:^(NSNotification *note) {
+        if (!sShowUserAvatars || ![NSThread isMainThread]) return;
+        id model = note.object;
+        if (![model isKindOfClass:objc_getClass("RDKComment")]) return;
+        if (![model respondsToSelector:@selector(fullName)]) return;
+        NSString *fullName = ((id (*)(id, SEL))objc_msgSend)(model, @selector(fullName));
+        if (![fullName isKindOfClass:[NSString class]] || fullName.length == 0) return;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            ApolloInlineAvatarReapplyAfterModelUpdate(fullName);
+        });
+    }];
     [[NSNotificationCenter defaultCenter] addObserverForName:ApolloUserAvatarsToggleChangedNotification
                                                       object:nil
                                                        queue:[NSOperationQueue mainQueue]


### PR DESCRIPTION
## Summary

Fixes the visible flicker and row bounce that could occur when voting on translated comments. It also fixes the follow-up regressions found during device-style scrolling and long-press testing: a stuck/duplicated translated body, a one-frame loss of the Liquid Glass blur, and overlapping text inside the context-menu preview.

The final result keeps the translated body stable while the vote arrow and score update normally. Apollo/UIKit's normal floating context-menu preview remains unchanged.

## Why this came back after the original fix

The original vote-flicker fix in #627 addressed Texture briefly committing **blank** layer contents during Apollo's vote-time cell reconfiguration. It made the affected visible cell finish drawing synchronously, which fixed ordinary, untranslated comments.

Translated comments exposed a different race. Every vote makes Apollo rebuild the comment body node from its model, so the replacement starts with the **original-language** text before the translation module can identify the newly attached node and restore the cached translation. The synchronous display passes from #627 prevent a blank frame, but they can still commit that stale original-language surface. That is why untranslated comments remained perfect while translated comments could flash Portuguese for one frame.

The earlier changes in this PR removed the accompanying collapse and height movement and made the language flash much less frequent, but frame-by-frame testing showed that changing the node's logical text was not enough: Texture could still display an older backing surface for one frame even when `attributedText` was already translated.

The first complete flicker fix froze the settled translated body into an independent bitmap during the short vote rebuild. Its first host was the app window, which solved the language flash but used fixed screen coordinates; scrolling moved the real cell while the bitmap stayed behind, producing the stuck/duplicated comment seen on device.

Moving the bitmap into the table's scroll view fixed that duplicate, but exposed two more hierarchy problems. The cover's extreme layer depth could paint above iOS 26's scroll-edge glass for its 120 ms warm-up, making text under the top bar appear sharp for a frame. It also lived outside its owning table cell, so UIKit's context-menu transition could move/mask the cell without moving the cover in exactly the same way.

There was a second context-menu race as well: Apollo builds temporary `CommentCellNode` clones for its preview and measures them once before UIKit positions the menu. The vote fix's new translation retries could mistake that clone for a rebuilt on-screen body and translate it **after** the preview height was captured, causing clipping and overlapping text.

## What changed

- **Crowd-control state:** clears a carried-over server `collapsed = YES` flag on vote-time model copies only when the visible row is actually rendered expanded (probed via the byline's collapsed-children badge / disclosure chevron layers). Rows rendered collapsed on purpose (pinned-collapse, manual, blocked/AutoMod) and off-screen comments keep their flag, so a vote can neither pop a collapsed row open nor re-collapse an expanded pinned comment.
- **Row-height stability:** coalesces Texture height re-queries during the short rebuild window, preserves marker-line parity, and makes the translation re-entrancy guard content-aware so rapid votes cannot strand the original text.
- **Avatar stability:** reapplies the existing same-size avatar placeholder after a vote rebuild, preventing cold avatar-cache misses from shrinking and later expanding the byline.
- **Translated body stability:** caches an independent, fully rendered bitmap of the settled translated body and preloads a body-only cover. During a vote rebuild that cover is shown immediately, then hidden once the replacement node settles. The score, arrow, byline, and interaction remain live because the cover is limited to the comment body.
- **Correct cover hierarchy:** hosts the cover in Texture's stable `UITableViewCell.contentView` wrapper with normal sibling ordering. It now follows scrolling and context-menu cell movement, remains beneath Liquid Glass, and stays full-height while Apollo briefly resizes the inner Texture node.
- **Preview-clone isolation:** limits both immediate and delayed cached-translation adoption to comment nodes backed by the active comments table. Real vote replacements pass after Apollo attaches them to their row; temporary context-menu clones do not, so Apollo's native floating preview keeps its originally measured geometry without overlapping text.
- **Reuse cleanup:** cancels delayed snapshot warm-ups when a cell exits visibility and uses per-schedule identity tokens so an old delayed block cannot recreate a cover after reuse.

The cover is scoped to visible translated comments, refuses to cache original-language text, supports overlapping rapid votes, invalidates on reuse or width changes, and owns its pixels independently so Texture cannot clear or recycle the captured surface.

## Before / after

<table>
  <tr>
    <th align="center">Before</th>
    <th align="center">After</th>
  </tr>
  <tr>
    <td align="center"><img src="https://github.com/user-attachments/assets/d442b78f-c0c0-42cc-9ef1-a11bb594340e" width="360" alt="Before: translated comment flashes during a vote"></td>
    <td align="center"><img src="https://github.com/user-attachments/assets/e83887b8-3b12-45e0-aab8-6e2f5591d974" width="360" alt="After: translated comment remains stable during a vote"></td>
  </tr>
</table>

## Verification

Tested after merging the latest `main` into the PR branch in Apollo-Sim2 (iOS 26.5, Liquid Glass shell, Google translation provider) against live Portuguese comments:

- Four repeated direct vote toggles on the final build exercised the cached-cover/reapply path every time; every recorded frame retained the English body and translation marker.
- A 902-frame translated-comment scroll recording kept the top-bar blur active throughout, with no sharp cover frame, stuck body, or duplicate comment.
- Long-press testing retained Apollo/UIKit's original floating comment preview (confirmed against an untouched latest-`main` build) while eliminating the escaped cover and overlapping translated text.
- Existing collapse, height, marker, avatar, rapid-vote, menu-vote, and scroll-churn scenarios remained stable.
- Simulator build and production iOS 14 device package both compile successfully.

Not yet tested on a physical device.

