### PR TITLE
Fix keyless multi-image gallery posts failing with INVALID_MEDIA_ASSETS

### DIFF
--- a/src/ApolloImageUploadHost.xm
+++ b/src/ApolloImageUploadHost.xm
@@ -1369,6 +1369,23 @@ static NSURLRequest *ApolloImgChestRewriteSubmitRequest(NSURLRequest *request, N
     return modified;
 }
 
+// Scan a submit body's form pairs for the `url` field that maps to a recorded
+// synthetic Reddit gallery album, returning its member asset IDs (album id via
+// outAlbumID). A map hit is proof this submit is one of OUR Reddit-hosted
+// multi-image posts, regardless of the configured upload provider — genuine
+// Imgur albums never populate sRedditUploadGalleryAssetIDsByAlbumID.
+static NSArray<NSString *> *ApolloRedditGalleryAssetIDsFromSubmitPairs(NSArray<NSString *> *pairs, NSString **outAlbumID) {
+    for (NSString *pair in pairs) {
+        NSRange equals = [pair rangeOfString:@"="];
+        NSString *key = ApolloFormDecodeComponent(equals.location == NSNotFound ? pair : [pair substringToIndex:equals.location]);
+        if (![key isEqualToString:@"url"]) continue;
+        NSString *value = ApolloFormDecodeComponent(equals.location == NSNotFound ? @"" : [pair substringFromIndex:equals.location + 1]);
+        NSArray<NSString *> *assetIDs = ApolloRedditGalleryAssetIDsForURLString(value, outAlbumID);
+        if (assetIDs.count > 0) return assetIDs;
+    }
+    return nil;
+}
+
 NSURLRequest *ApolloRedditMaybeRewriteSubmitRequest(NSURLRequest *request) {
     if (!ApolloIsRedditLegacySubmitRequest(request)) return nil;
 
@@ -1409,6 +1426,26 @@ NSURLRequest *ApolloRedditMaybeRewriteSubmitRequest(NSURLRequest *request) {
         return imgChestRequest;
     }
 
+    // Reddit gallery submit (provider-independent): if the submit's url maps to
+    // a recorded synthetic Reddit gallery album, rewrite it to
+    // /api/submit_gallery_post. This runs above the provider split because
+    // keyless Web JSON uploads are claimed for Reddit regardless of the Media
+    // Upload Host (see ApolloShouldUseCookieRedditUpload) — the synthetic
+    // imgur.com/a/<id> link doesn't exist on Imgur — and a map hit is proof of
+    // a Reddit-hosted multi-image post either way. (The synthesizer never
+    // records a gallery containing video, so the video guard is belt-and-braces.)
+    {
+        NSString *galleryAlbumID = nil;
+        NSArray<NSString *> *galleryAssetIDs = ApolloRedditGalleryAssetIDsFromSubmitPairs(pairs, &galleryAlbumID);
+        if (galleryAssetIDs.count >= 2) {
+            if (ApolloRedditUploadAssetIDsContainVideo(galleryAssetIDs)) {
+                ApolloLog(@"[RedditUpload] Refusing unsupported mixed/video gallery submit (albumID=%@, items=%lu)", galleryAlbumID ?: @"(missing)", (unsigned long)galleryAssetIDs.count);
+                return nil;
+            }
+            return ApolloRedditGallerySubmitRequestFromForm(request, formValues, galleryAssetIDs, galleryAlbumID, canInjectComposerBodyText ? composerBodyText : nil);
+        }
+    }
+
     if (sImageUploadProvider != ImageUploadProviderReddit) {
         if (!shouldInjectComposerBodyText) return nil;
         NSURLRequest *bodyRequest = ApolloSubmitRequestByInjectingMediaBodyText(request, pairs, composerBodyText);
@@ -1422,8 +1459,6 @@ NSURLRequest *ApolloRedditMaybeRewriteSubmitRequest(NSURLRequest *request) {
 
     BOOL hasUploadedURLField = NO;
     BOOL hasUploadedTextField = NO;
-    NSString *galleryAlbumID = nil;
-    NSArray<NSString *> *galleryAssetIDs = nil;
     NSString *uploadedURLAssetID = nil;
     NSString *uploadedURLHost = nil;
     for (NSString *pair in pairs) {
@@ -1436,15 +1471,7 @@ NSURLRequest *ApolloRedditMaybeRewriteSubmitRequest(NSURLRequest *request) {
             uploadedURLHost = ApolloHostForRedditMediaURL(stagedURL);
             uploadedURLAssetID = ApolloAssetIDForRedditUploadedMediaURL(stagedURL) ?: uploadedURLAssetID;
         }
-        if ([key isEqualToString:@"url"] && galleryAssetIDs.count == 0) galleryAssetIDs = ApolloRedditGalleryAssetIDsForURLString(value, &galleryAlbumID);
         if ([key isEqualToString:@"text"] && ApolloFirstRedditUploadedMediaURLInString(value).length > 0) hasUploadedTextField = YES;
-    }
-    if (galleryAssetIDs.count >= 2) {
-        if (ApolloRedditUploadAssetIDsContainVideo(galleryAssetIDs)) {
-            ApolloLog(@"[RedditUpload] Refusing unsupported mixed/video gallery submit (albumID=%@, items=%lu)", galleryAlbumID ?: @"(missing)", (unsigned long)galleryAssetIDs.count);
-            return nil;
-        }
-        return ApolloRedditGallerySubmitRequestFromForm(request, formValues, galleryAssetIDs, galleryAlbumID, shouldInjectComposerBodyText ? composerBodyText : nil);
     }
     if (!ApolloStringContainsRedditUploadedMedia(body)) {
         ApolloMediaPostBodyLogSubmitDecision(@"skip", formValues, composerBodyText, hostedMediaForm, @"no-reddit-uploaded-media");
@@ -2888,6 +2915,24 @@ static void ApolloWarnKeylessUploadUnavailableOnce(void) {
     });
 }
 
+// The lowercased username the current compose will SUBMIT as, when that
+// account is a keyless (web-session) one — nil when the posting account is an
+// API-key account (its own bearer is the right lease identity) or can't be
+// resolved. The temporary posting account chosen via the title chooser wins;
+// otherwise the active account posts. An account is keyless exactly when it
+// has a stored web session: auth modes are mutually exclusive per account,
+// and an interactive OAuth sign-in removes any stale session entry (see
+// ApolloAccountCredentials.h / ApolloWebSessionStore.h).
+static NSString *ApolloRedditKeylessPostingUsername(void) {
+    NSString *composeToken = ApolloMediaComposerActivePostingBearerToken();
+    if (composeToken.length > 0 && !ApolloWebJSONBearerIsSynthetic(composeToken)) return nil;
+    NSString *username = composeToken.length > 0 ? ApolloWebJSONUsernameFromSyntheticBearer(composeToken) : nil;
+    if (username.length == 0) username = ApolloActiveWebSessionUsername();
+    username = username.lowercaseString;
+    if (username.length == 0) return nil;
+    return ApolloWebSessionFor(username).cookieHeader.length > 0 ? username : nil;
+}
+
 // The bearer used for the Reddit media lease. Prefer the compose's posting-account
 // token, then the last captured token. In the keyless Web JSON escape hatch there
 // is no real bearer, so return the synthetic placeholder — the chokepoint rewrite
@@ -2896,6 +2941,19 @@ static void ApolloWarnKeylessUploadUnavailableOnce(void) {
 static NSString *ApolloRedditUploadBearerToken(void) {
     NSString *composeToken = ApolloMediaComposerActivePostingBearerToken();
     if (composeToken.length > 0) return composeToken;
+    // Before falling back to the last globally-captured bearer, make sure the
+    // account that will SUBMIT isn't a keyless web-session account. On a mixed
+    // API-key + keyless install sLatestRedditBearerToken holds the OTHER
+    // account's real bearer (captured from its background traffic); handing it
+    // to a keyless upload makes Reddit reject the post with "All media assets
+    // must be owned by the submitter of this post" (INVALID_MEDIA_ASSETS,
+    // enforced server-side since ~mid-July 2026). Returning the keyless
+    // account's synthetic placeholder makes the WHOLE upload path treat it as
+    // keyless — the routing decision (ApolloShouldUseCookieRedditUpload) and
+    // the lease both key off this, so single images route correctly too, not
+    // just galleries.
+    NSString *keylessUsername = ApolloRedditKeylessPostingUsername();
+    if (keylessUsername.length > 0) return ApolloWebJSONSyntheticBearerTokenForUsername(keylessUsername);
     if (sLatestRedditBearerToken.length > 0) return [sLatestRedditBearerToken copy];
     if (ApolloWebJSONHasUsableSession()) return ApolloWebJSONSyntheticBearerTokenForUsername(ApolloActiveWebSessionUsername());
     return nil;
@@ -2933,14 +2991,23 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
     // different account, which makes Reddit reject the submit with
     // "All media assets must be owned by the submitter of this post".
     NSString *composeToken = ApolloMediaComposerActivePostingBearerToken();
+    // Posting-account-centric identity (INVALID_MEDIA_ASSETS fix): when the
+    // submitting account is keyless, ApolloRedditUploadBearerToken() already
+    // returns its synthetic placeholder (never a foreign captured bearer), so
+    // `token` is synthetic here and the keyless branch below leases under the
+    // account that actually submits.
+    NSString *keylessUsername = ApolloRedditKeylessPostingUsername();
     NSString *token = ApolloRedditUploadBearerToken();
-    // Keyless Web JSON: no real bearer (just the synthetic placeholder), so the
-    // lease goes to the old-reddit web endpoint with cookie + modhash instead.
+    // Keyless Web JSON: no real bearer of Apollo's own. Below we first try the
+    // posting account's web bearer (fresh token_v2 or an accounts-service
+    // mint) on the real oauth media lease — that creates an asset OWNED by the
+    // submitter, which gallery submits require — and only fall back to the
+    // old-reddit cookie + modhash web lease when no bearer can be produced.
     BOOL cookieMode = ApolloWebJSONBearerIsSynthetic(token);
-    if (composeToken.length > 0 && ![composeToken isEqualToString:sLatestRedditBearerToken]) {
+    if (composeToken.length > 0 && ![composeToken isEqualToString:sLatestRedditBearerToken] && !cookieMode) {
         ApolloLog(@"[RedditUpload] Using temporary posting account token for upload (differs from last captured Reddit token)");
-    } else if (ApolloWebJSONBearerIsSynthetic(token)) {
-        ApolloLog(@"[RedditUpload] No real bearer token; routing media lease through the Web JSON cookie session");
+    } else if (cookieMode) {
+        ApolloLog(@"[RedditUpload] Keyless posting account — leasing media under its own web identity");
     }
     NSString *userAgent = sUserAgent.length > 0 ? sUserAgent : defaultUserAgent;
     if (ApolloRedditNativeUploadAttemptIsCancelled(attempt, @"before-media-upload")) return;
@@ -2950,11 +3017,18 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
         ApolloUpdateActiveUploadAlertProgress(progress);
     };
     ApolloUpdateActiveUploadAlertProgress(0.0);
+    // The bearer the media upload actually rode (posting account's own web
+    // bearer in keyless mode) — a video's poster upload must reuse it so both
+    // assets land on the same account. usedCookieLease tracks whether the
+    // fallback cookie web lease carried the upload; it's the only path with no
+    // asset_id in the response.
+    __block NSString *resolvedUploadBearer = token;
+    __block BOOL usedCookieLease = NO;
     ApolloRedditMediaUploadCompletion mediaCompletion = ^(NSURL *mediaURL, NSString *assetID, NSString *webSocketURL, NSError *error) {
         if (ApolloRedditNativeUploadAttemptIsCancelled(attempt, @"media-upload-completion")) return;
         // Cookie uploads (image_upload_s3.json) never return an asset_id — the S3
         // <Location> URL is the whole payload — so only require it off the cookie path.
-        if (error || !mediaURL || (!cookieMode && assetID.length == 0)) {
+        if (error || !mediaURL || (!usedCookieLease && assetID.length == 0)) {
             ApolloLog(@"[RedditUpload] Upload failed: %@", error.localizedDescription);
             if (videoContext) ApolloMediaComposerCompleteVideoUploadContext(videoContext, YES, @"media-upload-error");
             completionHandler(nil, nil, error ?: [NSError errorWithDomain:@"ApolloRedditMediaUpload" code:50
@@ -2994,7 +3068,7 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
             NSString *posterFilename = [NSString stringWithFormat:@"apollo-video-poster-%@.jpg", [NSUUID UUID].UUIDString];
             ApolloLog(@"[RedditUpload] Uploading video poster image for assetID=%@ (%lu bytes)", assetID, (unsigned long)videoPosterData.length);
             attempt.stage = @"poster-upload";
-            attempt.posterOperation = ApolloUploadMediaDataToRedditCancellable(videoPosterData, posterFilename, @"image/jpeg", token, userAgent, nil, ^(NSURL *posterURL, NSString *posterAssetID, NSString *posterWebSocketURL, NSError *posterError) {
+            attempt.posterOperation = ApolloUploadMediaDataToRedditCancellable(videoPosterData, posterFilename, @"image/jpeg", resolvedUploadBearer, userAgent, nil, ^(NSURL *posterURL, NSString *posterAssetID, NSString *posterWebSocketURL, NSError *posterError) {
                 if (ApolloRedditNativeUploadAttemptIsCancelled(attempt, @"poster-upload-completion")) return;
                 if (posterError || !posterURL) {
                     ApolloLog(@"[RedditUpload] Video poster upload failed for assetID=%@: %@", assetID, posterError.localizedDescription ?: @"missing poster URL");
@@ -3029,26 +3103,76 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
         if (videoContext) ApolloMediaComposerCompleteVideoUploadContext(videoContext, YES, @"media-upload-success");
         completeSyntheticUpload();
     };
-    // Resolve the active account's per-account session once so the cookie and
+    // API-key posting account: unchanged — lease with its real bearer.
+    if (!cookieMode) {
+        if (mediaFileURL) {
+            attempt.mediaOperation = ApolloUploadMediaFileToRedditCancellable(mediaFileURL, filename, mimeType, token, userAgent, progressHandler, mediaCompletion);
+        } else {
+            attempt.mediaOperation = ApolloUploadMediaDataToRedditCancellable(mediaData, filename, mimeType, token, userAgent, progressHandler, mediaCompletion);
+        }
+        return;
+    }
+
+    // Keyless posting account. Resolve ITS session once so the cookie and
     // modhash can't come from two different accounts if a switch races the
-    // upload. A nil entry (account switched away mid-flight) fails fast rather
-    // than making a doomed request with the synthetic bearer.
-    ApolloWebSessionEntry *webSession = cookieMode ? ApolloActiveWebSession() : nil;
-    if (cookieMode && webSession.cookieHeader.length == 0) {
-        ApolloLog(@"[RedditUpload] Cookie mode requested but no active web session — aborting upload");
+    // upload; a missing entry (account switched away / signed out mid-flight)
+    // fails fast rather than making a doomed request.
+    NSString *sessionUsername = keylessUsername.length > 0 ? keylessUsername : ApolloActiveWebSessionUsername().lowercaseString;
+    ApolloWebSessionEntry *webSession = sessionUsername.length > 0 ? ApolloWebSessionFor(sessionUsername) : nil;
+    if (webSession.cookieHeader.length == 0) {
+        ApolloLog(@"[RedditUpload] Keyless upload requested but no web session for u/%@ — aborting upload", sessionUsername ?: @"(unknown)");
         completionHandler(nil, nil, [NSError errorWithDomain:@"ApolloRedditMediaUpload" code:54
             userInfo:@{NSLocalizedDescriptionKey: @"No active web session for the posting account — try again after switching back to it"}]);
         return;
     }
-    if (mediaFileURL) {
-        attempt.mediaOperation = cookieMode
-            ? ApolloUploadMediaFileToRedditViaCookieCancellable(mediaFileURL, filename, mimeType, webSession.cookieHeader, webSession.modhash, userAgent, progressHandler, mediaCompletion)
-            : ApolloUploadMediaFileToRedditCancellable(mediaFileURL, filename, mimeType, token, userAgent, progressHandler, mediaCompletion);
-    } else {
-        attempt.mediaOperation = cookieMode
-            ? ApolloUploadMediaDataToRedditViaCookieCancellable(mediaData, filename, mimeType, webSession.cookieHeader, webSession.modhash, userAgent, progressHandler, mediaCompletion)
-            : ApolloUploadMediaDataToRedditCancellable(mediaData, filename, mimeType, token, userAgent, progressHandler, mediaCompletion);
-    }
+
+    void (^startCookieLeaseUpload)(void) = ^{
+        usedCookieLease = YES;
+        resolvedUploadBearer = nil;
+        if (mediaFileURL) {
+            attempt.mediaOperation = ApolloUploadMediaFileToRedditViaCookieCancellable(mediaFileURL, filename, mimeType, webSession.cookieHeader, webSession.modhash, userAgent, progressHandler, mediaCompletion);
+        } else {
+            attempt.mediaOperation = ApolloUploadMediaDataToRedditViaCookieCancellable(mediaData, filename, mimeType, webSession.cookieHeader, webSession.modhash, userAgent, progressHandler, mediaCompletion);
+        }
+    };
+
+    // Try the posting account's own real bearer first (fresh token_v2 or an
+    // accounts-service mint): the oauth media/asset.json lease then creates an
+    // asset OWNED by the submitter, with a real asset_id — which is what lets
+    // multi-image gallery submits pass Reddit's ownership check. The resolve
+    // can mint synchronously (bounded network wait), so hop off the calling
+    // queue; everything downstream is async callbacks anyway.
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        if (ApolloRedditNativeUploadAttemptIsCancelled(attempt, @"keyless-bearer-resolve")) return;
+        NSString *ownBearer = sessionUsername.length > 0 ? ApolloWebJSONKeylessOAuthBearer(sessionUsername) : nil;
+        if (ApolloRedditNativeUploadAttemptIsCancelled(attempt, @"keyless-bearer-resolved")) return;
+        if (ownBearer.length == 0) {
+            ApolloLog(@"[RedditUpload] No web bearer for u/%@ — using the cookie web lease (galleries need the bearer)", sessionUsername ?: @"(unknown)");
+            startCookieLeaseUpload();
+            return;
+        }
+        resolvedUploadBearer = ownBearer;
+        ApolloLog(@"[RedditUpload] Leasing media under u/%@'s own web bearer", sessionUsername);
+        // A minted bearer is unproven until a fetch succeeds with it — a dead
+        // session yields an anonymous token that the lease 401/403s. Report
+        // that outcome (drops the mint + arms the backoff) and retry once
+        // through the cookie web lease so single-image uploads still work.
+        ApolloRedditMediaUploadCompletion bearerOutcomeCompletion = ^(NSURL *mediaURL, NSString *assetID, NSString *webSocketURL, NSError *error) {
+            BOOL authRejected = error && [error.domain isEqualToString:@"ApolloRedditMediaUpload"] && (error.code == 401 || error.code == 403);
+            if (authRejected && !ApolloRedditNativeUploadAttemptIsCancelled(attempt, @"keyless-bearer-rejected")) {
+                ApolloWebJSONInvalidateOAuthBearerForAccount(sessionUsername, ownBearer);
+                ApolloLog(@"[RedditUpload] Web-bearer media lease rejected (HTTP %ld) — retrying via the cookie web lease", (long)error.code);
+                startCookieLeaseUpload();
+                return;
+            }
+            mediaCompletion(mediaURL, assetID, webSocketURL, error);
+        };
+        if (mediaFileURL) {
+            attempt.mediaOperation = ApolloUploadMediaFileToRedditCancellable(mediaFileURL, filename, mimeType, ownBearer, userAgent, progressHandler, bearerOutcomeCompletion);
+        } else {
+            attempt.mediaOperation = ApolloUploadMediaDataToRedditCancellable(mediaData, filename, mimeType, ownBearer, userAgent, progressHandler, bearerOutcomeCompletion);
+        }
+    });
 }
 
 // MARK: - Hooks (token capture + upload interception)

--- a/src/ApolloPhotoPostComposerScrollFix.xm
+++ b/src/ApolloPhotoPostComposerScrollFix.xm
@@ -1009,6 +1009,15 @@ static NSString *ApolloPhotoComposerTextForView(UIView *view) {
     if ([view isKindOfClass:[UITextField class]]) return ((UITextField *)view).text;
     if ([view isKindOfClass:[UITextView class]]) return ((UITextView *)view).text;
     if ([view isKindOfClass:[UIButton class]]) return [(UIButton *)view currentTitle];
+    // Never probe accessibilityLabel on scroll-view containers. With
+    // accessibility active (VoiceOver, or the simulator's automation harness),
+    // -[UITableViewAccessibility accessibilityLabel] enumerates its elements
+    // and REALIZES cells — dequeue → heightForRow → the compose hooks' scope
+    // check → this function again on the same table — a mutual recursion that
+    // blew the 1MB main stack (SIGSEGV in the stack guard page; this walk is
+    // also the long-standing "[StackGuard] heightForRow ~850KB" spike). Real
+    // text never lives on the scroll view itself, so nothing is lost.
+    if ([view isKindOfClass:[UIScrollView class]]) return nil;
     NSString *accessibilityLabel = view.accessibilityLabel;
     return accessibilityLabel.length > 0 ? accessibilityLabel : nil;
 }
@@ -1027,7 +1036,7 @@ static BOOL ApolloPhotoComposerViewContainsText(UIView *rootView, NSString *need
     return NO;
 }
 
-static BOOL ApolloPhotoComposerControllerIsInScope(UIViewController *controller) {
+static BOOL ApolloPhotoComposerControllerIsInScopeUnguarded(UIViewController *controller) {
     if (!controller.isViewLoaded || !controller.view.window) return NO;
 
     NSString *title = controller.navigationItem.title ?: controller.title;
@@ -1049,6 +1058,21 @@ static BOOL ApolloPhotoComposerControllerIsInScope(UIViewController *controller)
         ApolloPhotoComposerViewContainsText(view, @"Link") &&
         ApolloPhotoComposerViewContainsText(view, @"Text");
     return hasPostingContext || hasPostMode;
+}
+
+// Re-entrancy guard (belt and braces for the accessibility recursion handled
+// in ApolloPhotoComposerTextForView): if a scope check's view-tree walk
+// somehow re-enters the compose table's delegate hooks — which call back into
+// this function — answer NO for the inner throwaway pass instead of recursing
+// to stack exhaustion. The recursion is a synchronous same-thread stack, so a
+// plain static is a correct guard.
+static BOOL ApolloPhotoComposerControllerIsInScope(UIViewController *controller) {
+    static BOOL sScopeCheckInProgress = NO;
+    if (sScopeCheckInProgress) return NO;
+    sScopeCheckInProgress = YES;
+    BOOL inScope = ApolloPhotoComposerControllerIsInScopeUnguarded(controller);
+    sScopeCheckInProgress = NO;
+    return inScope;
 }
 
 static NSString *ApolloMediaComposerTrimmedBodyText(NSString *text) {
@@ -3025,6 +3049,13 @@ static UICollectionView *ApolloPhotoComposerFindImageStrip(UIViewController *con
 }
 
 static BOOL ApolloPhotoComposerStripShouldCancelContentTouch(id self, SEL _cmd, UIView *view) {
+    // Always cancel the in-progress content touch so a horizontal drag turns
+    // into a strip scroll. This is the whole point of the fix — the raw
+    // collection view starts with delaysContentTouches/canCancelContentTouches
+    // tuned so a touch that lands on a thumbnail never becomes a scroll.
+    // (Apollo's ImageSlider has no drag-to-reorder — verified against the
+    // binary: no moveItemAt:/beginInteractiveMovement/drag-delegate anywhere —
+    // so there's no lift gesture to preserve here; the strip only scrolls.)
     return YES;
 }
 
@@ -3079,6 +3110,31 @@ static void ApolloPhotoComposerApplyScrollFix(UICollectionView *collectionView) 
     objc_setAssociatedObject(collectionView, &kApolloPhotoComposerScrollFixAppliedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     ApolloLog(@"[PhotoComposerScroll] enabled selected-photo strip horizontal scrolling (ancestor recognizers=%lu)", (unsigned long)requiredCount);
 }
+
+// Root cause of "swiping the thumbnails doesn't always move them — do it a few
+// times and it works": the repair passes below only run on controller-level
+// events (appearance, controller layout, dismiss bursts), but the thumbnail
+// strip materializes asynchronously after the photo picker dismisses (and
+// again each time "Choose Media" adds more). Its collection view often
+// attaches AFTER the last burst, so the horizontal-scroll enablement isn't in
+// place yet — the strip won't scroll until some later repair happens to fire.
+// Apply the fix deterministically the moment the strip lands in a window
+// instead: its collection view's delegate is the Apollo.ImageSlider… cell,
+// wired before the view attaches. One cheap class-name check per collection
+// view window-attach app-wide; ApolloPhotoComposerApplyScrollFix dedupes via
+// its applied-key.
+%hook UICollectionView
+
+- (void)didMoveToWindow {
+    %orig;
+    if (!self.window) return;
+    NSString *delegateClass = self.delegate ? NSStringFromClass([self.delegate class]) : @"";
+    if (ApolloPhotoComposerStringContains(delegateClass, @"ImageSlider")) {
+        ApolloPhotoComposerApplyScrollFix(self);
+    }
+}
+
+%end
 
 static void ApolloPhotoComposerRepairController(UIViewController *controller, NSString *reason) {
     if (!ApolloPhotoComposerControllerHasDirectScopeSignal(controller)) return;

--- a/src/ApolloRedditMediaUpload.m
+++ b/src/ApolloRedditMediaUpload.m
@@ -495,7 +495,14 @@ static void ApolloRequestRedditMediaAsset(NSData *mediaData,
         return;
     }
 
-    NSURL *url = [NSURL URLWithString:@"https://oauth.reddit.com/api/media/asset.json"];
+    // Probe fragment: this is a tweak-internal request, so the transport hooks
+    // must leave it alone — the Web JSON chokepoint must not re-point it (the
+    // /api/media/* exclusion already covers that, belt and suspenders), and
+    // crucially the bearer capture must not read this Authorization header. In
+    // keyless mode the bearer here is the posting account's minted web bearer,
+    // and capturing it would poison sLatestRedditBearerToken for mixed
+    // API-key + keyless installs. The fragment never reaches the wire.
+    NSURL *url = ApolloWebJSONProbeURL([NSURL URLWithString:@"https://oauth.reddit.com/api/media/asset.json"]);
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     request.HTTPMethod = @"POST";
     [request setValue:[@"Bearer " stringByAppendingString:bearerToken] forHTTPHeaderField:@"Authorization"];

--- a/src/ApolloWebJSON.h
+++ b/src/ApolloWebJSON.h
@@ -110,6 +110,13 @@ BOOL ApolloWebJSONRequestIsInternal(NSURL *url);
 // request with ApolloWebJSONProbeURL so the transport hooks leave it alone.
 NSString *ApolloWebJSONKeylessOAuthBearer(NSString *username);
 
+// Fetch-outcome feedback for ApolloWebJSONKeylessOAuthBearer callers: report a
+// 401/403 so a minted bearer proven dead (an anonymous token from a signed-out
+// session) is dropped and its account backs off instead of re-minting a doomed
+// token every attempt. No-op for a token_v2 bearer. Pass the SAME username you
+// gave ApolloWebJSONKeylessOAuthBearer (the mint cache keys on it).
+void ApolloWebJSONInvalidateOAuthBearerForAccount(NSString *username, NSString *bearer);
+
 // Hydrates the legacy single-session globals from the keychain, migrating any
 // legacy NSUserDefaults cookie value, then any legacy single-global session,
 // into the per-account ApolloWebSessionStore (see that file's harvest path for

--- a/src/ApolloWebJSON.m
+++ b/src/ApolloWebJSON.m
@@ -1749,6 +1749,24 @@ NSString *ApolloWebJSONKeylessOAuthBearer(NSString *username) {
     return ApolloWebJSONUsableTokenV2ForSession(session) ?: ApolloWebJSONMintWebBearerForAccount(user);
 }
 
+// Fetch-outcome feedback for ApolloWebJSONKeylessOAuthBearer callers: a 401/403
+// with a minted bearer is the signature of a dead session having been handed an
+// anonymous token (the mint itself can't tell). Drop the cached mint and
+// remember the failure so the next attempt backs off instead of re-minting a
+// doomed token. token_v2 bearers have nothing to drop — they age out of the
+// stored cookie header on their own. Pass the SAME username you gave
+// ApolloWebJSONKeylessOAuthBearer (nil/empty → the active account, matching its
+// fallback) so the mint cache, which keys on that string, resolves.
+void ApolloWebJSONInvalidateOAuthBearerForAccount(NSString *username, NSString *bearer) {
+    NSString *user = username.length ? username : ApolloActiveWebSessionUsername();
+    if (user.length == 0 || bearer.length == 0) return;
+    NSString *cached = ApolloWebJSONCachedMintedBearerForUser(user);
+    if (![cached isEqualToString:bearer]) return;
+    ApolloWebJSONDropMintedBearerForUser(user);
+    ApolloWebJSONRecordMintFailureForUser(user);
+    ApolloLog(@"[WebJSON] Dropped rejected web bearer for u/%@ (fetch outcome 401/403)", user);
+}
+
 NSArray *ApolloWebJSONRescueFlairList(NSHTTPURLResponse *response) {
     NSURL *failedURL = response.URL;
     if (!failedURL) return nil;
@@ -1764,21 +1782,16 @@ NSArray *ApolloWebJSONRescueFlairList(NSHTTPURLResponse *response) {
     // failed request; fall back to the active session for safety.
     NSString *username = ApolloWebJSONAccountFromURL(failedURL) ?: ApolloActiveWebSessionUsername();
     if (username.length == 0) return nil;
-    ApolloWebSessionEntry *session = ApolloWebSessionFor(username);
-    if (session.cookieHeader.length == 0) return nil;
 
-    // Prefer the stored token_v2 cookie while it's still fresh (harvests are
-    // <24h old at first); after that, mint a bearer from the accounts token
-    // service. A minted bearer is unproven until the fetch below succeeds
-    // with it — a dead session can yield an anonymous token, so the 401/403
-    // outcome is what decides whether the mint "worked".
-    NSString *token = ApolloWebJSONUsableTokenV2ForSession(session);
-    BOOL minted = NO;
-    if (token.length == 0) {
-        token = ApolloWebJSONMintWebBearerForAccount(username);
-        minted = token.length > 0;
-    }
+    // Resolve the account's own OAuth bearer (fresh token_v2, else a minted
+    // accounts-service bearer). A minted bearer is unproven until the fetch
+    // below succeeds — a dead session can yield an anonymous token, so the
+    // 401/403 outcome is what decides whether it "worked". `minted` (a bearer
+    // that came from the mint, not the token_v2 cookie) drives that outcome
+    // handling; the mint cache is the source of truth for it.
+    NSString *token = ApolloWebJSONKeylessOAuthBearer(username);
     if (token.length == 0) return nil;
+    BOOL minted = [token isEqualToString:ApolloWebJSONCachedMintedBearerForUser(username)];
 
     // Same path + query as the failed www request, back on the oauth host.
     NSURLComponents *components = [NSURLComponents componentsWithURL:failedURL resolvingAgainstBaseURL:NO];
@@ -1810,14 +1823,11 @@ NSArray *ApolloWebJSONRescueFlairList(NSHTTPURLResponse *response) {
         return nil;
     }
     if (status == 401 || status == 403) {
-        if (minted) {
-            // The freshly minted bearer doesn't authenticate — the signature
-            // of a dead session being handed an anonymous token. Drop it and
-            // remember the failure so the next opens don't repay the mint
-            // cost immediately. (Nothing was ever persisted from the mint.)
-            ApolloWebJSONDropMintedBearerForUser(username);
-            ApolloWebJSONRecordMintFailureForUser(username);
-        }
+        // A minted bearer that doesn't authenticate is the signature of a dead
+        // session handed an anonymous token — drop it and remember the failure
+        // so the next opens don't repay the mint cost immediately. No-op for a
+        // token_v2 bearer (it isn't the cached mint). Nothing was persisted.
+        ApolloWebJSONInvalidateOAuthBearerForAccount(username, token);
         ApolloLog(@"[WebJSON] Flair rescue got HTTP %ld for %@%@", (long)status, failedURL.path,
                   minted ? @" with a freshly minted bearer — treating the web session as signed out" : @"");
         return nil;

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1896,8 +1896,15 @@ static NSURLRequest *ApolloLocalFastFailRequest(NSString *path) {
     NSString *host = [url host];
     NSString *path = [url path];
 
-    NSData *redditAlbumResponseData = sImageUploadProvider == ImageUploadProviderReddit ? ApolloRedditSyntheticImgurAlbumResponseDataForRequest(request) : nil;
-    if (sImageUploadProvider == ImageUploadProviderReddit && redditAlbumResponseData.length > 0) {
+    // Not gated on the Reddit provider setting: keyless Web JSON uploads are
+    // claimed for Reddit regardless of the Media Upload Host (see
+    // ApolloShouldUseCookieRedditUpload), so their multi-image albums must be
+    // synthesized into Reddit galleries too. The synthesis only succeeds when
+    // >= 2 of the album's member tokens map to RECORDED Reddit uploads, so a
+    // genuine Imgur album (Imgur-hosted member ids) still passes through to
+    // Imgur untouched. ImgChest keeps its own album responder below.
+    NSData *redditAlbumResponseData = sImageUploadProvider != ImageUploadProviderImgChest ? ApolloRedditSyntheticImgurAlbumResponseDataForRequest(request) : nil;
+    if (redditAlbumResponseData.length > 0) {
         NSHTTPURLResponse *fakeHTTPResponse = [[NSHTTPURLResponse alloc] initWithURL:url
                                                                           statusCode:200
                                                                          HTTPVersion:@"HTTP/1.1"


### PR DESCRIPTION
Fixes multi-image gallery posts failing with `INVALID_MEDIA_ASSETS` ("All Media assets must be owned by the submitter of this post") when posting from a keyless (API-key-free) account on a setup that *also* has an API-key account signed in.

### Post
<img width="294" height="425" alt="api key free image and multi image upload" src="https://github.com/user-attachments/assets/a63eb84b-4553-4b71-a10e-9743373cbce1" />

### What was happening
The image upload grabbed `sLatestRedditBearerToken` as its fallback bearer — which on a mixed setup holds the *other* (API-key) account's token. So the images got uploaded and owned by that account, while the gallery submit went out as the keyless account over its cookie session. Uploader ≠ submitter, so Reddit rejected it (they started enforcing this server-side around mid-July, same window the token_v2 stuff broke). Single-image posts and the API-key account were unaffected, which is why it looked like just multi-image keyless was broken.

### The fix
Make the media lease use the keyless posting account's *own* identity, at the shared chokepoint. `ApolloRedditUploadBearerToken()` now returns that account's synthetic bearer instead of a foreign captured one, so both the routing decision (`ApolloShouldUseCookieRedditUpload`) and the lease treat it as keyless. The upload then leases via `oauth media/asset.json` under the account's own web bearer — fresh `token_v2`, else an `accounts.reddit.com` mint reusing the #669 infra — producing assets owned by the submitter. Falls back to the old cookie web lease if no bearer can be minted (dead session). Because the fix lives in the shared bearer resolver, single-image keyless uploads on mixed setups are fixed too, not just galleries.

Also in here:
- Probe-mark the oauth media lease URL so a minted bearer can't poison `sLatestRedditBearerToken` (matches the sibling cookie lease).
- Hoist the synthetic-gallery detection above the provider split into one helper (was two provider-gated copies) and broaden the album-synth gate `== Reddit` → `!= ImgChest` — safe, since genuine Imgur albums never populate the gallery map.

### Composer fixes bundled in
- **Compose crash (stack overflow):** the composer's scope check probed `accessibilityLabel` on a `UITableView`, which realizes cells and recurses straight back into the scope check. This is also where those `[StackGuard] heightForRow ~850KB` log spikes came from. Skip `accessibilityLabel` on scroll views + a same-thread re-entrancy guard.
- **Thumbnail strip swipe:** the selected-image row now reliably scrolls left/right to see all your images before posting. It was applying the scroll enabler on timing-based passes that often missed the strip's async attach — now it applies the moment the strip attaches to a window.

Stacks on #669 — merge that first (the diff will show its commits until then). Verified in the sim (keyless 5-/3-/1-image galleries all post clean, then deleted); strip-swipe confirmed on device.
