### PR TITLE
Fix login not persisting on sideloads: recover scoped keychain reads (root cause: account split across access groups)

### DIFF
--- a/src/ApolloAccountCredentials.h
+++ b/src/ApolloAccountCredentials.h
@@ -74,6 +74,9 @@ NSString *ApolloEffectiveRedirectURI(void);
 // ([[RDKClient sharedClient] currentUser].username), or nil if none/unavailable.
 NSString * _Nullable ApolloActiveAccountUsername(void);
 
+// Login-persistence diagnostics: count of persisted accounts and how many carry a currentUser.
+void ApolloPersistedAccountStats(NSInteger *outCount, NSInteger *outWithUser);
+
 // Interactive OAuth (API-key) sign-in tracking. Auth modes are mutually
 // exclusive per account, but nothing used to enforce the transition: an
 // account that once had a web session and later signs in WITH an API key kept

--- a/src/ApolloAccountCredentials.m
+++ b/src/ApolloAccountCredentials.m
@@ -226,6 +226,27 @@ static os_unfair_lock sOAuthSignInLock = OS_UNFAIR_LOCK_INIT;
 static CFAbsoluteTime sOAuthSignInArmedAt = 0;
 static NSSet<NSString *> *sOAuthSignInPreexisting = nil; // lowercased usernames at arm time
 
+// Login-persistence diagnostics: how many accounts are in the persisted RedditAccounts2 blob,
+// and how many of those still carry a currentUser identity. `count>0` with `withUser<count`
+// means the blob survived but an identity/token was cleared — a different failure than the
+// whole blob vanishing (`count==0`).
+void ApolloPersistedAccountStats(NSInteger *outCount, NSInteger *outWithUser) {
+    NSInteger count = 0, withUser = 0;
+    NSUserDefaults *group = [[NSUserDefaults alloc] initWithSuiteName:kApolloAccountCredsGroupSuite];
+    id accounts = ApolloAccountCredsUnarchive([group objectForKey:@"RedditAccounts2"]);
+    if ([accounts isKindOfClass:[NSArray class]]) {
+        count = (NSInteger)[(NSArray *)accounts count];
+        for (id client in (NSArray *)accounts) {
+            id user = nil;
+            @try { user = [client valueForKey:@"currentUser"]; }
+            @catch (__unused NSException *e) { user = nil; }
+            if (user) withUser++;
+        }
+    }
+    if (outCount) *outCount = count;
+    if (outWithUser) *outWithUser = withUser;
+}
+
 // All lowercased usernames currently in the persisted RedditAccounts2 blob.
 static NSSet<NSString *> *ApolloAllPersistedAccountUsernames(void) {
     NSMutableSet<NSString *> *names = [NSMutableSet set];

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -123,4 +123,14 @@ void ApolloInjectPublicStickyAsSubredditIfNeeded(NSMutableArray *children, NSStr
 // ActionController is tagged on first build so re-builds re-inject and other
 // menus can't claim the item.
 void ApolloInjectDeletedCommentsMenuItemIfNeeded(NSMutableArray *children, NSString *menuTitle, id actionController);
+
+// Container keychain mirror (Tweak.xm): the Valet items the real keychain could not persist
+// on a keychain-broken sideload, so a backup taken there still carries the signed-in account.
+// Returns an array of { "service", "account", "data" } dicts (empty when the mirror is dormant).
+NSArray<NSDictionary *> *ApolloKeychainMirrorItemsForBackup(void);
+
+// Append a login-persistence diagnostic line to the cross-launch buffer in the app container.
+// Mirrors the line into a file that survives force-quit, so Export Debug Logs carries the
+// session that actually signed the user out. Safe to call from any thread; never logs secrets.
+void ApolloAppendLoginDiag(NSString *line);
 __END_DECLS

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -133,4 +133,10 @@ NSArray<NSDictionary *> *ApolloKeychainMirrorItemsForBackup(void);
 // Mirrors the line into a file that survives force-quit, so Export Debug Logs carries the
 // session that actually signed the user out. Safe to call from any thread; never logs secrets.
 void ApolloAppendLoginDiag(NSString *line);
+
+// Dev-only login-persistence debug (see Tweak.xm). A report of where the account keychain item
+// lives (access group/size/protection per copy), and a best-effort attempt to create a real
+// cross-access-group duplicate to reproduce the root cause. Both also write to the diag log.
+NSString *ApolloDebugAccountKeychainReport(void);
+NSString *ApolloDebugCreateCrossGroupAccountDuplicate(void);
 __END_DECLS

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -6,6 +6,7 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 #import <OSLog/OSLog.h>
+#import <os/lock.h>
 
 #pragma mark - Logging
 
@@ -19,6 +20,75 @@ os_log_t ApolloFixLog(void) {
         sProcessStartDate = [NSDate date];
     });
     return log;
+}
+
+#pragma mark - Persistent login diagnostics (cross-launch)
+
+// The os_log export (ApolloCollectLogs) only sees the current process, so a force-quit
+// sign-out discards the session that actually wiped the account. To make that case
+// diagnosable, the login-persistence tags ([KeychainTrace], [AccountSnapshot],
+// [KeychainSelfHeal], [KeychainMirror]) are ALSO appended to a file in the app container that
+// survives relaunch. The exporter prepends this file, so a user's Export Debug Logs carries the
+// prior session even after a force-quit. Bounded to a tail so it can't grow without limit;
+// file-protected at rest (it can contain account-item byte lengths, never values or tokens).
+static NSString *ApolloLoginDiagLogPath(void) {
+    return [[NSHomeDirectory() stringByAppendingPathComponent:@"Library"]
+                stringByAppendingPathComponent:@"ApolloLoginDiag.log"];
+}
+
+static const NSUInteger kApolloLoginDiagMaxBytes = 256 * 1024; // ~256KB tail is plenty of sessions
+
+void ApolloAppendLoginDiag(NSString *line) {
+    if (![line isKindOfClass:[NSString class]] || line.length == 0) return;
+    static os_unfair_lock lock = OS_UNFAIR_LOCK_INIT;
+    static NSDateFormatter *fmt = nil;
+    os_unfair_lock_lock(&lock);
+    if (!fmt) {
+        fmt = [[NSDateFormatter alloc] init];
+        fmt.dateFormat = @"MM-dd HH:mm:ss.SSS";
+        fmt.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+    }
+    NSString *stamped = [NSString stringWithFormat:@"[%@] %@\n", [fmt stringFromDate:[NSDate date]], line];
+    NSString *path = ApolloLoginDiagLogPath();
+    NSFileManager *fm = [NSFileManager defaultManager];
+
+    @try {
+        NSFileHandle *fh = [NSFileHandle fileHandleForWritingAtPath:path];
+        if (!fh) {
+            [fm createFileAtPath:path contents:nil
+                      attributes:@{NSFileProtectionKey: NSFileProtectionCompleteUntilFirstUserAuthentication}];
+            fh = [NSFileHandle fileHandleForWritingAtPath:path];
+        }
+        if (fh) {
+            unsigned long long end = [fh seekToEndOfFile];
+            [fh writeData:[stamped dataUsingEncoding:NSUTF8StringEncoding]];
+            [fh closeFile];
+            // Trim to the tail when it grows past the cap: reload, keep the last N bytes from a
+            // line boundary, rewrite. Cheap because it only fires occasionally.
+            if (end + stamped.length > kApolloLoginDiagMaxBytes) {
+                NSData *all = [NSData dataWithContentsOfFile:path];
+                if (all.length > kApolloLoginDiagMaxBytes) {
+                    NSData *tail = [all subdataWithRange:NSMakeRange(all.length - kApolloLoginDiagMaxBytes, kApolloLoginDiagMaxBytes)];
+                    NSString *tailStr = [[NSString alloc] initWithData:tail encoding:NSUTF8StringEncoding];
+                    NSRange nl = [tailStr rangeOfString:@"\n"];
+                    if (nl.location != NSNotFound && nl.location + 1 < tailStr.length) {
+                        tailStr = [tailStr substringFromIndex:nl.location + 1];
+                    }
+                    [tailStr writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:nil];
+                }
+            }
+        }
+    } @catch (__unused NSException *e) {
+        // Diagnostics must never take the app down; a lost line is acceptable.
+    }
+    os_unfair_lock_unlock(&lock);
+}
+
+// The prior/persistent diagnostics tail, for the exporter to prepend. Empty string if none.
+static NSString *ApolloPersistentLoginDiagnostics(void) {
+    NSString *contents = [NSString stringWithContentsOfFile:ApolloLoginDiagLogPath()
+                                                   encoding:NSUTF8StringEncoding error:nil];
+    return contents.length ? contents : @"";
 }
 
 static NSString *ApolloCollectLogsFiltered(BOOL aiOnly) {
@@ -55,13 +125,23 @@ static NSString *ApolloCollectLogsFiltered(BOOL aiOnly) {
             }
         }
 
-        if (filteredEntries.count == 0) {
+        // The cross-launch login-diagnostics tail (prior sessions too) — prepended for the full
+        // log so a force-quit sign-out is still diagnosable. Not included in the AI-only export.
+        NSString *persistent = aiOnly ? @"" : ApolloPersistentLoginDiagnostics();
+
+        if (filteredEntries.count == 0 && persistent.length == 0) {
             return aiOnly
                 ? @"No Apollo AI log entries found since app launch."
                 : @"No [ApolloFix] log entries found since app launch.";
         }
 
         NSMutableString *output = [NSMutableString new];
+        if (persistent.length) {
+            [output appendString:@"===== Persistent login diagnostics (spans previous sessions; survives force-quit) =====\n"];
+            [output appendString:persistent];
+            if (![persistent hasSuffix:@"\n"]) [output appendString:@"\n"];
+            [output appendString:@"===== Current session ([ApolloFix] os_log) =====\n"];
+        }
         [output appendFormat:@"%@ — %@ (%lu entries)\n\n",
             aiOnly ? @"Apollo AI Logs" : @"ApolloFix Logs",
             [NSDateFormatter localizedStringFromDate:[NSDate date]

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -37,6 +37,10 @@ static NSString *ApolloLoginDiagLogPath(void) {
 }
 
 static const NSUInteger kApolloLoginDiagMaxBytes = 256 * 1024; // ~256KB tail is plenty of sessions
+// When trimming, drop back to this (not just under the cap) so the next ~64KB of lines don't each
+// re-trigger a full read+rewrite of the file. Without the headroom, once the buffer is at capacity
+// every single append would rewrite the whole file — expensive on the keychain hot path.
+static const NSUInteger kApolloLoginDiagTrimTo = 192 * 1024;
 
 void ApolloAppendLoginDiag(NSString *line) {
     if (![line isKindOfClass:[NSString class]] || line.length == 0) return;
@@ -68,7 +72,7 @@ void ApolloAppendLoginDiag(NSString *line) {
             if (end + stamped.length > kApolloLoginDiagMaxBytes) {
                 NSData *all = [NSData dataWithContentsOfFile:path];
                 if (all.length > kApolloLoginDiagMaxBytes) {
-                    NSData *tail = [all subdataWithRange:NSMakeRange(all.length - kApolloLoginDiagMaxBytes, kApolloLoginDiagMaxBytes)];
+                    NSData *tail = [all subdataWithRange:NSMakeRange(all.length - kApolloLoginDiagTrimTo, kApolloLoginDiagTrimTo)];
                     NSString *tailStr = [[NSString alloc] initWithData:tail encoding:NSUTF8StringEncoding];
                     NSRange nl = [tailStr rangeOfString:@"\n"];
                     if (nl.location != NSNotFound && nl.location + 1 < tailStr.length) {

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -2245,7 +2245,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         return (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 ||
                 indexPath.row == 3 || indexPath.row == 11);
     }
-    if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 || indexPath.row == 3 || indexPath.row == 4)) return YES;
+    if (indexPath.section == SectionAbout && (indexPath.row == 0 || indexPath.row == 1 || indexPath.row == 2 || indexPath.row == 3 || indexPath.row == 4 || indexPath.row == 6)) return YES;
     if (indexPath.section == SectionNotificationBackend) {
         return (indexPath.row == kNotifBackendRowTestConnection || indexPath.row == kNotifBackendRowTestBark);
     }

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -2955,25 +2955,48 @@ static NSArray<NSDictionary *> *ApolloCaptureValetKeychainItems(void) {
         (__bridge id)kSecReturnAttributes: @YES,
         (__bridge id)kSecReturnData:       @YES,
     };
+    // Keyed by service+account so mirror-only items can be merged in without duplicating a key.
+    NSMutableDictionary<NSString *, NSDictionary *> *byKey = [NSMutableDictionary dictionary];
+
+    // The enumeration can fail (errSecMissingEntitlement -34018 on a broken-keychain device) or
+    // return nothing (errSecItemNotFound) — the exact devices the mirror exists for. Don't early
+    // return on that: fall through so the mirror merge below still runs and the backup carries
+    // the account.
     CFTypeRef result = NULL;
     OSStatus st = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
-    if (st != errSecSuccess || !result) {
-        if (result) CFRelease(result);
-        return items;
+    if (st == errSecSuccess && result) {
+        NSArray *found = (__bridge_transfer NSArray *)result;
+        for (NSDictionary *item in found) {
+            NSString *service = item[(__bridge id)kSecAttrService];
+            NSData *data = item[(__bridge id)kSecValueData];
+            if (![service isKindOfClass:[NSString class]] || ![service containsString:kValetServiceSubstring]) continue;
+            if (![data isKindOfClass:[NSData class]]) continue;
+            NSString *account = item[(__bridge id)kSecAttrAccount];
+            NSString *acct = [account isKindOfClass:[NSString class]] ? account : @"";
+            byKey[[NSString stringWithFormat:@"%@\n%@", service, acct]] = @{
+                @"service": service, @"account": acct, @"data": data,
+            };
+        }
+    } else if (result) {
+        CFRelease(result);
     }
-    NSArray *found = (__bridge_transfer NSArray *)result;
-    for (NSDictionary *item in found) {
-        NSString *service = item[(__bridge id)kSecAttrService];
-        NSData *data = item[(__bridge id)kSecValueData];
+
+    // Merge the container mirror. On a keychain-broken device the account item exists ONLY in
+    // the mirror (the real keychain enumeration above missed it), and where both exist the
+    // mirror value is the authoritative one (the real copy is the stale row that failed to
+    // update), so mirror entries win.
+    for (NSDictionary *item in ApolloKeychainMirrorItemsForBackup()) {
+        NSString *service = item[@"service"];
+        NSData *data = item[@"data"];
         if (![service isKindOfClass:[NSString class]] || ![service containsString:kValetServiceSubstring]) continue;
         if (![data isKindOfClass:[NSData class]]) continue;
-        NSString *account = item[(__bridge id)kSecAttrAccount];
-        [items addObject:@{
-            @"service": service,
-            @"account": ([account isKindOfClass:[NSString class]] ? account : @""),
-            @"data":    data,
-        }];
+        NSString *acct = [item[@"account"] isKindOfClass:[NSString class]] ? item[@"account"] : @"";
+        byKey[[NSString stringWithFormat:@"%@\n%@", service, acct]] = @{
+            @"service": service, @"account": acct, @"data": data,
+        };
     }
+
+    [items addObjectsFromArray:byKey.allValues];
     return items;
 }
 

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -884,7 +884,9 @@ typedef NS_ENUM(NSInteger, Tag) {
         case SectionSubreddits: return 10 - (sSubredditListEnhancements ? 0 : 1) - (sCommunityHighlights ? 0 : 1);
         case SectionNotificationBackend: return kNotifBackendRowCount;
         case SectionPrivacy: return 1; // Anonymous Install Count toggle
-        case SectionAbout: return 6; // GitHub + Reddit + Thanks To + Export Logs + Privacy Policy + Version
+        // GitHub + Reddit + Thanks To + Export Logs + Privacy Policy + Version, plus a dev-only
+        // "Login Persistence Debug" row when FLEX (developer mode) is enabled.
+        case SectionAbout: return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableFLEX] ? 7 : 6;
         default: return 0;
     }
 }
@@ -1797,6 +1799,21 @@ typedef NS_ENUM(NSInteger, Tag) {
             cell.detailTextLabel.text = @TWEAK_VERSION;
             return cell;
         }
+        case 6: { // dev-only, only present when FLEX is enabled (see numberOfRowsInSection)
+            UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"Cell_About_LoginDebug"];
+            if (!cell) {
+                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"Cell_About_LoginDebug"];
+            }
+            cell.textLabel.text = @"🔧 Login Persistence Debug";
+            BOOL forceMiss = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyDebugForceAccountReadMiss];
+            BOOL noRecover = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyDebugDisableKeychainRecovery];
+            cell.detailTextLabel.text = [NSString stringWithFormat:@"force-miss %@ · recovery %@",
+                                         forceMiss ? @"ON" : @"off", noRecover ? @"OFF" : @"on"];
+            cell.detailTextLabel.textColor = (forceMiss || noRecover) ? [UIColor systemRedColor] : [UIColor secondaryLabelColor];
+            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+            cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+            return cell;
+        }
         default: return [[UITableViewCell alloc] init];
     }
 }
