### PR TITLE
Add two-step select-then-vote flow for Reddit polls with radio list and vote button

### DIFF
--- a/src/ApolloAISummary.xm
+++ b/src/ApolloAISummary.xm
@@ -28,81 +28,8 @@
 #import "ApolloAICloudBridge.h"
 #import "ApolloThemeRuntime.h"
 #import "ApolloState.h"
+#import "ApolloTextureDecls.h"
 #import "Tweak.h"
-
-#pragma mark - Texture declarations
-
-typedef NS_ENUM(unsigned char, ApolloAIStackDirection) {
-    ApolloAIStackDirectionHorizontal = 0,
-    ApolloAIStackDirectionVertical = 1,
-};
-
-typedef NS_ENUM(unsigned char, ApolloAIStackJustifyContent) {
-    ApolloAIStackJustifyContentStart = 0,
-};
-
-typedef NS_ENUM(unsigned char, ApolloAIStackAlignItems) {
-    ApolloAIStackAlignItemsStart = 0,
-    ApolloAIStackAlignItemsStretch = 3,
-};
-
-@class ASLayoutSpec;
-@class ASStackLayoutSpec;
-@class ASInsetLayoutSpec;
-@class ASBackgroundLayoutSpec;
-@class ASDisplayNode;
-@class ASTextNode;
-
-@interface ASDisplayNode : NSObject
-- (void)addSubnode:(ASDisplayNode *)subnode;
-- (void)setNeedsLayout;
-- (void)invalidateCalculatedLayout;
-- (UIView *)view;
-- (void)onDidLoad:(void (^)(__kindof ASDisplayNode *node))body;
-@property (nonatomic) BOOL userInteractionEnabled;
-@property (nullable, nonatomic, copy) UIColor *backgroundColor;
-@property (nonatomic) CGFloat cornerRadius;
-@property (nonatomic) BOOL clipsToBounds;
-@property (nonatomic) CGFloat borderWidth;
-@property (nullable, nonatomic) CGColorRef borderColor;
-@end
-
-@interface ASTextNode : ASDisplayNode
-@property (nonatomic, copy) NSAttributedString *attributedText;
-@property (nonatomic) NSUInteger maximumNumberOfLines;
-@end
-
-@interface ASLayoutSpec : NSObject
-@end
-
-@interface ASStackLayoutSpec : ASLayoutSpec
-@property (nonatomic) ApolloAIStackDirection direction;
-@property (nonatomic) CGFloat spacing;
-@property (nonatomic) ApolloAIStackJustifyContent justifyContent;
-@property (nonatomic) ApolloAIStackAlignItems alignItems;
-@property (nonatomic) NSUInteger flexWrap;
-@property (nonatomic) NSUInteger alignContent;
-@property (nonatomic) CGFloat lineSpacing;
-@property (nullable, nonatomic) NSArray *children;
-+ (instancetype)stackLayoutSpecWithDirection:(ApolloAIStackDirection)direction
-                                     spacing:(CGFloat)spacing
-                              justifyContent:(ApolloAIStackJustifyContent)justifyContent
-                                  alignItems:(ApolloAIStackAlignItems)alignItems
-                                    children:(NSArray *)children;
-@end
-
-@interface ASInsetLayoutSpec : ASLayoutSpec
-@property (nonatomic) UIEdgeInsets insets;
-@property (nullable, nonatomic) id child;
-+ (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id)child;
-@end
-
-@interface ASBackgroundLayoutSpec : ASLayoutSpec
-+ (instancetype)backgroundLayoutSpecWithChild:(id)child background:(id)background;
-@end
-
-// ASSizeRange as emitted by Apollo's class-dumped headers.
-struct ApolloAISizeRange { CGSize min; CGSize max; };
 
 #pragma mark - FoundationModels bridge (declared, resolved at runtime)
 
@@ -1768,27 +1695,6 @@ static UIColor *ApolloAISummaryThemeAccent(id headerNode) {
     return tc ? [accent resolvedColorWithTraitCollection:tc] : accent;
 }
 
