### PR TITLE
Scroll performance round 2: profiler-guided hot-path fixes (stacks on #724)

### DIFF
--- a/src/ApolloCommentVoteFlicker.xm
+++ b/src/ApolloCommentVoteFlicker.xm
@@ -46,6 +46,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloTranslation.h"
+#import "ApolloState.h"
 
 @interface ASDisplayNode : NSObject
 @property (nonatomic) BOOL neverShowPlaceholders;
@@ -361,13 +362,17 @@ static void ApolloVFHandleModelUpdate(id note, void (^origCall)(void)) {
     ApolloVFTrackCell(self, YES);
     // Cached translations can be installed by the global text-node preempt
     // before the normal translation apply function ever runs. Prime after the
-    // cell has settled so that fast path also has a ready vote cover.
-    __weak id weakCell = self;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.35 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        id strongCell = weakCell;
-        if (!strongCell || ![sApolloVFVisibleCells containsObject:strongCell]) return;
-        ApolloTranslationPrimeVoteBodySnapshot(strongCell);
-    });
+    // cell has settled so that fast path also has a ready vote cover. With
+    // bulk translation off there is nothing to snapshot — skip the per-cell
+    // timer + comment-extraction work entirely.
+    if (sEnableBulkTranslation) {
+        __weak id weakCell = self;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.35 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            id strongCell = weakCell;
+            if (!strongCell || ![sApolloVFVisibleCells containsObject:strongCell]) return;
+            ApolloTranslationPrimeVoteBodySnapshot(strongCell);
+        });
+    }
 }
 - (void)didExitVisibleState {
     %orig;

--- a/src/ApolloInlineLinkPreviewURLHiding.xm
+++ b/src/ApolloInlineLinkPreviewURLHiding.xm
@@ -54,11 +54,21 @@ static BOOL ApolloLPURLIsHTTP(NSURL *url) {
 
 static BOOL ApolloLPURLHidingShouldProcessTextNode(id textNode) {
     if (!textNode) return NO;
-    NSString *className = NSStringFromClass([textNode class]);
-    if ([className containsString:@"MarkdownTextNode"]) return YES;
-    if ([className containsString:@"Markdown"]) return YES;
-    if ([className hasPrefix:@"_TtC6Apollo"] && [className containsString:@"TextNode"]) return YES;
-    return NO;
+    // The verdict is a pure function of the class, and this runs for every
+    // setAttributedText app-wide (feed scrolling included) — cache it on the
+    // class object itself instead of re-running NSStringFromClass plus the
+    // substring scans each time. Class objects are immortal and associated
+    // storage is thread-safe (these hooks also fire on Texture's background
+    // layout threads).
+    Class cls = [textNode class];
+    static char kApolloLPURLHidingClassVerdictKey;
+    NSNumber *cached = objc_getAssociatedObject(cls, &kApolloLPURLHidingClassVerdictKey);
+    if (cached) return cached.boolValue;
+    NSString *className = NSStringFromClass(cls);
+    BOOL verdict = [className containsString:@"Markdown"] ||
+                   ([className hasPrefix:@"_TtC6Apollo"] && [className containsString:@"TextNode"]);
+    objc_setAssociatedObject(cls, &kApolloLPURLHidingClassVerdictKey, @(verdict), OBJC_ASSOCIATION_RETAIN);
+    return verdict;
 }
 
 static BOOL ApolloLPURLsMatch(NSURL *a, NSURL *b) {

--- a/src/ApolloInlineLinkPreviews.xm
+++ b/src/ApolloInlineLinkPreviews.xm
@@ -4364,26 +4364,15 @@ static void ApolloLPStackGuardReport(const char *where, size_t used, size_t size
 }
 %end
 
-// Wide-spec probe: ASStackLayoutSpec's layout stack-allocates per child, so a
-// runaway children array (a re-append loop) would eat stack with no extra
-// frames. A legitimate comment body stays well under this.
-%hook ASStackLayoutSpec
-- (id)calculateLayoutThatFits:(struct CDStruct_90e057aa)constrainedSize {
-    NSArray *probeChildren = [(id)self respondsToSelector:@selector(children)] ? [(id)self children] : nil;
-    if (probeChildren.count >= 300) {
-        static CFAbsoluteTime sLastWideLog = 0;
-        CFAbsoluteTime now = CFAbsoluteTimeGetCurrent();
-        if (sLastWideLog == 0 || now - sLastWideLog >= 10.0) {
-            sLastWideLog = now;
-            NSString *line = [NSString stringWithFormat:@"[StackGuard] wide ASStackLayoutSpec: children=%lu",
-                              (unsigned long)probeChildren.count];
-            ApolloLog(@"%@", line);
-            ApolloAppendLoginDiag(line);
-        }
-    }
-    return %orig;
-}
-%end
+// The wide-spec probe (an ASStackLayoutSpec.calculateLayoutThatFits hook that
+// counted children per spec) was removed: it ran for EVERY Texture stack layout
+// in the app — feeds compute thousands per second across the background layout
+// threads while scrolling — and a Time Profiler pass attributed a measurable
+// slice of scroll-time CPU to its respondsToSelector/children probing alone.
+// It was a purely diagnostic tripwire that never fired in the field; the
+// protective machinery (the main-stack exhaustion checks above and the safe
+// bail + scheduled relayout in LinkButtonNode.layoutSpecThatFits below) is
+// untouched and still catches the actual failure regardless of cause.
 // ======================== END stack-guard sentinel ========================
 
 %hook _TtC6Apollo14LinkButtonNode

--- a/src/ApolloLinkPreviewCache.m
+++ b/src/ApolloLinkPreviewCache.m
@@ -15,6 +15,15 @@ static const NSTimeInterval ApolloLinkPreviewCacheDiskFlushInterval = 8.0;
 @interface ApolloLinkPreviewCache ()
 @property (nonatomic, strong) NSMutableDictionary<NSString *, NSDictionary *> *entries;
 @property (nonatomic, strong) NSCache<NSString *, ApolloLinkPreview *> *memoryCache;
+// Known-absent keys (no disk entry either), so repeat measures of a URL whose
+// fetch hasn't completed skip the dispatch_sync onto the disk queue — misses
+// are the steady state while scrolling. Markers are set only inside the queue
+// (so they can never predate init's synchronous disk load) and cleared by
+// storePreview:.
+@property (nonatomic, strong) NSCache<NSString *, NSNumber *> *missCache;
+// url.absoluteString -> SHA-256 hex key; the digest + hex loop otherwise runs
+// on every lookup, memory hit or not.
+@property (nonatomic, strong) NSCache<NSString *, NSString *> *keyCache;
 @property (nonatomic, strong) dispatch_queue_t queue;
 @property (nonatomic, copy) NSString *cachePath;
 @property (nonatomic) BOOL diskDirty;
@@ -38,6 +47,10 @@ static const NSTimeInterval ApolloLinkPreviewCacheDiskFlushInterval = 8.0;
         _queue = dispatch_queue_create("com.apollo.linkpreviews.cache", DISPATCH_QUEUE_SERIAL);
         _memoryCache = [NSCache new];
         _memoryCache.countLimit = ApolloLinkPreviewCacheMaxEntries;
+        _missCache = [NSCache new];
+        _missCache.countLimit = 1024;
+        _keyCache = [NSCache new];
+        _keyCache.countLimit = 1024;
 
         NSArray<NSString *> *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
         NSString *cacheDirectory = paths.firstObject ?: NSTemporaryDirectory();
@@ -97,6 +110,8 @@ static const NSTimeInterval ApolloLinkPreviewCacheDiskFlushInterval = 8.0;
 
 - (NSString *)cacheKeyForURL:(NSURL *)url {
     NSString *absoluteString = url.absoluteString ?: @"";
+    NSString *cachedKey = [self.keyCache objectForKey:absoluteString];
+    if (cachedKey) return cachedKey;
     NSData *data = [absoluteString dataUsingEncoding:NSUTF8StringEncoding];
     unsigned char hash[CC_SHA256_DIGEST_LENGTH];
     CC_SHA256(data.bytes, (CC_LONG)data.length, hash);
@@ -105,7 +120,9 @@ static const NSTimeInterval ApolloLinkPreviewCacheDiskFlushInterval = 8.0;
     for (NSUInteger index = 0; index < CC_SHA256_DIGEST_LENGTH; index++) {
         [result appendFormat:@"%02x", hash[index]];
     }
-    return result;
+    NSString *key = [result copy];
+    [self.keyCache setObject:key forKey:absoluteString];
+    return key;
 }
 
 - (NSTimeInterval)ttlForURL:(NSURL *)url preview:(ApolloLinkPreview *)preview {
@@ -134,6 +151,10 @@ static const NSTimeInterval ApolloLinkPreviewCacheDiskFlushInterval = 8.0;
     ApolloLinkPreview *memoryPreview = [self.memoryCache objectForKey:key];
     if (memoryPreview && [self previewIsFresh:memoryPreview forURL:url]) return memoryPreview;
 
+    // A key already proven absent stays absent until a store clears its
+    // marker — answer without touching the disk queue.
+    if ([self.missCache objectForKey:key]) return nil;
+
     __block ApolloLinkPreview *preview = nil;
     dispatch_sync(self.queue, ^{
         NSDictionary *entry = self.entries[key];
@@ -148,6 +169,7 @@ static const NSTimeInterval ApolloLinkPreviewCacheDiskFlushInterval = 8.0;
             [self markDiskDirtyLocked];
             preview = nil;
         }
+        if (!preview) [self.missCache setObject:@YES forKey:key];
     });
     return preview;
 }
@@ -165,6 +187,7 @@ static const NSTimeInterval ApolloLinkPreviewCacheDiskFlushInterval = 8.0;
     if (![url isKindOfClass:[NSURL class]] || !preview) return;
     if (!preview.fetchedAt) preview.fetchedAt = [NSDate date];
     NSString *key = [self cacheKeyForURL:url];
+    [self.missCache removeObjectForKey:key];
     NSMutableDictionary *entry = [[preview dictionaryRepresentation] mutableCopy];
     entry[@"url"] = url.absoluteString ?: @"";
     entry[@"lastAccess"] = @([[NSDate date] timeIntervalSince1970]);

--- a/src/ApolloScrollEdgePopFix.xm
+++ b/src/ApolloScrollEdgePopFix.xm
@@ -226,7 +226,12 @@ static void ApolloEdgeBeginTransition(UINavigationController *nav, UIViewControl
 %hook ScrollEdgeEffectView
 
 - (void)layoutSubviews {
-    if (ApolloEdgePocketsFrozenFor(ApolloEdgeOwningScrollView(self))) return;
+    // Steady state (no pop transition in flight): skip the superview walk —
+    // ApolloEdgePocketsFrozenFor's own first condition is this same counter,
+    // so the outcome is identical, just without paying the walk on every
+    // effect-view layout during ordinary scrolling.
+    if (sTransitionsInFlight > 0 &&
+        ApolloEdgePocketsFrozenFor(ApolloEdgeOwningScrollView(self))) return;
     %orig;
 }
 

--- a/src/ApolloTagFilters.xm
+++ b/src/ApolloTagFilters.xm
@@ -531,6 +531,21 @@ static void ApolloTagRemoveBlurOverlay(id cell) {
 
 static void ApolloTagApplyDecisionToCell(id cell) {
     if (!cell) return;
+    // Feature off: skip the link ivar-walk + associated-object churn this
+    // otherwise pays on every post-cell layout during scrolling. A cell that
+    // still carries state from when the filter WAS on gets the same teardown
+    // the "none" decision below performs (a nil decision reads as "none"
+    // everywhere it is consumed).
+    if (!sTagFilterEnabled) {
+        if (objc_getAssociatedObject(cell, kApolloTagOverlaysKey) ||
+            objc_getAssociatedObject(cell, kApolloTagDecisionKey)) {
+            objc_setAssociatedObject(cell, kApolloTagDecisionKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            UIView *cellView = ApolloTagCellView(cell);
+            if (cellView) cellView.hidden = NO;
+            ApolloTagRemoveBlurOverlay(cell);
+        }
+        return;
+    }
     RDKLink *link = ApolloTagLinkFromCell(cell);
     NSString *decision = ApolloTagFilterDecisionForLink(link);
 

--- a/src/ApolloThemeIntegrations.xm
+++ b/src/ApolloThemeIntegrations.xm
@@ -65,10 +65,20 @@ static NSString *ListCellOwner(UITableViewCell *cell) {
     if (![v isKindOfClass:[UITableView class]]) return nil;
     id delegate = ((UITableView *)v).delegate;
     if (!delegate) return nil;
-    NSString *owner = NSStringFromClass([delegate class]);
+    // The in-scope verdict is a pure function of the delegate's class, and this
+    // runs from the global UITableViewCell layoutSubviews hook on every cell
+    // layout pass while a theme is active — cache it on the class object
+    // instead of re-running NSStringFromClass + five substring scans each time
+    // (@"" marks a cached out-of-scope class; class objects are immortal).
+    Class cls = [delegate class];
+    static char kListCellOwnerVerdictKey;
+    NSString *cached = objc_getAssociatedObject(cls, &kListCellOwnerVerdictKey);
+    if (cached) return cached.length > 0 ? cached : nil;
+    NSString *owner = NSStringFromClass(cls);
     BOOL inScope = [owner containsString:@"ViewController"]
         && ([owner containsString:@"Settings"] || [owner containsString:@"Search"]
             || [owner containsString:@"Friends"] || [owner containsString:@"Inbox"]);
+    objc_setAssociatedObject(cls, &kListCellOwnerVerdictKey, inScope ? owner : @"", OBJC_ASSOCIATION_RETAIN);
     return inScope ? owner : nil;
 }
 

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -3078,6 +3078,23 @@ static NSString *ApolloDetectDominantLanguage(NSString *text) {
     return detected;
 }
 
+// Cache-only probe of the detector. Returns the cached verdict (nil can mean
+// "cached: no detectable language") and reports via *outCached whether the
+// verdict is final without running the recognizer. Inputs the full detector
+// would reject without caching (non-strings, <8 chars) are also final. Never
+// runs NLLanguageRecognizer, so scroll-time main-thread callers can use it to
+// decide whether the real detection needs a background hop first.
+static NSString *ApolloDetectDominantLanguageIfCached(NSString *text, BOOL *outCached) {
+    if (outCached) *outCached = NO;
+    if (![text isKindOfClass:[NSString class]]) { if (outCached) *outCached = YES; return nil; }
+    NSString *trimmed = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (trimmed.length < 8) { if (outCached) *outCached = YES; return nil; }
+    NSString *cached = [sDetectedLanguageCache objectForKey:trimmed];
+    if (!cached) return nil;
+    if (outCached) *outCached = YES;
+    return [cached isEqualToString:kApolloNoDetectedLanguage] ? nil : cached;
+}
+
 // YES if `langCode` (a base ISO code like "it") is one the user added to the
 // "Don't Translate" skip list. Skip codes are persisted lowercase and base-only
 // (TranslationSettingsViewController -normalizedLanguageCodeFromIdentifier:), and
@@ -8132,7 +8149,26 @@ static void ApolloMaybeTranslatePostTitleNode(id titleNode) {
 
     // Strip links so URLs don't pollute language detection.
     NSString *detectionText = ApolloProtectTranslationLinks(titleText, NULL);
-    NSString *detected = ApolloDetectDominantLanguage(detectionText);
+    BOOL detectionCached = NO;
+    NSString *detected = ApolloDetectDominantLanguageIfCached(detectionText, &detectionCached);
+    if (!detectionCached) {
+        // NLLanguageRecognizer costs several ms per fresh string — running it
+        // inline meant every newly appearing post paid it on the main thread at
+        // cell-appear time, the worst moment of a scroll frame (a Time Profiler
+        // pass put the detection cluster at ~25% of main-thread busy time during
+        // feed scrolling). Warm the shared cache on a background queue, then
+        // re-run this whole pass: every gate above re-validates against current
+        // node/VC state, and the warm cache makes the re-run synchronous.
+        __weak id weakRetryTitleNode = titleNode;
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+            (void)ApolloDetectDominantLanguage(detectionText);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                id strongRetryTitleNode = weakRetryTitleNode;
+                if (strongRetryTitleNode) ApolloMaybeTranslatePostTitleNode(strongRetryTitleNode);
+            });
+        });
+        return;
+    }
     if ([detected isEqualToString:targetLanguage]) return;
 
     // TAP-TO-TRANSLATE: marker + hold as soon as the title is detectably
@@ -8277,7 +8313,22 @@ static void ApolloMaybeTranslateFeedPostBodyNode(id feedCellNode, id excludeTitl
     if (targetLanguage.length == 0) return;
 
     NSString *detectionText = ApolloProtectTranslationLinks(previewText, NULL);
-    NSString *detected = ApolloDetectDominantLanguage(detectionText);
+    BOOL detectionCached = NO;
+    NSString *detected = ApolloDetectDominantLanguageIfCached(detectionText, &detectionCached);
+    if (!detectionCached) {
+        // Same background warm-then-rerun as the title path above: never run
+        // NLLanguageRecognizer on the main thread at cell-appear time.
+        __weak id weakRetryCellNode = feedCellNode;
+        __weak id weakRetryTitleNode = excludeTitleNode;
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+            (void)ApolloDetectDominantLanguage(detectionText);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                id strongRetryCellNode = weakRetryCellNode;
+                if (strongRetryCellNode) ApolloMaybeTranslateFeedPostBodyNode(strongRetryCellNode, weakRetryTitleNode);
+            });
+        });
+        return;
+    }
     if ([detected isEqualToString:targetLanguage]) return;
 
     ApolloLog(@"[FeedBodyDBG] body translate (len=%lu)", (unsigned long)previewText.length);

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -1072,19 +1072,25 @@ static NSString *ApolloProtectTranslationLinks(NSString *sourceText, NSDictionar
         }
     };
 
