### PR TITLE
Fix Mod Queue filter menu anchoring on Liquid Glass

### DIFF
--- a/src/ApolloNativeActionMenus.xm
+++ b/src/ApolloNativeActionMenus.xm
@@ -1496,8 +1496,32 @@ static BOOL ApolloNativeActionMenuCanFallbackPresent(id presenter, id actionCont
 %end
 
 %hook _TtC6Apollo22ModQueueViewController
+- (void)modQueueFilterNodeTapped {
+    id filterNode = ApolloReadObjectIvar(self, "modQueueFilterNode");
+    UIView *filterNodeView = ApolloNativeActionMenuViewForObject(filterNode);
+    BOOL filterNodeDispatchActive = sApolloNativeActionMenuCaptureDepth > 0
+        && sApolloNativeActionMenuSourceView == filterNodeView;
+    id source = filterNodeDispatchActive
+        ? filterNode
+        : ApolloReadObjectIvar(self, "filterBarButtonItem");
+    ApolloNativeActionMenuBeginCapture(source, self);
+    %orig;
+    ApolloNativeActionMenuEndCapture();
+}
+
 - (void)titleViewButtonTappedWithSender:(id)sender {
     ApolloNativeActionMenuBeginCapture(sender, self);
+    %orig;
+    ApolloNativeActionMenuEndCapture();
+}
+%end
+
+%hook _TtC6Apollo18ModQueueFilterNode
+- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
+    // The nav-bar item and bottom filter node call the same no-argument action.
+    // Texture dispatches the node's target synchronously from this method, so
+    // preserve the actual touched node for the nested controller hook above.
+    ApolloNativeActionMenuBeginCapture(self, self);
     %orig;
     ApolloNativeActionMenuEndCapture();
 }


### PR DESCRIPTION
This PR fixes the Mod Queue content filter menu morphing the entire screen into a black background under Liquid Glass instead of opening from the control that was tapped.

| Before | After |
| --- | --- |
| <img width="400" alt="After" src="https://github.com/user-attachments/assets/3bc59345-8100-448d-af0c-3385ecc71bef" /> | <img width="400" alt="Before" src="https://github.com/user-attachments/assets/4efa238e-78ef-499e-92ac-b340e5827b98" /> |

### The problem

Apollo's top-right Mod Queue filter button and bottom filter node both invoke the no-argument `modQueueFilterNodeTapped` action, which presents the menu containing "Posts and Comments", "Posts Only", and "Comments Only". The existing native-menu integration only captured `titleViewButtonTappedWithSender:`, an unrelated action, so the filter presentation had no captured source view.

Without a source control, the native menu fallback used the navigation controller's full-screen view as the Liquid Glass morph preview. UIKit therefore animated the whole interface away and left the menu floating over a black background.

### Correct Mod Queue menu anchoring

- Hook `modQueueFilterNodeTapped` and use the `filterBarButtonItem` as the source for top-right button presentations.
- Preserve the bottom `ModQueueFilterNode` as the source by wrapping Texture's synchronous touch-up action dispatch in a nested capture.
- Continue using the existing proxy anchor and targeted-preview path once the correct control has been resolved.
