### PR TITLE
Clarify what "Inline Media in Chat" covers now that modern Chat/Modmail exist

### DIFF
--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -197,9 +197,12 @@ extern BOOL sEnableFlairColors;
 // fresh installs (registerDefaults). When NO, Apollo's native behavior (text
 // link + optional link card) is preserved. See ApolloInlineImages.xm.
 extern BOOL sEnableInlineImages;
-// Master toggle for chat media enhancements (inline images/GIFs/emoji/snoomoji in DM/chat
-// bubbles + working media sends + tap-to-fullscreen). Default ON via registerDefaults; OFF =
-// stock Apollo chat. Independent of sShowUserAvatars. See ApolloChatInlineImages/Composer.xm.
+// Master toggle for message media enhancements (inline images/GIFs/emoji/snoomoji in message
+// bubbles + working media sends + tap-to-fullscreen), in every thread Apollo draws itself:
+// legacy Direct Chat, private messages, and native Moderator Mail. Default ON via
+// registerDefaults; OFF = stock Apollo threads. Unaffected by the modern Chat/Modmail toggles,
+// which swap their own surface for a web one that renders its own media (private messages stay
+// native either way). Independent of sShowUserAvatars. See ApolloChatInlineImages/Composer.xm.
 extern BOOL sEnableChatMedia;
 
 // On-device AI summaries (Apple FoundationModels, iOS 26+). Off by default.

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -217,9 +217,13 @@ static NSString *const UDKeyScrollEdgeEffectStyle = @"ScrollEdgeEffectStyle";
 // Render image URLs (i.redd.it, preview.redd.it, i.imgur.com, generic .png/.jpg/.jpeg/.webp)
 // inline within post selftext and comments instead of leaving them as plain text links.
 static NSString *const UDKeyEnableInlineImages = @"EnableInlineImages";
-// Master toggle for the chat media enhancements: render inbound images/GIFs/emoji/snoomoji
-// inline in DM/chat bubbles, rewrite outgoing media embeds so image/GIF sends work, and tap an
-// image/GIF to open it full screen. OFF = stock Apollo chat (media shown as plain text links).
+// Master toggle for the message media enhancements: render inbound images/GIFs/emoji/snoomoji
+// inline in message bubbles, rewrite outgoing media embeds so image/GIF sends work, and tap an
+// image/GIF to open it full screen. OFF = stock Apollo threads (media shown as plain text links).
+// Scoped to the threads Apollo draws itself with PrivateMessageViewController — legacy Direct
+// Chat, private messages, and native Moderator Mail — so turning on modern Chat/Modmail (which
+// are web surfaces rendering their own media) narrows what this reaches without ever emptying
+// it: private messages are always native.
 // Independent of "Show User Profile Pictures" (avatars have their own toggle). See ApolloChat*.xm.
 static NSString *const UDKeyEnableChatMedia = @"EnableChatMedia";
 // Horizontal alignment for inline media that is narrower than the row (e.g. tall portrait images).

--- a/src/settings/InlineMediaSettingsViewController.m
+++ b/src/settings/InlineMediaSettingsViewController.m
@@ -1,5 +1,6 @@
 #import "InlineMediaSettingsViewController.h"
 #import "ApolloCommon.h"
+#import "ApolloDirectChatWeb.h"
 #import "ApolloMediaAutoplay.h"
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
@@ -555,7 +556,7 @@ typedef NS_ENUM(NSInteger, ApolloIMSection) {
 
 typedef NS_ENUM(NSInteger, ApolloIMMasterRow) {
     ApolloIMMasterRowPreviews = 0,   // inline media in posts + comments
-    ApolloIMMasterRowChat,           // inline media in Chat / DMs
+    ApolloIMMasterRowChat,           // inline media in Apollo's native message threads
     ApolloIMMasterRowCount,
 };
 
@@ -725,6 +726,55 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
     }
 }
 
