### PR TITLE
Social links: resolve profiles in under a second (was 7-8s+)

### DIFF
--- a/src/ApolloProfileSocialLinks.h
+++ b/src/ApolloProfileSocialLinks.h
@@ -9,12 +9,17 @@
 //                "Social Links" sheet listing them all, each row tappable)
 //
 // Reddit's OAuth API (Apollo's token) can't read social links — about.json omits
-// them and gql 404s our token — so, like Community Highlights / the Sidebar weekly
-// stats, we scrape the server-rendered public profile page in a hidden WKWebView
-// (it sails past Reddit's JS bot-challenge that plain requests get 403'd by).
-// Results are cached per-username. Icons come from each link's domain favicon
-// (bundled coffee glyph for Buy Me a Coffee / Ko-fi), so brands render without a
-// bundled logo set. See ApolloProfileSocialLinks.m.
+// them and gql 404s our token — so we read Reddit's server-rendered markup.
+// FAST PATH (default): one direct NSURLSession GET of the profile-header-details
+// svc endpoint + native parse of the social-link tracker markup (~0.5s for every
+// profile bucket; the active account's web-session cookies ride along when
+// available, which also clears Reddit's logged-out hard block on flagged
+// networks). SECOND CHANCE: the full profile page (settles deleted users).
+// FALLBACK: the original hidden-WKWebView scrape — it renders and hydrates like
+// a real browser — for responses neither direct GET can classify. Results are cached per-username (memory + a TTL disk cache). Icons
+// come from each link's domain favicon (bundled coffee glyph for Buy Me a
+// Coffee / Ko-fi), so brands render without a bundled logo set. See
+// ApolloProfileSocialLinks.m.
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>

--- a/src/ApolloProfileSocialLinks.m
+++ b/src/ApolloProfileSocialLinks.m
@@ -3,6 +3,8 @@
 #import "ApolloProfileSocialLinks.h"
 #import "ApolloCommon.h"
 #import "ApolloState.h"
+#import "ApolloWebSessionStore.h"   // ApolloActiveWebSession() — logged-in scrape cookies
+#import "ApolloWebJSON.h"           // ApolloWebJSONProbeURL() — opt-out of the Web JSON rewrite
 #import <WebKit/WebKit.h>
 #import <objc/runtime.h>
 
