### PR TITLE
Add icon-only tab bar setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/settings/ApolloSettingsNativeInjections.xm \
     $(SRC_DIR)/ApolloPerPostCommentSort.xm \
     $(SRC_DIR)/ApolloLiquidGlass.xm \
+    $(SRC_DIR)/ApolloTabBarTitles.xm \
     $(SRC_DIR)/ApolloLiquidGlassIconPicker.xm \
     $(SRC_DIR)/ApolloModmailLayout.xm \
     $(SRC_DIR)/ApolloAutoHideTabBar.xm \

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -48,6 +48,9 @@ float ApolloSanitizedHoldSpeed(float value);
 extern BOOL sProxyImgurDDG;
 extern BOOL sShowUserAvatars;
 extern BOOL sUseProfileAvatarTabIcon;
+// Hide the visible main-tab labels while retaining/restoring the underlying
+// UITabBarItem titles. Opt-in; default OFF via registerDefaults.
+extern BOOL sHideTabBarTitles;
 // When ON (default), profile pages show Reborn's detailed profile — the banner,
 // large avatar/snoovatar, display name, bio, and the Social Links band (Buy Me a
 // Coffee, Instagram, X, …). When OFF, profiles revert to Apollo's compact stock

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -51,6 +51,18 @@ extern BOOL sUseProfileAvatarTabIcon;
 // Hide the visible main-tab labels while retaining/restoring the underlying
 // UITabBarItem titles. Opt-in; default OFF via registerDefaults.
 extern BOOL sHideTabBarTitles;
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Central setter used by the settings UI. Enabling icon-only mode also clears
+// Apollo's narrower "Hide Username on Tab Bar" preference because every tab
+// title is already hidden, then refreshes both settings surfaces live.
+void ApolloSetHideTabBarTitlesEnabled(BOOL enabled);
+// Repairs a persisted both-on state during launch or settings restore.
+void ApolloNormalizeNativeHideUsernameForIconOnlyTabBar(void);
+#ifdef __cplusplus
+}
+#endif
 // When ON (default), profile pages show Reborn's detailed profile — the banner,
 // large avatar/snoovatar, display name, bio, and the Social Links band (Buy Me a
 // Coffee, Instagram, X, …). When OFF, profiles revert to Apollo's compact stock

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -29,6 +29,7 @@ float sVideoHoldSpeed = 2.0f;        // effective default 2.0× via registerDefa
 BOOL sProxyImgurDDG = NO;
 BOOL sShowUserAvatars = NO;
 BOOL sUseProfileAvatarTabIcon = NO;
+BOOL sHideTabBarTitles = NO;
 BOOL sShowDetailedProfiles = YES;   // effective default ON via registerDefaults (UDKeyShowDetailedProfiles)
 BOOL sShowSubredditHeaders = NO;
 BOOL sCommunityHighlights = NO;

