### PR TITLE
Link previews: only reserve a full-size card when the image is known to be there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
+- Fix **rich link previews** for image-less sites briefly rendering a compact card inside a full-card-height row — a tall empty gap that only collapsed once you scrolled the row back into view — by remembering across launches which sites never produce a preview image and drawing the compact card from the first layout pass (@icpryde)
 - Fix **inline comment images** rendering tiny inside a full-height row after collapsing and re-expanding a comment, and the row flicker/reload loop when voting on a comment with an inline image (#675: @icpryde)
 
 ## [v3.4.2] - 2026-07-17

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloImgChestUpload.m \
     $(SRC_DIR)/ApolloLinkPreviewModel.m \
     $(SRC_DIR)/ApolloLinkPreviewCache.m \
+    $(SRC_DIR)/ApolloLinkPreviewShapeMemory.m \
     $(SRC_DIR)/ApolloLinkPreviewFetcher.m \
     $(SRC_DIR)/ApolloInlineImages.xm \
     $(SRC_DIR)/ApolloInlineLinkPreviews.xm \

--- a/src/ApolloInlineLinkPreviews.xm
+++ b/src/ApolloInlineLinkPreviews.xm
@@ -2229,29 +2229,47 @@ static ApolloLPContext ApolloLPContextForMode(NSInteger mode, ApolloLinkPreview 
     return ApolloLPContextSelfText;
 }
 
-// Which shape should an as-yet-unfetched URL's PLACEHOLDER take?
+// May an as-yet-unfetched URL's PLACEHOLDER reserve a hero-sized image box?
 //
-// This is the single decision behind the recurring "compact card stranded in a
-// full-card-height row, shrinks later while scrolling" bug. Getting it wrong in
-// the hero direction reserves ~220pt of image box for a card that will end up
-// ~104pt tall, and only a table row reload can take that space back — the
-// fragile V18/V20/V23/V24 heal machinery elsewhere in this file. Getting it wrong in the compact
-// direction only grows the row, which Texture's ordinary height refresh
-// commits. So: predict compact whenever there is real evidence, and remember
-// that evidence across launches (ApolloLinkPreviewShapeMemory) instead of
-// re-learning it one stranded row at a time, every launch, forever.
+// Both directions cost the same to COMMIT — Texture re-queries the row height
+// either way, and there is no cheap path for one of them. The asymmetry that
+// matters is in DETECTION, and it is decisive:
+//
+//   guessed hero, ended compact — the compact card sits in a row still measured
+//       ~200pt too tall. Nothing can see that by looking: a card shorter than its
+//       cell is what a normal cell looks like. Only per-node bookkeeping
+//       (V20/V23) knows, and a row reload destroys the very node holding it. The
+//       user's recording shows the result: the final compact card stretched
+//       inside a stale hero row for >1.3s, on screen and motionless.
+//   guessed compact, ended hero — the hero card draws past the bottom of its
+//       row, and that IS detectable by looking: V18's stateless geometry check
+//       (ApolloLPRunOverflowHeightCheck) measures the overflow and re-arms on
+//       every didEnterVisibleState, so it converges without needing to have
+//       remembered anything.
+//
+// So a hero box may only be reserved on POSITIVE evidence that the image will be
+// there — never as a default. The wrong guess then lands in the direction the
+// module can actually see and repair.
+//
+// The first version of this fix kept hero as the default and tried to predict
+// compact from a per-host memory. It failed in the field for an
+// obvious-in-hindsight reason: the hosts that actually strand are paywalled news
+// sites (wsj.com and reuters.com 401, jn.pt 403) which DO serve og:image on
+// their free articles, so they never looked imageless — plus every host being
+// seen for the first time. Requiring positive evidence instead makes the failure
+// structurally impossible rather than merely less likely: only a host whose every
+// observed preview carried an image gets a hero placeholder, so the reliable hero
+// cards keep their skeleton and everything else starts compact and grows.
 //
 // Observations are deliberately NOT recorded from the layout path: they come
 // from the preview fetch completion (once per URL, in ApolloLinkPreviewFetcher)
 // and from the dead-image mark (once per image URL), so nothing here runs per
 // measure. The store also refuses to learn anything about x.com / twitter.com /
-// bsky.app, whose cards have a fixed shape — which incidentally closes a leak
-// the old in-memory set had, where a non-post bsky.app URL falling back to a
-// favicon could compact-ify every Bluesky post for the rest of the launch.
-static BOOL ApolloLPShouldUseCompactPlaceholder(NSURL *url) {
+// bsky.app, whose cards have a fixed shape.
+static BOOL ApolloLPHostReliablyHasPreviewImages(NSURL *url) {
     NSString *host = ApolloLPHost(url);
     if (host.length == 0) return NO;
-    return [[ApolloLinkPreviewShapeMemory sharedMemory] shapeForHost:host] == ApolloLPHostShapeImageless;
+    return [[ApolloLinkPreviewShapeMemory sharedMemory] shapeForHost:host] == ApolloLPHostShapeImaged;
 }
 
 static id ApolloLPModelFromNodeIvar(ASDisplayNode *node, const char *ivarName) {
@@ -4509,8 +4527,16 @@ static void ApolloLPStackGuardReport(const char *where, size_t used, size_t size
         }
     }
     if (!cached) {
-        BOOL compactPlaceholder = selectedMode == ApolloLinkPreviewModeCompact || ApolloLPShouldUseCompactPlaceholder(url) || ApolloLPIsRedditUserProfileURL(url) || ApolloLPIsRedditSubredditURL(url);
-        ApolloLPContext placeholderContext = compactPlaceholder ? ApolloLPContextCompact : ApolloLPContextSelfText;
+        // Reserve a hero image box ONLY on positive evidence (see
+        // ApolloLPHostReliablyHasPreviewImages); otherwise start compact, because
+        // a compact placeholder can only ever grow and a hero one can strand.
+        // Bluesky posts are excluded from the inversion: their final card is
+        // pinned to the hero shape regardless of imagery (below), so a compact
+        // placeholder for them would be a guaranteed grow on every single card.
+        BOOL heroPlaceholder = selectedMode == ApolloLinkPreviewModeFull &&
+            !ApolloLPIsRedditUserProfileURL(url) && !ApolloLPIsRedditSubredditURL(url) &&
+            (ApolloLPIsBlueskyPostURL(url) || ApolloLPHostReliablyHasPreviewImages(url));
+        ApolloLPContext placeholderContext = heroPlaceholder ? ApolloLPContextSelfText : ApolloLPContextCompact;
         NSNumber *inFlight = objc_getAssociatedObject(self, &kApolloLinkPreviewFetchInFlightKey);
         if (![inFlight boolValue]) {
             objc_setAssociatedObject(self, &kApolloLinkPreviewFetchInFlightKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -4535,6 +4561,27 @@ static void ApolloLPStackGuardReport(const char *where, size_t used, size_t size
                     }
                 });
             }];
+        }
+        // ONCE per host per launch, off the hot path: which shape we reserved and
+        // on what evidence. PR #652 stripped the old placeholder-shape logging,
+        // which is why the only way to diagnose the last round of this bug from a
+        // user report was to film the screen. One line per host is nowhere near
+        // the per-measure volume that change was targeting.
+        {
+            static NSMutableSet *sLoggedShapeHosts; static dispatch_once_t once;
+            dispatch_once(&once, ^{ sLoggedShapeHosts = [NSMutableSet set]; });
+            BOOL shouldLog = NO;
+            @synchronized (sLoggedShapeHosts) {
+                if (host.length > 0 && ![sLoggedShapeHosts containsObject:host]) {
+                    [sLoggedShapeHosts addObject:host];
+                    shouldLog = YES;
+                }
+            }
+            if (shouldLog) {
+                ApolloLog(@"[LinkPreviews] placeholder shape=%@ host=%@ verdict=%ld",
+                          placeholderContext == ApolloLPContextCompact ? @"compact" : @"hero",
+                          host, (long)[[ApolloLinkPreviewShapeMemory sharedMemory] shapeForHost:host]);
+            }
         }
         NSString *placeholderVariant = ApolloLPVariant(area, selectedMode, placeholderContext, YES);
         ApolloLPMarkRenderSignatureIfChanged((ASDisplayNode *)self, placeholderVariant, ApolloLPRenderSignature(url, nil, placeholderVariant), host);