@@ -231,6 +233,7 @@ static void ApolloSLRequestFaviconForHost(NSString *host, void (^completion)(UII
     if (!url) { drain(nil); return; }
     NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url];
     req.timeoutInterval = 12.0;
+    CFAbsoluteTime t0 = CFAbsoluteTimeGetCurrent();
     [[[NSURLSession sharedSession] dataTaskWithRequest:req completionHandler:^(NSData *data, NSURLResponse *resp, NSError *err) {
         // Google returns a 16px globe placeholder for unknown domains; keep it anyway
         // (still better than our generic glyph for most real services).
@@ -239,6 +242,8 @@ static void ApolloSLRequestFaviconForHost(NSString *host, void (^completion)(UII
         // rows and the header badges all render at a consistent size/weight regardless
         // of each favicon's native pixel size or internal transparent padding.
         UIImage *normalized = image ? ApolloSLNormalizedFavicon(image) : nil;
+        ApolloLog(@"[SocialLinks][perf] favicon %@ %@ in %.2fs", key,
+                  normalized ? @"loaded" : @"failed", CFAbsoluteTimeGetCurrent() - t0);
         dispatch_async(dispatch_get_main_queue(), ^{
             if (normalized) [ApolloSLFaviconCache() setObject:normalized forKey:key];
             drain(normalized);
@@ -292,6 +297,292 @@ static NSArray<ApolloSocialLink *> *ApolloSLLinksFromJSON(NSArray *raw) {
     return links;
 }
 
+#pragma mark - Disk cache (TTL)
+
+// Social links change rarely, so a tiny per-user JSON file in Library/Caches
+// (OS-purgeable) makes repeat visits across launches resolve with ZERO reddit
+// requests. The TTL bounds staleness; pull-to-refresh bypasses it via -refresh.
+// (Same shape as the Badge Book scraper's disk cache.)
+static NSTimeInterval const kApolloSLDiskTTL = 6.0 * 60.0 * 60.0;
+static NSUInteger const kApolloSLDiskMaxFiles = 150;
+
+static NSString *ApolloSLDiskDir(void) {
+    static NSString *dir; static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        NSString *caches = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
+        dir = [caches stringByAppendingPathComponent:@"ApolloSocialLinks"];
+        [[NSFileManager defaultManager] createDirectoryAtPath:dir withIntermediateDirectories:YES attributes:nil error:nil];
+    });
+    return dir;
+}
+
+// Cache keys are lowercased reddit usernames — [a-z0-9_-] for every real
+// account, but nothing upstream ENFORCES that, and this path feeds file writes
+// and -refresh deletes. Filter defensively so no conceivable username can
+// traverse out of the cache dir (collisions after filtering just share a cache
+// slot — harmless).
+static NSString *ApolloSLDiskPath(NSString *key) {
+    static NSCharacterSet *unsafe; static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        unsafe = [[NSCharacterSet characterSetWithCharactersInString:
+                   @"abcdefghijklmnopqrstuvwxyz0123456789_-"] invertedSet];
+    });
+    NSString *safe = [[key componentsSeparatedByCharactersInSet:unsafe] componentsJoinedByString:@""];
+    if (safe.length == 0) safe = [NSString stringWithFormat:@"h%lx", (unsigned long)key.hash];
+    return [[ApolloSLDiskDir() stringByAppendingPathComponent:safe] stringByAppendingPathExtension:@"json"];
+}
+
+// Expired entries are only ever skipped on read — sweep once per launch
+// (piggybacked on the first save, already off-main): drop anything past the TTL,
+// then cap the directory to the most recently written entries.
+static void ApolloSLDiskSweepOnce(void) {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        NSFileManager *fm = [NSFileManager defaultManager];
+        NSString *dir = ApolloSLDiskDir();
+        NSArray<NSString *> *names = [fm contentsOfDirectoryAtPath:dir error:nil];
+        if (names.count == 0) return;
+        NSDate *now = [NSDate date];
+        NSMutableArray<NSDictionary *> *live = [NSMutableArray array];
+        for (NSString *name in names) {
+            NSString *path = [dir stringByAppendingPathComponent:name];
+            NSDate *modified = [fm attributesOfItemAtPath:path error:nil].fileModificationDate;
+            if (modified && [now timeIntervalSinceDate:modified] > kApolloSLDiskTTL) {
+                [fm removeItemAtPath:path error:nil];
+                continue;
+            }
+            [live addObject:@{ @"path": path, @"date": modified ?: now }];
+        }
+        if (live.count > kApolloSLDiskMaxFiles) {
+            [live sortUsingComparator:^NSComparisonResult(NSDictionary *a, NSDictionary *b) {
+                return [b[@"date"] compare:a[@"date"]];   // newest first
+            }];
+            for (NSUInteger i = kApolloSLDiskMaxFiles; i < live.count; i++) {
+                [fm removeItemAtPath:live[i][@"path"] error:nil];
+            }
+        }
+    });
+}
+
+static void ApolloSLDiskSave(NSString *key, NSArray<ApolloSocialLink *> *links) {
+    if (key.length == 0 || !links) return;
+    NSMutableArray *raw = [NSMutableArray array];
+    for (ApolloSocialLink *link in links) {
+        if (link.urlString.length == 0) continue;
+        [raw addObject:@{ @"url": link.urlString, @"title": link.title ?: @"" }];
+    }
+    NSDictionary *doc = @{ @"v": @1, @"ts": @([NSDate date].timeIntervalSince1970), @"links": raw };
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        NSData *data = [NSJSONSerialization dataWithJSONObject:doc options:0 error:nil];
+        if (data) [data writeToFile:ApolloSLDiskPath(key) atomically:YES];
+        ApolloSLDiskSweepOnce();
+    });
+}
+
+// Returns the stored raw link dicts (possibly empty — "confirmed none" is a
+// cacheable answer), or nil when there is no fresh entry.
+static NSArray<NSDictionary *> *ApolloSLDiskLoadRaw(NSString *key, double *outAgeHours) {
+    NSData *data = [NSData dataWithContentsOfFile:ApolloSLDiskPath(key)];
+    if (!data) return nil;
+    NSDictionary *doc = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    if (![doc isKindOfClass:[NSDictionary class]] || [doc[@"v"] integerValue] != 1) return nil;
+    NSTimeInterval age = [NSDate date].timeIntervalSince1970 - [doc[@"ts"] doubleValue];
+    if (age < 0 || age > kApolloSLDiskTTL) return nil;
+    if (outAgeHours) *outAgeHours = age / 3600.0;
+    return [doc[@"links"] isKindOfClass:[NSArray class]] ? doc[@"links"] : @[];
+}
+
+#pragma mark - Direct HTTP fast path
+
+// Same desktop Safari UA for both the direct GETs and the WKWebView fallback —
+// Reddit serves the fully server-rendered shreddit profile (header + right rail
+// with the Social Links section inline) to it.
+static NSString *const kApolloSLDesktopUA =
+    @"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+
+// Minimal entity decode for the handful Reddit emits in attribute content.
+// &amp; must go LAST so "&amp;lt;" doesn't double-decode.
+static NSString *ApolloSLDecodeEntities(NSString *s) {
+    if (s.length == 0 || [s rangeOfString:@"&"].location == NSNotFound) return s;
+    NSMutableString *m = [s mutableCopy];
+    NSDictionary<NSString *, NSString *> *first = @{
+        @"&lt;": @"<", @"&gt;": @">", @"&quot;": @"\"",
+        @"&#39;": @"'", @"&#x27;": @"'", @"&#x2F;": @"/", @"&nbsp;": @" ",
+    };
+    for (NSString *k in first) {
+        [m replaceOccurrencesOfString:k withString:first[k] options:0 range:NSMakeRange(0, m.length)];
+    }
+    [m replaceOccurrencesOfString:@"&amp;" withString:@"&" options:0 range:NSMakeRange(0, m.length)];
+    return m;
+}
+
+// attr="value" from inside a single tag string (attribute order varies). The
+// needle is space-prefixed so `noun` never matches inside another attribute's
+// name — attributes are always space-separated after the tag name.
+static NSString *ApolloSLTagAttr(NSString *tag, NSString *name) {
+    NSString *needle = [NSString stringWithFormat:@" %@=\"", name];
+    NSRange start = [tag rangeOfString:needle];
+    if (start.location == NSNotFound) return nil;
+    NSUInteger from = NSMaxRange(start);
+    NSRange end = [tag rangeOfString:@"\"" options:0 range:NSMakeRange(from, tag.length - from)];
+    if (end.location == NSNotFound) return nil;
+    return ApolloSLDecodeEntities([tag substringWithRange:NSMakeRange(from, end.location - from)]);
+}
+
+// Every social link on the server-rendered profile page is wrapped in
+//   <faceplate-tracker source="profile" action="click" noun="social_link"
+//     data-faceplate-tracking-context="{"social_link":{"type":"BUY_ME_A_COFFEE",
+//     "url":"https://...","name":"...","position":0}}">
+// (context JSON entity-encoded; verified against live markup 2026-07-21). The
+// live page upgrades these into shadow DOM, but a direct GET sees the raw
+// light-DOM markup for free — and the tracking context carries a cleaner
+// url+name than the anchor markup does. Returns the same {url, title} dicts the
+// WebView extraction JS produces, in page order. NOTE the exact match on noun:
+// the owner's own profile also carries a noun="add_social_link" tracker (the
+// "Add Social Link" button) that must not count as a link.
+static NSArray<NSDictionary *> *ApolloSLParseSocialLinkTrackers(NSString *html) {
+    static NSRegularExpression *tagRE; static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        tagRE = [NSRegularExpression regularExpressionWithPattern:@"<faceplate-tracker\\b[^>]*>" options:0 error:nil];
+    });
+    NSMutableArray *out = [NSMutableArray array];
+    [tagRE enumerateMatchesInString:html options:0 range:NSMakeRange(0, html.length)
+                         usingBlock:^(NSTextCheckingResult *m, NSMatchingFlags flags, BOOL *stop) {
+        NSString *tag = [html substringWithRange:m.range];
+        if (![ApolloSLTagAttr(tag, @"noun") isEqualToString:@"social_link"]) return;
+        NSString *ctx = ApolloSLTagAttr(tag, @"data-faceplate-tracking-context");
+        if (ctx.length == 0) return;
+        NSDictionary *j = [NSJSONSerialization JSONObjectWithData:[ctx dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
+        NSDictionary *sl = ([j isKindOfClass:[NSDictionary class]] && [j[@"social_link"] isKindOfClass:[NSDictionary class]]) ? j[@"social_link"] : nil;
+        NSString *url = [sl[@"url"] isKindOfClass:[NSString class]] ? sl[@"url"] : nil;
+        if (url.length == 0) return;
+        NSString *name = [sl[@"name"] isKindOfClass:[NSString class]] ? sl[@"name"] : @"";
+        [out addObject:@{ @"url": url, @"title": name }];
+    }];
+    return out;
+}
+
+// Page classification, verified against live responses (2026-07-21):
+//   • Reddit serves TWO real-profile shapes, and both server-render the
+//     social-link trackers inline when the user has links: the desktop shape
+//     puts them in the right rail (host-verified: spez/corderjones), while the
+//     shape CFNetwork gets (transport fingerprint — no right rail at all) puts
+//     them in the profile-header chips (sim-verified via the last-direct.html
+//     dump). Both carry data-testid="profile-main", so profile-main + zero
+//     trackers definitively means "no links" on either shape;
+//   • nonexistent/deleted users get HTTP **200** with a chrome-only shell saying
+//     "nobody on Reddit goes by that name" (www never 404s profiles) — that
+//     sentence match relies on the session's pinned Accept-Language: en-US;
+//   • anything else (flagged-network block page, consent wall, layout
+//     experiment) is NOT definitive → WebView fallback.
+static BOOL ApolloSLLooksLikeRealProfile(NSString *html) {
+    return [html rangeOfString:@"data-testid=\"profile-main\""].location != NSNotFound;
+}
+static BOOL ApolloSLHasRightRail(NSString *html) {
+    return [html rangeOfString:@"right-rail-entity-panel-root"].location != NSNotFound;
+}
+static BOOL ApolloSLLooksLikeUserGone(NSString *html) {
+    return [html rangeOfString:@"nobody on Reddit goes by that name" options:NSCaseInsensitiveSearch].location != NSNotFound;
+}
+// Old-reddit chrome: what www serves a logged-in session whose account has the
+// "old Reddit as default" preference — no shreddit markup at all. The direct
+// path retries once WITHOUT cookies when it sees this.
+static BOOL ApolloSLLooksLikeOldReddit(NSString *html) {
+    return [html rangeOfString:@"id=\"header-bottom-left\""].location != NSNotFound;
+}
+
+// Ephemeral, cookie-jar-free session: the account's web-session cookies ride
+// along per-request only, and nothing a response Set-Cookie's is ever stored —
+// so the scrape can't poison shared state (the reason the WebView path needs
+// its isolated store dance).
+static NSURLSession *ApolloSLDirectSession(void) {
+    static NSURLSession *session; static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        NSURLSessionConfiguration *config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+        config.HTTPCookieStorage = nil;
+        config.HTTPShouldSetCookies = NO;
+        // timeoutIntervalForRequest is an IDLE timer (resets on every received
+        // byte) — a slow-dripping 500KB response could hold a leg open for
+        // minutes without the resource cap.
+        config.timeoutIntervalForRequest = 12.0;
+        config.timeoutIntervalForResource = 25.0;
+        config.HTTPAdditionalHeaders = @{ @"Accept-Language": @"en-US,en;q=0.9" };
+        session = [NSURLSession sessionWithConfiguration:config];
+    });
+    return session;
+}
+
+// Hard local-connectivity failures — the kind where a WKWebView attempt can't
+// do any better than the direct GET just did. Escalating past one of these
+// only burns an 18s hidden-WebView poll per profile visit while offline.
+static BOOL ApolloSLIsOfflineErrorCode(NSInteger code) {
+    switch (code) {
+        case NSURLErrorNotConnectedToInternet:
+        case NSURLErrorNetworkConnectionLost:
+        case NSURLErrorCannotConnectToHost:
+        case NSURLErrorCannotFindHost:
+        case NSURLErrorDNSLookupFailed:
+        case NSURLErrorInternationalRoamingOff:
+        case NSURLErrorDataNotAllowed:
+            return YES;
+        default:
+            return NO;
+    }
+}
+
+// GET a Reddit page; completion(html or nil, status, errorCode, elapsed, bytes)
+// on the session's BACKGROUND delegate queue — the caller parses the
+// (multi-hundred-KB) HTML right there and hops to main only with the extracted
+// results. errorCode is the NSURLError code on transport failure, else 0.
+static void ApolloSLGetHTML(NSString *urlString, NSString *cookieHeader,
+                            void (^completion)(NSString *html, NSInteger status, NSInteger errorCode, double elapsed, long bytes)) {
+    NSURL *url = [NSURL URLWithString:urlString];
+    // Tag with the Web JSON probe fragment (never sent over the wire): every
+    // task in the process passes through the tweak's _onqueue_resume rewrite,
+    // and for web-session accounts a bare /user/<name>/ GET is a whitelisted
+    // "listing read" — it would come back as the overview JSON instead of the
+    // profile HTML.
+    url = ApolloWebJSONProbeURL(url) ?: url;
+    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url];
+    [req setValue:kApolloSLDesktopUA forHTTPHeaderField:@"User-Agent"];
+    if (cookieHeader.length) [req setValue:cookieHeader forHTTPHeaderField:@"Cookie"];
+    CFAbsoluteTime t0 = CFAbsoluteTimeGetCurrent();
+    NSURLSessionDataTask *task = [ApolloSLDirectSession() dataTaskWithRequest:req
+                                                           completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        double elapsed = CFAbsoluteTimeGetCurrent() - t0;
+        NSInteger status = [response isKindOfClass:[NSHTTPURLResponse class]] ? ((NSHTTPURLResponse *)response).statusCode : 0;
+        NSString *html = (status == 200 && data.length)
+            ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] : nil;
+#if APOLLO_SIM_BUILD
+        // Sim-only: keep the last direct response on disk so marker/classifier
+        // drift can be diagnosed against the page the APP actually received
+        // (Reddit's page shape varies per request context — host-side fetches
+        // are not a faithful reproduction).
+        if (data.length) [data writeToFile:[ApolloSLDiskDir() stringByAppendingPathComponent:@"last-direct.html"] atomically:YES];
+#endif
+        completion(html, status, error ? error.code : 0, elapsed, (long)data.length);
+    }];
+    [task resume];
+}
+
+static NSString *ApolloSLEscapedUsername(NSString *username) {
+    NSMutableCharacterSet *allowed = [[NSCharacterSet alphanumericCharacterSet] mutableCopy];
+    [allowed addCharactersInString:@"_-"];
+    return [username stringByAddingPercentEncodingWithAllowedCharacters:allowed] ?: username;
+}
+
+// ANY live session for the active account — primary (API-Key-Free) or
+// poll-only. The pollOnly split exists to keep cookie transport away from OAuth
+// accounts' API traffic; an isolated, read-only page scrape is neither
+// transport nor identity, and the cookies' only job here is getting past
+// Reddit's logged-out hard block on flagged networks. Main thread only.
+static NSString *ApolloSLScrapeCookieHeader(void) {
+    NSString *primary = ApolloActiveWebSession().cookieHeader;
+    if (primary.length > 0) return primary;
+    NSString *active = ApolloActiveWebSessionUsername();
+    return active.length > 0 ? ApolloWebSessionPollFor(active).cookieHeader : nil;
+}
+
 @interface ApolloSLWebFetch : NSObject <WKNavigationDelegate>
 @property (nonatomic, strong) WKWebView *web;
 @property (nonatomic, copy) NSString *username;