-    NSError *regexError = nil;
-    NSRegularExpression *markdownLinkRegex = [NSRegularExpression regularExpressionWithPattern:@"\\[[^\\]\\n]+\\]\\([^\\s)]+(?:\\s+\\\"[^\\\"]*\\\")?\\)"
-                                                                                       options:0
-                                                                                         error:&regexError];
-    if (!regexError && markdownLinkRegex) {
+    // Compiled once — this runs per title/body per node event on the main
+    // thread during scrolling, and NSRegularExpression is immutable and
+    // thread-safe for concurrent matching (same rationale as the PR #652
+    // display-text regex caching).
+    static NSRegularExpression *markdownLinkRegex;
+    static NSRegularExpression *bareURLRegex;
+    static dispatch_once_t regexOnce;
+    dispatch_once(&regexOnce, ^{
+        markdownLinkRegex = [NSRegularExpression regularExpressionWithPattern:@"\\[[^\\]\\n]+\\]\\([^\\s)]+(?:\\s+\\\"[^\\\"]*\\\")?\\)"
+                                                                      options:0
+                                                                        error:NULL];
+        bareURLRegex = [NSRegularExpression regularExpressionWithPattern:@"(?i)\\bhttps?://[^\\s<>()\\[\\]{}\\\"']+"
+                                                                 options:0
+                                                                   error:NULL];
+    });
+    if (markdownLinkRegex) {
         replaceMatches(markdownLinkRegex, NO);
     }
-
-    regexError = nil;
-    NSRegularExpression *bareURLRegex = [NSRegularExpression regularExpressionWithPattern:@"(?i)\\bhttps?://[^\\s<>()\\[\\]{}\\\"']+"
-                                                                                options:0
-                                                                                  error:&regexError];
-    if (!regexError && bareURLRegex) {
+    if (bareURLRegex) {
         replaceMatches(bareURLRegex, YES);
     }
 
@@ -3076,6 +3082,22 @@ static NSString *ApolloDetectDominantLanguage(NSString *text) {
     NSString *detected = ApolloDominantLanguageWithConfidence(trimmed, NULL);
     [sDetectedLanguageCache setObject:(detected ?: kApolloNoDetectedLanguage) forKey:trimmed];
     return detected;
+}
+
+// Serial background queue for cache-warming language detection. Serial on
+// purpose: a fast scroll schedules many detections in bursts, often for the
+// same string via multiple node events — on a concurrent queue those raced
+// dozens of recognizer runs side by side (measured 33 worker threads all
+// inside NLLanguageRecognizer); serialized, the first warm populates the
+// cache and every duplicate behind it becomes a cache hit.
+static dispatch_queue_t ApolloTranslationDetectionQueue(void) {
+    static dispatch_queue_t queue;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        queue = dispatch_queue_create("com.apollofix.translation.detect",
+                                      dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_UTILITY, 0));
+    });
+    return queue;
 }
 
 // Cache-only probe of the detector. Returns the cached verdict (nil can mean
