### PR TITLE
Fix lists stuck under the tab bar on iOS 27

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloLiquidGlassIconPicker.xm \
     $(SRC_DIR)/ApolloModmailLayout.xm \
     $(SRC_DIR)/ApolloAutoHideTabBar.xm \
+    $(SRC_DIR)/ApolloListBottomInsetGuard.xm \
     $(SRC_DIR)/ApolloTabBarCollapseSide.xm \
     $(SRC_DIR)/ApolloIPadTabBarBottom.xm \
     $(SRC_DIR)/ApolloScrollEdgeEffect.xm \

--- a/src/ApolloListBottomInsetGuard.xm
+++ b/src/ApolloListBottomInsetGuard.xm
@@ -1,0 +1,88 @@
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import "ApolloCommon.h"
+
+// MARK: - List Bottom Inset Guard (issue #732)
+//
+// On iOS 27 (Liquid Glass), Apollo's lists can end up with their last row
+// stuck under the floating tab bar: the last comment after leaving and
+// returning to the app, the target comment of an apollo:// deep link
+// opened from another app, and the feed's load-next-page button with
+// infinite scrolling off.
+//
+// Root cause (recovered from the binary, see the issue notes): Apollo's
+// ASTableViewController recomputes each list's contentInset.bottom in its
+// layout pass as
+//     view.safeAreaInsets.bottom (+ extras: comment jump button, etc.)
+// with contentInsetAdjustmentBehavior = .never, so UIKit never corrects
+// it. On iOS 27 the tab bar's minimize state resets across app-activation
+// transitions (backgrounding, deep-link opens), and a layout pass can land
+// while the reported bottom safe area transiently excludes the tab bar.
+// Apollo bakes the too-small value into the inset; because scrolling alone
+// never dirties the view controller's layout again, the deficit sticks
+// until something forces a clean relayout (e.g. pull-to-refresh).
+//
+// Instead of repairing the damage after the fact, correct the write
+// itself: when Apollo sets a table's contentInset while its bottom safe
+// area under-reports the tab bar actually overlapping the list, add back
+// exactly that shortfall. Apollo's extras are preserved, every entry point
+// is covered (background return, deep link, load-more), and the clamped
+// scroll offset never jumps because the inset never dips. When safe area
+// and bar agree — the healthy steady state — the delta is zero and the
+// write passes through untouched.
+
+@interface ASTableView : UITableView
+@end
+
+static BOOL ApolloBottomInsetGuardEnabled(void) {
+    // The failure needs the iOS 26+ Liquid Glass floating tab bar (minimize
+    // state machine); legacy-chrome installs never hit the transient.
+    if (!IsLiquidGlass()) return NO;
+    if (@available(iOS 26.0, *)) return YES;
+    return NO;
+}
+
+static UIViewController *ApolloInsetGuardOwningViewController(UIView *view) {
+    UIResponder *responder = view;
+    while ((responder = responder.nextResponder)) {
+        if ([responder isKindOfClass:[UIViewController class]]) {
+            return (UIViewController *)responder;
+        }
+    }
+    return nil;
+}
+
+// How much of the tab bar actually overlaps the owning view's bottom edge —
+// what safeAreaInsets.bottom should be reporting while the bar is on screen.
+static CGFloat ApolloInsetGuardTabBarOverlap(UIViewController *vc) {
+    UITabBar *tabBar = vc.tabBarController.tabBar;
+    if (!tabBar || tabBar.hidden || tabBar.alpha < 0.01 || !tabBar.superview) return 0.0;
+    CGRect barInView = [tabBar.superview convertRect:tabBar.frame toView:vc.view];
+    CGFloat overlap = CGRectGetMaxY(vc.view.bounds) - CGRectGetMinY(barInView);
+    // Sanity cap: a full expanded bar plus home indicator is well under this.
+    return MAX(0.0, MIN(overlap, 200.0));
+}
+
+%hook ASTableView
+
+- (void)setContentInset:(UIEdgeInsets)inset {
+    if (!ApolloBottomInsetGuardEnabled() || !self.window ||
+        self.contentInsetAdjustmentBehavior != UIScrollViewContentInsetAdjustmentNever) {
+        %orig(inset);
+        return;
+    }
+    UIViewController *vc = ApolloInsetGuardOwningViewController(self);
+    if (!vc || !vc.tabBarController) {
+        %orig(inset);
+        return;
+    }
+    CGFloat shortfall = ApolloInsetGuardTabBarOverlap(vc) - vc.view.safeAreaInsets.bottom;
+    if (shortfall > 0.5) {
+        inset.bottom += shortfall;
+        ApolloLog(@"[ListBottomInsetGuard] Corrected bottom inset by %.1f (bar overlap not in safe area) on %@",
+                  shortfall, NSStringFromClass(vc.class));
+    }
+    %orig(inset);
+}
+
+%end