@@ -299,6 +590,10 @@ static NSArray<ApolloSocialLink *> *ApolloSLLinksFromJSON(NSArray *raw) {
 @property (nonatomic) int polls;
 @property (nonatomic) int emptyAfterReady;
 @property (nonatomic) BOOL sawProfile;   // the real shreddit profile page loaded (not the bot interstitial)
+@property (nonatomic) BOOL holdsSlot;    // owns the single concurrent-fallback slot
+@property (nonatomic) BOOL finished;
+@property (nonatomic) NSInteger pollGen; // generation counter — keeps exactly ONE poll chain alive
+@property (nonatomic) double startedAt;  // CFAbsoluteTime the page load began (drives cadence + timeout)
 @end
 
 @implementation ApolloSLWebFetch
@@ -329,6 +624,26 @@ static NSArray<ApolloSocialLink *> *ApolloSLLinksFromJSON(NSArray *raw) {
     return store;
 }
 
+// The WebView is now the RARE path (direct HTTP resolves almost everything), but
+// when a network trips it, several profile visits in a row could otherwise stack
+// hidden full-window WKWebViews. Mirror the Badge Book scraper: one runs at a
+// time, the rest queue (drained newest-first — that's the profile the user is
+// actually looking at), bounded backlog, and a watchdog so a wedged WebView
+// can't hold the slot forever.
+static int const kApolloSLMaxConcurrentWebFetches = 1;
+static int sApolloSLActiveWebFetches = 0;   // main thread only
+static NSUInteger const kApolloSLMaxQueuedWebFetches = 6;
+// The poll loop caps itself at kApolloSLWebPollTimeout (18s) wall-clock; the
+// watchdog is the belt-and-braces above it for a WebView that stops answering
+// evaluateJavaScript entirely.
+static NSTimeInterval const kApolloSLWebFetchWatchdog = 45.0;
+
+static NSMutableArray<ApolloSLWebFetch *> *ApolloSLWebFetchQueue(void) {
+    static NSMutableArray *q; static dispatch_once_t once;
+    dispatch_once(&once, ^{ q = [NSMutableArray array]; });
+    return q;
+}
+
 - (void)startForUsername:(NSString *)username completion:(void (^)(NSArray<ApolloSocialLink *> *))done {
     // WKWebView must be created/used on the main thread.
     if (![NSThread isMainThread]) {
@@ -336,6 +651,35 @@ static NSArray<ApolloSocialLink *> *ApolloSLLinksFromJSON(NSArray *raw) {
         return;
     }
     self.username = username; self.done = done; self.polls = 0; self.emptyAfterReady = 0; self.sawProfile = NO;
+
+    // Wait for a free slot before touching the window at all — a queued scrape
+    // costs nothing until it actually starts.
+    if (!self.holdsSlot) {
+        if (sApolloSLActiveWebFetches >= kApolloSLMaxConcurrentWebFetches) {
+            NSMutableArray<ApolloSLWebFetch *> *queue = ApolloSLWebFetchQueue();
+            if (![queue containsObject:self]) [queue addObject:self];
+            ApolloLog(@"[SocialLinks][web] u/%@ queued behind %d active fallback scrape(s) (%lu waiting)",
+                      username, sApolloSLActiveWebFetches, (unsigned long)queue.count);
+            while (queue.count > kApolloSLMaxQueuedWebFetches) {
+                ApolloSLWebFetch *oldest = queue.firstObject;
+                [queue removeObjectAtIndex:0];
+                ApolloLog(@"[SocialLinks][web] u/%@ dropped from the fallback queue (backlog full)", oldest.username);
+                [oldest finish:nil];   // failure — not cached, so a later visit retries
+            }
+            return;
+        }
+        sApolloSLActiveWebFetches++;
+        self.holdsSlot = YES;
+        __weak typeof(self) ws = self;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kApolloSLWebFetchWatchdog * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            typeof(self) ss = ws;
+            if (!ss || ss.finished) return;
+            ApolloLog(@"[SocialLinks][web] u/%@ watchdog fired — abandoning fallback scrape", ss.username);
+            [ss finish:nil];
+        });
+    }
+
     UIWindow *win = nil;
     for (UIScene *s in UIApplication.sharedApplication.connectedScenes) {
         if (![s isKindOfClass:[UIWindowScene class]]) continue;
@@ -343,22 +687,86 @@ static NSArray<ApolloSocialLink *> *ApolloSLLinksFromJSON(NSArray *raw) {
     }
     if (!win) win = ApolloAllWindows().firstObject;
     if (!win) { [self finish:nil]; return; }
-    WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
-    config.websiteDataStore = [ApolloSLWebFetch apollo_scrapeDataStore];
-    self.web = [[WKWebView alloc] initWithFrame:win.bounds configuration:config];
-    self.web.navigationDelegate = self;
-    self.web.alpha = 0.011; self.web.userInteractionEnabled = NO;
-    self.web.customUserAgent = @"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
-    [win insertSubview:self.web atIndex:0];
-    NSString *urlString = [NSString stringWithFormat:@"https://www.reddit.com/user/%@/", username];
-    [self.web loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:urlString]]];
-    ApolloLog(@"[SocialLinks][web] loading u/%@", username);
-    [self pollAfter:3.0];
+
+    // Reddit HARD-BLOCKS logged-out page loads from flagged networks (the
+    // interstitial says "log in to your Reddit account to continue" and never
+    // self-solves). When the active account has a harvested web session, scrape
+    // LOGGED IN with those cookies — seeded into an ISOLATED per-scrape store,
+    // never the shared logged-out one (logged-in cookies there would reintroduce
+    // the old-reddit-preference poison that store exists to avoid). No session →
+    // shared logged-out store, which still works from non-flagged networks.
+    NSString *sessionCookieHeader = ApolloSLScrapeCookieHeader();
+    void (^proceed)(WKWebsiteDataStore *) = ^(WKWebsiteDataStore *store) {
+        // The cookie-seed completions below arrive async from WebKit's network
+        // process — if they straggle past the watchdog's finish:, building the
+        // WebView now would insert one into the window that nothing ever tears
+        // down.
+        if (self.finished) return;
+        WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+        config.websiteDataStore = store;
+        self.web = [[WKWebView alloc] initWithFrame:win.bounds configuration:config];
+        self.web.navigationDelegate = self;
+        self.web.alpha = 0.011; self.web.userInteractionEnabled = NO;
+        self.web.customUserAgent = kApolloSLDesktopUA;
+        [win insertSubview:self.web atIndex:0];
+        NSString *urlString = [NSString stringWithFormat:@"https://www.reddit.com/user/%@/", ApolloSLEscapedUsername(self.username)];
+        [self.web loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:urlString]]];
+        ApolloLog(@"[SocialLinks][web] loading u/%@", self.username);
+        self.startedAt = CFAbsoluteTimeGetCurrent();
+        [self pollAfter:0.75];
+    };
+
+    if (sessionCookieHeader.length == 0) {
+        proceed([ApolloSLWebFetch apollo_scrapeDataStore]);
+        return;
+    }
+
+    // Parse "name=value; name2=value2" into cookies and seed them (async) before
+    // the first load. __Host- prefixed cookies must be host-scoped, not domain.
+    NSMutableArray<NSHTTPCookie *> *cookies = [NSMutableArray array];
+    for (NSString *pair in [sessionCookieHeader componentsSeparatedByString:@";"]) {
+        NSRange eq = [pair rangeOfString:@"="];
+        if (eq.location == NSNotFound) continue;
+        NSString *cname = [[pair substringToIndex:eq.location] stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+        NSString *value = [[pair substringFromIndex:NSMaxRange(eq)] stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+        if (cname.length == 0) continue;
+        NSDictionary *props = @{
+            NSHTTPCookieName: cname,
+            NSHTTPCookieValue: value,
+            NSHTTPCookiePath: @"/",
+            NSHTTPCookieDomain: [cname hasPrefix:@"__Host-"] ? @"www.reddit.com" : @".reddit.com",
+            NSHTTPCookieSecure: @"TRUE",
+        };
+        NSHTTPCookie *cookie = [NSHTTPCookie cookieWithProperties:props];
+        if (cookie) [cookies addObject:cookie];
+    }
+    if (cookies.count == 0) {
+        proceed([ApolloSLWebFetch apollo_scrapeDataStore]);
+        return;
+    }
+    ApolloLog(@"[SocialLinks][web] u/%@ seeding %lu session cookies (logged-in scrape)",
+              username, (unsigned long)cookies.count);
+    WKWebsiteDataStore *store = [WKWebsiteDataStore nonPersistentDataStore];
+    WKHTTPCookieStore *cookieStore = store.httpCookieStore;
+    __block NSUInteger remaining = cookies.count;
+    for (NSHTTPCookie *cookie in cookies) {
+        [cookieStore setCookie:cookie completionHandler:^{
+            if (--remaining == 0) proceed(store);
+        }];
+    }
 }
 
+// Schedules the next timer poll, invalidating any previously scheduled one (the
+// generation counter guarantees a single chain even when didFinishNavigation
+// injects an immediate poll).
 - (void)pollAfter:(double)d {
+    NSInteger gen = ++self.pollGen;
     __weak typeof(self) ws = self;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(d * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{ [ws poll]; });
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(d * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        typeof(self) ss = ws;
+        if (!ss || ss.finished || ss.pollGen != gen) return;
+        [ss poll];
+    });
 }
 
 // JS: extract social links from the public profile page, with diagnostics so the
