### PR TITLE
Info row: don't fire the comment tap when the touch was actually a scroll

### DIFF
--- a/src/ApolloStatsRowTouch.xm
+++ b/src/ApolloStatsRowTouch.xm
@@ -94,6 +94,15 @@ static BOOL SRTTouchHitsNode(ApolloSRTNode *node, UIView *cellView, UITouch *tou
     return CGRectContainsPoint(rect, pt);
 }
 
+// The scrolling list a cell lives in (the feed / comments table). Nearest ancestor
+// only — that's the one whose pan owns the touch.
+static UIScrollView *SRTEnclosingScrollView(UIView *view) {
+    for (UIView *v = view; v; v = v.superview) {
+        if ([v isKindOfClass:[UIScrollView class]]) return (UIScrollView *)v;
+    }
+    return nil;
+}
+
 // MARK: - "Jump to comments" pending flag (set on bubble tap, consumed on appear)
 
 // A feed tap → push is near-instant; the comments view's viewDidAppear fires a
@@ -623,6 +632,11 @@ static const void *kSRTLoupeScrollLockKey = &kSRTLoupeScrollLockKey; // RETAIN: 
 static const void *kSRTLoupeCancelKey = &kSRTLoupeCancelKey;   // NSNumber BOOL: finger dragged away — release cancels
 static const void *kSRTLoupeTouchStartKey = &kSRTLoupeTouchStartKey; // NSValue CGPoint: touch-down point (window coords)
 static const void *kSRTLoupeTintKey = &kSRTLoupeTintKey;       // RETAIN: accent resolved once per hold
+// Per-comment-tap live state: what the touch landed on, so the tap can tell
+// itself apart from a scroll that merely started on the bubble (issue #698).
+static const void *kSRTTapTouchStartKey = &kSRTTapTouchStartKey;     // NSValue CGPoint: touch-down point (window coords)
+static const void *kSRTTapScrollOffsetKey = &kSRTTapScrollOffsetKey; // NSValue CGPoint: list contentOffset at touch-down
+static const void *kSRTTapScrollMovingKey = &kSRTTapScrollMovingKey; // NSNumber BOOL: list already moving at touch-down
 
 enum { kSRTGestureTypeCommentTap = 1, kSRTGestureTypeLoupe = 2 };
 