@@ -2089,6 +2106,8 @@ typedef NS_ENUM(NSInteger, Tag) {
             [self exportLogs];
         } else if (indexPath.row == 4) {
             [self presentURLInApolloBrowser:[NSURL URLWithString:@"https://apolloreborn.app/privacy"]];
+        } else if (indexPath.row == 6) {
+            [self presentLoginPersistenceDebugSheetFromIndexPath:indexPath];
         }
     } else if (indexPath.section == SectionMedia) {
         UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
@@ -2268,6 +2287,74 @@ typedef NS_ENUM(NSInteger, Tag) {
             });
         });
     }];
+}
+
+#pragma mark - Login Persistence Debug (dev-only, FLEX-gated)
+
+- (void)presentLoginPersistenceDebugResult:(NSString *)text title:(NSString *)title {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:text preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Copy" style:UIAlertActionStyleDefault handler:^(UIAlertAction *a) {
+        UIPasteboard.generalPasteboard.string = text;
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (void)presentLoginPersistenceDebugSheetFromIndexPath:(NSIndexPath *)indexPath {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    BOOL forceMiss = [defaults boolForKey:UDKeyDebugForceAccountReadMiss];
+    BOOL noRecover = [defaults boolForKey:UDKeyDebugDisableKeychainRecovery];
+
+    UIAlertController *sheet = [UIAlertController
+        alertControllerWithTitle:@"Login Persistence Debug"
+                         message:@"Dev-only fault injection. This simulates the broken-keychain read on THIS device to exercise the fix — a pass here is a regression check, not field confirmation. \"Disable recovery\" + \"force read-miss\" will actually sign you out (reproduces the bug)."
+                  preferredStyle:UIAlertControllerStyleActionSheet];
+
+    [sheet addAction:[UIAlertAction actionWithTitle:(forceMiss ? @"✓ Force account read-miss (ON)" : @"Force account read-miss (off)")
+                                              style:UIAlertActionStyleDefault
+                                            handler:^(UIAlertAction *a) {
+        [defaults setBool:!forceMiss forKey:UDKeyDebugForceAccountReadMiss];
+        [self.tableView reloadData];
+    }]];
+
+    [sheet addAction:[UIAlertAction actionWithTitle:(noRecover ? @"✓ Disable recovery — watch the wipe (ON)" : @"Disable recovery — watch the wipe (off)")
+                                              style:(noRecover ? UIAlertActionStyleDestructive : UIAlertActionStyleDefault)
+                                            handler:^(UIAlertAction *a) {
+        [defaults setBool:!noRecover forKey:UDKeyDebugDisableKeychainRecovery];
+        [self.tableView reloadData];
+    }]];
+
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Dump account keychain report"
+                                              style:UIAlertActionStyleDefault
+                                            handler:^(UIAlertAction *a) {
+        [self presentLoginPersistenceDebugResult:ApolloDebugAccountKeychainReport() title:@"Account keychain report"];
+    }]];
+
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Create real cross-group duplicate (best-effort)"
+                                              style:UIAlertActionStyleDefault
+                                            handler:^(UIAlertAction *a) {
+        [self presentLoginPersistenceDebugResult:ApolloDebugCreateCrossGroupAccountDuplicate() title:@"Cross-group duplicate"];
+    }]];
+
+    if (forceMiss || noRecover) {
+        [sheet addAction:[UIAlertAction actionWithTitle:@"Clear all fault flags"
+                                                  style:UIAlertActionStyleDefault
+                                                handler:^(UIAlertAction *a) {
+            [defaults setBool:NO forKey:UDKeyDebugForceAccountReadMiss];
+            [defaults setBool:NO forKey:UDKeyDebugDisableKeychainRecovery];
+            [self.tableView reloadData];
+        }]];
+    }
+
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    UIPopoverPresentationController *pop = sheet.popoverPresentationController;
+    if (pop) {
+        UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:indexPath];
+        pop.sourceView = cell ?: self.view;
+        pop.sourceRect = cell ? cell.bounds : CGRectZero;
+    }
+    [self presentViewController:sheet animated:YES completion:nil];
 }
 
 #pragma mark - Troubleshooting VC

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -513,10 +513,12 @@ static long ApolloExistingAccountBlobMaxLen(NSString *service, NSString *account
 static BOOL ApolloShouldBlockDestructiveAccountWrite(NSDictionary *query, NSData *newValue) {
     if (ApolloDebugDisableRecovery()) return NO;
     if (!IsAccountsFamilyQuery(query)) return NO;
+    // Only guard an actual DATA write — an attribute-only update (no kSecValueData) destroys
+    // nothing and must pass through.
+    if (![newValue isKindOfClass:[NSData class]]) return NO;
     NSString *account = query[(__bridge id)kSecAttrAccount];
     if (ApolloWasAccountServed(account)) return NO; // reads worked this session — trust the write
-    NSUInteger newLen = [newValue isKindOfClass:[NSData class]] ? newValue.length : 0;
-    if (newLen >= kAccountBlobPopulatedThreshold) return NO; // not an empty/tiny write
+    if (newValue.length >= kAccountBlobPopulatedThreshold) return NO; // not an empty/tiny write
     long existing = ApolloExistingAccountBlobMaxLen(query[(__bridge id)kSecAttrService], account);
     return existing >= (long)kAccountBlobPopulatedThreshold; // a populated copy exists — protect it
 }
@@ -919,6 +921,18 @@ static OSStatus SecItemAdd_replacement(CFDictionaryRef query, CFTypeRef *result)
         return errSecSuccess;
     }
 #endif
+    // Last line of defense, checked BEFORE touching the keychain: never let a failed-read session
+    // erase a populated account blob. Because of the access-group split, a stripped empty add can
+    // *succeed* into the app's default drawer (no duplicate there) and create a fresh empty copy
+    // that recovery's newest-by-date pick would then serve — so this has to run before the real
+    // add, not after. Non-Valet / non-accounts / populated / already-served writes pass straight
+    // through. Report success so Valet doesn't error; the good blob is untouched.
+    if (ApolloShouldBlockDestructiveAccountWrite(strippedQuery, strippedQuery[(__bridge id)kSecValueData])) {
+        ApolloLoginDiag(@"[KeychainGuard] BLOCKED empty add over populated account blob (no successful read this session) account=%@ writeLen=%ld",
+                        strippedQuery[(__bridge id)kSecAttrAccount], ApolloValueDataLength(strippedQuery));
+        return errSecSuccess;
+    }
+
     OSStatus status = ApolloRealSecItemAdd(strippedQuery, result);
     if (!IsValetQuery(strippedQuery)) return status;
 
@@ -931,14 +945,6 @@ static OSStatus SecItemAdd_replacement(CFDictionaryRef query, CFTypeRef *result)
     NSString *account = strippedQuery[(__bridge id)kSecAttrAccount];
     ApolloKeychainTrace(@"ADD", strippedQuery, status,
                         [NSString stringWithFormat:@"writeLen=%ld", ApolloValueDataLength(strippedQuery)]);