@@ -374,23 +782,45 @@ static NSArray<ApolloSocialLink *> *ApolloSLLinksFromJSON(NSArray *raw) {
     "for(var s=0;s<sels.length;s++){var els=document.querySelectorAll(sels[s]);for(var j=0;j<els.length;j++)push(els[j],true);}"
     "if(out.length===0){var scope=document.querySelector('shreddit-async-loader[bundlename*=\"profile\"]')||document.querySelector('aside')||document.querySelector('main')||document.body;if(scope){var as=scope.querySelectorAll('a[href]');for(var k=0;k<as.length;k++)push(as[k],false);}}"
     "var diag=[];var all=document.querySelectorAll('a[href]');for(var m=0;m<all.length&&diag.length<24;m++){var a2=all[m];if(!reddit(a2.hostname)&&!inFeed(a2)){var p=a2.parentElement;diag.push({h:a2.href,t:(a2.textContent||'').trim().slice(0,28),pt:p?p.tagName.toLowerCase():'',pc:p?(((p.getAttribute('class')||'')+'|'+(p.getAttribute('slot')||''))).slice(0,46):''});}}"
-    "var profile=!!document.querySelector('shreddit-app')&&(document.title||'').toLowerCase().indexOf('verification')<0;"
-    "return JSON.stringify({links:out,total:all.length,diag:diag,ready:document.readyState,profile:profile});"
+    // `profile` must mean PROFILE CONTENT RENDERED, not just the app chrome:
+    // gated profiles (NSFW consent gate) serve a content-free shell that
+    // already carries <shreddit-app>, and counting that as "loaded" is how a
+    // still-hydrating page got mis-cached as "no links". data-testid=
+    // "profile-main" is the header container — same marker the direct-GET
+    // classifier trusts — and appears in both the server-rendered and the
+    // client-hydrated DOM. `shell` is reported separately for diagnostics.
+    "var shell=!!document.querySelector('shreddit-app');"
+    "var profile=!!document.querySelector('[data-testid=\"profile-main\"]')&&(document.title||'').toLowerCase().indexOf('verification')<0;"
+    "return JSON.stringify({links:out,total:all.length,diag:diag,ready:document.readyState,shell:shell,profile:profile});"
     "})()";
 }
 
