### PR TITLE
Fix API-key-free sign-in creating an unreadable account keychain item

### DIFF
--- a/src/ApolloWebJSONIdentity.xm
+++ b/src/ApolloWebJSONIdentity.xm
@@ -313,6 +313,18 @@ static void ApolloWebJSONWriteValetItem(NSString *account, NSData *data) {
         (__bridge id)kSecAttrAccount: account,
     };
     NSMutableDictionary *add = [identity mutableCopy];
+    // MANDATORY. Valet encodes its accessibility into the service name above
+    // (…_AccessibleAfterFirstUnlock) AND passes kSecAttrAccessible on every read. Omit it here
+    // and SecItemAdd defaults the item to kSecAttrAccessibleWhenUnlocked, which a read filters on
+    // but SecItemAdd's duplicate check does NOT (service + account + access group are the primary
+    // key). The item then misses Valet's read (-25300) while still colliding on add (-25299), and
+    // AccountManager, finding no accounts, writes an empty array over the good one.
+    //
+    // This is unrecoverable without an explicit heal: nothing ever deletes 2RedditAccounts2 (sign
+    // out writes an empty array over it), so the item is created exactly once per device and every
+    // later write is an update — and an update never changes the protection class. Whichever
+    // writer creates it first decides its fate permanently.
+    add[(__bridge id)kSecAttrAccessible] = (__bridge id)kSecAttrAccessibleAfterFirstUnlock;
     add[(__bridge id)kSecValueData] = data;
     OSStatus st = SecItemAdd((__bridge CFDictionaryRef)add, NULL);
     if (st == errSecDuplicateItem) {

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -3125,9 +3125,14 @@ static NSArray<NSDictionary *> *ApolloCaptureValetKeychainItems(void) {
             if (![data isKindOfClass:[NSData class]]) continue;
             NSString *account = item[(__bridge id)kSecAttrAccount];
             NSString *acct = [account isKindOfClass:[NSString class]] ? account : @"";
-            byKey[[NSString stringWithFormat:@"%@\n%@", service, acct]] = @{
-                @"service": service, @"account": acct, @"data": data,
-            };
+            // Keep the protection class in the backup: a replay that drops it lands the item as
+            // kSecAttrAccessibleWhenUnlocked, which Valet's AfterFirstUnlock read can never see.
+            // The query above already fetches it. Backups predating this have no "accessible" key;
+            // ApolloReplayValetKeychainItems falls back to AfterFirstUnlock for those.
+            id accessible = item[(__bridge id)kSecAttrAccessible];
+            NSMutableDictionary *entry = [@{ @"service": service, @"account": acct, @"data": data } mutableCopy];
+            if ([accessible isKindOfClass:[NSString class]]) entry[@"accessible"] = accessible;
+            byKey[[NSString stringWithFormat:@"%@\n%@", service, acct]] = entry;
         }
     } else if (result) {
         CFRelease(result);
@@ -3142,6 +3147,9 @@ static NSArray<NSDictionary *> *ApolloCaptureValetKeychainItems(void) {
         NSData *data = item[@"data"];
         if (![service isKindOfClass:[NSString class]] || ![service containsString:kValetServiceSubstring]) continue;
         if (![data isKindOfClass:[NSData class]]) continue;
+        // Mirror entries carry no protection class (the container mirror only stores
+        // service/account/data), so a mirror-only item restores as AfterFirstUnlock — correct for
+        // the keychain-broken devices the mirror exists for.
         NSString *acct = [item[@"account"] isKindOfClass:[NSString class]] ? item[@"account"] : @"";
         byKey[[NSString stringWithFormat:@"%@\n%@", service, acct]] = @{
             @"service": service, @"account": acct, @"data": data,
@@ -3165,6 +3173,15 @@ static void ApolloReplayValetKeychainItems(NSArray<NSDictionary *> *items) {
             (__bridge id)kSecAttrAccount:  (item[@"account"] ?: @""),
         };
         NSMutableDictionary *add = [identity mutableCopy];
+        // MANDATORY — see ApolloWebJSONWriteValetItem for the full rationale. Without it,
+        // SecItemAdd defaults the item to kSecAttrAccessibleWhenUnlocked while Valet reads with
+        // AfterFirstUnlock, so the read misses an item that provably exists and AccountManager
+        // wipes the account. Prefer the class the item was captured with; fall back to
+        // AfterFirstUnlock, which is what Apollo's account valet uses and the safe floor for a
+        // credential that must be readable during background token refresh.
+        id accessible = item[@"accessible"];
+        add[(__bridge id)kSecAttrAccessible] = [accessible isKindOfClass:[NSString class]]
+            ? accessible : (__bridge id)kSecAttrAccessibleAfterFirstUnlock;
         add[(__bridge id)kSecValueData] = data;
         OSStatus st = SecItemAdd((__bridge CFDictionaryRef)add, NULL);
         if (st == errSecDuplicateItem) {

--- a/src/CustomAPIViewController.m
+++ b/src/CustomAPIViewController.m
@@ -3125,14 +3125,13 @@ static NSArray<NSDictionary *> *ApolloCaptureValetKeychainItems(void) {
             if (![data isKindOfClass:[NSData class]]) continue;
             NSString *account = item[(__bridge id)kSecAttrAccount];
             NSString *acct = [account isKindOfClass:[NSString class]] ? account : @"";
-            // Keep the protection class in the backup: a replay that drops it lands the item as
-            // kSecAttrAccessibleWhenUnlocked, which Valet's AfterFirstUnlock read can never see.
-            // The query above already fetches it. Backups predating this have no "accessible" key;
-            // ApolloReplayValetKeychainItems falls back to AfterFirstUnlock for those.
-            id accessible = item[(__bridge id)kSecAttrAccessible];
-            NSMutableDictionary *entry = [@{ @"service": service, @"account": acct, @"data": data } mutableCopy];
-            if ([accessible isKindOfClass:[NSString class]]) entry[@"accessible"] = accessible;
-            byKey[[NSString stringWithFormat:@"%@\n%@", service, acct]] = entry;
+            // The protection class isn't stored: it's recovered from the service name on replay
+            // (see ApolloAccessibleFromValetService), which is poison-proof — an item captured on
+            // an affected device carries the wrong class, but its service name still names the
+            // right one.
+            byKey[[NSString stringWithFormat:@"%@\n%@", service, acct]] = @{
+                @"service": service, @"account": acct, @"data": data,
+            };
         }
     } else if (result) {
         CFRelease(result);
@@ -3163,6 +3162,26 @@ static NSArray<NSDictionary *> *ApolloCaptureValetKeychainItems(void) {
 // Replay captured Valet keychain items back into the keychain. On a device this writes the
 // real keychain (our SecItem hooks strip the access group so the unsigned/sideloaded app can
 // store them); in the simulator the tweak's keychain shim intercepts these adds.
+// Valet encodes the accessibility it reads with into its service name
+// (…_AccessibleAfterFirstUnlock), so that — not the item's stored class — is the class an item
+// under that service MUST carry to be readable. Derive it from the service string, which is the
+// same source of truth Valet uses. Returns NULL for a non-Valet or unrecognized service so the
+// caller can fall back. Deliberately ignores whatever class the item was captured with: a backup
+// taken on an already-affected device recorded WhenUnlocked (the poison), and replaying that
+// faithfully would recreate an item its own reader can't see.
+static CFStringRef ApolloAccessibleFromValetService(id service) {
+    if (![service isKindOfClass:[NSString class]]) return NULL;
+    NSRange r = [(NSString *)service rangeOfString:@"_Accessible" options:NSBackwardsSearch];
+    if (r.location == NSNotFound) return NULL;
+    NSString *suffix = [(NSString *)service substringFromIndex:r.location + r.length];
+    if ([suffix isEqualToString:@"AfterFirstUnlock"])               return kSecAttrAccessibleAfterFirstUnlock;
+    if ([suffix isEqualToString:@"AfterFirstUnlockThisDeviceOnly"]) return kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
+    if ([suffix isEqualToString:@"WhenUnlocked"])                   return kSecAttrAccessibleWhenUnlocked;
+    if ([suffix isEqualToString:@"WhenUnlockedThisDeviceOnly"])     return kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
+    if ([suffix isEqualToString:@"WhenPasscodeSetThisDeviceOnly"])  return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
+    return NULL;
+}
+
 static void ApolloReplayValetKeychainItems(NSArray<NSDictionary *> *items) {
     for (NSDictionary *item in items) {
         NSData *data = item[@"data"];
@@ -3173,15 +3192,14 @@ static void ApolloReplayValetKeychainItems(NSArray<NSDictionary *> *items) {
             (__bridge id)kSecAttrAccount:  (item[@"account"] ?: @""),
         };
         NSMutableDictionary *add = [identity mutableCopy];
-        // MANDATORY — see ApolloWebJSONWriteValetItem for the full rationale. Without it,
+        // MANDATORY — see ApolloWebJSONWriteValetItem for why. Without a protection class,
         // SecItemAdd defaults the item to kSecAttrAccessibleWhenUnlocked while Valet reads with
         // AfterFirstUnlock, so the read misses an item that provably exists and AccountManager
-        // wipes the account. Prefer the class the item was captured with; fall back to
-        // AfterFirstUnlock, which is what Apollo's account valet uses and the safe floor for a
-        // credential that must be readable during background token refresh.
-        id accessible = item[@"accessible"];
-        add[(__bridge id)kSecAttrAccessible] = [accessible isKindOfClass:[NSString class]]
-            ? accessible : (__bridge id)kSecAttrAccessibleAfterFirstUnlock;
+        // wipes the account. Take the class from the service name (the reader's own source of
+        // truth), falling back to AfterFirstUnlock — Apollo's account valet, and the safe floor
+        // for a credential that must be readable during background token refresh.
+        CFStringRef accessible = ApolloAccessibleFromValetService(item[@"service"]);
+        add[(__bridge id)kSecAttrAccessible] = (__bridge id)(accessible ?: kSecAttrAccessibleAfterFirstUnlock);
         add[(__bridge id)kSecValueData] = data;
         OSStatus st = SecItemAdd((__bridge CFDictionaryRef)add, NULL);
         if (st == errSecDuplicateItem) {


### PR DESCRIPTION
## Summary
Two code paths write Apollo's `2RedditAccounts2` keychain item without `kSecAttrAccessible`, so iOS defaults it to `WhenUnlocked` while Valet reads it as `AfterFirstUnlock`. The read misses an item that provably exists, `AccountManager` concludes there are no accounts, and writes an empty array over the good one. Both writers now set the protection class explicitly.

## Impact
- Signing in with API-Key-Free Mode as the first sign-in on a device no longer creates a permanently broken account item.
- **This does not repair already-affected users.** Nothing ever deletes `2RedditAccounts2`, so an item that was created wrong stays wrong forever, and every later write is an update that cannot change its protection class. A separate one-time heal is required to fix anyone already in this state, available in #682.
- `Backup Settings` now records each item's protection class. Backups taken before this change have no `accessible` key and fall back to `AfterFirstUnlock` on restore, which is what Apollo's account valet uses.

## Changes
- `ApolloWebJSONIdentity.xm` — `ApolloWebJSONWriteValetItem` now sets `kSecAttrAccessibleAfterFirstUnlock`. This is the API-key-free (web session) sign-in path and the dominant source of broken items.
- `CustomAPIViewController.m` — `ApolloReplayValetKeychainItems` (settings restore) sets the class, preferring the one the item was captured with and falling back to `AfterFirstUnlock`.
- `CustomAPIViewController.m` — `ApolloCaptureValetKeychainItems` stores `accessible` in the backup; its query already fetched the attribute and discarded it.

## Reasoning
- The mismatch is possible because accessibility filters a keychain read but is **not** part of a generic password's primary key (service + account + access group are). So one wrong attribute makes the item invisible to Valet's read (`-25300`) while still colliding on add (`-25299`) — the contradiction that makes this look unexplainable from the outside.
- Valet cannot produce this state itself: its service name encodes the accessibility (`…_AccessibleAfterFirstUnlock`), so changing the class addresses a different item entirely. Only a writer that reuses Valet's service string while omitting the class can create it, which is why only these two paths are affected — every other `SecItemAdd` in the tweak already passes `AfterFirstUnlock`.
- The comments are deliberately long. `ApolloWebJSONWriteValetItem`'s own comment states it "mirrors ApolloReplayValetKeychainItems" — the omission spread by copying, from a restore-only path into the sign-in path new users take. Documenting the constraint at both call sites is what stops the next copy from dropping it again.

## Testing
- Reproduced initial bug on device: install with an Apple ID never used to sideload on that device (a new team prefix means a virgin keychain access group, so the item gets created rather than updated), then sign in with API-Key-Free Mode as the first sign-in. The item lands as `WhenUnlocked` and Valet's scoped read returns `-25300` on every launch thereafter.
- Observed symptoms on that install: Account tab shows "no accounts added" while the account switcher looks populated, the username renders fully lowercase, backgrounding and returning drops the session entirely, and an added API-key account does not survive a restart.
- Mechanism confirmed by a single-variable test on a separate healthy install: rewriting only the protection class — same blob, service, account, and access group — flips it into a real `-25300` and back.
- Verified that this build prevents the bug end-to-end, and signing in without an API key on a fresh keychain persists the accounts