### PR TITLE
Fix stale and un-themed backgrounds in Apollo Reborn settings screens

### DIFF
--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -1,5 +1,6 @@
 #import "ApolloCommon.h"
 #import "ApolloState.h"
+#import "ApolloThemeRuntime.h"
 #import <QuartzCore/QuartzCore.h>
 #import <mach-o/dyld.h>
 #import <mach-o/loader.h>
@@ -363,10 +364,13 @@ void ApolloApplyInheritedSettingsTableTheme(UITableViewController *controller) {
     if (!controller) return;
 
     UITableView *source = ApolloInheritedSettingsThemeSourceTableView(controller);
-    UIColor *backgroundColor = source.backgroundColor ?: controller.tableView.backgroundColor;
+    BOOL stale = ApolloThemeSourceTableIsStale(source);
+    UIColor *backgroundColor = (stale ? nil : source.backgroundColor)
+        ?: ApolloThemePageBackgroundColor() ?: controller.tableView.backgroundColor;
     controller.view.backgroundColor = backgroundColor;
     controller.tableView.backgroundColor = backgroundColor;
-    controller.tableView.separatorColor = source.separatorColor ?: [UIColor separatorColor];
+    controller.tableView.separatorColor = (stale ? nil : source.separatorColor)
+        ?: ApolloThemeSeparatorColor() ?: [UIColor separatorColor];
 }
 
 #pragma mark - LinkButtonNode URL extraction

--- a/src/ApolloThemeRuntime.h
+++ b/src/ApolloThemeRuntime.h
@@ -38,6 +38,18 @@ UIColor *ApolloThemeAccentColor(void);
 // own last-resort (typically secondarySystemGroupedBackgroundColor).
 UIColor *ApolloThemeCardBackgroundColor(void);
 
+// The EFFECTIVE page background for tweak-drawn UI: the custom theme's page
+// color when one is active, else the stock theme's (Pure Black Dark Mode
+// aware). nil only if neither can be determined — callers supply their own
+// last-resort (typically systemGroupedBackgroundColor).
+UIColor *ApolloThemePageBackgroundColor(void);
+
+// The EFFECTIVE separator color for tweak-drawn UI: the custom theme's
+// separator when one is active, else the stock theme's (Pure Black Dark
+// Mode aware). nil only if neither can be determined — callers supply their
+// own last-resort (typically UIColor.separatorColor).
+UIColor *ApolloThemeSeparatorColor(void);
+
 // Re-derive a caller-provided system font in the active theme's system design.
 // Returns `base` unchanged when the theme runtime is inactive or the active
 // theme uses the default system font.

--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -864,33 +864,35 @@ static NSString * const kUsePurerBlackDarkModeKey = @"UsePurePUREBlackMode";
 static NSString * const kPureBlackReduceSmearingKey = @"PureBlackModeReduceSmearing";
 
 // Stock AppColorTheme metadata, indexed by raw value: enum case name, accent
-// {light, dark}, and card background {light, dark} (docs/theme-builder-RE.md;
+// {light, dark}, card background {light, dark}, page background
+// {light, dark}, and separator {light, dark} (docs/theme-builder-RE.md;
 // accents recovered from the 1.15.11 binary's accent switch — jump table
-// 0x100ae3c14, arms off 0x10068b6bc). One table so all three stay in sync.
+// 0x100ae3c14, arms off 0x10068b6bc). One table so all five stay in sync.
 //
-// tinted themes (solarized/outrun/sunset/sepia/dracula) retint their own
-// background and ignore Pure Black entirely. Non-tinted themes share one
-// baseline (0x20252F) that ApolloStockNonTintedDarkCardRGB overrides per
+// tinted themes (solarized/outrun/sunset/sepia/dracula) retint everything
+// themselves and ignore Pure Black entirely. Non-tinted themes share one
+// baseline each (card 0x20252F, page 0x2B3039, separator 0x474E5C) that
+// ApolloStockNonTintedDarkCardRGB / ...PageRGB / ...SeparatorRGB override per
 // Apollo's Pure Black tier.