+// Hydration usually lands links within a couple of seconds of the page loading;
+// the slow tail is Reddit's JS bot-challenge (~5-10s before it redirects). So:
+// poll FAST early (hydration window), back off after 5s (challenge window), and
+// give up on wall-clock rather than poll count.
+static NSTimeInterval const kApolloSLWebPollFastCadence = 0.75;
+static NSTimeInterval const kApolloSLWebPollSlowCadence = 2.0;
+static NSTimeInterval const kApolloSLWebPollFastWindow  = 5.0;
+static NSTimeInterval const kApolloSLWebPollTimeout     = 18.0;
+// Never accept "no links" before this much wall-clock: an accepted "none" is
+// cached for hours, and on gated profiles the chips can hydrate a beat after
+// the app shell reports loaded.
+static NSTimeInterval const kApolloSLWebMinTimeForNone  = 4.0;
+
 - (void)poll {
-    if (!self.web) return;
+    if (!self.web || self.finished) return;
     self.polls++;
     __weak typeof(self) ws = self;
     [self.web evaluateJavaScript:[self extractionJS] completionHandler:^(id res, NSError *e) {
-        typeof(self) ss = ws; if (!ss) return;
+        typeof(self) ss = ws; if (!ss || ss.finished) return;
         if (e) ApolloLog(@"[SocialLinks][web] u/%@ JS error (poll#%d): %@", ss.username, ss.polls, e.localizedDescription);
         NSString *s = [res isKindOfClass:[NSString class]] ? res : @"{}";
         NSDictionary *j = [NSJSONSerialization JSONObjectWithData:[s dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
         if (![j isKindOfClass:[NSDictionary class]]) j = @{};
         NSArray *rawLinks = [j[@"links"] isKindOfClass:[NSArray class]] ? j[@"links"] : @[];
         NSString *ready = [j[@"ready"] isKindOfClass:[NSString class]] ? j[@"ready"] : @"";
+        double elapsed = CFAbsoluteTimeGetCurrent() - ss.startedAt;
         // Only the REAL profile page counts — not Reddit's "please wait for verification"
         // interstitial (which is itself a fully-loaded page with no links).
         BOOL profileLoaded = [j[@"profile"] boolValue];
@@ -398,7 +828,8 @@ static NSArray<ApolloSocialLink *> *ApolloSLLinksFromJSON(NSArray *raw) {
 
         if (rawLinks.count > 0) {
             NSArray<ApolloSocialLink *> *links = ApolloSLLinksFromJSON(rawLinks);
-            ApolloLog(@"[SocialLinks][web] u/%@ found %lu link(s) (poll#%d)", ss.username, (unsigned long)links.count, ss.polls);
+            ApolloLog(@"[SocialLinks][web] u/%@ found %lu link(s) (poll#%d, %.2fs)",
+                      ss.username, (unsigned long)links.count, ss.polls, elapsed);
             [ss finish:links];
             return;
         }
@@ -412,61 +843,264 @@ static NSArray<ApolloSocialLink *> *ApolloSLLinksFromJSON(NSArray *raw) {
                 ApolloLog(@"[SocialLinks][web] u/%@ no links yet (ready=%@ anchors=%@). external-anchor diag: %@",
                           ss.username, ready, j[@"total"], diag);
             }
-            // Give hydration a few extra polls past the loaded profile, then accept "none".
-            if (ss.emptyAfterReady >= 3) {
-                ApolloLog(@"[SocialLinks][web] u/%@ resolved: no social links", ss.username);
+            // Give hydration a few empty passes AND a minimum wall-clock past the
+            // loaded profile, then accept "none".
+            if (ss.emptyAfterReady >= 3 && elapsed >= kApolloSLWebMinTimeForNone) {
+                ApolloLog(@"[SocialLinks][web] u/%@ resolved: no social links (%.2fs)", ss.username, elapsed);
                 [ss finish:@[]];
                 return;
             }
+        } else if (ss.polls == 4 || ss.polls == 10) {
+            // Still waiting on profile content — say what we're looking at (bare
+            // consent-gate shell? challenge page?) so a stuck state is diagnosable.
+            ApolloLog(@"[SocialLinks][web] u/%@ waiting on profile content (poll#%d %.1fs ready=%@ shell=%d anchors=%@)",
+                      ss.username, ss.polls, elapsed, ready, [j[@"shell"] boolValue], j[@"total"]);
         }
 
-        if (ss.polls >= 8) {
+        if (elapsed >= kApolloSLWebPollTimeout) {
             // Saw the real profile but no links → cache "none" (don't re-scrape every visit).
             // Never reached the profile (stuck on interstitial / load failure) → nil so it retries.
             ApolloLog(@"[SocialLinks][web] u/%@ timed out (ready=%@ sawProfile=%d)", ss.username, ready, ss.sawProfile);
             [ss finish:(ss.sawProfile ? @[] : nil)];
             return;
         }
-        [ss pollAfter:2.0];
+        [ss pollAfter:(elapsed < kApolloSLWebPollFastWindow ? kApolloSLWebPollFastCadence : kApolloSLWebPollSlowCadence)];
     }];
 }
 
 - (void)finish:(NSArray<ApolloSocialLink *> *)links {
+    if (self.finished) return;   // watchdog / poll / queue-drop can race
+    self.finished = YES;
     if (self.web) { self.web.navigationDelegate = nil; [self.web stopLoading]; [self.web removeFromSuperview]; self.web = nil; }
+    // Release the slot BEFORE the completion so a waiting scrape starts straight
+    // away rather than a callback-chain later.
+    NSMutableArray<ApolloSLWebFetch *> *queue = ApolloSLWebFetchQueue();
+    [queue removeObject:self];
+    if (self.holdsSlot) {
+        self.holdsSlot = NO;
+        sApolloSLActiveWebFetches = MAX(0, sApolloSLActiveWebFetches - 1);
+        // One slot freed → start one waiter, newest first. Hopped through the
+        // runloop because a queued start that fails immediately calls finish
+        // again, which would re-enter this block.
+        ApolloSLWebFetch *next = queue.lastObject;
+        if (next) {
+            [queue removeLastObject];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (next.finished) return;
+                [next startForUsername:next.username completion:next.done];
+            });
+        }
+    }
     void (^d)(NSArray *) = self.done; self.done = nil;
     if (d) d(links);
 }
 
-- (void)webView:(WKWebView *)wv didFinishNavigation:(WKNavigation *)nav {}
+// Event-driven check the moment a navigation lands — the initial page load or
+// the bot-challenge's redirect to the real profile — so resolution doesn't wait
+// out the timer cadence. pollGen++ orphans the pending timer poll; the injected
+// poll schedules its own successor, keeping a single chain.
+- (void)webView:(WKWebView *)wv didFinishNavigation:(WKNavigation *)nav {
+    if (self.finished || !self.web) return;
+    self.pollGen++;
+    [self poll];
+}
+
+// A provisional-load failure means the page never arrived at all (offline, DNS,
+// TLS) — waiting out the 18s poll timeout adds nothing. NSURLErrorCancelled is
+// our own stopLoading during teardown; ignore it.
+- (void)webView:(WKWebView *)wv didFailProvisionalNavigation:(WKNavigation *)nav withError:(NSError *)error {
+    if (self.finished || error.code == NSURLErrorCancelled) return;
+    ApolloLog(@"[SocialLinks][web] u/%@ page load failed (err=%ld) — abandoning", self.username, (long)error.code);
+    [self finish:nil];
+}
 
 @end
 
-// completion(links) on the main queue — synchronous on a warm cache, else after the
-// scrape. links is an (possibly empty) array on success, or nil on failure (not cached
-// so a later visit retries).
+// Hand the scrape to the hidden-WKWebView fallback (rare path — see
+// ApolloSLStartDirectAttempt for when it's reached).
+static void ApolloSLStartWebFallback(NSString *username, NSString *key, CFAbsoluteTime t0,
+                                     void (^deliver)(NSArray<ApolloSocialLink *> *links)) {
+    ApolloSLWebFetch *fetch = [[ApolloSLWebFetch alloc] init];
+    ApolloSLFetchers()[key] = fetch;
+    [fetch startForUsername:username completion:^(NSArray<ApolloSocialLink *> *links) {
+        ApolloLog(@"[SocialLinks][perf] u/%@ complete in %.2fs (WebView fallback: %@)",
+                  username, CFAbsoluteTimeGetCurrent() - t0,
+                  links ? [NSString stringWithFormat:@"%lu link(s)", (unsigned long)links.count] : @"failed");
+        deliver(links);
+    }];
+}
+
+// Stage 2: direct GET of the full profile page. Reaches here only when the
+// header-details endpoint (stage 1) wasn't definitive — its main jobs now are
+// resolving deleted users (the page carries the not-found sentence; the
+// header-details doc for a gone user is just indistinguishably empty) and
+// covering an endpoint drift. allowCookies is the old-reddit-preference escape
+// hatch: a logged-in session whose account prefers old reddit gets old-reddit
+// HTML back (no shreddit markup at all), so retry once logged out before
+// burning a WebView on it.
+static void ApolloSLStartPageAttempt(NSString *username, NSString *key, BOOL allowCookies,
+                                     CFAbsoluteTime t0, void (^deliver)(NSArray<ApolloSocialLink *> *links)) {
+    NSString *cookieHeader = allowCookies ? ApolloSLScrapeCookieHeader() : nil;
+    NSString *urlString = [NSString stringWithFormat:@"https://www.reddit.com/user/%@/", ApolloSLEscapedUsername(username)];
+    ApolloSLGetHTML(urlString, cookieHeader, ^(NSString *html, NSInteger status, NSInteger errorCode, double elapsed, long bytes) {
+        // Parse + classify here on the background queue; main gets results only.
+        NSArray<NSDictionary *> *raw = html ? ApolloSLParseSocialLinkTrackers(html) : nil;
+        NSArray<ApolloSocialLink *> *links = (raw.count > 0) ? ApolloSLLinksFromJSON(raw) : nil;
+        BOOL realProfile = html && ApolloSLLooksLikeRealProfile(html);
+        BOOL rightRail = html && ApolloSLHasRightRail(html);   // logged for shape-drift diagnostics
+        BOOL gone = (status == 404) || (html && ApolloSLLooksLikeUserGone(html));
+        BOOL definitiveNone = realProfile;
+        BOOL oldReddit = html && ApolloSLLooksLikeOldReddit(html);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (links.count > 0) {
+                ApolloLog(@"[SocialLinks][perf] u/%@ page: %lu link(s) in %.2fs (%ldKB)",
+                          username, (unsigned long)links.count, elapsed, bytes / 1024);
+                deliver(links);
+            } else if (gone) {
+                ApolloLog(@"[SocialLinks][perf] u/%@ page: user not found (%.2fs) — no links", username, elapsed);
+                deliver(@[]);
+            } else if (definitiveNone) {
+                ApolloLog(@"[SocialLinks][perf] u/%@ page: profile has no social links (%.2fs, %ldKB)",
+                          username, elapsed, bytes / 1024);
+                deliver(@[]);
+            } else if (oldReddit && cookieHeader.length > 0) {
+                ApolloLog(@"[SocialLinks][perf] u/%@ page: old-reddit layout logged in — retrying logged out", username);
+                ApolloSLStartPageAttempt(username, key, NO, t0, deliver);
+            } else if (ApolloSLIsOfflineErrorCode(errorCode)) {
+                // No connectivity — a WebView can't do better. Fail fast (nil is
+                // not cached, so the next visit retries).
+                ApolloLog(@"[SocialLinks][perf] u/%@ page: offline (err=%ld) — giving up for now", username, (long)errorCode);
+                deliver(nil);
+            } else if (CFAbsoluteTimeGetCurrent() - t0 > 30.0) {
+                // Both direct legs crawled to their timeouts — a network this
+                // slow won't finish a full WebView render either.
+                ApolloLog(@"[SocialLinks][perf] u/%@ page: %.0fs elapsed already — skipping WebView fallback",
+                          username, CFAbsoluteTimeGetCurrent() - t0);
+                deliver(nil);
+            } else {
+                // The marker booleans say WHY classification failed — that's what
+                // to read when a page shape changes out from under us.
+                ApolloLog(@"[SocialLinks][perf] u/%@ page GET not usable (http=%ld err=%ld %ldKB %.2fs profile=%d rightRail=%d oldReddit=%d) — WebView fallback",
+                          username, (long)status, (long)errorCode, bytes / 1024, elapsed, realProfile, rightRail, oldReddit);
+                ApolloSLStartWebFallback(username, key, t0, deliver);
+            }
+        });
+    });
+}
+
+// Stage 1 (the primary path): the profile-header-details svc endpoint —
+// discovered in the SSR page's own client routes, unsigned and
+// username-templated:
+//   https://www.reddit.com/svc/shreddit/profiles/profile-header-details/<name>
+// It server-renders the profile HEADER (stats + social-link chips) for EVERY
+// profile, including the ones whose /user/<name>/ page comes back as a
+// content-free client-rendered shell (bucketed per-user server-side; NOT an
+// NSFW gate — verified against live responses 2026-07-21). Markers:
+//   • real user: data-testid="karma-number" / "profile-details-content-wrapper"
+//     (+ the same faceplate social_link trackers when links exist);
+//   • nonexistent user: HTTP 200 but NONE of the content testids — ambiguous
+//     with a block/challenge page, so it falls through to stage 2, whose
+//     not-found sentence settles it.
+static BOOL ApolloSLHeaderDetailsRendered(NSString *html) {
+    return [html rangeOfString:@"data-testid=\"karma-number\""].location != NSNotFound ||
+           [html rangeOfString:@"data-testid=\"profile-details-content-wrapper\""].location != NSNotFound;
+}
+
+static void ApolloSLStartDirectAttempt(NSString *username, NSString *key,
+                                       CFAbsoluteTime t0, void (^deliver)(NSArray<ApolloSocialLink *> *links)) {
+    NSString *cookieHeader = ApolloSLScrapeCookieHeader();
+    NSString *urlString = [NSString stringWithFormat:@"https://www.reddit.com/svc/shreddit/profiles/profile-header-details/%@",
+                           ApolloSLEscapedUsername(username)];
+    ApolloSLGetHTML(urlString, cookieHeader, ^(NSString *html, NSInteger status, NSInteger errorCode, double elapsed, long bytes) {
+        // Parse + classify here on the background queue; main gets results only.
+        NSArray<NSDictionary *> *raw = html ? ApolloSLParseSocialLinkTrackers(html) : nil;
+        NSArray<ApolloSocialLink *> *links = (raw.count > 0) ? ApolloSLLinksFromJSON(raw) : nil;
+        BOOL rendered = html && ApolloSLHeaderDetailsRendered(html);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (links.count > 0) {
+                ApolloLog(@"[SocialLinks][perf] u/%@ header-details: %lu link(s) in %.2fs (%ldKB)",
+                          username, (unsigned long)links.count, elapsed, bytes / 1024);
+                deliver(links);
+            } else if (rendered) {
+                ApolloLog(@"[SocialLinks][perf] u/%@ header-details: profile has no social links (%.2fs, %ldKB)",
+                          username, elapsed, bytes / 1024);
+                deliver(@[]);
+            } else if (ApolloSLIsOfflineErrorCode(errorCode)) {
+                // No connectivity — the page GET and WebView would fail the same
+                // way. Fail fast (nil is not cached, so the next visit retries).
+                ApolloLog(@"[SocialLinks][perf] u/%@ header-details: offline (err=%ld) — giving up for now", username, (long)errorCode);
+                deliver(nil);
+            } else {
+                // Deleted user / blocked / endpoint drift — the page attempt
+                // tells those apart.
+                ApolloLog(@"[SocialLinks][perf] u/%@ header-details not definitive (http=%ld err=%ld %ldKB %.2fs) — trying profile page",
+                          username, (long)status, (long)errorCode, bytes / 1024, elapsed);
+                ApolloSLStartPageAttempt(username, key, YES, t0, deliver);
+            }
+        });
+    });
+}
+
+// completion(links) on the main queue — synchronous on a warm cache, else after
+// the fetch. links is an (possibly empty) array on success, or nil on failure
+// (not cached so a later visit retries).
+//
+// FAST PATH (default): one direct NSURLSession GET of the profile-header-details
+// svc endpoint + native parse of the server-rendered social-link markup —
+// resolves in well under a second for every profile bucket, no WKWebView, no
+// JS, no polling. The active account's web-session cookies ride along when
+// available, which also clears Reddit's logged-out hard block on flagged
+// networks. SECOND CHANCE: the full profile page GET (settles deleted users,
+// survives endpoint drift). FALLBACK: the hidden-WKWebView scrape, for
+// responses neither direct GET can classify.
 static void ApolloSLFetchLinks(NSString *username, void (^completion)(NSArray<ApolloSocialLink *> *links)) {
     NSString *key = username.lowercaseString ?: @"";
     if (key.length == 0) { if (completion) completion(nil); return; }
+    // Deleted-author placeholder, not a real account — nothing to fetch.
+    if ([key isEqualToString:@"[deleted]"]) { if (completion) completion(nil); return; }
 
     NSArray<ApolloSocialLink *> *cached = [ApolloSLLinksCache() objectForKey:key];
     if (cached) { if (completion) completion(cached); return; }
 
-    // Queue this completion; if a scrape is already running, just wait on it.
+    // Queue this completion; if a fetch is already running, just wait on it.
     NSMutableArray *waiters = ApolloSLPending()[key];
     if (waiters) { if (completion) [waiters addObject:[completion copy]]; return; }
+
+    // Fresh disk-cached result (tiny JSON, sub-ms read) → zero network.
+    double ageHours = 0.0;
+    NSArray<NSDictionary *> *disk = ApolloSLDiskLoadRaw(key, &ageHours);
+    if (disk) {
+        NSArray<ApolloSocialLink *> *links = ApolloSLLinksFromJSON(disk);
+        [ApolloSLLinksCache() setObject:links forKey:key];
+        ApolloLog(@"[SocialLinks][perf] u/%@ served from disk cache (age %.1fh)", username, ageHours);
+        if (completion) completion(links);
+        return;
+    }
+
     waiters = [NSMutableArray array];
     if (completion) [waiters addObject:[completion copy]];
     ApolloSLPending()[key] = waiters;
 
-    ApolloSLWebFetch *fetch = [[ApolloSLWebFetch alloc] init];
-    ApolloSLFetchers()[key] = fetch;
-    [fetch startForUsername:username completion:^(NSArray<ApolloSocialLink *> *links) {
-        if (links) [ApolloSLLinksCache() setObject:links forKey:key];  // cache success (incl. empty)
+    ApolloLog(@"[SocialLinks][perf] u/%@ fetch begin (no cache)", username);
+    CFAbsoluteTime t0 = CFAbsoluteTimeGetCurrent();
+    void (^deliver)(NSArray<ApolloSocialLink *> *) = ^(NSArray<ApolloSocialLink *> *links) {
+        // The one line every path ends on — total wall-clock from fetch begin to
+        // the UI callback, whichever route (direct / logged-out retry / WebView)
+        // resolved it.
+        ApolloLog(@"[SocialLinks][perf] u/%@ resolved in %.2fs total: %@",
+                  username, CFAbsoluteTimeGetCurrent() - t0,
+                  links ? [NSString stringWithFormat:@"%lu link(s)", (unsigned long)links.count]
+                        : @"failed (will retry on next visit)");
+        if (links) {                                            // cache success (incl. empty)
+            [ApolloSLLinksCache() setObject:links forKey:key];
+            ApolloSLDiskSave(key, links);
+        }
         NSArray *toNotify = ApolloSLPending()[key];
         [ApolloSLPending() removeObjectForKey:key];
         [ApolloSLFetchers() removeObjectForKey:key];
         for (void (^waiter)(NSArray *) in toNotify) waiter(links);
-    }];
+    };
+    ApolloSLStartDirectAttempt(username, key, t0, deliver);
 }
 
 #pragma mark - Slide-up "Social Links" sheet