-
-    // Last line of defense: never let a failed-read session erase a populated account blob by
-    // self-healing an empty add over it. Report success so Valet doesn't error; keep the good blob.
-    if (ApolloShouldBlockDestructiveAccountWrite(strippedQuery, strippedQuery[(__bridge id)kSecValueData])) {
-        ApolloLoginDiag(@"[KeychainGuard] BLOCKED empty add over populated account blob (no successful read this session) account=%@ writeLen=%ld",
-                        account, ApolloValueDataLength(strippedQuery));
-        return errSecSuccess;
-    }
 
     if (status == errSecDuplicateItem) {
         if (ApolloExistingKeychainItemHasSameValue(strippedQuery) ||

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -290,7 +290,8 @@ static void ApolloMirrorPut(NSString *service, NSString *account, NSData *data, 
 
 // A real write for this key finally landed — drop the mirror entry so the real keychain is
 // authoritative again (lets a device recover out of mirror mode if the keychain starts working).
-static void ApolloMirrorRemove(NSString *service, NSString *account) {
+// Returns YES if a mirror entry was actually dropped.
+static BOOL ApolloMirrorRemove(NSString *service, NSString *account) {
     NSString *key = ApolloKeychainMirrorKey(service, account);
     os_unfair_lock_lock(&sMirrorLock);
     NSMutableDictionary *store = ApolloMirrorLoadLocked();
@@ -302,6 +303,7 @@ static void ApolloMirrorRemove(NSString *service, NSString *account) {
     os_unfair_lock_unlock(&sMirrorLock);
     if (had) ApolloLoginDiag(@"[KeychainMirror] real keychain took over item; dropped mirror service=%@ account=%@",
                              service, account);
+    return had;
 }
 
 // Snapshot for Backup Settings, so a backup taken on a keychain-broken device still carries
@@ -314,8 +316,11 @@ NSArray<NSDictionary *> *ApolloKeychainMirrorItemsForBackup(void) {
     return values ?: @[];
 }
 
-// Build a SecItemCopyMatching result for mirrored data, honoring the query's return flags
-// (same shape contract as the real keychain / the sim shim's SimKeychainServe).
+// Build a SecItemCopyMatching result for mirrored/recovered data, honoring the query's return
+// flags (same shape contract as the real keychain / the sim shim's SimKeychainServe).
+// NOTE: a kSecReturnAttributes result carries only service/account/data — NOT accessibility,
+// access group, or creation/modification dates. This is faithful for Valet's data reads (which
+// is all that uses it), but an attribute-inspecting caller would be served an incomplete dict.
 static OSStatus ApolloMirrorServe(NSDictionary *q, NSData *data, CFTypeRef *result) {
     if (!result) return errSecSuccess;
     if (q[(__bridge id)kSecReturnAttributes]) {
@@ -431,6 +436,91 @@ static OSStatus ApolloValetRecoverRead(NSDictionary *query, CFTypeRef *result, N
     return ApolloMirrorServe(query, data, result);
 }
 
+// Dev-only fault-injection flags (FLEX-gated; see the "fault injection" section below for the
+// full rationale). Declared up here because the destructive-write guard consults the
+// disable-recovery toggle to stay bypassable when reproducing the raw wipe.
+static BOOL ApolloDebugForceAccountReadMiss(void) {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"ApolloDebugForceAccountReadMiss"];
+}
+static BOOL ApolloDebugDisableRecovery(void) {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"ApolloDebugDisableKeychainRecovery"];
+}
+
+// MARK: - Destructive-write guard (last line of defense)
+//
+// Recovery only fires on errSecItemNotFound. Any OTHER read-failure mode — errSecInteractionNotAllowed,
+// a transient -34018, an enumeration miss, a TTL race — still lets AccountManager prune to an
+// empty array, and the self-heal would then force that empty blob over the good one, exactly as
+// 3.4.1 does. Since the whole bug class is "a failed read turns into a destructive write", refuse
+// to overwrite a populated account blob with an empty/tiny one UNLESS that item was successfully
+// served (a real scoped read OR recovery) earlier this session. A genuine sign-out always follows
+// a session with working reads, so it still persists; a session that never once read the account
+// has no business erasing it.
+static const NSUInteger kAccountBlobPopulatedThreshold = 512; // empty array ~219B; populated >1KB
+
+// The account-family items whose destruction logs the user out.
+static BOOL IsAccountsFamilyQuery(NSDictionary *query) {
+    if (!IsValetQuery(query)) return NO;
+    NSString *account = query[(__bridge id)kSecAttrAccount];
+    return [account isKindOfClass:[NSString class]] &&
+           ([account containsString:@"RedditAccounts2"] || [account containsString:@"ApplicationOnlyAccount2"]);
+}
+
+// Accounts successfully served (real read or recovery) this session, so their writes are trusted.
+static os_unfair_lock sServedLock = OS_UNFAIR_LOCK_INIT;
+static NSMutableSet<NSString *> *sServedAccounts;
+
+static void ApolloMarkAccountServed(NSString *account) {
+    if (![account isKindOfClass:[NSString class]]) return;
+    os_unfair_lock_lock(&sServedLock);
+    if (!sServedAccounts) sServedAccounts = [NSMutableSet set];
+    [sServedAccounts addObject:account];
+    os_unfair_lock_unlock(&sServedLock);
+}
+static BOOL ApolloWasAccountServed(NSString *account) {
+    os_unfair_lock_lock(&sServedLock);
+    BOOL served = [sServedAccounts containsObject:account];
+    os_unfair_lock_unlock(&sServedLock);
+    return served;
+}
+
+// Largest existing copy of this account item across all access groups (via enumeration), or -1.
+static long ApolloExistingAccountBlobMaxLen(NSString *service, NSString *account) {
+    NSDictionary *q = @{
+        (__bridge id)kSecClass:              (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecMatchLimit:         (__bridge id)kSecMatchLimitAll,
+        (__bridge id)kSecReturnAttributes:   @YES,
+        (__bridge id)kSecReturnData:         @YES,
+        (__bridge id)kSecAttrSynchronizable: (__bridge id)kSecAttrSynchronizableAny,
+    };
+    CFTypeRef result = NULL;
+    OSStatus st = ApolloRealSecItemCopyMatching(q, &result);
+    if (st != errSecSuccess || !result) { if (result) CFRelease(result); return -1; }
+    NSArray *found = (__bridge_transfer NSArray *)result;
+    long maxLen = -1;
+    for (NSDictionary *item in found) {
+        if (![item[(__bridge id)kSecAttrService] isEqual:service]) continue;
+        if (![item[(__bridge id)kSecAttrAccount] isEqual:account]) continue;
+        NSData *data = item[(__bridge id)kSecValueData];
+        if ([data isKindOfClass:[NSData class]] && (long)data.length > maxLen) maxLen = (long)data.length;
+    }
+    return maxLen;
+}
+
+// YES if this write would erase a populated account blob after a session with no successful read
+// of it — the failed-read→destructive-write signature. Bypassed by the dev "disable recovery"
+// toggle so the raw wipe can still be reproduced on demand.
+static BOOL ApolloShouldBlockDestructiveAccountWrite(NSDictionary *query, NSData *newValue) {
+    if (ApolloDebugDisableRecovery()) return NO;
+    if (!IsAccountsFamilyQuery(query)) return NO;
+    NSString *account = query[(__bridge id)kSecAttrAccount];
+    if (ApolloWasAccountServed(account)) return NO; // reads worked this session — trust the write
+    NSUInteger newLen = [newValue isKindOfClass:[NSData class]] ? newValue.length : 0;
+    if (newLen >= kAccountBlobPopulatedThreshold) return NO; // not an empty/tiny write
+    long existing = ApolloExistingAccountBlobMaxLen(query[(__bridge id)kSecAttrService], account);
+    return existing >= (long)kAccountBlobPopulatedThreshold; // a populated copy exists — protect it
+}
+
 // MARK: - Login-persistence fault injection (dev-only self-test)
 //
 // The affected-device failure signature — a SCOPED account read returning -25300 while an
@@ -442,12 +532,7 @@ static OSStatus ApolloValetRecoverRead(NSDictionary *query, CFTypeRef *result, N
 // green result here is a regression check, NOT field confirmation (that still needs an affected
 // user's log). Every simulated read is logged [FaultInjection] so it can never be mistaken for a
 // genuine keychain failure. Inert unless the (FLEX-gated) toggles are set.
-static BOOL ApolloDebugForceAccountReadMiss(void) {
-    return [[NSUserDefaults standardUserDefaults] boolForKey:@"ApolloDebugForceAccountReadMiss"];
-}
-static BOOL ApolloDebugDisableRecovery(void) {
-    return [[NSUserDefaults standardUserDefaults] boolForKey:@"ApolloDebugDisableKeychainRecovery"];
-}
+// (ApolloDebugForceAccountReadMiss / ApolloDebugDisableRecovery are defined above the guard.)
 
 // MARK: - Keychain trace (login-persistence diagnostics)
 //
@@ -847,6 +932,14 @@ static OSStatus SecItemAdd_replacement(CFDictionaryRef query, CFTypeRef *result)
     ApolloKeychainTrace(@"ADD", strippedQuery, status,
                         [NSString stringWithFormat:@"writeLen=%ld", ApolloValueDataLength(strippedQuery)]);
 
+    // Last line of defense: never let a failed-read session erase a populated account blob by
+    // self-healing an empty add over it. Report success so Valet doesn't error; keep the good blob.
+    if (ApolloShouldBlockDestructiveAccountWrite(strippedQuery, strippedQuery[(__bridge id)kSecValueData])) {
+        ApolloLoginDiag(@"[KeychainGuard] BLOCKED empty add over populated account blob (no successful read this session) account=%@ writeLen=%ld",
+                        account, ApolloValueDataLength(strippedQuery));
+        return errSecSuccess;
+    }
+
     if (status == errSecDuplicateItem) {
         if (ApolloExistingKeychainItemHasSameValue(strippedQuery) ||
             ApolloUpdateStaleKeychainItem(strippedQuery)) {
@@ -914,6 +1007,7 @@ static OSStatus SecItemCopyMatching_replacement(CFDictionaryRef query, CFTypeRef
         if (mirrored) {
             ApolloKeychainTrace(@"COPY", strippedQuery, errSecSuccess,
                                 [NSString stringWithFormat:@"route=mirror readLen=%lu", (unsigned long)mirrored.length]);
+            if (IsAccountsFamilyQuery(strippedQuery)) ApolloMarkAccountServed(account);
             return ApolloMirrorServe(strippedQuery, mirrored, result);
         }
     }
@@ -957,8 +1051,15 @@ static OSStatus SecItemCopyMatching_replacement(CFDictionaryRef query, CFTypeRef
                             strippedQuery[(__bridge id)kSecAttrAccount],
                             [queriedGroup isKindOfClass:[NSString class]] ? queriedGroup : @"(stripped/none)",
                             foundGroup ?: @"?");
+            if (IsAccountsFamilyQuery(strippedQuery)) ApolloMarkAccountServed(strippedQuery[(__bridge id)kSecAttrAccount]);
             return errSecSuccess;
         }
+    }
+
+    // A genuine successful read marks the account as served this session, so the destructive-write
+    // guard trusts a later empty write (a real sign-out) rather than blocking it.
+    if (status == errSecSuccess && IsAccountsFamilyQuery(strippedQuery)) {
+        ApolloMarkAccountServed(strippedQuery[(__bridge id)kSecAttrAccount]);
     }
 
     if (ApolloIsAccountsBlobQuery(strippedQuery)) {
@@ -1002,6 +1103,14 @@ static OSStatus SecItemUpdate_replacement(CFDictionaryRef query, CFDictionaryRef
         return SimKeychainStore()[key] ? errSecSuccess : errSecItemNotFound;
     }
 #endif
+
+    // Last line of defense (see SecItemAdd_replacement): don't let a failed-read session update a
+    // populated account blob down to empty. Guard BEFORE the real update so the good blob survives.
+    if (ApolloShouldBlockDestructiveAccountWrite(strippedQuery, attrs[(__bridge id)kSecValueData])) {
+        ApolloLoginDiag(@"[KeychainGuard] BLOCKED empty update over populated account blob (no successful read this session) account=%@ writeLen=%ld",
+                        strippedQuery[(__bridge id)kSecAttrAccount], ApolloValueDataLength(attrs));
+        return errSecSuccess;
+    }
 
     OSStatus status = ApolloRealSecItemUpdate(strippedQuery, attrs);
     if (!IsValetQuery(strippedQuery)) return status;
@@ -1088,7 +1197,12 @@ static OSStatus SecItemDelete_replacement(CFDictionaryRef query) {
         // copies, and drop any container mirror entry so sign-out really signs out.
         NSDictionary *broadened = ApolloQueryByBroadeningSynchronizable(strippedQuery);
         if (broadened != strippedQuery) ApolloRealSecItemDelete(broadened);
-        ApolloMirrorRemove(strippedQuery[(__bridge id)kSecAttrService], strippedQuery[(__bridge id)kSecAttrAccount]);
+        BOOL droppedMirror = ApolloMirrorRemove(strippedQuery[(__bridge id)kSecAttrService], strippedQuery[(__bridge id)kSecAttrAccount]);
+        // On the -34018 cohort the item lived only in the container mirror, so the real delete
+        // returns a failing status even though the delete succeeded from Valet's point of view.
+        // Report success when the mirror held the key, so Valet.canAccessKeychain()'s canary (which
+        // may exercise delete) isn't left gating the whole account load off on exactly those devices.
+        if (droppedMirror && status != errSecSuccess) status = errSecSuccess;
     }
     return status;
 }

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -431,6 +431,24 @@ static OSStatus ApolloValetRecoverRead(NSDictionary *query, CFTypeRef *result, N
     return ApolloMirrorServe(query, data, result);
 }
 
+// MARK: - Login-persistence fault injection (dev-only self-test)
+//
+// The affected-device failure signature — a SCOPED account read returning -25300 while an
+// enumeration returns the item — is confirmed from real field logs, but no maintainer device
+// exhibits it, so there's nothing to test the fix against locally. These dev-only toggles
+// replay that exact signature on any device by forcing the account read to miss, so the
+// wipe->recover chain can be exercised on real hardware. This tests the RESPONSE, not the
+// real-world cause: on a healthy device the enumeration trivially returns the real account, so a
+// green result here is a regression check, NOT field confirmation (that still needs an affected
+// user's log). Every simulated read is logged [FaultInjection] so it can never be mistaken for a
+// genuine keychain failure. Inert unless the (FLEX-gated) toggles are set.
+static BOOL ApolloDebugForceAccountReadMiss(void) {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"ApolloDebugForceAccountReadMiss"];
+}
+static BOOL ApolloDebugDisableRecovery(void) {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"ApolloDebugDisableKeychainRecovery"];
+}
+
 // MARK: - Keychain trace (login-persistence diagnostics)
 //
 // We could not reproduce the "logged out after force-quit / after idling in the background"
@@ -591,6 +609,100 @@ static NSString *ApolloAccountsBlobGroupBreakdown(void) {
     }
     return [NSString stringWithFormat:@"copies=%lu %@",
             (unsigned long)copies.count, [copies componentsJoinedByString:@" "]];
+}
+
+// Exported for the dev-only debug screen: a human-readable report of where the account item
+// lives (each copy's access group / size / protection class), plus the current defaults state.
+NSString *ApolloDebugAccountKeychainReport(void) {
+    NSString *breakdown = ApolloAccountsBlobGroupBreakdown();
+    ApolloLoginDiag(@"[DebugReport] %@", breakdown);
+    return breakdown;
+}
+
+// Best-effort: try to create a genuine cross-access-group DUPLICATE of the account item, to
+// reproduce the real root cause (not a mock) on a device whose signing entitles a second
+// keychain group. Reads the current item via enumeration, then writes a copy into candidate
+// groups using the UN-stripped real SecItemAdd (our normal hook strips the group, so this must
+// bypass it). Logs each attempt's status: 0 = duplicate created, -34018 = not entitled to that
+// group (so this device can't exhibit the split via it), -25299 = a copy already there. Returns
+// a summary for display. Only meaningful with an account signed in.
+NSString *ApolloDebugCreateCrossGroupAccountDuplicate(void) {
+    // 1. Find the current account item + its access group + data.
+    NSDictionary *q = @{
+        (__bridge id)kSecClass:              (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecMatchLimit:         (__bridge id)kSecMatchLimitAll,
+        (__bridge id)kSecReturnAttributes:   @YES,
+        (__bridge id)kSecReturnData:         @YES,
+        (__bridge id)kSecAttrSynchronizable: (__bridge id)kSecAttrSynchronizableAny,
+    };
+    CFTypeRef result = NULL;
+    OSStatus st = ApolloRealSecItemCopyMatching(q, &result);
+    if (st != errSecSuccess || !result) {
+        if (result) CFRelease(result);
+        return [NSString stringWithFormat:@"No account item to duplicate (enum status=%d). Sign in first.", (int)st];
+    }
+    NSArray *found = (__bridge_transfer NSArray *)result;
+    NSDictionary *acctItem = nil;
+    for (NSDictionary *item in found) {
+        NSString *service = item[(__bridge id)kSecAttrService];
+        NSString *account = item[(__bridge id)kSecAttrAccount];
+        if ([service isKindOfClass:[NSString class]] && [service containsString:kValetServiceSubstring] &&
+            [account isKindOfClass:[NSString class]] && [account containsString:@"RedditAccounts2"] &&
+            [item[(__bridge id)kSecValueData] isKindOfClass:[NSData class]]) {
+            acctItem = item;
+            break;
+        }
+    }
+    if (!acctItem) return @"No 2RedditAccounts2 item found in the keychain. Sign in first.";
+
+    NSString *service = acctItem[(__bridge id)kSecAttrService];
+    NSString *account = acctItem[(__bridge id)kSecAttrAccount];
+    NSData *data = acctItem[(__bridge id)kSecValueData];
+    NSString *currentGroup = [acctItem[(__bridge id)kSecAttrAccessGroup] isKindOfClass:[NSString class]]
+                                 ? acctItem[(__bridge id)kSecAttrAccessGroup] : nil;
+
+    // 2. Candidate second groups, derived from the current group's team prefix. The app group's
+    //    keychain form and a synthetic sibling both make plausible "second drawer" targets; which
+    //    (if any) the signer entitles varies by install method.
+    NSMutableArray<NSString *> *candidates = [NSMutableArray array];
+    NSString *prefix = nil;
+    if (currentGroup.length) {
+        NSRange dot = [currentGroup rangeOfString:@"."];
+        if (dot.location != NSNotFound) prefix = [currentGroup substringToIndex:dot.location];
+    }
+    if (prefix.length) {
+        [candidates addObject:[NSString stringWithFormat:@"%@.group.com.christianselig.apollo", prefix]];
+        [candidates addObject:[NSString stringWithFormat:@"%@.com.christianselig.Apollo", prefix]];
+        [candidates addObject:[NSString stringWithFormat:@"%@.com.christianselig.Apollo.debugdup", prefix]];
+    }
+
+    NSMutableString *report = [NSMutableString stringWithFormat:@"Current group: %@\ndata: %lu bytes\n",
+                               currentGroup ?: @"?", (unsigned long)data.length];
+    if (candidates.count == 0) {
+        [report appendString:@"Could not derive a team prefix — cannot attempt a second group."];
+        ApolloLoginDiag(@"[DebugDup] %@", report);
+        return report;
+    }
+    for (NSString *grp in candidates) {
+        if ([grp isEqualToString:currentGroup]) { [report appendFormat:@"\n%@ — skipped (== current)", grp]; continue; }
+        NSDictionary *add = @{
+            (__bridge id)kSecClass:           (__bridge id)kSecClassGenericPassword,
+            (__bridge id)kSecAttrService:     service,
+            (__bridge id)kSecAttrAccount:     account,
+            (__bridge id)kSecAttrAccessGroup: grp,
+            (__bridge id)kSecAttrAccessible:  (__bridge id)kSecAttrAccessibleAfterFirstUnlock,
+            (__bridge id)kSecValueData:       data,
+        };
+        OSStatus as = ApolloRealSecItemAdd(add, NULL); // un-stripped: keep the explicit group
+        NSString *note = as == errSecSuccess ? @"DUPLICATE CREATED"
+                       : as == errSecDuplicateItem ? @"already present here"
+                       : as == -34018 ? @"not entitled to this group"
+                       : @"failed";
+        [report appendFormat:@"\n%@ -> status=%d (%@)", grp, (int)as, note];
+    }
+    ApolloInvalidateRecoverCache();
+    ApolloLoginDiag(@"[DebugDup] %@", [report stringByReplacingOccurrencesOfString:@"\n" withString:@" | "]);
+    return report;
 }
 
 static void ApolloLogAccountSnapshot(NSString *reason) {
@@ -806,17 +918,26 @@ static OSStatus SecItemCopyMatching_replacement(CFDictionaryRef query, CFTypeRef
         }
     }
 
-    // For the trace, capture the returned byte length even when the caller passed result=NULL
-    // (an existence check) — do our own attributed read on the accounts item so the log always
-    // carries the size that distinguishes an empty blob from a populated one.
-    OSStatus status = ApolloRealSecItemCopyMatching(strippedQuery, result);
-    if (status == errSecItemNotFound && IsValetQuery(strippedQuery)) {
-        // Only fall back to the broadened (synced-included) read on a local miss, so a
-        // good local item always wins over a potentially stale synced one.
-        NSDictionary *broadened = ApolloQueryByBroadeningSynchronizable(strippedQuery);
-        if (broadened != strippedQuery) {
-            status = ApolloRealSecItemCopyMatching(broadened, result);
-            ApolloKeychainTrace(@"COPY-broadened", strippedQuery, status, nil);
+    // Dev-only fault injection: force the account scoped read to miss so the wipe->recover chain
+    // can be exercised on a healthy device (see "fault injection" above). Skips the real reads
+    // for the accounts item and drops straight to -25300, exactly as an affected device does.
+    OSStatus status;
+    if (ApolloIsAccountsBlobQuery(strippedQuery) && ApolloDebugForceAccountReadMiss()) {
+        status = errSecItemNotFound;
+        ApolloLoginDiag(@"[FaultInjection] forcing account scoped read miss (SIMULATED — not a real keychain failure)");
+    } else {
+        // For the trace, capture the returned byte length even when the caller passed result=NULL
+        // (an existence check) — do our own attributed read on the accounts item so the log always
+        // carries the size that distinguishes an empty blob from a populated one.
+        status = ApolloRealSecItemCopyMatching(strippedQuery, result);
+        if (status == errSecItemNotFound && IsValetQuery(strippedQuery)) {
+            // Only fall back to the broadened (synced-included) read on a local miss, so a
+            // good local item always wins over a potentially stale synced one.
+            NSDictionary *broadened = ApolloQueryByBroadeningSynchronizable(strippedQuery);
+            if (broadened != strippedQuery) {
+                status = ApolloRealSecItemCopyMatching(broadened, result);
+                ApolloKeychainTrace(@"COPY-broadened", strippedQuery, status, nil);
+            }
         }
     }
 
@@ -824,7 +945,8 @@ static OSStatus SecItemCopyMatching_replacement(CFDictionaryRef query, CFTypeRef
     // affected devices the scoped read misses an item that an enumeration can see. Serve the
     // enumerated value so Valet's read succeeds and AccountManager never issues the wiping
     // empty write. This is the read-side counterpart of the write-side self-heal.
-    if (status == errSecItemNotFound && ApolloIsSingleItemValetQuery(strippedQuery)) {
+    // (The dev-only "disable recovery" toggle skips this so the raw wipe can be observed.)
+    if (status == errSecItemNotFound && ApolloIsSingleItemValetQuery(strippedQuery) && !ApolloDebugDisableRecovery()) {
         NSString *foundGroup = nil;
         OSStatus recovered = ApolloValetRecoverRead(strippedQuery, result, &foundGroup);
         if (recovered == errSecSuccess) {

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -860,25 +860,6 @@ static NSMutableDictionary *ApolloSelfHealSearchQuery(NSDictionary *query) {
     return searchQuery;
 }
 
-// The existing item's kSecAttrAccessible (protection class), read broadened so a synced/shadow
-// copy still yields it. Returns nil if unreadable — the caller supplies a background-safe
-// default. Used to preserve accessibility across a delete+recreate.
-static id ApolloExistingItemAccessible(NSDictionary *strippedQuery) {
-    NSMutableDictionary *readQuery = ApolloSelfHealSearchQuery(strippedQuery);
-    readQuery[(__bridge id)kSecAttrSynchronizable] = (__bridge id)kSecAttrSynchronizableAny;
-    readQuery[(__bridge id)kSecReturnAttributes] = @YES;
-    readQuery[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitOne;
-    CFTypeRef out = NULL;
-    id accessible = nil;
-    if (ApolloRealSecItemCopyMatching(readQuery, &out) == errSecSuccess && out) {
-        if (CFGetTypeID(out) == CFDictionaryGetTypeID()) {
-            accessible = ((__bridge NSDictionary *)out)[(__bridge id)kSecAttrAccessible];
-        }
-        CFRelease(out);
-    }
-    return accessible;
-}
-
 // Updating in place (vs. delete+recreate) keeps a synced item synced instead of
 // deleting it from every device on the account.
 static BOOL ApolloUpdateStaleKeychainItem(NSDictionary *query) {
@@ -1146,22 +1127,21 @@ static OSStatus SecItemUpdate_replacement(CFDictionaryRef query, CFDictionaryRef
         if (status == errSecItemNotFound) {
             NSData *value = attrs[(__bridge id)kSecValueData];
             if ([value isKindOfClass:[NSData class]]) {
-                // Preserve the item's protection class across the delete+recreate. Dropping it
-                // would default to kSecAttrAccessibleWhenUnlocked, which cannot be read while the
-                // device is locked — exactly the background token-refresh window where users
-                // report getting signed out. Capture the original if readable; otherwise use
-                // AfterFirstUnlock, which allows background reads and is the safe floor for an
-                // account credential.
-                id accessible = ApolloExistingItemAccessible(strippedQuery)
-                                ?: (__bridge id)kSecAttrAccessibleAfterFirstUnlock;
+                // Recreate with AfterFirstUnlock, ALWAYS — never preserve the old item's class.
+                // An earlier revision copied the existing item's kSecAttrAccessible here, which we
+                // now know can faithfully preserve the poisoned WhenUnlocked class that made the
+                // item unreadable in the first place (see #681/#682: two writers omitted the
+                // attribute and securityd defaulted it). Every Valet service this gate can reach
+                // encodes AfterFirstUnlock in its service string, so that IS the item's correct
+                // class — and it stays readable during background token refresh.
                 ApolloDeleteStaleKeychainItem(strippedQuery);
                 NSMutableDictionary *add = ApolloSelfHealSearchQuery(strippedQuery);
                 [add removeObjectForKey:(__bridge id)kSecAttrSynchronizable];
-                add[(__bridge id)kSecAttrAccessible] = accessible;
+                add[(__bridge id)kSecAttrAccessible] = (__bridge id)kSecAttrAccessibleAfterFirstUnlock;
                 add[(__bridge id)kSecValueData] = value;
                 status = ApolloRealSecItemAdd(add, NULL);
-                ApolloLoginDiag(@"[KeychainSelfHeal] update->add recreate service=%@ account=%@ accessible=%@ status=%d",
-                                service, account, accessible, (int)status);
+                ApolloLoginDiag(@"[KeychainSelfHeal] update->add recreate service=%@ account=%@ accessible=AfterFirstUnlock status=%d",
+                                service, account, (int)status);
             }
         }
     }

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -359,7 +359,8 @@ static BOOL ApolloIsSingleItemValetQuery(NSDictionary *query) {
 // cache keeps the tight websession-cookie read loop from re-enumerating on every call; any Valet
 // write invalidates it so a later read reflects the newest value (incl. a genuine sign-out).
 static os_unfair_lock sRecoverLock = OS_UNFAIR_LOCK_INIT;
-static NSMutableDictionary<NSString *, NSData *> *sRecoverCache; // "service\naccount" -> newest data
+static NSMutableDictionary<NSString *, NSData *> *sRecoverCache;      // "service\naccount" -> newest data
+static NSMutableDictionary<NSString *, NSString *> *sRecoverGroupCache; // "service\naccount" -> its access group
 static CFAbsoluteTime sRecoverCacheBuiltAt = 0;
 static const CFTimeInterval kRecoverCacheTTL = 1.5;
 
@@ -372,6 +373,7 @@ static void ApolloRebuildRecoverCacheLocked(void) {
         (__bridge id)kSecAttrSynchronizable: (__bridge id)kSecAttrSynchronizableAny,
     };
     NSMutableDictionary<NSString *, NSData *> *cache = [NSMutableDictionary dictionary];
+    NSMutableDictionary<NSString *, NSString *> *groups = [NSMutableDictionary dictionary];
     NSMutableDictionary<NSString *, NSDate *> *newest = [NSMutableDictionary dictionary];
     CFTypeRef result = NULL;
     OSStatus st = ApolloRealSecItemCopyMatching(q, &result);
@@ -391,6 +393,8 @@ static void ApolloRebuildRecoverCacheLocked(void) {
             // sign-out blob) wins over an older duplicate.
             if (!prev || [mod compare:prev] != NSOrderedAscending) {
                 cache[key] = data;
+                id grp = item[(__bridge id)kSecAttrAccessGroup];
+                groups[key] = [grp isKindOfClass:[NSString class]] ? grp : @"?";
                 newest[key] = mod;
             }
         }
@@ -398,6 +402,7 @@ static void ApolloRebuildRecoverCacheLocked(void) {
         CFRelease(result);
     }
     sRecoverCache = cache;
+    sRecoverGroupCache = groups;
     sRecoverCacheBuiltAt = CFAbsoluteTimeGetCurrent();
 }
 
@@ -407,7 +412,10 @@ static void ApolloInvalidateRecoverCache(void) {
     os_unfair_lock_unlock(&sRecoverLock);
 }
 
-static OSStatus ApolloValetRecoverRead(NSDictionary *query, CFTypeRef *result) {
+// outGroup (optional) receives the access group the recovered item actually lives in, so a
+// [KeychainRecover] log can compare it against the group Valet's scoped query targeted — the
+// direct confirmation of the "account split across access groups" root cause.
+static OSStatus ApolloValetRecoverRead(NSDictionary *query, CFTypeRef *result, NSString **outGroup) {
     NSString *service = query[(__bridge id)kSecAttrService];
     NSString *account = query[(__bridge id)kSecAttrAccount];
     if (![service isKindOfClass:[NSString class]] || ![account isKindOfClass:[NSString class]]) return errSecItemNotFound;
@@ -417,6 +425,7 @@ static OSStatus ApolloValetRecoverRead(NSDictionary *query, CFTypeRef *result) {
         ApolloRebuildRecoverCacheLocked();
     }
     NSData *data = sRecoverCache[key];
+    if (outGroup) *outGroup = sRecoverGroupCache[key];
     os_unfair_lock_unlock(&sRecoverLock);
     if (!data) return errSecItemNotFound;
     return ApolloMirrorServe(query, data, result);
@@ -545,6 +554,45 @@ static NSString *ApolloProtectedDataString(void) {
     return [app isProtectedDataAvailable] ? @"unlocked" : @"LOCKED";
 }
 
+// Every physical copy of the account item across access groups, with each copy's group, byte
+// length, protection class, and synchronizable flag. This is the direct test of the root-cause
+// theory: if the account is split across drawers, this shows >1 copy in different groups (and/or
+// a copy whose group differs from what Valet's scoped query targets). One enumeration; only runs
+// at snapshot time (lifecycle transitions), so it's low-frequency.
+static NSString *ApolloAccountsBlobGroupBreakdown(void) {
+    NSDictionary *q = @{
+        (__bridge id)kSecClass:              (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecMatchLimit:         (__bridge id)kSecMatchLimitAll,
+        (__bridge id)kSecReturnAttributes:   @YES,
+        (__bridge id)kSecReturnData:         @YES,
+        (__bridge id)kSecAttrSynchronizable: (__bridge id)kSecAttrSynchronizableAny,
+    };
+    CFTypeRef result = NULL;
+    OSStatus st = ApolloRealSecItemCopyMatching(q, &result);
+    if (st != errSecSuccess || !result) {
+        if (result) CFRelease(result);
+        return [NSString stringWithFormat:@"enum-status=%d", (int)st];
+    }
+    NSArray *found = (__bridge_transfer NSArray *)result;
+    NSMutableArray<NSString *> *copies = [NSMutableArray array];
+    for (NSDictionary *item in found) {
+        NSString *service = item[(__bridge id)kSecAttrService];
+        NSString *account = item[(__bridge id)kSecAttrAccount];
+        if (![service isKindOfClass:[NSString class]] || ![service containsString:kValetServiceSubstring]) continue;
+        if (![account isKindOfClass:[NSString class]] || ![account containsString:@"RedditAccounts2"]) continue;
+        id grp = item[(__bridge id)kSecAttrAccessGroup];
+        id acc = item[(__bridge id)kSecAttrAccessible];
+        NSData *data = item[(__bridge id)kSecValueData];
+        long len = [data isKindOfClass:[NSData class]] ? (long)data.length : -1;
+        BOOL sync = [item[(__bridge id)kSecAttrSynchronizable] boolValue];
+        [copies addObject:[NSString stringWithFormat:@"{grp=%@ len=%ld prot=%@ sync=%d}",
+                           [grp isKindOfClass:[NSString class]] ? grp : @"?", len,
+                           [acc isKindOfClass:[NSString class]] ? acc : @"?", sync]];
+    }
+    return [NSString stringWithFormat:@"copies=%lu %@",
+            (unsigned long)copies.count, [copies componentsJoinedByString:@" "]];
+}
+
 static void ApolloLogAccountSnapshot(NSString *reason) {
     // Defaults mirror (group suite): what Apollo's own loader reads. Length distinguishes a
     // populated archive from an empty/absent one without unarchiving; the account stats separate
@@ -565,6 +613,8 @@ static void ApolloLogAccountSnapshot(NSString *reason) {
     ApolloLoginDiag(@"[AccountSnapshot] %@ | device=%@ | keychain: len=%ld status=%d accessible=%@ | defaults: len=%ld index=%ld accounts=%ld withUser=%ld | mirror: len=%ld | active=%@",
                     reason, ApolloProtectedDataString(), kcLen, (int)kcStatus, accessible ?: @"?",
                     defaultsLen, (long)index, (long)acctCount, (long)acctWithUser, mirrorLen, active ?: @"(nil)");
+    // The access-group breakdown (root-cause confirmation) — separate line to keep both legible.
+    ApolloLoginDiag(@"[AccountBlobGroups] %@ | %@", reason, ApolloAccountsBlobGroupBreakdown());
 }
 
 // Fixes apollo-reborn#567: an iCloud-synced Valet item can miss a plain read
@@ -775,10 +825,16 @@ static OSStatus SecItemCopyMatching_replacement(CFDictionaryRef query, CFTypeRef
     // enumerated value so Valet's read succeeds and AccountManager never issues the wiping
     // empty write. This is the read-side counterpart of the write-side self-heal.
     if (status == errSecItemNotFound && ApolloIsSingleItemValetQuery(strippedQuery)) {
-        OSStatus recovered = ApolloValetRecoverRead(strippedQuery, result);
+        NSString *foundGroup = nil;
+        OSStatus recovered = ApolloValetRecoverRead(strippedQuery, result, &foundGroup);
         if (recovered == errSecSuccess) {
-            ApolloLoginDiag(@"[KeychainRecover] scoped read missed but enumeration found item; served recovered value account=%@",
-                            strippedQuery[(__bridge id)kSecAttrAccount]);
+            // The group Valet's original (pre-strip) query targeted vs the group the item
+            // actually lives in — a mismatch is the direct proof of the access-group split.
+            id queriedGroup = ((__bridge NSDictionary *)query)[(__bridge id)kSecAttrAccessGroup];
+            ApolloLoginDiag(@"[KeychainRecover] scoped read missed but enumeration found item; served recovered value account=%@ queriedGroup=%@ foundGroup=%@",
+                            strippedQuery[(__bridge id)kSecAttrAccount],
+                            [queriedGroup isKindOfClass:[NSString class]] ? queriedGroup : @"(stripped/none)",
+                            foundGroup ?: @"?");
             return errSecSuccess;
         }
     }

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -2,6 +2,7 @@
 #import <dlfcn.h>
 #import <objc/runtime.h>
 #import <objc/message.h>
+#import <os/lock.h>
 #import <sys/utsname.h>
 #import <Security/Security.h>
 #import <StoreKit/StoreKit.h>
@@ -21,6 +22,7 @@
 #import "ApolloState.h"
 #import "Tweak.h"
 #import "CustomAPIViewController.h"
+#import "Version.h"
 #import "UserDefaultConstants.h"
 #import "ApolloPostFilterStore.h"
 #import "Defaults.h"
@@ -163,6 +165,408 @@ static OSStatus SimKeychainServe(NSDictionary *q, NSData *data, CFTypeRef *resul
 }
 #endif
 
+// Real-keychain entry points captured by fishhook (see %ctor). The self-heal helpers and
+// the replacements below call through these to reach Security.framework directly, bypassing
+// our own replacements (no re-entrancy).
+static void *SecItemCopyMatching_orig;
+static void *SecItemAdd_orig;
+static void *SecItemUpdate_orig;
+static void *SecItemDelete_orig;
+
+static OSStatus ApolloRealSecItemCopyMatching(NSDictionary *q, CFTypeRef *result) {
+    return ((OSStatus (*)(CFDictionaryRef, CFTypeRef *))SecItemCopyMatching_orig)((__bridge CFDictionaryRef)q, result);
+}
+static OSStatus ApolloRealSecItemAdd(NSDictionary *q, CFTypeRef *result) {
+    return ((OSStatus (*)(CFDictionaryRef, CFTypeRef *))SecItemAdd_orig)((__bridge CFDictionaryRef)q, result);
+}
+static OSStatus ApolloRealSecItemUpdate(NSDictionary *q, NSDictionary *attrs) {
+    return ((OSStatus (*)(CFDictionaryRef, CFDictionaryRef))SecItemUpdate_orig)((__bridge CFDictionaryRef)q, (__bridge CFDictionaryRef)attrs);
+}
+static OSStatus ApolloRealSecItemDelete(NSDictionary *q) {
+    return ((OSStatus (*)(CFDictionaryRef))SecItemDelete_orig)((__bridge CFDictionaryRef)q);
+}
+
+// A login-persistence diagnostic line: into os_log (current-session export) AND the cross-launch
+// buffer in the container (survives force-quit, so the session that signed the user out is still
+// in Export Debug Logs). Used by every [KeychainTrace]/[AccountSnapshot]/[KeychainSelfHeal]/
+// [KeychainMirror] site below. Never pass secrets — only statuses, byte lengths, and disposition.
+static void ApolloLoginDiag(NSString *fmt, ...) NS_FORMAT_FUNCTION(1, 2);
+static void ApolloLoginDiag(NSString *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    NSString *line = [[NSString alloc] initWithFormat:fmt arguments:args];
+    va_end(args);
+    ApolloLog(@"%@", line);
+    ApolloAppendLoginDiag(line);
+}
+
+// MARK: - Device keychain mirror (failure-scoped fallback store)
+//
+// The self-heal above fixes the common case: a synced/duplicate Valet item the real keychain
+// can still be coerced into writing. But some sideload/free-signer devices have a keychain
+// that is *unusable* for Apollo's items entirely — securityd rejects every Sec* call with
+// errSecMissingEntitlement (-34018) on a bad keychain-access-groups entitlement, or a
+// migration-orphaned item that reads/updates/deletes as not-found yet still blocks an add.
+// In those cases Valet's save silently fails and AccountManager wipes the signed-in account,
+// so the user is logged out on the next cold launch.
+//
+// When (and only when) the real keychain cannot persist a Valet item, mirror its value to a
+// file-protected plist in the app container and report success to Valet. A key that has a
+// mirror entry is one the real keychain failed to hold, so the mirror is authoritative for
+// it: reads are served from the mirror until a *real* write for that key later succeeds, at
+// which point the mirror entry is dropped and the real keychain takes over again. Healthy
+// devices never create an entry, so this is dormant unless the keychain is actually broken.
+//
+// Tradeoff: refresh tokens then live at rest under file protection rather than keychain
+// protection. Apollo's own Backup Settings already exports these same items to a plain zip,
+// and NSFileProtectionCompleteUntilFirstUserAuthentication keeps them encrypted at rest.
+static NSString *ApolloKeychainMirrorPath(void) {
+    return [[NSHomeDirectory() stringByAppendingPathComponent:@"Library"]
+                stringByAppendingPathComponent:@"ApolloKeychainMirror.plist"];
+}
+static NSString *ApolloKeychainMirrorKey(NSString *service, NSString *account) {
+    return [NSString stringWithFormat:@"%@\n%@", service ?: @"", account ?: @""];
+}
+
+static os_unfair_lock sMirrorLock = OS_UNFAIR_LOCK_INIT;
+// Guarded by sMirrorLock. Each entry: mirrorKey -> { "service", "account", "data" }.
+static NSMutableDictionary<NSString *, NSDictionary *> *sMirror;
+
+static NSMutableDictionary *ApolloMirrorLoadLocked(void) {
+    if (!sMirror) {
+        NSDictionary *disk = [NSDictionary dictionaryWithContentsOfFile:ApolloKeychainMirrorPath()];
+        sMirror = disk ? [disk mutableCopy] : [NSMutableDictionary dictionary];
+    }
+    return sMirror;
+}
+
+static void ApolloMirrorPersistLocked(void) {
+    NSString *path = ApolloKeychainMirrorPath();
+    if (sMirror.count == 0) {
+        [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+        return;
+    }
+    if ([sMirror writeToFile:path atomically:YES]) {
+        // The mirror deliberately rides along in device backups (unlike keychain items, which
+        // local unencrypted backups exclude): the account then survives device migration, where
+        // sideloaded keychain items usually do not. Encrypted at rest via file protection.
+        [[NSFileManager defaultManager]
+            setAttributes:@{NSFileProtectionKey: NSFileProtectionCompleteUntilFirstUserAuthentication}
+             ofItemAtPath:path error:nil];
+    } else {
+        // If this fails the mirror is memory-only and the account is gone on the next cold
+        // launch with no on-disk fingerprint — loud, since a mirror engagement is our only
+        // trace of a broken keychain.
+        ApolloLoginDiag(@"[KeychainMirror] FAILED to write mirror to %@ — mirror is memory-only this session", path);
+    }
+}
+
+static NSData *ApolloMirrorGet(NSString *service, NSString *account) {
+    os_unfair_lock_lock(&sMirrorLock);
+    NSDictionary *entry = ApolloMirrorLoadLocked()[ApolloKeychainMirrorKey(service, account)];
+    NSData *data = [entry[@"data"] isKindOfClass:[NSData class]] ? entry[@"data"] : nil;
+    os_unfair_lock_unlock(&sMirrorLock);
+    return data;
+}
+
+// Stash a value the real keychain refused to hold. Loud on purpose — a mirror engagement is
+// the fingerprint of a broken keychain and should be visible in an uploaded log. failStatus is
+// the OSStatus from the real keychain's final rejection, so a log distinguishes an
+// entitlement rejection (-34018) from a still-colliding orphan (-25299) or other cause.
+static void ApolloMirrorPut(NSString *service, NSString *account, NSData *data, OSStatus failStatus) {
+    if (![data isKindOfClass:[NSData class]]) return;
+    os_unfair_lock_lock(&sMirrorLock);
+    NSMutableDictionary *store = ApolloMirrorLoadLocked();
+    store[ApolloKeychainMirrorKey(service, account)] = @{
+        @"service": service ?: @"",
+        @"account": account ?: @"",
+        @"data":    data,
+    };
+    ApolloMirrorPersistLocked();
+    os_unfair_lock_unlock(&sMirrorLock);
+    ApolloLoginDiag(@"[KeychainMirror] real keychain could not persist item (status=%d); mirrored %lu bytes to container service=%@ account=%@",
+                    (int)failStatus, (unsigned long)data.length, service, account);
+}
+
+// A real write for this key finally landed — drop the mirror entry so the real keychain is
+// authoritative again (lets a device recover out of mirror mode if the keychain starts working).
+static void ApolloMirrorRemove(NSString *service, NSString *account) {
+    NSString *key = ApolloKeychainMirrorKey(service, account);
+    os_unfair_lock_lock(&sMirrorLock);
+    NSMutableDictionary *store = ApolloMirrorLoadLocked();
+    BOOL had = store[key] != nil;
+    if (had) {
+        [store removeObjectForKey:key];
+        ApolloMirrorPersistLocked();
+    }
+    os_unfair_lock_unlock(&sMirrorLock);
+    if (had) ApolloLoginDiag(@"[KeychainMirror] real keychain took over item; dropped mirror service=%@ account=%@",
+                             service, account);
+}
+
+// Snapshot for Backup Settings, so a backup taken on a keychain-broken device still carries
+// the account (the mirror is the only place the item exists there). Non-static: used by
+// CustomAPIViewController's backup capture.
+NSArray<NSDictionary *> *ApolloKeychainMirrorItemsForBackup(void) {
+    os_unfair_lock_lock(&sMirrorLock);
+    NSArray *values = [ApolloMirrorLoadLocked() allValues];
+    os_unfair_lock_unlock(&sMirrorLock);
+    return values ?: @[];
+}
+
+// Build a SecItemCopyMatching result for mirrored data, honoring the query's return flags
+// (same shape contract as the real keychain / the sim shim's SimKeychainServe).
+static OSStatus ApolloMirrorServe(NSDictionary *q, NSData *data, CFTypeRef *result) {
+    if (!result) return errSecSuccess;
+    if (q[(__bridge id)kSecReturnAttributes]) {
+        NSMutableDictionary *attrs = [NSMutableDictionary dictionary];
+        if (q[(__bridge id)kSecAttrAccount]) attrs[(__bridge id)kSecAttrAccount] = q[(__bridge id)kSecAttrAccount];
+        if (q[(__bridge id)kSecAttrService]) attrs[(__bridge id)kSecAttrService] = q[(__bridge id)kSecAttrService];
+        if (q[(__bridge id)kSecReturnData]) attrs[(__bridge id)kSecValueData] = data;
+        *result = (__bridge_retained CFTypeRef)attrs;
+    } else {
+        *result = (__bridge_retained CFTypeRef)data;
+    }
+    return errSecSuccess;
+}
+
+// A single-item Valet read (service + account, not an enumeration) — the only shape the mirror
+// can answer. kSecMatchLimitAll enumerations (e.g. backup capture) must fall through to the
+// real keychain and pick up mirror items via ApolloKeychainMirrorItemsForBackup instead.
+static BOOL ApolloIsSingleItemValetQuery(NSDictionary *query) {
+    if (!IsValetQuery(query)) return NO;
+    if (!query[(__bridge id)kSecAttrAccount]) return NO;
+    id limit = query[(__bridge id)kSecMatchLimit];
+    if (limit && [limit isEqual:(__bridge id)kSecMatchLimitAll]) return NO;
+    return YES;
+}
+
+// MARK: - Scoped-read recovery via enumeration
+//
+// Confirmed root cause (device logs, two signers). On these keychains every SCOPED Valet read
+// (service+account, MatchLimitOne) returns errSecItemNotFound (-25300), while an unscoped
+// MatchLimitAll enumeration returns the very same item. Apollo's AccountManager reads
+// 2RedditAccounts2 scoped, gets -25300, concludes "no accounts", and writes an empty ~219-byte
+// array over the good account in BOTH the keychain and its NSUserDefaults mirror — logging the
+// user out within ~1ms, on every launch/foreground. Every add returning -25299 (duplicate)
+// confirms the item is physically present; the likely mechanism is a MatchLimitOne ambiguity
+// over duplicate items across access groups. The exact cause doesn't change the remedy.
+//
+// Remedy: when a single-item Valet read still returns -25300 after synchronizable broadening,
+// recover the item from a MatchLimitAll enumeration (which works here) and serve it — so
+// Apollo's read succeeds and it never issues the wiping empty write. Self-reinforcing: a
+// successful read prevents the empty write, so the good blob stays the newest item. A short-TTL
+// cache keeps the tight websession-cookie read loop from re-enumerating on every call; any Valet
+// write invalidates it so a later read reflects the newest value (incl. a genuine sign-out).
+static os_unfair_lock sRecoverLock = OS_UNFAIR_LOCK_INIT;
+static NSMutableDictionary<NSString *, NSData *> *sRecoverCache; // "service\naccount" -> newest data
+static CFAbsoluteTime sRecoverCacheBuiltAt = 0;
+static const CFTimeInterval kRecoverCacheTTL = 1.5;
+
+static void ApolloRebuildRecoverCacheLocked(void) {
+    NSDictionary *q = @{
+        (__bridge id)kSecClass:              (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecMatchLimit:         (__bridge id)kSecMatchLimitAll,
+        (__bridge id)kSecReturnAttributes:   @YES,
+        (__bridge id)kSecReturnData:         @YES,
+        (__bridge id)kSecAttrSynchronizable: (__bridge id)kSecAttrSynchronizableAny,
+    };
+    NSMutableDictionary<NSString *, NSData *> *cache = [NSMutableDictionary dictionary];
+    NSMutableDictionary<NSString *, NSDate *> *newest = [NSMutableDictionary dictionary];
+    CFTypeRef result = NULL;
+    OSStatus st = ApolloRealSecItemCopyMatching(q, &result);
+    if (st == errSecSuccess && result) {
+        NSArray *found = (__bridge_transfer NSArray *)result;
+        for (NSDictionary *item in found) {
+            NSString *service = item[(__bridge id)kSecAttrService];
+            NSString *account = item[(__bridge id)kSecAttrAccount];
+            NSData *data = item[(__bridge id)kSecValueData];
+            if (![service isKindOfClass:[NSString class]] || ![account isKindOfClass:[NSString class]]) continue;
+            if (![data isKindOfClass:[NSData class]]) continue;
+            NSString *key = [NSString stringWithFormat:@"%@\n%@", service, account];
+            id modAttr = item[(__bridge id)kSecAttrModificationDate];
+            NSDate *mod = [modAttr isKindOfClass:[NSDate class]] ? modAttr : [NSDate distantPast];
+            NSDate *prev = newest[key];
+            // Keep the newest by modification date so a genuine later write (incl. an empty
+            // sign-out blob) wins over an older duplicate.
+            if (!prev || [mod compare:prev] != NSOrderedAscending) {
+                cache[key] = data;
+                newest[key] = mod;
+            }
+        }
+    } else if (result) {
+        CFRelease(result);
+    }
+    sRecoverCache = cache;
+    sRecoverCacheBuiltAt = CFAbsoluteTimeGetCurrent();
+}
+
+static void ApolloInvalidateRecoverCache(void) {
+    os_unfair_lock_lock(&sRecoverLock);
+    sRecoverCacheBuiltAt = 0;
+    os_unfair_lock_unlock(&sRecoverLock);
+}
+
+static OSStatus ApolloValetRecoverRead(NSDictionary *query, CFTypeRef *result) {
+    NSString *service = query[(__bridge id)kSecAttrService];
+    NSString *account = query[(__bridge id)kSecAttrAccount];
+    if (![service isKindOfClass:[NSString class]] || ![account isKindOfClass:[NSString class]]) return errSecItemNotFound;
+    NSString *key = [NSString stringWithFormat:@"%@\n%@", service, account];
+    os_unfair_lock_lock(&sRecoverLock);
+    if (!sRecoverCache || CFAbsoluteTimeGetCurrent() - sRecoverCacheBuiltAt > kRecoverCacheTTL) {
+        ApolloRebuildRecoverCacheLocked();
+    }
+    NSData *data = sRecoverCache[key];
+    os_unfair_lock_unlock(&sRecoverLock);
+    if (!data) return errSecItemNotFound;
+    return ApolloMirrorServe(query, data, result);
+}
+
+// MARK: - Keychain trace (login-persistence diagnostics)
+//
+// We could not reproduce the "logged out after force-quit / after idling in the background"
+// bug on any maintainer device or in the simulator, and two rounds of RE-guided fixes did not
+// resolve it in the field. So instrument the account item's full keychain lifecycle: our
+// SecItem hooks sit on the exact seam between Valet and securityd and see every raw call and
+// its real OSStatus, which is the one vantage point that can answer the decisive question —
+// does the signed-in account blob actually persist to the keychain and survive to the next
+// read, or is something writing an empty blob over it (an upstream wipe) vs. a write silently
+// failing (a persistence failure)? The byte length distinguishes those: Apollo's account blob
+// is an archived array of [String:String] dicts — a populated account is multiple KB, an empty
+// array is a couple hundred bytes.
+//
+// This is always-on (not gated behind a debug build): account keychain traffic is
+// low-frequency, users already capture ApolloLog via the in-app log viewer, and affected users
+// are actively uploading logs. Everything is tagged [KeychainTrace] for grep.
+
+// The account-secrets item AccountManager loads on launch (Valet account key "2RedditAccounts2"),
+// whose disappearance == signed out. Its exact byte length over time is the smoking gun.
+static BOOL ApolloIsAccountsBlobQuery(NSDictionary *query) {
+    if (!IsValetQuery(query)) return NO;
+    NSString *account = query[(__bridge id)kSecAttrAccount];
+    return [account isKindOfClass:[NSString class]] && [account containsString:@"RedditAccounts2"];
+}
+
+// Human-readable synchronizable disposition of a query, for the trace.
+static NSString *ApolloSyncDispositionString(NSDictionary *query) {
+    id sync = query[(__bridge id)kSecAttrSynchronizable];
+    if (!sync) return @"unset";
+    if ([sync isEqual:(__bridge id)kSecAttrSynchronizableAny]) return @"any";
+    if ([sync isEqual:(__bridge id)kCFBooleanTrue]) return @"yes";
+    if ([sync isEqual:(__bridge id)kCFBooleanFalse]) return @"no";
+    return [sync description];
+}
+
+// Byte length of the value data in a query/attributes dict (-1 if none present).
+static long ApolloValueDataLength(NSDictionary *dict) {
+    id value = dict[(__bridge id)kSecValueData];
+    return [value isKindOfClass:[NSData class]] ? (long)[(NSData *)value length] : -1;
+}
+
+// One trace line per Valet keychain operation. `op` is the call name; `extra` is optional
+// trailing context (byte lengths, route taken). ALL Valet traffic is traced — not just the
+// account blob — so the canary Valet.canAccessKeychain() writes/reads (its master gate: a NO
+// there skips the whole account load) and any account-adjacent item are captured too. Valet
+// traffic is low-frequency, so this doesn't flood.
+static BOOL ApolloTraceAllValet(void) { return YES; }
+
+static void ApolloKeychainTrace(NSString *op, NSDictionary *query, OSStatus status, NSString *extra) {
+    BOOL isAccounts = ApolloIsAccountsBlobQuery(query);
+    if (!isAccounts && !ApolloTraceAllValet()) return;
+    if (!IsValetQuery(query)) return;
+    NSString *account = query[(__bridge id)kSecAttrAccount] ?: @"(nil)";
+    ApolloLoginDiag(@"[KeychainTrace] %@ account=%@ sync=%@ status=%d%@%@",
+                    op, account, ApolloSyncDispositionString(query), (int)status,
+                    isAccounts ? @" <ACCOUNTS>" : @"",
+                    extra.length ? [@" " stringByAppendingString:extra] : @"");
+}
+
+// A point-in-time snapshot of where the signed-in account actually lives, logged at each app
+// lifecycle transition. This is what catches the *warm* sign-out ("logged in at home, signed
+// out by the time I got to the store") — a wipe while the app is only backgrounded, which no
+// cold-launch trace can see. Cross-referenced with the [KeychainTrace] write sizes, it pins the
+// moment and the layer (keychain vs defaults mirror vs our container mirror) the account
+// vanished from. Reads go through the real keychain (raw truth), not our mirror-serving hook.
+static NSString *const kApolloGroupSuite = @"group.com.christianselig.apollo";
+
+// Real-keychain byte length of the accounts item (-1 = absent, -2 = read error/status). Also
+// reports the status and the item's protection class (kSecAttrAccessible) out-params. The
+// protection class matters for the warm-signout theory: a WhenUnlocked item cannot be read
+// while the device is locked in the background, which would present exactly as "signed out
+// after idling". Enumerates generic passwords and filters, so no exact Valet service string
+// is needed. -34018 distinguishes an entitlement rejection from a genuine not-found.
+static long ApolloRealAccountsBlobLength(OSStatus *outStatus, NSString **outAccessible) {
+    NSDictionary *q = @{
+        (__bridge id)kSecClass:            (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecMatchLimit:       (__bridge id)kSecMatchLimitAll,
+        (__bridge id)kSecReturnAttributes: @YES,
+        (__bridge id)kSecReturnData:       @YES,
+        (__bridge id)kSecAttrSynchronizable: (__bridge id)kSecAttrSynchronizableAny,
+    };
+    CFTypeRef result = NULL;
+    OSStatus st = ApolloRealSecItemCopyMatching(q, &result);
+    if (outStatus) *outStatus = st;
+    if (st != errSecSuccess || !result) { if (result) CFRelease(result); return (st == errSecItemNotFound) ? -1 : -2; }
+    NSArray *found = (__bridge_transfer NSArray *)result;
+    long len = -1;
+    for (NSDictionary *item in found) {
+        NSString *service = item[(__bridge id)kSecAttrService];
+        NSString *account = item[(__bridge id)kSecAttrAccount];
+        if (![service isKindOfClass:[NSString class]] || ![service containsString:kValetServiceSubstring]) continue;
+        if (![account isKindOfClass:[NSString class]] || ![account containsString:@"RedditAccounts2"]) continue;
+        NSData *data = item[(__bridge id)kSecValueData];
+        len = [data isKindOfClass:[NSData class]] ? (long)data.length : -1;
+        if (outAccessible) {
+            id acc = item[(__bridge id)kSecAttrAccessible];
+            *outAccessible = [acc isKindOfClass:[NSString class]] ? acc : [acc description];
+        }
+        break;
+    }
+    return len;
+}
+
+// Container-mirror byte length of the accounts item (-1 = not mirrored).
+static long ApolloMirrorAccountsBlobLength(void) {
+    for (NSDictionary *item in ApolloKeychainMirrorItemsForBackup()) {
+        NSString *account = item[@"account"];
+        if ([account isKindOfClass:[NSString class]] && [account containsString:@"RedditAccounts2"]) {
+            NSData *data = item[@"data"];
+            return [data isKindOfClass:[NSData class]] ? (long)data.length : -1;
+        }
+    }
+    return -1;
+}
+
+// Device lock state — "protected data available" is NO while the device is locked. A keychain
+// read that fails only when this is NO is the accessibility-class signature of the warm signout.
+static NSString *ApolloProtectedDataString(void) {
+    id app = [UIApplication respondsToSelector:@selector(sharedApplication)] ? [UIApplication sharedApplication] : nil;
+    if (![app respondsToSelector:@selector(isProtectedDataAvailable)]) return @"?";
+    return [app isProtectedDataAvailable] ? @"unlocked" : @"LOCKED";
+}
+
+static void ApolloLogAccountSnapshot(NSString *reason) {
+    // Defaults mirror (group suite): what Apollo's own loader reads. Length distinguishes a
+    // populated archive from an empty/absent one without unarchiving; the account stats separate
+    // "blob present but identity/token cleared" (count>0, withUser<count) from "blob gone".
+    NSUserDefaults *group = [[NSUserDefaults alloc] initWithSuiteName:kApolloGroupSuite];
+    id defaultsBlob = [group objectForKey:@"RedditAccounts2"];
+    long defaultsLen = [defaultsBlob isKindOfClass:[NSData class]] ? (long)[(NSData *)defaultsBlob length] : -1;
+    NSInteger index = [group objectForKey:@"CurrentRedditAccountIndex"] ? [group integerForKey:@"CurrentRedditAccountIndex"] : -999;
+    NSString *active = ApolloActiveAccountUsername();
+    NSInteger acctCount = 0, acctWithUser = 0;
+    ApolloPersistedAccountStats(&acctCount, &acctWithUser);
+
+    OSStatus kcStatus = errSecSuccess;
+    NSString *accessible = nil;
+    long kcLen = ApolloRealAccountsBlobLength(&kcStatus, &accessible);
+    long mirrorLen = ApolloMirrorAccountsBlobLength();
+
+    ApolloLoginDiag(@"[AccountSnapshot] %@ | device=%@ | keychain: len=%ld status=%d accessible=%@ | defaults: len=%ld index=%ld accounts=%ld withUser=%ld | mirror: len=%ld | active=%@",
+                    reason, ApolloProtectedDataString(), kcLen, (int)kcStatus, accessible ?: @"?",
+                    defaultsLen, (long)index, (long)acctCount, (long)acctWithUser, mirrorLen, active ?: @"(nil)");
+}
+
 // Fixes apollo-reborn#567: an iCloud-synced Valet item can miss a plain read
 // (errSecItemNotFound) but still collide on add (errSecDuplicateItem), and
 // AccountManager wipes the account instead of retrying. Broaden reads to include
@@ -175,13 +579,11 @@ static NSDictionary *ApolloQueryByBroadeningSynchronizable(NSDictionary *query) 
     return broadened;
 }
 
-static void *SecItemCopyMatching_orig;
-
 static OSStatus ApolloCopyExistingKeychainItem(NSDictionary *strippedQuery, CFTypeRef *outResult) {
     NSMutableDictionary *readQuery = [strippedQuery mutableCopy];
     [readQuery removeObjectForKey:(__bridge id)kSecValueData];
     NSDictionary *broadened = ApolloQueryByBroadeningSynchronizable(readQuery);
-    return ((OSStatus (*)(CFDictionaryRef, CFTypeRef *))SecItemCopyMatching_orig)((__bridge CFDictionaryRef)broadened, outResult);
+    return ApolloRealSecItemCopyMatching(broadened, outResult);
 }
 
 static BOOL ApolloExistingKeychainItemHasSameValue(NSDictionary *strippedQuery) {
@@ -209,6 +611,25 @@ static NSMutableDictionary *ApolloSelfHealSearchQuery(NSDictionary *query) {
     return searchQuery;
 }
 
+// The existing item's kSecAttrAccessible (protection class), read broadened so a synced/shadow
+// copy still yields it. Returns nil if unreadable — the caller supplies a background-safe
+// default. Used to preserve accessibility across a delete+recreate.
+static id ApolloExistingItemAccessible(NSDictionary *strippedQuery) {
+    NSMutableDictionary *readQuery = ApolloSelfHealSearchQuery(strippedQuery);
+    readQuery[(__bridge id)kSecAttrSynchronizable] = (__bridge id)kSecAttrSynchronizableAny;
+    readQuery[(__bridge id)kSecReturnAttributes] = @YES;
+    readQuery[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitOne;
+    CFTypeRef out = NULL;
+    id accessible = nil;
+    if (ApolloRealSecItemCopyMatching(readQuery, &out) == errSecSuccess && out) {
+        if (CFGetTypeID(out) == CFDictionaryGetTypeID()) {
+            accessible = ((__bridge NSDictionary *)out)[(__bridge id)kSecAttrAccessible];
+        }
+        CFRelease(out);
+    }
+    return accessible;
+}
+
 // Updating in place (vs. delete+recreate) keeps a synced item synced instead of
 // deleting it from every device on the account.
 static BOOL ApolloUpdateStaleKeychainItem(NSDictionary *query) {
@@ -218,9 +639,9 @@ static BOOL ApolloUpdateStaleKeychainItem(NSDictionary *query) {
     NSMutableDictionary *searchQuery = ApolloSelfHealSearchQuery(query);
     searchQuery[(__bridge id)kSecAttrSynchronizable] = (__bridge id)kSecAttrSynchronizableAny;
     NSDictionary *update = @{(__bridge id)kSecValueData: newValue};
-    OSStatus status = SecItemUpdate((__bridge CFDictionaryRef)searchQuery, (__bridge CFDictionaryRef)update);
-    ApolloLog(@"[KeychainSelfHeal] updated duplicate item in place service=%@ account=%@ status=%d",
-              query[(__bridge id)kSecAttrService], query[(__bridge id)kSecAttrAccount], (int)status);
+    OSStatus status = ApolloRealSecItemUpdate(searchQuery, update);
+    ApolloLoginDiag(@"[KeychainSelfHeal] updated duplicate item in place service=%@ account=%@ status=%d",
+                    query[(__bridge id)kSecAttrService], query[(__bridge id)kSecAttrAccount], (int)status);
     return status == errSecSuccess;
 }
 
@@ -229,16 +650,15 @@ static BOOL ApolloUpdateStaleKeychainItem(NSDictionary *query) {
 static void ApolloDeleteStaleKeychainItem(NSDictionary *query) {
     NSMutableDictionary *deleteQuery = ApolloSelfHealSearchQuery(query);
     deleteQuery[(__bridge id)kSecAttrSynchronizable] = (__bridge id)kCFBooleanFalse;
-    OSStatus status = SecItemDelete((__bridge CFDictionaryRef)deleteQuery);
+    OSStatus status = ApolloRealSecItemDelete(deleteQuery);
     if (status == errSecItemNotFound) {
         deleteQuery[(__bridge id)kSecAttrSynchronizable] = (__bridge id)kSecAttrSynchronizableAny;
-        status = SecItemDelete((__bridge CFDictionaryRef)deleteQuery);
+        status = ApolloRealSecItemDelete(deleteQuery);
     }
-    ApolloLog(@"[KeychainSelfHeal] deleted stale duplicate item service=%@ account=%@ status=%d",
-              query[(__bridge id)kSecAttrService], query[(__bridge id)kSecAttrAccount], (int)status);
+    ApolloLoginDiag(@"[KeychainSelfHeal] deleted stale duplicate item service=%@ account=%@ status=%d",
+                    query[(__bridge id)kSecAttrService], query[(__bridge id)kSecAttrAccount], (int)status);
 }
 
-static void *SecItemAdd_orig;
 static OSStatus SecItemAdd_replacement(CFDictionaryRef query, CFTypeRef *result) {
     NSDictionary *strippedQuery = stripGroupAccessAttr(query);
 #if APOLLO_SIM_BUILD
@@ -252,15 +672,44 @@ static OSStatus SecItemAdd_replacement(CFDictionaryRef query, CFTypeRef *result)
         return errSecSuccess;
     }
 #endif
-    OSStatus status = ((OSStatus (*)(CFDictionaryRef, CFTypeRef *))SecItemAdd_orig)((__bridge CFDictionaryRef)strippedQuery, result);
-    if (status == errSecDuplicateItem && IsValetQuery(strippedQuery)) {
+    OSStatus status = ApolloRealSecItemAdd(strippedQuery, result);
+    if (!IsValetQuery(strippedQuery)) return status;
+
+    // Any Valet write may change what a later read should return (a new account, a token
+    // refresh, or a genuine sign-out's empty blob) — drop the recovery cache so the next read
+    // re-enumerates the live keychain rather than serving a stale value.
+    ApolloInvalidateRecoverCache();
+
+    NSString *service = strippedQuery[(__bridge id)kSecAttrService];
+    NSString *account = strippedQuery[(__bridge id)kSecAttrAccount];
+    ApolloKeychainTrace(@"ADD", strippedQuery, status,
+                        [NSString stringWithFormat:@"writeLen=%ld", ApolloValueDataLength(strippedQuery)]);
+
+    if (status == errSecDuplicateItem) {
         if (ApolloExistingKeychainItemHasSameValue(strippedQuery) ||
             ApolloUpdateStaleKeychainItem(strippedQuery)) {
             if (result) ApolloCopyExistingKeychainItem(strippedQuery, result);
+            ApolloMirrorRemove(service, account);
             return errSecSuccess;
         }
         ApolloDeleteStaleKeychainItem(strippedQuery);
-        status = ((OSStatus (*)(CFDictionaryRef, CFTypeRef *))SecItemAdd_orig)((__bridge CFDictionaryRef)strippedQuery, result);
+        status = ApolloRealSecItemAdd(strippedQuery, result);
+        ApolloKeychainTrace(@"ADD-retry", strippedQuery, status, nil);
+    }
+
+    if (status == errSecSuccess) {
+        ApolloMirrorRemove(service, account);
+        return status;
+    }
+
+    // The real keychain could not hold this Valet item after every self-heal attempt
+    // (bad keychain entitlement -34018, an undeletable orphan still colliding, etc.).
+    // Fall back to the container mirror so the account still persists across launches.
+    NSData *value = strippedQuery[(__bridge id)kSecValueData];
+    if ([value isKindOfClass:[NSData class]]) {
+        ApolloMirrorPut(service, account, value, status);
+        if (result) ApolloMirrorServe(strippedQuery, value, result);
+        return errSecSuccess;
     }
     return status;
 }
@@ -293,21 +742,70 @@ static OSStatus SecItemCopyMatching_replacement(CFDictionaryRef query, CFTypeRef
     }
 #endif
 
-    OSStatus status = ((OSStatus (*)(CFDictionaryRef, CFTypeRef *))SecItemCopyMatching_orig)((__bridge CFDictionaryRef)strippedQuery, result);
+    // A key with a mirror entry is one the real keychain failed to persist, so its real-keychain
+    // copy (if any) is stale by definition — the mirror is authoritative until a real write for
+    // that key succeeds and drops the entry. Only single-item reads can be served this way.
+    if (ApolloIsSingleItemValetQuery(strippedQuery)) {
+        NSString *service = strippedQuery[(__bridge id)kSecAttrService];
+        NSString *account = strippedQuery[(__bridge id)kSecAttrAccount];
+        NSData *mirrored = ApolloMirrorGet(service, account);
+        if (mirrored) {
+            ApolloKeychainTrace(@"COPY", strippedQuery, errSecSuccess,
+                                [NSString stringWithFormat:@"route=mirror readLen=%lu", (unsigned long)mirrored.length]);
+            return ApolloMirrorServe(strippedQuery, mirrored, result);
+        }
+    }
+
+    // For the trace, capture the returned byte length even when the caller passed result=NULL
+    // (an existence check) — do our own attributed read on the accounts item so the log always
+    // carries the size that distinguishes an empty blob from a populated one.
+    OSStatus status = ApolloRealSecItemCopyMatching(strippedQuery, result);
     if (status == errSecItemNotFound && IsValetQuery(strippedQuery)) {
         // Only fall back to the broadened (synced-included) read on a local miss, so a
         // good local item always wins over a potentially stale synced one.
         NSDictionary *broadened = ApolloQueryByBroadeningSynchronizable(strippedQuery);
         if (broadened != strippedQuery) {
-            status = ((OSStatus (*)(CFDictionaryRef, CFTypeRef *))SecItemCopyMatching_orig)((__bridge CFDictionaryRef)broadened, result);
+            status = ApolloRealSecItemCopyMatching(broadened, result);
+            ApolloKeychainTrace(@"COPY-broadened", strippedQuery, status, nil);
         }
+    }
+
+    // Last-resort read recovery (see "Scoped-read recovery via enumeration" above): on the
+    // affected devices the scoped read misses an item that an enumeration can see. Serve the
+    // enumerated value so Valet's read succeeds and AccountManager never issues the wiping
+    // empty write. This is the read-side counterpart of the write-side self-heal.
+    if (status == errSecItemNotFound && ApolloIsSingleItemValetQuery(strippedQuery)) {
+        OSStatus recovered = ApolloValetRecoverRead(strippedQuery, result);
+        if (recovered == errSecSuccess) {
+            ApolloLoginDiag(@"[KeychainRecover] scoped read missed but enumeration found item; served recovered value account=%@",
+                            strippedQuery[(__bridge id)kSecAttrAccount]);
+            return errSecSuccess;
+        }
+    }
+
+    if (ApolloIsAccountsBlobQuery(strippedQuery)) {
+        long readLen = -1;
+        if (status == errSecSuccess) {
+            CFTypeRef probe = NULL;
+            NSMutableDictionary *probeQ = [strippedQuery mutableCopy];
+            [probeQ removeObjectForKey:(__bridge id)kSecReturnAttributes];
+            [probeQ removeObjectForKey:(__bridge id)kSecReturnRef];
+            probeQ[(__bridge id)kSecReturnData] = @YES;
+            probeQ[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitOne;
+            if (ApolloRealSecItemCopyMatching(probeQ, &probe) == errSecSuccess && probe) {
+                if (CFGetTypeID(probe) == CFDataGetTypeID()) readLen = (long)CFDataGetLength((CFDataRef)probe);
+                CFRelease(probe);
+            }
+        }
+        ApolloKeychainTrace(@"COPY", strippedQuery, status,
+                            [NSString stringWithFormat:@"route=real readLen=%ld", readLen]);
     }
     return status;
 }
 
-static void *SecItemUpdate_orig;
 static OSStatus SecItemUpdate_replacement(CFDictionaryRef query, CFDictionaryRef attributesToUpdate) {
     NSDictionary *strippedQuery = stripGroupAccessAttr(query);
+    NSDictionary *attrs = (__bridge NSDictionary *)attributesToUpdate;
 
     // Block attempts to disable Ultra/Pro
     if (IsUltraProOverrideKey(strippedQuery)) {
@@ -317,7 +815,7 @@ static OSStatus SecItemUpdate_replacement(CFDictionaryRef query, CFDictionaryRef
 #if APOLLO_SIM_BUILD
     if (IsValetQuery(strippedQuery)) {
         NSString *key = SimKeychainKey(strippedQuery[(__bridge id)kSecAttrService], strippedQuery[(__bridge id)kSecAttrAccount]);
-        id value = ((__bridge NSDictionary *)attributesToUpdate)[(__bridge id)kSecValueData];
+        id value = attrs[(__bridge id)kSecValueData];
         if ([value isKindOfClass:[NSData class]]) {
             SimKeychainStore()[key] = value;
             SimKeychainPersist();
@@ -327,13 +825,71 @@ static OSStatus SecItemUpdate_replacement(CFDictionaryRef query, CFDictionaryRef
     }
 #endif
 
-    return ((OSStatus (*)(CFDictionaryRef, CFDictionaryRef))SecItemUpdate_orig)((__bridge CFDictionaryRef)strippedQuery, attributesToUpdate);
+    OSStatus status = ApolloRealSecItemUpdate(strippedQuery, attrs);
+    if (!IsValetQuery(strippedQuery)) return status;
+
+    ApolloInvalidateRecoverCache(); // see SecItemAdd_replacement
+
+    NSString *service = strippedQuery[(__bridge id)kSecAttrService];
+    NSString *account = strippedQuery[(__bridge id)kSecAttrAccount];
+    // The most decisive trace line: the exact byte length Valet is writing to the account item.
+    // A populated account is multiple KB; an empty array is a couple hundred bytes. Seeing a
+    // small write land here (status=0) is proof of an upstream wipe rather than our persistence
+    // failing — a distinction two rounds of blind fixes could not make.
+    ApolloKeychainTrace(@"UPDATE", strippedQuery, status,
+                        [NSString stringWithFormat:@"writeLen=%ld", ApolloValueDataLength(attrs)]);
+
+    // The write path's missing half (mirror of the SecItemAdd self-heal): Valet reaches
+    // SecItemUpdate because its existence check saw an item, but a plain update only matches
+    // non-synced items, so a synced/shadow row makes the update miss (errSecItemNotFound) and
+    // Valet's save silently fails — the account is never persisted. Broaden to synced items;
+    // if the row is still unreachable, force the write to land as a fresh local item.
+    if (status == errSecItemNotFound) {
+        NSMutableDictionary *broadened = [strippedQuery mutableCopy];
+        broadened[(__bridge id)kSecAttrSynchronizable] = (__bridge id)kSecAttrSynchronizableAny;
+        status = ApolloRealSecItemUpdate(broadened, attrs);
+        ApolloLoginDiag(@"[KeychainSelfHeal] broadened update service=%@ account=%@ status=%d", service, account, (int)status);
+
+        if (status == errSecItemNotFound) {
+            NSData *value = attrs[(__bridge id)kSecValueData];
+            if ([value isKindOfClass:[NSData class]]) {
+                // Preserve the item's protection class across the delete+recreate. Dropping it
+                // would default to kSecAttrAccessibleWhenUnlocked, which cannot be read while the
+                // device is locked — exactly the background token-refresh window where users
+                // report getting signed out. Capture the original if readable; otherwise use
+                // AfterFirstUnlock, which allows background reads and is the safe floor for an
+                // account credential.
+                id accessible = ApolloExistingItemAccessible(strippedQuery)
+                                ?: (__bridge id)kSecAttrAccessibleAfterFirstUnlock;
+                ApolloDeleteStaleKeychainItem(strippedQuery);
+                NSMutableDictionary *add = ApolloSelfHealSearchQuery(strippedQuery);
+                [add removeObjectForKey:(__bridge id)kSecAttrSynchronizable];
+                add[(__bridge id)kSecAttrAccessible] = accessible;
+                add[(__bridge id)kSecValueData] = value;
+                status = ApolloRealSecItemAdd(add, NULL);
+                ApolloLoginDiag(@"[KeychainSelfHeal] update->add recreate service=%@ account=%@ accessible=%@ status=%d",
+                                service, account, accessible, (int)status);
+            }
+        }
+    }
+
+    if (status == errSecSuccess) {
+        ApolloMirrorRemove(service, account);
+        return status;
+    }
+
+    // Real keychain still can't hold it — mirror the new value (see SecItemAdd_replacement).
+    NSData *value = attrs[(__bridge id)kSecValueData];
+    if ([value isKindOfClass:[NSData class]]) {
+        ApolloMirrorPut(service, account, value, status);
+        return errSecSuccess;
+    }
+    return status;
 }
 
-#if APOLLO_SIM_BUILD
-static void *SecItemDelete_orig;
 static OSStatus SecItemDelete_replacement(CFDictionaryRef query) {
     NSDictionary *strippedQuery = stripGroupAccessAttr(query);
+#if APOLLO_SIM_BUILD
     if (IsValetQuery(strippedQuery)) {
         NSString *key = SimKeychainKey(strippedQuery[(__bridge id)kSecAttrService], strippedQuery[(__bridge id)kSecAttrAccount]);
         if (SimKeychainStore()[key]) {
@@ -342,9 +898,22 @@ static OSStatus SecItemDelete_replacement(CFDictionaryRef query) {
         }
         return errSecSuccess;
     }
-    return ((OSStatus (*)(CFDictionaryRef))SecItemDelete_orig)((__bridge CFDictionaryRef)strippedQuery);
-}
 #endif
+    OSStatus status = ApolloRealSecItemDelete(strippedQuery);
+    if (IsValetQuery(strippedQuery)) {
+        ApolloInvalidateRecoverCache(); // a delete must not be masked by a stale recovery cache
+        // A delete of the accounts item is a hard sign-out — trace it so an upstream wipe that
+        // deletes (rather than empties) the blob is visible with a caller-side timestamp.
+        ApolloKeychainTrace(@"DELETE", strippedQuery, status, nil);
+        // Valet's own removeObject and Apollo's cleanup delete without kSecAttrSynchronizable,
+        // which leaves a synced shadow behind to re-break the next sign-in. Also sweep synced
+        // copies, and drop any container mirror entry so sign-out really signs out.
+        NSDictionary *broadened = ApolloQueryByBroadeningSynchronizable(strippedQuery);
+        if (broadened != strippedQuery) ApolloRealSecItemDelete(broadened);
+        ApolloMirrorRemove(strippedQuery[(__bridge id)kSecAttrService], strippedQuery[(__bridge id)kSecAttrAccount]);
+    }
+    return status;
+}
 
 // --- Device detection (for Pixel Pals and Dynamic Island behaviour) ---
 // Apollo's device model mapper (sub_1007a3cdc) only recognizes models up to iPhone 14 Pro Max.
@@ -2103,21 +2672,16 @@ static void initializeRandomSources() {
     NSDate *dateIn90d = [NSDate dateWithTimeIntervalSinceNow:60*60*24*90];
     [[NSUserDefaults standardUserDefaults] setObject:dateIn90d forKey:@"WallpaperPromptMostRecent2"];
 
-    // Sideload fixes
-    rebind_symbols((struct rebinding[4]) {
+    // Sideload fixes. SecItemDelete is hooked on device too now (not just the simulator): the
+    // keychain self-heal and container mirror need it to sweep synced shadow items on sign-out,
+    // so a subsequent sign-in isn't re-broken by a stale synced copy.
+    rebind_symbols((struct rebinding[5]) {
         {"SecItemAdd", (void *)SecItemAdd_replacement, (void **)&SecItemAdd_orig},
         {"SecItemCopyMatching", (void *)SecItemCopyMatching_replacement, (void **)&SecItemCopyMatching_orig},
         {"SecItemUpdate", (void *)SecItemUpdate_replacement, (void **)&SecItemUpdate_orig},
-        {"uname", (void *)uname_replacement, (void **)&uname_orig}
-    }, 4);
-
-#if APOLLO_SIM_BUILD
-    // Virtualized-keychain delete (see the SecItem* shim above): only needed in the simulator,
-    // where the real keychain is unreachable. Kept out of the device rebind set entirely.
-    rebind_symbols((struct rebinding[1]) {
         {"SecItemDelete", (void *)SecItemDelete_replacement, (void **)&SecItemDelete_orig},
-    }, 1);
-#endif
+        {"uname", (void *)uname_replacement, (void **)&uname_orig}
+    }, 5);
 
     if ([[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableFLEX]) {
         if (!%c(FLEXManager)) {
@@ -2219,4 +2783,26 @@ static void initializeRandomSources() {
                 usingBlock:^(NSNotification *note) {
         ApolloSendUsageHeartbeatIfNeeded();
     }];
+
+    // Login-persistence diagnostics: snapshot where the account lives at each lifecycle
+    // transition so a warm sign-out (wiped while only backgrounded — the "signed out by the
+    // time I got to the store" reports) is pinned to an event and a storage layer. Cheap and
+    // low-frequency; cross-references with the [KeychainTrace] write sizes.
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+    NSDictionary<NSNotificationName, NSString *> *snapshotEvents = @{
+        UIApplicationDidBecomeActiveNotification:   @"didBecomeActive",
+        UIApplicationWillResignActiveNotification:  @"willResignActive",
+        UIApplicationDidEnterBackgroundNotification: @"didEnterBackground",
+        UIApplicationWillEnterForegroundNotification: @"willEnterForeground",
+    };
+    for (NSNotificationName name in snapshotEvents) {
+        NSString *reason = snapshotEvents[name];
+        [nc addObserverForName:name object:nil queue:[NSOperationQueue mainQueue]
+                    usingBlock:^(NSNotification *note) { ApolloLogAccountSnapshot(reason); }];
+    }
+    // Session boundary in the persistent buffer so a force-quit + relaunch is legible, followed
+    // by a baseline snapshot of the on-disk state at launch (before AccountManager loads).
+    NSString *appVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: @"?";
+    ApolloLoginDiag(@"===== launch (Apollo %@, tweak %@) =====", appVersion, @TWEAK_VERSION);
+    ApolloLogAccountSnapshot(@"ctor");
 }

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -17,6 +17,11 @@ static NSString *const UDKeyUseCustomOAuthSignIn = @"UseCustomOAuthSignIn";
 static NSString *const UDKeyUserAgent = @"UserAgent";
 static NSString *const UDKeyBlockAnnouncements = @"DisableApollonouncements";
 static NSString *const UDKeyEnableFLEX = @"EnableFlexDebugging";
+// Login-persistence debug (dev-only, gated behind FLEX). Force the account keychain read to
+// miss (simulate the broken-keychain -25300), and/or disable enumeration recovery, so the
+// wipe->recover chain can be exercised on any device. Inert unless set.
+static NSString *const UDKeyDebugForceAccountReadMiss = @"ApolloDebugForceAccountReadMiss";
+static NSString *const UDKeyDebugDisableKeychainRecovery = @"ApolloDebugDisableKeychainRecovery";
 static NSString *const UDKeyShowRandNsfw = @"ShowRandNsfwButton";
 static NSString *const UDKeyRandomSubredditsSource = @"RandomSubredditsSource";
 static NSString *const UDKeyRandNsfwSubredditsSource = @"RandNsfwSubredditsSource";


### PR DESCRIPTION
## Summary

Fixes the "keeps signing me out" reports that survived 3.4.0/3.4.1 — the account disappears after a force-quit, and often just after the app idles in the background. Confirmed from instrumented logs on two affected devices and two signers (Signulous, iOS 27 beta), covering **both** API-key and API-free (web-session) accounts.

This supersedes #672, which chased an incomplete hypothesis. That PR's write-side work turned out to be *necessary but not sufficient*; this branch adds the missing half and is a clean history off `main`.

## Symptom

The signed-in account is present for a few milliseconds at launch/foreground, then vanishes — in both the keychain and Apollo's `NSUserDefaults` account mirror — with no network activity. It repeats on every launch and every return-from-background, so the user is perpetually logged out. The maintainer team can't reproduce it, and it does not reproduce in the simulator.

## Root cause

Apollo stores its accounts in the keychain via **Valet**, keyed `service = VAL_…SharedAccessGroupIdentifier…com.christianselig.Apollo…AfterFirstUnlock`, `account = 2RedditAccounts2`. On the affected devices the account item's keychain access is **split-brained**:

- A **scoped** read (exact `service` + `account`, `kSecMatchLimitOne`) returns `errSecItemNotFound` (**-25300**).
- An **add** of the same item returns `errSecDuplicateItem` (**-25299**) — so a copy is definitely present.
- An unscoped **enumeration** (`kSecMatchLimitAll`, no service/account filter) returns the item *with its data* (e.g. `len=1690`).

These three facts are certain from the logs (see below). Apollo's `AccountManager` loads the account with the scoped read, receives `-25300`, concludes there are **no accounts**, and persists an **empty array** (`writeLen=219`) over the good account — in both the keychain and the defaults mirror. That empty write is the wipe.

```
[AccountSnapshot] ctor        | keychain: len=1690 status=0 | defaults: accounts=1 withUser=1 | active=boiLemonade   ← signed in
[KeychainTrace]   COPY 2RedditAccounts2 status=-25300 <ACCOUNTS>                                                     ← scoped read: not found
[KeychainTrace]   ADD  2RedditAccounts2 status=-25299 <ACCOUNTS> writeLen=219                                        ← Apollo writes empty array
[AccountCredentials] ApolloActiveAccountUsername: index 0 out of range (count 0)                                     ← signed out
```

### Why the keychain is split (mechanism)

Every keychain item lives in exactly one **access group**. A write without an explicit group lands in the app's *default* group (`teamID.bundleID`); a read without an explicit group searches *all* entitled groups. Valet's `SharedGroupValet` normally pins **both** reads and writes to one shared group, so they stay consistent.

Apollo-Reborn's long-standing sideload fix (`stripGroupAccessAttr`, #55c420f, 2023) removes `kSecAttrAccessGroup` from every keychain query so a sideloaded/re-signed app isn't rejected for lacking the shared-group entitlement (`errSecMissingEntitlement` / -34018). The side effect: **Valet scopes its queries to the *original developer's* team access group, but re-signing files the item under the *re-signer's* group.**

**Confirmed** by the `queriedGroup`-vs-`foundGroup` diagnostic on a device driving the fault-injection path:

```
[KeychainRecover] account=2RedditAccounts2 queriedGroup=XG3L8T56DK.com.christianselig.Apollo foundGroup=B5HS2472N8.*
```

`XG3L8T56DK` is Christian Selig's original App Store team id (baked into Valet's `SharedGroupValet` config); `B5HS2472N8.*` is the re-signer's wildcard group where the item actually lives. The strip papers over this on a single-copy wildcard device (a stripped read still finds the item); on affected devices the stripped scoped read still can't resolve it (**-25300**), an add sees it as a duplicate (**-25299**), and only a return-everything enumeration retrieves it — exactly the observed signature. The `[DebugDup]` action on that device returned `-34018` for every candidate second group, confirming a wildcard-entitled device *structurally can't* create the split, which is why maintainer devices stay healthy.

## Fix

Two composing halves, a fallback, and diagnostics:

1. **Write side (self-heal) — load-bearing.** On these devices a plain add always collides `-25299`, so a Valet write would otherwise never persist. We catch the duplicate and update the item in place (broadened to synced items). This is the only reason the good blob lands in the keychain for the read side to recover.
2. **Read side (enumeration recovery) — the missing half.** When a single-item Valet read still returns `-25300` after synchronizable broadening, recover the item from a `kSecMatchLimitAll` enumeration and serve it, so Valet's read succeeds and `AccountManager` never issues the wiping empty write. Self-reinforcing: a good read prevents the empty write, so the good blob stays newest. A 1.5s TTL cache keeps the tight web-session-cookie read loop cheap; any Valet write invalidates it so a genuine sign-out (empty blob, newest by modification date) is still honored.
3. **Fallback (container mirror).** For the separate `-34018` cohort (bad `keychain-access-groups` entitlement, e.g. the SideStore-beta signing regression) where the keychain can't hold the item at all, mirror the value to a file-protected container plist and serve reads from it. Dormant on healthy devices and on the `-25300` cohort above.
4. **Destructive-write guard (last line of defense).** Recovery only fires on `errSecItemNotFound`; other read-failure modes (`errSecInteractionNotAllowed`, a transient `-34018`, an enumeration miss, a TTL race) could still let `AccountManager` prune and the self-heal force an empty blob over the good one. So for the account items, an empty/tiny add-or-update over a populated blob is refused **unless** that item was successfully served (real read *or* recovery) earlier this session — a genuine sign-out always follows a session with working reads, so it still persists. Closes the whole "failed read → destructive write" class rather than just `-25300`.
5. **Diagnostics.** `[KeychainTrace]`, `[AccountSnapshot]`, `[KeychainRecover]`, `[AccountBlobGroups]`, mirrored to a cross-launch container buffer so a force-quit sign-out is still in **Export Debug Logs**. Only statuses, byte lengths, dispositions, and access-group names are logged — never account values or tokens. Verbose by design for now to confirm the fix in the field; to be trimmed once validated.

### Both account types

Recovery is general — it fires for any single-item Valet read — so it covers both paths by construction:

- **API accounts:** OAuth tokens live in `2RedditAccounts2` → recovered → no wipe.
- **API-free (web-session) accounts:** the synthesized `RDKClient` also lives in `2RedditAccounts2` (recovered), **and** the session cookie lives in `websession:<user>:cookie` under service `com.christianselig.Apollo.webjson` (contains the Valet substring, so it's recovered the same way) → web-mode requests authenticate. Recovery also lets launch-time web-session synthesis read the real blob, so it correctly skips instead of fighting the wipe.

Recovery only ever serves items that physically exist in the keychain; it returns not-found otherwise, so healthy devices and genuine absences are unaffected.

## Test plan

- [x] Device build clean (`make package FINALPACKAGE=1 ARCHS=arm64`)
- [x] Simulator build clean; launches injected, restores the account, no faults. (The sim's own keychain returns `-34018`, so recovery/self-heal stay dormant there — the affected `-25300` path can only be exercised on a real device.)
- [ ] **Affected-device validation (the real gate):** an affected user updates to this build, signs in once, and confirms the account persists across force-quit and background-idle, with `[KeychainRecover]` firing in the log. Do this for one **API** account and one **API-free** account.

## Known caveat for already-wiped devices

Recovery serves the **newest** copy of the account item so a genuine sign-out is honored. A device already in the wiped state (its newest copy is the empty `219`-byte blob written by the old build) therefore needs the user to **sign in one more time** after installing this build; from then on the good blob is newest and recovery keeps it indefinitely. Applies to both account types. Worth wording in the release notes so "still signed out on first launch" isn't misread as the fix failing.

## Not addressed here

Separate cohorts in the same threads: `AppleDeveloperError 3014` ("app group is invalid", an install-time provisioning failure) and "sign-in never succeeds" (a different failure than losing an established session).

