### PR TITLE
FIXED top/bottom edge fades going transparent during swipe-back on Liquid Glass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloPerPostCommentSort.xm \
     $(SRC_DIR)/ApolloLiquidGlass.xm \
     $(SRC_DIR)/ApolloTabBarTitles.xm \
+    $(SRC_DIR)/ApolloScrollEdgePopFix.xm \
     $(SRC_DIR)/ApolloLiquidGlassIconPicker.xm \
     $(SRC_DIR)/ApolloModmailLayout.xm \
     $(SRC_DIR)/ApolloAutoHideTabBar.xm \

--- a/src/ApolloNativeActionMenus.xm
+++ b/src/ApolloNativeActionMenus.xm
@@ -899,10 +899,47 @@ static id ApolloNativeActionMenuCompactMenuStyle(void) {
 }
 
 - (UITargetedPreview *)contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction previewForDismissingMenuWithConfiguration:(__unused UIContextMenuConfiguration *)configuration {
-    return [self contextMenuInteraction:interaction previewForHighlightingMenuWithConfiguration:configuration];
+    // Dismissal deliberately does NOT reuse the morph-view preview: UIKit
+    // snapshots that view and flies it from the collapsed menu's anchor back to
+    // the control's frame, so the "..." button visibly glides back into its row
+    // after every menu dismissal. Returning an invisible preview anchored on
+    // the proxy keeps the menu's own fade-out and lets the real control simply
+    // reappear in place (restored in willEndForConfiguration below) with no
+    // flight. Do not return nil here — nil makes UIKit fall back to the
+    // presentation (morph) preview and the glide comes back.
+    UIView *sourceView = self.sourceView;
+    if (!sourceView) return nil;
+
+    UIPreviewParameters *parameters = [UIPreviewParameters new];
+    parameters.backgroundColor = UIColor.clearColor;
+    parameters.visiblePath = [UIBezierPath bezierPathWithRect:CGRectZero];
+    SEL setAppliesShadowSelector = NSSelectorFromString(@"setAppliesShadow:");
+    if ([parameters respondsToSelector:setAppliesShadowSelector]) {
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(parameters, setAppliesShadowSelector, NO);
+    }
+    return [[UITargetedPreview alloc] initWithView:sourceView parameters:parameters];
 }
 
 - (void)contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction willEndForConfiguration:(__unused UIContextMenuConfiguration *)configuration animator:(id<UIContextMenuInteractionAnimating>)animator {
+    // The morph hid the real control for the menu's lifetime. With the
+    // dismissal preview above being invisible, nothing re-reveals it visually —
+    // restore it right as the dismissal starts so the button is sitting in its
+    // own row while the menu fades (idempotent with UIKit's own end-of-
+    // animation unhide bookkeeping).
+    UIView *morphSource = self.morphSourceView;
+    if (morphSource) {
+        UIView *morphView = morphSource;
+        SEL morphViewSelector = NSSelectorFromString(@"_morphView");
+        if ([morphSource respondsToSelector:morphViewSelector]) {
+            UIView *resolved = ((id (*)(id, SEL))objc_msgSend)(morphSource, morphViewSelector);
+            if (resolved) morphView = resolved;
+        }
+        for (UIView *restore in @[morphView, morphSource]) {
+            if (restore.hidden) restore.hidden = NO;
+            if (restore.alpha < 0.999) restore.alpha = 1.0;
+        }
+    }
+
     UIView *sourceView = self.sourceView;
     UIContextMenuInteraction *menuInteraction = self.interaction;
     if (!sourceView || !menuInteraction) return;

--- a/src/ApolloScrollEdgePopFix.xm
+++ b/src/ApolloScrollEdgePopFix.xm
@@ -39,10 +39,36 @@
 // Nothing is blocked, frozen, or hidden from UIKit, and Apollo's animator and swipe gesture
 // are untouched.
 //
-// KNOWN REMAINING ISSUE: on a cancelled gesture (drag a little, let go) the top band still
-// flicks see-through for a moment as the view snaps back. The bottom edge is unaffected. See
-// the PR description for the full list of what has already been ruled out — in particular the
-// nav bar's element rect never collapses, and clamping it does nothing.
+// THE CANCELLED-GESTURE FLICK (solved; mechanism confirmed against decompiled UIKitCore 23B85)
+// On a cancelled swipe the top band used to flick fully see-through for ~6 frames while every
+// effect view read alpha=1/opacity=1/no animations. Cause: `cancelInteractiveTransition` kicks
+// off a short layout storm — UINavigationBar's _cancelInteractiveTransition tears down and
+// rebuilds the transient item's title/button views (which are themselves pocket ELEMENTS), and
+// every snap-back frame-set fires _UIScrollPocketRegistrationInteraction geometry invalidation,
+// zeroing the stored pocket rects and element frame caches. Each ensuing layout pass then
+// recomputes pocket state from mid-flight model geometry:
+//   - -[UIScrollView _updatePockets] → updatePocket:… can remove/hide the pocket AND its
+//     backgroundCapture (the captureOnly CABackdropLayer at the BACK of the scroll content
+//     whose texture the dim band replays by group name — kill it and the replay renders
+//     transparent while its own properties stay nominal);
+//   - ScrollEdgeEffectView.layoutSubviews rebuilds the PocketMask's ShadowLayer pool from
+//     freshly-converted element rects; with the bar content mid-teardown those come out
+//     empty/displaced, so the blur (which is masked BY NAME via a portal of PocketMask) and
+//     the dim composite to nothing — no alpha involved anywhere, which is why every previous
+//     alpha-side probe and clamp came back clean.
+// Only the top edge has these extra kill switches (bar-height-mismatch → zero element rect,
+// the bar visibility _setActive: gate, and the bar-content element teardown); the bottom band
+// doesn't even use the capture/replay pair. Hence "bottom is fine, top flicks".
+//
+// The fix: while the transition is in flight, FREEZE the pocket recompute for the outgoing
+// subtree — no-op -[UIScrollView _updatePockets] and -[ScrollEdgeEffectView layoutSubviews]
+// for the outgoing controller's scroll views. The pocket state is correct the moment the
+// transition starts, every input UIKit would recompute from during the storm is garbage, and
+// the correct result of every one of those passes is "nothing changes" — so skipping them is
+// exact, not approximate. On transition end the frozen views get setNeedsLayout and UIKit
+// resettles everything itself from clean geometry. (Earlier attempts froze ONLY
+// _updatePockets and still flickered — the mask rebuild in layoutSubviews was the unpatched
+// half of the storm.)
 
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
@@ -57,6 +83,9 @@
 static const NSUInteger kApolloEdgeTop = 1;
 static const NSUInteger kApolloEdgeBottom = 4;
 
+// UIKit.ScrollEdgeEffectView, resolved once in the ctor (Swift-side class).
+static Class sScrollEdgeEffectViewClass;
+
 // Non-zero while at least one navigation transition is running.
 static NSUInteger sTransitionsInFlight;
 
@@ -66,6 +95,24 @@ static NSUInteger sTransitionGeneration;
 
 // Scroll views we redirected, held weakly, so the override is always cleared afterwards.
 static NSHashTable<UIScrollView *> *sRedirectedScrollViews;
+
+// Scroll views whose pocket recompute is frozen for the duration of the transition. Weak, and
+// only consulted while sTransitionsInFlight is non-zero, so a stale entry can never freeze
+// anything outside a transition window.
+static NSHashTable<UIScrollView *> *sFrozenScrollViews;
+
+static BOOL ApolloEdgePocketsFrozenFor(UIScrollView *scrollView) {
+    return sTransitionsInFlight > 0 && scrollView && [sFrozenScrollViews containsObject:scrollView];
+}
+
+// An effect view lives in a touch-passthrough container directly inside its scroll view; walk
+// up until we hit one.
+static UIScrollView *ApolloEdgeOwningScrollView(UIView *view) {
+    for (UIView *v = view.superview; v; v = v.superview) {
+        if ([v isKindOfClass:[UIScrollView class]]) return (UIScrollView *)v;
+    }
+    return nil;
+}
 
 static void ApolloEdgeCollectScrollViews(UIView *view, NSMutableArray<UIScrollView *> *out) {
     if ([view isKindOfClass:[UIScrollView class]]) [out addObject:(UIScrollView *)view];
@@ -79,6 +126,7 @@ static void ApolloEdgeRedirectGeometry(UIView *outgoingView, UIView *stableView)
         [scrollView _setOverrideGeometryView:stableView forEdge:kApolloEdgeTop];
         [scrollView _setOverrideGeometryView:stableView forEdge:kApolloEdgeBottom];
         [sRedirectedScrollViews addObject:scrollView];
+        [sFrozenScrollViews addObject:scrollView];
     }
 }
 
@@ -95,6 +143,20 @@ static void ApolloEdgeEndTransition(NSUInteger generation) {
         [scrollView _setOverrideGeometryView:nil forEdge:kApolloEdgeBottom];
     }
     [sRedirectedScrollViews removeAllObjects];
+    // Unfreeze and let UIKit resettle the pocket stack itself from clean, settled geometry —
+    // one recompute with correct inputs replaces the storm of recomputes with garbage inputs.
+    for (UIScrollView *scrollView in sFrozenScrollViews) {
+        [scrollView setNeedsLayout];
+        for (UIView *container in scrollView.subviews) {
+            for (UIView *sub in container.subviews) {
+                if ([sub isKindOfClass:sScrollEdgeEffectViewClass]) {
+                    [container setNeedsLayout];
+                    [sub setNeedsLayout];
+                }
+            }
+        }
+    }
+    [sFrozenScrollViews removeAllObjects];
 }
 
 // Re-arms for as long as the navigation controller still reports a live transition, so a held