--- a/src/ApolloTabBarTitles.xm
+++ b/src/ApolloTabBarTitles.xm
@@ -1,0 +1,233 @@
+// ApolloTabBarTitles — optional icon-only main navigation.
+//
+// Clearing a UITabBarItem's title is the public UIKit way to remove its visible
+// label and, on the iOS 26 floating tab bar, lets the system choose the compact
+// icon-only item layout. We keep the latest real title beside the item so the
+// setting can be toggled live and so Apollo remains free to rename an item while
+// its label is hidden. VoiceOver receives that real title explicitly whenever
+// the item did not already provide a custom accessibility label.
+//
+// Pre-Liquid-Glass tab bars need the traditional six-point image adjustment to
+// center an icon in the space formerly shared with its label. iOS 26 performs
+// that centering itself, so its original image insets are left untouched.
+
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+#import "UserDefaultConstants.h"
+
+static char kApolloTabBarTitleStateCapturedKey;
+static char kApolloTabBarOriginalTitleKey;
+static char kApolloTabBarOriginalImageInsetsKey;
+static char kApolloTabBarOriginalAccessibilityLabelKey;
+static char kApolloTabBarGeneratedAccessibilityLabelKey;
+
+// All UIKit mutations below synchronously re-enter the UITabBarItem hooks. A
+// narrow guard distinguishes our apply/restore writes from Apollo's real title
+// and inset updates, which must be remembered even while the labels are hidden.
+static BOOL sApolloTabBarTitlesMutating = NO;
+
+static id ApolloTabBarNullableValue(id value) {
+    return value ?: NSNull.null;
+}
+
+static id ApolloTabBarUnwrapNullableValue(id value) {
+    return value == NSNull.null ? nil : value;
+}
+
+static BOOL ApolloTabBarTitleStateWasCaptured(UITabBarItem *item) {
+    return [objc_getAssociatedObject(item, &kApolloTabBarTitleStateCapturedKey) boolValue];
+}
+
+static void ApolloTabBarCaptureTitleStateIfNeeded(UITabBarItem *item) {
+    if (!item || ApolloTabBarTitleStateWasCaptured(item)) return;
+
+    objc_setAssociatedObject(item, &kApolloTabBarTitleStateCapturedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(item, &kApolloTabBarOriginalTitleKey,
+                             ApolloTabBarNullableValue(item.title), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(item, &kApolloTabBarOriginalImageInsetsKey,
+                             [NSValue valueWithUIEdgeInsets:item.imageInsets], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(item, &kApolloTabBarOriginalAccessibilityLabelKey,
+                             ApolloTabBarNullableValue(item.accessibilityLabel), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static NSString *ApolloTabBarStoredTitle(UITabBarItem *item) {
+    return ApolloTabBarUnwrapNullableValue(objc_getAssociatedObject(item, &kApolloTabBarOriginalTitleKey));
+}
+
+static UIEdgeInsets ApolloTabBarIconOnlyInsets(UIEdgeInsets originalInsets) {
+    if (IsLiquidGlass()) return originalInsets;
+    return UIEdgeInsetsMake(originalInsets.top + 6.0,
+                            originalInsets.left,
+                            originalInsets.bottom - 6.0,
+                            originalInsets.right);
+}
+
+static void ApolloTabBarPreserveAccessibilityName(UITabBarItem *item, NSString *title) {
+    if (!item || title.length == 0 || item.accessibilityLabel.length > 0) return;
+
+    item.accessibilityLabel = title;
+    objc_setAssociatedObject(item, &kApolloTabBarGeneratedAccessibilityLabelKey,
+                             @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static void ApolloTabBarApplyIconOnlyToItem(UITabBarItem *item) {
+    if (!item) return;
+
+    if (!sHideTabBarTitles) {
+        if (!ApolloTabBarTitleStateWasCaptured(item)) return;
+
+        NSString *storedTitle = ApolloTabBarStoredTitle(item);
+        NSValue *storedInsets = objc_getAssociatedObject(item, &kApolloTabBarOriginalImageInsetsKey);
+        BOOL generatedAccessibilityLabel =
+            [objc_getAssociatedObject(item, &kApolloTabBarGeneratedAccessibilityLabelKey) boolValue];
+        id originalAccessibilityValue =
+            objc_getAssociatedObject(item, &kApolloTabBarOriginalAccessibilityLabelKey);
+
+        sApolloTabBarTitlesMutating = YES;
+        item.title = storedTitle;
+        if (storedInsets) item.imageInsets = storedInsets.UIEdgeInsetsValue;
+        // Only undo the label we generated. If another component replaced it
+        // while icon-only mode was active, that newer explicit label wins.
+        if (generatedAccessibilityLabel &&
+            (item.accessibilityLabel.length == 0 || [item.accessibilityLabel isEqualToString:storedTitle])) {
+            item.accessibilityLabel = ApolloTabBarUnwrapNullableValue(originalAccessibilityValue);
+        }
+        sApolloTabBarTitlesMutating = NO;
+
+        objc_setAssociatedObject(item, &kApolloTabBarTitleStateCapturedKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(item, &kApolloTabBarOriginalTitleKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(item, &kApolloTabBarOriginalImageInsetsKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(item, &kApolloTabBarOriginalAccessibilityLabelKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(item, &kApolloTabBarGeneratedAccessibilityLabelKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return;
+    }
+
+    ApolloTabBarCaptureTitleStateIfNeeded(item);
+    NSString *storedTitle = ApolloTabBarStoredTitle(item);
+    NSValue *storedInsets = objc_getAssociatedObject(item, &kApolloTabBarOriginalImageInsetsKey);
+    ApolloTabBarPreserveAccessibilityName(item, storedTitle);
+
+    sApolloTabBarTitlesMutating = YES;
+    item.title = nil;
+    if (storedInsets && !IsLiquidGlass()) {
+        item.imageInsets = ApolloTabBarIconOnlyInsets(storedInsets.UIEdgeInsetsValue);
+    }
+    sApolloTabBarTitlesMutating = NO;
+}
+
+static void ApolloTabBarApplyIconOnlyToBar(UITabBar *tabBar) {
+    for (UITabBarItem *item in tabBar.items) {
+        ApolloTabBarApplyIconOnlyToItem(item);
+    }
+}
+
+static NSUInteger ApolloTabBarApplyToViewTree(UIView *view) {
+    if (!view) return 0;
+    NSUInteger barCount = 0;
+    if ([view isKindOfClass:UITabBar.class]) {
+        ApolloTabBarApplyIconOnlyToBar((UITabBar *)view);
+        barCount++;
+    }
+    for (UIView *subview in view.subviews) {
+        barCount += ApolloTabBarApplyToViewTree(subview);
+    }
+    return barCount;
+}
+
+static void ApolloTabBarRefreshVisibleBars(NSString *reason) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSUInteger barCount = 0;
+        for (UIWindow *window in ApolloAllWindows()) {
+            if (!window.hidden && window.alpha > 0.01) {
+                barCount += ApolloTabBarApplyToViewTree(window);
+            }
+        }
+        ApolloLog(@"[TabBarTitles] %@ labels on %lu visible tab bar(s) (%@)",
+                  sHideTabBarTitles ? @"Hid" : @"Restored",
+                  (unsigned long)barCount,
+                  reason ?: @"refresh");
+    });
+}
+
+%hook UITabBarItem
+
+- (void)setTitle:(NSString *)title {
+    if (sApolloTabBarTitlesMutating) {
+        %orig(title);
+        return;
+    }
+
+    if (!sHideTabBarTitles) {
+        // An off-screen item may have missed the live window walk. Restore its
+        // other state before accepting Apollo's newest title.
+        if (ApolloTabBarTitleStateWasCaptured(self)) {
+            ApolloTabBarApplyIconOnlyToItem(self);
+        }
+        %orig(title);
+        return;
+    }
+
+    ApolloTabBarCaptureTitleStateIfNeeded(self);
+    NSString *previousStoredTitle = ApolloTabBarStoredTitle(self);
+    objc_setAssociatedObject(self, &kApolloTabBarOriginalTitleKey,
+                             ApolloTabBarNullableValue(title), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    BOOL generatedAccessibilityLabel =
+        [objc_getAssociatedObject(self, &kApolloTabBarGeneratedAccessibilityLabelKey) boolValue];
+    if (generatedAccessibilityLabel &&
+        (self.accessibilityLabel.length == 0 || [self.accessibilityLabel isEqualToString:previousStoredTitle])) {
+        self.accessibilityLabel = title;
+    } else {
+        ApolloTabBarPreserveAccessibilityName(self, title);
+    }
+    %orig(nil);
+}
+
+- (void)setImageInsets:(UIEdgeInsets)imageInsets {
+    if (sApolloTabBarTitlesMutating) {
+        %orig(imageInsets);
+        return;
+    }
+
+    if (!sHideTabBarTitles) {
+        if (ApolloTabBarTitleStateWasCaptured(self)) {
+            ApolloTabBarApplyIconOnlyToItem(self);
+        }
+        %orig(imageInsets);
+        return;
+    }
+
+    ApolloTabBarCaptureTitleStateIfNeeded(self);
+    objc_setAssociatedObject(self, &kApolloTabBarOriginalImageInsetsKey,
+                             [NSValue valueWithUIEdgeInsets:imageInsets], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    %orig(ApolloTabBarIconOnlyInsets(imageInsets));
+}
+
+%end
+
+%hook UITabBar
+
+- (void)didMoveToWindow {
+    %orig;
+    ApolloTabBarApplyIconOnlyToBar(self);
+}
+
+- (void)setItems:(NSArray<UITabBarItem *> *)items animated:(BOOL)animated {
+    %orig(items, animated);
+    ApolloTabBarApplyIconOnlyToBar(self);
+}
+
+%end
+
+%ctor {
+    [[NSNotificationCenter defaultCenter]
+        addObserverForName:ApolloTabBarTitlesChangedNotification
+                    object:nil
+                     queue:NSOperationQueue.mainQueue
+                usingBlock:^(__unused NSNotification *notification) {
+        ApolloTabBarRefreshVisibleBars(@"setting changed");
+    }];
+}

--- a/src/ApolloTabBarTitles.xm
+++ b/src/ApolloTabBarTitles.xm
@@ -17,6 +17,11 @@
 #import "ApolloCommon.h"
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
+#import "settings/ApolloSettingsGeneralTable.h"
+
+static NSString *const kApolloNativeHideUsernameOnTabBarKey = @"HideUsernameOnTabBar";
+static NSString *const kApolloNativeHideUsernameOnTabBarChangedNotification =
+    @"com.christianselig.HideUsernameOnTabBarChanged";
 
 static char kApolloTabBarTitleStateCapturedKey;
 static char kApolloTabBarOriginalTitleKey;
@@ -28,6 +33,53 @@ static char kApolloTabBarGeneratedAccessibilityLabelKey;
 // narrow guard distinguishes our apply/restore writes from Apollo's real title
 // and inset updates, which must be remembered even while the labels are hidden.
 static BOOL sApolloTabBarTitlesMutating = NO;
+
+static void ApolloTabBarConfigureNativeUsernameSubviews(UIView *view, BOOL enabled) {
+    if ([view isKindOfClass:UISwitch.class]) {
+        UISwitch *toggle = (UISwitch *)view;
+        BOOL nativeSettingOn = [NSUserDefaults.standardUserDefaults
+            boolForKey:kApolloNativeHideUsernameOnTabBarKey];
+        [toggle setOn:(enabled && nativeSettingOn) animated:NO];
+        toggle.enabled = enabled;
+    } else if ([view isKindOfClass:UILabel.class]) {
+        ((UILabel *)view).enabled = enabled;
+    }
+    for (UIView *subview in view.subviews) {
+        ApolloTabBarConfigureNativeUsernameSubviews(subview, enabled);
+    }
+}
+
+static void ApolloTabBarConfigureNativeUsernameCell(UITableViewCell *cell) {
+    if (!cell) return;
+    BOOL enabled = !sHideTabBarTitles;
+    ApolloTabBarConfigureNativeUsernameSubviews(cell.contentView, enabled);
+    if (cell.accessoryView && ![cell.accessoryView isDescendantOfView:cell.contentView]) {
+        ApolloTabBarConfigureNativeUsernameSubviews(cell.accessoryView, enabled);
+        cell.accessoryView.alpha = enabled ? 1.0 : 0.5;
+    }
+    cell.contentView.alpha = enabled ? 1.0 : 0.5;
+}
+
+void ApolloNormalizeNativeHideUsernameForIconOnlyTabBar(void) {
+    if (!sHideTabBarTitles) return;
+    NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
+    if (![defaults boolForKey:kApolloNativeHideUsernameOnTabBarKey]) return;
+
+    [defaults setBool:NO forKey:kApolloNativeHideUsernameOnTabBarKey];
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:kApolloNativeHideUsernameOnTabBarChangedNotification
+                      object:nil];
+    ApolloLog(@"[TabBarTitles] Cleared redundant native Hide Username on Tab Bar setting");
+}
+
+void ApolloSetHideTabBarTitlesEnabled(BOOL enabled) {
+    sHideTabBarTitles = enabled;
+    [NSUserDefaults.standardUserDefaults setBool:enabled forKey:UDKeyHideTabBarTitles];
+    if (enabled) ApolloNormalizeNativeHideUsernameForIconOnlyTabBar();
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:ApolloTabBarTitlesChangedNotification
+                      object:nil];
+}
 
 static id ApolloTabBarNullableValue(id value) {
     return value ?: NSNull.null;
@@ -223,11 +275,30 @@ static void ApolloTabBarRefreshVisibleBars(NSString *reason) {
 %end
 
 %ctor {
+    ApolloGeneralTableConfigureNativeRow(@"Hide Username on Tab Bar",
+        ^(__unused UIViewController *vc, UITableViewCell *cell) {
+            ApolloTabBarConfigureNativeUsernameCell(cell);
+        });
+
     [[NSNotificationCenter defaultCenter]
         addObserverForName:ApolloTabBarTitlesChangedNotification
                     object:nil
                      queue:NSOperationQueue.mainQueue
                 usingBlock:^(__unused NSNotification *notification) {
+        ApolloNormalizeNativeHideUsernameForIconOnlyTabBar();
+        ApolloGeneralTableRefreshNativeRowConfigurations();
         ApolloTabBarRefreshVisibleBars(@"setting changed");
+    }];
+
+    // A settings restore or another native caller can try to re-enable the
+    // narrower username option. Icon-only mode wins while active, and the row
+    // is refreshed so its switch remains visibly off and disabled.
+    [[NSNotificationCenter defaultCenter]
+        addObserverForName:kApolloNativeHideUsernameOnTabBarChangedNotification
+                    object:nil
+                     queue:NSOperationQueue.mainQueue
+                usingBlock:^(__unused NSNotification *notification) {
+        ApolloNormalizeNativeHideUsernameForIconOnlyTabBar();
+        ApolloGeneralTableRefreshNativeRowConfigurations();
     }];
 }

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -2677,6 +2677,7 @@ static void initializeRandomSources() {
                                     UDKeyCommentLinkHost: @(CommentLinkHostOff),
                                     UDKeyShowUserAvatars: @NO,
                                     UDKeyUseProfileAvatarTabIcon: @NO,
+                                    UDKeyHideTabBarTitles: @NO,
                                     UDKeyShowDetailedProfiles: @YES,
                                     UDKeyShowSubredditHeaders: @NO,
                                     UDKeyCommunityHighlights: @NO,
@@ -2825,6 +2826,7 @@ static void initializeRandomSources() {
     if (sCommentLinkHost < CommentLinkHostOff || sCommentLinkHost > CommentLinkHostImgChest) sCommentLinkHost = CommentLinkHostOff;
     sShowUserAvatars = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars];
     sUseProfileAvatarTabIcon = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon];
+    sHideTabBarTitles = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyHideTabBarTitles];
     sShowDetailedProfiles = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowDetailedProfiles];
     sShowSubredditHeaders = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowSubredditHeaders];
     sCommunityHighlights = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyCommunityHighlights];

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -2827,6 +2827,7 @@ static void initializeRandomSources() {
     sShowUserAvatars = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars];
     sUseProfileAvatarTabIcon = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon];
     sHideTabBarTitles = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyHideTabBarTitles];
+    ApolloNormalizeNativeHideUsernameForIconOnlyTabBar();
     sShowDetailedProfiles = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowDetailedProfiles];
     sShowSubredditHeaders = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowSubredditHeaders];
     sCommunityHighlights = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyCommunityHighlights];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -83,6 +83,12 @@ static NSString *const UDKeyCommentLinkHost = @"CommentLinkHost";
 static NSString *const ApolloCommentLinkHostChangedNotification = @"ApolloCommentLinkHostChangedNotification";
 static NSString *const UDKeyShowUserAvatars = @"ShowUserAvatars";
 static NSString *const UDKeyUseProfileAvatarTabIcon = @"UseProfileAvatarTabIcon";
+// When ON, the main tab bar removes its visible text labels and lets UIKit lay
+// out a clean icon-only navigation menu. The original titles remain available
+// to accessibility and are restored live when the setting is turned off.
+// Default OFF. See ApolloTabBarTitles.xm.
+static NSString *const UDKeyHideTabBarTitles = @"HideTabBarTitles";
+static NSString *const ApolloTabBarTitlesChangedNotification = @"ApolloTabBarTitlesChangedNotification";
 // When ON (default), profile pages show Reborn's detailed profile — the banner,
 // large avatar/snoovatar, display name, bio, and the Social Links band. When OFF,
 // the profile page reverts to Apollo's compact stock layout: the detailed header is

--- a/src/settings/ApolloSettingsGeneralTable.h
+++ b/src/settings/ApolloSettingsGeneralTable.h
@@ -51,6 +51,19 @@ void ApolloGeneralTableInjectSelectableRow(NSString *anchorTitle,
                                                                        UITableViewCell *donor),
                                            void (^onSelect)(UIViewController *vc));
 
+// Reconfigure a native row whenever Eureka supplies its cell. This leaves the
+// native form and index-path geometry untouched; it is intended for small
+// cross-feature state adjustments such as disabling a redundant switch. The
+// title is matched with ApolloGeneralTableCellHasTitle().
+void ApolloGeneralTableConfigureNativeRow(NSString *title,
+                                          void (^configure)(UIViewController *vc,
+                                                            UITableViewCell *cell));
+
+// Re-run all registered native-row configurators for the currently visible
+// General cells. Off-screen rows are configured the next time Eureka supplies
+// their cell.
+void ApolloGeneralTableRefreshNativeRowConfigurations(void);
+
 // The live General-screen instance, if any (weak-backed; nil once it's gone).
 UIViewController *ApolloGeneralTableActiveVC(void);
 

--- a/src/settings/ApolloSettingsGeneralTable.xm
+++ b/src/settings/ApolloSettingsGeneralTable.xm
@@ -74,6 +74,15 @@ typedef UITableViewCell *(^ApolloGTRowFactory)(UIViewController *vc, UITableView
 static NSMutableArray<BOOL (^)(UITableViewCell *)> *sGTHideMatchers;
 static NSMutableArray<ApolloGTInjection *> *sGTInjections;
 
+@interface ApolloGTNativeRowConfiguration : NSObject
+@property (nonatomic, copy) NSString *title;
+@property (nonatomic, copy) void (^configure)(UIViewController *vc, UITableViewCell *cell);
+@end
+@implementation ApolloGTNativeRowConfiguration
+@end
+
+static NSMutableArray<ApolloGTNativeRowConfiguration *> *sGTNativeRowConfigurations;
+
 void ApolloGeneralTableHideRows(BOOL (^cellMatcher)(UITableViewCell *cell)) {
     if (!cellMatcher) return;
     if (!sGTHideMatchers) sGTHideMatchers = [NSMutableArray array];
@@ -100,6 +109,17 @@ void ApolloGeneralTableInjectSelectableRow(NSString *anchorTitle,
     [sGTInjections addObject:inj];
 }
 
+void ApolloGeneralTableConfigureNativeRow(NSString *title,
+                                          void (^configure)(UIViewController *vc,
+                                                            UITableViewCell *cell)) {
+    if (!title || !configure) return;
+    ApolloGTNativeRowConfiguration *configuration = [ApolloGTNativeRowConfiguration new];
+    configuration.title = title;
+    configuration.configure = configure;
+    if (!sGTNativeRowConfigurations) sGTNativeRowConfigurations = [NSMutableArray array];
+    [sGTNativeRowConfigurations addObject:configuration];
+}
+
 // MARK: - shared title matching
 
 static BOOL ApolloGTStringMatchesTitle(NSString *text, NSString *title) {
@@ -124,6 +144,15 @@ BOOL ApolloGeneralTableCellHasTitle(UITableViewCell *cell, NSString *title) {
     if (!cell || !title) return NO;
     if (ApolloGTStringMatchesTitle(cell.textLabel.text, title)) return YES;
     return ApolloGTLabelTreeHasTitle(cell.contentView, title, 0);
+}
+
+static void ApolloGTApplyNativeRowConfigurations(UIViewController *vc, UITableViewCell *cell) {
+    if (!vc || !cell) return;
+    for (ApolloGTNativeRowConfiguration *configuration in sGTNativeRowConfigurations) {
+        if (ApolloGeneralTableCellHasTitle(cell, configuration.title)) {
+            configuration.configure(vc, cell);
+        }
+    }
 }
 
 // MARK: - map state
@@ -352,6 +381,15 @@ static void ApolloGTZeroReturn(NSInvocation *inv) {
 
     [inv invokeWithTarget:vc];
 
+    // Native rows pass through Eureka unchanged, then receive any registered
+    // state-only configuration. Applying after every dequeue makes off-screen
+    // rows agree as soon as they scroll into view without rebuilding the form.
+    if (sel == @selector(tableView:cellForRowAtIndexPath:)) {
+        __unsafe_unretained UITableViewCell *cell = nil;
+        [inv getReturnValue:&cell];
+        ApolloGTApplyNativeRowConfigurations(vc, cell);
+    }
+
     // Echoed index paths (willSelect, targetIndexPathForMove, ...) go back
     // native -> display. Pin the replacement to the pool: setReturnValue: does
     // not retain, and "small NSIndexPaths are tagged (immortal) pointers" is a
@@ -402,6 +440,16 @@ static UITableView *ApolloGTFindTable(UIViewController *vc) {
     return nil;
 }
 
+void ApolloGeneralTableRefreshNativeRowConfigurations(void) {
+    UIViewController *vc = sApolloGTActiveVC;
+    if (!vc || !vc.viewIfLoaded.window) return;
+    UITableView *tv = ApolloGTFindTable(vc);
+    if (!tv) return;
+    for (NSIndexPath *indexPath in tv.indexPathsForVisibleRows) {
+        ApolloGTApplyNativeRowConfigurations(vc, [tv cellForRowAtIndexPath:indexPath]);
+    }
+}
+
 UITableViewCell *ApolloGeneralTableVisibleCellForTitle(UIViewController *vc, NSString *title) {
     if (!vc || !title || !vc.viewIfLoaded.window) return nil;
     UITableView *tv = ApolloGTFindTable(vc);
@@ -438,7 +486,8 @@ UITableViewCell *ApolloGeneralTableVisibleCellForTitle(UIViewController *vc, NSS
 // guard (the old sPPCSScanning flag is gone by construction).
 static void ApolloGTScanAndInstall(UIViewController *vc) {
     if (objc_getAssociatedObject(vc, kApolloGTProxyKey)) return;
-    if (sGTHideMatchers.count == 0 && sGTInjections.count == 0) return;
+    if (sGTHideMatchers.count == 0 && sGTInjections.count == 0 &&
+        sGTNativeRowConfigurations.count == 0) return;
     UITableView *tv = ApolloGTFindTable(vc);
     if (!tv) {
         ApolloLog(@"[GeneralTable] no table view found; leaving the screen native");
@@ -457,6 +506,7 @@ static void ApolloGTScanAndInstall(UIViewController *vc) {
                 for (NSInteger r = 0; r < rowCount; r++) {
                     UITableViewCell *cell = [ds tableView:tv
                                     cellForRowAtIndexPath:[NSIndexPath indexPathForRow:r inSection:s]];
+                    ApolloGTApplyNativeRowConfigurations(vc, cell);
                     [cells addObject:cell ?: [UITableViewCell new]];
                 }
 
@@ -516,7 +566,7 @@ static void ApolloGTScanAndInstall(UIViewController *vc) {
         return;
     }
 
-    if (displayBySection.count == 0) {
+    if (displayBySection.count == 0 && sGTNativeRowConfigurations.count == 0) {
         ApolloLog(@"[GeneralTable] nothing matched (no hides, no anchors); screen left native");
         return;
     }

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -1490,6 +1490,12 @@ typedef NS_ENUM(NSInteger, Tag) {
                                       isOn:^BOOL { return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon]; }
                                   onToggle:^(UISwitch *sender) { [weakSelf profileTabAvatarSwitchToggled:sender]; }];
 
+    ApolloSettingsRow *iconOnlyTabBar =
+        [ApolloSettingsRow switchRowWithID:@"profiles.iconOnlyTabBar"
+                                     title:@"Icon-Only Tab Bar"
+                                      isOn:^BOOL { return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyHideTabBarTitles]; }
+                                  onToggle:^(UISwitch *sender) { [weakSelf iconOnlyTabBarSwitchToggled:sender]; }];
+
     // Single toggle for Reborn's detailed profile page: banner, large
     // avatar/snoovatar, display name, bio, and the Social Links band (all of
     // which live in the custom header). Off → Apollo's compact stock profile.
@@ -1500,8 +1506,8 @@ typedef NS_ENUM(NSInteger, Tag) {
                                   onToggle:^(UISwitch *sender) { [weakSelf showDetailedProfilesSwitchToggled:sender]; }];
 
     return [ApolloSettingsSection sectionWithTitle:nil
-                                            footer:@"Show profile pictures, and open Reborn's detailed profile pages with a banner, bio and social links."
-                                              rows:@[ userAvatars, profileTabAvatar, detailedProfiles ]];
+                                            footer:@"Customize profile pictures, profile pages and the tab bar. Icon-Only Tab Bar hides the text labels while keeping each icon's accessibility name."
+                                              rows:@[ userAvatars, profileTabAvatar, iconOnlyTabBar, detailedProfiles ]];
 }
 
 // Subreddits group screen (ApolloSubredditsSettingsViewController), two
@@ -3067,6 +3073,12 @@ typedef NS_ENUM(NSInteger, Tag) {
     sUseProfileAvatarTabIcon = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sUseProfileAvatarTabIcon forKey:UDKeyUseProfileAvatarTabIcon];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloProfileTabAvatarIconChangedNotification" object:nil];
+}
+
+- (void)iconOnlyTabBarSwitchToggled:(UISwitch *)sender {
+    sHideTabBarTitles = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sHideTabBarTitles forKey:UDKeyHideTabBarTitles];
+    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloTabBarTitlesChangedNotification object:nil];
 }
 
 - (void)showDetailedProfilesSwitchToggled:(UISwitch *)sender {

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -3076,9 +3076,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 }
 
 - (void)iconOnlyTabBarSwitchToggled:(UISwitch *)sender {
-    sHideTabBarTitles = sender.isOn;
-    [[NSUserDefaults standardUserDefaults] setBool:sHideTabBarTitles forKey:UDKeyHideTabBarTitles];
-    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloTabBarTitlesChangedNotification object:nil];
+    ApolloSetHideTabBarTitlesEnabled(sender.isOn);
 }
 
 - (void)showDetailedProfilesSwitchToggled:(UISwitch *)sender {


### PR DESCRIPTION
## Summary

- Adds an **Icon-Only Tab Bar** toggle in the Profiles section of the new settings layout, alongside the profile tab icon option.
- Hides every visible tab title while preserving the existing icons, navigation behavior, and accessibility names.
- Applies the change immediately, persists it across launches, and restores the original titles and icon positioning when disabled.
- Coordinates with Apollo's existing **Hide Username on Tab Bar** setting:
  - Enabling icon-only automatically turns the redundant username setting off.
  - The username row becomes disabled and visibly faded while icon-only is enabled.
  - Turning icon-only off re-enables the username setting without turning it back on automatically.

## Screenshot

<img width="555" height="230" alt="Icon-only tab bar" src="https://github.com/user-attachments/assets/a07c11b8-75e1-4b70-8625-00b78e5ec387" />

## Validation

- Built successfully for the iOS Simulator.
- Tested interactively on the primary **Apollo-Sim** simulator (sim1, not sim2).
- Verified labeled and icon-only tab bar states and live switching between them.
- Verified the icon-only preference remains selected after relaunch.
- Verified **Hide Username on Tab Bar** on -> **Icon-Only Tab Bar** on clears the username preference, disables/fades its row, and leaves all tab titles hidden.
- Verified the disabled username switch cannot be toggled.
- Verified turning icon-only off restores tab titles and re-enables the username setting.