-static const struct { const char *name; uint32_t light, dark; uint32_t bgLight, bgDark; BOOL tinted; } kStockThemes[] = {
-    {"default",         0x007AFF, 0x2399FF, 0xFFFFFF, 0x20252F, NO},
-    {"nefertiti",       0x01A200, 0x01A200, 0xFFFFFF, 0x20252F, NO},
-    {"fieryStare",      0xFF0000, 0xFD0000, 0xFFFFFF, 0x20252F, NO},
-    {"spookyPumpkin",   0xFF6200, 0xF25D00, 0xFFFFFF, 0x20252F, NO},
-    {"solarized",       0x268BD2, 0x268BD2, 0xFDF6E3, 0x002B36, YES},
-    {"outrun",          0xC400A6, 0xFF00D8, 0xCFD7E8, 0x061636, YES},
-    {"sunset",          0xFF6600, 0xFF7D00, 0xFFE3D0, 0x000F29, YES},
-    {"sepia",           0xB88023, 0xD3AC72, 0xF1EAD9, 0x211E1A, YES},
-    {"monochromatic",   0x000000, 0xFFFFFF, 0xFFFFFF, 0x20252F, NO},
-    {"navy",            0x0058B8, 0x0060C9, 0xFFFFFF, 0x20252F, NO},
-    {"skiesOnSkies",    0x00B5F2, 0x01ADE8, 0xFFFFFF, 0x20252F, NO},
-    {"majesticPurple",  0x8800FF, 0x9C2CFF, 0xFFFFFF, 0x20252F, NO},
-    {"magentasplosion", 0xFF00B2, 0xE800A2, 0xFFFFFF, 0x20252F, NO},
-    {"sniffingWalnut",  0xA74E00, 0xA74E00, 0xFFFFFF, 0x20252F, NO},
-    {"fisherKing",      0x808286, 0x76787D, 0xFFFFFF, 0x20252F, NO},
-    {"chumbus",         0xF8F8F8, 0x20242B, 0xFFFFFF, 0x20252F, NO},
-    {"dracula",         0x9760FF, 0xAD81FF, 0xF8F8F3, 0x1A1D29, YES},
-    {"mint",            0x37BB98, 0x62DFA7, 0xFFFFFF, 0x20252F, NO},
+static const struct { const char *name; uint32_t light, dark; uint32_t bgLight, bgDark; uint32_t pageLight, pageDark; uint32_t sepLight, sepDark; BOOL tinted; } kStockThemes[] = {
+    {"default",         0x007AFF, 0x2399FF, 0xFFFFFF, 0x20252F, 0xF2F3F7, 0x2B3039, 0xEEEEEF, 0x474E5C, NO},
+    {"nefertiti",       0x01A200, 0x01A200, 0xFFFFFF, 0x20252F, 0xF2F3F7, 0x2B3039, 0xEEEEEF, 0x474E5C, NO},
+    {"fieryStare",      0xFF0000, 0xFD0000, 0xFFFFFF, 0x20252F, 0xF2F3F7, 0x2B3039, 0xEEEEEF, 0x474E5C, NO},
+    {"spookyPumpkin",   0xFF6200, 0xF25D00, 0xFFFFFF, 0x20252F, 0xF2F3F7, 0x2B3039, 0xEEEEEF, 0x474E5C, NO},
+    {"solarized",       0x268BD2, 0x268BD2, 0xFDF6E3, 0x002B36, 0xE6DFCF, 0x003745, 0xE0DCCD, 0x002836, YES},
+    {"outrun",          0xC400A6, 0xFF00D8, 0xCFD7E8, 0x061636, 0xBAC1D1, 0x081D47, 0xB5B9C7, 0x06214D, YES},
+    {"sunset",          0xFF6600, 0xFF7D00, 0xFFE3D0, 0x000F29, 0xF2D8C7, 0x12223D, 0xE0CBBD, 0x061B40, YES},
+    {"sepia",           0xB88023, 0xD3AC72, 0xF1EAD9, 0x211E1A, 0xDBD5CA, 0x38332C, 0xD4CEC0, 0x29271F, YES},
+    {"monochromatic",   0x000000, 0xFFFFFF, 0xFFFFFF, 0x20252F, 0xF2F3F7, 0x2B3039, 0xEEEEEF, 0x474E5C, NO},
+    {"navy",            0x0058B8, 0x0060C9, 0xFFFFFF, 0x20252F, 0xF2F3F7, 0x2B3039, 0xEEEEEF, 0x474E5C, NO},
+    {"skiesOnSkies",    0x00B5F2, 0x01ADE8, 0xFFFFFF, 0x20252F, 0xF2F3F7, 0x2B3039, 0xEEEEEF, 0x474E5C, NO},
+    {"majesticPurple",  0x8800FF, 0x9C2CFF, 0xFFFFFF, 0x20252F, 0xF2F3F7, 0x2B3039, 0xEEEEEF, 0x474E5C, NO},
+    {"magentasplosion", 0xFF00B2, 0xE800A2, 0xFFFFFF, 0x20252F, 0xF2F3F7, 0x2B3039, 0xEEEEEF, 0x474E5C, NO},
+    {"sniffingWalnut",  0xA74E00, 0xA74E00, 0xFFFFFF, 0x20252F, 0xF2F3F7, 0x2B3039, 0xEEEEEF, 0x474E5C, NO},
+    {"fisherKing",      0x808286, 0x76787D, 0xFFFFFF, 0x20252F, 0xF2F3F7, 0x2B3039, 0xEEEEEF, 0x474E5C, NO},
+    {"chumbus",         0xF8F8F8, 0x20242B, 0xFFFFFF, 0x20252F, 0xF2F3F7, 0x2B3039, 0xEEEEEF, 0x474E5C, NO},
+    {"dracula",         0x9760FF, 0xAD81FF, 0xF8F8F3, 0x1A1D29, 0xEDEDE8, 0x222636, 0xD7D3E0, 0x242838, YES},
+    {"mint",            0x37BB98, 0x62DFA7, 0xFFFFFF, 0x20252F, 0xF2F3F7, 0x2B3039, 0xEEEEEF, 0x474E5C, NO},
 };
 enum { kStockThemeCount = sizeof(kStockThemes) / sizeof(kStockThemes[0]) };
 
@@ -1012,6 +1014,91 @@ static UIColor *ApolloThemeStockCardBackgroundColor(void) {
 UIColor *ApolloThemeCardBackgroundColor(void) {
     UIColor *custom = ApolloThemeRuntimeColor(ApolloThemeTokenSecondaryBackground);
     return custom ?: ApolloThemeStockCardBackgroundColor();
+}
+
+// Dark-mode page-background override for a non-tinted stock theme. Simpler
+// than the card override: Apollo's page background is already black as soon
+// as Pure Black itself is on — PURER only pushes the CARD the rest of the
+// way, it doesn't change the page any further.
+static BOOL ApolloStockNonTintedDarkPageRGB(uint32_t *outRGB) {
+    NSUserDefaults *d = GroupDefaults();
+    if (![d boolForKey:kUsePureBlackDarkModeKey]) return NO;
+    if (outRGB) *outRGB = [d boolForKey:kPureBlackReduceSmearingKey] ? 0x050505 : 0x000000;
+    return YES;
+}
+
+// Page background ("secondaryBG") of the currently-selected stock Apollo
+// theme; nil while the custom runtime is active (donor hijack) or theme
+// unknown. Internal — external callers go through ApolloThemePageBackgroundColor().
+static UIColor *ApolloThemeStockPageBackgroundColor(void) {
+    if (sEnabled) return nil;
+    uint8_t raw = 0;
+    if (!GetLiveAppColorThemeRaw(&raw)) return nil;
+    if (raw >= kStockThemeCount) return nil;
+    uint32_t light = kStockThemes[raw].pageLight, dark = kStockThemes[raw].pageDark;
+    BOOL tinted = kStockThemes[raw].tinted;
+    return [UIColor colorWithDynamicProvider:^UIColor *(UITraitCollection *tc) {
+        uint32_t rgb = light;
+        if (tc.userInterfaceStyle == UIUserInterfaceStyleDark) {
+            uint32_t pureBlackRGB = 0;
+            rgb = (!tinted && ApolloStockNonTintedDarkPageRGB(&pureBlackRGB)) ? pureBlackRGB : dark;
+        }
+        sBypassHook++;
+        UIColor *c = ApolloThemeUIColorFromRGB(rgb);
+        sBypassHook--;
+        return c;
+    }];
+}
+
+// The EFFECTIVE page background for tweak-drawn UI: the custom theme's page
+// color when one is active, else the stock theme's (Pure Black Dark Mode
+// aware). nil only if neither can be determined — callers supply their own
+// last-resort (typically systemGroupedBackgroundColor).
+UIColor *ApolloThemePageBackgroundColor(void) {
+    UIColor *custom = ApolloThemeRuntimeColor(ApolloThemeTokenBackground);
+    return custom ?: ApolloThemeStockPageBackgroundColor();
+}
+
+// Dark-mode separator override for a non-tinted stock theme. One "on" value
+// covers both Pure Black tiers — PURER doesn't push the separator any
+// further than plain Pure Black does (unlike the card).
+static BOOL ApolloStockNonTintedDarkSeparatorRGB(uint32_t *outRGB) {
+    NSUserDefaults *d = GroupDefaults();
+    if (![d boolForKey:kUsePureBlackDarkModeKey]) return NO;
+    if (outRGB) *outRGB = 0x313741;
+    return YES;
+}
+
+// Separator color of the currently-selected stock Apollo theme; nil while
+// the custom runtime is active (donor hijack) or theme unknown. Internal —
+// external callers go through ApolloThemeSeparatorColor().
+static UIColor *ApolloThemeStockSeparatorColor(void) {
+    if (sEnabled) return nil;
+    uint8_t raw = 0;
+    if (!GetLiveAppColorThemeRaw(&raw)) return nil;
+    if (raw >= kStockThemeCount) return nil;
+    uint32_t light = kStockThemes[raw].sepLight, dark = kStockThemes[raw].sepDark;
+    BOOL tinted = kStockThemes[raw].tinted;
+    return [UIColor colorWithDynamicProvider:^UIColor *(UITraitCollection *tc) {
+        uint32_t rgb = light;
+        if (tc.userInterfaceStyle == UIUserInterfaceStyleDark) {
+            uint32_t pureBlackRGB = 0;
+            rgb = (!tinted && ApolloStockNonTintedDarkSeparatorRGB(&pureBlackRGB)) ? pureBlackRGB : dark;
+        }
+        sBypassHook++;
+        UIColor *c = ApolloThemeUIColorFromRGB(rgb);
+        sBypassHook--;
+        return c;
+    }];
+}
+
+// The EFFECTIVE separator color for tweak-drawn UI: the custom theme's
+// separator when one is active, else the stock theme's (Pure Black Dark
+// Mode aware). nil only if neither can be determined — callers supply their
+// own last-resort (typically UIColor.separatorColor).
+UIColor *ApolloThemeSeparatorColor(void) {
+    UIColor *custom = ApolloThemeRuntimeColor(ApolloThemeTokenSeparator);
+    return custom ?: ApolloThemeStockSeparatorColor();
 }
 
 void ApolloThemeRuntimeEnable(void) {

--- a/src/settings/ApolloSettingsTableViewController.m
+++ b/src/settings/ApolloSettingsTableViewController.m
@@ -29,11 +29,13 @@ static char kApolloAccentActionCellKey;
 
 - (UIColor *)apollo_themeCellBackgroundColor {
     UITableView *source = [self apollo_sourceThemeTableView];
-    for (UITableViewCell *cell in source.visibleCells) {
-        UIColor *color = cell.backgroundColor ?: cell.contentView.backgroundColor;
-        if (color) return color;
+    if (!ApolloThemeSourceTableIsStale(source)) {
+        for (UITableViewCell *cell in source.visibleCells) {
+            UIColor *color = cell.backgroundColor ?: cell.contentView.backgroundColor;
+            if (color) return color;
+        }
     }
-    return [UIColor secondarySystemGroupedBackgroundColor];
+    return ApolloThemeCardBackgroundColor() ?: [UIColor secondarySystemGroupedBackgroundColor];
 }
 
 - (UIColor *)apollo_themeAccentColor {


### PR DESCRIPTION
## Summary
Apollo Reborn's own settings screens (e.g. Setup → Accounts & API Keys) can end up with frozen or incorrectly-themed card, page, and separator colors after a light/dark appearance toggle. This ports the same fix already shipped for the icon picker (#668) to the settings table base class, and extends it to cover two color paths the icon picker didn't need: page background and separators.

## Impact
Users on a nested Apollo Reborn settings screen who toggle system appearance, or who use one of Apollo's stock themes together with Pure Black Dark Mode, will see the card background, page background, and row separators all update correctly and consistently instead of some staying frozen at a stale or generic color.

## Changes
- `ApolloSettingsTableViewController.m`: `apollo_themeCellBackgroundColor` now skips sampling a covered (detached) source table and falls back to the shared `ApolloThemeCardBackgroundColor()` instead of a generic system color.
- `ApolloCommon.m`: `ApolloApplyInheritedSettingsTableTheme` gets the same staleness guard for both the page background and separator color, falling back to two new theme-aware functions instead of sampling a possibly-stale source or a hardcoded system color.
- `ApolloThemeRuntime.{h,xm}`: `kStockThemes[]` extended with per-theme page-background and separator columns (light/dark), and new `ApolloThemePageBackgroundColor()` / `ApolloThemeSeparatorColor()` public functions mirroring the existing `ApolloThemeCardBackgroundColor()`.

## Reasoning
Non-tinted stock themes (accent-only, e.g. Default, Fiery Stare) resolve their dark card/page/separator colors through Apollo's own Pure Black Dark Mode tiers — off, Pure Black, and a stronger "PURER Black" tier — while tinted themes (Solarized, Outrun, Sunset, Sepia, Dracula) retint everything themselves and ignore Pure Black entirely. The three color functions aren't symmetric in how far each tier reaches: PURER pushes the card color further than plain Pure Black does, but page background and separator already reach their darkest value as soon as Pure Black itself is on, regardless of PURER. All values were confirmed against live behavior rather than assumed from older documentation, which had incompletely described this tiering.

## Testing
Manually verified in the iOS Simulator across dark/light toggles while a settings screen was covered by another pushed screen, with a tinted stock theme (Sunset, Sepia) and a non-tinted one (Fiery Stare) active, and through all three Pure Black tiers including Reduce Smearing — card, page, and separator colors matched the expected hex values exactly in each case. Also verified on-device by manually changing the device appearance from the Control Center and from the Settings app, and confirming that the background and separator correctly change color.

## Video Example
### Before
https://github.com/user-attachments/assets/7fa166aa-67fb-44eb-9c10-84ceba8d1776

### After
https://github.com/user-attachments/assets/24027b29-5c4b-4fad-a903-c8e90b06f18b

