### PR TITLE
Move Open Links/YouTube into Open in App, Hide Username into Profiles + native scroll-away search bar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/settings/ApolloSettingsNativeInjections.xm \
     $(SRC_DIR)/ApolloPerPostCommentSort.xm \
     $(SRC_DIR)/ApolloLiquidGlass.xm \
+    $(SRC_DIR)/ApolloTabBarTitles.xm \
     $(SRC_DIR)/ApolloLiquidGlassIconPicker.xm \
     $(SRC_DIR)/ApolloModmailLayout.xm \
     $(SRC_DIR)/ApolloAutoHideTabBar.xm \

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -48,6 +48,9 @@ float ApolloSanitizedHoldSpeed(float value);
 extern BOOL sProxyImgurDDG;
 extern BOOL sShowUserAvatars;
 extern BOOL sUseProfileAvatarTabIcon;
+// Hide the visible main-tab labels while retaining/restoring the underlying
+// UITabBarItem titles. Opt-in; default OFF via registerDefaults.
+extern BOOL sHideTabBarTitles;
 // When ON (default), profile pages show Reborn's detailed profile — the banner,
 // large avatar/snoovatar, display name, bio, and the Social Links band (Buy Me a
 // Coffee, Instagram, X, …). When OFF, profiles revert to Apollo's compact stock

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -51,6 +51,18 @@ extern BOOL sUseProfileAvatarTabIcon;
 // Hide the visible main-tab labels while retaining/restoring the underlying
 // UITabBarItem titles. Opt-in; default OFF via registerDefaults.
 extern BOOL sHideTabBarTitles;
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Central setter used by the settings UI. Enabling icon-only mode also clears
+// Apollo's narrower "Hide Username on Tab Bar" preference because every tab
+// title is already hidden, then refreshes both settings surfaces live.
+void ApolloSetHideTabBarTitlesEnabled(BOOL enabled);
+// Repairs a persisted both-on state during launch or settings restore.
+void ApolloNormalizeNativeHideUsernameForIconOnlyTabBar(void);
+#ifdef __cplusplus
+}
+#endif
 // When ON (default), profile pages show Reborn's detailed profile — the banner,
 // large avatar/snoovatar, display name, bio, and the Social Links band (Buy Me a
 // Coffee, Instagram, X, …). When OFF, profiles revert to Apollo's compact stock

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -29,6 +29,7 @@ float sVideoHoldSpeed = 2.0f;        // effective default 2.0× via registerDefa
 BOOL sProxyImgurDDG = NO;
 BOOL sShowUserAvatars = NO;
 BOOL sUseProfileAvatarTabIcon = NO;
+BOOL sHideTabBarTitles = NO;
 BOOL sShowDetailedProfiles = YES;   // effective default ON via registerDefaults (UDKeyShowDetailedProfiles)
 BOOL sShowSubredditHeaders = NO;
 BOOL sCommunityHighlights = NO;