@@ -737,10 +1371,12 @@ static void ApolloSocialLinkOpenURL(NSURL *url, UIViewController *opener) {
     });
 }
 
-// Pull-to-refresh: drop the cached links for this user and re-scrape.
+// Pull-to-refresh: drop the cached links for this user (memory AND disk) and re-fetch.
 - (void)refresh {
     if (self.username.length == 0) return;
-    [ApolloSLLinksCache() removeObjectForKey:self.username.lowercaseString];
+    NSString *key = self.username.lowercaseString;
+    [ApolloSLLinksCache() removeObjectForKey:key];
+    [[NSFileManager defaultManager] removeItemAtPath:ApolloSLDiskPath(key) error:nil];
     self.loadedUsername = nil;
     [self reload];
 }

--- a/src/ApolloWebJSON.h
+++ b/src/ApolloWebJSON.h
@@ -203,6 +203,12 @@ BOOL ApolloWebJSONDiskAccountHasRealCredential(NSString *username);
 // (e.g. ApolloRedditMediaUpload.m) issue themselves with the cookie already set.
 NSURL *ApolloWebJSONProbeURL(NSURL *url);
 
+// YES when `url` carries the probe fragment — i.e. it's one of our own
+// self-authored requests (session probes, upload leases, scrape GETs). Such
+// requests must pass through the network hooks completely untouched: no Web
+// JSON rewrite, no User-Agent stamping (they pick their UA deliberately).
+BOOL ApolloWebJSONURLIsProbe(NSURL *url);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ApolloWebJSON.m
+++ b/src/ApolloWebJSON.m
@@ -89,7 +89,11 @@ static NSURL *ApolloWebJSONURLWithFragment(NSURL *url, NSString *fragment) {
     return c.URL ?: url;
 }
 