@@ -812,7 +826,82 @@ static void SRTWireCornerFailureRequirements(UIGestureRecognizer *loupe, UIView 
     UIView *cellView = nil;
     @try { cellView = [(ApolloSRTNode *)cell view]; } @catch (__unused id e) {}
     ApolloSRTNode *commentsNode = SRTCommentsNodeForCell(cell);
-    return SRTTouchHitsNode(commentsNode, cellView, touch, kSRTCommentInsets);
+    if (!SRTTouchHitsNode(commentsNode, cellView, touch, kSRTCommentInsets)) return NO;
+    // Snapshot the touch: where the finger landed, and whether the list was at
+    // rest under it. srtCommentTapShouldBegin measures against this to reject a
+    // scroll that merely started on the bubble (issue #698).
+    UIScrollView *sv = SRTEnclosingScrollView(cellView);
+    objc_setAssociatedObject(gr, kSRTTapTouchStartKey,
+                             [NSValue valueWithCGPoint:[touch locationInView:nil]],
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(gr, kSRTTapScrollOffsetKey,
+                             sv ? [NSValue valueWithCGPoint:sv.contentOffset] : nil,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(gr, kSRTTapScrollMovingKey,
+                             @(sv.isDragging || sv.isDecelerating),
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return YES;
+}
+
+// A finger that moved the list at all was scrolling, not tapping; a couple of
+// points of slop absorb the jitter a settling list can still report.
+static const CGFloat kSRTTapMaxScroll = 3.0;
+// Backstop travel for drags the list never followed (bouncing at a scroll limit,
+// a horizontal swipe). Loose enough that a heavy-thumbed tap still counts.
+static const CGFloat kSRTTapMaxTravel = 24.0;
+
+// Issue #698: a touch that lands on the comment bubble and then scrolls is not a
+// tap, but it used to recognize as one on release — firing the haptic and arming
+// jump-to-comments while nothing on the row lit up ("random vibrations while
+// scrolling", no visual feedback).
+//
+// Ordinary taps inside a scroll view get this protection for free: the list's pan
+// excludes them under UIKit's default arbitration, which is exactly what the
+// sibling age/% tap in ApolloCreatedAtAlert relies on. Ours can't — the loupe
+// needs blanket simultaneous recognition (see the note below
+// shouldRecognizeSimultaneouslyWith…), and that keeps this tap alive through a
+// scroll too. Nor does the recognizer's own movement tolerance help: the cell
+// travels WITH the finger while scrolling, so in cell coordinates the touch never
+// moved at all. So the veto has to be explicit, and measured against the things a
+// scroll actually changes.
+- (BOOL)srtCommentTapShouldBegin:(UIGestureRecognizer *)gr {
+    if (!sInfoRowTapComments) return NO;
+    id cell = objc_getAssociatedObject(gr, kSRTCommentGestureCellKey);
+    if (!cell) return NO;
+    UIView *cellView = nil;
+    @try { cellView = [(ApolloSRTNode *)cell view]; } @catch (__unused id e) {}
+    UIScrollView *sv = SRTEnclosingScrollView(cellView);
+
+    // 1) The list was already moving when the finger landed, or still is: a drag
+    //    that wandered onto the bubble, or the everyday "tap to stop a fling" —
+    //    which UIKit itself swallows (no row selection, no highlight), so we must
+    //    too.
+    if ([objc_getAssociatedObject(gr, kSRTTapScrollMovingKey) boolValue] || sv.isDragging) {
+        ApolloLog(@"[StatsRow] comment tap vetoed — list moving under the touch");
+        return NO;
+    }
+    // 2) The list moved under this touch: it scrolled, so this was a drag. The
+    //    most reliable signal of the three — immune to whether the pan happens to
+    //    have ended before us on touch-up.
+    NSValue *offVal = objc_getAssociatedObject(gr, kSRTTapScrollOffsetKey);
+    if (sv && offVal) {
+        CGPoint was = offVal.CGPointValue, now = sv.contentOffset;
+        if (fabs(now.y - was.y) > kSRTTapMaxScroll || fabs(now.x - was.x) > kSRTTapMaxScroll) {
+            ApolloLog(@"[StatsRow] comment tap vetoed — list scrolled %.0fpt under the touch", now.y - was.y);
+            return NO;
+        }
+    }
+    // 3) The finger itself travelled too far to be a tap.
+    NSValue *startVal = objc_getAssociatedObject(gr, kSRTTapTouchStartKey);
+    if (startVal) {
+        CGPoint start = startVal.CGPointValue, now = [gr locationInView:nil];
+        CGFloat dx = now.x - start.x, dy = now.y - start.y;
+        if (hypot(dx, dy) > kSRTTapMaxTravel) {
+            ApolloLog(@"[StatsRow] comment tap vetoed — finger travelled (%.0f, %.0f)", dx, dy);
+            return NO;
+        }
+    }
+    return YES;
 }
 
 // Max finger travel between touch-down and the 0.3s mark that still reads as a
@@ -826,6 +915,7 @@ static const CGFloat kSRTHoldMaxTravel  = 40.0;
 // fails the press cleanly, releasing every recognizer wired to wait on us.
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gr {
     NSNumber *type = objc_getAssociatedObject(gr, kSRTGestureTypeKey);
+    if (type.integerValue == kSRTGestureTypeCommentTap) return [self srtCommentTapShouldBegin:gr];
     if (type.integerValue != kSRTGestureTypeLoupe) return YES;
     id cell = objc_getAssociatedObject(gr, kSRTCommentGestureCellKey);
     if (!sIconRowMagnifier || !cell) return NO;
@@ -833,14 +923,9 @@ static const CGFloat kSRTHoldMaxTravel  = 40.0;
     // The feed is already scrolling under this touch — that's a swipe, not a hold.
     UIView *cellView = nil;
     @try { cellView = [(ApolloSRTNode *)cell view]; } @catch (__unused id e) {}
-    for (UIView *v = cellView; v; v = v.superview) {
-        if ([v isKindOfClass:[UIScrollView class]]) {
-            if (((UIScrollView *)v).isDragging) {
-                ApolloLog(@"[StatsRow] loupe vetoed — feed is scrolling");
-                return NO;
-            }
-            break;
-        }
+    if (SRTEnclosingScrollView(cellView).isDragging) {
+        ApolloLog(@"[StatsRow] loupe vetoed — feed is scrolling");
+        return NO;
     }
     // The finger has visibly travelled since touch-down — swipe intent.
     NSValue *startVal = objc_getAssociatedObject(gr, kSRTLoupeTouchStartKey);


### PR DESCRIPTION
Fixes #698.

**The problem**

Touch the comment bubble in the info row, immediately scroll, then let go — you get the tap haptic on release, even though the feed just scrolled and nothing on the row lit up. That's the "random vibration while scrolling" in the issue. It's very specific: it only happens on the comment bubble (not the score or the age), and only if you start scrolling right away — hold still too long and you just get the context menu instead.

The haptic is the visible half. The invisible half is worse: the same phantom tap also arms jump-to-comments for 2.5s, so if you open any post right after that scroll, it silently lands at the comments instead of the top.

**Why only the comment bubble**

Taps inside a scroll view normally get protected for free — the list's pan gesture excludes them under UIKit's default arbitration, so a touch that turns into a scroll never recognizes as a tap. That's exactly what the age/% tap in `ApolloCreatedAtAlert` relies on, which is why it doesn't misfire.

Our comment tap opts out of that. The press-and-hold magnifier needs blanket simultaneous recognition (an exclusive loupe silently never leaves Possible — there's a long note about it in the file), and that blanket `return YES` also keeps this tap alive right through a scroll.

The recognizer's own movement tolerance can't save it either: while you scroll, the cell travels *with* your finger, so measured in cell coordinates the touch never moved at all.

And `gestureRecognizerShouldBegin:` short-circuited with `return YES` for anything that wasn't the loupe, so the tap had no veto whatsoever.

**The fix**

Give the comment tap its own `shouldBegin` veto, measured against the things a scroll actually changes. `shouldReceiveTouch:` snapshots the touch-down state (finger position in window coords, the list's `contentOffset`, whether it was already moving), and the tap is rejected when:

1. the list was already dragging/decelerating when the finger landed — a drag that wandered onto the bubble, or the everyday "tap to stop a fling", both of which UIKit itself swallows (no row selection, no highlight), or is still dragging now;
2. the list scrolled more than 3pt under the touch — the most reliable of the three, since it doesn't depend on whether the pan happened to end before us on touch-up;
3. the finger travelled more than 24pt — backstop for drags the list never followed (bouncing at a scroll limit, a horizontal swipe).

Nothing else changes: the magnifier's arbitration is untouched, and a real tap (including a sloppy one) still fires exactly as before. Also folded the loupe's identical inline scroll-view walk into the small `SRTEnclosingScrollView` helper this needed — same semantics, 8 lines to 4.

**Testing** (simulator, iOS 26, Liquid Glass)

Built the unfixed code first and confirmed the phantom fires, then rebuilt with the fix and re-ran the same gestures. Watched `[StatsRow]` os_log lines rather than trusting the screen, since the haptic isn't observable in the sim.

| | before | after |
|---|---|---|
| drag up from the comment bubble (scrolls ~230pt, post never opens) | tap fires, jump armed | vetoed |
| drag down from the comment bubble | — | vetoed |
| same, with Magnify Info Row **off** (reporter's config) | — | vetoed |
| genuine tap on the bubble | fires, lands at the action bar | unchanged |
| sloppy tap, ~5pt of jitter | — | still fires, lands correctly |
| press-and-hold magnifier, release on Comments | works | works |
| pure hold with magnifier off | — | context menu, no phantom tap |