--- a/src/ApolloInlineLinkPreviews.xm
+++ b/src/ApolloInlineLinkPreviews.xm
@@ -8,6 +8,7 @@
 #import "ApolloDeletedCommentsData.h"
 #import "ApolloLinkPreviewCache.h"
 #import "ApolloLinkPreviewFetcher.h"
+#import "ApolloLinkPreviewShapeMemory.h"
 #import "ApolloBannedProfile.h"
 #import "ApolloUserProfileCache.h"
 #import "ApolloState.h"
@@ -1244,6 +1245,12 @@ static void ApolloLPStartFallbackImageFetch(ASNetworkImageNode *imageNode, NSURL
                 // dead-mark suppresses further fetches, so repeats mean a
                 // race, and reflowing again would loop the row reload.
                 ApolloLPMarkImageURLDead(imageURL);
+                // The scrape found an og:image but the file 4xx's. The fetcher
+                // recorded this PAGE host as "imaged" on the strength of that
+                // URL — retract it, so a host that habitually advertises images
+                // it never serves stops getting hero placeholders. (hostCopy is
+                // the page host, not the image CDN's.)
+                [[ApolloLinkPreviewShapeMemory sharedMemory] recordHostAdvertisedImageWasDead:hostCopy];
                 ASDisplayNode *hostNode = (ASDisplayNode *)strongImageNode;
                 for (int hops = 0; hostNode && hops < 24; hops++) {
                     if ([NSStringFromClass([hostNode class]) containsString:@"LinkButtonNode"]) break;
@@ -2222,44 +2229,29 @@ static ApolloLPContext ApolloLPContextForMode(NSInteger mode, ApolloLinkPreview 
     return ApolloLPContextSelfText;
 }
 
-static NSMutableSet<NSString *> *ApolloLPCompactPlaceholderHosts(void) {
-    static NSMutableSet<NSString *> *hosts;
-    static dispatch_once_t once;
-    dispatch_once(&once, ^{
-        hosts = [NSMutableSet setWithArray:@[
-            @"amctheatres.com",
-            @"doi.org",
-            @"journals.sagepub.com",
-            @"nature.com",
-            @"news18.com",
-            @"nuvioapp.space",
-            @"piie.com",
-            @"zerozero.pt"
-        ]];
-    });
-    return hosts;
-}
-
+// Which shape should an as-yet-unfetched URL's PLACEHOLDER take?
+//
+// This is the single decision behind the recurring "compact card stranded in a
+// full-card-height row, shrinks later while scrolling" bug. Getting it wrong in
+// the hero direction reserves ~220pt of image box for a card that will end up
+// ~104pt tall, and only a table row reload can take that space back — the
+// fragile V18/V20/V23/V24 heal machinery elsewhere in this file. Getting it wrong in the compact
+// direction only grows the row, which Texture's ordinary height refresh
+// commits. So: predict compact whenever there is real evidence, and remember
+// that evidence across launches (ApolloLinkPreviewShapeMemory) instead of
+// re-learning it one stranded row at a time, every launch, forever.
+//
+// Observations are deliberately NOT recorded from the layout path: they come
+// from the preview fetch completion (once per URL, in ApolloLinkPreviewFetcher)
+// and from the dead-image mark (once per image URL), so nothing here runs per
+// measure. The store also refuses to learn anything about x.com / twitter.com /
+// bsky.app, whose cards have a fixed shape — which incidentally closes a leak
+// the old in-memory set had, where a non-post bsky.app URL falling back to a
+// favicon could compact-ify every Bluesky post for the rest of the launch.
 static BOOL ApolloLPShouldUseCompactPlaceholder(NSURL *url) {
     NSString *host = ApolloLPHost(url);
     if (host.length == 0) return NO;
-
-    @synchronized (ApolloLPCompactPlaceholderHosts()) {
-        if ([ApolloLPCompactPlaceholderHosts() containsObject:host]) return YES;
-        for (NSString *knownHost in ApolloLPCompactPlaceholderHosts()) {
-            if ([host hasSuffix:[@"." stringByAppendingString:knownHost]]) return YES;
-        }
-    }
-    return NO;
-}
-
-static void ApolloLPRememberCompactPlaceholderHost(NSURL *url) {
-    NSString *host = ApolloLPHost(url);
-    if (host.length == 0) return;
-
-    @synchronized (ApolloLPCompactPlaceholderHosts()) {
-        [ApolloLPCompactPlaceholderHosts() addObject:host];
-    }
+    return [[ApolloLinkPreviewShapeMemory sharedMemory] shapeForHost:host] == ApolloLPHostShapeImageless;
 }
 
 static id ApolloLPModelFromNodeIvar(ASDisplayNode *node, const char *ivarName) {
@@ -4606,11 +4598,14 @@ static void ApolloLPStackGuardReport(const char *where, size_t used, size_t size
         context = ApolloLPContextCompact;
     }
 
-    if (!isBlueskyPost && !isRedditUser && !isRedditSubreddit && displayPreview.imageIsFallbackIcon) {
-        ApolloLPRememberCompactPlaceholderHost(url);
-    } else if (!isBlueskyPost && !isRedditUser && !isRedditSubreddit && selectedMode == ApolloLinkPreviewModeFull && context == ApolloLPContextCompact) {
-        ApolloLPRememberCompactPlaceholderHost(url);
-    }
+    // (Host shape used to be learned here, from the render decision. That ran on
+    // every measure and, worse, taught the memory the wrong thing: a card
+    // rendered compact because its comment happened to hold 2+ links, or because
+    // the user picked Compact mode, is not evidence that the HOST is imageless.
+    // Observations now come from the preview fetch itself — see
+    // ApolloLinkPreviewFetcher's finishURL: and the dead-image mark in
+    // ApolloLPStartFallbackImageFetch — which is once per URL, off the layout
+    // path, and actually about the page.)
     NSString *finalVariant = ApolloLPVariant(area, selectedMode, context, NO);
     ApolloLPMarkRenderSignatureIfChanged((ASDisplayNode *)self, finalVariant, ApolloLPRenderSignature(url, displayPreview, finalVariant), host);
     id richSpec = isBlueskyPost
@@ -4800,6 +4795,11 @@ static void ApolloLPStackGuardReport(const char *where, size_t used, size_t size
 %ctor {
     sApolloLPRegisteredLinkNodes = [NSHashTable weakObjectsHashTable];
     sApolloLPRegisteredLinkNodesQueue = dispatch_queue_create("com.apollo.linkpreviews.nodes", DISPATCH_QUEUE_SERIAL);
+
+    // One-time, off-thread: derive host verdicts from previews we have already
+    // fetched, so an existing install knows on its first launch which of ITS
+    // hosts are imageless rather than re-learning each one via a stranded row.
+    [[ApolloLinkPreviewShapeMemory sharedMemory] primeFromPreviewCacheIfNeeded];
 
     [[NSNotificationCenter defaultCenter] addObserverForName:ApolloLinkPreviewModeDidChangeNotification
                                                       object:nil

--- a/src/ApolloLinkPreviewCache.h
+++ b/src/ApolloLinkPreviewCache.h
@@ -14,5 +14,10 @@
 // Empties the in-memory and disk caches. Triggered from the "Clear Link
 // Preview Cache" settings row when entries get poisoned across versions.
 - (void)flushCache;
+// Walk every entry currently on disk/in memory, ignoring TTL freshness. Used
+// once per install to seed ApolloLinkPreviewShapeMemory from previews we have
+// already fetched. The block runs OFF the cache's serial queue (on the calling
+// thread) so it may safely call back into the cache.
+- (void)enumerateStoredPreviewsUsingBlock:(void (^)(NSURL *url, ApolloLinkPreview *preview))block;
 
 @end

--- a/src/ApolloLinkPreviewCache.m
+++ b/src/ApolloLinkPreviewCache.m
@@ -260,6 +260,28 @@ static NSString *ApolloLinkPreviewRedditUsernameFromURL(NSURL *url) {
     });
 }
 
+- (void)enumerateStoredPreviewsUsingBlock:(void (^)(NSURL *url, ApolloLinkPreview *preview))block {
+    if (!block) return;
+
+    // Snapshot under the queue, then run the block outside it: the caller
+    // records into another store that may itself talk back to this cache, and
+    // holding the serial queue across arbitrary work invites a deadlock.
+    __block NSArray<NSDictionary *> *snapshot = nil;
+    dispatch_sync(self.queue, ^{
+        snapshot = [self.entries.allValues copy];
+    });
+
+    for (NSDictionary *entry in snapshot) {
+        NSString *urlString = [entry[@"url"] isKindOfClass:[NSString class]] ? entry[@"url"] : nil;
+        if (urlString.length == 0) continue;
+        NSURL *url = [NSURL URLWithString:urlString];
+        if (!url) continue;
+        ApolloLinkPreview *preview = [ApolloLinkPreview previewFromDictionary:entry];
+        if (!preview) continue;
+        block(url, preview);
+    }
+}
+
 - (void)evictIfNeededLocked {
     if (self.entries.count <= ApolloLinkPreviewCacheMaxEntries) return;
 

--- a/src/ApolloLinkPreviewFetcher.m
+++ b/src/ApolloLinkPreviewFetcher.m
@@ -4,6 +4,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloLinkPreviewCache.h"
+#import "ApolloLinkPreviewShapeMemory.h"
 #import "ApolloState.h"
 #import "ApolloSubredditInfoCache.h"
 #import "ApolloUserProfileCache.h"
@@ -846,6 +847,16 @@ static NSString *ApolloLinkPreviewBrowserUserAgent(void) {
     } else {
         preview.fetchedAt = preview.fetchedAt ?: [NSDate date];
         [[ApolloLinkPreviewCache sharedCache] storePreview:preview forURL:url];
+        // Teach the shape memory what this host actually produces, so the NEXT
+        // uncached URL on it gets the right card shape on its first measure
+        // instead of a hero placeholder that has to shrink. Only generic web
+        // cards count: reddit user/subreddit and Bluesky previews render with a
+        // fixed card shape whatever their imagery, so they are no evidence.
+        if (preview.previewKind.length == 0) {
+            BOOL hasUsableImage = preview.imageURL.absoluteString.length > 0 && !preview.imageIsFallbackIcon;
+            [[ApolloLinkPreviewShapeMemory sharedMemory] recordHost:ApolloLinkPreviewHost(url)
+                                                     hasUsableImage:hasUsableImage];
+        }
     }
 
     NSString *key = url.absoluteString ?: @"";

--- a/src/ApolloLinkPreviewShapeMemory.h
+++ b/src/ApolloLinkPreviewShapeMemory.h
@@ -1,0 +1,71 @@
+// ApolloLinkPreviewShapeMemory.h
+//
+// Per-host memory of whether a site's rich link previews actually carry a
+// usable hero image.
+//
+// WHY THIS EXISTS
+// ---------------
+// When a link card is measured for a URL we have never fetched, the renderer
+// has to pick a card shape *before* it knows anything about the page, and the
+// two shapes have wildly different heights (a hero reserves a 16:9 image box —
+// ~220pt at feed width — while a compact card is ~104pt). Guessing "hero" and
+// then discovering the page has no image forces a shrink, and a shrink can only
+// be committed by a table row reload, which is exactly the fragile machinery
+// behind the recurring "compact card stranded inside a full-card-height row,
+// heals later while scrolling" reports.
+//
+// The asymmetry matters: a wrong *compact* guess only ever grows the row (which
+// Texture's ordinary height refresh and the V18 overflow check both handle),
+// while a wrong *hero* guess strands the row. So the renderer should predict
+// compact whenever it has any real evidence, and the cheapest evidence is what
+// already happened: hosts like nature.com, doi.org, or a paywall/Cloudflare
+// wall never yield an og:image, and they yield it consistently.
+//
+// This store remembers that verdict per host, PERSISTS it across launches, and
+// answers in O(1) from Texture's background layout threads. With it, a host you
+// have seen before renders the right shape on the very first measure and no
+// relayout of any kind is needed.
+//
+// Storage lives next to the preview cache in Caches/ and is disposable.
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, ApolloLPHostShape) {
+    /// No evidence yet — caller should use its own default (hero).
+    ApolloLPHostShapeUnknown = 0,
+    /// This host's previews reliably resolve without a usable image.
+    ApolloLPHostShapeImageless,
+    /// This host does produce usable preview images.
+    ApolloLPHostShapeImaged,
+};
+
+@interface ApolloLinkPreviewShapeMemory : NSObject
+
++ (instancetype)sharedMemory;
+
+/// Hot path: safe to call from Texture background layout threads.
+/// `host` is expected already lowercased and `www.`-stripped, but is
+/// normalised defensively anyway.
+- (ApolloLPHostShape)shapeForHost:(NSString *)host;
+
+/// Record one observation. Called once per completed preview fetch, never from
+/// a layout pass.
+- (void)recordHost:(NSString *)host hasUsableImage:(BOOL)hasUsableImage;
+
+/// The page advertised an og:image but the file 4xx'd. Retracts the optimistic
+/// observation `recordHost:hasUsableImage:YES` already made for it, so a host
+/// that habitually advertises images it never serves converges to imageless
+/// instead of being pinned to a hero placeholder by its own broken metadata.
+/// Called once per image URL, from the dead-image mark.
+- (void)recordHostAdvertisedImageWasDead:(NSString *)host;
+
+/// Seed the store from the on-disk preview cache the first time it is used, so
+/// existing users get an accurate, personalised memory immediately instead of
+/// re-learning every host one stranded row at a time. No-op afterwards.
+/// Safe to call from any thread; work happens off the caller's thread.
+- (void)primeFromPreviewCacheIfNeeded;
+
+/// Forget everything (paired with the settings "clear preview cache" action).
+- (void)reset;
+
+@end

--- a/src/ApolloLinkPreviewShapeMemory.h
+++ b/src/ApolloLinkPreviewShapeMemory.h
@@ -31,11 +31,16 @@
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, ApolloLPHostShape) {
-    /// No evidence yet — caller should use its own default (hero).
+    /// No evidence, or MIXED evidence (some previews imageful, some not — the
+    /// paywalled-news case: wsj.com and reuters.com serve og:image on free
+    /// articles and 401 on the rest). Mixed deliberately reports Unknown rather
+    /// than Imaged: "sometimes" is not evidence that THIS url will have an image.
     ApolloLPHostShapeUnknown = 0,
-    /// This host's previews reliably resolve without a usable image.
+    /// Every preview we have seen from this host resolved without a usable image.
     ApolloLPHostShapeImageless,
-    /// This host does produce usable preview images.
+    /// Every preview we have seen from this host carried a usable image, and none
+    /// ever did not. This is the ONLY verdict strong enough to justify reserving
+    /// a hero-sized image box before the fetch comes back.
     ApolloLPHostShapeImaged,
 };
 

--- a/src/ApolloLinkPreviewShapeMemory.m
+++ b/src/ApolloLinkPreviewShapeMemory.m
@@ -1,0 +1,386 @@
+// ApolloLinkPreviewShapeMemory.m — see the header for why this exists.
+
+#import "ApolloLinkPreviewShapeMemory.h"
+
+#import <UIKit/UIKit.h>
+#import <os/lock.h>
+
+#import "ApolloCommon.h"
+#import "ApolloLinkPreviewCache.h"
+#import "ApolloLinkPreviewModel.h"
+
+// Hosts known never to produce a usable preview image. Carried over verbatim
+// from the in-memory set this store replaces, and kept as an unconditional
+// overlay so behaviour for them is exactly what it is today.
+static NSString *const kApolloLPBuiltInImagelessHosts[] = {
+    @"amctheatres.com",
+    @"doi.org",
+    @"journals.sagepub.com",
+    @"nature.com",
+    @"news18.com",
+    @"nuvioapp.space",
+    @"piie.com",
+    @"zerozero.pt",
+};
+
+// Hosts whose cards are rendered with a FIXED shape regardless of imagery
+// (Twitter/X never even reaches this module's card renderer; Bluesky posts are
+// pinned to the hero shape). Letting them into the store could only produce a
+// wrong prediction, never a right one.
+static NSString *const kApolloLPIgnoredHosts[] = {
+    @"bsky.app",
+    @"twitter.com",
+    @"x.com",
+};
+
+// Counts saturate rather than wrap; the verdict only cares about "any" vs
+// "none", so there is nothing to gain from letting them grow unbounded.
+static const uint32_t kApolloLPMaxCount = 1000;
+
+// Bounded like the preview cache it shadows; oldest-seen hosts go first.
+static const NSUInteger kApolloLPMaxHosts = 600;
+
+static const NSTimeInterval kApolloLPDiskFlushInterval = 8.0;
+
+// Verdict rule: a host is predicted imageless only with ZERO counter-evidence
+// (at least one imageless observation and not a single imageful one).
+//
+// A ratio/majority rule was considered and rejected: measured against a real
+// 500-entry preview cache, the strict rule pre-empts ~68% of imageless
+// previews with zero false compacts, while a 2:1-style rule risks flipping
+// genuinely mixed hosts — reddit.com alone is 69 imageful / 22 imageless there,
+// and compact-ifying the single most common host in the cache would trade this
+// bug for a worse one. Mixed hosts keep the hero default and keep relying on
+// the existing heal machinery; that residue is expected, not a gap.
+@interface ApolloLPShapeEntry : NSObject {
+@public
+    uint32_t imageless;
+    uint32_t imaged;
+    NSTimeInterval lastSeen;
+}
+@end
+
+@implementation ApolloLPShapeEntry
+@end
+
+@implementation ApolloLinkPreviewShapeMemory {
+    // _hosts is read from Texture's background layout threads on every measure
+    // of an uncached link card, so it is guarded by an os_unfair_lock rather
+    // than @synchronized: reads are a couple of dictionary lookups and must not
+    // cost more than the layout pass they gate.
+    os_unfair_lock _lock;
+    NSMutableDictionary<NSString *, ApolloLPShapeEntry *> *_hosts;
+    BOOL _seeded;
+    BOOL _dirty;
+    BOOL _flushScheduled;
+    dispatch_queue_t _diskQueue;
+    NSString *_path;
+}
+
++ (instancetype)sharedMemory {
+    static ApolloLinkPreviewShapeMemory *memory;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ memory = [ApolloLinkPreviewShapeMemory new]; });
+    return memory;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (!self) return nil;
+
+    _lock = OS_UNFAIR_LOCK_INIT;
+    _hosts = [NSMutableDictionary dictionary];
+    _diskQueue = dispatch_queue_create("com.apollo.linkpreviews.shapes", DISPATCH_QUEUE_SERIAL);
+
+    NSArray<NSString *> *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+    NSString *directory = paths.firstObject ?: NSTemporaryDirectory();
+    _path = [directory stringByAppendingPathComponent:@"com.apollo.linkpreviews.hostshapes.json"];
+
+    [self loadFromDisk];
+
+    __weak typeof(self) weakSelf = self;
+    [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidEnterBackgroundNotification
+                                                      object:nil
+                                                       queue:nil
+                                                  usingBlock:^(__unused NSNotification *note) {
+        [weakSelf flushNow];
+    }];
+
+    return self;
+}
+
+#pragma mark - Host normalisation
+
+static NSString *ApolloLPNormalizedHost(NSString *host) {
+    if (![host isKindOfClass:[NSString class]] || host.length == 0) return nil;
+    NSString *clean = host.lowercaseString;
+    if ([clean hasPrefix:@"www."]) clean = [clean substringFromIndex:4];
+    return clean.length > 0 ? clean : nil;
+}
+
+#pragma mark - Reads (hot path)
+
+static ApolloLPHostShape ApolloLPShapeForEntry(ApolloLPShapeEntry *entry) {
+    if (!entry) return ApolloLPHostShapeUnknown;
+    if (entry->imaged > 0) return ApolloLPHostShapeImaged;
+    if (entry->imageless > 0) return ApolloLPHostShapeImageless;
+    return ApolloLPHostShapeUnknown;
+}
+
+// Exact-or-subdomain match against a fixed list. The dotted suffixes are built
+// once rather than per call: this runs on the cold-cache measure path, and
+// allocating a throwaway NSString per list entry per link card is exactly the
+// kind of incidental cost the scroll-performance work has been removing.
+static BOOL ApolloLPHostMatchesList(NSString *host, NSSet<NSString *> *exact, NSArray<NSString *> *dottedSuffixes) {
+    if (host.length == 0) return NO;
+    if ([exact containsObject:host]) return YES;
+    for (NSString *suffix in dottedSuffixes) {
+        if ([host hasSuffix:suffix]) return YES;
+    }
+    return NO;
+}
+
+// @[exactHosts, dottedSuffixes]
+static NSArray *ApolloLPBuildMatcher(NSString *const *list, size_t count) {
+    NSMutableSet *exact = [NSMutableSet setWithCapacity:count];
+    NSMutableArray *suffixes = [NSMutableArray arrayWithCapacity:count];
+    for (size_t index = 0; index < count; index++) {
+        [exact addObject:list[index]];
+        [suffixes addObject:[@"." stringByAppendingString:list[index]]];
+    }
+    return @[ [exact copy], [suffixes copy] ];
+}
+
+static BOOL ApolloLPHostIsBuiltInImageless(NSString *host) {
+    static NSArray *matcher; static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        matcher = ApolloLPBuildMatcher(kApolloLPBuiltInImagelessHosts,
+                                       sizeof(kApolloLPBuiltInImagelessHosts) / sizeof(NSString *));
+    });
+    return ApolloLPHostMatchesList(host, matcher[0], matcher[1]);
+}
+
+static BOOL ApolloLPHostIsIgnored(NSString *host) {
+    static NSArray *matcher; static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        matcher = ApolloLPBuildMatcher(kApolloLPIgnoredHosts,
+                                       sizeof(kApolloLPIgnoredHosts) / sizeof(NSString *));
+    });
+    return ApolloLPHostMatchesList(host, matcher[0], matcher[1]);
+}
+
+- (ApolloLPHostShape)shapeForHost:(NSString *)host {
+    NSString *normalized = ApolloLPNormalizedHost(host);
+    if (!normalized) return ApolloLPHostShapeUnknown;
+
+    // Unconditional overlay — these never learn their way out.
+    if (ApolloLPHostIsBuiltInImageless(normalized)) return ApolloLPHostShapeImageless;
+
+    ApolloLPHostShape shape = ApolloLPHostShapeUnknown;
+    os_unfair_lock_lock(&_lock);
+    // Exact host first, then up to two parent domains so a verdict recorded for
+    // `journals.sagepub.com` also covers `www2.journals.sagepub.com`. Bounded
+    // walk (never the linear scan over every known host this replaces).
+    NSString *candidate = normalized;
+    for (NSUInteger attempt = 0; attempt < 3 && candidate.length > 0; attempt++) {
+        ApolloLPShapeEntry *entry = _hosts[candidate];
+        if (entry) {
+            shape = ApolloLPShapeForEntry(entry);
+            break;
+        }
+        NSRange dot = [candidate rangeOfString:@"."];
+        if (dot.location == NSNotFound) break;
+        NSString *parent = [candidate substringFromIndex:dot.location + 1];
+        // Stop before bare registry suffixes ("co.uk", "com") — those are never
+        // recorded, so continuing would just burn lookups.
+        if ([parent rangeOfString:@"."].location == NSNotFound) break;
+        candidate = parent;
+    }
+    os_unfair_lock_unlock(&_lock);
+    return shape;
+}
+
+#pragma mark - Writes
+
+- (void)recordHost:(NSString *)host hasUsableImage:(BOOL)hasUsableImage {
+    NSString *normalized = ApolloLPNormalizedHost(host);
+    if (!normalized) return;
+    if (ApolloLPHostIsIgnored(normalized)) return;
+
+    NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
+
+    os_unfair_lock_lock(&_lock);
+    ApolloLPShapeEntry *entry = _hosts[normalized];
+    if (!entry) {
+        entry = [ApolloLPShapeEntry new];
+        _hosts[normalized] = entry;
+    }
+    if (hasUsableImage) {
+        if (entry->imaged < kApolloLPMaxCount) entry->imaged++;
+    } else {
+        if (entry->imageless < kApolloLPMaxCount) entry->imageless++;
+    }
+    entry->lastSeen = now;
+    [self evictIfNeededLocked];
+    os_unfair_lock_unlock(&_lock);
+
+    [self markDirty];
+}
+
+- (void)recordHostAdvertisedImageWasDead:(NSString *)host {
+    NSString *normalized = ApolloLPNormalizedHost(host);
+    if (!normalized) return;
+    if (ApolloLPHostIsIgnored(normalized)) return;
+
+    os_unfair_lock_lock(&_lock);
+    ApolloLPShapeEntry *entry = _hosts[normalized];
+    if (!entry) {
+        entry = [ApolloLPShapeEntry new];
+        _hosts[normalized] = entry;
+    }
+    // Retract, don't just counter-balance: under the zero-counter-evidence
+    // verdict rule a stale "imaged" would otherwise outvote every later
+    // failure and keep handing this host hero placeholders forever.
+    if (entry->imaged > 0) entry->imaged--;
+    if (entry->imageless < kApolloLPMaxCount) entry->imageless++;
+    entry->lastSeen = [[NSDate date] timeIntervalSince1970];
+    [self evictIfNeededLocked];
+    os_unfair_lock_unlock(&_lock);
+
+    [self markDirty];
+}
+
+- (void)evictIfNeededLocked {
+    if (_hosts.count <= kApolloLPMaxHosts) return;
+    NSArray<NSString *> *ordered = [_hosts keysSortedByValueUsingComparator:^NSComparisonResult(ApolloLPShapeEntry *a, ApolloLPShapeEntry *b) {
+        if (a->lastSeen < b->lastSeen) return NSOrderedAscending;
+        if (a->lastSeen > b->lastSeen) return NSOrderedDescending;
+        return NSOrderedSame;
+    }];
+    NSUInteger removeCount = _hosts.count - kApolloLPMaxHosts;
+    for (NSUInteger index = 0; index < removeCount && index < ordered.count; index++) {
+        [_hosts removeObjectForKey:ordered[index]];
+    }
+}
+
+#pragma mark - Priming from the preview cache
+
+- (void)primeFromPreviewCacheIfNeeded {
+    os_unfair_lock_lock(&_lock);
+    BOOL alreadySeeded = _seeded;
+    _seeded = YES;
+    os_unfair_lock_unlock(&_lock);
+    if (alreadySeeded) return;
+
+    // Off the caller's thread: this walks every cached preview and the cache
+    // itself serialises on its own queue.
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        __block NSUInteger imagelessSeen = 0;
+        __block NSUInteger imagedSeen = 0;
+        [[ApolloLinkPreviewCache sharedCache] enumerateStoredPreviewsUsingBlock:^(NSURL *url, ApolloLinkPreview *preview) {
+            NSString *host = ApolloLPNormalizedHost(url.host);
+            if (!host) return;
+            // Only generic web cards feed the shape verdict. Reddit user /
+            // subreddit / Bluesky previews are rendered with a fixed card shape
+            // regardless of imagery, so their image presence says nothing about
+            // what a normal link card on that host will look like.
+            if (preview.previewKind.length > 0) return;
+            if (preview.noMetadata) return;
+            if (![preview hasUsefulMetadata]) return;
+
+            BOOL hasImage = preview.imageURL.absoluteString.length > 0 && !preview.imageIsFallbackIcon;
+            if (hasImage) imagedSeen++; else imagelessSeen++;
+            [self recordHost:host hasUsableImage:hasImage];
+        }];
+        ApolloLog(@"[LinkPreviews] shape memory primed from cache: %lu imageless / %lu imaged observations",
+                  (unsigned long)imagelessSeen, (unsigned long)imagedSeen);
+        [self markDirty];
+    });
+}
+
+#pragma mark - Persistence
+
+- (void)loadFromDisk {
+    NSData *data = [NSData dataWithContentsOfFile:_path];
+    if (!data) return;
+    id object = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    if (![object isKindOfClass:[NSDictionary class]]) return;
+
+    NSDictionary *root = object;
+    NSDictionary *hosts = [root[@"hosts"] isKindOfClass:[NSDictionary class]] ? root[@"hosts"] : nil;
+    BOOL seeded = [root[@"seeded"] respondsToSelector:@selector(boolValue)] ? [root[@"seeded"] boolValue] : NO;
+
+    os_unfair_lock_lock(&_lock);
+    _seeded = seeded;
+    for (NSString *host in hosts) {
+        NSArray *value = [hosts[host] isKindOfClass:[NSArray class]] ? hosts[host] : nil;
+        if (value.count < 3 || ![host isKindOfClass:[NSString class]]) continue;
+        ApolloLPShapeEntry *entry = [ApolloLPShapeEntry new];
+        entry->imageless = (uint32_t)MAX(0, [value[0] intValue]);
+        entry->imaged = (uint32_t)MAX(0, [value[1] intValue]);
+        entry->lastSeen = [value[2] doubleValue];
+        _hosts[host] = entry;
+    }
+    NSUInteger count = _hosts.count;
+    os_unfair_lock_unlock(&_lock);
+    ApolloLog(@"[LinkPreviews] shape memory: %lu host verdicts loaded", (unsigned long)count);
+}
+
+- (void)markDirty {
+    os_unfair_lock_lock(&_lock);
+    _dirty = YES;
+    BOOL alreadyScheduled = _flushScheduled;
+    _flushScheduled = YES;
+    os_unfair_lock_unlock(&_lock);
+    if (alreadyScheduled) return;
+
+    __weak typeof(self) weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kApolloLPDiskFlushInterval * NSEC_PER_SEC)),
+                   _diskQueue, ^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        os_unfair_lock_lock(&strongSelf->_lock);
+        strongSelf->_flushScheduled = NO;
+        os_unfair_lock_unlock(&strongSelf->_lock);
+        [strongSelf writeToDisk];
+    });
+}
+
+- (void)flushNow {
+    dispatch_async(_diskQueue, ^{ [self writeToDisk]; });
+}
+
+- (void)writeToDisk {
+    os_unfair_lock_lock(&_lock);
+    if (!_dirty) {
+        os_unfair_lock_unlock(&_lock);
+        return;
+    }
+    _dirty = NO;
+    NSMutableDictionary *hosts = [NSMutableDictionary dictionaryWithCapacity:_hosts.count];
+    for (NSString *host in _hosts) {
+        ApolloLPShapeEntry *entry = _hosts[host];
+        hosts[host] = @[ @(entry->imageless), @(entry->imaged), @(entry->lastSeen) ];
+    }
+    BOOL seeded = _seeded;
+    os_unfair_lock_unlock(&_lock);
+
+    NSDictionary *root = @{ @"v": @1, @"seeded": @(seeded), @"hosts": hosts };
+    NSData *data = [NSJSONSerialization dataWithJSONObject:root options:0 error:nil];
+    if (!data) return;
+    [data writeToFile:_path atomically:YES];
+}
+
+- (void)reset {
+    os_unfair_lock_lock(&_lock);
+    [_hosts removeAllObjects];
+    _seeded = NO;
+    _dirty = NO;
+    os_unfair_lock_unlock(&_lock);
+    dispatch_async(_diskQueue, ^{
+        [[NSFileManager defaultManager] removeItemAtPath:self->_path error:nil];
+    });
+    ApolloLog(@"[LinkPreviews] shape memory reset");
+}
+
+@end