@@ -8160,7 +8182,7 @@ static void ApolloMaybeTranslatePostTitleNode(id titleNode) {
         // re-run this whole pass: every gate above re-validates against current
         // node/VC state, and the warm cache makes the re-run synchronous.
         __weak id weakRetryTitleNode = titleNode;
-        dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        dispatch_async(ApolloTranslationDetectionQueue(), ^{
             (void)ApolloDetectDominantLanguage(detectionText);
             dispatch_async(dispatch_get_main_queue(), ^{
                 id strongRetryTitleNode = weakRetryTitleNode;
@@ -8320,7 +8342,7 @@ static void ApolloMaybeTranslateFeedPostBodyNode(id feedCellNode, id excludeTitl
         // NLLanguageRecognizer on the main thread at cell-appear time.
         __weak id weakRetryCellNode = feedCellNode;
         __weak id weakRetryTitleNode = excludeTitleNode;
-        dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        dispatch_async(ApolloTranslationDetectionQueue(), ^{
             (void)ApolloDetectDominantLanguage(detectionText);
             dispatch_async(dispatch_get_main_queue(), ^{
                 id strongRetryCellNode = weakRetryCellNode;


### PR DESCRIPTION
## What this is

Scrolling was starting to feel laggy again even with #652 merged and #724 open, so I built a test tree of current main + every open PR (including #724), ran it in the simulator, and CPU-sampled the Apollo process during a fixed 14-swipe feed scroll to see where tweak time actually goes now. This PR fixes what the profiler pointed at. It deliberately touches **no file that any open PR touches**, so it stacks cleanly on top of #724 — happy to have it folded into that PR instead if that's easier.

## Fixes (profiler-guided)

1. **Removed the StackGuard "wide-spec probe"** (`ApolloInlineLinkPreviews.xm`). The `ASStackLayoutSpec calculateLayoutThatFits:` hook ran for *every* Texture stack layout in the app — thousands per second across the background layout threads while scrolling — purely to log a diagnostic that has never fired. It was the single largest tweak entry in the profile (964 inclusive samples / 14s scroll). The actual protective machinery (main-stack exhaustion sentinels + the safe bail & relayout in `LinkButtonNode.layoutSpecThatFits`) is untouched.

2. **Language detection off the main thread** (`ApolloTranslation.xm`). With translation enabled, post-title and feed-body translation ran `NLLanguageRecognizer` inline on the main thread at cell-appear time — the worst possible moment of a scroll frame (~25% of main-thread busy time in the profile). Detection now probes the existing cache synchronously (cache hits keep the exact old code path), and on a miss warms the cache on a **serial** utility queue, then re-runs the full pass on main so every gate re-validates against current node/VC state. Serial matters: a first version used the concurrent global queue and a fast scroll raced 33 recognizer threads side by side; serialized, duplicate warms collapse into cache hits. Main-thread detection samples went **273 → 1** on the same workload.

3. **Cached the link-protection regexes** (`ApolloTranslation.xm`). `ApolloProtectTranslationLinks` compiled two `NSRegularExpression`s on every call — per title/body per node event during scroll. Same fix and rationale as #652's display-text regex caching.

4. **Tag Filters head gate** (`ApolloTagFilters.xm`). With the feature off, the per-cell apply still did the link ivar-walk + associated-object churn on every post-cell layout. Now it bails immediately (with teardown preserved for cells that still carry filter state from when it was on).

5. **Per-class verdict cache for URL-hiding** (`ApolloInlineLinkPreviewURLHiding.xm`). The should-process check ran `NSStringFromClass` + substring scans for every `setAttributedText` app-wide. The verdict is a pure function of the class, so it's now cached on the class object.

6. **Link-preview cache read path** (`ApolloLinkPreviewCache.m`). Reads negative-cache known-absent keys so repeat measures of a URL whose fetch hasn't completed skip the `dispatch_sync` onto the disk-write queue (misses are the steady state while scrolling), and the SHA-256 cache key is memoized per URL string.

7. **Two more audit-confirmed gates** (`ApolloThemeIntegrations.xm`, `ApolloScrollEdgePopFix.xm`). ListCellOwner re-ran `NSStringFromClass` + five substring scans per cell layout while a theme is active — the verdict is a pure function of the table delegate's class and is now cached on it. ScrollEdgeEffectView's layoutSubviews paid a superview walk on every layout during ordinary scrolling before the transitions-in-flight counter (the freeze predicate's own first condition) could bail.

## Numbers

Same fixed workload (14 idb swipes / 14s, 1ms stack sampling, sim), main-thread tweak-frame samples: **3830 → 2163 (−44%)**. The remainder is dominated by hook wrappers whose counts are almost entirely the wrapped `%orig` (UIKit's own scroll work — verified by leaf analysis) plus legitimate translation of actually-foreign posts.

## Verified

- Sim (integration tree = main + all 13 open PRs + this): feed scroll, link previews, comments, tab-bar auto-hide all normal.
- Translation end-to-end on a **cold cache**: fresh launch translates foreign posts (chip + globe state correct), globe toggle off restores originals, toggle back on re-translates new content live through the new async path.
- Device build (`make package`, pinned iOS 26 SDK / iOS 14 floor): zero errors.
- Regression check: #652's regex caching is intact in current main (under post-#630 symbol names), and #724's seven optimizations all survived the all-PRs merge intact.

## Leftovers spotted while profiling (not in this PR — they live in files open PRs own)

- `ApolloInlineImages.xm` (~4506): the LinkButtonNode `layoutSpecThatFits:` hook re-derives the URL string (iOS 26: `class_getInstanceVariable` of `urlTextNode` + attributedText read + prefix alloc) and re-parses `NSURL` on **every measure** — the exact pattern #724 fixed in ApolloInlineLinkPreviews' hook on the same class. Same fix applies: compare an `OBJC_ASSOCIATION_COPY`'d cached string per node and only re-parse when it changes (atomic policies — measures run on Texture's background layout threads). (#728's file.)
- `ApolloSubredditHighlights.xm` (~2070): with Community Highlights on and Subreddit Headers off, the managed feed table's `layoutSubviews` derives the subreddit name on **every scroll frame** — ivar hierarchy walks plus `ApolloHLNormalizedName` allocating a fresh inverted `NSCharacterSet` (63-char set!), a blocked-names array, and two lowercase copies per frame. Memoize per VC keyed on the ivar/title inputs and hoist the set/array into statics. (#724's file.)

- `ApolloDeletedCommentsUI.xm`: the MarkdownNode `layoutSpecThatFits` hook does an ungated supernode walk (up to 10 hops of `class_getName`/`strstr`) on every measure — could take the same per-class/feature gate treatment (#724's file).
- `ApolloSubredditHeaders.xm`: `ApolloSubredditNeedsInstall` runs the table-view hunt before the `!sShowSubredditHeaders` bail; flag check should come first (#696/#724 file).
- `ApolloUserProfileCache.m`: `updateFollowState` still writes the disk file directly instead of going through #724's coalesced save (#724's file).
- `ApolloAccountCredentials.m`: `ApolloActiveAccountUsername()` unarchives the full ~50KB `RedditAccounts2` blob on every call (badge writes, chat poller ticks, network-chokepoint checks); a memoized copy invalidated on account change would kill a lot of repeat work (#696/#697 file).