-static BOOL ApolloWebJSONURLIsProbe(NSURL *url) {
+// Exported (ApolloWebJSON.h): Tweak.xm's _onqueue_resume hook uses this to leave
+// probe-tagged requests entirely alone — including their User-Agent, which the
+// scrape paths set to desktop Safari deliberately (the app UA makes Reddit
+// render device=mobile, dropping the server-side markup the scrapers parse).
+BOOL ApolloWebJSONURLIsProbe(NSURL *url) {
     return [url.fragment isEqualToString:kApolloWebJSONProbeMarker];
 }
 

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -2174,6 +2174,16 @@ static NSURLRequest *ApolloLocalFastFailRequest(NSString *path) {
             [self setValue:mutableRequest forKey:@"_currentRequest"];
         }
     } else if ([requestURL.host isEqualToString:@"oauth.reddit.com"] || [requestURL.host isEqualToString:@"www.reddit.com"]) {
+        // Probe-tagged requests (fragment marker) are our OWN self-authored
+        // traffic — session probes, upload leases, the social-links scrape GETs.
+        // They authenticate themselves and pick their User-Agent deliberately
+        // (stamping the app UA here made Reddit render device=mobile, which
+        // drops the server-side markup the scrapers parse) — leave them alone.
+        if (ApolloWebJSONURLIsProbe(requestURL)) {
+            %orig;
+            return;
+        }
+
         // Web JSON spike: when the flag is on, whitelisted listing reads are
         // re-pointed at cookie-authenticated www.reddit.com/...json instead of
         // the oauth host (see ApolloWebJSON.m). Returns nil when off/not


### PR DESCRIPTION
## Problem

The profile Social Links band took **7–8 seconds minimum** to appear — every profile visit loaded the full desktop profile page in a hidden WKWebView with a hardcoded 3s initial poll + 2s cadence, and concluding "no links" required three empty polls past page load (the common case was the worst case). Failures took 17s. Results were memory-cached only, so every app launch re-scraped every profile, and on networks Reddit flags ("blocked by network security") the logged-out scrape could never resolve at all.

## What this does

**Fast path** — one direct `NSURLSession` GET of `/svc/shreddit/profiles/profile-header-details/<user>`, an unsigned svc route lifted from the SSR page's own client routing table. It server-renders the profile header (karma + social-link chips) for *every* profile — including the ones whose `/user/<name>/` page Reddit serves as a content-free client-rendered shell (per-user server bucketing; verified unrelated to NSFW, karma, or age). Links parse natively from the `faceplate-tracker noun="social_link"` tracking-context JSON. **Typical resolution: 0.4–0.9s**, measured live for both page buckets.

**Second chance** — direct GET of the full profile page: settles deleted users (www answers HTTP **200** with a "nobody on Reddit goes by that name" shell, never a 404) and retries once cookieless when a logged-in session's old-reddit preference poisons the layout.

**Fallback** — the original hidden-WKWebView scrape, now rare and much better behaved: one concurrent slot + newest-first bounded queue, 45s watchdog, event-driven poll on `didFinishNavigation` with a 0.75s/2s stepped cadence, 18s wall-clock cap, and a *content-rendered* signal (`profile-main` testid rather than the `<shreddit-app>` shell tag) so a gated shell can't mis-cache a false "no links".

**Cookies** — both direct legs attach the active account's web session (primary *or* poll-only) per-request from a cookie-jar-free ephemeral session. That clears Reddit's logged-out hard block on flagged networks — which previously made the feature silently dead there.

**Caching** — results (including confirmed-empty) persist in a 6h-TTL disk cache (`Library/Caches/ApolloSocialLinks`, swept + capped, sanitized filenames); relaunches render with zero network. Pull-to-refresh drops memory + disk.

## Root cause worth knowing: our own UA stamp (first commit)

The header-details endpoint initially returned link-less markup **in-app only**. Cause: the `_onqueue_resume` hook stamps the app UA onto every `www.reddit.com` request, Reddit's `device=mobile|desktop` render is UA-driven, and the mobile render omits the chips. Probe-tagged (self-authored) requests now bypass that hook entirely via the exported `ApolloWebJSONURLIsProbe()`. This also corrects the earlier "shreddit fingerprints CFNetwork → mobile" theory from the Badge Book work (#689) — that was this stamp all along, so #689's direct path gets desktop markup once this lands.

## Stability audit

Reviewed for races, deliver-once, leaks, and failure states; fixes folded in: offline fails fast (connectivity `NSURLError` codes + `didFailProvisionalNavigation` skip the WebView; nil results uncached so later visits retry), `timeoutIntervalForResource` capped (idle-timer trap), late cookie-seed can no longer leak a WebView past the watchdog, disk keys filtered to `[a-z0-9_-]`, `[deleted]` short-circuits.

## Testing

- Sim, live: linked profiles (both page buckets), no-links profiles, deleted users, disk-cache relaunch hits, pull-to-refresh, flagged-network behavior with and without session cookies — timings in the `[SocialLinks][perf]` log lines.
- Device + sim targets build clean.
- Offline path is code-verified (not exercised live) — airplane mode + profile visit should log `offline (err=-1009) — giving up for now` at ~zero cost.

## Notes

- Trivial merge overlap with #689: it adds `ApolloSharedScrapeDataStore()` to `ApolloProfileSocialLinks.{h,m}`; both sides keep.
- The WebView fallback's remaining real use is flagged-network-without-session; everything else resolves direct.