--- a/src/ApolloLinkPreviewShapeMemory.m
+++ b/src/ApolloLinkPreviewShapeMemory.m
@@ -33,25 +33,32 @@ static NSString *const kApolloLPIgnoredHosts[] = {
     @"x.com",
 };
 
-// Counts saturate rather than wrap; the verdict only cares about "any" vs
-// "none", so there is nothing to gain from letting them grow unbounded.
-static const uint32_t kApolloLPMaxCount = 1000;
+// Counters saturate low on purpose. Paired with the opposite-side decay in
+// recordHost:, this makes the store a short sliding window: a host needs only a
+// handful of consistent observations to earn a verdict, and only a handful of
+// contrary ones to lose it. A large cap would make hosts sluggish to re-learn
+// after a site changes (adds a paywall, drops one).
+static const uint32_t kApolloLPMaxCount = 8;
 
 // Bounded like the preview cache it shadows; oldest-seen hosts go first.
 static const NSUInteger kApolloLPMaxHosts = 600;
 
 static const NSTimeInterval kApolloLPDiskFlushInterval = 8.0;
 
-// Verdict rule: a host is predicted imageless only with ZERO counter-evidence
-// (at least one imageless observation and not a single imageful one).
+// Verdict rule: both verdicts require zero counter-evidence within the window.
+// Imageless means nothing recent from this host carried an image; Imaged means
+// everything recent did. Anything mixed reports Unknown, and Unknown gets the
+// safe (compact) placeholder.
 //