-// A baseline-aligned SF Symbol as an attributed string, sized to `font` and
-// tinted `tint`. Returns nil if the symbol is unavailable so callers can fall
-// back to a plain glyph.
-static NSAttributedString *ApolloAISymbolAttachment(NSString *symbolName, UIFont *font, UIColor *tint) {
-    if (@available(iOS 13.0, *)) {
-        UIImageSymbolConfiguration *cfg = [UIImageSymbolConfiguration configurationWithFont:font];
-        UIImage *image = [UIImage systemImageNamed:symbolName withConfiguration:cfg];
-        if (image) {
-            image = [image imageWithTintColor:tint renderingMode:UIImageRenderingModeAlwaysOriginal];
-            NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
-            attachment.image = image;
-            // Center the glyph on the font's cap height so it sits on the text
-            // baseline rather than floating above it.
-            CGFloat y = (font.capHeight - image.size.height) / 2.0;
-            attachment.bounds = CGRectMake(0, y, image.size.width, image.size.height);
-            return [NSAttributedString attributedStringWithAttachment:attachment];
-        }
-    }
-    return nil;
-}
-
 static NSAttributedString *ApolloAISummaryAttributedText(NSString *title,
                                                          ApolloAIBoxState state,
                                                          NSString *bodyText,
@@ -1837,7 +1743,7 @@ static NSAttributedString *ApolloAISummaryAttributedText(NSString *title,
     NSString *symbolName = isPost ? @"sparkles" : @"text.bubble.fill";
     UIColor *iconTint = accent;
     if (state == ApolloAIBoxStateError) { symbolName = @"exclamationmark.triangle.fill"; iconTint = errorColor; }
-    NSAttributedString *iconAttachment = ApolloAISymbolAttachment(symbolName, titleFont, iconTint);
+    NSAttributedString *iconAttachment = ApolloSymbolAttachment(symbolName, titleFont, iconTint);
     if (iconAttachment) {
         [result appendAttributedString:iconAttachment];
         [result appendAttributedString:[[NSAttributedString alloc] initWithString:@"  " attributes:titleAttributes]];
@@ -1869,7 +1775,7 @@ static NSAttributedString *ApolloAISummaryAttributedText(NSString *title,
     BOOL showChevron = expanded || state == ApolloAIBoxStateReady || state == ApolloAIBoxStateError;
     if (showChevron) {
         NSAttributedString *chevronAttachment =
-            ApolloAISymbolAttachment(expanded ? @"chevron.down" : @"chevron.right", chevronFont, secondary);
+            ApolloSymbolAttachment(expanded ? @"chevron.down" : @"chevron.right", chevronFont, secondary);
         [result appendAttributedString:[[NSAttributedString alloc] initWithString:@"  " attributes:chevronAttributes]];
         if (chevronAttachment) {
             [result appendAttributedString:chevronAttachment];
@@ -3525,7 +3431,7 @@ static void ApolloAILogTableStructure(UIViewController *vc) {
     ApolloAIForceHeaderRemeasure(fullName);
 }
 
-- (id)layoutSpecThatFits:(struct ApolloAISizeRange)constrainedSize {
+- (id)layoutSpecThatFits:(struct ApolloTextureSizeRange)constrainedSize {
     id originalSpec = %orig;
     if (!sEnableAISummaries) return originalSpec;
     ApolloAILogLayoutChildrenOnce((id)self, originalSpec);

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -29,6 +29,11 @@ UIImage *ApolloEmojiSettingsIcon(NSString *emoji, UIColor *backgroundColor, CGFl
 UIImage *ApolloBuyMeACoffeeSettingsIcon(CGFloat size);
 UIImage *ApolloRebornOptionsSettingsIcon(CGFloat size);
 
+// Baseline-aligned SF Symbol as an attributed string, sized to `font` and
+// tinted `tint`. Returns nil if the symbol can't load, so callers can fall
+// back to a plain-text glyph. Shared by ApolloAISummary.xm/ApolloPollVoting.xm.
+NSAttributedString *ApolloSymbolAttachment(NSString *symbolName, UIFont *font, UIColor *tint);
+
 // Resolve a path to a bundled tweak resource across the install layouts we
 // support (jailbreak rootful/rootless, Sideloadly/cyan/azule deb fuse, and
 // inject-deb-local.sh). Returns nil if no layout has the file.

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -549,6 +549,23 @@ UIImage *ApolloEmojiSettingsIcon(NSString *emoji, UIColor *backgroundColor, CGFl
     }];
 }
 
+NSAttributedString *ApolloSymbolAttachment(NSString *symbolName, UIFont *font, UIColor *tint) {
+    if (@available(iOS 13.0, *)) {
+        UIImageSymbolConfiguration *config = [UIImageSymbolConfiguration configurationWithFont:font];
+        UIImage *image = [UIImage systemImageNamed:symbolName withConfiguration:config];
+        if (!image) return nil;
+        image = [image imageWithTintColor:tint renderingMode:UIImageRenderingModeAlwaysOriginal];
+        NSTextAttachment *attachment = [NSTextAttachment new];
+        attachment.image = image;
+        // Center the glyph on the font's cap height so it sits on the text
+        // baseline rather than floating above it.
+        CGFloat y = (font.capHeight - image.size.height) / 2.0;
+        attachment.bounds = CGRectMake(0, y, image.size.width, image.size.height);
+        return [NSAttributedString attributedStringWithAttachment:attachment];
+    }
+    return nil;
+}
+
 static NSString *ApolloBundledResourcePNGPath(NSString *resourceName) {
     return ApolloBundledResourcePath(resourceName, @"png");
 }

--- a/src/ApolloPollVoting.xm
+++ b/src/ApolloPollVoting.xm
@@ -53,22 +53,16 @@ BOOL ApolloPollsFeatureEnabled(void) {
 @end
 
 // MARK: - Minimal Texture (AsyncDisplayKit) forward declarations for the
-// radio-list + Vote button layout injection (see the PollOptionNode and
-// PollNode -layoutSpecThatFits: hooks further down). Real Texture headers
-// aren't on this build's include path, so — mirroring the existing technique
-// in ApolloAISummary.xm/ApolloInlineImages.xm — this just declares the
-// selectors/enums actually used; the runtime resolves them against Apollo's
-// own bundled Texture implementation.
+// radio-list + Vote button layout injection below. Real Texture headers
+// aren't on the include path, so — mirroring ApolloAISummary.xm/
+// ApolloInlineImages.xm — this declares only the selectors/enums used; the
+// runtime resolves them against Apollo's bundled Texture implementation.
 //
-// Enum values below are confirmed against the compiled binary in Hopper:
-// -[PollNode layoutSpecThatFits:] builds its existing option/results stack
-// with stackLayoutSpecWithDirection:0x0, i.e. Vertical=0/Horizontal=1 — the
-// same ordering ApolloInlineImages.xm's (already-working) declarations use.
-// Do NOT copy ApolloAISummary.xm's local ApolloAIStackDirection enum for a
-// stack built from scratch here: its Horizontal/Vertical values are swapped
-// relative to real Texture, and that file only gets away with it because it
-// merely clones an existing stack's already-correct direction property
-// rather than constructing a fresh spec from the enum's raw values.
+// Enum values confirmed in Hopper: -[PollNode layoutSpecThatFits:] builds
+// its stack with stackLayoutSpecWithDirection:0x0, i.e. Vertical=0/
+// Horizontal=1. Don't reuse ApolloAISummary.xm's local direction enum here —
+// its values are swapped relative to real Texture, which only works there
+// because it clones an existing stack rather than building one from scratch.
 typedef NS_ENUM(unsigned char, ApolloPollStackDirection) {
     ApolloPollStackDirectionVertical = 0,
     ApolloPollStackDirectionHorizontal = 1,
@@ -120,13 +114,11 @@ typedef NS_ENUM(unsigned char, ApolloPollStackAlignItems) {
 + (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id)child;
 @end
 
-// Stretches `background` to match `child`'s laid-out size, behind it. Needed
-// for the Vote pill: ASInsetLayoutSpec's insets only reserve empty space in
-// the PARENT layout around a child — they never grow the child's own frame,
-// so a color/cornerRadius set directly on an inset-wrapped ASTextNode renders
-// tight to the text, not padded. Wrapping the padded text in this spec, with
-// a separate plain ASDisplayNode as `background`, is Texture's actual pattern
-// for a padded pill/card (mirrors ApolloAISummary.xm's box background).
+// Stretches `background` behind `child`'s laid-out size. Needed for the Vote
+// pill: ASInsetLayoutSpec only reserves space in the parent layout, it never
+// grows the child's own frame, so a color set directly on padded text renders
+// tight instead of padded. This is Texture's real pattern for a padded pill
+// (mirrors ApolloAISummary.xm's box background).
 @interface ASBackgroundLayoutSpec : ASLayoutSpec
 + (instancetype)backgroundLayoutSpecWithChild:(id)child background:(ASDisplayNode *)background;
 @end
@@ -281,10 +273,9 @@ static UIView *ApolloPollNodeView(id node);
 static void ApolloPollRenderCurrentVote(id pollNode);
 static void ApolloPollScheduleAuthoritativeRefreshes(NSString *postID, NSString *username,
                                                       NSUInteger sequence);
-// Radio-list + Vote button state (defined further down, near their %hook
-// call sites); forward-declared here because ApolloPollBeginVote and
-// ApolloPollRollbackOptimisticVote — both defined earlier in the file — need
-// to clear/refresh the two-step selection UI.
+// Radio-list + Vote button state, defined further down near their %hook
+// sites; forward-declared because ApolloPollBeginVote/RollbackOptimisticVote
+// above need to clear/refresh the two-step selection UI.
 static void ApolloPollSetPendingSelection(id pollNode, NSString *optionID);
 static void ApolloPollRefreshOptionRadios(id pollNode);
 static void ApolloPollRefreshVoteButton(id pollNode);
@@ -1332,45 +1323,34 @@ static void ApolloPollPresentAccessibilityPicker(id pollNode, RDKLink *link,
 
 // MARK: - Radio list + Vote button (deliberate two-step voting)
 //
-// Reddit poll votes are irreversible, so a single tap that immediately casts
-// a vote is replaced, for ordinary touch input, with a two-step interaction:
-// tapping an option only SELECTS it (its radio fills), and a separate "Vote"
-// button — always present below the options, disabled until a selection
-// exists — commits it. The button IS the confirmation step, so no additional
-// "Are you sure?" alert is needed. (The VoiceOver/Switch Control path above,
-// ApolloPollPresentAccessibilityPicker, is left as a direct one-step vote:
-// picking an item from that sheet is already an explicit, deliberate action.)
+// Reddit poll votes are irreversible, so an ordinary tap only SELECTS an
+// option (its radio fills); a separate "Vote" button below the options,
+// disabled until something is selected, commits it — the button itself is
+// the confirmation step, so no extra alert is needed. The VoiceOver/Switch
+// Control path (ApolloPollPresentAccessibilityPicker above) stays one-step:
+// picking from that sheet is already a deliberate, explicit action.
 //
-// Mechanism: mirrors ApolloAISummary.xm's layout-injection pattern. Each
-// hooked -layoutSpecThatFits: below calls %orig, lazily creates+caches its
-// own subnode(s) via addSubnode:, and splices them into the returned spec
-// tree so they occupy real measured space — never an overlay. Because the
-// Vote button is present (albeit disabled) from the very first layout pass,
-// this never needs AISummary's post-display beginUpdates/realize-display
-// remeasure machinery: Texture measures the taller row correctly up front.
-// Live selection changes after a tap are applied by mutating the
-// already-mounted cached nodes directly (ApolloPollRefreshOptionRadios/
-// RefreshVoteButton below) rather than by re-triggering layoutSpecThatFits:
-// a glyph/button-style swap never changes measured size, and Texture does
-// not guarantee that invalidating a parent's calculated layout re-invokes
-// every child's own -layoutSpecThatFits:.
+// Mechanism mirrors ApolloAISummary.xm: each hooked -layoutSpecThatFits:
+// calls %orig, lazily creates+caches its own subnode(s), and splices them
+// into the returned spec tree as real stack children (not an overlay) so
+// Texture measures the taller row correctly from the first layout pass —
+// no post-display remeasure needed. Selection changes afterward mutate the
+// cached nodes directly (ApolloPollRefreshOptionRadios/RefreshVoteButton)
+// rather than re-triggering layout, since a glyph/style swap doesn't change
+// measured size and Texture doesn't guarantee a relayout reaches every child.
 
-// ApolloReborn.dylib is injected into Apollo's process rather than linked
-// against it at build time, so referencing a Texture class directly by name
-// (e.g. [ASStackLayoutSpec ...]) fails at LINK time — no _OBJC_CLASS_$_
-// symbol exists in this build's inputs, even though the class exists once
-// actually loaded into Apollo (confirmed by trying it: `ld: symbol(s) not
-// found ... _OBJC_CLASS_$_ASStackLayoutSpec`). Every Texture class below is
-// therefore resolved via objc_getClass(...) at the point of use instead —
-// matching how this file already resolves _TtC6Apollo14PollOptionNode
-// elsewhere — rather than a dedicated per-class cache: objc_getClass is a
-// cheap runtime hash lookup, called only a handful of times per poll render.
+// ApolloReborn.dylib is injected rather than linked against Apollo, so
+// referencing a Texture class by name (e.g. [ASStackLayoutSpec ...]) fails
+// at LINK time even though the class exists once Apollo actually loads
+// (confirmed: `ld: symbol(s) not found ... _OBJC_CLASS_$_ASStackLayoutSpec`).
+// Every Texture class below is resolved via objc_getClass(...) at the point
+// of use instead, matching how this file already resolves
+// _TtC6Apollo14PollOptionNode elsewhere.
 
-// A baseline-aligned SF Symbol as an attributed string, sized to `font` and
-// tinted `tint`. Mirrors ApolloAISummary.xm's ApolloAISymbolAttachment (kept
-// as its own copy here, per this file's existing preference for
-// self-contained helpers over cross-file sharing). Returns nil if the symbol
-// image can't be loaded so callers can fall back to a plain-text glyph.
+// Baseline-aligned SF Symbol as an attributed string, sized to `font` and
+// tinted `tint` (own copy of ApolloAISummary.xm's ApolloAISymbolAttachment,
+// per this file's preference for self-contained helpers). Returns nil if the
+// symbol can't load, so callers fall back to a plain-text glyph.
 static NSAttributedString *ApolloPollSymbolAttachment(NSString *symbolName, UIFont *font, UIColor *tint) {
     UIImageSymbolConfiguration *config = [UIImageSymbolConfiguration configurationWithFont:font];
     UIImage *image = [UIImage systemImageNamed:symbolName withConfiguration:config];
@@ -1383,13 +1363,12 @@ static NSAttributedString *ApolloPollSymbolAttachment(NSString *symbolName, UIFo
     return [NSAttributedString attributedStringWithAttachment:attachment];
 }
 
-// -layoutSpecThatFits: can run off the main thread (Texture's whole point).
-// ApolloThemeAccentColor() is a dynamic provider color; resolving it against
-// an in-hierarchy view's traitCollection avoids picking the wrong light/dark
-// variant when ambient trait context is unspecified on a background thread
-// (same pattern as ApolloManualSignInViewController.m/
+// -layoutSpecThatFits: can run off the main thread. ApolloThemeAccentColor()
+// is a dynamic provider color, so resolve it against an in-hierarchy view's
+// traitCollection to avoid picking the wrong light/dark variant on a
+// background thread (same pattern as ApolloManualSignInViewController.m/
 // ApolloLiveCommentsFollow.xm). Only resolves once the node's view already
-// exists — never force-loads a Texture node's view from a background thread.
+// exists — never force-loads it from a background thread.
 static UIColor *ApolloPollResolvedAccentColor(ASDisplayNode *node) {
     UIColor *accent = ApolloThemeAccentColor() ?: UIColor.systemBlueColor;
     BOOL loaded = [node respondsToSelector:@selector(isNodeLoaded)] && node.isNodeLoaded;
@@ -1428,12 +1407,10 @@ static void ApolloPollSetPendingSelection(id pollNode, NSString *optionID) {
                               OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 
-// Lazily creates (if not already cached under `key` on `host`) a bare
-// ASTextNode, adds it as a subnode of `host`, and caches the reference for
-// next time. `didCreate` (if non-NULL) reports whether this call created a
-// FRESH node vs. returning the already-cached one, so callers can apply
-// one-time initial content without ever stomping state a later refresh
-// (ApolloPollRefreshOptionRadios/RefreshVoteButton) already applied.
+// Lazily creates+caches a bare ASTextNode under `key` on `host` (added via
+// addSubnode:). `didCreate` (if non-NULL) reports whether this call made a
+// fresh node vs. returned the cached one, so callers can set one-time
+// initial content without overwriting a later refresh's state.
 static ASTextNode *ApolloPollEnsureTextNode(ASDisplayNode *host, const void *key, BOOL *didCreate) {
     ASTextNode *node = objc_getAssociatedObject(host, key);
     if (node) {
@@ -1449,13 +1426,10 @@ static ASTextNode *ApolloPollEnsureTextNode(ASDisplayNode *host, const void *key
     return node;
 }
 
-// The leading radio glyph on a PollOptionNode. Called from
-// -[PollOptionNode layoutSpecThatFits:] (structural: only needs to run once
-// per node instance) to splice it into the row's layout; the glyph's
+// The leading radio glyph on a PollOptionNode. Called once per node instance
+// from -[PollOptionNode layoutSpecThatFits:] to splice it into the row;
 // selected/unselected content is refreshed separately, out of band, by
-// ApolloPollRefreshOptionRadios below — never by re-running layout, so the
-// default-unselected content set here on first creation is the only content
-// this function itself ever applies.
+// ApolloPollRefreshOptionRadios — this only ever sets the initial state.
 static ASTextNode *ApolloPollEnsureRadioNode(ASDisplayNode *optionNode) {
     BOOL didCreate = NO;
     ASTextNode *radio = ApolloPollEnsureTextNode(optionNode, kApolloPollRadioNodeKey, &didCreate);
@@ -1465,21 +1439,18 @@ static ASTextNode *ApolloPollEnsureRadioNode(ASDisplayNode *optionNode) {
     return radio;
 }
 
-// The Vote pill's text label. Deliberately carries no background/cornerRadius
-// of its own — see ApolloPollEnsureVoteButtonBackgroundNode below for why a
-// color set directly on this node wouldn't include the padding around it. No
-// default content is set here (unlike the radio above): the PollNode layout
-// hook always calls ApolloPollRefreshVoteButton right before this, on every
-// pass, so there's no "first creation" gap to fill.
+// The Vote pill's text label — no background/cornerRadius of its own (see
+// ApolloPollEnsureVoteButtonBackgroundNode for why). No default content set
+// here either: the PollNode layout hook always calls
+// ApolloPollRefreshVoteButton right before this, on every pass.
 static ASTextNode *ApolloPollEnsureVoteButtonTextNode(ASDisplayNode *pollNode) {
     return ApolloPollEnsureTextNode(pollNode, kApolloPollVoteButtonTextNodeKey, NULL);
 }
 
 // The Vote pill's visual chrome — a plain node stretched (via
-// ASBackgroundLayoutSpec in the PollNode layout hook below) to cover the
-// text node PLUS its surrounding ASInsetLayoutSpec padding. This is also the
-// tap-hit target (ApolloPollTouchHitVoteButton), so the padded area is
-// tappable too, matching how it looks.
+// ASBackgroundLayoutSpec below) to cover the text node plus its padding.
+// Also the tap-hit target (ApolloPollTouchHitVoteButton), so the padded
+// area is tappable, matching how it looks.
 static ASDisplayNode *ApolloPollEnsureVoteButtonBackgroundNode(ASDisplayNode *pollNode) {
     ASDisplayNode *background = objc_getAssociatedObject(pollNode, kApolloPollVoteButtonNodeKey);
     if (background) return background;
@@ -1493,10 +1464,9 @@ static ASDisplayNode *ApolloPollEnsureVoteButtonBackgroundNode(ASDisplayNode *po
     return background;
 }
 
-// Walks a mounted poll's option ROW VIEWS (not the Swift optionNodes array
-// ivar, which is a bridged Array<PollOptionNode> and not safely readable as a
-// plain NSArray from ObjC — see ApolloPollOptionAtPoint above, which already
-// walks the view tree for the same reason). Mirrors its exact recursion shape.
+// Walks a mounted poll's option row VIEWS, not the Swift optionNodes array
+// ivar (a bridged Array<PollOptionNode>, unsafe to read as plain NSArray from
+// ObjC — see ApolloPollOptionAtPoint above). Mirrors its recursion shape.
 static void ApolloPollForEachOptionNode(UIView *containerView, NSUInteger depth,
                                         void (^body)(id optionNode)) {
     Class optionClass = objc_getClass("_TtC6Apollo14PollOptionNode");
@@ -1510,11 +1480,9 @@ static void ApolloPollForEachOptionNode(UIView *containerView, NSUInteger depth,
     }
 }
 
-// Re-derives every option row's radio glyph from the current pending
-// selection. Pure content mutation on already-mounted, fixed-size nodes — no
-// relayout, no beginUpdates: swapping between the "circle"/
-// "largecircle.fill.circle" SF Symbols never changes measured size at a fixed
-// point size.
+// Re-derives every option row's radio glyph from the pending selection.
+// Pure content mutation on already-mounted nodes — no relayout needed, since
+// swapping "circle"/"largecircle.fill.circle" never changes measured size.
 static void ApolloPollRefreshOptionRadios(id pollNode) {
     UIView *pollView = ApolloPollNodeView(pollNode);
     if (!pollView) return;
@@ -1530,12 +1498,10 @@ static void ApolloPollRefreshOptionRadios(id pollNode) {
     });
 }
 
-// Restyles the Vote pill (enabled/accent vs. disabled/dim) from the current
-// pending selection. Same "mutate the mounted nodes directly" approach as the
-// radios, and for the same reason (no size change → no relayout needed): the
-// text/background split doesn't change either node's own measured size,
-// since the background is stretched by the ASBackgroundLayoutSpec in the
-// PollNode layout hook rather than resized here.
+// Restyles the Vote pill (enabled/accent vs. disabled/dim) from the pending
+// selection. Same direct-mutation approach as the radios and for the same
+// reason: the background is stretched by ASBackgroundLayoutSpec in the
+// PollNode layout hook, not resized here, so no relayout is needed.
 static void ApolloPollRefreshVoteButton(id pollNode) {
     ASTextNode *text = ApolloPollEnsureVoteButtonTextNode(pollNode);
     ASDisplayNode *background = ApolloPollEnsureVoteButtonBackgroundNode(pollNode);
@@ -1548,13 +1514,11 @@ static void ApolloPollRefreshVoteButton(id pollNode) {
     [text setNeedsDisplay];
 }
 
-// Hit-test the cached Vote pill's BACKGROUND node frame — that's the node
-// stretched to the full padded pill size (see
-// ApolloPollEnsureVoteButtonBackgroundNode), so the padding is tappable too,
-// not just the tight text. It's a DIRECT subnode of pollNode (added via
-// addSubnode: there), so its view's frame is already expressed in pollNode's
-// own view's coordinate space — the same space ApolloPollOptionAtPoint above
-// already hit-tests option rows in — no coordinate conversion needed.
+// Hit-test the cached Vote pill's background node frame — stretched to the
+// full padded pill (see ApolloPollEnsureVoteButtonBackgroundNode), so the
+// padding is tappable too. It's a direct subnode of pollNode, so its frame
+// is already in pollNode's view's coordinate space, same as
+// ApolloPollOptionAtPoint's option-row hit-testing — no conversion needed.
 static BOOL ApolloPollTouchHitVoteButton(id pollNode, CGPoint pointInPollView) {
     ASDisplayNode *background = objc_getAssociatedObject(pollNode, kApolloPollVoteButtonNodeKey);
     BOOL loaded = [background respondsToSelector:@selector(isNodeLoaded)] && background.isNodeLoaded;
@@ -1563,12 +1527,10 @@ static BOOL ApolloPollTouchHitVoteButton(id pollNode, CGPoint pointInPollView) {
     return CGRectContainsPoint(backgroundView.frame, pointInPollView);
 }
 
-// Injects the leading radio glyph into each unvoted option row. PollResultNode
-// (a separate class) renders voted polls, so PollOptionNode only ever exists
-// for an open, interactive poll — EXCEPT an ended-but-never-voted poll, which
-// Apollo still renders with PollOptionNode rows even though
-// pollNodeTappedWithSender: below routes taps to %orig for it. Skip the radio
-// there so a no-longer-votable poll never shows a selectable-looking control.
+// Injects the leading radio glyph into each unvoted option row. PollOptionNode
+// only exists for an interactive poll — except an ended-but-never-voted poll,
+// which still renders PollOptionNode rows even though taps route to %orig.
+// Skip the radio there so a no-longer-votable poll doesn't look selectable.
 %hook _TtC6Apollo14PollOptionNode
 - (id)layoutSpecThatFits:(struct ApolloPollSizeRange)constrainedSize {
     id originalSpec = %orig;
@@ -1609,11 +1571,9 @@ static BOOL ApolloPollTouchHitVoteButton(id pollNode, CGPoint pointInPollView) {
     if (card && pollView) pollView.backgroundColor = card;
 }
 
-// Appends the always-present (disabled-until-selected) Vote button below the
-// existing option/results content — see the "Radio list + Vote button"
-// section above for the full mechanism. Splicing it in as a genuine stack
-// child, rather than an overlay, is what makes Texture measure the taller
-// row correctly.
+// Appends the always-present, disabled-until-selected Vote button below the
+// option/results content — see "Radio list + Vote button" above for the
+// mechanism.
 - (id)layoutSpecThatFits:(struct ApolloPollSizeRange)constrainedSize {
     id originalSpec = %orig;
     if (!ApolloPollsFeatureEnabled()) return originalSpec;
@@ -1628,10 +1588,9 @@ static BOOL ApolloPollTouchHitVoteButton(id pollNode, CGPoint pointInPollView) {
     Class insetClass = objc_getClass("ASInsetLayoutSpec");
     Class backgroundClass = objc_getClass("ASBackgroundLayoutSpec");
     if (!stackClass || !insetClass || !backgroundClass) return originalSpec;
-    // The padded text (foreground) drives the pill's size; the background
-    // node is stretched to match it, so the padding is part of the visible
-    // (and tappable — see ApolloPollTouchHitVoteButton) pill, not empty
-    // space outside it.
+    // The padded text drives the pill's size; the background is stretched to
+    // match, so the padding is part of the visible, tappable pill (see
+    // ApolloPollTouchHitVoteButton), not empty space around it.
     id textInset = [insetClass
         insetLayoutSpecWithInsets:UIEdgeInsetsMake(6, 16, 6, 16) child:text];
     id pill = [backgroundClass backgroundLayoutSpecWithChild:textInset background:background];
@@ -1813,10 +1772,8 @@ static BOOL ApolloPollTouchHitVoteButton(id pollNode, CGPoint pointInPollView) {
     UIView *pollView = ApolloPollNodeView(pollNode);
     BOOL hasTouchPoint = ApolloPollConsumeLastTouchPoint(pollNode, &touchPoint) && pollView != nil;
 
-    // Deliberate two-step voting: Reddit poll votes are irreversible, so an
-    // ordinary tap on an option row only SELECTS it (fills its radio); only a
-    // tap on the always-present Vote button commits it. The button IS the
-    // confirmation step — no separate "Are you sure?" alert.
+    // Two-step voting (see "Radio list + Vote button" above): a tap on the
+    // Vote button commits the pending selection.
     if (hasTouchPoint && ApolloPollTouchHitVoteButton(pollNode, touchPoint)) {
         NSString *pendingID = ApolloPollPendingSelection(pollNode);
         RDKPollOption *pendingOption = nil;
@@ -1848,11 +1805,10 @@ static BOOL ApolloPollTouchHitVoteButton(id pollNode, CGPoint pointInPollView) {
         return;
     }
 
-    // The whole legacy PollNode is one control, so Apollo routes taps on
-    // "N Votes · Closes in …" (and any other non-option/non-button area)
-    // through this same action. Only touchless assistive-tech activation
-    // needs an option list; picking an item there is itself a deliberate,
-    // explicit action, so it still votes directly rather than only selecting.
+    // PollNode is one control, so Apollo routes taps on "N Votes · Closes in …"
+    // (and any other non-option/non-button area) through this same action. Only
+    // touchless assistive tech needs the option list below — picking from it is
+    // already a deliberate action, so it still votes directly.
     ApolloPollDiagnosticLog(@" poll action ignored metadata/accessibility path post=%@ link=%@ pollNode=%@",
               link.identifier, ApolloPollPointer(link), ApolloPollPointer(pollNode));
     if (UIAccessibilityIsVoiceOverRunning() || UIAccessibilityIsSwitchControlRunning()) {

--- a/src/ApolloPollVoting.xm
+++ b/src/ApolloPollVoting.xm
@@ -1360,29 +1360,11 @@ static void ApolloPollPresentAccessibilityPicker(id pollNode, RDKLink *link,
 // (e.g. [ASStackLayoutSpec ...]) fails at LINK time — no _OBJC_CLASS_$_
 // symbol exists in this build's inputs, even though the class exists once
 // actually loaded into Apollo (confirmed by trying it: `ld: symbol(s) not
-// found ... _OBJC_CLASS_$_ASStackLayoutSpec`). Resolve via objc_getClass at
-// runtime instead, exactly like ApolloPollEnsureRadioNode/VoteButtonNode
-// already do for ASTextNode below.
-static Class ApolloPollStackLayoutSpecClass(void) {
-    static Class cls;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{ cls = objc_getClass("ASStackLayoutSpec"); });
-    return cls;
-}
-
-static Class ApolloPollInsetLayoutSpecClass(void) {
-    static Class cls;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{ cls = objc_getClass("ASInsetLayoutSpec"); });
-    return cls;
-}
-
-static Class ApolloPollBackgroundLayoutSpecClass(void) {
-    static Class cls;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{ cls = objc_getClass("ASBackgroundLayoutSpec"); });
-    return cls;
-}
+// found ... _OBJC_CLASS_$_ASStackLayoutSpec`). Every Texture class below is
+// therefore resolved via objc_getClass(...) at the point of use instead —
+// matching how this file already resolves _TtC6Apollo14PollOptionNode
+// elsewhere — rather than a dedicated per-class cache: objc_getClass is a
+// cheap runtime hash lookup, called only a handful of times per poll render.
 
 // A baseline-aligned SF Symbol as an attributed string, sized to `font` and
 // tinted `tint`. Mirrors ApolloAISummary.xm's ApolloAISymbolAttachment (kept
@@ -1446,35 +1428,51 @@ static void ApolloPollSetPendingSelection(id pollNode, NSString *optionID) {
                               OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 
-// Lazily creates and caches the leading radio glyph on a PollOptionNode.
-// Called from -[PollOptionNode layoutSpecThatFits:] (structural: only needs
-// to run once per node instance) to splice it into the row's layout; the
-// glyph's selected/unselected content is refreshed separately, out of band,
-// by ApolloPollRefreshOptionRadios below — never by re-running layout.
-static ASTextNode *ApolloPollEnsureRadioNode(ASDisplayNode *optionNode) {
-    ASTextNode *radio = objc_getAssociatedObject(optionNode, kApolloPollRadioNodeKey);
-    if (radio) return radio;
+// Lazily creates (if not already cached under `key` on `host`) a bare
+// ASTextNode, adds it as a subnode of `host`, and caches the reference for
+// next time. `didCreate` (if non-NULL) reports whether this call created a
+// FRESH node vs. returning the already-cached one, so callers can apply
+// one-time initial content without ever stomping state a later refresh
+// (ApolloPollRefreshOptionRadios/RefreshVoteButton) already applied.
+static ASTextNode *ApolloPollEnsureTextNode(ASDisplayNode *host, const void *key, BOOL *didCreate) {
+    ASTextNode *node = objc_getAssociatedObject(host, key);
+    if (node) {
+        if (didCreate) *didCreate = NO;
+        return node;
+    }
     Class textNodeClass = objc_getClass("ASTextNode");
     if (!textNodeClass) return nil;
-    radio = [textNodeClass new];
-    radio.attributedText = ApolloPollRadioAttributedText(NO, ApolloPollResolvedAccentColor(optionNode));
-    [optionNode addSubnode:radio];
-    objc_setAssociatedObject(optionNode, kApolloPollRadioNodeKey, radio, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    node = [textNodeClass new];
+    [host addSubnode:node];
+    objc_setAssociatedObject(host, key, node, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (didCreate) *didCreate = YES;
+    return node;
+}
+
+// The leading radio glyph on a PollOptionNode. Called from
+// -[PollOptionNode layoutSpecThatFits:] (structural: only needs to run once
+// per node instance) to splice it into the row's layout; the glyph's
+// selected/unselected content is refreshed separately, out of band, by
+// ApolloPollRefreshOptionRadios below — never by re-running layout, so the
+// default-unselected content set here on first creation is the only content
+// this function itself ever applies.
+static ASTextNode *ApolloPollEnsureRadioNode(ASDisplayNode *optionNode) {
+    BOOL didCreate = NO;
+    ASTextNode *radio = ApolloPollEnsureTextNode(optionNode, kApolloPollRadioNodeKey, &didCreate);
+    if (didCreate) {
+        radio.attributedText = ApolloPollRadioAttributedText(NO, ApolloPollResolvedAccentColor(optionNode));
+    }
     return radio;
 }
 
 // The Vote pill's text label. Deliberately carries no background/cornerRadius
 // of its own — see ApolloPollEnsureVoteButtonBackgroundNode below for why a
-// color set directly on this node wouldn't include the padding around it.
+// color set directly on this node wouldn't include the padding around it. No
+// default content is set here (unlike the radio above): the PollNode layout
+// hook always calls ApolloPollRefreshVoteButton right before this, on every
+// pass, so there's no "first creation" gap to fill.
 static ASTextNode *ApolloPollEnsureVoteButtonTextNode(ASDisplayNode *pollNode) {
-    ASTextNode *text = objc_getAssociatedObject(pollNode, kApolloPollVoteButtonTextNodeKey);
-    if (text) return text;
-    Class textNodeClass = objc_getClass("ASTextNode");
-    if (!textNodeClass) return nil;
-    text = [textNodeClass new];
-    [pollNode addSubnode:text];
-    objc_setAssociatedObject(pollNode, kApolloPollVoteButtonTextNodeKey, text, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    return text;
+    return ApolloPollEnsureTextNode(pollNode, kApolloPollVoteButtonTextNodeKey, NULL);
 }
 
 // The Vote pill's visual chrome — a plain node stretched (via
@@ -1582,8 +1580,8 @@ static BOOL ApolloPollTouchHitVoteButton(id pollNode, CGPoint pointInPollView) {
 
     ASTextNode *radio = ApolloPollEnsureRadioNode((ASDisplayNode *)self);
     if (!radio) return originalSpec;
-    Class stackClass = ApolloPollStackLayoutSpecClass();
-    Class insetClass = ApolloPollInsetLayoutSpecClass();
+    Class stackClass = objc_getClass("ASStackLayoutSpec");
+    Class insetClass = objc_getClass("ASInsetLayoutSpec");
     if (!stackClass || !insetClass) return originalSpec;
     ASStackLayoutSpec *row = [stackClass
         stackLayoutSpecWithDirection:ApolloPollStackDirectionHorizontal
@@ -1626,9 +1624,9 @@ static BOOL ApolloPollTouchHitVoteButton(id pollNode, CGPoint pointInPollView) {
     ASTextNode *text = ApolloPollEnsureVoteButtonTextNode((ASDisplayNode *)self);
     ASDisplayNode *background = ApolloPollEnsureVoteButtonBackgroundNode((ASDisplayNode *)self);
     if (!text || !background) return originalSpec;
-    Class stackClass = ApolloPollStackLayoutSpecClass();
-    Class insetClass = ApolloPollInsetLayoutSpecClass();
-    Class backgroundClass = ApolloPollBackgroundLayoutSpecClass();
+    Class stackClass = objc_getClass("ASStackLayoutSpec");
+    Class insetClass = objc_getClass("ASInsetLayoutSpec");
+    Class backgroundClass = objc_getClass("ASBackgroundLayoutSpec");
     if (!stackClass || !insetClass || !backgroundClass) return originalSpec;
     // The padded text (foreground) drives the pill's size; the background
     // node is stretched to match it, so the padding is part of the visible

--- a/src/ApolloPollVoting.xm
+++ b/src/ApolloPollVoting.xm
@@ -4,6 +4,7 @@
 #import "ApolloWebSessionStore.h"
 #import "ApolloThemeRuntime.h"
 #import "ApolloState.h"
+#import "ApolloTextureDecls.h"
 #import "UIWindow+Apollo.h"
 #import <objc/message.h>
 #import <objc/runtime.h>
@@ -52,17 +53,14 @@ BOOL ApolloPollsFeatureEnabled(void) {
 - (void)setNeedsLayout;
 @end
 
-// MARK: - Minimal Texture (AsyncDisplayKit) forward declarations for the
-// radio-list + Vote button layout injection below. Real Texture headers
-// aren't on the include path, so — mirroring ApolloAISummary.xm/
-// ApolloInlineImages.xm — this declares only the selectors/enums used; the
-// runtime resolves them against Apollo's bundled Texture implementation.
+// MARK: - Radio list + Vote button layout injection (see ApolloTextureDecls.h
+// for the shared Texture forward declarations this and ApolloAISummary.xm
+// both use).
 //
-// Enum values confirmed in Hopper: -[PollNode layoutSpecThatFits:] builds
-// its stack with stackLayoutSpecWithDirection:0x0, i.e. Vertical=0/
-// Horizontal=1. Don't reuse ApolloAISummary.xm's local direction enum here —
-// its values are swapped relative to real Texture, which only works there
-// because it clones an existing stack rather than building one from scratch.
+// Local direction/justifyContent/alignItems enum, deliberately not shared
+// with ApolloAISummary.xm's copy (see ApolloTextureDecls.h) — values
+// confirmed in Hopper: -[PollNode layoutSpecThatFits:] builds its stack with
+// stackLayoutSpecWithDirection:0x0, i.e. Vertical=0/Horizontal=1.
 typedef NS_ENUM(unsigned char, ApolloPollStackDirection) {
     ApolloPollStackDirectionVertical = 0,
     ApolloPollStackDirectionHorizontal = 1,
@@ -78,54 +76,6 @@ typedef NS_ENUM(unsigned char, ApolloPollStackAlignItems) {
     ApolloPollStackAlignItemsCenter = 2,
     ApolloPollStackAlignItemsStretch = 3,
 };
-
-@class ASLayoutSpec, ASStackLayoutSpec, ASInsetLayoutSpec, ASBackgroundLayoutSpec, ASTextNode, ASDisplayNode;
-
-@interface ASDisplayNode : NSObject
-- (void)addSubnode:(ASDisplayNode *)subnode;
-- (ASDisplayNode *)supernode;
-- (void)setNeedsLayout;
-- (void)setNeedsDisplay;
-- (void)invalidateCalculatedLayout;
-- (BOOL)isNodeLoaded;
-- (UIView *)view;
-@property (nonatomic, copy) UIColor *backgroundColor;
-@property (nonatomic) CGFloat cornerRadius;
-@property (nonatomic) BOOL clipsToBounds;
-@end
-
-@interface ASTextNode : ASDisplayNode
-@property (nonatomic, copy) NSAttributedString *attributedText;
-@end
-
-@interface ASLayoutSpec : NSObject
-@property (nullable, nonatomic) NSArray *children;
-@end
-
-@interface ASStackLayoutSpec : ASLayoutSpec
-+ (instancetype)stackLayoutSpecWithDirection:(ApolloPollStackDirection)direction
-                                     spacing:(CGFloat)spacing
-                              justifyContent:(ApolloPollStackJustifyContent)justifyContent
-                                  alignItems:(ApolloPollStackAlignItems)alignItems
-                                    children:(NSArray *)children;
-@end
-
-@interface ASInsetLayoutSpec : ASLayoutSpec
-+ (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id)child;
-@end
-
-// Stretches `background` behind `child`'s laid-out size. Needed for the Vote
-// pill: ASInsetLayoutSpec only reserves space in the parent layout, it never
-// grows the child's own frame, so a color set directly on padded text renders
-// tight instead of padded. This is Texture's real pattern for a padded pill
-// (mirrors ApolloAISummary.xm's box background).
-@interface ASBackgroundLayoutSpec : ASLayoutSpec
-+ (instancetype)backgroundLayoutSpecWithChild:(id)child background:(ASDisplayNode *)background;
-@end
-
-// ASSizeRange stand-in (named CDStruct_90e057aa in class-dumped headers) so
-// Logos can hook the by-value struct argument of -layoutSpecThatFits:.
-struct ApolloPollSizeRange { CGSize min; CGSize max; };
 
 // Associated-object keys for the radio-list + Vote button state below.
 static const void *kApolloPollPendingOptionKey = &kApolloPollPendingOptionKey;   // NSString*, on PollNode: not-yet-committed selected option id
@@ -1347,22 +1297,6 @@ static void ApolloPollPresentAccessibilityPicker(id pollNode, RDKLink *link,
 // of use instead, matching how this file already resolves
 // _TtC6Apollo14PollOptionNode elsewhere.
 
-// Baseline-aligned SF Symbol as an attributed string, sized to `font` and
-// tinted `tint` (own copy of ApolloAISummary.xm's ApolloAISymbolAttachment,
-// per this file's preference for self-contained helpers). Returns nil if the
-// symbol can't load, so callers fall back to a plain-text glyph.
-static NSAttributedString *ApolloPollSymbolAttachment(NSString *symbolName, UIFont *font, UIColor *tint) {
-    UIImageSymbolConfiguration *config = [UIImageSymbolConfiguration configurationWithFont:font];
-    UIImage *image = [UIImage systemImageNamed:symbolName withConfiguration:config];
-    if (!image) return nil;
-    image = [image imageWithTintColor:tint renderingMode:UIImageRenderingModeAlwaysOriginal];
-    NSTextAttachment *attachment = [NSTextAttachment new];
-    attachment.image = image;
-    CGFloat y = (font.capHeight - image.size.height) / 2.0;
-    attachment.bounds = CGRectMake(0, y, image.size.width, image.size.height);
-    return [NSAttributedString attributedStringWithAttachment:attachment];
-}
-
 // -layoutSpecThatFits: can run off the main thread. ApolloThemeAccentColor()
 // is a dynamic provider color, so resolve it against an in-hierarchy view's
 // traitCollection to avoid picking the wrong light/dark variant on a
@@ -1379,7 +1313,7 @@ static UIColor *ApolloPollResolvedAccentColor(ASDisplayNode *node) {
 static NSAttributedString *ApolloPollRadioAttributedText(BOOL selected, UIColor *tint) {
     UIFont *font = [UIFont systemFontOfSize:20.0 weight:UIFontWeightRegular];
     NSString *symbol = selected ? @"largecircle.fill.circle" : @"circle";
-    return ApolloPollSymbolAttachment(symbol, font, tint) ?:
+    return ApolloSymbolAttachment(symbol, font, tint) ?:
         [[NSAttributedString alloc] initWithString:(selected ? @"●" : @"○")
             attributes:@{ NSForegroundColorAttributeName: tint, NSFontAttributeName: font }];
 }
@@ -1532,7 +1466,7 @@ static BOOL ApolloPollTouchHitVoteButton(id pollNode, CGPoint pointInPollView) {
 // which still renders PollOptionNode rows even though taps route to %orig.
 // Skip the radio there so a no-longer-votable poll doesn't look selectable.
 %hook _TtC6Apollo14PollOptionNode
-- (id)layoutSpecThatFits:(struct ApolloPollSizeRange)constrainedSize {
+- (id)layoutSpecThatFits:(struct ApolloTextureSizeRange)constrainedSize {
     id originalSpec = %orig;
     if (!ApolloPollsFeatureEnabled()) return originalSpec;
 
@@ -1574,7 +1508,7 @@ static BOOL ApolloPollTouchHitVoteButton(id pollNode, CGPoint pointInPollView) {
 // Appends the always-present, disabled-until-selected Vote button below the
 // option/results content — see "Radio list + Vote button" above for the
 // mechanism.
-- (id)layoutSpecThatFits:(struct ApolloPollSizeRange)constrainedSize {
+- (id)layoutSpecThatFits:(struct ApolloTextureSizeRange)constrainedSize {
     id originalSpec = %orig;
     if (!ApolloPollsFeatureEnabled()) return originalSpec;
     RDKPoll *poll = ApolloPollObjectIvar(self, "poll");

--- a/src/ApolloPollVoting.xm
+++ b/src/ApolloPollVoting.xm
@@ -52,6 +52,95 @@ BOOL ApolloPollsFeatureEnabled(void) {
 - (void)setNeedsLayout;
 @end
 
+// MARK: - Minimal Texture (AsyncDisplayKit) forward declarations for the
+// radio-list + Vote button layout injection (see the PollOptionNode and
+// PollNode -layoutSpecThatFits: hooks further down). Real Texture headers
+// aren't on this build's include path, so — mirroring the existing technique
+// in ApolloAISummary.xm/ApolloInlineImages.xm — this just declares the
+// selectors/enums actually used; the runtime resolves them against Apollo's
+// own bundled Texture implementation.
+//
+// Enum values below are confirmed against the compiled binary in Hopper:
+// -[PollNode layoutSpecThatFits:] builds its existing option/results stack
+// with stackLayoutSpecWithDirection:0x0, i.e. Vertical=0/Horizontal=1 — the
+// same ordering ApolloInlineImages.xm's (already-working) declarations use.
+// Do NOT copy ApolloAISummary.xm's local ApolloAIStackDirection enum for a
+// stack built from scratch here: its Horizontal/Vertical values are swapped
+// relative to real Texture, and that file only gets away with it because it
+// merely clones an existing stack's already-correct direction property
+// rather than constructing a fresh spec from the enum's raw values.
+typedef NS_ENUM(unsigned char, ApolloPollStackDirection) {
+    ApolloPollStackDirectionVertical = 0,
+    ApolloPollStackDirectionHorizontal = 1,
+};
+typedef NS_ENUM(unsigned char, ApolloPollStackJustifyContent) {
+    ApolloPollStackJustifyContentStart = 0,
+    ApolloPollStackJustifyContentCenter = 1,
+    ApolloPollStackJustifyContentEnd = 2,
+};
+typedef NS_ENUM(unsigned char, ApolloPollStackAlignItems) {
+    ApolloPollStackAlignItemsStart = 0,
+    ApolloPollStackAlignItemsEnd = 1,
+    ApolloPollStackAlignItemsCenter = 2,
+    ApolloPollStackAlignItemsStretch = 3,
+};
+
+@class ASLayoutSpec, ASStackLayoutSpec, ASInsetLayoutSpec, ASBackgroundLayoutSpec, ASTextNode, ASDisplayNode;
+
+@interface ASDisplayNode : NSObject
+- (void)addSubnode:(ASDisplayNode *)subnode;
+- (ASDisplayNode *)supernode;
+- (void)setNeedsLayout;
+- (void)setNeedsDisplay;
+- (void)invalidateCalculatedLayout;
+- (BOOL)isNodeLoaded;
+- (UIView *)view;
+@property (nonatomic, copy) UIColor *backgroundColor;
+@property (nonatomic) CGFloat cornerRadius;
+@property (nonatomic) BOOL clipsToBounds;
+@end
+
+@interface ASTextNode : ASDisplayNode
+@property (nonatomic, copy) NSAttributedString *attributedText;
+@end
+
+@interface ASLayoutSpec : NSObject
+@property (nullable, nonatomic) NSArray *children;
+@end
+
+@interface ASStackLayoutSpec : ASLayoutSpec
++ (instancetype)stackLayoutSpecWithDirection:(ApolloPollStackDirection)direction
+                                     spacing:(CGFloat)spacing
+                              justifyContent:(ApolloPollStackJustifyContent)justifyContent
+                                  alignItems:(ApolloPollStackAlignItems)alignItems
+                                    children:(NSArray *)children;
+@end
+
+@interface ASInsetLayoutSpec : ASLayoutSpec
++ (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id)child;
+@end
+
+// Stretches `background` to match `child`'s laid-out size, behind it. Needed
+// for the Vote pill: ASInsetLayoutSpec's insets only reserve empty space in
+// the PARENT layout around a child — they never grow the child's own frame,
+// so a color/cornerRadius set directly on an inset-wrapped ASTextNode renders
+// tight to the text, not padded. Wrapping the padded text in this spec, with
+// a separate plain ASDisplayNode as `background`, is Texture's actual pattern
+// for a padded pill/card (mirrors ApolloAISummary.xm's box background).
+@interface ASBackgroundLayoutSpec : ASLayoutSpec
++ (instancetype)backgroundLayoutSpecWithChild:(id)child background:(ASDisplayNode *)background;
+@end
+
+// ASSizeRange stand-in (named CDStruct_90e057aa in class-dumped headers) so
+// Logos can hook the by-value struct argument of -layoutSpecThatFits:.
+struct ApolloPollSizeRange { CGSize min; CGSize max; };
+
+// Associated-object keys for the radio-list + Vote button state below.
+static const void *kApolloPollPendingOptionKey = &kApolloPollPendingOptionKey;   // NSString*, on PollNode: not-yet-committed selected option id
+static const void *kApolloPollRadioNodeKey = &kApolloPollRadioNodeKey;           // ASTextNode*, on PollOptionNode: leading radio glyph
+static const void *kApolloPollVoteButtonNodeKey = &kApolloPollVoteButtonNodeKey; // ASDisplayNode*, on PollNode: the Vote pill's padded background (also the tap-hit target)
+static const void *kApolloPollVoteButtonTextNodeKey = &kApolloPollVoteButtonTextNodeKey; // ASTextNode*, on PollNode: the "Vote" label
+
 // Reddit's website uses this named same-origin mutation. Keep the private
 // operation name in one place so a server-side rename fails cleanly.
 static NSString *const kApolloPollVoteOperation = @"UpdatePostPollVoteState";
@@ -192,6 +281,13 @@ static UIView *ApolloPollNodeView(id node);
 static void ApolloPollRenderCurrentVote(id pollNode);
 static void ApolloPollScheduleAuthoritativeRefreshes(NSString *postID, NSString *username,
                                                       NSUInteger sequence);
+// Radio-list + Vote button state (defined further down, near their %hook
+// call sites); forward-declared here because ApolloPollBeginVote and
+// ApolloPollRollbackOptimisticVote — both defined earlier in the file — need
+// to clear/refresh the two-step selection UI.
+static void ApolloPollSetPendingSelection(id pollNode, NSString *optionID);
+static void ApolloPollRefreshOptionRadios(id pollNode);
+static void ApolloPollRefreshVoteButton(id pollNode);
 static NSMapTable<NSString *, id> *sApolloPollHeadersByPostID;
 static NSString *sApolloPollDiagnosticPostID;
 static NSUInteger sApolloPollDiagnosticSequence;
@@ -846,15 +942,16 @@ static void ApolloPollClearTouchHighlight(id pollNode) {
     objc_setAssociatedObject(pollNode, kApolloPollHighlightOriginalColorKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-// Consume the touch point recorded by the PollNode touchesEnded hook and map
-// it to the option row it landed on. Returns nil for taps outside the rows and
-// for touchless activations (VoiceOver sends the control action directly).
-static RDKPollOption *ApolloPollConsumeTappedOption(id pollNode) {
+// Consume (get + clear) the touch point recorded by the PollNode touchesEnded
+// hook below. Returns NO (outPoint untouched) for a touchless activation
+// (VoiceOver/Switch Control sends the control action directly, with no touch
+// point ever recorded).
+static BOOL ApolloPollConsumeLastTouchPoint(id pollNode, CGPoint *outPoint) {
     NSValue *pointValue = objc_getAssociatedObject(pollNode, kApolloPollLastTouchPointKey);
     objc_setAssociatedObject(pollNode, kApolloPollLastTouchPointKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    UIView *pollView = ApolloPollNodeView(pollNode);
-    if (!pointValue || !pollView) return nil;
-    return ApolloPollOptionAtPoint(pollView, pointValue.CGPointValue, 1);
+    if (!pointValue) return NO;
+    *outPoint = pointValue.CGPointValue;
+    return YES;
 }
 
 // Apollo builds the poll's "N Votes · Closes in …" title once in PollNode's
@@ -1023,6 +1120,14 @@ static void ApolloPollRollbackOptimisticVote(NSString *postID, RDKLink *original
 
     RDKLink *publishLink = currentLink ?: originalLink;
     id publishNode = currentPollNode ?: originalPollNode;
+
+    // A failed/cancelled vote must also reset the two-step selection UI, or
+    // the radio/Vote button would keep showing a choice that was never
+    // actually recorded.
+    ApolloPollSetPendingSelection(publishNode, nil);
+    ApolloPollRefreshOptionRadios(publishNode);
+    ApolloPollRefreshVoteButton(publishNode);
+
     if (publishLink) ApolloPollPublishLinkUpdate(publishLink, publishNode);
     else ApolloPollRenderCurrentVote(publishNode);
 }
@@ -1142,6 +1247,9 @@ static void ApolloPollBeginVote(RDKLink *link, RDKPollOption *option, NSString *
               ApolloPollPointer([sApolloPollHeadersByPostID objectForKey:baseID]));
     ApolloPollLogModel(@"tap before optimistic mutation", link);
 
+    // The two-step selection is now being committed; nothing left to track.
+    ApolloPollSetPendingSelection(pollNode, nil);
+
     // Optimistic UI: selecting an option behaves like checking a control.
     // Network latency is no longer part of the interaction feedback path.
     poll.userSelectionIdentifier = option.identifier;
@@ -1222,6 +1330,271 @@ static void ApolloPollPresentAccessibilityPicker(id pollNode, RDKLink *link,
     [presenter presentViewController:sheet animated:YES completion:nil];
 }
 
+// MARK: - Radio list + Vote button (deliberate two-step voting)
+//
+// Reddit poll votes are irreversible, so a single tap that immediately casts
+// a vote is replaced, for ordinary touch input, with a two-step interaction:
+// tapping an option only SELECTS it (its radio fills), and a separate "Vote"
+// button — always present below the options, disabled until a selection
+// exists — commits it. The button IS the confirmation step, so no additional
+// "Are you sure?" alert is needed. (The VoiceOver/Switch Control path above,
+// ApolloPollPresentAccessibilityPicker, is left as a direct one-step vote:
+// picking an item from that sheet is already an explicit, deliberate action.)
+//
+// Mechanism: mirrors ApolloAISummary.xm's layout-injection pattern. Each
+// hooked -layoutSpecThatFits: below calls %orig, lazily creates+caches its
+// own subnode(s) via addSubnode:, and splices them into the returned spec
+// tree so they occupy real measured space — never an overlay. Because the
+// Vote button is present (albeit disabled) from the very first layout pass,
+// this never needs AISummary's post-display beginUpdates/realize-display
+// remeasure machinery: Texture measures the taller row correctly up front.
+// Live selection changes after a tap are applied by mutating the
+// already-mounted cached nodes directly (ApolloPollRefreshOptionRadios/
+// RefreshVoteButton below) rather than by re-triggering layoutSpecThatFits:
+// a glyph/button-style swap never changes measured size, and Texture does
+// not guarantee that invalidating a parent's calculated layout re-invokes
+// every child's own -layoutSpecThatFits:.
+
+// ApolloReborn.dylib is injected into Apollo's process rather than linked
+// against it at build time, so referencing a Texture class directly by name
+// (e.g. [ASStackLayoutSpec ...]) fails at LINK time — no _OBJC_CLASS_$_
+// symbol exists in this build's inputs, even though the class exists once
+// actually loaded into Apollo (confirmed by trying it: `ld: symbol(s) not
+// found ... _OBJC_CLASS_$_ASStackLayoutSpec`). Resolve via objc_getClass at
+// runtime instead, exactly like ApolloPollEnsureRadioNode/VoteButtonNode
+// already do for ASTextNode below.
+static Class ApolloPollStackLayoutSpecClass(void) {
+    static Class cls;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ cls = objc_getClass("ASStackLayoutSpec"); });
+    return cls;
+}
+
+static Class ApolloPollInsetLayoutSpecClass(void) {
+    static Class cls;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ cls = objc_getClass("ASInsetLayoutSpec"); });
+    return cls;
+}
+
+static Class ApolloPollBackgroundLayoutSpecClass(void) {
+    static Class cls;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ cls = objc_getClass("ASBackgroundLayoutSpec"); });
+    return cls;
+}
+
+// A baseline-aligned SF Symbol as an attributed string, sized to `font` and
+// tinted `tint`. Mirrors ApolloAISummary.xm's ApolloAISymbolAttachment (kept
+// as its own copy here, per this file's existing preference for
+// self-contained helpers over cross-file sharing). Returns nil if the symbol
+// image can't be loaded so callers can fall back to a plain-text glyph.
+static NSAttributedString *ApolloPollSymbolAttachment(NSString *symbolName, UIFont *font, UIColor *tint) {
+    UIImageSymbolConfiguration *config = [UIImageSymbolConfiguration configurationWithFont:font];
+    UIImage *image = [UIImage systemImageNamed:symbolName withConfiguration:config];
+    if (!image) return nil;
+    image = [image imageWithTintColor:tint renderingMode:UIImageRenderingModeAlwaysOriginal];
+    NSTextAttachment *attachment = [NSTextAttachment new];
+    attachment.image = image;
+    CGFloat y = (font.capHeight - image.size.height) / 2.0;
+    attachment.bounds = CGRectMake(0, y, image.size.width, image.size.height);
+    return [NSAttributedString attributedStringWithAttachment:attachment];
+}
+
+// -layoutSpecThatFits: can run off the main thread (Texture's whole point).
+// ApolloThemeAccentColor() is a dynamic provider color; resolving it against
+// an in-hierarchy view's traitCollection avoids picking the wrong light/dark
+// variant when ambient trait context is unspecified on a background thread
+// (same pattern as ApolloManualSignInViewController.m/
+// ApolloLiveCommentsFollow.xm). Only resolves once the node's view already
+// exists — never force-loads a Texture node's view from a background thread.
+static UIColor *ApolloPollResolvedAccentColor(ASDisplayNode *node) {
+    UIColor *accent = ApolloThemeAccentColor() ?: UIColor.systemBlueColor;
+    BOOL loaded = [node respondsToSelector:@selector(isNodeLoaded)] && node.isNodeLoaded;
+    UITraitCollection *tc = loaded ? node.view.traitCollection : nil;
+    return tc ? [accent resolvedColorWithTraitCollection:tc] : accent;
+}
+
+static NSAttributedString *ApolloPollRadioAttributedText(BOOL selected, UIColor *tint) {
+    UIFont *font = [UIFont systemFontOfSize:20.0 weight:UIFontWeightRegular];
+    NSString *symbol = selected ? @"largecircle.fill.circle" : @"circle";
+    return ApolloPollSymbolAttachment(symbol, font, tint) ?:
+        [[NSAttributedString alloc] initWithString:(selected ? @"●" : @"○")
+            attributes:@{ NSForegroundColorAttributeName: tint, NSFontAttributeName: font }];
+}
+
+static NSAttributedString *ApolloPollVoteButtonAttributedText(BOOL enabled, UIColor *accent) {
+    UIColor *textColor = enabled
+        ? (ApolloColorIsLight(accent) ? UIColor.blackColor : UIColor.whiteColor)
+        : [UIColor.labelColor colorWithAlphaComponent:0.35];
+    NSMutableParagraphStyle *paragraph = [NSMutableParagraphStyle new];
+    paragraph.alignment = NSTextAlignmentCenter;
+    return [[NSAttributedString alloc] initWithString:@"Vote" attributes:@{
+        NSFontAttributeName: [UIFont systemFontOfSize:16.0 weight:UIFontWeightSemibold],
+        NSForegroundColorAttributeName: textColor,
+        NSParagraphStyleAttributeName: paragraph,
+    }];
+}
+
+static NSString *ApolloPollPendingSelection(id pollNode) {
+    return objc_getAssociatedObject(pollNode, kApolloPollPendingOptionKey);
+}
+
+static void ApolloPollSetPendingSelection(id pollNode, NSString *optionID) {
+    if (!pollNode) return;
+    objc_setAssociatedObject(pollNode, kApolloPollPendingOptionKey, [optionID copy],
+                              OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+// Lazily creates and caches the leading radio glyph on a PollOptionNode.
+// Called from -[PollOptionNode layoutSpecThatFits:] (structural: only needs
+// to run once per node instance) to splice it into the row's layout; the
+// glyph's selected/unselected content is refreshed separately, out of band,
+// by ApolloPollRefreshOptionRadios below — never by re-running layout.
+static ASTextNode *ApolloPollEnsureRadioNode(ASDisplayNode *optionNode) {
+    ASTextNode *radio = objc_getAssociatedObject(optionNode, kApolloPollRadioNodeKey);
+    if (radio) return radio;
+    Class textNodeClass = objc_getClass("ASTextNode");
+    if (!textNodeClass) return nil;
+    radio = [textNodeClass new];
+    radio.attributedText = ApolloPollRadioAttributedText(NO, ApolloPollResolvedAccentColor(optionNode));
+    [optionNode addSubnode:radio];
+    objc_setAssociatedObject(optionNode, kApolloPollRadioNodeKey, radio, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return radio;
+}
+
+// The Vote pill's text label. Deliberately carries no background/cornerRadius
+// of its own — see ApolloPollEnsureVoteButtonBackgroundNode below for why a
+// color set directly on this node wouldn't include the padding around it.
+static ASTextNode *ApolloPollEnsureVoteButtonTextNode(ASDisplayNode *pollNode) {
+    ASTextNode *text = objc_getAssociatedObject(pollNode, kApolloPollVoteButtonTextNodeKey);
+    if (text) return text;
+    Class textNodeClass = objc_getClass("ASTextNode");
+    if (!textNodeClass) return nil;
+    text = [textNodeClass new];
+    [pollNode addSubnode:text];
+    objc_setAssociatedObject(pollNode, kApolloPollVoteButtonTextNodeKey, text, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return text;
+}
+
+// The Vote pill's visual chrome — a plain node stretched (via
+// ASBackgroundLayoutSpec in the PollNode layout hook below) to cover the
+// text node PLUS its surrounding ASInsetLayoutSpec padding. This is also the
+// tap-hit target (ApolloPollTouchHitVoteButton), so the padded area is
+// tappable too, matching how it looks.
+static ASDisplayNode *ApolloPollEnsureVoteButtonBackgroundNode(ASDisplayNode *pollNode) {
+    ASDisplayNode *background = objc_getAssociatedObject(pollNode, kApolloPollVoteButtonNodeKey);
+    if (background) return background;
+    Class displayNodeClass = objc_getClass("ASDisplayNode");
+    if (!displayNodeClass) return nil;
+    background = [displayNodeClass new];
+    background.cornerRadius = 10.0;
+    background.clipsToBounds = YES;
+    [pollNode addSubnode:background];
+    objc_setAssociatedObject(pollNode, kApolloPollVoteButtonNodeKey, background, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return background;
+}
+
+// Walks a mounted poll's option ROW VIEWS (not the Swift optionNodes array
+// ivar, which is a bridged Array<PollOptionNode> and not safely readable as a
+// plain NSArray from ObjC — see ApolloPollOptionAtPoint above, which already
+// walks the view tree for the same reason). Mirrors its exact recursion shape.
+static void ApolloPollForEachOptionNode(UIView *containerView, NSUInteger depth,
+                                        void (^body)(id optionNode)) {
+    Class optionClass = objc_getClass("_TtC6Apollo14PollOptionNode");
+    for (UIView *row in containerView.subviews) {
+        id node = [row respondsToSelector:@selector(asyncdisplaykit_node)] ? [row asyncdisplaykit_node] : nil;
+        if (node && [node isKindOfClass:optionClass]) {
+            body(node);
+            continue;
+        }
+        if (depth > 0) ApolloPollForEachOptionNode(row, depth - 1, body);
+    }
+}
+
+// Re-derives every option row's radio glyph from the current pending
+// selection. Pure content mutation on already-mounted, fixed-size nodes — no
+// relayout, no beginUpdates: swapping between the "circle"/
+// "largecircle.fill.circle" SF Symbols never changes measured size at a fixed
+// point size.
+static void ApolloPollRefreshOptionRadios(id pollNode) {
+    UIView *pollView = ApolloPollNodeView(pollNode);
+    if (!pollView) return;
+    NSString *pending = ApolloPollPendingSelection(pollNode);
+    ApolloPollForEachOptionNode(pollView, 1, ^(id optionNode) {
+        ASTextNode *radio = ApolloPollEnsureRadioNode(optionNode);
+        if (!radio) return;
+        RDKPollOption *option = ApolloPollObjectIvar(optionNode, "option");
+        BOOL selected = pending.length > 0 && [pending isEqualToString:option.identifier];
+        UIColor *tint = ApolloPollResolvedAccentColor(optionNode);
+        radio.attributedText = ApolloPollRadioAttributedText(selected, tint);
+        [radio setNeedsDisplay];
+    });
+}
+
+// Restyles the Vote pill (enabled/accent vs. disabled/dim) from the current
+// pending selection. Same "mutate the mounted nodes directly" approach as the
+// radios, and for the same reason (no size change → no relayout needed): the
+// text/background split doesn't change either node's own measured size,
+// since the background is stretched by the ASBackgroundLayoutSpec in the
+// PollNode layout hook rather than resized here.
+static void ApolloPollRefreshVoteButton(id pollNode) {
+    ASTextNode *text = ApolloPollEnsureVoteButtonTextNode(pollNode);
+    ASDisplayNode *background = ApolloPollEnsureVoteButtonBackgroundNode(pollNode);
+    if (!text || !background) return;
+    BOOL enabled = ApolloPollPendingSelection(pollNode).length > 0;
+    UIColor *accent = ApolloPollResolvedAccentColor(pollNode);
+    background.backgroundColor = enabled ? accent : [accent colorWithAlphaComponent:0.15];
+    text.attributedText = ApolloPollVoteButtonAttributedText(enabled, accent);
+    [background setNeedsDisplay];
+    [text setNeedsDisplay];
+}
+
+// Hit-test the cached Vote pill's BACKGROUND node frame — that's the node
+// stretched to the full padded pill size (see
+// ApolloPollEnsureVoteButtonBackgroundNode), so the padding is tappable too,
+// not just the tight text. It's a DIRECT subnode of pollNode (added via
+// addSubnode: there), so its view's frame is already expressed in pollNode's
+// own view's coordinate space — the same space ApolloPollOptionAtPoint above
+// already hit-tests option rows in — no coordinate conversion needed.
+static BOOL ApolloPollTouchHitVoteButton(id pollNode, CGPoint pointInPollView) {
+    ASDisplayNode *background = objc_getAssociatedObject(pollNode, kApolloPollVoteButtonNodeKey);
+    BOOL loaded = [background respondsToSelector:@selector(isNodeLoaded)] && background.isNodeLoaded;
+    UIView *backgroundView = loaded ? background.view : nil;
+    if (!backgroundView || !backgroundView.window) return NO;
+    return CGRectContainsPoint(backgroundView.frame, pointInPollView);
+}
+
+// Injects the leading radio glyph into each unvoted option row. PollResultNode
+// (a separate class) renders voted polls, so PollOptionNode only ever exists
+// for an open, interactive poll — EXCEPT an ended-but-never-voted poll, which
+// Apollo still renders with PollOptionNode rows even though
+// pollNodeTappedWithSender: below routes taps to %orig for it. Skip the radio
+// there so a no-longer-votable poll never shows a selectable-looking control.
+%hook _TtC6Apollo14PollOptionNode
+- (id)layoutSpecThatFits:(struct ApolloPollSizeRange)constrainedSize {
+    id originalSpec = %orig;
+    if (!ApolloPollsFeatureEnabled()) return originalSpec;
+
+    id pollNode = [(ASDisplayNode *)self supernode];
+    RDKPoll *poll = pollNode ? ApolloPollObjectIvar(pollNode, "poll") : nil;
+    if (poll.hasPollEnded) return originalSpec;
+
+    ASTextNode *radio = ApolloPollEnsureRadioNode((ASDisplayNode *)self);
+    if (!radio) return originalSpec;
+    Class stackClass = ApolloPollStackLayoutSpecClass();
+    Class insetClass = ApolloPollInsetLayoutSpecClass();
+    if (!stackClass || !insetClass) return originalSpec;
+    ASStackLayoutSpec *row = [stackClass
+        stackLayoutSpecWithDirection:ApolloPollStackDirectionHorizontal
+                              spacing:2.0
+                       justifyContent:ApolloPollStackJustifyContentStart
+                           alignItems:ApolloPollStackAlignItemsCenter
+                             children:@[radio, originalSpec]];
+    return [insetClass insetLayoutSpecWithInsets:UIEdgeInsetsMake(0, 8, 0, 0) child:row];
+}
+%end
+
 // PollNode is an ASControlNode: Apollo registers pollNodeTappedWithSender: for
 // its TouchUpInside event, and taps anywhere inside the poll — option rows
 // included, since plain option subnodes bubble touches up the responder chain —
@@ -1236,6 +1609,42 @@ static void ApolloPollPresentAccessibilityPicker(id pollNode, RDKLink *link,
     UIColor *card = ApolloThemeRuntimeColor(ApolloThemeTokenSecondaryBackground);
     UIView *pollView = ApolloPollNodeView(self);
     if (card && pollView) pollView.backgroundColor = card;
+}
+
+// Appends the always-present (disabled-until-selected) Vote button below the
+// existing option/results content — see the "Radio list + Vote button"
+// section above for the full mechanism. Splicing it in as a genuine stack
+// child, rather than an overlay, is what makes Texture measure the taller
+// row correctly.
+- (id)layoutSpecThatFits:(struct ApolloPollSizeRange)constrainedSize {
+    id originalSpec = %orig;
+    if (!ApolloPollsFeatureEnabled()) return originalSpec;
+    RDKPoll *poll = ApolloPollObjectIvar(self, "poll");
+    if (!poll || poll.hasPollEnded || poll.userSelectionIdentifier.length > 0) return originalSpec;
+
+    ApolloPollRefreshVoteButton(self);
+    ASTextNode *text = ApolloPollEnsureVoteButtonTextNode((ASDisplayNode *)self);
+    ASDisplayNode *background = ApolloPollEnsureVoteButtonBackgroundNode((ASDisplayNode *)self);
+    if (!text || !background) return originalSpec;
+    Class stackClass = ApolloPollStackLayoutSpecClass();
+    Class insetClass = ApolloPollInsetLayoutSpecClass();
+    Class backgroundClass = ApolloPollBackgroundLayoutSpecClass();
+    if (!stackClass || !insetClass || !backgroundClass) return originalSpec;
+    // The padded text (foreground) drives the pill's size; the background
+    // node is stretched to match it, so the padding is part of the visible
+    // (and tappable — see ApolloPollTouchHitVoteButton) pill, not empty
+    // space outside it.
+    id textInset = [insetClass
+        insetLayoutSpecWithInsets:UIEdgeInsetsMake(6, 16, 6, 16) child:text];
+    id pill = [backgroundClass backgroundLayoutSpecWithChild:textInset background:background];
+    id buttonMargin = [insetClass
+        insetLayoutSpecWithInsets:UIEdgeInsetsMake(0, 20, 16, 20) child:pill];
+    return [stackClass
+        stackLayoutSpecWithDirection:ApolloPollStackDirectionVertical
+                              spacing:0
+                       justifyContent:ApolloPollStackJustifyContentStart
+                           alignItems:ApolloPollStackAlignItemsStretch
+                             children:@[originalSpec, buttonMargin]];
 }
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
@@ -1389,39 +1798,70 @@ static void ApolloPollPresentAccessibilityPicker(id pollNode, RDKLink *link,
     if (![pollNode isKindOfClass:objc_getClass("_TtC6Apollo8PollNode")]) {
         pollNode = ApolloPollObjectIvar(self, "pollNode");
     }
-    RDKPollOption *option = ApolloPollConsumeTappedOption(pollNode);
+
     // Apollo's original action is still useful for an ended/already-voted
     // poll's native result presentation. Its legacy "open Reddit to vote"
     // modal is only reachable for an active unvoted poll, which the native
     // feature owns completely below.
     if (poll.hasPollEnded || poll.userSelectionIdentifier.length > 0) {
+        CGPoint discardedPoint;
+        ApolloPollConsumeLastTouchPoint(pollNode, &discardedPoint); // drop any stray touch point
         %orig;
         return;
     }
 
     NSString *username = ApolloActiveAccountUsername();
-    if (option) {
-        ApolloPollDiagnosticLog(@" poll action resolved option post=%@ link=%@ pollNode=%@ option=%@(%@)",
+    CGPoint touchPoint;
+    UIView *pollView = ApolloPollNodeView(pollNode);
+    BOOL hasTouchPoint = ApolloPollConsumeLastTouchPoint(pollNode, &touchPoint) && pollView != nil;
+
+    // Deliberate two-step voting: Reddit poll votes are irreversible, so an
+    // ordinary tap on an option row only SELECTS it (fills its radio); only a
+    // tap on the always-present Vote button commits it. The button IS the
+    // confirmation step — no separate "Are you sure?" alert.
+    if (hasTouchPoint && ApolloPollTouchHitVoteButton(pollNode, touchPoint)) {
+        NSString *pendingID = ApolloPollPendingSelection(pollNode);
+        RDKPollOption *pendingOption = nil;
+        for (RDKPollOption *candidate in poll.options) {
+            if ([candidate.identifier isEqualToString:pendingID]) { pendingOption = candidate; break; }
+        }
+        if (!pendingOption) return; // Vote tapped with nothing selected: no-op.
+        ApolloPollDiagnosticLog(@" vote button tapped post=%@ link=%@ pollNode=%@ option=%@(%@)",
                   link.identifier, ApolloPollPointer(link), ApolloPollPointer(pollNode),
-                  option.identifier, ApolloPollPointer(option));
+                  pendingOption.identifier, ApolloPollPointer(pendingOption));
         if (username.length == 0) {
             ApolloPollShowError(ApolloPollPresenter(), @"Sign in to a Reddit account to vote in polls.");
             return;
         }
-        ApolloPollBeginVote(link, option, username, pollNode);
-    } else {
-        // The whole legacy PollNode is one control, so Apollo routes taps on
-        // "N Votes · Closes in …" through the same action that used to present
-        // its web-voting modal. Under native polls that metadata is deliberately
-        // inert. Only touchless assistive-tech activation needs an option list.
-        ApolloPollDiagnosticLog(@" poll action ignored metadata/accessibility path post=%@ link=%@ pollNode=%@",
-                  link.identifier, ApolloPollPointer(link), ApolloPollPointer(pollNode));
-        if (UIAccessibilityIsVoiceOverRunning() || UIAccessibilityIsSwitchControlRunning()) {
-            if (username.length > 0) {
-                ApolloPollPresentAccessibilityPicker(pollNode, link, username);
-            } else {
-                ApolloPollShowError(ApolloPollPresenter(), @"Sign in to a Reddit account to vote in polls.");
-            }
+        ApolloPollBeginVote(link, pendingOption, username, pollNode);
+        return;
+    }
+
+    RDKPollOption *tappedOption = hasTouchPoint ? ApolloPollOptionAtPoint(pollView, touchPoint, 1) : nil;
+    if (tappedOption) {
+        ApolloPollDiagnosticLog(@" option row selected (not yet voted) post=%@ link=%@ pollNode=%@ option=%@(%@)",
+                  link.identifier, ApolloPollPointer(link), ApolloPollPointer(pollNode),
+                  tappedOption.identifier, ApolloPollPointer(tappedOption));
+        ApolloPollSetPendingSelection(pollNode, tappedOption.identifier);
+        ApolloPollRefreshOptionRadios(pollNode);
+        ApolloPollRefreshVoteButton(pollNode);
+        UISelectionFeedbackGenerator *feedback = [UISelectionFeedbackGenerator new];
+        [feedback selectionChanged];
+        return;
+    }
+
+    // The whole legacy PollNode is one control, so Apollo routes taps on
+    // "N Votes · Closes in …" (and any other non-option/non-button area)
+    // through this same action. Only touchless assistive-tech activation
+    // needs an option list; picking an item there is itself a deliberate,
+    // explicit action, so it still votes directly rather than only selecting.
+    ApolloPollDiagnosticLog(@" poll action ignored metadata/accessibility path post=%@ link=%@ pollNode=%@",
+              link.identifier, ApolloPollPointer(link), ApolloPollPointer(pollNode));
+    if (UIAccessibilityIsVoiceOverRunning() || UIAccessibilityIsSwitchControlRunning()) {
+        if (username.length > 0) {
+            ApolloPollPresentAccessibilityPicker(pollNode, link, username);
+        } else {
+            ApolloPollShowError(ApolloPollPresenter(), @"Sign in to a Reddit account to vote in polls.");
         }
     }
 }

--- a/src/ApolloPollVoting.xm
+++ b/src/ApolloPollVoting.xm
@@ -1461,6 +1461,32 @@ static BOOL ApolloPollTouchHitVoteButton(id pollNode, CGPoint pointInPollView) {
     return CGRectContainsPoint(backgroundView.frame, pointInPollView);
 }
 
+// Overrides the option text's paragraph alignment to match sPollOptionAlignment.
+// Apollo rebuilds textNode's attributedText inside %orig on every pass, so
+// this must re-run every time; mutating the node in place works since %orig's
+// returned spec already references this same instance.
+static void ApolloPollApplyOptionTextAlignment(id optionNode) {
+    ASTextNode *textNode = ApolloPollObjectIvar(optionNode, "textNode");
+    if (![textNode isKindOfClass:objc_getClass("ASTextNode")]) return;
+    NSAttributedString *current = textNode.attributedText;
+    if (current.length == 0) return;
+    NSTextAlignment alignment = (sPollOptionAlignment == ApolloPollOptionAlignmentLeft)
+        ? NSTextAlignmentLeft : NSTextAlignmentCenter;
+    // Always rewrite, no "already matches" short-circuit: a run with no
+    // NSParagraphStyleAttributeName reads back as nil, and -[nil alignment]
+    // is 0 same as NSTextAlignmentLeft, which would false-positive-skip.
+    NSMutableAttributedString *realigned = [current mutableCopy];
+    [realigned enumerateAttribute:NSParagraphStyleAttributeName
+                           inRange:NSMakeRange(0, realigned.length)
+                           options:0
+                        usingBlock:^(NSParagraphStyle *value, NSRange range, BOOL *stop) {
+        NSMutableParagraphStyle *paragraph = value ? [value mutableCopy] : [NSMutableParagraphStyle new];
+        paragraph.alignment = alignment;
+        [realigned addAttribute:NSParagraphStyleAttributeName value:paragraph range:range];
+    }];
+    textNode.attributedText = realigned;
+}
+
 // Injects the leading radio glyph into each unvoted option row. PollOptionNode
 // only exists for an interactive poll — except an ended-but-never-voted poll,
 // which still renders PollOptionNode rows even though taps route to %orig.
@@ -1468,23 +1494,54 @@ static BOOL ApolloPollTouchHitVoteButton(id pollNode, CGPoint pointInPollView) {
 %hook _TtC6Apollo14PollOptionNode
 - (id)layoutSpecThatFits:(struct ApolloTextureSizeRange)constrainedSize {
     id originalSpec = %orig;
-    if (!ApolloPollsFeatureEnabled()) return originalSpec;
+
+    // Alignment is a display preference, independent of the native-voting
+    // feature (radio glyph + Vote button) gated further down — applies even
+    // with Native Polls off, or to an ended/voted poll's results text.
+    ApolloPollApplyOptionTextAlignment(self);
+
+    // originalSpec is always ASCenterLayoutSpec > ASInsetLayoutSpec >
+    // ASTextNode (confirmed via a runtime spec-tree dump). ASCenterLayoutSpec
+    // unconditionally centers its child, which is what Center mode wants, so
+    // leave it alone there. Left mode has no property to ask it to left-align
+    // instead, so unwrap it and reuse its one child (Apollo's padding-only
+    // inset spec) directly, dropping the centering wrapper.
+    id optionContent = originalSpec;
+    if (sPollOptionAlignment == ApolloPollOptionAlignmentLeft) {
+        Class centerClass = objc_getClass("ASCenterLayoutSpec");
+        if (centerClass && [originalSpec isKindOfClass:centerClass]) {
+            id unwrapped = ((ASLayoutSpec *)originalSpec).children.firstObject;
+            if (unwrapped) optionContent = unwrapped;
+        }
+    }
+
+    if (!ApolloPollsFeatureEnabled()) return optionContent;
 
     id pollNode = [(ASDisplayNode *)self supernode];
     RDKPoll *poll = pollNode ? ApolloPollObjectIvar(pollNode, "poll") : nil;
-    if (poll.hasPollEnded) return originalSpec;
+    if (poll.hasPollEnded) return optionContent;
 
     ASTextNode *radio = ApolloPollEnsureRadioNode((ASDisplayNode *)self);
-    if (!radio) return originalSpec;
+    if (!radio) return optionContent;
     Class stackClass = objc_getClass("ASStackLayoutSpec");
     Class insetClass = objc_getClass("ASInsetLayoutSpec");
-    if (!stackClass || !insetClass) return originalSpec;
+    if (!stackClass || !insetClass) return optionContent;
+
+    // flexShrink:1 lets optionContent shrink to the width left over after the
+    // radio (default is unconstrained-natural-width, which just overflows
+    // instead of wrapping). flexGrow makes it fill that leftover width
+    // instead of hugging its own tight content — needed in Center mode so
+    // centered text has room to center in; Left mode leaves it at 0 so a
+    // short option stays pinned left by justifyContent:Start.
+    ASLayoutElementStyle *contentStyle = [(ASLayoutSpec *)optionContent style];
+    contentStyle.flexShrink = 1.0;
+    contentStyle.flexGrow = (sPollOptionAlignment == ApolloPollOptionAlignmentLeft) ? 0.0 : 1.0;
     ASStackLayoutSpec *row = [stackClass
         stackLayoutSpecWithDirection:ApolloPollStackDirectionHorizontal
                               spacing:2.0
                        justifyContent:ApolloPollStackJustifyContentStart
                            alignItems:ApolloPollStackAlignItemsCenter
-                             children:@[radio, originalSpec]];
+                             children:@[radio, optionContent]];
     return [insetClass insetLayoutSpecWithInsets:UIEdgeInsetsMake(0, 8, 0, 0) child:row];
 }
 %end

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -324,6 +324,14 @@ extern BOOL sWebJSONEnabled;
 // hook checks it; loaded at launch and updated live by the Polls settings
 // toggle. Read through ApolloPollsFeatureEnabled() (ApolloCommon.h).
 extern BOOL sPollsFeatureEnabled;
+// Horizontal alignment of the option text next to its radio glyph in a native
+// poll (ApolloPollVoting.xm, PollOptionNode layoutSpecThatFits: hook). Default
+// Center — matches Apollo's own pre-radio-glyph poll option layout.
+typedef NS_ENUM(NSInteger, ApolloPollOptionAlignment) {
+    ApolloPollOptionAlignmentCenter = 0,
+    ApolloPollOptionAlignmentLeft   = 1,
+};
+extern NSInteger sPollOptionAlignment;
 // Serialized "name=value; name=value" Cookie header harvested from a
 // www.reddit.com web login (must include reddit_session). nil until the user
 // completes the Web Session Login flow. Persisted in the keychain (it's a full

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -96,6 +96,7 @@ NSArray<NSString *> *sTranslationSkipLanguages = nil;
 
 BOOL sWebJSONEnabled = NO;
 BOOL sPollsFeatureEnabled = NO;
+NSInteger sPollOptionAlignment = ApolloPollOptionAlignmentCenter;
 NSString *sWebSessionCookieHeader = nil;
 NSString *sWebSessionModhash = nil;
 NSString *sWebSessionUsername = nil;

--- a/src/ApolloTextureDecls.h
+++ b/src/ApolloTextureDecls.h
@@ -1,0 +1,92 @@
+//
+//  ApolloTextureDecls.h
+//  Apollo-Reborn
+//
+//  Minimal Texture (AsyncDisplayKit) forward declarations shared by files
+//  that splice content into Apollo's Texture layout trees via
+//  -layoutSpecThatFits: hooks (ApolloAISummary.xm, ApolloPollVoting.xm). Real
+//  Texture headers aren't on this build's include path, so this declares
+//  only the selectors/properties those two files actually use; the runtime
+//  resolves them against Apollo's own bundled Texture implementation, and
+//  every class named below is still looked up via objc_getClass/
+//  NSClassFromString at the point of use rather than referenced directly
+//  (ApolloReborn.dylib is injected rather than linked against Apollo, so a
+//  direct class reference fails at link time).
+//
+//  Deliberately does NOT declare the stack layout's direction/justifyContent/
+//  alignItems as a shared named enum: each caller keeps its own local
+//  NS_ENUM with its own independently-verified raw values (a past bug had
+//  one file's direction enum silently swapped relative to real Texture), and
+//  this header only types those parameters/properties as the underlying
+//  `unsigned char`, so a bad value in one caller's enum can't leak into the
+//  other's.
+//
+//  Not folded into ApolloCommon.h and not meant for blanket import — several
+//  other files (e.g. ApolloInlineImages.xm) declare their own, differently
+//  shaped local copies of these same class names, which would collide if
+//  this header were pulled in everywhere. Import it explicitly only from a
+//  file that needs it.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class ASLayoutSpec, ASStackLayoutSpec, ASInsetLayoutSpec, ASBackgroundLayoutSpec, ASTextNode, ASDisplayNode;
+
+@interface ASDisplayNode : NSObject
+- (void)addSubnode:(ASDisplayNode *)subnode;
+- (ASDisplayNode *)supernode;
+- (void)setNeedsLayout;
+- (void)setNeedsDisplay;
+- (void)invalidateCalculatedLayout;
+- (BOOL)isNodeLoaded;
+- (UIView *)view;
+- (void)onDidLoad:(void (^)(__kindof ASDisplayNode *node))body;
+@property (nonatomic) BOOL userInteractionEnabled;
+@property (nullable, nonatomic, copy) UIColor *backgroundColor;
+@property (nonatomic) CGFloat cornerRadius;
+@property (nonatomic) BOOL clipsToBounds;
+@property (nonatomic) CGFloat borderWidth;
+@property (nullable, nonatomic) CGColorRef borderColor;
+@end
+
+@interface ASTextNode : ASDisplayNode
+@property (nonatomic, copy) NSAttributedString *attributedText;
+@property (nonatomic) NSUInteger maximumNumberOfLines;
+@end
+
+@interface ASLayoutSpec : NSObject
+@property (nullable, nonatomic) NSArray *children;
+@end
+
+@interface ASStackLayoutSpec : ASLayoutSpec
+@property (nonatomic) unsigned char direction;
+@property (nonatomic) CGFloat spacing;
+@property (nonatomic) unsigned char justifyContent;
+@property (nonatomic) unsigned char alignItems;
+@property (nonatomic) NSUInteger flexWrap;
+@property (nonatomic) NSUInteger alignContent;
+@property (nonatomic) CGFloat lineSpacing;
++ (instancetype)stackLayoutSpecWithDirection:(unsigned char)direction
+                                     spacing:(CGFloat)spacing
+                              justifyContent:(unsigned char)justifyContent
+                                  alignItems:(unsigned char)alignItems
+                                    children:(NSArray *)children;
+@end
+
+@interface ASInsetLayoutSpec : ASLayoutSpec
+@property (nonatomic) UIEdgeInsets insets;
+@property (nullable, nonatomic) id child;
++ (instancetype)insetLayoutSpecWithInsets:(UIEdgeInsets)insets child:(id)child;
+@end
+
+@interface ASBackgroundLayoutSpec : ASLayoutSpec
++ (instancetype)backgroundLayoutSpecWithChild:(id)child background:(ASDisplayNode *)background;
+@end
+
+NS_ASSUME_NONNULL_END
+
+// ASSizeRange stand-in (named CDStruct_90e057aa in class-dumped headers) so
+// Logos can hook the by-value struct argument of -layoutSpecThatFits:.
+struct ApolloTextureSizeRange { CGSize min; CGSize max; };

--- a/src/ApolloTextureDecls.h
+++ b/src/ApolloTextureDecls.h
@@ -32,7 +32,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class ASLayoutSpec, ASStackLayoutSpec, ASInsetLayoutSpec, ASBackgroundLayoutSpec, ASTextNode, ASDisplayNode;
+@class ASLayoutSpec, ASStackLayoutSpec, ASInsetLayoutSpec, ASBackgroundLayoutSpec, ASTextNode, ASDisplayNode, ASLayoutElementStyle;
+
+// Real Texture's ASLayoutElementStyle has many more properties; only the two
+// flex-sizing ones used so far are declared here.
+@interface ASLayoutElementStyle : NSObject
+@property (nonatomic) CGFloat flexGrow;
+@property (nonatomic) CGFloat flexShrink;
+@end
 
 @interface ASDisplayNode : NSObject
 - (void)addSubnode:(ASDisplayNode *)subnode;
@@ -49,6 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL clipsToBounds;
 @property (nonatomic) CGFloat borderWidth;
 @property (nullable, nonatomic) CGColorRef borderColor;
+@property (nonatomic, readonly) ASLayoutElementStyle *style;
 @end
 
 @interface ASTextNode : ASDisplayNode
@@ -58,6 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ASLayoutSpec : NSObject
 @property (nullable, nonatomic) NSArray *children;
+@property (nonatomic, readonly) ASLayoutElementStyle *style;
 @end
 
 @interface ASStackLayoutSpec : ASLayoutSpec

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -2977,6 +2977,11 @@ static void initializeRandomSources() {
     // hooks, so reading before they're in place returns nothing.
     sWebJSONEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyWebJSONEnabled];
     sPollsFeatureEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyPollsEnabled];
+    sPollOptionAlignment = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyPollOptionAlignment];
+    if (sPollOptionAlignment != ApolloPollOptionAlignmentCenter && sPollOptionAlignment != ApolloPollOptionAlignmentLeft) {
+        sPollOptionAlignment = ApolloPollOptionAlignmentCenter;
+        [standardDefaults setInteger:sPollOptionAlignment forKey:UDKeyPollOptionAlignment];
+    }
     // Surface a revoked/expired cookie (detected response-side in
     // ApolloWebJSONNoteResponse) as a re-login prompt wherever the user is.
     [[NSNotificationCenter defaultCenter] addObserverForName:ApolloWebJSONSessionExpiredNotification

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -341,6 +341,9 @@ static NSString *const UDKeyWebJSONEnabled = @"WebJSONEnabled";
 // of UDKeyWebJSONEnabled: turning polls on does NOT reroute the request
 // pipeline; it only unlocks the poll tap handler and the compose "Poll" type.
 static NSString *const UDKeyPollsEnabled = @"PollsEnabled";
+// Horizontal alignment of poll option text (ApolloPollOptionAlignment).
+// Default Center (0).
+static NSString *const UDKeyPollOptionAlignment = @"PollOptionAlignment";
 // Legacy NSUserDefaults location of the harvested "name=value; ..." Cookie
 // header. The cookie is now stored in the keychain (ApolloWebJSON.m); this key
 // is retained only so ApolloWebJSONLoadPersistedCredentials can migrate an older

--- a/src/settings/ApolloPollSettingsViewController.m
+++ b/src/settings/ApolloPollSettingsViewController.m
@@ -6,10 +6,12 @@
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
 
-// Sections. The sign-in section only exists while the master toggle is on, so
-// the screen reads as "turn it on, then set up the account it needs."
+// Sections. Options is always present (a display preference, independent of
+// the Polls toggle). Sign-in only exists while the toggle is on, so the
+// screen reads as "turn it on, then set up the account it needs."
 typedef NS_ENUM(NSInteger, ApolloPollSettingsSection) {
     ApolloPollSettingsSectionToggle = 0,
+    ApolloPollSettingsSectionOptions,  // always present
     ApolloPollSettingsSectionSignIn,   // present only when the toggle is on
 };
 
@@ -48,7 +50,7 @@ typedef NS_ENUM(NSInteger, ApolloPollSettingsSection) {
 #pragma mark - Table structure
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-    return [self pollsEnabled] ? 2 : 1;
+    return [self pollsEnabled] ? 3 : 2;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
@@ -67,6 +69,9 @@ typedef NS_ENUM(NSInteger, ApolloPollSettingsSection) {
                 "through your reddit.com web session — captured automatically when "
                 "you sign in, so there's usually nothing to set up.\n\n"
                 "Experimental — if anything looks off, please report it.";
+    }
+    if (section == ApolloPollSettingsSectionOptions) {
+        return @"How option text is aligned within the poll.";
     }
     if (section == ApolloPollSettingsSectionSignIn) {
         NSString *username = [self activeUsername];
@@ -95,7 +100,23 @@ typedef NS_ENUM(NSInteger, ApolloPollSettingsSection) {
     if (indexPath.section == ApolloPollSettingsSectionToggle) {
         return [self toggleCell];
     }
+    if (indexPath.section == ApolloPollSettingsSectionOptions) {
+        return [self alignmentCell];
+    }
     return [self signInCell];
+}
+
+- (NSString *)alignmentText {
+    return sPollOptionAlignment == ApolloPollOptionAlignmentLeft ? @"Left" : @"Center";
+}
+
+- (UITableViewCell *)alignmentCell {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:nil];
+    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    cell.textLabel.text = @"Option Text Alignment";
+    cell.detailTextLabel.text = [self alignmentText];
+    cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+    return cell;
 }
 
 - (UITableViewCell *)toggleCell {
@@ -150,12 +171,18 @@ typedef NS_ENUM(NSInteger, ApolloPollSettingsSection) {
 #pragma mark - Selection
 
 - (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == ApolloPollSettingsSectionOptions) return YES;
     if (indexPath.section != ApolloPollSettingsSectionSignIn) return NO;
     return [self activeUsername] != nil;
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    if (indexPath.section == ApolloPollSettingsSectionOptions) {
+        UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+        [self presentAlignmentSheetFromSourceView:cell];
+        return;
+    }
     if (indexPath.section != ApolloPollSettingsSectionSignIn) return;
     NSString *username = [self activeUsername];
     if (!username) return;
@@ -164,6 +191,34 @@ typedef NS_ENUM(NSInteger, ApolloPollSettingsSection) {
     } else {
         [self startSignInForUsername:username];
     }
+}
+
+#pragma mark - Option alignment
+
+- (void)presentAlignmentSheetFromSourceView:(UIView *)sourceView {
+    UIAlertController *sheet = [UIAlertController
+        alertControllerWithTitle:@"Option Text Alignment"
+                         message:@"How option text lines up next to its selection circle."
+                  preferredStyle:UIAlertControllerStyleActionSheet];
+    NSArray<NSNumber *> *values = @[@(ApolloPollOptionAlignmentCenter), @(ApolloPollOptionAlignmentLeft)];
+    NSArray<NSString *> *titles = @[@"Center", @"Left"];
+    for (NSUInteger i = 0; i < values.count; i++) {
+        NSInteger value = values[i].integerValue;
+        NSString *title = titles[i];
+        if (sPollOptionAlignment == value) title = [title stringByAppendingString:@" (Current)"];
+        [sheet addAction:[UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault
+                                                handler:^(UIAlertAction *action) {
+            sPollOptionAlignment = value;
+            [[NSUserDefaults standardUserDefaults] setInteger:value forKey:UDKeyPollOptionAlignment];
+            [self.tableView reloadRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:0
+                                                                        inSection:ApolloPollSettingsSectionOptions]]
+                                  withRowAnimation:UITableViewRowAnimationNone];
+        }]];
+    }
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    sheet.popoverPresentationController.sourceView = sourceView ?: self.view;
+    sheet.popoverPresentationController.sourceRect = (sourceView ?: self.view).bounds;
+    [self presentViewController:sheet animated:YES completion:nil];
 }
 
 #pragma mark - Sign-in flow
@@ -217,7 +272,8 @@ typedef NS_ENUM(NSInteger, ApolloPollSettingsSection) {
     }
     // Update the cached gate so poll hooks react immediately, no relaunch.
     sPollsFeatureEnabled = toggle.on;
-    // Reveal/hide the sign-in section with a soft animation.
+    // Reveal/hide just the sign-in section with a soft animation — Options
+    // stays put, it doesn't depend on this toggle.
     NSIndexSet *signIn = [NSIndexSet indexSetWithIndex:ApolloPollSettingsSectionSignIn];
     [self.tableView beginUpdates];
     if (toggle.on) {


### PR DESCRIPTION
## Summary
Native poll voting in Apollo (from #643) currently casts the vote immediately after tapping an option. This PR makes it require two taps instead of one: tapping an option only selects it (its radio glyph fills in), and a separate "Vote" button (disabled until an option is selected) actually casts the vote. This matches the fact that Reddit poll votes are irreversible, and the Vote button acts as a confirmation step to prevent accidental votes.

## Impact
- Poll voting UX changes from immediate tap-to-vote to select-then-confirm: each option row now shows a radio glyph, and a "Vote" pill appears below the options (dimmed until a selection is made).
- The VoiceOver/Switch Control voting path is unchanged — picking an option from the existing accessibility sheet still votes directly, since that's already a deliberate, explicit action.
- A failed or cancelled vote correctly resets the pending selection UI rather than leaving a stale-looking choice on screen.

## Changes
- `PollOptionNode`'s `layoutSpecThatFits:` is hooked to splice a leading radio glyph (SF Symbol, with a plain-text fallback) into each option row, skipped for polls that have already ended.
- `PollNode`'s `layoutSpecThatFits:` is hooked to append the Vote pill (text + padded background) as a real stack child below the existing option/results content, so Texture measures the taller row correctly from the first layout pass.
- The tap handler now distinguishes three touch targets — an option row, the Vote button, or neither — using a new `ApolloPollConsumeLastTouchPoint` helper that hands back the raw touch point (replacing the old `ApolloPollConsumeTappedOption`, which resolved straight to an option and couldn't also hit-test the button).
- Selection state lives in a new per-`PollNode` "pending option" association; live radio/button restyling mutates the already-mounted nodes directly instead of re-triggering layout.
- Extracted the minimal Texture (AsyncDisplayKit) forward declarations this feature needed into a new `src/ApolloTextureDecls.h`, shared with `ApolloAISummary.xm` (which had its own near-identical copy) instead of duplicating them; moved the SF-Symbol-to-attributed-string helper both files independently implemented into `ApolloCommon.h`/`.m` as `ApolloSymbolAttachment`.

## Reasoning
- Texture (AsyncDisplayKit) isn't linked at build time since ApolloReborn.dylib is injected rather than linked against Apollo, so every Texture class here is resolved via `objc_getClass` at the point of use rather than referenced directly.
- The Vote pill's padding is implemented via `ASBackgroundLayoutSpec` (a separate background node stretched to match the padded text) rather than a color set directly on the text node, since `ASInsetLayoutSpec` only reserves space in the parent layout and never grows the child's own frame.
- Selection changes after the initial layout pass mutate the cached radio/button nodes in place rather than re-running `layoutSpecThatFits:`, since a glyph/style swap never changes measured size and Texture doesn't guarantee a parent layout invalidation re-invokes every child's own layout method.
- `ApolloTextureDecls.h` deliberately doesn't share a single named enum for the stack layout's direction/justifyContent/alignItems: `ApolloAISummary.xm`'s existing enum has its direction values swapped relative to real Texture (harmless there only because it clones an already-correct stack rather than building one from raw values), so each caller keeps its own independently-verified local `NS_ENUM` and the shared header just types those parameters as the underlying `unsigned char`.
- The new header isn't folded into `ApolloCommon.h` despite being widely useful, because several other files (e.g. `ApolloInlineImages.xm`) already declare their own differently-shaped local copies of the same Texture class names — importing it globally would collide with those.

## Testing
Verified with a clean simulator-target build (`make TARGET=simulator:clang:latest:15.0 LOGOS_DEFAULT_GENERATOR=internal APOLLO_SIM_BUILD=1`) that `ApolloPollVoting.xm` and `ApolloAISummary.xm` compile against the shared header without warnings, and that it doesn't collide with `ApolloInlineImages.xm`'s separate local Texture declarations.

Verified on-device that polls display the radio glyph and Vote button, tapping an option fills in the radio glyph and allows the Vote button to be selected, and tapping the Vote button casts the vote to Reddit.

## Screenshots
**No option selected**
<img width="316" height="206" alt="image" src="https://github.com/user-attachments/assets/12ec97cc-de45-4b90-bc81-01e1f2c753d2" />

**Option selected**
<img width="311" height="205" alt="image" src="https://github.com/user-attachments/assets/d32f765e-6270-4de3-b725-e931329eddce" />