--- a/src/ApolloSimDebugTap.xm
+++ b/src/ApolloSimDebugTap.xm
@@ -18,6 +18,7 @@
 #import "ApolloCommon.h"
 #import "UIWindow+Apollo.h"
 #import <objc/message.h>
+#import <objc/runtime.h>
 
 @interface UITouch (ApolloSimDebugTap)
 - (void)setPhase:(UITouchPhase)phase;
@@ -163,11 +164,144 @@ static void ApolloSimDebugTypeText(NSString *text) {
               (unsigned long)text.length, NSStringFromClass(responder.class));
 }
 
+// "dump" command: log geometry/inset state for every on-screen scroll view and
+// tab bar, so inset regressions (e.g. issue #732) can be measured across
+// app lifecycle transitions without any UI interaction.
+static void ApolloSimDebugDumpScrollViews(UIView *view, int depth) {
+    if (!view) return;
+    if ([view isKindOfClass:[UIScrollView class]]) {
+        UIScrollView *sv = (UIScrollView *)view;
+        if (sv.frame.size.height > 100) {
+            UIEdgeInsets ci = sv.contentInset;
+            UIEdgeInsets ai = sv.adjustedContentInset;
+            UIEdgeInsets sa = sv.safeAreaInsets;
+            ApolloLog(@"[SimDump] %@ frame=%@ offset=(%.1f,%.1f) contentH=%.1f inset(T%.1f B%.1f) adjusted(T%.1f B%.1f) safeArea(T%.1f B%.1f) adjBehavior=%ld vertBounce=%d",
+                      NSStringFromClass(sv.class), NSStringFromCGRect(sv.frame),
+                      sv.contentOffset.x, sv.contentOffset.y, sv.contentSize.height,
+                      ci.top, ci.bottom, ai.top, ai.bottom, sa.top, sa.bottom,
+                      (long)sv.contentInsetAdjustmentBehavior, sv.bounces);
+        }
+    }
+    if ([view isKindOfClass:[UITabBar class]]) {
+        ApolloLog(@"[SimDump] UITabBar frame=%@ hidden=%d alpha=%.2f superH=%.1f",
+                  NSStringFromCGRect(view.frame), view.hidden, view.alpha,
+                  view.superview.bounds.size.height);
+    }
+    for (UIView *sub in view.subviews) {
+        ApolloSimDebugDumpScrollViews(sub, depth + 1);
+    }
+}
+
+static void ApolloSimDebugPerformDump(void) {
+    for (UIWindow *window in ApolloAllWindows()) {
+        if (window.hidden) continue;
+        ApolloLog(@"[SimDump] === window %@ ===", NSStringFromClass(window.class));
+        ApolloSimDebugDumpScrollViews(window, 0);
+        UIViewController *root = window.rootViewController;
+        UIViewController *vc = root;
+        while (vc && ![vc isKindOfClass:[UITabBarController class]]) {
+            vc = vc.childViewControllers.firstObject;
+        }
+        if ([vc isKindOfClass:[UITabBarController class]]) {
+            UITabBarController *tbc = (UITabBarController *)vc;
+            NSNumber *minBehavior = nil;
+            SEL sel = NSSelectorFromString(@"tabBarMinimizeBehavior");
+            if ([tbc respondsToSelector:sel]) {
+                NSInteger v = ((NSInteger (*)(id, SEL))objc_msgSend)(tbc, sel);
+                minBehavior = @(v);
+            }
+            NSNumber *minimized = nil;
+            SEL minSel = NSSelectorFromString(@"isTabBarMinimized");
+            if ([tbc respondsToSelector:minSel]) {
+                minimized = @(((BOOL (*)(id, SEL))objc_msgSend)(tbc, minSel));
+            }
+            ApolloLog(@"[SimDump] TabBarController minimizeBehavior=%@ minimized=%@ safeArea(B%.1f)",
+                      minBehavior ?: @"n/a", minimized ?: @"n/a",
+                      tbc.view.safeAreaInsets.bottom);
+        }
+    }
+    ApolloLog(@"[SimDump] === end ===");
+}
+
+// "fakesafe N" command: make every UIView's safeAreaInsets.bottom
+// under-report by N points — emulating the iOS 27 device transient where a
+// layout pass sees a bottom safe area that excludes the tab bar (issue
+// #732) — then dirty all layout so Apollo's inset math reruns against the
+// faked value. "fakesafe 0" restores reality. Sim-only test harness for
+// ApolloListBottomInsetGuard.
+//
+// Manual swizzle rather than %hook: Logos emits hook-registration glue at
+// the end of the file, OUTSIDE this #if APOLLO_SIM_BUILD region, which
+// breaks device builds. The swizzle is installed lazily on first use.
+static CGFloat sApolloSimFakeSafeAreaDeficit = 0.0;
+static UIEdgeInsets (*sApolloSimOrigSafeAreaInsets)(id, SEL);
+
+static UIEdgeInsets ApolloSimFakedSafeAreaInsets(id self, SEL _cmd) {
+    UIEdgeInsets insets = sApolloSimOrigSafeAreaInsets(self, _cmd);
+    if (sApolloSimFakeSafeAreaDeficit > 0.0) {
+        insets.bottom = MAX(0.0, insets.bottom - sApolloSimFakeSafeAreaDeficit);
+    }
+    return insets;
+}
+
+static void ApolloSimInstallFakeSafeAreaHook(void) {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        Method method = class_getInstanceMethod([UIView class], @selector(safeAreaInsets));
+        if (!method) return;
+        sApolloSimOrigSafeAreaInsets = (UIEdgeInsets (*)(id, SEL))method_getImplementation(method);
+        method_setImplementation(method, (IMP)ApolloSimFakedSafeAreaInsets);
+    });
+}
+
+static void ApolloSimDebugDirtyAllLayout(UIView *view) {
+    [view setNeedsLayout];
+    for (UIView *sub in view.subviews) {
+        ApolloSimDebugDirtyAllLayout(sub);
+    }
+}
+
 static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *observer,
                                           CFStringRef name, const void *object, CFDictionaryRef userInfo) {
     dispatch_async(dispatch_get_main_queue(), ^{
         NSString *contents = [NSString stringWithContentsOfFile:kApolloSimTapFile
                                                        encoding:NSUTF8StringEncoding error:nil];
+        if ([contents hasPrefix:@"dump"]) {
+            ApolloSimDebugPerformDump();
+            return;
+        }
+        if ([contents hasPrefix:@"fakesafe "]) {
+            ApolloSimInstallFakeSafeAreaHook();
+            sApolloSimFakeSafeAreaDeficit = [[contents substringFromIndex:9] doubleValue];
+            for (UIWindow *window in ApolloAllWindows()) {
+                if (window.hidden) continue;
+                ApolloSimDebugDirtyAllLayout(window);
+                [window layoutIfNeeded];
+            }
+            ApolloLog(@"[SimDump] fakesafe deficit=%.1f applied + relayout forced",
+                      sApolloSimFakeSafeAreaDeficit);
+            return;
+        }
+        // "minbehavior N" command: set the main tab bar controller's
+        // tabBarMinimizeBehavior (1=never → expands a minimized bar,
+        // 2=onScrollDown) to emulate iOS 27's expand-on-foreground reset.
+        if ([contents hasPrefix:@"minbehavior "]) {
+            NSInteger value = [[contents substringFromIndex:12] integerValue];
+            for (UIWindow *window in ApolloAllWindows()) {
+                UIViewController *vc = window.rootViewController;
+                while (vc && ![vc isKindOfClass:[UITabBarController class]]) {
+                    vc = vc.childViewControllers.firstObject;
+                }
+                if (![vc isKindOfClass:[UITabBarController class]]) continue;
+                SEL sel = NSSelectorFromString(@"setTabBarMinimizeBehavior:");
+                if ([vc respondsToSelector:sel]) {
+                    ((void (*)(id, SEL, NSInteger))objc_msgSend)(vc, sel, value);
+                    ApolloLog(@"[SimDump] set tabBarMinimizeBehavior=%ld", (long)value);
+                }
+                break;
+            }
+            return;
+        }
         if ([contents hasPrefix:@"text "]) {
             NSString *payload = [[contents substringFromIndex:5] stringByTrimmingCharactersInSet:
                 NSCharacterSet.newlineCharacterSet];


### PR DESCRIPTION
Fixes #732 (duplicate: #619).

## Symptom

On iOS 27 with the Liquid Glass variant, list content gets stuck under the floating tab bar. Reported manifestations (issue + Reddit thread):

- The last comment of a thread after leaving and returning to the app, with a visible scroll jump on resume ([#732](https://github.com/Apollo-Reborn/Apollo-Reborn/issues/732))
- The target comment of an `apollo://` deep link opened from another app — it can't be scrolled into view
- The feed's load-next-page button with infinite scrolling off

Pull-to-refresh heals it; leaving and returning re-breaks it. 26.5 is unaffected (confirmed by icpryde on the 26.5 sim and in the Reddit thread).

## Root cause

Recovered from the binary: Apollo's `ASTableViewController` recomputes each list's `contentInset.bottom` in its layout pass as `view.safeAreaInsets.bottom` + extras (e.g. the 70pt comment jump button), with `contentInsetAdjustmentBehavior = .never` — so UIKit never corrects it. Healthy values on iOS 27: comments 83 + 70 = 153, feed 83.

On iOS 27 the tab bar's minimize state resets across app-activation transitions, and a layout pass can land while the reported bottom safe area transiently excludes the tab bar. Apollo bakes the too-small value into the inset, the clamped bottom offset gets dragged down with it (the visible jump), and because plain scrolling never dirties the view controller's layout, the deficit sticks until something forces a clean relayout — exactly why pull-to-refresh fixes it.

## Fix

`ApolloListBottomInsetGuard` corrects the write at the source: a hook on `-[ASTableView setContentInset:]` (iOS 26+ Liquid Glass only, tab-bar-hosted lists only, `.never` adjustment only) adds back the exact shortfall whenever the owning view's bottom safe area under-reports the tab bar actually overlapping the list. Apollo's own extras are preserved because only the safe-area deficit is compensated; when safe area and bar agree — the healthy steady state — the delta is zero and every write passes through untouched. Because the inset never dips, the offset never gets clamped down, so the resume-time scroll jump disappears too. All three manifestations are covered by construction, including deep links into freshly created comment views.

## Verification

The iOS 27 simulator (24A5380i) doesn't exhibit the OS transient itself, so the sim debug bridge gained a `fakesafe N` command (sim-only builds) that globally under-reports `safeAreaInsets.bottom` by N and forces a relayout — running Apollo's real inset recompute against the same bad input the device sees:

- Comments thread scrolled to the bottom, `fakesafe 49`: guard logs `Corrected bottom inset by 49.0 … on Apollo.CommentsViewController`; inset holds 153 and the offset holds the exact bottom-pinned value — no jump.
- Feed, `fakesafe 49`: same correction on `Apollo.PostsViewController`, inset holds 83 (covers the load-next-page case).
- `fakesafe 0`: zero corrections logged during normal browsing/navigation — the guard is a strict pass-through.
- `make package` (device) and the simulator build both pass.

Needs a confirmation pass on a real iOS 27 device (reporter says it reproduces every time), since the sim can't trigger the OS-level transient organically.