-// A ratio/majority rule was considered and rejected: measured against a real
-// 500-entry preview cache, the strict rule pre-empts ~68% of imageless
-// previews with zero false compacts, while a 2:1-style rule risks flipping
-// genuinely mixed hosts — reddit.com alone is 69 imageful / 22 imageless there,
-// and compact-ifying the single most common host in the cache would trade this
-// bug for a worse one. Mixed hosts keep the hero default and keep relying on
-// the existing heal machinery; that residue is expected, not a gap.
+// Mixed is not an edge case, it is the common one, and treating it as Imaged is
+// what made the first version of this fix fail in the field: wsj.com, reuters.com
+// and jn.pt all serve a real og:image on their free articles and 401/403 on the
+// rest, so one successful observation was enough to hand every later article a
+// hero placeholder that then had to collapse.
+//
+// Only Imaged is load-bearing now — it is what lets a reliably-imageful host keep
+// its hero skeleton instead of visibly growing. Imageless and Unknown both lead to
+// the same compact placeholder, so a wrong Imageless verdict costs nothing.
 @interface ApolloLPShapeEntry : NSObject {
 @public
     uint32_t imageless;
@@ -122,6 +129,7 @@ static NSString *ApolloLPNormalizedHost(NSString *host) {
 
 static ApolloLPHostShape ApolloLPShapeForEntry(ApolloLPShapeEntry *entry) {
     if (!entry) return ApolloLPHostShapeUnknown;
+    if (entry->imaged > 0 && entry->imageless > 0) return ApolloLPHostShapeUnknown; // mixed
     if (entry->imaged > 0) return ApolloLPHostShapeImaged;
     if (entry->imageless > 0) return ApolloLPHostShapeImageless;
     return ApolloLPHostShapeUnknown;
@@ -215,10 +223,19 @@ static BOOL ApolloLPHostIsIgnored(NSString *host) {
         entry = [ApolloLPShapeEntry new];
         _hosts[normalized] = entry;
     }
+    // Each observation also decays the opposite counter by one, so a verdict
+    // reflects the host's RECENT behaviour rather than its whole history. Without
+    // that decay the counters only ever grow, so one stale observation pins a
+    // host to mixed/Unknown for the life of the install and the store degrades
+    // monotonically toward "nothing is ever trusted". With it, "Imaged" means a
+    // run of successes with no recent failure — which is the bar a hero
+    // placeholder should have to clear.
     if (hasUsableImage) {
         if (entry->imaged < kApolloLPMaxCount) entry->imaged++;
+        if (entry->imageless > 0) entry->imageless--;
     } else {
         if (entry->imageless < kApolloLPMaxCount) entry->imageless++;
+        if (entry->imaged > 0) entry->imaged--;
     }
     entry->lastSeen = now;
     [self evictIfNeededLocked];
@@ -238,9 +255,9 @@ static BOOL ApolloLPHostIsIgnored(NSString *host) {
         entry = [ApolloLPShapeEntry new];
         _hosts[normalized] = entry;
     }
-    // Retract, don't just counter-balance: under the zero-counter-evidence
-    // verdict rule a stale "imaged" would otherwise outvote every later
-    // failure and keep handing this host hero placeholders forever.
+    // Same shape as an ordinary imageless observation: the fetcher already
+    // counted this host as imageful on the strength of an og:image URL that
+    // turns out to 404, so that credit has to come back off.
     if (entry->imaged > 0) entry->imaged--;
     if (entry->imageless < kApolloLPMaxCount) entry->imageless++;
     entry->lastSeen = [[NSDate date] timeIntervalSince1970];

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -16,6 +16,7 @@
 #import "ApolloBadgeBookScraper.h"   // ApolloBadgeBookInvalidate() — Clear Tweak Caches
 #import "ApolloUserProfileCache.h"
 #import "ApolloLinkPreviewCache.h"
+#import "ApolloLinkPreviewShapeMemory.h"
 #import "settings/ApolloDeletedCommentsSettingsViewController.h"
 #import "settings/ApolloLinkPreviewSettingsViewController.h"
 #import "settings/ApolloProfileLayoutViewController.h"
@@ -3248,6 +3249,9 @@ typedef NS_ENUM(NSInteger, Tag) {
     [alert addAction:[UIAlertAction actionWithTitle:@"Clear" style:UIAlertActionStyleDestructive handler:^(__unused UIAlertAction *action) {
         [[ApolloUserProfileCache sharedCache] clearAllCaches];
         [[ApolloLinkPreviewCache sharedCache] flushCache];
+        // The learned per-host card-shape verdicts are derived from those same
+        // previews, so they go with them.
+        [[ApolloLinkPreviewShapeMemory sharedMemory] reset];
         [[ApolloSubredditInfoCache sharedCache] clearAllCaches];
         ApolloBadgeBookInvalidate(nil);   // per-user earned/trophy state, memory + disk
         ApolloBannedProfileClearDismissedOverlays();


### PR DESCRIPTION
Fixes the thing where a link post in the feed shows the small compact preview card but the row is still sized for the big one, so there's a chunk of empty space under it — and then it snaps to the right size a second or so later. Only hits some posts, which is why it looks random.

> **Round 2.** The first version of this PR did not hold up on device — see [what went wrong](#what-went-wrong-in-round-1). The approach has changed from *predicting the exception* to *changing the default*.

## why this keeps coming back

The card shape gets picked twice. First for the **placeholder**, drawn *before* we've fetched anything, so it's a guess. Then again for the real render once the fetch lands. If the page turns out to have no usable image (paywall, Cloudflare wall, 403, 404, a PDF…) the real render is the compact card — but the row was already measured for a hero, ~220pt of image box vs ~104pt.

Shrinking a row can only be committed by a table row reload, and that reload gets deferred or dropped while the row isn't in `indexPathsForVisibleRows`. That's the `V24-row-reload-dropped-renote` line in my logs. So the gap sits there until you scroll the row back on screen — which is exactly what it looks like.

Every previous round here (V12/V18/V20/V21/V23/V24) has been patching the heal. This one patches the guess.

And the reason the guess was basically always wrong: the only "this one will be compact" signal was `ApolloLPCompactPlaceholderHosts` — an in-memory `NSMutableSet` behind a `dispatch_once`, 8 hardcoded hosts, thrown away every launch. So every host got re-learned by stranding a row, once per launch, forever.

## what went wrong in round 1

Round 1 kept the full-size card as the default and tried to *predict* which sites would end up compact, from a learned per-host memory. Two things killed it:

1. **The sites that strand are paywalled news.** `wsj.com` and `reuters.com` return **401** to our own fetch, `jn.pt` returns **403**. But those sites serve a perfectly good `og:image` on their *free* articles — so they never looked imageless, and kept earning a full-size placeholder that then had to collapse. (Reddit's own scraper gets the image; our on-device fetch is bot-walled. That's why the card falls back to a favicon.)
2. **The placeholder branch is the first-encounter path.** In a 3.5-hour device log, **41 of 41** placeholder renders were URLs the app had never seen, across 34 hosts. No predictor — learned or hardcoded — can answer for a site it is seeing for the first time.

Worth noting what it *isn't*: the preview cache is pinned at its 500-entry cap and evicts on every store, but there were **zero** same-URL re-fetches in that log, so cache sizing would have prevented none of the 41.

## what this does instead

Stop predicting the exception; change the default. A full-size image box is now reserved **only** for a host whose every recent preview carried an image. Unknown, mixed and known-imageless all start compact.

- Verdicts require zero counter-evidence *within a window*: each observation decays the opposite counter (cap 8). Without decay the counters only grew, so one stale observation pinned a host to "mixed" forever and the store degraded toward trusting nothing. Now "reliably imageful" means a run of successes with no recent failure.
- Bluesky posts keep their full-size placeholder — their card is pinned to that shape regardless of imagery, so starting them compact would be a guaranteed grow on every single one.
- Restored a **once-per-host** log line naming the shape and the evidence for it. #652 stripped the old placeholder-shape logging, which is why the only way to diagnose round 1 from a user report was to film the screen.

## why this direction, precisely

Not "growth is free" — that was round 1's justification and it was wrong. Committing a height change costs the same in both directions. The asymmetry is in **detection**:

- **Guessed full-size, ended compact.** A card shorter than its cell is what a normal cell looks like, so nothing can spot it by looking. Only per-node bookkeeping knows, and the row reload that heals it destroys the node holding that bookkeeping.
- **Guessed compact, ended full-size.** The card draws past the bottom of its row, which V18's stateless geometry check measures directly and re-arms on every `didEnterVisibleState`. It converges without having had to remember anything.

The wrong guess now lands in the direction the module can actually see.

The user's recording backs this up precisely: the stranded box is **not** the placeholder — it's the *final compact card* with its background stretched to a stale full-size row height (370×303pt vs the correct 370×102pt). The content was already final and compact in the first visible frame; only the height was stale. It scrolled into view **already stranded**, was fully visible and stranded from t=1.00s, and did not collapse until t=2.00s — **0.67s after the fling had stopped**, with the scroll offset unchanged across the collapse itself. The collapse is then followed by ~0.5s of visible reflow churn (one transient frame re-renders the card tall again and stacks two byline rows).

So it is not a reload that was dropped for being off-screen; it is latency in resolve→re-measure→reload, a second of which the user spends looking at it. (Being strict about what the footage does *not* show: because the row was scrolled into view shortly before it collapsed, this clip alone cannot prove a stranded row would collapse with no scrolling at all.)

## twitter / bluesky

Untouched.

- **Twitter/X** returns to Apollo's native card before any of this runs (the `isTwitterURL` bail sits above the cache read), so it can't be reached.
- **Bluesky** posts keep their hero placeholder and hero card. The store flat-out refuses to learn anything about `x.com` / `twitter.com` / `bsky.app` — which also closes an existing leak, where a non-post `bsky.app` URL falling back to a favicon could write "bsky.app" into the old memo and compact-ify every Bluesky post for the rest of the launch.

Confirmed in the sim: a `bsky.app` card still gets `ctx=hero`, and nothing bsky/twitter ever lands in the store.

## testing

Apollo-Sim2, iOS 26.5, Liquid Glass. **Not device-tested.** Both targets compile clean.

- Cold cache: **29/29 compact placeholders, zero full-size** — the stranding case cannot occur.
- After one pass: 25 reliably-imageful hosts (apnews, cnn, bloomberg, kyivindependent, news.sky.com, ndtv…) get their full-size skeleton back, so those cards do **not** grow. `reuters.com` and `lemonde.fr` hold compact verdicts.
- All 35 settled rows measured correct (full-size ~450pt / compact ~248pt), none odd.
- Grow direction filmed with a 1.6s artificial fetch delay so the placeholder stays on screen: renders clean, no gap, no overlap.

## what this doesn't cover

Hosts whose fetch comes back with no metadata at all fall through to Apollo's native card, which is a different shape change the shape memory doesn't predict. Rarer, and none of the reported cases hit it — a blocked/404 page still produces a URL-derived title, so it goes down the compact path. Left alone on purpose.

The V12/V18/V20/V21/V23/V24 heal machinery all stays. There are ~7 genuinely mixed hosts in my cache that can never be answered at host granularity, so this removes most of the shrink events, not all of them.