+// The message-media toggle is scoped to the threads Apollo draws ITSELF with
+// _TtC6Apollo28PrivateMessageViewController — one bubble UI serving three
+// surfaces: legacy Direct Chat (Reddit mirrors chat rooms into the old message
+// inbox as "[direct chat room]" items), ordinary private messages, and native
+// Moderator Mail conversations (same class; see its newModmailConversation /
+// currentModmailSendMode fields).
+//
+// Reddit's modern Chat / Modmail are authenticated web surfaces that render
+// their own media, so switching either on takes that surface out of this
+// setting's reach — hence the caveat sentence. It never empties the list
+// though: private messages are always drawn natively (they exist for API-key
+// and API-key-free accounts alike, /message/* being a routable keyless path),
+// so this toggle always still governs something and must stay switchable
+// rather than being forced off and greyed out when modern Chat is on.
+//
+// Both gates are the EFFECTIVE state, not the raw defaults: they already fold
+// in the iOS 16 floor and the forced-on behaviour for API-key-free accounts,
+// so a keyless account correctly sees the Chat + Moderator Mail caveat without
+// the switches themselves having been touched.
+static NSString *ApolloIMMessageMediaFooter(void) {
+    BOOL modernChat = ApolloModernChatShouldOpen();
+    BOOL modernModmail = ApolloModernModmailShouldOpen();
+
+    NSMutableArray<NSString *> *native = [NSMutableArray array];
+    if (!modernChat) [native addObject:@"Direct Chat"];
+    [native addObject:@"private messages"];
+    if (!modernModmail) [native addObject:@"Moderator Mail"];
+
+    NSString *nativeList = native.count == 3
+        ? [NSString stringWithFormat:@"%@, %@, and %@", native[0], native[1], native[2]]
+        : (native.count == 2
+            ? [NSString stringWithFormat:@"%@ and %@", native[0], native[1]]
+            : native.firstObject);
+
+    NSMutableString *footer = [NSMutableString stringWithFormat:
+        @"Inline Media Previews renders image, GIF, and video links inside post text and comments "
+        @"instead of leaving them as plain links. Inline Media in Messages does the same inside the "
+        @"message threads Apollo draws itself — %@.", nativeList];
+
+    if (modernChat || modernModmail) {
+        BOOL both = modernChat && modernModmail;
+        [footer appendFormat:@" Reddit's modern %@ %@ %@ own media, so this setting doesn't apply there.",
+            both ? @"Chat and Moderator Mail" : (modernChat ? @"Chat" : @"Moderator Mail"),
+            both ? @"render" : @"renders",
+            both ? @"their" : @"its"];
+    }
+    return footer;
+}
+
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
     switch (section) {
         case ApolloIMSectionPreview:  return @"Preview";
@@ -737,7 +787,7 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
     switch (section) {
         case ApolloIMSectionMaster:
-            return @"Inline Media Previews renders image, GIF, and video links inside post text and comments instead of leaving them as plain links. Inline Media in Chat does the same for direct messages.";
+            return ApolloIMMessageMediaFooter();
         case ApolloIMSectionOptions:
             return @"Tap to Play shows a paused GIF with a play button in the bottom corner — it plays that one GIF inline and becomes a pause button, and tapping the rest of the GIF opens the fullscreen viewer as usual. Never shows a static preview (tap opens the viewer). WiFi Only autoplays on WiFi and behaves like Tap to Play on cellular.";
         default:
@@ -760,7 +810,10 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
         }
         case ApolloIMSectionMaster:
             if (indexPath.row == ApolloIMMasterRowChat) {
-                return [self switchCellLabel:@"Inline Media in Chat"
+                // Deliberately NOT disabled when modern Chat/Modmail is on: those
+                // only take their own surface out of scope, and native private
+                // message threads always remain. See ApolloIMMessageMediaFooter.
+                return [self switchCellLabel:@"Inline Media in Messages"
                                           on:sEnableChatMedia
                                      enabled:YES
                                       action:@selector(chatMediaSwitchToggled:)];
@@ -825,10 +878,11 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
                   withRowAnimation:UITableViewRowAnimationNone];
 }
 
-// Master toggle for chat media (inline images/GIFs/emoji/snoomoji + working
-// media sends + tap-to-fullscreen). Open chats re-render their cells on next
-// display/scroll, so no immediate-refresh notification is needed. Independent
-// of the posts/comments inline toggle and of Show User Profile Pictures.
+// Master toggle for message-thread media (inline images/GIFs/emoji/snoomoji +
+// working media sends + tap-to-fullscreen) in every thread Apollo draws itself.
+// Open threads re-render their cells on next display/scroll, so no immediate-
+// refresh notification is needed. Independent of the posts/comments inline
+// toggle and of Show User Profile Pictures.
 - (void)chatMediaSwitchToggled:(UISwitch *)sw {
     sEnableChatMedia = sw.on;
     [[NSUserDefaults standardUserDefaults] setBool:sEnableChatMedia forKey:UDKeyEnableChatMedia];


### PR DESCRIPTION
Follow-up to #658. Started as "should *Inline Media in Chat* switch itself off and grey out when *Use Modern Reddit Chat* is on?" — the answer turned out to be **no**, but the toggle is genuinely misleading as it stands, so this makes it say what it actually does.

<table>
<tr><th width="50%">Before</th><th width="50%">After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/f3f8d69b-0684-41c8-a714-accff7401469" alt="Before: row reads Inline Media in Chat, footer says it does the same for direct messages"></td>
<td><img src="https://github.com/user-attachments/assets/a2e8caa5-3d8a-4e2e-b3ad-c06594a02a97" alt="After: row reads Inline Media in Messages, footer lists private messages and notes modern Chat and Moderator Mail render their own media"></td>
</tr>
</table>

Both shots are the same account — API-key-free, so modern Chat *and* modern Modmail are forced on. The old copy still promises "does the same for direct messages" there, which is exactly the confusion this started from.

**Why it shouldn't be forced off**

`sEnableChatMedia` gates `ApolloChatProcessCell` on `_TtC6Apollo28PrivateMessageViewController`, and that one MessageKit bubble UI serves **three** surfaces, not just chat:

1. **legacy Direct Chat** — Reddit mirrors chat rooms into the old message inbox with a `[direct chat room]` / `[group chat room]` subject, and Apollo renders those mirrors as a thread;
2. **ordinary private messages**;
3. **native Moderator Mail conversations** — same class (see its `newModmailConversationID` / `newModmailConversation` / `currentModmailSendMode` / `modmailInboxViewController` fields).

Modern Chat only takes away (1): `ApolloChatFilterOutChats` strips the mirrors out of every native inbox page, and the Direct Chat row pushes the web controller instead. Modern Modmail only takes away (3): the `UINavigationController` hook swaps pushes of `ModmailInboxViewController`. **Neither touches (2).** The Messages box still opens Apollo's own native list, and its threads still open Apollo's own bubble UI — for API-key *and* API-key-free accounts alike, since `/message/*` is a routable keyless path in `ApolloWebJSON`.

<img src="https://github.com/user-attachments/assets/a3bf5f01-2a64-479c-ac29-67331bf4f088" width="420" alt="Inbox Boxes with modern Chat on: Direct Chat and Messages both listed, plus Moderator Mail">

Boxes with modern Chat + Modmail on: **Direct Chat** goes to Reddit's web Chat, but **Messages** is still Apollo's own native list — which is why the switch has to stay live.

So it never becomes a no-op, and greying it out whenever modern Chat is on would silently kill inline media in PMs for everyone.

**On the Modmail question specifically:** yes, inline media works the same way there, and the API-key/keyless split matters. Both `ApolloModernChatShouldOpen()` and `ApolloModernModmailShouldOpen()` return YES unconditionally for an API-key-free account (`ApolloModernChatIsRequiredForActiveAccount()` — native Modmail needs OAuth creds a keyless account deliberately doesn't have). So on a keyless account this setting only ever reaches private messages, while on an API-key account with modern Modmail off it still covers native Moderator Mail conversations too.

**The change**

Relabel the row **"Inline Media in Messages"**, and build the section footer from the *effective* modern Chat/Modmail state instead of hardcoding it — listing the surfaces it still reaches and naming the ones Reddit now draws itself. The switch stays enabled in every case.

| modern Chat | modern Modmail | footer (second half) |
|---|---|---|
| off | off | …does the same inside the message threads Apollo draws itself — **Direct Chat, private messages, and Moderator Mail**. |
| **on** | off | …— **private messages and Moderator Mail**. Reddit's modern **Chat** renders its own media, so this setting doesn't apply there. |
| off | **on** | …— **Direct Chat and private messages**. Reddit's modern **Moderator Mail** renders its own media, so this setting doesn't apply there. |
| **on** | **on** | …— **private messages**. Reddit's modern **Chat and Moderator Mail** render their own media, so this setting doesn't apply there. |

Because the gates are the effective state, this needs no wiring to the two switches in Accounts & API Keys — a keyless account reads the bottom row without either switch having been touched, and the pre-iOS-16 case (where `ApolloModernMailboxOSSupported()` is NO and both surfaces stay native) correctly reads the top row. The screen already does `reloadData` in `viewWillAppear:`, so flipping a modern toggle and coming back updates the footer.

`sEnableChatMedia` / `UDKeyEnableChatMedia` are untouched — same key, same default, no migration.

**Verified in the sim** (Apollo-Sim3, glass, dark, iOS 26.x) on an API-key-free account, which is the forced-on case:

- footer renders the both-on variant, switch still enabled and toggleable (screenshots above, before/after built from the same navigation on two builds);
- log confirms modern Chat owns the chat surface — `[ChatsFilter] dropped 11 legacy chat mirror(s) from a native inbox page (modern Chat active)`;
- Boxes still lists **Direct Chat** (→ web Chat) *and* **Messages** (→ Apollo's native list, native nav bar + compose/mark-read buttons, not a web view). That account has 11 chats and 0 real PMs, so its native list is empty — which is exactly the point: the 11 moved to the web surface, and anything left in Messages is still Apollo-drawn and still governed by this toggle.

All four footer strings were also generated offline from the same builder to check the wording and the singular/plural agreement (`renders its` vs `render their`).

**Judgement call worth a second opinion:** the rename. "Inline Media in Chat" is the name people know, but "Chat" is precisely the word that misleads once modern Chat is on — it's the reason this came up at all. If you'd rather keep the old label, it's a one-line revert and the dynamic footer still carries the explanation.

Not device-tested.

