### PR TITLE
Add Hide Feed Descriptions toggle for the subreddit list

### DIFF
--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -114,6 +114,9 @@ extern BOOL sPerPostCommentSort;
 extern BOOL sModernSubredditDividers;
 // Master toggle for subreddit list enhancements (see UDKeySubredditListEnhancements).
 extern BOOL sSubredditListEnhancements;
+// Hide the description subtitles under the subreddit list's built-in feed rows
+// (see UDKeyHideSubredditListDescriptions). Independent of the enhancements master.
+extern BOOL sHideSubredditListDescriptions;
 
 // Color post (link) flairs and user/author flairs using Reddit's assigned
 // colors (filled pill + matching text color). When NO, Apollo's default grey

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -45,6 +45,7 @@ BOOL sInfoRowOverlayMode = NO;     // info icons → transient overlay; default 
 BOOL sInfoRowTapTranslation = YES; // effective default ON via registerDefaults (UDKeyInfoRowTapTranslation)
 BOOL sModernSubredditDividers = YES;
 BOOL sSubredditListEnhancements = YES;
+BOOL sHideSubredditListDescriptions = NO;
 BOOL sEnableFlairColors = NO;
 BOOL sEnableInlineImages = NO;
 BOOL sEnableChatMedia = NO;   // effective default YES via registerDefaults (UDKeyEnableChatMedia)

--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -2071,10 +2071,16 @@ static void ApolloSubredditIndexRevertTableToNative(UITableView *tableView) {
 }
 
 // Master/dividers changed: re-style or revert every known list, including ones in a