--- a/src/ApolloTabBarTitles.xm
+++ b/src/ApolloTabBarTitles.xm
@@ -1,0 +1,233 @@
+// ApolloTabBarTitles — optional icon-only main navigation.
+//
+// Clearing a UITabBarItem's title is the public UIKit way to remove its visible
+// label and, on the iOS 26 floating tab bar, lets the system choose the compact
+// icon-only item layout. We keep the latest real title beside the item so the
+// setting can be toggled live and so Apollo remains free to rename an item while
+// its label is hidden. VoiceOver receives that real title explicitly whenever
+// the item did not already provide a custom accessibility label.
+//
+// Pre-Liquid-Glass tab bars need the traditional six-point image adjustment to
+// center an icon in the space formerly shared with its label. iOS 26 performs
+// that centering itself, so its original image insets are left untouched.
+
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+#import "UserDefaultConstants.h"
+
+static char kApolloTabBarTitleStateCapturedKey;
+static char kApolloTabBarOriginalTitleKey;
+static char kApolloTabBarOriginalImageInsetsKey;
+static char kApolloTabBarOriginalAccessibilityLabelKey;
+static char kApolloTabBarGeneratedAccessibilityLabelKey;
+
+// All UIKit mutations below synchronously re-enter the UITabBarItem hooks. A
+// narrow guard distinguishes our apply/restore writes from Apollo's real title
+// and inset updates, which must be remembered even while the labels are hidden.
+static BOOL sApolloTabBarTitlesMutating = NO;
+
+static id ApolloTabBarNullableValue(id value) {
+    return value ?: NSNull.null;
+}
+
+static id ApolloTabBarUnwrapNullableValue(id value) {
+    return value == NSNull.null ? nil : value;
+}
+
+static BOOL ApolloTabBarTitleStateWasCaptured(UITabBarItem *item) {
+    return [objc_getAssociatedObject(item, &kApolloTabBarTitleStateCapturedKey) boolValue];
+}
+
+static void ApolloTabBarCaptureTitleStateIfNeeded(UITabBarItem *item) {
+    if (!item || ApolloTabBarTitleStateWasCaptured(item)) return;
+
+    objc_setAssociatedObject(item, &kApolloTabBarTitleStateCapturedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(item, &kApolloTabBarOriginalTitleKey,
+                             ApolloTabBarNullableValue(item.title), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(item, &kApolloTabBarOriginalImageInsetsKey,
+                             [NSValue valueWithUIEdgeInsets:item.imageInsets], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(item, &kApolloTabBarOriginalAccessibilityLabelKey,
+                             ApolloTabBarNullableValue(item.accessibilityLabel), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static NSString *ApolloTabBarStoredTitle(UITabBarItem *item) {
+    return ApolloTabBarUnwrapNullableValue(objc_getAssociatedObject(item, &kApolloTabBarOriginalTitleKey));
+}
+
+static UIEdgeInsets ApolloTabBarIconOnlyInsets(UIEdgeInsets originalInsets) {
+    if (IsLiquidGlass()) return originalInsets;
+    return UIEdgeInsetsMake(originalInsets.top + 6.0,
+                            originalInsets.left,
+                            originalInsets.bottom - 6.0,
+                            originalInsets.right);
+}
+
+static void ApolloTabBarPreserveAccessibilityName(UITabBarItem *item, NSString *title) {
+    if (!item || title.length == 0 || item.accessibilityLabel.length > 0) return;
+
+    item.accessibilityLabel = title;
+    objc_setAssociatedObject(item, &kApolloTabBarGeneratedAccessibilityLabelKey,
+                             @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static void ApolloTabBarApplyIconOnlyToItem(UITabBarItem *item) {
+    if (!item) return;
+
+    if (!sHideTabBarTitles) {
+        if (!ApolloTabBarTitleStateWasCaptured(item)) return;
+
+        NSString *storedTitle = ApolloTabBarStoredTitle(item);
+        NSValue *storedInsets = objc_getAssociatedObject(item, &kApolloTabBarOriginalImageInsetsKey);
+        BOOL generatedAccessibilityLabel =
+            [objc_getAssociatedObject(item, &kApolloTabBarGeneratedAccessibilityLabelKey) boolValue];
+        id originalAccessibilityValue =
+            objc_getAssociatedObject(item, &kApolloTabBarOriginalAccessibilityLabelKey);
+
+        sApolloTabBarTitlesMutating = YES;
+        item.title = storedTitle;
+        if (storedInsets) item.imageInsets = storedInsets.UIEdgeInsetsValue;
+        // Only undo the label we generated. If another component replaced it
+        // while icon-only mode was active, that newer explicit label wins.
+        if (generatedAccessibilityLabel &&
+            (item.accessibilityLabel.length == 0 || [item.accessibilityLabel isEqualToString:storedTitle])) {
+            item.accessibilityLabel = ApolloTabBarUnwrapNullableValue(originalAccessibilityValue);
+        }
+        sApolloTabBarTitlesMutating = NO;
+
+        objc_setAssociatedObject(item, &kApolloTabBarTitleStateCapturedKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(item, &kApolloTabBarOriginalTitleKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(item, &kApolloTabBarOriginalImageInsetsKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(item, &kApolloTabBarOriginalAccessibilityLabelKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(item, &kApolloTabBarGeneratedAccessibilityLabelKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return;
+    }
+
+    ApolloTabBarCaptureTitleStateIfNeeded(item);
+    NSString *storedTitle = ApolloTabBarStoredTitle(item);
+    NSValue *storedInsets = objc_getAssociatedObject(item, &kApolloTabBarOriginalImageInsetsKey);
+    ApolloTabBarPreserveAccessibilityName(item, storedTitle);
+
+    sApolloTabBarTitlesMutating = YES;
+    item.title = nil;
+    if (storedInsets && !IsLiquidGlass()) {
+        item.imageInsets = ApolloTabBarIconOnlyInsets(storedInsets.UIEdgeInsetsValue);
+    }
+    sApolloTabBarTitlesMutating = NO;
+}
+
+static void ApolloTabBarApplyIconOnlyToBar(UITabBar *tabBar) {
+    for (UITabBarItem *item in tabBar.items) {
+        ApolloTabBarApplyIconOnlyToItem(item);
+    }
+}
+
+static NSUInteger ApolloTabBarApplyToViewTree(UIView *view) {
+    if (!view) return 0;
+    NSUInteger barCount = 0;
+    if ([view isKindOfClass:UITabBar.class]) {
+        ApolloTabBarApplyIconOnlyToBar((UITabBar *)view);
+        barCount++;
+    }
+    for (UIView *subview in view.subviews) {
+        barCount += ApolloTabBarApplyToViewTree(subview);
+    }
+    return barCount;
+}
+
+static void ApolloTabBarRefreshVisibleBars(NSString *reason) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSUInteger barCount = 0;
+        for (UIWindow *window in ApolloAllWindows()) {
+            if (!window.hidden && window.alpha > 0.01) {
+                barCount += ApolloTabBarApplyToViewTree(window);
+            }
+        }
+        ApolloLog(@"[TabBarTitles] %@ labels on %lu visible tab bar(s) (%@)",
+                  sHideTabBarTitles ? @"Hid" : @"Restored",
+                  (unsigned long)barCount,
+                  reason ?: @"refresh");
+    });
+}
+
+%hook UITabBarItem
+
+- (void)setTitle:(NSString *)title {
+    if (sApolloTabBarTitlesMutating) {
+        %orig(title);
+        return;
+    }
+
+    if (!sHideTabBarTitles) {
+        // An off-screen item may have missed the live window walk. Restore its
+        // other state before accepting Apollo's newest title.
+        if (ApolloTabBarTitleStateWasCaptured(self)) {
+            ApolloTabBarApplyIconOnlyToItem(self);
+        }
+        %orig(title);
+        return;
+    }
+
+    ApolloTabBarCaptureTitleStateIfNeeded(self);
+    NSString *previousStoredTitle = ApolloTabBarStoredTitle(self);
+    objc_setAssociatedObject(self, &kApolloTabBarOriginalTitleKey,
+                             ApolloTabBarNullableValue(title), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    BOOL generatedAccessibilityLabel =
+        [objc_getAssociatedObject(self, &kApolloTabBarGeneratedAccessibilityLabelKey) boolValue];
+    if (generatedAccessibilityLabel &&
+        (self.accessibilityLabel.length == 0 || [self.accessibilityLabel isEqualToString:previousStoredTitle])) {
+        self.accessibilityLabel = title;
+    } else {
+        ApolloTabBarPreserveAccessibilityName(self, title);
+    }
+    %orig(nil);
+}
+
+- (void)setImageInsets:(UIEdgeInsets)imageInsets {
+    if (sApolloTabBarTitlesMutating) {
+        %orig(imageInsets);
+        return;
+    }
+
+    if (!sHideTabBarTitles) {
+        if (ApolloTabBarTitleStateWasCaptured(self)) {
+            ApolloTabBarApplyIconOnlyToItem(self);
+        }
+        %orig(imageInsets);
+        return;
+    }
+
+    ApolloTabBarCaptureTitleStateIfNeeded(self);
+    objc_setAssociatedObject(self, &kApolloTabBarOriginalImageInsetsKey,
+                             [NSValue valueWithUIEdgeInsets:imageInsets], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    %orig(ApolloTabBarIconOnlyInsets(imageInsets));
+}
+
+%end
+
+%hook UITabBar
+
+- (void)didMoveToWindow {
+    %orig;
+    ApolloTabBarApplyIconOnlyToBar(self);
+}
+
+- (void)setItems:(NSArray<UITabBarItem *> *)items animated:(BOOL)animated {
+    %orig(items, animated);
+    ApolloTabBarApplyIconOnlyToBar(self);
+}
+
+%end
+
+%ctor {
+    [[NSNotificationCenter defaultCenter]
+        addObserverForName:ApolloTabBarTitlesChangedNotification
+                    object:nil
+                     queue:NSOperationQueue.mainQueue
+                usingBlock:^(__unused NSNotification *notification) {
+        ApolloTabBarRefreshVisibleBars(@"setting changed");
+    }];
+}

--- a/src/ApolloTabBarTitles.xm
+++ b/src/ApolloTabBarTitles.xm
@@ -17,6 +17,11 @@
 #import "ApolloCommon.h"
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
+#import "settings/ApolloSettingsGeneralTable.h"
+
+static NSString *const kApolloNativeHideUsernameOnTabBarKey = @"HideUsernameOnTabBar";
+static NSString *const kApolloNativeHideUsernameOnTabBarChangedNotification =
+    @"com.christianselig.HideUsernameOnTabBarChanged";
 
 static char kApolloTabBarTitleStateCapturedKey;
 static char kApolloTabBarOriginalTitleKey;
@@ -28,6 +33,53 @@ static char kApolloTabBarGeneratedAccessibilityLabelKey;
 // narrow guard distinguishes our apply/restore writes from Apollo's real title
 // and inset updates, which must be remembered even while the labels are hidden.
 static BOOL sApolloTabBarTitlesMutating = NO;
+
+static void ApolloTabBarConfigureNativeUsernameSubviews(UIView *view, BOOL enabled) {
+    if ([view isKindOfClass:UISwitch.class]) {
+        UISwitch *toggle = (UISwitch *)view;
+        BOOL nativeSettingOn = [NSUserDefaults.standardUserDefaults
+            boolForKey:kApolloNativeHideUsernameOnTabBarKey];
+        [toggle setOn:(enabled && nativeSettingOn) animated:NO];
+        toggle.enabled = enabled;
+    } else if ([view isKindOfClass:UILabel.class]) {
+        ((UILabel *)view).enabled = enabled;
+    }
+    for (UIView *subview in view.subviews) {
+        ApolloTabBarConfigureNativeUsernameSubviews(subview, enabled);
+    }
+}
+
+static void ApolloTabBarConfigureNativeUsernameCell(UITableViewCell *cell) {
+    if (!cell) return;
+    BOOL enabled = !sHideTabBarTitles;
+    ApolloTabBarConfigureNativeUsernameSubviews(cell.contentView, enabled);
+    if (cell.accessoryView && ![cell.accessoryView isDescendantOfView:cell.contentView]) {
+        ApolloTabBarConfigureNativeUsernameSubviews(cell.accessoryView, enabled);
+        cell.accessoryView.alpha = enabled ? 1.0 : 0.5;
+    }
+    cell.contentView.alpha = enabled ? 1.0 : 0.5;
+}
+
+void ApolloNormalizeNativeHideUsernameForIconOnlyTabBar(void) {
+    if (!sHideTabBarTitles) return;
+    NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
+    if (![defaults boolForKey:kApolloNativeHideUsernameOnTabBarKey]) return;
+
+    [defaults setBool:NO forKey:kApolloNativeHideUsernameOnTabBarKey];
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:kApolloNativeHideUsernameOnTabBarChangedNotification
+                      object:nil];
+    ApolloLog(@"[TabBarTitles] Cleared redundant native Hide Username on Tab Bar setting");
+}
+
+void ApolloSetHideTabBarTitlesEnabled(BOOL enabled) {
+    sHideTabBarTitles = enabled;
+    [NSUserDefaults.standardUserDefaults setBool:enabled forKey:UDKeyHideTabBarTitles];
+    if (enabled) ApolloNormalizeNativeHideUsernameForIconOnlyTabBar();
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:ApolloTabBarTitlesChangedNotification
+                      object:nil];
+}
 
 static id ApolloTabBarNullableValue(id value) {
     return value ?: NSNull.null;
@@ -223,11 +275,30 @@ static void ApolloTabBarRefreshVisibleBars(NSString *reason) {
 %end
 
 %ctor {
+    ApolloGeneralTableConfigureNativeRow(@"Hide Username on Tab Bar",
+        ^(__unused UIViewController *vc, UITableViewCell *cell) {
+            ApolloTabBarConfigureNativeUsernameCell(cell);
+        });
+
     [[NSNotificationCenter defaultCenter]
         addObserverForName:ApolloTabBarTitlesChangedNotification
                     object:nil
                      queue:NSOperationQueue.mainQueue
                 usingBlock:^(__unused NSNotification *notification) {
+        ApolloNormalizeNativeHideUsernameForIconOnlyTabBar();
+        ApolloGeneralTableRefreshNativeRowConfigurations();
         ApolloTabBarRefreshVisibleBars(@"setting changed");
+    }];
+
+    // A settings restore or another native caller can try to re-enable the
+    // narrower username option. Icon-only mode wins while active, and the row
+    // is refreshed so its switch remains visibly off and disabled.
+    [[NSNotificationCenter defaultCenter]
+        addObserverForName:kApolloNativeHideUsernameOnTabBarChangedNotification
+                    object:nil
+                     queue:NSOperationQueue.mainQueue
+                usingBlock:^(__unused NSNotification *notification) {
+        ApolloNormalizeNativeHideUsernameForIconOnlyTabBar();
+        ApolloGeneralTableRefreshNativeRowConfigurations();
     }];
 }

--- a/src/ApolloTabBarTitles.xm
+++ b/src/ApolloTabBarTitles.xm
@@ -19,9 +19,9 @@
 #import "UserDefaultConstants.h"
 #import "settings/ApolloSettingsGeneralTable.h"
 
-static NSString *const kApolloNativeHideUsernameOnTabBarKey = @"HideUsernameOnTabBar";
-static NSString *const kApolloNativeHideUsernameOnTabBarChangedNotification =
-    @"com.christianselig.HideUsernameOnTabBarChanged";
+// Apollo's native "Hide Username on Tab Bar" key + change notification are
+// shared definitions in UserDefaultConstants.h (UDKeyNativeHideUsernameOnTabBar)
+// — the Profiles settings screen mirrors the same key.
 
 static char kApolloTabBarTitleStateCapturedKey;
 static char kApolloTabBarOriginalTitleKey;
@@ -38,7 +38,7 @@ static void ApolloTabBarConfigureNativeUsernameSubviews(UIView *view, BOOL enabl
     if ([view isKindOfClass:UISwitch.class]) {
         UISwitch *toggle = (UISwitch *)view;
         BOOL nativeSettingOn = [NSUserDefaults.standardUserDefaults
-            boolForKey:kApolloNativeHideUsernameOnTabBarKey];
+            boolForKey:UDKeyNativeHideUsernameOnTabBar];
         [toggle setOn:(enabled && nativeSettingOn) animated:NO];
         toggle.enabled = enabled;
     } else if ([view isKindOfClass:UILabel.class]) {
@@ -63,11 +63,11 @@ static void ApolloTabBarConfigureNativeUsernameCell(UITableViewCell *cell) {
 void ApolloNormalizeNativeHideUsernameForIconOnlyTabBar(void) {
     if (!sHideTabBarTitles) return;
     NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
-    if (![defaults boolForKey:kApolloNativeHideUsernameOnTabBarKey]) return;
+    if (![defaults boolForKey:UDKeyNativeHideUsernameOnTabBar]) return;
 
-    [defaults setBool:NO forKey:kApolloNativeHideUsernameOnTabBarKey];
+    [defaults setBool:NO forKey:UDKeyNativeHideUsernameOnTabBar];
     [[NSNotificationCenter defaultCenter]
-        postNotificationName:kApolloNativeHideUsernameOnTabBarChangedNotification
+        postNotificationName:ApolloNativeHideUsernameOnTabBarChangedNotification
                       object:nil];
     ApolloLog(@"[TabBarTitles] Cleared redundant native Hide Username on Tab Bar setting");
 }
@@ -294,7 +294,7 @@ static void ApolloTabBarRefreshVisibleBars(NSString *reason) {
     // narrower username option. Icon-only mode wins while active, and the row
     // is refreshed so its switch remains visibly off and disabled.
     [[NSNotificationCenter defaultCenter]
-        addObserverForName:kApolloNativeHideUsernameOnTabBarChangedNotification
+        addObserverForName:ApolloNativeHideUsernameOnTabBarChangedNotification
                     object:nil
                      queue:NSOperationQueue.mainQueue
                 usingBlock:^(__unused NSNotification *notification) {

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -2677,6 +2677,7 @@ static void initializeRandomSources() {
                                     UDKeyCommentLinkHost: @(CommentLinkHostOff),
                                     UDKeyShowUserAvatars: @NO,
                                     UDKeyUseProfileAvatarTabIcon: @NO,
+                                    UDKeyHideTabBarTitles: @NO,
                                     UDKeyShowDetailedProfiles: @YES,
                                     UDKeyShowSubredditHeaders: @NO,
                                     UDKeyCommunityHighlights: @NO,
@@ -2825,6 +2826,7 @@ static void initializeRandomSources() {
     if (sCommentLinkHost < CommentLinkHostOff || sCommentLinkHost > CommentLinkHostImgChest) sCommentLinkHost = CommentLinkHostOff;
     sShowUserAvatars = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars];
     sUseProfileAvatarTabIcon = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon];
+    sHideTabBarTitles = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyHideTabBarTitles];
     sShowDetailedProfiles = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowDetailedProfiles];
     sShowSubredditHeaders = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowSubredditHeaders];
     sCommunityHighlights = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyCommunityHighlights];

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -2827,6 +2827,7 @@ static void initializeRandomSources() {
     sShowUserAvatars = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars];
     sUseProfileAvatarTabIcon = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon];
     sHideTabBarTitles = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyHideTabBarTitles];
+    ApolloNormalizeNativeHideUsernameForIconOnlyTabBar();
     sShowDetailedProfiles = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowDetailedProfiles];
     sShowSubredditHeaders = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowSubredditHeaders];
     sCommunityHighlights = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyCommunityHighlights];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -83,6 +83,12 @@ static NSString *const UDKeyCommentLinkHost = @"CommentLinkHost";
 static NSString *const ApolloCommentLinkHostChangedNotification = @"ApolloCommentLinkHostChangedNotification";
 static NSString *const UDKeyShowUserAvatars = @"ShowUserAvatars";
 static NSString *const UDKeyUseProfileAvatarTabIcon = @"UseProfileAvatarTabIcon";
+// When ON, the main tab bar removes its visible text labels and lets UIKit lay
+// out a clean icon-only navigation menu. The original titles remain available
+// to accessibility and are restored live when the setting is turned off.
+// Default OFF. See ApolloTabBarTitles.xm.
+static NSString *const UDKeyHideTabBarTitles = @"HideTabBarTitles";
+static NSString *const ApolloTabBarTitlesChangedNotification = @"ApolloTabBarTitlesChangedNotification";
 // When ON (default), profile pages show Reborn's detailed profile — the banner,
 // large avatar/snoovatar, display name, bio, and the Social Links band. When OFF,
 // the profile page reverts to Apollo's compact stock layout: the detailed header is

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -56,6 +56,22 @@ static NSString *const UDKeyOpenLinksInSteamApp = @"OpenLinksInSteamApp";
 // be gathered in one place and hidden from Apollo's own General settings. We
 // read/write the same key Apollo uses, so the two stay in sync.
 static NSString *const UDKeyOpenVideosInYouTubeApp = @"OpenVideosInYouTubeApp";
+// Apollo NATIVE key backing its "Open Links in" browser picker (String token;
+// missing = the in-app default). Verified tokens, recovered by driving the
+// native picker in the sim and reading back the persisted value:
+//   in-app-safari (In-App Safari), external-safari (Safari), chrome, firefox,
+//   firefox-focus, edge, dolphin, brave, duckduckgo, icab
+// Reborn's "Open in App" screen mirrors this key (same gather-and-hide pattern
+// as UDKeyOpenVideosInYouTubeApp above; the token literal is also read in
+// ApolloShareLinks.xm's ApolloOpensLinksInSystemBrowser()).
+static NSString *const UDKeyNativeOpenLinksIn = @"OpenLinksIn";
+// Apollo NATIVE key + change notification for its "Hide Username on Tab Bar"
+// switch. Apollo observes the notification (hideUsernameOnTabBarChangedWithNotification:)
+// and re-lays-out the profile tab live, so mirrors must post it after writing
+// the key. Reborn's Profiles settings screen mirrors this row (gather-and-hide);
+// ApolloTabBarTitles.xm clears the key while Icon-Only Tab Bar is active.
+static NSString *const UDKeyNativeHideUsernameOnTabBar = @"HideUsernameOnTabBar";
+static NSString *const ApolloNativeHideUsernameOnTabBarChangedNotification = @"com.christianselig.HideUsernameOnTabBarChanged";
 // Reborn "Open in App" deep-link toggles — open these services' links in their
 // app via Universal Links (see ApolloShareLinks.xm). Default OFF (opt-in). The
 // key string literals are duplicated in ApolloShareLinks.xm; keep them in sync.

--- a/src/settings/ApolloOpenInAppViewController.h
+++ b/src/settings/ApolloOpenInAppViewController.h
@@ -4,11 +4,10 @@
 // into Apollo's native Settings → General → Open Links section (see
 // ApolloSettingsNativeInjections.xm).
 //
-// Holds only the "open this kind of link in a dedicated app" toggles Apollo
-// has no native setting for: Bluesky / GitHub / Steam (UDKeyOpenLinksIn*App).
-// YouTube and browser choice are Apollo's own General → Other rows ("Open
-// Videos in YouTube App", "Open Links in") — this screen used to duplicate
-// them; the duplicates were dropped in the settings IA restructure.
-// Declarative form — see -buildForm.
+// Holds the "open this kind of link in a dedicated app" toggles Apollo has no
+// native setting for — Bluesky / GitHub / Steam (UDKeyOpenLinksIn*App) — plus
+// mirrors of Apollo's own YouTube switch and "Open Links in" browser picker
+// (same native defaults keys; the native General → Other rows are hidden, see
+// ApolloSettingsNativeInjections.xm). Declarative form — see -buildForm.
 @interface ApolloOpenInAppViewController : ApolloSettingsFormViewController
 @end

--- a/src/settings/ApolloOpenInAppViewController.m
+++ b/src/settings/ApolloOpenInAppViewController.m
@@ -4,12 +4,69 @@
 #import "ApolloSettingsForm.h"
 #import "UserDefaultConstants.h"
 
-// Only services Apollo has no native setting for live here. Browser choice and
-// YouTube are handled by Apollo's own General → Other rows ("Open Links in",
-// "Open Videos in YouTube App") — this screen used to duplicate both against
-// the same defaults keys, with the native rows hidden; the duplicates were
-// dropped in the settings IA restructure (the native picker is richer: it
-// offers Chrome/Firefox/etc. when installed).
+// This screen gathers every "open links in an app" preference in one place:
+// Reborn's own per-service deep-link toggles (Bluesky/GitHub/Steam), plus
+// mirrors of Apollo's two NATIVE rows — "Open Videos in YouTube App" and the
+// "Open Links in" browser picker — which read/write Apollo's own defaults keys
+// and are hidden from Apollo's General settings (the gather-and-hide
+// registration lives in ApolloSettingsNativeInjections.xm). The mirrored picker
+// reproduces the native option list faithfully, including its
+// installed-browser filtering — see ApolloOpenInAppBrowserOptions().
+
+// The browsers Apollo's native "Open Links in" picker can offer, in the
+// native menu's order. Tokens + labels were recovered by driving the native
+// picker in the sim (with canOpenURL faked YES for every browser) and reading
+// back the persisted UDKeyNativeOpenLinksIn value after each pick. The first
+// two entries have no probe scheme: they're always offered. Every probe scheme
+// is declared in Apollo's LSApplicationQueriesSchemes, so canOpenURL answers
+// honestly instead of auto-NO.
+static NSArray<NSArray<NSString *> *> *ApolloOpenInAppBrowserTable(void) {
+    // @[label, token, probe scheme ("" = always shown)]
+    return @[
+        @[@"In-App Safari", @"in-app-safari",   @""],
+        @[@"Safari",        @"external-safari", @""],
+        @[@"Chrome",        @"chrome",          @"googlechromes"],
+        @[@"Firefox",       @"firefox",         @"firefox"],
+        @[@"Firefox Focus", @"firefox-focus",   @"firefox-focus"],
+        @[@"Edge",          @"edge",            @"microsoft-edge-https"],
+        @[@"Dolphin",       @"dolphin",         @"dolphin"],
+        @[@"Brave",         @"brave",           @"brave"],
+        @[@"DuckDuckGo",    @"duckduckgo",      @"ddgQuickLink"],
+        @[@"iCab Mobile",   @"icab",            @"x-icabmobile"],
+    ];
+}
+
+static NSString *ApolloOpenInAppCurrentBrowserToken(void) {
+    NSString *token = [[NSUserDefaults standardUserDefaults] stringForKey:UDKeyNativeOpenLinksIn];
+    return token.length > 0 ? token : @"in-app-safari"; // missing key = Apollo's in-app default
+}
+
+// The rows offered by the picker right now: the two Safari modes always, a
+// third-party browser only when installed — matching the native picker — or
+// when it's already the persisted choice (so a value restored from a backup
+// stays visible and re-selectable instead of silently vanishing).
+static NSArray<NSArray<NSString *> *> *ApolloOpenInAppBrowserOptions(void) {
+    NSString *current = ApolloOpenInAppCurrentBrowserToken();
+    NSMutableArray<NSArray<NSString *> *> *options = [NSMutableArray array];
+    for (NSArray<NSString *> *entry in ApolloOpenInAppBrowserTable()) {
+        NSString *probeScheme = entry[2];
+        BOOL offered = probeScheme.length == 0 || [entry[1] isEqualToString:current];
+        if (!offered) {
+            NSURL *probe = [NSURL URLWithString:[probeScheme stringByAppendingString:@"://"]];
+            offered = probe && [[UIApplication sharedApplication] canOpenURL:probe];
+        }
+        if (offered) [options addObject:entry];
+    }
+    return options;
+}
+
+static NSString *ApolloOpenInAppBrowserLabelForToken(NSString *token) {
+    for (NSArray<NSString *> *entry in ApolloOpenInAppBrowserTable()) {
+        if ([entry[1] isEqualToString:token]) return entry[0];
+    }
+    return token; // future/unknown token: show it raw rather than mislabeling it
+}
+
 @implementation ApolloOpenInAppViewController
 
 - (void)viewDidLoad {
@@ -25,6 +82,8 @@
 }
 
 - (NSArray<ApolloSettingsSection *> *)buildForm {
+    __weak typeof(self) weakSelf = self;
+
     // Plain app names (alphabetical) — the section footer carries the
     // "open links in their app" explanation, so the rows don't repeat it.
     // (X/Twitter is intentionally not here — Apollo already ships a native
@@ -54,11 +113,54 @@
             [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:UDKeyOpenLinksInSteamApp];
         }];
 
+    // Mirror of Apollo's native "Open Videos in YouTube App" switch: same key,
+    // so Apollo's own YouTube handling and Reborn's Shorts deep-linking
+    // (ApolloShareLinks.xm) both pick the change up live.
+    ApolloSettingsRow *youTube =
+        [ApolloSettingsRow switchRowWithID:@"youtube"
+                                     title:@"YouTube"
+                                      isOn:^BOOL { return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyOpenVideosInYouTubeApp]; }
+                                  onToggle:^(UISwitch *sender) {
+            [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:UDKeyOpenVideosInYouTubeApp];
+        }];
+
+    // Mirror of Apollo's native "Open Links in" browser picker: same key, same
+    // options (installed browsers only), same tokens.
+    ApolloSettingsRow *browser =
+        [ApolloSettingsRow valueRowWithID:@"browser"
+                                    title:@"Open Links in"
+                                   detail:^NSString * { return ApolloOpenInAppBrowserLabelForToken(ApolloOpenInAppCurrentBrowserToken()); }
+                                 onSelect:^{ [weakSelf presentBrowserPicker]; }];
+
     return @[
         [ApolloSettingsSection sectionWithTitle:@"Apps"
-                                         footer:@"When enabled, links to these services open directly in their app (if installed) instead of a web view.\n\nYouTube and browser choice are Apollo's own settings: General → Other → \"Open Videos in YouTube App\" and \"Open Links in\"."
-                                           rows:@[ bluesky, gitHub, steam ]],
+                                         footer:@"When enabled, links to these services open directly in their app (if installed) instead of a web view."
+                                           rows:@[ bluesky, gitHub, steam, youTube ]],
+        [ApolloSettingsSection sectionWithTitle:@"Browser"
+                                         footer:@"Choose where every other web link opens. In-App Safari opens links inside Apollo; Safari and the other browsers appear as they're installed. This is Apollo's own setting, relocated here."
+                                           rows:@[ browser ]],
     ];
+}
+
+- (void)presentBrowserPicker {
+    NSArray<NSArray<NSString *> *> *options = ApolloOpenInAppBrowserOptions();
+    NSString *current = ApolloOpenInAppCurrentBrowserToken();
+
+    NSMutableArray<NSString *> *titles = [NSMutableArray array];
+    NSInteger currentIndex = 0;
+    for (NSUInteger i = 0; i < options.count; i++) {
+        [titles addObject:options[i][0]];
+        if ([options[i][1] isEqualToString:current]) currentIndex = (NSInteger)i;
+    }
+
+    __weak typeof(self) weakSelf = self;
+    ApolloSettingsPresentPicker(self, [self cellForRowID:@"browser"], @"Open Links in", titles, currentIndex,
+                                ^(NSInteger pickedIndex) {
+        if (pickedIndex < 0 || pickedIndex >= (NSInteger)options.count) return;
+        [[NSUserDefaults standardUserDefaults] setObject:options[pickedIndex][1]
+                                                  forKey:UDKeyNativeOpenLinksIn];
+        [weakSelf reloadRowWithID:@"browser"];
+    });
 }
 
 @end

--- a/src/settings/ApolloSettings.xm
+++ b/src/settings/ApolloSettings.xm
@@ -143,15 +143,6 @@ static UIImage *ApolloRootSettingsArtworkAtStandardSize(UIImage *artwork) {
     }];
 }
 
-static UITableView *ApolloRootSettingsTableInView(UIView *view) {
-    if ([view isKindOfClass:UITableView.class]) return (UITableView *)view;
-    for (UIView *subview in view.subviews) {
-        UITableView *tableView = ApolloRootSettingsTableInView(subview);
-        if (tableView) return tableView;
-    }
-    return nil;
-}
-
 %hook SettingsViewController
 
 // Settings search lives on the root screen's navigation item (see
@@ -161,22 +152,9 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
     %orig;
     ApolloSettingsSearchAttach((UIViewController *)self);
     ApolloRemoveLegacySettingsExportButton((UIViewController *)self);
-
-    // Apollo predates navigation-item search on this screen and leaves its old
-    // first-section breathing room in place. With a pinned search bar that
-    // becomes a conspicuous empty band, so opt out of the modern extra header
-    // padding. The grouped section's own inset remains intact.
-    UIViewController *vc = (UIViewController *)self;
-    UITableView *tableView = ApolloRootSettingsTableInView(vc.view);
-    if (tableView) {
-        if (@available(iOS 15.0, *)) tableView.sectionHeaderTopPadding = 0.0;
-        UIEdgeInsets inset = tableView.contentInset;
-        inset.top -= 24.0;
-        tableView.contentInset = inset;
-        UIEdgeInsets indicatorInsets = tableView.verticalScrollIndicatorInsets;
-        indicatorInsets.top -= 24.0;
-        tableView.verticalScrollIndicatorInsets = indicatorInsets;
-    }
+    // The search bar now scrolls away with the list (hidesSearchBarWhenScrolling),
+    // so Apollo's native first-section top spacing is correct again — the
+    // 24pt inset trim that hid the empty band under the *pinned* bar is gone.
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/src/settings/ApolloSettingsGeneralTable.h
+++ b/src/settings/ApolloSettingsGeneralTable.h
@@ -51,6 +51,19 @@ void ApolloGeneralTableInjectSelectableRow(NSString *anchorTitle,
                                                                        UITableViewCell *donor),
                                            void (^onSelect)(UIViewController *vc));
 