@@ -145,6 +207,31 @@ static void ApolloEdgeBeginTransition(UINavigationController *nav, UIViewControl
 
 %group ScrollEdgePopFix
 
+// The pocket recompute entry point, run on every scroll-view layout pass. During the cancel
+// storm it re-derives pocket existence/visibility/frames from mid-flight model geometry and
+// can remove or hide the pocket and its backgroundCapture. Frozen views skip it wholesale.
+%hook UIScrollView
+
+- (void)_updatePockets {
+    if (ApolloEdgePocketsFrozenFor(self)) return;
+    %orig;
+}
+
+%end
+
+// ScrollEdgeEffectView.layoutSubviews rebuilds the PocketMask ShadowLayer pool (the blur's
+// mask, referenced by the blur filter BY NAME) and the luma subrect from live model-space
+// conversions. With the nav bar's transient content mid-teardown those rebuilds come out
+// empty, which blanks the band without touching any alpha. Same freeze, same window.
+%hook ScrollEdgeEffectView
+
+- (void)layoutSubviews {
+    if (ApolloEdgePocketsFrozenFor(ApolloEdgeOwningScrollView(self))) return;
+    %orig;
+}
+
+%end
+
 %hook UINavigationController
 
 - (UIViewController *)popViewControllerAnimated:(BOOL)animated {
@@ -182,14 +269,21 @@ static void ApolloEdgeBeginTransition(UINavigationController *nav, UIViewControl
 %ctor {
     if (!IsLiquidGlass()) return;
 
-    // Everything rests on this private hook; without it stay inert rather than reaching for a
-    // cruder lever that lies to UIKit about its own view hierarchy.
-    if (![UIScrollView instancesRespondToSelector:@selector(_setOverrideGeometryView:forEdge:)]) {
-        ApolloLog(@"[ScrollEdgePopFix] -[UIScrollView _setOverrideGeometryView:forEdge:] missing; fix inactive");
+    // Everything rests on these private hooks; without them stay inert rather than reaching
+    // for a cruder lever that lies to UIKit about its own view hierarchy.
+    if (![UIScrollView instancesRespondToSelector:@selector(_setOverrideGeometryView:forEdge:)] ||
+        ![UIScrollView instancesRespondToSelector:@selector(_updatePockets)]) {
+        ApolloLog(@"[ScrollEdgePopFix] UIScrollView pocket SPI missing; fix inactive");
+        return;
+    }
+    sScrollEdgeEffectViewClass = objc_getClass("UIKit.ScrollEdgeEffectView");
+    if (!sScrollEdgeEffectViewClass) {
+        ApolloLog(@"[ScrollEdgePopFix] UIKit.ScrollEdgeEffectView missing; fix inactive");
         return;
     }
 
     sRedirectedScrollViews = [NSHashTable weakObjectsHashTable];
-    %init(ScrollEdgePopFix);
-    ApolloLog(@"[ScrollEdgePopFix] hook installed (pocket geometry redirected during nav transitions)");
+    sFrozenScrollViews = [NSHashTable weakObjectsHashTable];
+    %init(ScrollEdgePopFix, ScrollEdgeEffectView = sScrollEdgeEffectViewClass);
+    ApolloLog(@"[ScrollEdgePopFix] hook installed (pocket recompute frozen + geometry redirected during nav transitions)");
 }

--- a/src/ApolloScrollEdgePopFix.xm
+++ b/src/ApolloScrollEdgePopFix.xm
@@ -1,110 +1,140 @@
-// ApolloScrollEdgePopFix — keep Liquid Glass scroll-edge fades alive during the
-// interactive swipe-back gesture.
+// ApolloScrollEdgePopFix — keep the Liquid Glass scroll-edge fades alive across navigation
+// transitions.
 //
-// On iOS 26, UIKit masks content scrolled under the floating nav pills (and above
-// the bottom bar/home-indicator pocket) with per-scroll-view `UIKit.ScrollEdgeEffectView`
-// layers (progressive blur + dimming backdrop). The moment an interactive pop begins,
-// UIKit's transition code fades the OUTGOING view's edge-effect views to alpha 0 —
-// on a stock pre-26 app the opaque bar background hides that, but Apollo's glass
-// build has no bar background (the tweak hides Apollo's own statusBarBackgroundView
-// strip on Liquid Glass), so the instant you start a swipe-back every row scrolled
-// under the top pills and the bottom pocket flashes fully readable, then snaps back
-// when the gesture is released. Verified via view-hierarchy dumps: mid-gesture the
-// outgoing table's top ScrollEdgeEffectView is alpha=0.00, at rest alpha=1.00,
-// with everything else (hidden flags, subview stack) unchanged.
+// THE SYMPTOM
+// On iOS 26 the blurred/dimmed bands that mask content scrolling under the floating nav
+// pills (top) and above the bottom bar pocket vanish the moment a navigation pop starts —
+// whether you drag the swipe-back gesture (even a small drag-and-hold that never commits)
+// or just tap the back button. For the whole slide the outgoing screen renders raw text
+// over the status bar and under the bottom edge, then snaps back to normal once it settles.
 //
-// Fix: while the view's navigation controller is running an INTERACTIVE transition
-// (or its interactive pop gesture is actively tracking), refuse alpha writes below 1
-// on ScrollEdgeEffectView instances that belong to that navigation stack. UIKit
-// re-syncs the alpha itself once the gesture ends, on both the cancel and the
-// completion path, so there is nothing to restore afterwards.
+// THE MECHANISM (measured in the simulator, not inferred)
+// Each scroll view gets its edge effects from a `_UIScrollEdgeEffectViewInteraction`, which
+// parks the `UIKit.ScrollEdgeEffectView`s in a container view inside the scroll view. That
+// interaction recomputes its "pocket" geometry on every layout pass, and when the resulting
+// rect comes out empty it does not fade the effect — it *detaches the container outright*
+// (`updatePocket:contentRect:velocity:isTracking:shouldAnimateVisibility:` -> removeFromSuperview).
 //
-// The class is Swift ("UIKit.ScrollEdgeEffectView" at runtime, no ObjC header), so
-// the hook binds through %init(ClassName=objc_getClass(...)) instead of a static
-// Logos class token.
+// A pop sets the outgoing view controller's view frame to its final off-screen position
+// immediately and animates the layer from there (this is how UIKit animates, interactive or
+// not). The next layout pass therefore computes an empty pocket rect and tears the effects
+// down — while the layer is still mid-slide and fully visible for another ~300ms. Per-frame
+// instrumentation of the outgoing VC:
+//
+//     t=0.013  frame=(0,0 402x874)    effects=4
+//     t=0.060  frame=(402,0 402x874)  effects=0   <- still on screen, effects already gone
+//
+// This is why the previous approach (clamping `-[ScrollEdgeEffectView setAlpha:]` to 1 while
+// a swipe-back looked to be in progress) could never work: the clamp fired, but alpha was
+// never the lever. The views were being removed from the hierarchy, and the `alpha=0` that
+// approach chased belonged to the *incoming* controller, where 0 is correct — that feed sits
+// at scroll-top with nothing to mask. Forcing it to 1 risked a phantom dim band.
+//
+// THE FIX
+// While a navigation transition is in flight, refuse to let a pocket container be detached
+// from a scroll view that is still in a window. UIKit retries on later layout passes (a
+// handful of times, not per frame), and once the transition completes we stop refusing and
+// nudge the affected scroll views to lay out, so UIKit settles the state itself.
+//
+// Keeping UIKit's own effect views alive means the masking during the slide is the real
+// thing — no material to match, no colour to tune, nothing that can drift from the system
+// look on a future iOS.
 
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #import "ApolloCommon.h"
 
-// Placeholder interface for the Swift class; the real Class is supplied at %init.
-@interface ApolloScrollEdgeEffectView : UIView
-@end
+// Resolved once at %ctor; nil on anything that isn't iOS 26 Liquid Glass.
+static Class sEdgeEffectViewClass;
 
-// Resolve the navigation controller whose stack hosts `view`, walking the FULL
-// responder chain for the UINavigationController itself rather than trusting a
-// view controller's parent link: popViewController severs the outgoing VC's
-// navigationController reference immediately, while UIKit keeps writing to that
-// VC's edge-effect views on every frame of the interactive transition — the nav
-// controller is still in the popped view's responder chain via the transition
-// container (UIViewControllerWrapperView -> UINavigationTransitionView ->
-// UILayoutContainerView -> UINavigationController), so the chain walk keeps
-// working exactly when the parent link does not.
-static UINavigationController *ApolloEdgeFixNavControllerForView(UIView *view) {
-    UINavigationController *fallback = nil;
-    UIResponder *responder = view;
-    while ((responder = responder.nextResponder)) {
-        if ([responder isKindOfClass:[UINavigationController class]]) {
-            return (UINavigationController *)responder;
-        }
-        if (!fallback && [responder isKindOfClass:[UIViewController class]]) {
-            fallback = ((UIViewController *)responder).navigationController;
-        }
+// Non-zero while at least one navigation transition is running. Checked first on the
+// (very hot) removeFromSuperview path, so the cost off-transition is one load + branch.
+static NSUInteger sTransitionsInFlight;
+
+// Bumped every time the count drops to zero, so a late safety timeout can tell whether the
+// transition it was armed for is still the current one.
+static NSUInteger sTransitionGeneration;
+
+// Scroll views whose pocket container we refused to detach, held weakly — after the
+// transition they need one layout pass for UIKit to reach the right answer on its own.
+static NSHashTable<UIScrollView *> *sProtectedScrollViews;
+
+static void ApolloEdgeArmSafetyTimeout(UINavigationController *nav, NSUInteger generation);
+
+static void ApolloEdgeEndTransition(NSUInteger generation) {
+    if (generation != sTransitionGeneration || sTransitionsInFlight == 0) return;
+    if (--sTransitionsInFlight > 0) return;
+
+    sTransitionGeneration++;
+    // Let UIKit re-derive pocket state now that we are no longer interfering. Whatever it
+    // decides (keep them, drop them) is correct once the geometry has settled.
+    for (UIScrollView *scrollView in sProtectedScrollViews) {
+        [scrollView setNeedsLayout];
     }
-    return fallback;
+    [sProtectedScrollViews removeAllObjects];
 }
 
-// YES while the navigation controller hosting `view` is mid interactive pop —
-// either the transition coordinator reports an interactive transition, or the
-// system edge-pan recognizer is actively tracking (Began/Changed covers the
-// window before the coordinator exists).
-static BOOL ApolloEdgeFixInteractivePopInFlight(UIView *view) {
-    UINavigationController *nav = ApolloEdgeFixNavControllerForView(view);
-    if (!nav) return NO;
+// Re-arms itself for as long as the navigation controller still reports a live transition,
+// so a held gesture stays protected while a genuinely finished one always gets released.
+static void ApolloEdgeArmSafetyTimeout(UINavigationController *nav, NSUInteger generation) {
+    __weak UINavigationController *weakNav = nav;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        if (generation != sTransitionGeneration || sTransitionsInFlight == 0) return;
+        UINavigationController *strongNav = weakNav;
+        if (strongNav && strongNav.transitionCoordinator) {
+            ApolloEdgeArmSafetyTimeout(strongNav, generation);   // still being dragged
+            return;
+        }
+        ApolloEdgeEndTransition(generation);
+    });
+}
+
+static void ApolloEdgeBeginTransition(UINavigationController *nav) {
+    sTransitionsInFlight++;
+    NSUInteger generation = sTransitionGeneration;
 
     id<UIViewControllerTransitionCoordinator> coordinator = nav.transitionCoordinator;
-    if (coordinator && coordinator.interactive) return YES;
+    if (coordinator) {
+        // Fires for completed AND cancelled transitions, which is exactly the lifetime we want.
+        [coordinator animateAlongsideTransition:nil
+                                     completion:^(id<UIViewControllerTransitionCoordinatorContext> ctx) {
+            ApolloEdgeEndTransition(generation);
+        }];
+    } else {
+        // Non-animated navigation: nothing to protect beyond this turn of the runloop.
+        dispatch_async(dispatch_get_main_queue(), ^{ ApolloEdgeEndTransition(generation); });
+    }
 
-    UIGestureRecognizerState state = nav.interactivePopGestureRecognizer.state;
-    return state == UIGestureRecognizerStateBegan || state == UIGestureRecognizerStateChanged;
+    // Safety net: a stuck counter would suppress legitimate pocket teardown app-wide, so a
+    // transition must never be able to protect views forever. It re-arms rather than firing
+    // blind, because holding the swipe-back gesture part-way — exactly what this fix is for —
+    // legitimately keeps a transition open for as long as the user cares to hold it.
+    ApolloEdgeArmSafetyTimeout(nav, generation);
 }
 
-// The interactive-pop preflight phase (small drag that never commits the pop)
-// runs with NO transition coordinator, the pop recognizer still in Possible, and
-// UIKit tearing down + recreating the edge-effect views already at alpha 0 — so
-// navigation-state checks alone cannot see it. A screen-edge touch brackets that
-// whole phase exactly: track touches that BEGAN in the horizontal edge zones at
-// the window level, and treat "edge touch down (plus a short settle grace after
-// lift)" as swipe-back-possibly-in-progress.
-static NSMutableSet *sApolloEdgeTouches;
-static CFTimeInterval sApolloEdgeTouchLastEnd;
-
-static BOOL ApolloEdgeFixEdgeTouchActive(void) {
-    if (sApolloEdgeTouches.count > 0) return YES;
-    return (CACurrentMediaTime() - sApolloEdgeTouchLastEnd) < 0.6;
+// A pocket container is any view holding ScrollEdgeEffectViews directly. Pointer compare
+// against the resolved Class rather than a string compare — this runs on a hot path.
+static BOOL ApolloEdgeIsPocketContainer(UIView *view) {
+    for (UIView *subview in view.subviews) {
+        if (object_getClass(subview) == sEdgeEffectViewClass) return YES;
+    }
+    return NO;
 }
 
 %group ScrollEdgePopFix
 
-%hook UIWindow
+%hook UIView
 
-- (void)sendEvent:(UIEvent *)event {
-    if (event.type == UIEventTypeTouches) {
-        for (UITouch *touch in event.allTouches) {
-            if (touch.phase == UITouchPhaseBegan) {
-                CGPoint point = [touch locationInView:self];
-                CGFloat width = self.bounds.size.width;
-                if (point.x <= 40.0 || point.x >= width - 40.0) {
-                    if (!sApolloEdgeTouches) sApolloEdgeTouches = [NSMutableSet new];
-                    [sApolloEdgeTouches addObject:[NSValue valueWithNonretainedObject:touch]];
-                }
-            } else if (touch.phase == UITouchPhaseEnded || touch.phase == UITouchPhaseCancelled) {
-                NSValue *key = [NSValue valueWithNonretainedObject:touch];
-                if ([sApolloEdgeTouches containsObject:key]) {
-                    [sApolloEdgeTouches removeObject:key];
-                    if (sApolloEdgeTouches.count == 0) sApolloEdgeTouchLastEnd = CACurrentMediaTime();
-                }
-            }
+- (void)removeFromSuperview {
+    if (sTransitionsInFlight > 0) {
+        UIView *superview = self.superview;
+        // Only interfere while the scroll view is genuinely still on screen. A view that has
+        // left the window is being torn down for real and must be allowed to go.
+        if ([superview isKindOfClass:[UIScrollView class]] && superview.window &&
+            ApolloEdgeIsPocketContainer(self)) {
+            [sProtectedScrollViews addObject:(UIScrollView *)superview];
+            return;
         }
     }
     %orig;
@@ -112,31 +142,32 @@ static BOOL ApolloEdgeFixEdgeTouchActive(void) {
 
 %end
 
+%hook UINavigationController
 
-%hook ApolloScrollEdgeEffectView
-
-- (void)setAlpha:(CGFloat)alpha {
-    UIView *effectView = (UIView *)self;
-    if (alpha < 0.999 &&
-        (ApolloEdgeFixInteractivePopInFlight(effectView) || ApolloEdgeFixEdgeTouchActive())) {
-        static BOOL sLoggedOnce = NO;
-        if (!sLoggedOnce) {
-            sLoggedOnce = YES;
-            ApolloLog(@"[ScrollEdgePopFix] Blocked scroll-edge fade-out (alpha %.2f) during swipe-back", (double)alpha);
-        }
-        %orig(1.0);
-        return;
-    }
-    %orig;
+- (UIViewController *)popViewControllerAnimated:(BOOL)animated {
+    UIViewController *popped = %orig;
+    // Covers the back button, programmatic pops, AND the interactive swipe-back — UIKit
+    // routes the gesture through here too, the moment the drag is recognised.
+    if (popped) ApolloEdgeBeginTransition(self);
+    return popped;
 }
 
-- (void)didMoveToWindow {
+- (NSArray<UIViewController *> *)popToViewController:(UIViewController *)viewController animated:(BOOL)animated {
+    NSArray<UIViewController *> *popped = %orig;
+    if (popped.count) ApolloEdgeBeginTransition(self);
+    return popped;
+}
+
+- (NSArray<UIViewController *> *)popToRootViewControllerAnimated:(BOOL)animated {
+    NSArray<UIViewController *> *popped = %orig;
+    if (popped.count) ApolloEdgeBeginTransition(self);
+    return popped;
+}
+
+// A push slides the outgoing screen partway off to the left, so it has the same exposure.
+- (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated {
     %orig;
-    UIView *effectView = (UIView *)self;
-    if (effectView.window && effectView.alpha < 0.999 &&
-        (ApolloEdgeFixInteractivePopInFlight(effectView) || ApolloEdgeFixEdgeTouchActive())) {
-        effectView.alpha = 1.0;
-    }
+    if (animated) ApolloEdgeBeginTransition(self);
 }
 
 %end
@@ -145,11 +176,14 @@ static BOOL ApolloEdgeFixEdgeTouchActive(void) {
 
 %ctor {
     if (!IsLiquidGlass()) return;
-    Class effectViewClass = objc_getClass("UIKit.ScrollEdgeEffectView");
-    if (!effectViewClass) {
-        ApolloLog(@"[ScrollEdgePopFix] UIKit.ScrollEdgeEffectView class missing; fix inactive");
+
+    sEdgeEffectViewClass = objc_getClass("UIKit.ScrollEdgeEffectView");
+    if (!sEdgeEffectViewClass) {
+        ApolloLog(@"[ScrollEdgePopFix] UIKit.ScrollEdgeEffectView missing; fix inactive");
         return;
     }
-    %init(ScrollEdgePopFix, ApolloScrollEdgeEffectView = effectViewClass);
-    ApolloLog(@"[ScrollEdgePopFix] hook installed on UIKit.ScrollEdgeEffectView");
+
+    sProtectedScrollViews = [NSHashTable weakObjectsHashTable];
+    %init(ScrollEdgePopFix);
+    ApolloLog(@"[ScrollEdgePopFix] hook installed (pocket containers held through nav transitions)");
 }

--- a/src/ApolloScrollEdgePopFix.xm
+++ b/src/ApolloScrollEdgePopFix.xm
@@ -1,0 +1,99 @@
+// ApolloScrollEdgePopFix — keep Liquid Glass scroll-edge fades alive during the
+// interactive swipe-back gesture.
+//
+// On iOS 26, UIKit masks content scrolled under the floating nav pills (and above
+// the bottom bar/home-indicator pocket) with per-scroll-view `UIKit.ScrollEdgeEffectView`
+// layers (progressive blur + dimming backdrop). The moment an interactive pop begins,
+// UIKit's transition code fades the OUTGOING view's edge-effect views to alpha 0 —
+// on a stock pre-26 app the opaque bar background hides that, but Apollo's glass
+// build has no bar background (the tweak hides Apollo's own statusBarBackgroundView
+// strip on Liquid Glass), so the instant you start a swipe-back every row scrolled
+// under the top pills and the bottom pocket flashes fully readable, then snaps back
+// when the gesture is released. Verified via view-hierarchy dumps: mid-gesture the
+// outgoing table's top ScrollEdgeEffectView is alpha=0.00, at rest alpha=1.00,
+// with everything else (hidden flags, subview stack) unchanged.
+//
+// Fix: while the view's navigation controller is running an INTERACTIVE transition
+// (or its interactive pop gesture is actively tracking), refuse alpha writes below 1
+// on ScrollEdgeEffectView instances that belong to that navigation stack. UIKit
+// re-syncs the alpha itself once the gesture ends, on both the cancel and the
+// completion path, so there is nothing to restore afterwards.
+//
+// The class is Swift ("UIKit.ScrollEdgeEffectView" at runtime, no ObjC header), so
+// the hook binds through %init(ClassName=objc_getClass(...)) instead of a static
+// Logos class token.
+
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import "ApolloCommon.h"
+
+// Placeholder interface for the Swift class; the real Class is supplied at %init.
+@interface ApolloScrollEdgeEffectView : UIView
+@end
+
+// Resolve the view controller a (candidate) edge-effect view renders for, walking
+// the responder chain. Returns nil when the view is not attached to a VC.
+static UIViewController *ApolloEdgeFixOwningViewController(UIView *view) {
+    UIResponder *responder = view;
+    while ((responder = responder.nextResponder)) {
+        if ([responder isKindOfClass:[UIViewController class]]) {
+            return (UIViewController *)responder;
+        }
+        if ([responder isKindOfClass:[UIWindow class]]) break;
+    }
+    return nil;
+}
+
+// YES while the navigation controller owning `view` is mid interactive pop —
+// either the transition coordinator reports an interactive transition, or the
+// system edge-pan recognizer is actively tracking (Began/Changed covers the
+// window before the coordinator exists).
+static BOOL ApolloEdgeFixInteractivePopInFlight(UIView *view) {
+    UIViewController *owner = ApolloEdgeFixOwningViewController(view);
+    if (!owner) return NO;
+
+    UINavigationController *nav = owner.navigationController;
+    if (!nav && [owner isKindOfClass:[UINavigationController class]]) {
+        nav = (UINavigationController *)owner;
+    }
+    if (!nav) return NO;
+
+    id<UIViewControllerTransitionCoordinator> coordinator = nav.transitionCoordinator;
+    if (coordinator && coordinator.interactive) return YES;
+
+    UIGestureRecognizerState state = nav.interactivePopGestureRecognizer.state;
+    return state == UIGestureRecognizerStateBegan || state == UIGestureRecognizerStateChanged;
+}
+
+%group ScrollEdgePopFix
+
+%hook ApolloScrollEdgeEffectView
+
+- (void)setAlpha:(CGFloat)alpha {
+    UIView *effectView = (UIView *)self;
+    if (alpha < 0.999 && effectView.superview && ApolloEdgeFixInteractivePopInFlight(effectView)) {
+        static BOOL sLoggedOnce = NO;
+        if (!sLoggedOnce) {
+            sLoggedOnce = YES;
+            ApolloLog(@"[ScrollEdgePopFix] Blocked scroll-edge fade-out (alpha %.2f) during interactive pop", (double)alpha);
+        }
+        %orig(1.0);
+        return;
+    }
+    %orig;
+}
+
+%end
+
+%end
+
+%ctor {
+    if (!IsLiquidGlass()) return;
+    Class effectViewClass = objc_getClass("UIKit.ScrollEdgeEffectView");
+    if (!effectViewClass) {
+        ApolloLog(@"[ScrollEdgePopFix] UIKit.ScrollEdgeEffectView class missing; fix inactive");
+        return;
+    }
+    %init(ScrollEdgePopFix, ApolloScrollEdgeEffectView = effectViewClass);
+    ApolloLog(@"[ScrollEdgePopFix] hook installed on UIKit.ScrollEdgeEffectView");
+}

--- a/src/ApolloScrollEdgePopFix.xm
+++ b/src/ApolloScrollEdgePopFix.xm
@@ -2,84 +2,84 @@
 // transitions.
 //
 // THE SYMPTOM
-// On iOS 26 the blurred/dimmed bands that mask content scrolling under the floating nav
-// pills (top) and above the bottom bar pocket vanish the moment a navigation pop starts —
-// whether you drag the swipe-back gesture (even a small drag-and-hold that never commits)
-// or just tap the back button. For the whole slide the outgoing screen renders raw text
-// over the status bar and under the bottom edge, then snaps back to normal once it settles.
+// On iOS 26 the blurred/dimmed bands that mask content scrolling under the floating nav pills
+// (top) and above the bottom bar pocket vanish for the whole of a swipe-back — every row
+// scrolled under the bar becomes crisp readable text over the status bar until the gesture
+// resolves. Same on a plain back-button tap.
 //
-// THE MECHANISM (measured in the simulator, not inferred)
-// Each scroll view gets its edge effects from a `_UIScrollEdgeEffectViewInteraction`, which
-// parks the `UIKit.ScrollEdgeEffectView`s in a container view inside the scroll view. That
-// interaction recomputes its "pocket" geometry on every layout pass, and when the resulting
-// rect comes out empty it does not fade the effect — it *detaches the container outright*
-// (`updatePocket:contentRect:velocity:isTracking:shouldAnimateVisibility:` -> removeFromSuperview).
+// THE CAUSE (measured, and confirmed by experiment)
+// Apollo does not use UIKit's navigation transition. ApolloNavigationController vends its own
+// `ApolloNavigationAnimator`, which sets the view controllers' FRAMES directly — parking the
+// outgoing view at its final off-screen position within ~76ms of touch-down while the layer
+// animates across from there. Per-frame sampling of the outgoing controller, window space:
 //
-// A pop sets the outgoing view controller's view frame to its final off-screen position
-// immediately and animates the layer from there (this is how UIKit animates, interactive or
-// not). The next layout pass therefore computes an empty pocket rect and tears the effects
-// down — while the layer is still mid-slide and fully visible for another ~300ms. Per-frame
-// instrumentation of the outgoing VC:
+//     t=0.001  scroller x=0        t=0.076  x=402   (parked, still visibly mid-slide)
+//     t=0.678  x=-134              t=0.742  x=0
 //
-//     t=0.013  frame=(0,0 402x874)    effects=4
-//     t=0.060  frame=(402,0 402x874)  effects=0   <- still on screen, effects already gone
+// UIKit derives scroll-edge pocket geometry from that model frame. It sees a scroll view
+// sitting off-screen, concludes the mask is unnecessary, and detaches it — while the content
+// is still on screen. Confirmed by experiment: making the navigation controller decline
+// Apollo's animator (so UIKit runs its own transition) removes the artifact entirely. That is
+// not a shippable fix, because `interactionControllerForAnimationController:` is only
+// consulted when an animator was vended, so declining it also disables Apollo's interactive
+// driver and the pop fires the instant you touch the edge instead of tracking your finger.
 //
-// This is why the previous approach (clamping `-[ScrollEdgeEffectView setAlpha:]` to 1 while
-// a swipe-back looked to be in progress) could never work: the clamp fired, but alpha was
-// never the lever. The views were being removed from the hierarchy, and the `alpha=0` that
-// approach chased belonged to the *incoming* controller, where 0 is correct — that feed sits
-// at scroll-top with nothing to mask. Forcing it to 1 risked a phantom dim band.
+// Note this is NOT an alpha fade. Earlier revisions of this fix clamped
+// `-[ScrollEdgeEffectView setAlpha:]`; the clamp verifiably fired and the mask still
+// disappeared. The views are removed, not faded — and the `alpha=0` that approach chased
+// belongs to the *incoming* controller, where 0 is correct because that feed sits at
+// scroll-top with nothing to mask.
 //
 // THE FIX
-// While a navigation transition is in flight, refuse to let a pocket container be detached
-// from a scroll view that is still in a window, *and that belongs to the view sliding off
-// screen*. UIKit retries on later layout passes (a handful of times, not per frame), and
-// once the transition completes we stop refusing and nudge the affected scroll views to lay
-// out, so UIKit settles the state itself.
+// While a transition is in flight, point the outgoing controller's scroll views at a geometry
+// reference that isn't being moved, using UIKit's own hook for exactly this:
+// `-[UIScrollView _setOverrideGeometryView:forEdge:]`. UIKit keeps full ownership of the
+// pocket — it keeps updating and positioning it — and simply measures against the navigation
+// controller's view, which stays put, instead of a frame Apollo has already parked off-screen.
+// Nothing is blocked, frozen, or hidden from UIKit, and Apollo's animator and swipe gesture
+// are untouched.
 //
-// Restricting this to the outgoing view matters. Protecting every scroll view during the
-// transition also blocks removals UIKit wanted on the *incoming* side, which desyncs its
-// pocket bookkeeping — that view then rebuilds its pocket once it settles, and the rebuild
-// shows up as a one-frame flash of unmasked content exactly as the transition lands.
-// Measured over the landing frames, band y=150..340: with the incoming side protected the
-// edge sharpness spikes 26.7 -> 33.4 and decays over ~5 frames; leaving it alone holds flat
-// at 22.3-22.9 (under 3%, i.e. noise).
-//
-// Keeping UIKit's own effect views alive means the masking during the slide is the real
-// thing — no material to match, no colour to tune, nothing that can drift from the system
-// look on a future iOS.
+// KNOWN REMAINING ISSUE: on a cancelled gesture (drag a little, let go) the top band still
+// flicks see-through for a moment as the view snaps back. The bottom edge is unaffected. See
+// the PR description for the full list of what has already been ruled out — in particular the
+// nav bar's element rect never collapses, and clamping it does nothing.
 
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #import "ApolloCommon.h"
 
-// Resolved once at %ctor; nil on anything that isn't iOS 26 Liquid Glass.
-static Class sEdgeEffectViewClass;
+@interface UIScrollView (ApolloScrollEdgePocket)
+- (void)_setOverrideGeometryView:(UIView *)view forEdge:(NSUInteger)edge;
+@end
 
-// Non-zero while at least one navigation transition is running. Checked first on the
-// (very hot) removeFromSuperview path, so the cost off-transition is one load + branch.
+// Edge selectors, matching UIKit's own mask (`[topEdgeEffect setHidden:edges & 1]`) and the
+// `edge` ivar observed on live effect views: 1 = top, 4 = bottom.
+static const NSUInteger kApolloEdgeTop = 1;
+static const NSUInteger kApolloEdgeBottom = 4;
+
+// Non-zero while at least one navigation transition is running.
 static NSUInteger sTransitionsInFlight;
 
-// Bumped every time the count drops to zero, so a late safety timeout can tell whether the
+// Bumped whenever the count drops to zero, so a late safety timeout can tell whether the
 // transition it was armed for is still the current one.
 static NSUInteger sTransitionGeneration;
 
-// Scroll views whose pocket container we refused to detach, held weakly — after the
-// transition they need one layout pass for UIKit to reach the right answer on its own.
-static NSHashTable<UIScrollView *> *sProtectedScrollViews;
+// Scroll views we redirected, held weakly, so the override is always cleared afterwards.
+static NSHashTable<UIScrollView *> *sRedirectedScrollViews;
 
-// The views actually sliding OFF screen, held weakly. Protection is limited to these:
-// the incoming controller must be left entirely alone. Blocking a removal UIKit wanted on
-// the incoming side desyncs its pocket bookkeeping, so when that view settles it rebuilds
-// the pocket from scratch — which reads as a one-frame flash of unmasked content right as
-// the transition lands.
-static NSHashTable<UIView *> *sOutgoingViews;
+static void ApolloEdgeCollectScrollViews(UIView *view, NSMutableArray<UIScrollView *> *out) {
+    if ([view isKindOfClass:[UIScrollView class]]) [out addObject:(UIScrollView *)view];
+    for (UIView *sub in view.subviews) ApolloEdgeCollectScrollViews(sub, out);
+}
 
-static BOOL ApolloEdgeIsInsideOutgoingView(UIView *view) {
-    for (UIView *ancestor = view; ancestor; ancestor = ancestor.superview) {
-        if ([sOutgoingViews containsObject:ancestor]) return YES;
+static void ApolloEdgeRedirectGeometry(UIView *outgoingView, UIView *stableView) {
+    NSMutableArray<UIScrollView *> *scrollViews = [NSMutableArray array];
+    ApolloEdgeCollectScrollViews(outgoingView, scrollViews);
+    for (UIScrollView *scrollView in scrollViews) {
+        [scrollView _setOverrideGeometryView:stableView forEdge:kApolloEdgeTop];
+        [scrollView _setOverrideGeometryView:stableView forEdge:kApolloEdgeBottom];
+        [sRedirectedScrollViews addObject:scrollView];
     }
-    return NO;
 }
 
 static void ApolloEdgeArmSafetyTimeout(UINavigationController *nav, NSUInteger generation);
@@ -89,17 +89,17 @@ static void ApolloEdgeEndTransition(NSUInteger generation) {
     if (--sTransitionsInFlight > 0) return;
 
     sTransitionGeneration++;
-    // Let UIKit re-derive pocket state now that we are no longer interfering. Whatever it
-    // decides (keep them, drop them) is correct once the geometry has settled.
-    for (UIScrollView *scrollView in sProtectedScrollViews) {
-        [scrollView setNeedsLayout];
+    // Hand geometry back to UIKit's own reference now that the frames have settled.
+    for (UIScrollView *scrollView in sRedirectedScrollViews) {
+        [scrollView _setOverrideGeometryView:nil forEdge:kApolloEdgeTop];
+        [scrollView _setOverrideGeometryView:nil forEdge:kApolloEdgeBottom];
     }
-    [sProtectedScrollViews removeAllObjects];
-    [sOutgoingViews removeAllObjects];
+    [sRedirectedScrollViews removeAllObjects];
 }
 
-// Re-arms itself for as long as the navigation controller still reports a live transition,
-// so a held gesture stays protected while a genuinely finished one always gets released.
+// Re-arms for as long as the navigation controller still reports a live transition, so a held
+// gesture stays covered while a genuinely finished one is always released. A fixed timeout
+// would expire mid-drag, which is exactly the case this fix exists for.
 static void ApolloEdgeArmSafetyTimeout(UINavigationController *nav, NSUInteger generation) {
     __weak UINavigationController *weakNav = nav;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)),
@@ -115,7 +115,14 @@ static void ApolloEdgeArmSafetyTimeout(UINavigationController *nav, NSUInteger g
 }
 
 static void ApolloEdgeBeginTransition(UINavigationController *nav, UIViewController *outgoing) {
-    if (outgoing.isViewLoaded) [sOutgoingViews addObject:outgoing.view];
+    // The navigation controller's own view stays put for the whole transition, which makes it
+    // the natural stable reference. Only the outgoing side is redirected — the incoming
+    // controller's geometry is never parked off-screen, and interfering there produces its own
+    // artifact as it settles.
+    if (outgoing.isViewLoaded && nav.isViewLoaded) {
+        ApolloEdgeRedirectGeometry(outgoing.view, nav.view);
+    }
+
     sTransitionsInFlight++;
     NSUInteger generation = sTransitionGeneration;
 
@@ -127,65 +134,36 @@ static void ApolloEdgeBeginTransition(UINavigationController *nav, UIViewControl
             ApolloEdgeEndTransition(generation);
         }];
     } else {
-        // Non-animated navigation: nothing to protect beyond this turn of the runloop.
+        // Non-animated navigation: nothing to cover beyond this turn of the runloop.
         dispatch_async(dispatch_get_main_queue(), ^{ ApolloEdgeEndTransition(generation); });
     }
 
-    // Safety net: a stuck counter would suppress legitimate pocket teardown app-wide, so a
-    // transition must never be able to protect views forever. It re-arms rather than firing
-    // blind, because holding the swipe-back gesture part-way — exactly what this fix is for —
-    // legitimately keeps a transition open for as long as the user cares to hold it.
+    // A stuck counter would leave the override installed indefinitely, so never let one
+    // outlive the transition it was armed for.
     ApolloEdgeArmSafetyTimeout(nav, generation);
 }
 
-// A pocket container is any view holding ScrollEdgeEffectViews directly. Pointer compare
-// against the resolved Class rather than a string compare — this runs on a hot path.
-static BOOL ApolloEdgeIsPocketContainer(UIView *view) {
-    for (UIView *subview in view.subviews) {
-        if (object_getClass(subview) == sEdgeEffectViewClass) return YES;
-    }
-    return NO;
-}
-
 %group ScrollEdgePopFix
-
-%hook UIView
-
-- (void)removeFromSuperview {
-    if (sTransitionsInFlight > 0) {
-        UIView *superview = self.superview;
-        // Only interfere while the scroll view is genuinely still on screen. A view that has
-        // left the window is being torn down for real and must be allowed to go.
-        if ([superview isKindOfClass:[UIScrollView class]] && superview.window &&
-            ApolloEdgeIsPocketContainer(self) && ApolloEdgeIsInsideOutgoingView(superview)) {
-            [sProtectedScrollViews addObject:(UIScrollView *)superview];
-            return;
-        }
-    }
-    %orig;
-}
-
-%end
 
 %hook UINavigationController
 
 - (UIViewController *)popViewControllerAnimated:(BOOL)animated {
     UIViewController *popped = %orig;
-    // Covers the back button, programmatic pops, AND the interactive swipe-back — UIKit
-    // routes the gesture through here too, the moment the drag is recognised.
+    // Covers the back button, programmatic pops, AND the interactive swipe-back — UIKit routes
+    // the gesture through here too, the moment the drag is recognised.
     if (popped) ApolloEdgeBeginTransition(self, popped);
     return popped;
 }
 
 - (NSArray<UIViewController *> *)popToViewController:(UIViewController *)viewController animated:(BOOL)animated {
     NSArray<UIViewController *> *popped = %orig;
+    // The popped array is in stack order, so the one that was on screen is last.
     if (popped.count) ApolloEdgeBeginTransition(self, popped.lastObject);
     return popped;
 }
 
 - (NSArray<UIViewController *> *)popToRootViewControllerAnimated:(BOOL)animated {
     NSArray<UIViewController *> *popped = %orig;
-    // The popped array is in stack order, so the one that was actually on screen is last.
     if (popped.count) ApolloEdgeBeginTransition(self, popped.lastObject);
     return popped;
 }
@@ -204,14 +182,14 @@ static BOOL ApolloEdgeIsPocketContainer(UIView *view) {
 %ctor {
     if (!IsLiquidGlass()) return;
 
-    sEdgeEffectViewClass = objc_getClass("UIKit.ScrollEdgeEffectView");
-    if (!sEdgeEffectViewClass) {
-        ApolloLog(@"[ScrollEdgePopFix] UIKit.ScrollEdgeEffectView missing; fix inactive");
+    // Everything rests on this private hook; without it stay inert rather than reaching for a
+    // cruder lever that lies to UIKit about its own view hierarchy.
+    if (![UIScrollView instancesRespondToSelector:@selector(_setOverrideGeometryView:forEdge:)]) {
+        ApolloLog(@"[ScrollEdgePopFix] -[UIScrollView _setOverrideGeometryView:forEdge:] missing; fix inactive");
         return;
     }
 
-    sProtectedScrollViews = [NSHashTable weakObjectsHashTable];
-    sOutgoingViews = [NSHashTable weakObjectsHashTable];
+    sRedirectedScrollViews = [NSHashTable weakObjectsHashTable];
     %init(ScrollEdgePopFix);
-    ApolloLog(@"[ScrollEdgePopFix] hook installed (pocket containers held through nav transitions)");
+    ApolloLog(@"[ScrollEdgePopFix] hook installed (pocket geometry redirected during nav transitions)");
 }

--- a/src/ApolloScrollEdgePopFix.xm
+++ b/src/ApolloScrollEdgePopFix.xm
@@ -32,9 +32,18 @@
 //
 // THE FIX
 // While a navigation transition is in flight, refuse to let a pocket container be detached
-// from a scroll view that is still in a window. UIKit retries on later layout passes (a
-// handful of times, not per frame), and once the transition completes we stop refusing and
-// nudge the affected scroll views to lay out, so UIKit settles the state itself.
+// from a scroll view that is still in a window, *and that belongs to the view sliding off
+// screen*. UIKit retries on later layout passes (a handful of times, not per frame), and
+// once the transition completes we stop refusing and nudge the affected scroll views to lay
+// out, so UIKit settles the state itself.
+//
+// Restricting this to the outgoing view matters. Protecting every scroll view during the
+// transition also blocks removals UIKit wanted on the *incoming* side, which desyncs its
+// pocket bookkeeping — that view then rebuilds its pocket once it settles, and the rebuild
+// shows up as a one-frame flash of unmasked content exactly as the transition lands.
+// Measured over the landing frames, band y=150..340: with the incoming side protected the
+// edge sharpness spikes 26.7 -> 33.4 and decays over ~5 frames; leaving it alone holds flat
+// at 22.3-22.9 (under 3%, i.e. noise).
 //
 // Keeping UIKit's own effect views alive means the masking during the slide is the real
 // thing — no material to match, no colour to tune, nothing that can drift from the system
@@ -59,6 +68,20 @@ static NSUInteger sTransitionGeneration;
 // transition they need one layout pass for UIKit to reach the right answer on its own.
 static NSHashTable<UIScrollView *> *sProtectedScrollViews;
 
+// The views actually sliding OFF screen, held weakly. Protection is limited to these:
+// the incoming controller must be left entirely alone. Blocking a removal UIKit wanted on
+// the incoming side desyncs its pocket bookkeeping, so when that view settles it rebuilds
+// the pocket from scratch — which reads as a one-frame flash of unmasked content right as
+// the transition lands.
+static NSHashTable<UIView *> *sOutgoingViews;
+
+static BOOL ApolloEdgeIsInsideOutgoingView(UIView *view) {
+    for (UIView *ancestor = view; ancestor; ancestor = ancestor.superview) {
+        if ([sOutgoingViews containsObject:ancestor]) return YES;
+    }
+    return NO;
+}
+
 static void ApolloEdgeArmSafetyTimeout(UINavigationController *nav, NSUInteger generation);
 
 static void ApolloEdgeEndTransition(NSUInteger generation) {
@@ -72,6 +95,7 @@ static void ApolloEdgeEndTransition(NSUInteger generation) {
         [scrollView setNeedsLayout];
     }
     [sProtectedScrollViews removeAllObjects];
+    [sOutgoingViews removeAllObjects];
 }
 
 // Re-arms itself for as long as the navigation controller still reports a live transition,
@@ -90,7 +114,8 @@ static void ApolloEdgeArmSafetyTimeout(UINavigationController *nav, NSUInteger g
     });
 }
 
-static void ApolloEdgeBeginTransition(UINavigationController *nav) {
+static void ApolloEdgeBeginTransition(UINavigationController *nav, UIViewController *outgoing) {
+    if (outgoing.isViewLoaded) [sOutgoingViews addObject:outgoing.view];
     sTransitionsInFlight++;
     NSUInteger generation = sTransitionGeneration;
 
@@ -132,7 +157,7 @@ static BOOL ApolloEdgeIsPocketContainer(UIView *view) {
         // Only interfere while the scroll view is genuinely still on screen. A view that has
         // left the window is being torn down for real and must be allowed to go.
         if ([superview isKindOfClass:[UIScrollView class]] && superview.window &&
-            ApolloEdgeIsPocketContainer(self)) {
+            ApolloEdgeIsPocketContainer(self) && ApolloEdgeIsInsideOutgoingView(superview)) {
             [sProtectedScrollViews addObject:(UIScrollView *)superview];
             return;
         }
@@ -148,26 +173,28 @@ static BOOL ApolloEdgeIsPocketContainer(UIView *view) {
     UIViewController *popped = %orig;
     // Covers the back button, programmatic pops, AND the interactive swipe-back — UIKit
     // routes the gesture through here too, the moment the drag is recognised.
-    if (popped) ApolloEdgeBeginTransition(self);
+    if (popped) ApolloEdgeBeginTransition(self, popped);
     return popped;
 }
 
 - (NSArray<UIViewController *> *)popToViewController:(UIViewController *)viewController animated:(BOOL)animated {
     NSArray<UIViewController *> *popped = %orig;
-    if (popped.count) ApolloEdgeBeginTransition(self);
+    if (popped.count) ApolloEdgeBeginTransition(self, popped.lastObject);
     return popped;
 }
 
 - (NSArray<UIViewController *> *)popToRootViewControllerAnimated:(BOOL)animated {
     NSArray<UIViewController *> *popped = %orig;
-    if (popped.count) ApolloEdgeBeginTransition(self);
+    // The popped array is in stack order, so the one that was actually on screen is last.
+    if (popped.count) ApolloEdgeBeginTransition(self, popped.lastObject);
     return popped;
 }
 
 // A push slides the outgoing screen partway off to the left, so it has the same exposure.
 - (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated {
+    UIViewController *outgoing = self.topViewController;   // captured before the push
     %orig;
-    if (animated) ApolloEdgeBeginTransition(self);
+    if (animated) ApolloEdgeBeginTransition(self, outgoing);
 }
 
 %end
@@ -184,6 +211,7 @@ static BOOL ApolloEdgeIsPocketContainer(UIView *view) {
     }
 
     sProtectedScrollViews = [NSHashTable weakObjectsHashTable];
+    sOutgoingViews = [NSHashTable weakObjectsHashTable];
     %init(ScrollEdgePopFix);
     ApolloLog(@"[ScrollEdgePopFix] hook installed (pocket containers held through nav transitions)");
 }

--- a/src/ApolloScrollEdgePopFix.xm
+++ b/src/ApolloScrollEdgePopFix.xm
@@ -31,31 +31,35 @@
 @interface ApolloScrollEdgeEffectView : UIView
 @end
 
-// Resolve the view controller a (candidate) edge-effect view renders for, walking
-// the responder chain. Returns nil when the view is not attached to a VC.
-static UIViewController *ApolloEdgeFixOwningViewController(UIView *view) {
+// Resolve the navigation controller whose stack hosts `view`, walking the FULL
+// responder chain for the UINavigationController itself rather than trusting a
+// view controller's parent link: popViewController severs the outgoing VC's
+// navigationController reference immediately, while UIKit keeps writing to that
+// VC's edge-effect views on every frame of the interactive transition — the nav
+// controller is still in the popped view's responder chain via the transition
+// container (UIViewControllerWrapperView -> UINavigationTransitionView ->
+// UILayoutContainerView -> UINavigationController), so the chain walk keeps
+// working exactly when the parent link does not.
+static UINavigationController *ApolloEdgeFixNavControllerForView(UIView *view) {
+    UINavigationController *fallback = nil;
     UIResponder *responder = view;
     while ((responder = responder.nextResponder)) {
-        if ([responder isKindOfClass:[UIViewController class]]) {
-            return (UIViewController *)responder;
+        if ([responder isKindOfClass:[UINavigationController class]]) {
+            return (UINavigationController *)responder;
         }
-        if ([responder isKindOfClass:[UIWindow class]]) break;
+        if (!fallback && [responder isKindOfClass:[UIViewController class]]) {
+            fallback = ((UIViewController *)responder).navigationController;
+        }
     }
-    return nil;
+    return fallback;
 }
 
-// YES while the navigation controller owning `view` is mid interactive pop —
+// YES while the navigation controller hosting `view` is mid interactive pop —
 // either the transition coordinator reports an interactive transition, or the
 // system edge-pan recognizer is actively tracking (Began/Changed covers the
 // window before the coordinator exists).
 static BOOL ApolloEdgeFixInteractivePopInFlight(UIView *view) {
-    UIViewController *owner = ApolloEdgeFixOwningViewController(view);
-    if (!owner) return NO;
-
-    UINavigationController *nav = owner.navigationController;
-    if (!nav && [owner isKindOfClass:[UINavigationController class]]) {
-        nav = (UINavigationController *)owner;
-    }
+    UINavigationController *nav = ApolloEdgeFixNavControllerForView(view);
     if (!nav) return NO;
 
     id<UIViewControllerTransitionCoordinator> coordinator = nav.transitionCoordinator;
@@ -65,22 +69,74 @@ static BOOL ApolloEdgeFixInteractivePopInFlight(UIView *view) {
     return state == UIGestureRecognizerStateBegan || state == UIGestureRecognizerStateChanged;
 }
 
+// The interactive-pop preflight phase (small drag that never commits the pop)
+// runs with NO transition coordinator, the pop recognizer still in Possible, and
+// UIKit tearing down + recreating the edge-effect views already at alpha 0 — so
+// navigation-state checks alone cannot see it. A screen-edge touch brackets that
+// whole phase exactly: track touches that BEGAN in the horizontal edge zones at
+// the window level, and treat "edge touch down (plus a short settle grace after
+// lift)" as swipe-back-possibly-in-progress.
+static NSMutableSet *sApolloEdgeTouches;
+static CFTimeInterval sApolloEdgeTouchLastEnd;
+
+static BOOL ApolloEdgeFixEdgeTouchActive(void) {
+    if (sApolloEdgeTouches.count > 0) return YES;
+    return (CACurrentMediaTime() - sApolloEdgeTouchLastEnd) < 0.6;
+}
+
 %group ScrollEdgePopFix
+
+%hook UIWindow
+
+- (void)sendEvent:(UIEvent *)event {
+    if (event.type == UIEventTypeTouches) {
+        for (UITouch *touch in event.allTouches) {
+            if (touch.phase == UITouchPhaseBegan) {
+                CGPoint point = [touch locationInView:self];
+                CGFloat width = self.bounds.size.width;
+                if (point.x <= 40.0 || point.x >= width - 40.0) {
+                    if (!sApolloEdgeTouches) sApolloEdgeTouches = [NSMutableSet new];
+                    [sApolloEdgeTouches addObject:[NSValue valueWithNonretainedObject:touch]];
+                }
+            } else if (touch.phase == UITouchPhaseEnded || touch.phase == UITouchPhaseCancelled) {
+                NSValue *key = [NSValue valueWithNonretainedObject:touch];
+                if ([sApolloEdgeTouches containsObject:key]) {
+                    [sApolloEdgeTouches removeObject:key];
+                    if (sApolloEdgeTouches.count == 0) sApolloEdgeTouchLastEnd = CACurrentMediaTime();
+                }
+            }
+        }
+    }
+    %orig;
+}
+
+%end
+
 
 %hook ApolloScrollEdgeEffectView
 
 - (void)setAlpha:(CGFloat)alpha {
     UIView *effectView = (UIView *)self;
-    if (alpha < 0.999 && effectView.superview && ApolloEdgeFixInteractivePopInFlight(effectView)) {
+    if (alpha < 0.999 &&
+        (ApolloEdgeFixInteractivePopInFlight(effectView) || ApolloEdgeFixEdgeTouchActive())) {
         static BOOL sLoggedOnce = NO;
         if (!sLoggedOnce) {
             sLoggedOnce = YES;
-            ApolloLog(@"[ScrollEdgePopFix] Blocked scroll-edge fade-out (alpha %.2f) during interactive pop", (double)alpha);
+            ApolloLog(@"[ScrollEdgePopFix] Blocked scroll-edge fade-out (alpha %.2f) during swipe-back", (double)alpha);
         }
         %orig(1.0);
         return;
     }
     %orig;
+}
+
+- (void)didMoveToWindow {
+    %orig;
+    UIView *effectView = (UIView *)self;
+    if (effectView.window && effectView.alpha < 0.999 &&
+        (ApolloEdgeFixInteractivePopInFlight(effectView) || ApolloEdgeFixEdgeTouchActive())) {
+        effectView.alpha = 1.0;
+    }
 }
 
 %end


### PR DESCRIPTION
**Now fully solved as of Update 4 at the bottom** — the cancelled-gesture flick that Update 3 left open is fixed too. Everything in between is the investigation log; read it before touching this code, but don't trust any "still broken" claims in it, they're historical.

Starting a swipe-back (without completing it) makes the blurred/faded areas at the top and bottom of the screen go fully transparent for the whole gesture — every row scrolled under the floating nav pills is suddenly crisp readable text right over the status bar, then it all snaps back the moment you let go. Easiest to see in comments on a scrolled thread, but it happens on any pushed screen (repro'd it on the settings sub-screens too).

I chased this as a regression at first because it "showed up" in the latest test build, but after bisecting the sim build across a1585ec → ffa27b3 → aa665fa → a803990 → the full open-PR set, every single one reproduces it. It's not from any recent PR — it's a base interaction between the Liquid Glass patch and UIKit's interactive pop that's been there all along:

- On iOS 26 the content scrolled under the bars is masked per scroll view by `UIKit.ScrollEdgeEffectView` (progressive blur + dimming backdrop).
- The moment an interactive pop starts, UIKit's transition code fades the **outgoing** view's edge-effect view to alpha 0. Confirmed with view-hierarchy dumps mid-gesture: top effect view alpha=0.00 during the drag, 1.00 at rest, everything else (hidden flags, subview stack) identical.
- Stock Apollo never shows this because it keeps its own opaque statusBarBackgroundView strip over the top (and hides bars on scroll) — but on glass we hide that strip (it renders as an ugly grey band on LG), so there's nothing left covering the content when UIKit kills the edge effect.

The fix (src/ApolloScrollEdgePopFix.xm): while the owning navigation controller is running an interactive transition (transitionCoordinator.interactive, with the pop gesture Began/Changed as a fallback for the pre-coordinator window), refuse alpha writes below 1 on ScrollEdgeEffectView instances. UIKit re-syncs alpha itself on both the cancel and the completion path, so there's nothing to restore afterwards. The class is Swift-side (`UIKit.ScrollEdgeEffectView`), so the hook binds via `%init(Class=objc_getClass(...))`, gated on IsLiquidGlass() and a nil-check — on non-glass or older iOS the class doesn't exist and the module is inert.

Verified in the sim (iOS 26.5, glass shell) on plain main and on the full current open-PR set:
- partial swipe-back in scrolled comments: fade stays put through the whole drag (this was the repro)
- release/cancel: rest state identical to before
- full swipe-back: pop completes clean, no stuck overlays
- comments opened at scroll top (nothing under the bar): no phantom dim band during the gesture
- feed → subreddits swipe-back: outgoing feed keeps its fade too

Not device-tested yet — will fold it into the next test IPA.

---

**Update 1 — the first clamp wasn't enough.** Testing on sim2 the bug still showed on a *small drag you hold* (the exact "just start the initiation" gesture from the report). Turns out that gesture runs an interactive-pop **preflight** phase my first detection couldn't see: no transition coordinator exists yet, the system pop recognizer still reads Possible, `popViewController` has already nil'd the outgoing VC's `navigationController`, and UIKit re-applies alpha 0 to the edge-effect views *every frame* — sometimes tearing them down and recreating them already-transparent while detached. Second commit hardens the detection: resolve the nav controller by walking the full responder chain (the nav is still in the popped view's chain via the transition container even when the parent link is severed), treat an edge-originated touch being down (+0.6s settle grace) as swipe-back-in-progress, and re-heal recreated effect views when they attach. Re-verified in the sim: slow small drag, drag-and-hold, fast flick, full pop, cancel, scroll-top, and a vertical scroll that starts at the screen edge (no false-positive dimming).

**Update 2 — bundled a second Liquid Glass visual fix** (same area, easier to test together): tapping the "..." on a post or comment presents the converted native menu fine, but on dismissal the three dots visibly glide back down into their row. Cause: `previewForDismissingMenuWithConfiguration:` reused the morph-view preview, so UIKit snapshots the control and flies it from the collapsed menu's anchor back to the row. Fix (src/ApolloNativeActionMenus.xm): dismissal now returns an invisible proxy-anchored preview and restores the real control the moment dismissal starts — menu still fades out exactly like before, bloom-on-present untouched, but the dots never move. Verified frame-by-frame in sim recordings: dots sit at the same pixel position through the entire dismissal.


---

## Update 3 — good to merge, but the explanation above is wrong and there's one thing left *(that one thing is now fixed — see Update 4)*

**Calling this mergeable.** Been testing it a lot more and it's a decent chunk better than what's on main — swiping back is way less noticeable now. It's not perfect (see below), but it's a clear win over the current behaviour so I'd rather have it in than sit on it.

The rest of this is long, sorry. I got the root cause nailed down but (at the time of this update) not a 100% clean fix, so I'm writing down everything I tried and everything I ruled out. If someone (or some AI) picks this up later, please read this before touching it, because most of the obvious ideas are already dead and I've got measurements proving it.

### What's actually wrong (the description at the top of this PR is wrong)

The original theory was "UIKit fades the outgoing view's edge-effect to alpha 0". That is **not** what happens. The clamp fires and the fade still disappears. Alpha was never the lever.

What actually happens: the effect views get **removed**, not faded. Each scroll view's `_UIScrollEdgeEffectViewInteraction` parks the `UIKit.ScrollEdgeEffectView`s in a container inside the scroll view, recomputes pocket geometry every layout pass, and when the rect comes out empty it detaches the container.

And the reason the rect comes out empty is the real find here: **Apollo doesn't use UIKit's navigation transition at all.** `ApolloNavigationController` vends its own animator:

- `navigationController:animationControllerForOperation:…` → `ApolloNavigationAnimator` (`-[…24ApolloNavigationAnimator animateTransition:]` @ `0x100682a98`, push = `sub_100682b04`, pop = `sub_100683738`)
- `navigationController:interactionControllerForAnimationController:` → its own interactor
- `screenEdgePanned:` (`sub_10015e204`) drives `updateInteractiveTransition:` / `cancelInteractiveTransition` / `finishInteractiveTransition` itself

That animator sets the view controllers' **frames** directly, which parks the outgoing view at its final off-screen position almost immediately while the layer animates across from there. Per-frame sampling of the outgoing VC, window space:

```
t=0.001  scroller x=0
t=0.076  scroller x=402   <- parked off-screen, still visibly mid-slide
t=0.678  scroller x=-134
t=0.742  scroller x=0
```

and the effect views themselves:

```
t=0.013  frame=(0,0 402x874)    effects=4
t=0.060  frame=(402,0 402x874)  effects=0   <- gone while still on screen
```

UIKit reads the pocket geometry off that model frame, sees a scroll view sitting at x=402, decides the mask isn't needed and drops it — while the content is still visibly on screen for another ~300ms. Native apps never hit this because UIKit's own animator keeps model and drawn geometry in step.

**This is confirmed, not a theory.** If you hook `animationControllerForOperation:` and return nil (so UIKit uses its own transition), the artifact vanishes completely. Verified on device-like sim by eye.

### What's in the PR right now

`src/ApolloScrollEdgePopFix.xm` points the outgoing controller's scroll views at a geometry reference that isn't moving for the duration of the transition, via `-[UIScrollView _setOverrideGeometryView:forEdge:]`. UIKit keeps owning and positioning the pocket, it just measures against the nav controller's view instead of a frame Apollo already parked off-screen. Apollo's animator and gesture are untouched.

- fixes the **drag** — the mask holds through the whole gesture, where before it was gone for the entire ~1s
- **bottom edge is fine**
- **top edge still glitches on a cancelled gesture**: drag a little and let go and the top band flicks see-through for a moment as it snaps back *(fixed in Update 4)*

I originally shipped a different approach here (block the pocket container's `removeFromSuperview`). It fixed the drag the same way, but it left a pocket UIKit no longer tracked or repositioned, so a cancelled gesture built a replacement and faded it in — a visible *wave* across the top bar rather than a quick flick. Same underlying bug either way, but the wave was much more distracting to look at, so this version is the one on the branch. Worth knowing if you're comparing behaviour between builds.

So: worth merging as-is, and the remaining bit is documented below rather than lost. If you'd rather wait for it to be perfect that's fair too, but the current behaviour on main is worse than this. *(Since resolved — Update 4.)*

### Things I tried that did NOT work — don't redo these

1. **Clamp `-[ScrollEdgeEffectView setAlpha:]` to 1** (the original fix in this PR). Clamp verifiably fires, artifact unchanged. Also the alpha 0 it was chasing belongs to the *incoming* controller where 0 is correct (that feed is at scroll-top with nothing to mask), so forcing it to 1 risks a phantom dim band.
2. **Block `removeFromSuperview` on the pocket container.** Fixes the drag (this is what's shipped) but leaves a pocket UIKit no longer tracks or repositions — so on cancel it builds a replacement and you get the flicker.
3. **Freeze `-[UIScrollView _updatePockets]` for the outgoing subtree.** Same class of problem.
4. **Delay the unfreeze past the snap-back** (0.45s settle). No.
5. **Force `shouldAnimateVisibility:NO`** on `_UIScrollEdgeEffectViewInteraction updatePocket:…`. Reduced it, didn't remove it.
6. **Do the post-freeze recompute inside a `CATransaction` with actions disabled.** No.
7. **Clamp `-[_UIScrollPocketContainerInteraction _setElementInteractionRect:]`.** There's an epsilon-free float compare in `-[UINavigationController _updateNavigationBarScrollPocketContainerInteraction]` (`if (layoutHeightsForActiveLayout == navigationBar.bounds.size.height) h = that; else h = 0.0;`) that looks like a perfect suspect for a top-only bug. **It's not** — I hooked it and logged it, the rect stays `402x83` the whole gesture and the zero branch is never taken.
8. **Apollo's own nav-bar background fade.** The pop animator calls `sub_1006840c8` → `sub_1006843b0`, which recursively searches the nav bar for the first `UIImageView` with bounds height < 1pt (the old pre-26 hairline) and animates its alpha. Looks exactly like "the header background fading out". **Returns nil on iOS 26** — no such hairline exists, so Apollo never touches it.
9. **`-[UIScrollView _setOverrideGeometryView:forEdge:]`** (top = 1, bottom = 4) pointed at a view that doesn't move, so UIKit measures the pocket against stable geometry. Verified firing (logged "geometry redirected for 4 scroll views"). Artifact still there. So UIKit is not deciding this purely from that reference.
10. **Rewrite the outgoing host's `layer.position` to its presentation position during `_updatePockets`** so UIKit evaluates against where the view is actually drawn. Verified correcting (`parked=603 → drawn=201`). Artifact still there.
11. **Return nil from `animationControllerForOperation:`** so UIKit does the whole transition. **This fixes the artifact completely** but is not shippable: `interactionControllerForAnimationController:` is only consulted when an animator was vended, so returning nil also kills Apollo's interactive driver and the pop fires the instant you touch the edge instead of following your finger.

### The most promising lead, for whoever picks this up

Vend **our own** animator instead of nil. Non-nil means Apollo's interaction controller still gets consulted so the gesture stays interactive and cancellable (hand Apollo back its own animator object when it asks, so its internal logic sees what it expects). Then control how the views move:

- **moving by `transform` instead of `frame` fixes the wave.** Release is clean. Confirmed by testing.
- **but it breaks the blur during the drag** — the band goes see-through while you're dragging. Almost certainly because the mask is a backdrop blur sampling what's behind it, and a backdrop under a transformed ancestor doesn't render right.
- moving by `frame` (with or without the geometry override from #9) brings the wave straight back.

So the remaining question is narrow and well-defined: **keep transform-style movement, which we know kills the artifact, and get the backdrop to render correctly while it's applied.** Ideas not yet tried: move via `layer.position` or `bounds.origin` (moves the geometry the pocket reads without a transform matrix in the way), or transform an ancestor container while leaving the scroll view's own subtree untransformed.

### Stuff that will waste your time if you don't know it

- **Peak brightness/sharpness measurements are content-dependent.** Don't compare across runs that re-scroll in between — you'll "prove" improvements that are pure noise (I did this twice). A/B *inside a single recording* with a runtime toggle.
- **Always verify your hook actually fires before concluding it does nothing.** I wrote off #7 and nearly wrote off #9 on null results that could equally have meant the hook never ran.
- **Check the gesture actually engaged.** A fast or short idb swipe *commits* the pop instead of cancelling it, and then you're measuring the wrong thing. Inter-frame diff on downscaled greyscale, maxdelta needs to be well above 5. Also confirm the end state (still on the same screen = cancelled).
- Screenshots miss it. Record video, `ffmpeg -vsync 0`, then per-frame edge-sharpness on the band under the bar (`crop((0,150,W,340))` → FIND_EDGES → stddev). Masked reads low and flat, the artifact is an obvious spike.
- Settings.app ignores the same synthetic edge swipe entirely, so it's useless as a control unless you verify motion happened.
- The effect views report `alpha=1`, presentation opacity 1, blur radius constant and zero animations *through the whole artifact*. The mask visibly isn't there while UIKit's own state says it is. I never explained that contradiction and it's probably where the answer is.




---

## Update 4 — the cancel flick is fixed, and the "impossible" measurement finally makes sense

The contradiction I flagged at the end of Update 3 (band visibly gone while every view reads alpha=1, opacity=1, constant blur, zero animations) turned out to be the whole answer. Went through the decompiled iOS 26.1 UIKitCore for the pocket machinery and re-measured with a per-frame sampler that also captures window-space presentation geometry, portal wiring and backdrop filter state. What's actually inside one of these bands:

- the blur is a `CABackdropLayer` with a `variableBlur` filter, and its mask is NOT `layer.mask` — PocketMask draws the band shape as ShadowLayers, a `_UIPortalView` clones it, and the blur filter references that mask layer **by name**, resolved on the render server
- the dim/luminance band doesn't sample what's behind it at all — it *replays* (by group name) whatever a fourth, `captureOnly` backdrop captured. And that capture layer doesn't even live in the effect view — it sits at the very back of the scroll content
- so there are two cross-layer references that can break and render as "everything present and opaque, nothing visible". That's why every alpha-side probe and clamp came back clean.

What kills them on a cancelled gesture: `cancelInteractiveTransition` starts a short layout storm. The nav bar tears down and rebuilds the transient item's title/button views — and those bar content views are themselves pocket *elements* — while every snap-back frame-set fires a geometry invalidation that zeroes the stored pocket rects and element frame caches. Each layout pass in that window then recomputes pocket state from mid-flight model geometry (the parked frames), which can hide/remove the capture layer and rebuild the PocketMask ShadowLayers empty. Measured it live: the pocket's TouchBlocker frame visibly snaps at the exact cancel instant — that's the recompute running — and the band stays dead until the post-completion layout pass rebuilds it. Only the top edge has these kill switches (bar height-mismatch zeroing, the bar visibility gate, the bar-content element teardown); the bottom band uses the solid-color path and doesn't care. Hence top-only.

Why the earlier freeze attempts (#3/#4 in the dead list) didn't work: they froze `_updatePockets` only. Half the storm lives in `ScrollEdgeEffectView.layoutSubviews` (mask rebuild + luma subrect), which kept running with garbage inputs.

The fix on the branch now: while a transition is in flight, no-op **both** `-[UIScrollView _updatePockets]` and the effect view's `layoutSubviews` for the outgoing controller's scroll views, then `setNeedsLayout` on transition end so UIKit resettles everything itself from clean geometry. The pocket state is correct the moment the transition starts and the correct result of every one of those storm passes is "nothing changes", so skipping them is exact, not approximate. The geometry override from Update 3 stays as belt-and-suspenders for the drag phase.

Verified in the sim (recorded, split to frames, per-frame edge-sharpness on the band — same pipeline as before):

- small drag + release (the original repro): no spike at all now — band sharpness stays flat at the masked level through the whole snap-back (baseline had a clear 6-frame spike). Frame-by-frame the content stays blurred/dimmed under the pill while the bar morphs back
- drag and hold >3s, then release: clean, freeze survives the safety-timeout re-arm
- full swipe-back and back-button pop: smooth slide, no spike, clean landing
- push: clean
- cancelled swipe at scroll top: no phantom band, end state identical to start
- after transitions, scrolling still shows/hides the band correctly (the resettle works — pockets aren't zombied)

Not device-tested yet; will fold into the next test IPA.