-// deselected tab's detached hierarchy (which a window walk would miss).
+// deselected tab's detached hierarchy (which a window walk would miss). The registry
+// holds every RedditListViewController table, recognised or not — a list too short for
+// LooksLikeSubredditsTable (under 10 index titles, or no "A" entry) must not take the
+// apply branch, or ApplySeparatorInsets strips its separators while InstallOrUpdate
+// bails on the structural check and never draws the modern chrome in their place.
+// Unrecognised tables fall through to the revert branch, a no-op when nothing was
+// ever captured on them.
 static void ApolloSubredditIndexApplyEnhancementStateToKnownTables(void) {
     for (UITableView *tableView in sApolloSubredditKnownTables.allObjects) {
-        if (sSubredditListEnhancements) {
+        if (sSubredditListEnhancements && ApolloSubredditIndexEnsureSubredditTable(tableView)) {
             NSDictionary *anchor = ApolloSubredditIndexCaptureScrollAnchor(tableView);
             ApolloSubredditIndexApplySeparatorInsets(tableView);
             [UIView performWithoutAnimation:^{

--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -26,6 +26,10 @@ static char kApolloSubredditSelectionTableKey;
 static char kApolloSubredditHeaderSeparatorKey;
 static char kApolloSubredditHeaderGradientLayerKey;
 static char kApolloSubredditHeaderLoggedKey;
+// Section index this header is currently displayed for (stamped in willDisplayHeaderView)
+// plus the last pinned verdict, so the setFrame: hook only repaints on transitions.
+static char kApolloSubredditHeaderSectionKey;
+static char kApolloSubredditHeaderPinnedStateKey;
 static char kApolloSubredditMultiredditsSectionKey;
 static char kApolloSubredditMultiredditChildStyledKey;
 
@@ -34,6 +38,7 @@ static NSString * const ApolloSubredditIndexFavoriteSubredditsKey = @"FavoriteSu
 static void (*orig_ApolloRedditListWillDisplayHeader)(id self, SEL _cmd, UITableView *tableView, UIView *view, NSInteger section) = NULL;
 static void (*orig_ApolloRedditListWillDisplayCell)(id self, SEL _cmd, UITableView *tableView, UITableViewCell *cell, NSIndexPath *indexPath) = NULL;
 static void (*orig_ApolloSubredditHeaderLayoutSubviews)(id self, SEL _cmd) = NULL;
+static void (*orig_ApolloSubredditHeaderSetFrame)(id self, SEL _cmd, CGRect frame) = NULL;
 
 static const CGFloat ApolloSubredditIndexSlotHeight = 14.0;
 static const CGFloat ApolloSubredditIndexTouchWidth = 56.0;
@@ -1505,6 +1510,34 @@ static void ApolloSubredditIndexPrepareCellForDisplay(UITableView *tableView, UI
     ApolloSubredditIndexApplyMultiredditChildStyleIfNeeded(tableView, cell, indexPath);
 }
 
+// A plain-style section header is "pinned" (floating over rows under the nav bar) whenever the
+// table has lifted it above its resting slot — the top of its own section's rect. While pinned,
+// the modern header must stay transparent so only the title + accent line float over the rows
+// scrolling beneath; the opaque surface fill (see below) is only for headers at rest.
+static BOOL ApolloSubredditIndexHeaderIsPinned(UIView *header, UITableView *tableView) {
+    if (!header || !tableView) return NO;
+    NSNumber *sectionNumber = objc_getAssociatedObject(header, &kApolloSubredditHeaderSectionKey);
+    if (!sectionNumber) return NO;
+    NSInteger section = sectionNumber.integerValue;
+    if (section < 0 || section >= tableView.numberOfSections) return NO;
+    CGFloat restingY = CGRectGetMinY([tableView rectForSection:section]);
+    return CGRectGetMinY(header.frame) - restingY > 0.5;
+}
+
+// Resting modern headers get an opaque surface colour matching the rows: it fills the gap a
+// transparent header would leave over a mismatched table background (#450), and at rest it is
+// visually indistinguishable from a transparent header. Pinned headers must NOT keep it — an
+// opaque band floating over the rows reads as a solid stripe (the pinned-FAVORITES regression).
+static void ApolloSubredditIndexApplyHeaderSurfaceForPinnedState(UIView *header, UITableView *tableView, BOOL pinned) {
+    objc_setAssociatedObject(header, &kApolloSubredditHeaderPinnedStateKey, @(pinned), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (pinned) {
+        header.backgroundColor = [UIColor clearColor];
+        return;
+    }
+    UIColor *surfaceColor = ApolloSubredditIndexThemeListBackgroundColor(tableView, header);
+    header.backgroundColor = ApolloSubredditIndexColorIsVisible(surfaceColor) ? surfaceColor : tableView.backgroundColor;
+}
+
 static void ApolloSubredditIndexStyleHeaderView(UIView *header, UITableView *tableView) {
     if (!sSubredditListEnhancements) return;
     if (!header || !tableView) return;
@@ -1581,11 +1614,35 @@ static void ApolloSubredditIndexStyleHeaderView(UIView *header, UITableView *tab
     }
 
     // Fill the gap a transparent modern header would otherwise leave by giving the header its
-    // own opaque surface colour (matching the rows). This replaces the old approach of colouring
-    // the whole scroll view, which tripped the iOS 26 nav-bar glass reflection (#450). The header
-    // is a subview below the first row, so it never reaches the nav bar's reflected band.
-    UIColor *surfaceColor = ApolloSubredditIndexThemeListBackgroundColor(tableView, header);
-    header.backgroundColor = ApolloSubredditIndexColorIsVisible(surfaceColor) ? surfaceColor : tableView.backgroundColor;
+    // own opaque surface colour (matching the rows) — but only while it rests in its section
+    // slot. This replaces the old approach of colouring the whole scroll view, which tripped the
+    // iOS 26 nav-bar glass reflection (#450). The header is a subview below the first row, so it
+    // never reaches the nav bar's reflected band. While pinned it goes transparent instead (the
+    // setFrame: hook handles the transitions mid-scroll); see
+    // ApolloSubredditIndexApplyHeaderSurfaceForPinnedState.
+    ApolloSubredditIndexApplyHeaderSurfaceForPinnedState(header, tableView, ApolloSubredditIndexHeaderIsPinned(header, tableView));
+}
+
+// The table repositions a pinning/unpinning header exclusively through setFrame:, so this is
+// the one reliable per-scroll entry point for the rest-vs-pinned background swap. Cheap: bails
+// unless the header is one we styled, and only repaints when the pinned verdict flips.
+static void ApolloSubredditIndexHeaderSetFrameHook(id self, SEL _cmd, CGRect frame) {
+    if (orig_ApolloSubredditHeaderSetFrame) {
+        orig_ApolloSubredditHeaderSetFrame(self, _cmd, frame);
+    }
+
+    if (!sSubredditListEnhancements || !sModernSubredditDividers) return;
+    if (![self isKindOfClass:[UIView class]]) return;
+    UIView *header = (UIView *)self;
+    if (!objc_getAssociatedObject(header, &kApolloSubredditHeaderSectionKey)) return;
+
+    UITableView *tableView = ApolloSubredditIndexTableForView(header);
+    if (![objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue]) return;
+
+    BOOL pinned = ApolloSubredditIndexHeaderIsPinned(header, tableView);
+    NSNumber *lastPinned = objc_getAssociatedObject(header, &kApolloSubredditHeaderPinnedStateKey);
+    if (lastPinned && lastPinned.boolValue == pinned) return;
+    ApolloSubredditIndexApplyHeaderSurfaceForPinnedState(header, tableView, pinned);
 }
 
 static void ApolloSubredditIndexHeaderLayoutSubviewsHook(id self, SEL _cmd) {
@@ -1605,6 +1662,10 @@ static void ApolloSubredditIndexWillDisplayHeaderHook(id self, SEL _cmd, UITable
     if (orig_ApolloRedditListWillDisplayHeader) {
         orig_ApolloRedditListWillDisplayHeader(self, _cmd, tableView, view, section);
     }
+    // Stamp the section (headers are reused) and drop the cached pinned verdict so the
+    // setFrame: hook re-evaluates for the new slot.
+    objc_setAssociatedObject(view, &kApolloSubredditHeaderSectionKey, @(section), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(view, &kApolloSubredditHeaderPinnedStateKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloSubredditIndexStyleHeaderView(view, tableView);
     ApolloSubredditIndexTrackMultiredditsSection(tableView, view, section);
 }
@@ -1699,6 +1760,45 @@ static void ApolloSubredditIndexInstallHeaderLayoutHook(void) {
     const char *types = method_getTypeEncoding(inheritedMethod) ?: "v@:";
     BOOL added = class_addMethod(cls, selector, (IMP)ApolloSubredditIndexHeaderLayoutSubviewsHook, types);
     ApolloLog(@"[SubredditIndex] header layout hook installed via add=%d on %@", added, NSStringFromClass(cls));
+}
+
+static void ApolloSubredditIndexInstallHeaderSetFrameHook(void) {
+    Class cls = objc_getClass("Apollo.RecreatedTableSectionHeaderView");
+    if (!cls) cls = NSClassFromString(@"Apollo.RecreatedTableSectionHeaderView");
+    if (!cls) {
+        ApolloLog(@"[SubredditIndex] header setFrame hook skipped: RecreatedTableSectionHeaderView missing");
+        return;
+    }
+
+    SEL selector = @selector(setFrame:);
+    Method ownMethod = NULL;
+    unsigned int methodCount = 0;
+    Method *methods = class_copyMethodList(cls, &methodCount);
+    for (unsigned int idx = 0; idx < methodCount; idx++) {
+        if (method_getName(methods[idx]) == selector) {
+            ownMethod = methods[idx];
+            break;
+        }
+    }
+    free(methods);
+
+    if (ownMethod) {
+        orig_ApolloSubredditHeaderSetFrame = (void (*)(id, SEL, CGRect))method_getImplementation(ownMethod);
+        method_setImplementation(ownMethod, (IMP)ApolloSubredditIndexHeaderSetFrameHook);
+        ApolloLog(@"[SubredditIndex] header setFrame hook installed via replace on %@", NSStringFromClass(cls));
+        return;
+    }
+
+    Method inheritedMethod = class_getInstanceMethod(cls, selector);
+    if (!inheritedMethod) {
+        ApolloLog(@"[SubredditIndex] header setFrame hook skipped: inherited setFrame: missing on %@", NSStringFromClass(cls));
+        return;
+    }
+
+    orig_ApolloSubredditHeaderSetFrame = (void (*)(id, SEL, CGRect))method_getImplementation(inheritedMethod);
+    const char *types = method_getTypeEncoding(inheritedMethod) ?: "v@:{CGRect={CGPoint=dd}{CGSize=dd}}";
+    BOOL added = class_addMethod(cls, selector, (IMP)ApolloSubredditIndexHeaderSetFrameHook, types);
+    ApolloLog(@"[SubredditIndex] header setFrame hook installed via add=%d on %@", added, NSStringFromClass(cls));
 }
 
 %hook UITableView
@@ -1955,6 +2055,7 @@ static void ApolloSubredditIndexApplyRedditListCellPolishOnce(UITableViewCell *c
     ApolloSubredditIndexInstallHeaderHook();
     ApolloSubredditIndexInstallCellDisplayHook();
     ApolloSubredditIndexInstallHeaderLayoutHook();
+    ApolloSubredditIndexInstallHeaderSetFrameHook();
     [[NSNotificationCenter defaultCenter] addObserverForName:ApolloModernSubredditDividersChangedNotification
                                                       object:nil
                                                        queue:[NSOperationQueue mainQueue]

--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -1912,11 +1912,48 @@ static void ApolloSubredditIndexInstallHeaderSetFrameHook(void) {
     ApolloLog(@"[SubredditIndex] header setFrame hook installed via add=%d on %@", added, NSStringFromClass(cls));
 }
 
+// Classic mode draws the NATIVE A–Z index (the modern custom overlay lives on the
+// table's superview, above everything). UIKit adds each floating section header to
+// the table's subviews as it scrolls in — after the index view — so the opaque
+// header bands cover the letters as they pass. Keep the letters on top by re-raising
+// the index whenever a header sits above it. Scoped to the subreddit list; a no-op
+// pass is a cheap subview scan, and reordering doesn't invalidate layout.
+static void ApolloSubredditIndexRaiseNativeIndexAboveHeaders(UITableView *tableView) {
+    if (!tableView) return;
+    if (![sApolloSubredditKnownTables containsObject:tableView] &&
+        !ApolloSubredditIndexTableAlreadyRecognised(tableView)) return;
+
+    NSArray<UIView *> *subviews = tableView.subviews;
+    UIView *indexView = nil;
+    NSUInteger indexPosition = NSNotFound;
+    for (NSUInteger position = 0; position < subviews.count; position++) {
+        UIView *subview = subviews[position];
+        if ([NSStringFromClass(subview.class) rangeOfString:@"TableViewIndex"].location != NSNotFound) {
+            indexView = subview;
+            indexPosition = position;
+            break;
+        }
+    }
+    if (!indexView) return;
+
+    Class recreatedHeaderClass = objc_getClass("Apollo.RecreatedTableSectionHeaderView");
+    Class headerFooterClass = ApolloSubredditIndexTableHeaderFooterViewClass();
+    for (NSUInteger position = indexPosition + 1; position < subviews.count; position++) {
+        UIView *subview = subviews[position];
+        if ((recreatedHeaderClass && [subview isKindOfClass:recreatedHeaderClass]) ||
+            (headerFooterClass && [subview isKindOfClass:headerFooterClass])) {
+            [tableView bringSubviewToFront:indexView];
+            return;
+        }
+    }
+}
+
 %hook UITableView
 
 - (void)layoutSubviews {
     %orig;
     ApolloSubredditIndexInstallOrUpdate((UITableView *)self);
+    ApolloSubredditIndexRaiseNativeIndexAboveHeaders((UITableView *)self);
 }
 
 - (void)reloadData {

--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -30,6 +30,20 @@ static char kApolloSubredditHeaderLoggedKey;
 // plus the last pinned verdict, so the setFrame: hook only repaints on transitions.
 static char kApolloSubredditHeaderSectionKey;
 static char kApolloSubredditHeaderPinnedStateKey;
+// Live revert support: turning the Enhancements master OFF must restore the native
+// look without a relaunch. Native values are captured once, right before the first
+// enhancement mutation, and replayed by the restore pass.
+static char kApolloSubredditTableNativeStateKey;   // NSDictionary: insets/style/index colors
+static char kApolloSubredditCellNativeStateKey;    // NSDictionary: margins/spacing/backgrounds
+static char kApolloSubredditHeaderNativeStateKey;  // NSDictionary: header/label chrome
+static char kApolloSubredditHeaderStyledKey;       // we styled this header; restore needed
+
+// Weak registry of every table RedditListViewController vended cells for. Unlike a
+// window walk this reaches a list sitting in a deselected tab's detached hierarchy,
+// and it works with the enhancements master off.
+static NSHashTable<UITableView *> *sApolloSubredditKnownTables = nil;
+
+static void ApolloSubredditIndexRestoreCellNativeState(UITableViewCell *cell);
 static char kApolloSubredditMultiredditsSectionKey;
 static char kApolloSubredditMultiredditChildStyledKey;
 
@@ -164,7 +178,23 @@ static BOOL ApolloSubredditIndexLooksLikeSubredditsTable(UITableView *tableView,
     return hasA && (hasZ || hasHash);
 }
 
+// Capture the table's native separator/margin/index chrome exactly once, before the
+// enhancement suite first mutates it, so the master toggle can revert live.
+static void ApolloSubredditIndexCaptureTableNativeState(UITableView *tableView) {
+    if (!tableView) return;
+    if (objc_getAssociatedObject(tableView, &kApolloSubredditTableNativeStateKey)) return;
+    NSMutableDictionary *state = [NSMutableDictionary dictionary];
+    state[@"separatorInset"] = [NSValue valueWithUIEdgeInsets:tableView.separatorInset];
+    state[@"separatorStyle"] = @(tableView.separatorStyle);
+    state[@"layoutMargins"] = [NSValue valueWithUIEdgeInsets:tableView.layoutMargins];
+    state[@"sectionIndexColor"] = tableView.sectionIndexColor ?: (id)[NSNull null];
+    state[@"sectionIndexBackgroundColor"] = tableView.sectionIndexBackgroundColor ?: (id)[NSNull null];
+    state[@"sectionIndexTrackingBackgroundColor"] = tableView.sectionIndexTrackingBackgroundColor ?: (id)[NSNull null];
+    objc_setAssociatedObject(tableView, &kApolloSubredditTableNativeStateKey, state, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 static void ApolloSubredditIndexApplySeparatorInsets(UITableView *tableView) {
+    ApolloSubredditIndexCaptureTableNativeState(tableView);
     UIEdgeInsets inset = tableView.separatorInset;
     if (inset.right < ApolloSubredditIndexRightInset) {
         inset.right = ApolloSubredditIndexRightInset;
@@ -184,6 +214,7 @@ static void ApolloSubredditIndexApplySeparatorInsets(UITableView *tableView) {
 }
 
 static void ApolloSubredditIndexHideNativeIndex(UITableView *tableView) {
+    ApolloSubredditIndexCaptureTableNativeState(tableView);
     tableView.sectionIndexColor = [UIColor clearColor];
     tableView.sectionIndexBackgroundColor = [UIColor clearColor];
     tableView.sectionIndexTrackingBackgroundColor = [UIColor clearColor];
@@ -351,8 +382,27 @@ static BOOL ApolloSubredditIndexStarControlFrameIsPlausible(UIControl *control, 
     return plausibleSize && rightSide;
 }
 
+// Capture the cell's native chrome exactly once, before the enhancement suite first
+// mutates it (margins here, stack spacing in the row polish, backgrounds in the
+// multireddit child styling — all of which stash into this same dictionary).
+static NSMutableDictionary *ApolloSubredditIndexCaptureCellNativeState(UITableViewCell *cell) {
+    if (!cell) return nil;
+    NSMutableDictionary *state = objc_getAssociatedObject(cell, &kApolloSubredditCellNativeStateKey);
+    if (state) return state;
+    state = [NSMutableDictionary dictionary];
+    state[@"separatorInset"] = [NSValue valueWithUIEdgeInsets:cell.separatorInset];
+    state[@"layoutMargins"] = [NSValue valueWithUIEdgeInsets:cell.layoutMargins];
+    state[@"contentMargins"] = [NSValue valueWithUIEdgeInsets:cell.contentView.layoutMargins];
+    state[@"cellBackgroundColor"] = cell.backgroundColor ?: (id)[NSNull null];
+    state[@"contentBackgroundColor"] = cell.contentView.backgroundColor ?: (id)[NSNull null];
+    state[@"cellOpaque"] = @(cell.opaque);
+    objc_setAssociatedObject(cell, &kApolloSubredditCellNativeStateKey, state, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return state;
+}
+
 static void ApolloSubredditIndexApplyCellMarginsOnce(UITableViewCell *cell) {
     if ([objc_getAssociatedObject(cell, &kApolloSubredditCellMarginsAppliedKey) boolValue]) return;
+    ApolloSubredditIndexCaptureCellNativeState(cell);
 
     UIEdgeInsets inset = cell.separatorInset;
     if (inset.right < ApolloSubredditIndexRightInset) {
@@ -1161,40 +1211,6 @@ static void ApolloSubredditIndexInstallOrUpdate(UITableView *tableView) {
     }
 }
 
-static void ApolloSubredditIndexRefreshTablesInView(UIView *view) {
-    if (!sSubredditListEnhancements) return;
-    if (!view) return;
-
-    if ([view isKindOfClass:[UITableView class]]) {
-        UITableView *tableView = (UITableView *)view;
-        if (ApolloSubredditIndexShouldInspectTable(tableView)) {
-            NSArray<NSString *> *titles = ApolloSubredditIndexTitlesForTable(tableView);
-            BOOL isSubredditTable = ApolloSubredditIndexLooksLikeSubredditsTable(tableView, titles);
-            if (isSubredditTable) {
-                objc_setAssociatedObject(tableView, &kApolloSubredditIndexTableKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-                NSDictionary *anchor = ApolloSubredditIndexCaptureScrollAnchor(tableView);
-                ApolloSubredditIndexApplySeparatorInsets(tableView);
-                [UIView performWithoutAnimation:^{
-                    [tableView reloadData];
-                    [tableView layoutIfNeeded];
-                    ApolloSubredditIndexInstallOrUpdate(tableView);
-                    ApolloSubredditIndexRestoreScrollAnchor(tableView, anchor);
-                }];
-            }
-        }
-    }
-
-    for (UIView *subview in view.subviews) {
-        ApolloSubredditIndexRefreshTablesInView(subview);
-    }
-}
-
-static void ApolloSubredditIndexRefreshAllVisibleTables(void) {
-    for (UIWindow *window in ApolloAllWindows()) {
-        ApolloSubredditIndexRefreshTablesInView(window);
-    }
-}
-
 static BOOL ApolloSubredditIndexEnsureSubredditTable(UITableView *tableView) {
     if (!sSubredditListEnhancements) return NO;
     if (!tableView) return NO;
@@ -1333,6 +1349,7 @@ static void ApolloSubredditIndexApplyCellSelectionChrome(UITableViewCell *cell, 
     // Separator style belongs to the enhancement/divider suite — only touch it when that suite owns
     // this table. In classic mode we leave Apollo's native separators untouched.
     if (ApolloSubredditIndexEnsureSubredditTable(tableView)) {
+        ApolloSubredditIndexCaptureTableNativeState(tableView);
         UITableViewCellSeparatorStyle separatorStyle = sModernSubredditDividers ? UITableViewCellSeparatorStyleNone : UITableViewCellSeparatorStyleSingleLine;
         if (tableView.separatorStyle != separatorStyle) {
             tableView.separatorStyle = separatorStyle;
@@ -1469,6 +1486,11 @@ static void ApolloSubredditIndexApplyMultiredditChildStyle(UITableView *tableVie
     UIView *lineView = ApolloSubredditIndexMultiredditChildLineView(cell);
     if (!lineView) return;
 
+    NSMutableDictionary *nativeState = ApolloSubredditIndexCaptureCellNativeState(cell);
+    if (nativeState && !nativeState[@"multiredditLineColor"]) {
+        nativeState[@"multiredditLineColor"] = lineView.backgroundColor ?: (id)[NSNull null];
+    }
+
     cell.backgroundColor = [UIColor clearColor];
     cell.contentView.backgroundColor = [UIColor clearColor];
     cell.opaque = NO;
@@ -1510,6 +1532,66 @@ static void ApolloSubredditIndexPrepareCellForDisplay(UITableView *tableView, UI
     ApolloSubredditIndexApplyMultiredditChildStyleIfNeeded(tableView, cell, indexPath);
 }
 
+static void ApolloSubredditIndexUnhideVisualEffectViews(UIView *view) {
+    if (!view) return;
+    if ([view isKindOfClass:[UIVisualEffectView class]]) view.hidden = NO;
+    for (UIView *subview in view.subviews) {
+        ApolloSubredditIndexUnhideVisualEffectViews(subview);
+    }
+}
+
+// Undo everything the modern header styling did to this instance: injected gradient
+// separator, hidden effect views, background fills and label chrome (from the state
+// captured before the first styling pass). Apollo re-sets the title text and layout
+// on the next configure/layout pass. No-op unless we actually styled this header.
+static void ApolloSubredditIndexRestoreHeaderNativeChrome(UIView *header) {
+    if (!header) return;
+    if (![objc_getAssociatedObject(header, &kApolloSubredditHeaderStyledKey) boolValue]) return;
+    objc_setAssociatedObject(header, &kApolloSubredditHeaderStyledKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(header, &kApolloSubredditHeaderPinnedStateKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    UIView *separator = objc_getAssociatedObject(header, &kApolloSubredditHeaderSeparatorKey);
+    [separator removeFromSuperview];
+    objc_setAssociatedObject(header, &kApolloSubredditHeaderSeparatorKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    ApolloSubredditIndexUnhideVisualEffectViews(header);
+
+    NSDictionary *state = objc_getAssociatedObject(header, &kApolloSubredditHeaderNativeStateKey);
+    if (state) {
+        id headerBg = state[@"headerBackgroundColor"];
+        header.backgroundColor = [headerBg isKindOfClass:[UIColor class]] ? headerBg : nil;
+        header.opaque = [state[@"headerOpaque"] boolValue];
+
+        UILabel *label = ApolloSubredditIndexHeaderLabelInView(header);
+        if (label) {
+            UIFont *font = [state[@"labelFont"] isKindOfClass:[UIFont class]] ? state[@"labelFont"] : nil;
+            if (font) label.font = font;
+            UIColor *textColor = [state[@"labelTextColor"] isKindOfClass:[UIColor class]] ? state[@"labelTextColor"] : nil;
+            if (textColor) label.textColor = textColor;
+            NSNumber *alpha = state[@"labelAlpha"];
+            if (alpha) label.alpha = alpha.doubleValue;
+        }
+
+        Class headerFooterClass = ApolloSubredditIndexTableHeaderFooterViewClass();
+        if (headerFooterClass && [header isKindOfClass:headerFooterClass]) {
+            UITableViewHeaderFooterView *headerFooter = (UITableViewHeaderFooterView *)header;
+            if ([state[@"hadBackgroundView"] boolValue]) {
+                id backgroundViewColor = state[@"backgroundViewColor"];
+                headerFooter.backgroundView.backgroundColor = [backgroundViewColor isKindOfClass:[UIColor class]] ? backgroundViewColor : nil;
+            } else {
+                // ClearHeaderChrome installed this stand-in; the native header had none.
+                headerFooter.backgroundView = nil;
+            }
+            id contentBg = state[@"contentBackgroundColor"];
+            headerFooter.contentView.backgroundColor = [contentBg isKindOfClass:[UIColor class]] ? contentBg : nil;
+            headerFooter.contentView.opaque = [state[@"contentOpaque"] boolValue];
+        }
+    }
+
+    [header setNeedsLayout];
+    [header setNeedsDisplay];
+}
+
 // A plain-style section header is "pinned" (floating over rows under the nav bar) whenever the
 // table has lifted it above its resting slot — the top of its own section's rect. While pinned,
 // the modern header must stay transparent so only the title + accent line float over the rows
@@ -1539,7 +1621,12 @@ static void ApolloSubredditIndexApplyHeaderSurfaceForPinnedState(UIView *header,
 }
 
 static void ApolloSubredditIndexStyleHeaderView(UIView *header, UITableView *tableView) {
-    if (!sSubredditListEnhancements) return;
+    if (!sSubredditListEnhancements) {
+        // Master off: instead of leaving stale modern chrome on a reused header,
+        // put the instance back to its native look (no-op unless we styled it).
+        ApolloSubredditIndexRestoreHeaderNativeChrome(header);
+        return;
+    }
     if (!header || !tableView) return;
     if (![objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue]) {
         if (!ApolloSubredditIndexShouldInspectTable(tableView)) return;
@@ -1554,11 +1641,35 @@ static void ApolloSubredditIndexStyleHeaderView(UIView *header, UITableView *tab
     NSString *text = [[label.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] uppercaseString];
     if (!ApolloSubredditIndexStringLooksLikeHeaderTitle(text)) return;
 
-    UIView *separator = objc_getAssociatedObject(header, &kApolloSubredditHeaderSeparatorKey);
     if (!sModernSubredditDividers) {
-        separator.hidden = YES;
+        // Dividers off means native headers; also strips stale modern chrome from a
+        // header that was styled while dividers were on.
+        ApolloSubredditIndexRestoreHeaderNativeChrome(header);
         return;
     }
+
+    // Capture the native chrome once before the first styling pass, so the master
+    // (or dividers) toggle can put this instance back without a relaunch.
+    if (!objc_getAssociatedObject(header, &kApolloSubredditHeaderNativeStateKey)) {
+        NSMutableDictionary *nativeState = [NSMutableDictionary dictionary];
+        nativeState[@"headerBackgroundColor"] = header.backgroundColor ?: (id)[NSNull null];
+        nativeState[@"headerOpaque"] = @(header.opaque);
+        nativeState[@"labelFont"] = label.font ?: (id)[NSNull null];
+        nativeState[@"labelTextColor"] = label.textColor ?: (id)[NSNull null];
+        nativeState[@"labelAlpha"] = @(label.alpha);
+        Class headerFooterClass = ApolloSubredditIndexTableHeaderFooterViewClass();
+        if (headerFooterClass && [header isKindOfClass:headerFooterClass]) {
+            UITableViewHeaderFooterView *headerFooter = (UITableViewHeaderFooterView *)header;
+            nativeState[@"hadBackgroundView"] = @(headerFooter.backgroundView != nil);
+            nativeState[@"backgroundViewColor"] = headerFooter.backgroundView.backgroundColor ?: (id)[NSNull null];
+            nativeState[@"contentBackgroundColor"] = headerFooter.contentView.backgroundColor ?: (id)[NSNull null];
+            nativeState[@"contentOpaque"] = @(headerFooter.contentView.opaque);
+        }
+        objc_setAssociatedObject(header, &kApolloSubredditHeaderNativeStateKey, nativeState, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    objc_setAssociatedObject(header, &kApolloSubredditHeaderStyledKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    UIView *separator = objc_getAssociatedObject(header, &kApolloSubredditHeaderSeparatorKey);
 
     ApolloSubredditIndexClearHeaderChrome(header, label);
 
@@ -1832,11 +1943,6 @@ static void ApolloSubredditIndexInstallHeaderSetFrameHook(void) {
 // toggle can restore it even if Apollo only set the text once per cell.
 
 static char kApolloSubredditDescriptionStashKey;
-// Weak registry of tables these cells were vended for. The generic refresh
-// helper (ApolloSubredditIndexRefreshTablesInView) is gated on the enhancements
-// master and only walks attached views, but this toggle must also refresh a
-// classic-mode list and one sitting in a deselected tab's detached hierarchy.
-static NSHashTable<UITableView *> *sApolloSubredditDescriptionTables = nil;
 
 static Class ApolloSubredditIndexSubtitleCellClass(void) {
     static Class cls = Nil;
@@ -1850,9 +1956,6 @@ static Class ApolloSubredditIndexSubtitleCellClass(void) {
 static void ApolloSubredditIndexApplyDescriptionPreference(UITableView *tableView, UITableViewCell *cell) {
     Class subtitleCellClass = ApolloSubredditIndexSubtitleCellClass();
     if (!subtitleCellClass || ![cell isKindOfClass:subtitleCellClass]) return;
-
-    if (!sApolloSubredditDescriptionTables) sApolloSubredditDescriptionTables = [NSHashTable weakObjectsHashTable];
-    if (tableView) [sApolloSubredditDescriptionTables addObject:tableView];
 
     UILabel *detailLabel = cell.detailTextLabel;
     if (!detailLabel) return;
@@ -1871,7 +1974,7 @@ static void ApolloSubredditIndexApplyDescriptionPreference(UITableView *tableVie
 }
 
 static void ApolloSubredditIndexReloadDescriptionTables(void) {
-    for (UITableView *tableView in sApolloSubredditDescriptionTables.allObjects) {
+    for (UITableView *tableView in sApolloSubredditKnownTables.allObjects) {
         NSDictionary *anchor = ApolloSubredditIndexCaptureScrollAnchor(tableView);
         [UIView performWithoutAnimation:^{
             [tableView reloadData];
@@ -1881,10 +1984,86 @@ static void ApolloSubredditIndexReloadDescriptionTables(void) {
     }
 }
 
+// --- Live enhancement master revert -----------------------------------------
+// Turning Subreddit List Enhancements OFF used to leave stale modern chrome (accent
+// headers, hidden separators, the custom A–Z overlay, star proxies, widened margins)
+// until the app relaunched: the refresh path was gated on the now-off master, and the
+// persistent table tag kept the cell layoutSubviews hooks re-applying styling. This
+// pass puts a known table back to its captured native state and drops the tag so the
+// styling hooks disengage — while keeping the #452 tap-highlight fix, which is meant
+// to work in classic mode too.
+static void ApolloSubredditIndexRevertTableToNative(UITableView *tableView) {
+    if (!tableView) return;
+
+    if ([objc_getAssociatedObject(tableView, &kApolloSubredditIndexTableKey) boolValue]) {
+        objc_setAssociatedObject(tableView, &kApolloSubredditSelectionTableKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(tableView, &kApolloSubredditIndexTableKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    ApolloSubredditIndexOverlayView *overlay = objc_getAssociatedObject(tableView, &kApolloSubredditIndexOverlayKey);
+    [overlay removeFromSuperview];
+    objc_setAssociatedObject(tableView, &kApolloSubredditIndexOverlayKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    NSDictionary *state = objc_getAssociatedObject(tableView, &kApolloSubredditTableNativeStateKey);
+    if (state) {
+        tableView.separatorInset = [state[@"separatorInset"] UIEdgeInsetsValue];
+        tableView.separatorStyle = (UITableViewCellSeparatorStyle)[state[@"separatorStyle"] integerValue];
+        tableView.layoutMargins = [state[@"layoutMargins"] UIEdgeInsetsValue];
+        id indexColor = state[@"sectionIndexColor"];
+        tableView.sectionIndexColor = [indexColor isKindOfClass:[UIColor class]] ? indexColor : nil;
+        id indexBackground = state[@"sectionIndexBackgroundColor"];
+        tableView.sectionIndexBackgroundColor = [indexBackground isKindOfClass:[UIColor class]] ? indexBackground : nil;
+        id indexTracking = state[@"sectionIndexTrackingBackgroundColor"];
+        tableView.sectionIndexTrackingBackgroundColor = [indexTracking isKindOfClass:[UIColor class]] ? indexTracking : nil;
+    }
+
+    for (UITableViewCell *cell in tableView.visibleCells) {
+        ApolloSubredditIndexRestoreCellNativeState(cell);
+    }
+    NSInteger sectionCount = tableView.numberOfSections;
+    for (NSInteger section = 0; section < sectionCount; section++) {
+        ApolloSubredditIndexRestoreHeaderNativeChrome([tableView headerViewForSection:section]);
+    }
+
+    NSDictionary *anchor = ApolloSubredditIndexCaptureScrollAnchor(tableView);
+    [UIView performWithoutAnimation:^{
+        [tableView reloadData];
+        [tableView layoutIfNeeded];
+        ApolloSubredditIndexRestoreScrollAnchor(tableView, anchor);
+    }];
+}
+
+// Master/dividers changed: re-style or revert every known list, including ones in a
+// deselected tab's detached hierarchy (which a window walk would miss).
+static void ApolloSubredditIndexApplyEnhancementStateToKnownTables(void) {
+    for (UITableView *tableView in sApolloSubredditKnownTables.allObjects) {
+        if (sSubredditListEnhancements) {
+            NSDictionary *anchor = ApolloSubredditIndexCaptureScrollAnchor(tableView);
+            ApolloSubredditIndexApplySeparatorInsets(tableView);
+            [UIView performWithoutAnimation:^{
+                [tableView reloadData];
+                [tableView layoutIfNeeded];
+                ApolloSubredditIndexInstallOrUpdate(tableView);
+                ApolloSubredditIndexRestoreScrollAnchor(tableView, anchor);
+            }];
+        } else {
+            ApolloSubredditIndexRevertTableToNative(tableView);
+        }
+    }
+}
+
 %hook _TtC6Apollo24RedditListViewController
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     UITableViewCell *cell = %orig;
+    if (tableView) {
+        if (!sApolloSubredditKnownTables) sApolloSubredditKnownTables = [NSHashTable weakObjectsHashTable];
+        [sApolloSubredditKnownTables addObject:tableView];
+    }
+    if (!sSubredditListEnhancements) {
+        // Master off: strip any enhancement residue from a reused cell before display.
+        ApolloSubredditIndexRestoreCellNativeState(cell);
+    }
     ApolloSubredditIndexApplyDescriptionPreference(tableView, cell);
     return cell;
 }
@@ -1992,8 +2171,48 @@ static UIStackView *ApolloSubredditIndexRedditListMainStackView(UITableViewCell 
     return [value isKindOfClass:[UIStackView class]] ? (UIStackView *)value : nil;
 }
 
+// Undo every master-gated cell mutation from the captured native state: star proxy,
+// widened margins/insets, stack spacing, and the multireddit child recolor. The #452
+// selection chrome is deliberately left alone — it applies in classic mode too.
+// Idempotent, so it can run on every classic-mode display pass of a reused cell.
+static void ApolloSubredditIndexRestoreCellNativeState(UITableViewCell *cell) {
+    if (!cell) return;
+    ApolloSubredditIndexRemoveStarProxyFromCell(cell);
+
+    NSDictionary *state = objc_getAssociatedObject(cell, &kApolloSubredditCellNativeStateKey);
+    if (state) {
+        cell.separatorInset = [state[@"separatorInset"] UIEdgeInsetsValue];
+        cell.layoutMargins = [state[@"layoutMargins"] UIEdgeInsetsValue];
+        cell.contentView.layoutMargins = [state[@"contentMargins"] UIEdgeInsetsValue];
+        id cellBackground = state[@"cellBackgroundColor"];
+        cell.backgroundColor = [cellBackground isKindOfClass:[UIColor class]] ? cellBackground : nil;
+        id contentBackground = state[@"contentBackgroundColor"];
+        cell.contentView.backgroundColor = [contentBackground isKindOfClass:[UIColor class]] ? contentBackground : nil;
+        cell.opaque = [state[@"cellOpaque"] boolValue];
+
+        NSNumber *stackSpacing = state[@"stackSpacing"];
+        if (stackSpacing) {
+            UIStackView *mainStack = ApolloSubredditIndexRedditListMainStackView(cell);
+            if (mainStack) mainStack.spacing = stackSpacing.doubleValue;
+        }
+
+        id lineColor = state[@"multiredditLineColor"];
+        if ([lineColor isKindOfClass:[UIColor class]]) {
+            UIView *lineView = ApolloSubredditIndexMultiredditChildLineView(cell);
+            lineView.backgroundColor = lineColor;
+            lineView.layer.backgroundColor = ((UIColor *)lineColor).CGColor;
+        }
+    }
+
+    objc_setAssociatedObject(cell, &kApolloSubredditCellMarginsAppliedKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(cell, &kApolloSubredditRowPolishAppliedKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(cell, &kApolloSubredditMultiredditChildStyledKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [cell setNeedsLayout];
+}
+
 static void ApolloSubredditIndexApplyRedditListCellPolishOnce(UITableViewCell *cell, BOOL skipLeadingMarginClamp) {
     if ([objc_getAssociatedObject(cell, &kApolloSubredditRowPolishAppliedKey) boolValue]) return;
+    NSMutableDictionary *nativeState = ApolloSubredditIndexCaptureCellNativeState(cell);
 
     if (!skipLeadingMarginClamp) {
         UIEdgeInsets margins = cell.contentView.layoutMargins;
@@ -2005,6 +2224,7 @@ static void ApolloSubredditIndexApplyRedditListCellPolishOnce(UITableViewCell *c
 
     UIStackView *mainStack = ApolloSubredditIndexRedditListMainStackView(cell);
     if (mainStack && mainStack.spacing < ApolloSubredditRowIconTextGap) {
+        if (nativeState && !nativeState[@"stackSpacing"]) nativeState[@"stackSpacing"] = @(mainStack.spacing);
         mainStack.spacing = ApolloSubredditRowIconTextGap;
     }
 
@@ -2060,8 +2280,11 @@ static void ApolloSubredditIndexApplyRedditListCellPolishOnce(UITableViewCell *c
                                                       object:nil
                                                        queue:[NSOperationQueue mainQueue]
                                                   usingBlock:^(__unused NSNotification *notification) {
-        ApolloSubredditIndexRefreshAllVisibleTables();
-        ApolloLog(@"[SubredditIndex] divider-style-changed modern=%d", sModernSubredditDividers);
+        ApolloSubredditIndexApplyEnhancementStateToKnownTables();
+        ApolloLog(@"[SubredditIndex] enhancement-state-changed enhancements=%d modern=%d tables=%lu",
+                  sSubredditListEnhancements,
+                  sModernSubredditDividers,
+                  (unsigned long)sApolloSubredditKnownTables.allObjects.count);
     }];
     [[NSNotificationCenter defaultCenter] addObserverForName:ApolloHideSubredditListDescriptionsChangedNotification
                                                       object:nil
@@ -2070,7 +2293,7 @@ static void ApolloSubredditIndexApplyRedditListCellPolishOnce(UITableViewCell *c
         ApolloSubredditIndexReloadDescriptionTables();
         ApolloLog(@"[SubredditIndex] feed-descriptions-changed hide=%d tables=%lu",
                   sHideSubredditListDescriptions,
-                  (unsigned long)sApolloSubredditDescriptionTables.allObjects.count);
+                  (unsigned long)sApolloSubredditKnownTables.allObjects.count);
     }];
     ApolloLog(@"[SubredditIndex] polish active modernDividers=%d", sModernSubredditDividers);
 }

--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -1721,7 +1721,73 @@ static void ApolloSubredditIndexInstallHeaderLayoutHook(void) {
 
 %end
 
+// --- Hide Feed Descriptions ------------------------------------------------
+// The built-in feed rows (Home, Popular Posts, All Posts, Moderator Posts) are
+// the only rows in the subreddit list that use _TtC6Apollo27ApolloSubtitleTableViewCell
+// (regular subreddit rows are RedditListTableViewCell), so inside
+// RedditListViewController's data source that cell class alone identifies them.
+// Clearing detailTextLabel.text right after Apollo configures the cell — before
+// the table's self-sizing pass — both removes the description and lets the row
+// height collapse naturally. The original string is stashed on the cell so the
+// toggle can restore it even if Apollo only set the text once per cell.
+
+static char kApolloSubredditDescriptionStashKey;
+// Weak registry of tables these cells were vended for. The generic refresh
+// helper (ApolloSubredditIndexRefreshTablesInView) is gated on the enhancements
+// master and only walks attached views, but this toggle must also refresh a
+// classic-mode list and one sitting in a deselected tab's detached hierarchy.
+static NSHashTable<UITableView *> *sApolloSubredditDescriptionTables = nil;
+
+static Class ApolloSubredditIndexSubtitleCellClass(void) {
+    static Class cls = Nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        cls = NSClassFromString(@"_TtC6Apollo27ApolloSubtitleTableViewCell");
+    });
+    return cls;
+}
+
+static void ApolloSubredditIndexApplyDescriptionPreference(UITableView *tableView, UITableViewCell *cell) {
+    Class subtitleCellClass = ApolloSubredditIndexSubtitleCellClass();
+    if (!subtitleCellClass || ![cell isKindOfClass:subtitleCellClass]) return;
+
+    if (!sApolloSubredditDescriptionTables) sApolloSubredditDescriptionTables = [NSHashTable weakObjectsHashTable];
+    if (tableView) [sApolloSubredditDescriptionTables addObject:tableView];
+
+    UILabel *detailLabel = cell.detailTextLabel;
+    if (!detailLabel) return;
+
+    if (sHideSubredditListDescriptions) {
+        if (detailLabel.text.length > 0) {
+            objc_setAssociatedObject(cell, &kApolloSubredditDescriptionStashKey, detailLabel.text, OBJC_ASSOCIATION_COPY_NONATOMIC);
+            detailLabel.text = nil;
+        }
+    } else if (detailLabel.text.length == 0) {
+        // Apollo didn't repopulate the subtitle on this configure pass (cached
+        // per-row cell), so bring back the string we cleared earlier.
+        NSString *stashed = objc_getAssociatedObject(cell, &kApolloSubredditDescriptionStashKey);
+        if (stashed.length > 0) detailLabel.text = stashed;
+    }
+}
+
+static void ApolloSubredditIndexReloadDescriptionTables(void) {
+    for (UITableView *tableView in sApolloSubredditDescriptionTables.allObjects) {
+        NSDictionary *anchor = ApolloSubredditIndexCaptureScrollAnchor(tableView);
+        [UIView performWithoutAnimation:^{
+            [tableView reloadData];
+            [tableView layoutIfNeeded];
+            ApolloSubredditIndexRestoreScrollAnchor(tableView, anchor);
+        }];
+    }
+}
+
 %hook _TtC6Apollo24RedditListViewController
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = %orig;
+    ApolloSubredditIndexApplyDescriptionPreference(tableView, cell);
+    return cell;
+}
 
 - (void)favoriteSubredditButtonTapped:(id)sender {
     UIView *senderView = [sender isKindOfClass:[UIView class]] ? (UIView *)sender : nil;
@@ -1895,6 +1961,15 @@ static void ApolloSubredditIndexApplyRedditListCellPolishOnce(UITableViewCell *c
                                                   usingBlock:^(__unused NSNotification *notification) {
         ApolloSubredditIndexRefreshAllVisibleTables();
         ApolloLog(@"[SubredditIndex] divider-style-changed modern=%d", sModernSubredditDividers);
+    }];
+    [[NSNotificationCenter defaultCenter] addObserverForName:ApolloHideSubredditListDescriptionsChangedNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(__unused NSNotification *notification) {
+        ApolloSubredditIndexReloadDescriptionTables();
+        ApolloLog(@"[SubredditIndex] feed-descriptions-changed hide=%d tables=%lu",
+                  sHideSubredditListDescriptions,
+                  (unsigned long)sApolloSubredditDescriptionTables.allObjects.count);
     }];
     ApolloLog(@"[SubredditIndex] polish active modernDividers=%d", sModernSubredditDividers);
 }

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -2856,6 +2856,7 @@ static void initializeRandomSources() {
     }
     sModernSubredditDividers = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyModernSubredditDividers];
     sSubredditListEnhancements = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeySubredditListEnhancements];
+    sHideSubredditListDescriptions = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyHideSubredditListDescriptions];
     sEnableFlairColors = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableFlairColors];
     sEnableBulkTranslation = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableBulkTranslation];
     sAutoTranslateOnAppear = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyAutoTranslateOnAppear];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -36,6 +36,12 @@ static NSString *const UDKeySubredditListEnhancements = @"SubredditListEnhanceme
 static NSString *const UDKeyHiddenModeratorSubreddits = @"HiddenModeratorSubreddits";
 static NSString *const UDKeyModernSubredditDividers = @"ModernSubredditDividers";
 static NSString *const ApolloModernSubredditDividersChangedNotification = @"ApolloModernSubredditDividersChangedNotification";
+// Hides the description subtitles under the subreddit list's built-in feed rows
+// (Home, Popular Posts, All Posts, Moderator Posts). Independent of the
+// enhancements master — applies in both the classic and modern list styles.
+// Default NO. See ApolloSubredditIndexPolish.xm.
+static NSString *const UDKeyHideSubredditListDescriptions = @"HideSubredditListDescriptions";
+static NSString *const ApolloHideSubredditListDescriptionsChangedNotification = @"ApolloHideSubredditListDescriptionsChangedNotification";
 // Color post (link) and user/author flairs with Reddit's assigned colors. Default NO.
 static NSString *const UDKeyEnableFlairColors = @"EnableFlairColors";
 static NSString *const ApolloFlairColorsChangedNotification = @"ApolloFlairColorsChangedNotification";

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -1523,6 +1523,14 @@ typedef NS_ENUM(NSInteger, Tag) {
     // Sub-option: only exists while Subreddit List Enhancements is on.
     modernDividers.visible = ^BOOL { return sSubredditListEnhancements; };
 
+    // Deliberately NOT gated on the enhancements master: hides the description
+    // subtitles under Home/Popular/All/Moderator in both classic and modern lists.
+    ApolloSettingsRow *hideDescriptions =
+        [ApolloSettingsRow switchRowWithID:@"sub.hideFeedDescriptions"
+                                     title:@"Hide Feed Descriptions"
+                                      isOn:^BOOL { return sHideSubredditListDescriptions; }
+                                  onToggle:^(UISwitch *sender) { [weakSelf hideSubredditListDescriptionsSwitchToggled:sender]; }];
+
     ApolloSettingsRow *headers =
         [ApolloSettingsRow switchRowWithID:@"sub.headers"
                                      title:@"Show Subreddit Headers"
@@ -1543,8 +1551,8 @@ typedef NS_ENUM(NSInteger, Tag) {
     };
 
     return [ApolloSettingsSection sectionWithTitle:nil
-                                            footer:@"Enhance the subreddit list and community pages with dividers, headers and highlights."
-                                              rows:@[ enhancements, modernDividers, headers, highlights ]];
+                                            footer:@"Enhance the subreddit list and community pages with dividers, headers and highlights. Hide Feed Descriptions removes the subtitles under Home, Popular, All and Moderator Posts."
+                                              rows:@[ enhancements, modernDividers, hideDescriptions, headers, highlights ]];
 }
 
 - (ApolloSettingsSection *)buildSubredditsSourcesSection {
@@ -2963,6 +2971,12 @@ typedef NS_ENUM(NSInteger, Tag) {
     sModernSubredditDividers = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sModernSubredditDividers forKey:UDKeyModernSubredditDividers];
     [[NSNotificationCenter defaultCenter] postNotificationName:ApolloModernSubredditDividersChangedNotification object:nil];
+}
+
+- (void)hideSubredditListDescriptionsSwitchToggled:(UISwitch *)sender {
+    sHideSubredditListDescriptions = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sHideSubredditListDescriptions forKey:UDKeyHideSubredditListDescriptions];
+    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloHideSubredditListDescriptionsChangedNotification object:nil];
 }
 
 - (void)showRecentlyReadThumbnailsSwitchToggled:(UISwitch *)sender {


### PR DESCRIPTION
Adds a **Hide Feed Descriptions** toggle to the subreddit list settings.

When on, it removes the description subtitles under the built-in feed rows — Home ("Posts from subscriptions"), Popular Posts ("Most popular posts across Reddit"), All Posts ("Posts across all subreddits"), and Moderator Posts ("Posts from moderated subreddits") — leaving just the title + icon. The rows compact to match. Off = stock look.

Lives in Settings → Apollo Reborn → Features → Subreddits, right alongside Subreddit List Enhancements / Modern Subreddit Dividers. It's deliberately **not** gated on the enhancements master, so it works the same in both the classic and modern/enhanced list styles — turn it on once and it applies to whichever style you're using.

### How it works
The four feed rows are the only rows in the list that use `ApolloSubtitleTableViewCell` (regular subreddit rows are a different cell class), and Apollo re-sets the title + description on every `cellForRowAt` pass. So the change hooks `tableView:cellForRowAtIndexPath:` on `RedditListViewController` and clears `detailTextLabel` after the original runs — that single intercept is both the row identifier and the mechanism, and it works in classic mode where the rest of the polish module is gated off. RedditListViewController self-sizes its rows, so clearing the subtitle before the sizing pass lets the row height collapse and the title re-center on its own.

Flipping the toggle refreshes any already-visible list via a small weak-table registry (the module's existing refresh helper couldn't be reused — it's gated on the enhancements master and only walks attached windows, so it misses a list sitting on a background tab). New defaults key, so settings search and backup/restore pick it up automatically.

### Also: pinned modern headers are transparent again
Second commit fixes a side effect of #453 that showed up while testing this: since that fix moved the modern surface fill from the scroll view onto each section header, a header pinned under the nav bar while scrolling became a solid opaque band covering the rows sliding beneath it — you'd lose the row behind FAVORITES instead of seeing the title + accent line float over it.

Fix: headers keep the opaque surface fill **at rest** (that's what fills the theme-mismatch gap #453 was solving, and it's invisible there since it matches the rows) but go **transparent while pinned**. The table repositions a pinning header exclusively through `setFrame:`, so a hook there flips the background exactly on the pin/unpin transitions. The scroll view stays uncoloured, so the actual #450 nav-glass fix is untouched, and classic mode never enters the path.

### Also: Enhancements off now reverts the list live (no relaunch)
Third commit fixes a long-standing quirk that surfaced while testing the above: turning the Subreddit List Enhancements master off left stale modern chrome (accent headers, gradient lines, hidden separators, the custom A–Z overlay, star proxies, widened margins) until the app relaunched — the refresh path was gated on the now-off master, and the persistent table tag kept the cell hooks re-styling reused cells.

Now every native value is captured once right before the suite first mutates it, and flipping the master off replays it all: table separator/margin/index chrome restored, custom A–Z overlay removed (native index back), star proxies stripped, header chrome un-styled, enhancement tag dropped (the #452 tap-highlight fix keeps working — it's meant to apply in classic too). Reused cells/headers coming out of the pools get cleaned on their next vend. The observer now drives a weak registry of known list tables instead of walking attached windows, so a list sitting on a background tab reverts too — and turning the master back on re-applies the full modern look live as well. Same live path covers the Modern Dividers sub-toggle.

### Also: classic A–Z letters stay above the header bands
Fourth commit: in classic mode the native section index letters were being covered by the opaque native header bands as they scrolled past (UIKit adds each floating header to the table's subviews after the index view). The letters are now re-raised above the headers whenever one lands on top — scoped to the subreddit list, no-op in modern mode (its native index is hidden behind the custom overlay anyway).

### Testing
Verified in the iOS 26 simulator (Liquid Glass), signed-in account:
- Modern list: descriptions hide/show live on toggle
- Classic list (enhancements off): same behavior, confirmed after a fresh relaunch too
- Restore works — turning the toggle back off brings the descriptions back
- The row stays present and functional with the enhancements master off
- Pinned FAVORITES/letter headers now show the rows scrolling beneath (title + accent line only); resting headers unchanged; un-pinning restores the fill; classic headers stay fully native
- Enhancements OFF from full modern → list goes clean native live, pixel-matching a fresh classic launch; back ON → full modern returns live; both without relaunching
- Classic: the A–Z index letters render over the FAVORITES/MODERATOR/letter bands instead of disappearing behind them; modern overlay unaffected

Default is off (no behavior change unless enabled).