+// Reconfigure a native row whenever Eureka supplies its cell. This leaves the
+// native form and index-path geometry untouched; it is intended for small
+// cross-feature state adjustments such as disabling a redundant switch. The
+// title is matched with ApolloGeneralTableCellHasTitle().
+void ApolloGeneralTableConfigureNativeRow(NSString *title,
+                                          void (^configure)(UIViewController *vc,
+                                                            UITableViewCell *cell));
+
+// Re-run all registered native-row configurators for the currently visible
+// General cells. Off-screen rows are configured the next time Eureka supplies
+// their cell.
+void ApolloGeneralTableRefreshNativeRowConfigurations(void);
+
 // The live General-screen instance, if any (weak-backed; nil once it's gone).
 UIViewController *ApolloGeneralTableActiveVC(void);
 

--- a/src/settings/ApolloSettingsGeneralTable.xm
+++ b/src/settings/ApolloSettingsGeneralTable.xm
@@ -74,6 +74,15 @@ typedef UITableViewCell *(^ApolloGTRowFactory)(UIViewController *vc, UITableView
 static NSMutableArray<BOOL (^)(UITableViewCell *)> *sGTHideMatchers;
 static NSMutableArray<ApolloGTInjection *> *sGTInjections;
 
+@interface ApolloGTNativeRowConfiguration : NSObject
+@property (nonatomic, copy) NSString *title;
+@property (nonatomic, copy) void (^configure)(UIViewController *vc, UITableViewCell *cell);
+@end
+@implementation ApolloGTNativeRowConfiguration
+@end
+
+static NSMutableArray<ApolloGTNativeRowConfiguration *> *sGTNativeRowConfigurations;
+
 void ApolloGeneralTableHideRows(BOOL (^cellMatcher)(UITableViewCell *cell)) {
     if (!cellMatcher) return;
     if (!sGTHideMatchers) sGTHideMatchers = [NSMutableArray array];
@@ -100,6 +109,17 @@ void ApolloGeneralTableInjectSelectableRow(NSString *anchorTitle,
     [sGTInjections addObject:inj];
 }
 
+void ApolloGeneralTableConfigureNativeRow(NSString *title,
+                                          void (^configure)(UIViewController *vc,
+                                                            UITableViewCell *cell)) {
+    if (!title || !configure) return;
+    ApolloGTNativeRowConfiguration *configuration = [ApolloGTNativeRowConfiguration new];
+    configuration.title = title;
+    configuration.configure = configure;
+    if (!sGTNativeRowConfigurations) sGTNativeRowConfigurations = [NSMutableArray array];
+    [sGTNativeRowConfigurations addObject:configuration];
+}
+
 // MARK: - shared title matching
 
 static BOOL ApolloGTStringMatchesTitle(NSString *text, NSString *title) {
@@ -124,6 +144,15 @@ BOOL ApolloGeneralTableCellHasTitle(UITableViewCell *cell, NSString *title) {
     if (!cell || !title) return NO;
     if (ApolloGTStringMatchesTitle(cell.textLabel.text, title)) return YES;
     return ApolloGTLabelTreeHasTitle(cell.contentView, title, 0);
+}
+
+static void ApolloGTApplyNativeRowConfigurations(UIViewController *vc, UITableViewCell *cell) {
+    if (!vc || !cell) return;
+    for (ApolloGTNativeRowConfiguration *configuration in sGTNativeRowConfigurations) {
+        if (ApolloGeneralTableCellHasTitle(cell, configuration.title)) {
+            configuration.configure(vc, cell);
+        }
+    }
 }
 
 // MARK: - map state
@@ -352,6 +381,15 @@ static void ApolloGTZeroReturn(NSInvocation *inv) {
 
     [inv invokeWithTarget:vc];
 
+    // Native rows pass through Eureka unchanged, then receive any registered
+    // state-only configuration. Applying after every dequeue makes off-screen
+    // rows agree as soon as they scroll into view without rebuilding the form.
+    if (sel == @selector(tableView:cellForRowAtIndexPath:)) {
+        __unsafe_unretained UITableViewCell *cell = nil;
+        [inv getReturnValue:&cell];
+        ApolloGTApplyNativeRowConfigurations(vc, cell);
+    }
+
     // Echoed index paths (willSelect, targetIndexPathForMove, ...) go back
     // native -> display. Pin the replacement to the pool: setReturnValue: does
     // not retain, and "small NSIndexPaths are tagged (immortal) pointers" is a
@@ -402,6 +440,16 @@ static UITableView *ApolloGTFindTable(UIViewController *vc) {
     return nil;
 }
 
+void ApolloGeneralTableRefreshNativeRowConfigurations(void) {
+    UIViewController *vc = sApolloGTActiveVC;
+    if (!vc || !vc.viewIfLoaded.window) return;
+    UITableView *tv = ApolloGTFindTable(vc);
+    if (!tv) return;
+    for (NSIndexPath *indexPath in tv.indexPathsForVisibleRows) {
+        ApolloGTApplyNativeRowConfigurations(vc, [tv cellForRowAtIndexPath:indexPath]);
+    }
+}
+
 UITableViewCell *ApolloGeneralTableVisibleCellForTitle(UIViewController *vc, NSString *title) {
     if (!vc || !title || !vc.viewIfLoaded.window) return nil;
     UITableView *tv = ApolloGTFindTable(vc);
@@ -438,7 +486,8 @@ UITableViewCell *ApolloGeneralTableVisibleCellForTitle(UIViewController *vc, NSS
 // guard (the old sPPCSScanning flag is gone by construction).
 static void ApolloGTScanAndInstall(UIViewController *vc) {
     if (objc_getAssociatedObject(vc, kApolloGTProxyKey)) return;
-    if (sGTHideMatchers.count == 0 && sGTInjections.count == 0) return;
+    if (sGTHideMatchers.count == 0 && sGTInjections.count == 0 &&
+        sGTNativeRowConfigurations.count == 0) return;
     UITableView *tv = ApolloGTFindTable(vc);
     if (!tv) {
         ApolloLog(@"[GeneralTable] no table view found; leaving the screen native");
@@ -457,6 +506,7 @@ static void ApolloGTScanAndInstall(UIViewController *vc) {
                 for (NSInteger r = 0; r < rowCount; r++) {
                     UITableViewCell *cell = [ds tableView:tv
                                     cellForRowAtIndexPath:[NSIndexPath indexPathForRow:r inSection:s]];
+                    ApolloGTApplyNativeRowConfigurations(vc, cell);
                     [cells addObject:cell ?: [UITableViewCell new]];
                 }
 
@@ -516,7 +566,7 @@ static void ApolloGTScanAndInstall(UIViewController *vc) {
         return;
     }
 
-    if (displayBySection.count == 0) {
+    if (displayBySection.count == 0 && sGTNativeRowConfigurations.count == 0) {
         ApolloLog(@"[GeneralTable] nothing matched (no hides, no anchors); screen left native");
         return;
     }

--- a/src/settings/ApolloSettingsNativeInjections.xm
+++ b/src/settings/ApolloSettingsNativeInjections.xm
@@ -11,10 +11,20 @@
 //   Other      → "Saved Categories"      (under its master switch,
 //                                         "Allow Save Categories")
 //
+// It also registers the General-screen row HIDES for native rows Reborn
+// relocates onto its own screens (each still driving the same native defaults
+// key, so nothing behavioral moves — only where the control lives):
+//
+//   "Open Links in"               → Open in App (browser picker mirror)
+//   "Open Videos in YouTube App"  → Open in App (YouTube switch mirror)
+//   "Hide Username on Tab Bar"    → Apollo Reborn → Profiles (below Icon-Only
+//                                   Tab Bar, which supersedes it while active)
+//
 // Geometry is owned by settings/ApolloSettingsGeneralTable.xm — this file only
-// registers factories + selection handlers, and each push goes through the
-// route registry so "how do I get to screen X" stays one table. Fail-soft by
-// construction: an anchor that stops matching just means no row.
+// registers factories + selection handlers + hide matchers, and each push goes
+// through the route registry so "how do I get to screen X" stays one table.
+// Fail-soft by construction: an anchor or hide title that stops matching just
+// means the native screen keeps that row.
 
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
@@ -92,4 +102,13 @@ static const void *kApolloInjSavedCategoriesKey = &kApolloInjSavedCategoriesKey;
                                        @"Allow Save Categories",
                                        kApolloInjSavedCategoriesKey,
                                        @"saved-categories");
+
+    // Native rows relocated onto Reborn screens (see the header comment). The
+    // mirrors read/write the same native keys, so hiding these is pure
+    // deduplication — none of them is used as an injection anchor above.
+    ApolloGeneralTableHideRows(^BOOL(UITableViewCell *cell) {
+        return ApolloGeneralTableCellHasTitle(cell, @"Open Links in")
+            || ApolloGeneralTableCellHasTitle(cell, @"Open Videos in YouTube App")
+            || ApolloGeneralTableCellHasTitle(cell, @"Hide Username on Tab Bar");
+    });
 }

--- a/src/settings/ApolloSettingsSearch.m
+++ b/src/settings/ApolloSettingsSearch.m
@@ -225,6 +225,14 @@ static NSArray<ApolloSettingsSearchEntry *> *ApolloSettingsSearchBuildIndex(UITr
         // in General → Other. Keeping the snapshot entry would return a result
         // that can no longer be found or flashed after navigation.
         if ([row[0] isEqualToString:@"Always Offer Translate"]) continue;
+        // Reborn hides these three native General → Other rows and relocates
+        // them onto its own screens (Open in App / Profiles) against the same
+        // native keys — see ApolloSettingsNativeInjections.xm. The moved rows
+        // are indexed from the live Reborn screen crawl above, so the snapshot
+        // entries would navigate to a row that no longer exists.
+        if ([row[0] isEqualToString:@"Open Links in"]) continue;
+        if ([row[0] isEqualToString:@"Open Videos in YouTube App"]) continue;
+        if ([row[0] isEqualToString:@"Hide Username on Tab Bar"]) continue;
         // Reborn owns the prominent Feature Requests entry (Apollo Reborn →
         // About → Fider board), already indexed from the live Reborn crawl.
         // The native About row now just opens a new-vs-archived chooser, so a
@@ -587,141 +595,8 @@ static void ApolloSettingsSearchOpenEntry(UIViewController *settingsVC, ApolloSe
 
 #pragma mark - Attach
 
-#pragma mark - Pull to search
-
-// The nav-bar search field is always visible, but a deliberate downward pull on
-// the settings list also opens it — with a playful affordance drawn in the gap
-// the pull reveals: a magnifying glass that scales + fills in with pull
-// progress, a "Pull to search → Release to search" caption, and a soft haptic
-// as it arms. Overscroll is read off the table's own pan recognizer (no
-// scroll-delegate hooking), so Apollo's scrolling is untouched.
-static const CGFloat kPullActivateThreshold = 78.0;  // overscroll to arm (past this, release opens search)
-static const CGFloat kPullRevealStart       = 6.0;   // overscroll before the affordance starts fading in
-
-@interface ApolloSettingsSearchPullToActivate : NSObject
-@property (nonatomic, weak) UISearchController *searchController;
-@property (nonatomic, weak) UIScrollView *scrollView;
-@property (nonatomic, strong) UIView *affordance;
-@property (nonatomic, strong) UIImageView *glassIcon;
-@property (nonatomic, strong) UILabel *caption;
-@property (nonatomic, strong) UIImpactFeedbackGenerator *haptic;
-@property (nonatomic) CGFloat peakOverscroll;
-@property (nonatomic) BOOL armed;   // haptic + "release" state latched once per pull
-@end
-
-@implementation ApolloSettingsSearchPullToActivate
-
-// Build the pull affordance and pin it in the gap just under the search bar
-// (the container's safe-area top, which sits below the always-visible nav
-// field). It starts invisible and is revealed by the pull.
-- (void)installAffordanceInContainer:(UIView *)container {
-    UIView *host = [[UIView alloc] init];
-    host.translatesAutoresizingMaskIntoConstraints = NO;
-    host.userInteractionEnabled = NO;
-    host.alpha = 0.0;
-
-    UIImageView *glass = [[UIImageView alloc] initWithImage:
-        [UIImage systemImageNamed:@"magnifyingglass"
-                withConfiguration:[UIImageSymbolConfiguration configurationWithPointSize:20.0
-                                                                                  weight:UIImageSymbolWeightSemibold]]];
-    glass.translatesAutoresizingMaskIntoConstraints = NO;
-    glass.tintColor = [UIColor secondaryLabelColor];
-    [host addSubview:glass];
-
-    UILabel *label = [[UILabel alloc] init];
-    label.translatesAutoresizingMaskIntoConstraints = NO;
-    label.font = [UIFont systemFontOfSize:12.0 weight:UIFontWeightSemibold];
-    label.textColor = [UIColor secondaryLabelColor];
-    label.text = @"Pull to search";
-    [host addSubview:label];
-
-    [container addSubview:host];
-    UILayoutGuide *safe = container.safeAreaLayoutGuide;
-    [NSLayoutConstraint activateConstraints:@[
-        [host.topAnchor constraintEqualToAnchor:safe.topAnchor constant:6.0],
-        [host.leadingAnchor constraintEqualToAnchor:container.leadingAnchor],
-        [host.trailingAnchor constraintEqualToAnchor:container.trailingAnchor],
-        [glass.centerXAnchor constraintEqualToAnchor:host.centerXAnchor],
-        [glass.topAnchor constraintEqualToAnchor:host.topAnchor],
-        [label.centerXAnchor constraintEqualToAnchor:host.centerXAnchor],
-        [label.topAnchor constraintEqualToAnchor:glass.bottomAnchor constant:6.0],
-        [label.bottomAnchor constraintEqualToAnchor:host.bottomAnchor],
-    ]];
-    self.affordance = host;
-    self.glassIcon = glass;
-    self.caption = label;
-    self.haptic = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleMedium];
-}
-
-// Map pull progress onto the affordance: fade + scale the glass in, tint + relabel
-// once armed, and fire the haptic on the arming edge.
-- (void)renderOverscroll:(CGFloat)overscroll {
-    CGFloat progress = 0.0;
-    if (overscroll > kPullRevealStart) {
-        progress = (overscroll - kPullRevealStart) / (kPullActivateThreshold - kPullRevealStart);
-        progress = MAX(0.0, MIN(1.0, progress));
-    }
-    self.affordance.alpha = progress;
-    CGFloat scale = 0.6 + 0.4 * progress;
-    self.glassIcon.transform = CGAffineTransformMakeScale(scale, scale);
-
-    BOOL armed = overscroll >= kPullActivateThreshold;
-    if (armed != self.armed) {
-        self.armed = armed;
-        self.caption.text = armed ? @"Release to search" : @"Pull to search";
-        UIColor *accent = [self.searchController.searchResultsUpdater
-                              respondsToSelector:@selector(apollo_themeAccentColor)]
-            ? [(id)self.searchController.searchResultsUpdater apollo_themeAccentColor] : nil;
-        UIColor *tint = armed ? (accent ?: [UIColor systemBlueColor]) : [UIColor secondaryLabelColor];
-        [UIView animateWithDuration:0.15 animations:^{
-            self.glassIcon.tintColor = tint;
-            self.caption.textColor = tint;
-        }];
-        if (armed) { [self.haptic impactOccurred]; [self.haptic prepare]; }
-    }
-}
-
-- (void)handlePan:(UIPanGestureRecognizer *)pan {
-    UIScrollView *sv = self.scrollView;
-    UISearchController *sc = self.searchController;
-    if (!sv || !sc) return;
-    if (sc.active) { self.affordance.alpha = 0.0; return; }
-
-    CGFloat overscroll = -(sv.contentOffset.y + sv.adjustedContentInset.top);
-    switch (pan.state) {
-        case UIGestureRecognizerStateBegan:
-            self.peakOverscroll = 0;
-            self.armed = NO;
-            [self.haptic prepare];
-            break;
-        case UIGestureRecognizerStateChanged:
-            if (overscroll > self.peakOverscroll) self.peakOverscroll = overscroll;
-            [self renderOverscroll:overscroll];
-            break;
-        case UIGestureRecognizerStateEnded:
-        case UIGestureRecognizerStateCancelled: {
-            BOOL shouldActivate = self.peakOverscroll >= kPullActivateThreshold && !sc.active;
-            self.peakOverscroll = 0;
-            self.armed = NO;
-            [UIView animateWithDuration:0.2 animations:^{ self.affordance.alpha = 0.0; }];
-            if (shouldActivate) {
-                // Defer past the rubber-band settle so presenting the results
-                // controller isn't fighting the scroll animation.
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    sc.active = YES;
-                    [sc.searchBar becomeFirstResponder];
-                });
-            }
-            break;
-        }
-        default:
-            break;
-    }
-}
-@end
 
 static char kApolloSettingsSearchAttachedKey;
-static char kApolloSettingsSearchPullKey;
 
 void ApolloSettingsSearchAttach(UIViewController *settingsVC) {
     if (!settingsVC || objc_getAssociatedObject(settingsVC, &kApolloSettingsSearchAttachedKey)) return;
@@ -737,22 +612,18 @@ void ApolloSettingsSearchAttach(UIViewController *settingsVC) {
     results.searchController = searchController;
 
     settingsVC.navigationItem.searchController = searchController;
-    settingsVC.navigationItem.hidesSearchBarWhenScrolling = NO;
+    // Native iOS behavior: the search bar lives in the large-title area and
+    // scrolls away as the list scrolls up, revealing again on a scroll to the
+    // top — rather than staying pinned under the nav bar.
+    settingsVC.navigationItem.hidesSearchBarWhenScrolling = YES;
     settingsVC.definesPresentationContext = YES;
 
     objc_setAssociatedObject(settingsVC, &kApolloSettingsSearchAttachedKey, searchController, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-    // Pull-to-search: a downward overscroll reveals the animated affordance and,
-    // on release past the threshold, opens search.
-    UITableView *rootTable = ApolloSearchTableInViewController(settingsVC);
-    if (rootTable) {
-        ApolloSettingsSearchPullToActivate *pull = [[ApolloSettingsSearchPullToActivate alloc] init];
-        pull.searchController = searchController;
-        pull.scrollView = rootTable;
-        [pull installAffordanceInContainer:settingsVC.view];
-        [rootTable.panGestureRecognizer addTarget:pull action:@selector(handlePan:)];
-        objc_setAssociatedObject(settingsVC, &kApolloSettingsSearchPullKey, pull, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    }
+    // No custom pull-to-search affordance: with hidesSearchBarWhenScrolling the
+    // system already reveals the bar on a scroll to the top, so a bespoke
+    // overscroll gesture would fight that native reveal (it used to exist only
+    // because the bar was pinned and never moved).
 
     ApolloLog(@"[SettingsSearch] attached to %@", settingsVC);
 }

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -1490,6 +1490,12 @@ typedef NS_ENUM(NSInteger, Tag) {
                                       isOn:^BOOL { return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseProfileAvatarTabIcon]; }
                                   onToggle:^(UISwitch *sender) { [weakSelf profileTabAvatarSwitchToggled:sender]; }];
 
+    ApolloSettingsRow *iconOnlyTabBar =
+        [ApolloSettingsRow switchRowWithID:@"profiles.iconOnlyTabBar"
+                                     title:@"Icon-Only Tab Bar"
+                                      isOn:^BOOL { return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyHideTabBarTitles]; }
+                                  onToggle:^(UISwitch *sender) { [weakSelf iconOnlyTabBarSwitchToggled:sender]; }];
+
     // Single toggle for Reborn's detailed profile page: banner, large
     // avatar/snoovatar, display name, bio, and the Social Links band (all of
     // which live in the custom header). Off → Apollo's compact stock profile.
@@ -1500,8 +1506,8 @@ typedef NS_ENUM(NSInteger, Tag) {
                                   onToggle:^(UISwitch *sender) { [weakSelf showDetailedProfilesSwitchToggled:sender]; }];
 
     return [ApolloSettingsSection sectionWithTitle:nil
-                                            footer:@"Show profile pictures, and open Reborn's detailed profile pages with a banner, bio and social links."
-                                              rows:@[ userAvatars, profileTabAvatar, detailedProfiles ]];
+                                            footer:@"Customize profile pictures, profile pages and the tab bar. Icon-Only Tab Bar hides the text labels while keeping each icon's accessibility name."
+                                              rows:@[ userAvatars, profileTabAvatar, iconOnlyTabBar, detailedProfiles ]];
 }
 
 // Subreddits group screen (ApolloSubredditsSettingsViewController), two
@@ -3067,6 +3073,12 @@ typedef NS_ENUM(NSInteger, Tag) {
     sUseProfileAvatarTabIcon = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sUseProfileAvatarTabIcon forKey:UDKeyUseProfileAvatarTabIcon];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloProfileTabAvatarIconChangedNotification" object:nil];
+}
+
+- (void)iconOnlyTabBarSwitchToggled:(UISwitch *)sender {
+    sHideTabBarTitles = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sHideTabBarTitles forKey:UDKeyHideTabBarTitles];
+    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloTabBarTitlesChangedNotification object:nil];
 }
 
 - (void)showDetailedProfilesSwitchToggled:(UISwitch *)sender {

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -1113,11 +1113,11 @@ typedef NS_ENUM(NSInteger, Tag) {
                                               rows:@[ readThumbnails, readPostMax, filterNSFWRR ]];
 }
 
-// The "Open in App" screen (Bluesky / GitHub / Steam) now lives in native
-// General → Open Links — see ApolloSettingsNativeInjections.xm. Its old
-// YouTube toggle and Default Browser picker were dropped outright: they
-// wrote Apollo's own keys, and the native rows ("Open Videos in YouTube
-// App", "Open Links in") are shown again in General → Other.
+// The "Open in App" screen now lives in native General → Open Links — see
+// ApolloSettingsNativeInjections.xm. Besides the Bluesky / GitHub / Steam
+// toggles it mirrors Apollo's own YouTube switch and "Open Links in" browser
+// picker against their native keys; the native General → Other rows are
+// hidden (registration in the same file).
 
 // Compact state shown below the Info Row disclosure. This is derived from the
 // same globals as the destination form, so returning from that screen only
@@ -1496,6 +1496,23 @@ typedef NS_ENUM(NSInteger, Tag) {
                                       isOn:^BOOL { return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyHideTabBarTitles]; }
                                   onToggle:^(UISwitch *sender) { [weakSelf iconOnlyTabBarSwitchToggled:sender]; }];
 
+    // Mirror of Apollo's native "Hide Username on Tab Bar" switch (relocated
+    // here from General → Other, which now hides it — see
+    // ApolloSettingsNativeInjections.xm). Same key, and the native change
+    // notification is posted so Apollo relabels the profile tab live. While
+    // Icon-Only Tab Bar is on, every tab label is already hidden, so this
+    // narrower option shows off + disabled — the same treatment
+    // ApolloTabBarTitles.xm gives the native row.
+    ApolloSettingsRow *hideUsernameTab =
+        [ApolloSettingsRow switchRowWithID:@"profiles.hideUsernameTab"
+                                     title:@"Hide Username on Tab Bar"
+                                      isOn:^BOOL {
+            return !sHideTabBarTitles &&
+                   [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyNativeHideUsernameOnTabBar];
+        }
+                                  onToggle:^(UISwitch *sender) { [weakSelf hideUsernameTabSwitchToggled:sender]; }];
+    hideUsernameTab.enabled = ^BOOL { return !sHideTabBarTitles; };
+
     // Single toggle for Reborn's detailed profile page: banner, large
     // avatar/snoovatar, display name, bio, and the Social Links band (all of
     // which live in the custom header). Off → Apollo's compact stock profile.
@@ -1506,8 +1523,8 @@ typedef NS_ENUM(NSInteger, Tag) {
                                   onToggle:^(UISwitch *sender) { [weakSelf showDetailedProfilesSwitchToggled:sender]; }];
 
     return [ApolloSettingsSection sectionWithTitle:nil
-                                            footer:@"Customize profile pictures, profile pages and the tab bar. Icon-Only Tab Bar hides the text labels while keeping each icon's accessibility name."
-                                              rows:@[ userAvatars, profileTabAvatar, iconOnlyTabBar, detailedProfiles ]];
+                                            footer:@"Customize profile pictures, profile pages and the tab bar. Icon-Only Tab Bar hides every tab's text label (Hide Username on Tab Bar only hides yours), while keeping each icon's accessibility name."
+                                              rows:@[ userAvatars, profileTabAvatar, iconOnlyTabBar, hideUsernameTab, detailedProfiles ]];
 }
 
 // Subreddits group screen (ApolloSubredditsSettingsViewController), two
