### PR TITLE
Prepare v3.4.2 release and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ All notable changes to this project will be documented in this file.
 - Redesign **Detailed Profiles** with immersive banners, prominent avatars, glass stat cards, and improved Social Links (#655: @jordanearle)
 - Add modern **Reddit Chat** for API-Key-Free accounts, with an opt-in option for API-key accounts that preserves Apollo's legacy Direct Chat (#658: @icpryde)
 
+## [v3.4.2] - 2026-07-17
+
+### Features
+
+- Add the **Synthwave** Liquid Glass app icon to the in-app icon picker (#663: @IllIIllIllIllII)
+
+### Fixes
+
+- Fix the **Reddit account** being signed out after force-quitting or backgrounding the app on sideloaded installs — the account's keychain item was written with the wrong protection class and became invisible to Apollo's own read, which then overwrote it as empty; the item is now created correctly, repaired in place on affected devices, and served from an enumeration fallback so the account survives (#677, #681, #682: @jordanearle, @DeltAndy123)
+- Play more short-clip host links inline: add **streama.in** and **streamff.link** aliases and follow the moved **dubz** and **streamff** CDNs (#665: @icpryde)
+- Speed up loading of the full **Community Highlights** list (#661: @icpryde)
+- Fix **Video Hold Speed** staying stuck at the hold speed after scrubbing a fullscreen video (#667: @icpryde)
+- Fix the **Mod Queue** filter menu anchoring to the wrong spot on Liquid Glass builds (#679: @JeffreyCA)
+- Fix **Search** tab suggestion padding and the **Random Subreddit** icon's stroke weight (#680: @icpryde)
+- Fix the **Apollo Classic** Liquid Glass icon on iOS 27 (#666: @IllIIllIllIllII)
+
 ## [v3.4.1] - 2026-07-15
 
 ### Features
@@ -686,6 +702,7 @@ There are currently a few limitations:
 ## [v1.0.0] - 2023-10-13
 - Initial release
 
+[v3.4.2]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v1.15.11_3.4.1...v1.15.11_3.4.2
 [v3.4.1]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v1.15.11_3.4.0...v1.15.11_3.4.1
 [v3.4.0]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v1.15.11_3.3.0...v1.15.11_3.4.0
 [v3.3.0]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v1.15.11_3.2.0...v1.15.11_3.3.0

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: com.apollo.reborn
 Name: Apollo-Reborn
-Version: 3.4.1
+Version: 3.4.2
 Architecture: iphoneos-arm
 Description: Apollo for Reddit tweak with in-app configurable API keys
 Maintainer: Apollo Reborn team

--- a/distribution/config.json
+++ b/distribution/config.json
@@ -12,7 +12,7 @@
   },
   "app": {
     "bundleIdentifier": "com.christianselig.Apollo",
-    "buildVersion": "292",
+    "buildVersion": "293",
     "developerName": "Christian Selig (& Apollo-Reborn contributors)",
     "iconURL": "https://apolloreborn.app/assets/icon.png",
     "tintColor": "#F0542D",


### PR DESCRIPTION
Prepares the next patch release, publishing the PRs merged since v3.4.1 that weren't yet in the changelog. Follows the same shape as #659 / #582.

## Changes

- **Release metadata**
  - Bump package version `3.4.1` → `3.4.2` (`control`)
  - Increment IPA build number `292` → `293` (`distribution/config.json`)
- **Changelog**
  - Publish a new `v3.4.2` section dated 2026-07-17 with the merged-but-unlisted PRs
  - Add the `v3.4.2` comparison link
  - `[Unreleased]` is unchanged — its four items (#637, #643, #655, #658) are still open PRs

## What's in v3.4.2

**Features**
- Synthwave Liquid Glass icon (#663)

**Fixes**
- **Login persistence** — the account being signed out after force-quit/background on sideloads (wrong keychain protection class → unreadable item → wiped). Fixed at the source, healed in place on affected devices, and served via enumeration fallback (#677, #681, #682)
- More inline short-clip hosts: streama.in / streamff.link aliases + moved dubz/streamff CDNs (#665)
- Faster full Community Highlights load (#661)
- Video Hold Speed stuck after scrubbing (#667)
- Mod Queue filter menu anchoring on Liquid Glass (#679)
- Search suggestion padding + Random Subreddit icon stroke weight (#680)
- Apollo Classic Liquid Glass icon on iOS 27 (#666)

## Not included (intentionally)

- #664 (issue-template + changelog maintenance) and #683 (internal diagnostics dedupe/trim) — no user-facing change, so no changelog line.

## Contributors

All authors (@jordanearle, @DeltAndy123, @icpryde, @IllIIllIllIllII, @JeffreyCA) are already present in `contributors.json` — no contributor-file changes needed.