@@ -3076,7 +3093,18 @@ typedef NS_ENUM(NSInteger, Tag) {
 }
 
 - (void)iconOnlyTabBarSwitchToggled:(UISwitch *)sender {
+    // Enabling also clears the native Hide Username key (see
+    // ApolloSetHideTabBarTitlesEnabled), so the sibling row below must re-read
+    // its switch state and enablement either way.
     ApolloSetHideTabBarTitlesEnabled(sender.isOn);
+    [self reloadRowWithID:@"profiles.hideUsernameTab"];
+}
+
+- (void)hideUsernameTabSwitchToggled:(UISwitch *)sender {
+    [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:UDKeyNativeHideUsernameOnTabBar];
+    // Apollo natively observes this and relabels the profile tab immediately.
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:ApolloNativeHideUsernameOnTabBarChangedNotification object:nil];
 }
 
 - (void)showDetailedProfilesSwitchToggled:(UISwitch *)sender {

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -3076,9 +3076,7 @@ typedef NS_ENUM(NSInteger, Tag) {
 }
 
 - (void)iconOnlyTabBarSwitchToggled:(UISwitch *)sender {
-    sHideTabBarTitles = sender.isOn;
-    [[NSUserDefaults standardUserDefaults] setBool:sHideTabBarTitles forKey:UDKeyHideTabBarTitles];
-    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloTabBarTitlesChangedNotification object:nil];
+    ApolloSetHideTabBarTitlesEnabled(sender.isOn);
 }
 
 - (void)showDetailedProfilesSwitchToggled:(UISwitch *)sender {


### PR DESCRIPTION
Two things in here.

**1. Shuffle a few settings into more sensible homes**

Same idea as how Open in App already gathers the scattered "open in app" toggles — mirror the native key, then hide the native row so it isn't in two places.

- **Open Links in** (browser picker) and **Open Videos in YouTube App** → moved into **Open in App**. The browser picker mirrors Apollo's own one exactly — same tokens, same option list, and it only shows a browser when it's actually installed (pulled the real token list by driving the native picker in the sim: `in-app-safari`/`external-safari`/`chrome`/`firefox`/`firefox-focus`/`edge`/`dolphin`/`brave`/`duckduckgo`/`icab`).
- **Hide Username on Tab Bar** → moved into **Profiles**, sitting right under Icon-Only Tab Bar. It fades out + turns off while Icon-Only is on (since that already hides every label) and comes back when you turn Icon-Only off. Posts Apollo's change notification so the profile tab relabels live.

Nothing's deleted — the rows write the same native defaults keys, they're just relocated and the old native rows are hidden. Settings search finds them at their new spots (and no dupes).

<table>
<tr>
<td width="250"><img width="250" src="https://github.com/user-attachments/assets/aab651db-9b47-4ed7-adce-8c8d5de855a6" alt="Profiles screen"></td>
<td width="250"><img width="250" src="https://github.com/user-attachments/assets/20b4aab2-4ffb-433e-9e0f-f16f7ee18fe5" alt="Open in App screen"></td>
<td width="250"><img width="250" src="https://github.com/user-attachments/assets/e736d3c1-925d-4954-b476-e1470a6cd55e" alt="General Other section"></td>
</tr>
<tr>
<td align="center"><b>Profiles</b> — Hide Username on Tab Bar now sits under Icon-Only Tab Bar (fades out when that's on).</td>
<td align="center"><b>Open in App</b> — the YouTube toggle and the Open Links in browser picker, both relocated here.</td>
<td align="center"><b>General → Other</b> — the moved rows are gone from their old home, no duplicates.</td>
</tr>
</table>

**2. Settings search bar scrolls away now**

It was pinned in place. Flipped it to the normal iOS behavior — scrolls up and hides with the list, pull back to the top to show it again. Ripped out the old custom pull-to-search thing since the system reveal does that now (and they were fighting each other), and dropped the inset hack that was only there to hide the gap under the pinned bar.

Stacked on #691 (Icon-Only Tab Bar) since the Hide Username row lives next to it — the first two commits here are that PR and will drop off once it lands.

<table>
<tr>
<td width="300"><img width="300" src="https://github.com/user-attachments/assets/9fa7d20f-6b8c-4eac-80d6-8f661f38301c" alt="Search bar scroll-away"></td>
<td valign="middle">The search bar scrolls up and hides with the list, and reveals again on a pull back to the top — instead of staying stuck under the nav bar.</td>
</tr>
</table>

Sim-tested on iOS 26 (Sim2): all three moves work, the fade/supersede both directions, browser picker writes the right tokens, search finds everything, and the search bar scrolls like it should. Not device-tested yet.
