### PR TITLE
Gallery View: browse an image subreddit as a grid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloGalleryImageLoader.m \
     $(SRC_DIR)/ApolloGalleryImageViewer.m \
     $(SRC_DIR)/ApolloGalleryViewController.m \
+    $(SRC_DIR)/ApolloGalleryVideoExport.xm \
     $(SRC_DIR)/ApolloGalleryMenu.xm \
     $(SRC_DIR)/ApolloBannedProfile.xm \
     $(SRC_DIR)/ApolloImageUploadHost.xm \

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,11 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloPublicStickyAsSubreddit.xm \
     $(SRC_DIR)/ApolloSubredditHeaders.xm \
     $(SRC_DIR)/ApolloSubredditHighlights.xm \
+    $(SRC_DIR)/ApolloGalleryFeed.m \
+    $(SRC_DIR)/ApolloGalleryImageLoader.m \
+    $(SRC_DIR)/ApolloGalleryImageViewer.m \
+    $(SRC_DIR)/ApolloGalleryViewController.m \
+    $(SRC_DIR)/ApolloGalleryMenu.xm \
     $(SRC_DIR)/ApolloBannedProfile.xm \
     $(SRC_DIR)/ApolloImageUploadHost.xm \
     $(SRC_DIR)/ApolloPhotoPostComposerScrollFix.xm \

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -168,8 +168,9 @@ void ApolloAppendLoginDiag(NSString *line);
 NSString *ApolloDebugAccountKeychainReport(void);
 NSString *ApolloDebugPoisonAccountAccessibility(void);
 
-// ApolloGalleryMenu: when the subreddit "..." menu is being built, prepend an
-// inline "Gallery View" section to `children` (an NSMutableArray<UIMenuElement *>).
+// ApolloGalleryMenu: when the subreddit "..." menu is being built, insert an
+// inline "Gallery View" section into `children` (an NSMutableArray<UIMenuElement *>),
+// just below the leading "submit a post" affordance.
 // No-op for any other menu, and for feeds that aren't a single subreddit.
 // Called from ApolloNativeActionMenuBuildMenu as it converts the action sheet.
 void ApolloInjectGalleryViewMenuItemIfNeeded(NSMutableArray *children, NSString *menuTitle, id actionController);

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -167,4 +167,10 @@ void ApolloAppendLoginDiag(NSString *line);
 // also write to the diag log.
 NSString *ApolloDebugAccountKeychainReport(void);
 NSString *ApolloDebugPoisonAccountAccessibility(void);
+
+// ApolloGalleryMenu: when the subreddit "..." menu is being built, prepend an
+// inline "Gallery View" section to `children` (an NSMutableArray<UIMenuElement *>).
+// No-op for any other menu, and for feeds that aren't a single subreddit.
+// Called from ApolloNativeActionMenuBuildMenu as it converts the action sheet.
+void ApolloInjectGalleryViewMenuItemIfNeeded(NSMutableArray *children, NSString *menuTitle, id actionController);
 __END_DECLS

--- a/src/ApolloGalleryFeed.h
+++ b/src/ApolloGalleryFeed.h
@@ -31,12 +31,35 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-// One displayable picture. A single Reddit post yields one item for a normal
-// image post and N items for a gallery post (galleryCount > 1).
+// What a tile actually is. A bitmask so the filter can allow any combination.
+typedef NS_OPTIONS(NSUInteger, ApolloGalleryMediaKind) {
+    ApolloGalleryMediaKindPhoto = 1 << 0,   // still image
+    ApolloGalleryMediaKindGIF   = 1 << 1,   // silent loop — animated GIF *or* an mp4 Reddit transcoded one into
+    ApolloGalleryMediaKindVideo = 1 << 2,   // real video, usually with sound
+};
+static ApolloGalleryMediaKind const ApolloGalleryMediaKindAll =
+    ApolloGalleryMediaKindPhoto | ApolloGalleryMediaKindGIF | ApolloGalleryMediaKindVideo;
+
+// One displayable piece of media. A single Reddit post yields one item for a
+// normal image/video post and N items for a gallery post (galleryCount > 1).
 @interface ApolloGalleryItem : NSObject
 
-// Full-resolution image used by the fullscreen viewer.
+@property (nonatomic) ApolloGalleryMediaKind kind;
+
+// Full-resolution still. For video/GIF items this is the poster frame, shown
+// while the stream spins up.
 @property (nonatomic, copy) NSURL *imageURL;
+
+// Playable stream for GIF-as-mp4 and video items, nil for stills and for GIFs
+// backed by an actual animated .gif file (those animate through the image
+// loader instead). May be HLS (.m3u8) or a progressive mp4.
+@property (nonatomic, copy, nullable) NSURL *videoURL;
+// A self-contained mp4 that can be written to Photos, when one exists. Left nil
+// for v.redd.it, whose mp4 fallback carries no audio — saving it would silently
+// produce a mute copy, so Save is hidden there rather than lying.
+@property (nonatomic, copy, nullable) NSURL *videoDownloadURL;
+// Runtime in seconds; 0 when Reddit didn't report one.
+@property (nonatomic) NSTimeInterval duration;
 // Smaller preview used by the grid; falls back to imageURL when Reddit gave
 // us no resolutions to pick from.
 @property (nonatomic, copy) NSURL *thumbnailURL;
@@ -52,7 +75,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) BOOL isNSFW;
 @property (nonatomic) BOOL isSpoiler;
-@property (nonatomic) BOOL isAnimated;   // GIF; the viewer animates these
 
 // Position within a multi-image gallery post (0-based). galleryCount is 1 for
 // ordinary image posts.
@@ -63,6 +85,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSURL *postURL;
 // YES when the grid should blur this item's thumbnail.
 @property (nonatomic, readonly) BOOL shouldBlurThumbnail;
+// YES when the viewer should drive this item with AVPlayer rather than the
+// image loader.
+@property (nonatomic, readonly) BOOL playsAsVideo;
+// "0:42" / "1:23:45", or nil when the duration is unknown.
+@property (nonatomic, readonly, nullable) NSString *durationText;
 
 @end
 
@@ -91,7 +118,19 @@ typedef NS_ENUM(NSInteger, ApolloGalleryTopWindow) {
 - (instancetype)init NS_UNAVAILABLE;
 
 @property (nonatomic, readonly, copy) NSString *subreddit;
+// The items the UI should show: everything fetched so far, minus the kinds the
+// filter excludes. Filtering happens here rather than at parse time so toggling
+// a kind is instant and never costs a refetch.
 @property (nonatomic, readonly) NSArray<ApolloGalleryItem *> *items;
+// Everything fetched, whatever the filter says. Only useful for counts.
+@property (nonatomic, readonly) NSArray<ApolloGalleryItem *> *allItems;
+
+// Which kinds `items` includes. Never 0 — clearing the last kind is rejected,
+// since an empty gallery is never what someone meant. Persisted across launches.
+@property (nonatomic) ApolloGalleryMediaKind allowedKinds;
+// How many of everything fetched so far are of `kind`, for the filter menu's
+// subtitles.
+- (NSUInteger)countOfKind:(ApolloGalleryMediaKind)kind;
 
 // Changing either resets the feed (items cleared, cursor dropped). Use
 // -setSort:topWindow: to change both at once so only one reset happens.
@@ -110,7 +149,8 @@ typedef NS_ENUM(NSInteger, ApolloGalleryTopWindow) {
 @property (nonatomic, readonly) NSString *sortDisplayName;
 
 // Loads the next batch, walking as many listing pages as it takes to gather a
-// batch worth of pictures (image posts are sparse in mixed subreddits). The
+// batch worth of media the CURRENT FILTER admits (a video-only filter on a
+// mostly-photo subreddit would otherwise return a page of nothing). The
 // completion runs on the main thread with the index range appended to `items`;
 // `addedCount` is 0 when the batch found nothing new. A call made while a load
 // is already in flight, or after the feed is exhausted, completes immediately

--- a/src/ApolloGalleryFeed.h
+++ b/src/ApolloGalleryFeed.h
@@ -1,0 +1,125 @@
+// ApolloGalleryFeed.h
+//
+// Gallery View — the paged media feed behind the subreddit "Gallery View"
+// screen (see ApolloGalleryViewController / ApolloGalleryImageViewer).
+//
+// Image-focused subreddits are painful to browse post-by-post: every picture
+// costs a tap into comments and a tap back out. Gallery View flattens the
+// subreddit's listing into a scrolling grid of just the pictures, and taps
+// straight through to a fullscreen pager.
+//
+// This file is the data layer only: fetch a listing page, keep the `after`
+// cursor, turn each post into zero or more ApolloGalleryItems, and hand the
+// new items back. It has no UI dependencies.
+//
+// Auth: both supported modes work without any special-casing here.
+//   • API-key (OAuth) accounts — sLatestRedditBearerToken is a live bearer, so
+//     the request goes to oauth.reddit.com with an Authorization header, the
+//     same way ApolloSubredditHighlights fetches.
+//   • Keyless (web-session) accounts — the identity layer never populates
+//     sLatestRedditBearerToken with a real token, so we address
+//     www.reddit.com/...json instead; the __NSCFLocalSessionTask chokepoint in
+//     Tweak.xm hands that to ApolloWebJSONRewriteRequest, which attaches the
+//     harvested session cookie (listing reads are a routable path). Nothing
+//     here has to know which mode is active.
+//   • Signed out / neither — the www.reddit.com public JSON is used as-is.
+// If the first attempt comes back 401/403 the fetch retries once on the other
+// host, so a stale captured bearer can't strand the gallery.
+
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// One displayable picture. A single Reddit post yields one item for a normal
+// image post and N items for a gallery post (galleryCount > 1).
+@interface ApolloGalleryItem : NSObject
+
+// Full-resolution image used by the fullscreen viewer.
+@property (nonatomic, copy) NSURL *imageURL;
+// Smaller preview used by the grid; falls back to imageURL when Reddit gave
+// us no resolutions to pick from.
+@property (nonatomic, copy) NSURL *thumbnailURL;
+// Source pixel dimensions, used to lay the masonry grid out before the image
+// has loaded. CGSizeZero when Reddit didn't report them.
+@property (nonatomic) CGSize pixelSize;
+
+@property (nonatomic, copy, nullable) NSString *postTitle;
+@property (nonatomic, copy, nullable) NSString *author;      // no "u/" prefix
+@property (nonatomic, copy, nullable) NSString *subreddit;   // no "r/" prefix
+@property (nonatomic, copy, nullable) NSString *permalink;   // "/r/x/comments/..."
+@property (nonatomic, copy, nullable) NSString *postFullname; // "t3_..."
+
+@property (nonatomic) BOOL isNSFW;
+@property (nonatomic) BOOL isSpoiler;
+@property (nonatomic) BOOL isAnimated;   // GIF; the viewer animates these
+
+// Position within a multi-image gallery post (0-based). galleryCount is 1 for
+// ordinary image posts.
+@property (nonatomic) NSInteger galleryIndex;
+@property (nonatomic) NSInteger galleryCount;
+
+// Absolute reddit.com URL for the post, for share/open actions.
+@property (nonatomic, readonly, nullable) NSURL *postURL;
+// YES when the grid should blur this item's thumbnail.
+@property (nonatomic, readonly) BOOL shouldBlurThumbnail;
+
+@end
+
+// Listing sorts offered by the gallery's own sort menu. `top` and `controversial`
+// carry a time window; the others ignore it.
+typedef NS_ENUM(NSInteger, ApolloGallerySort) {
+    ApolloGallerySortHot = 0,
+    ApolloGallerySortNew,
+    ApolloGallerySortTop,
+    ApolloGallerySortRising,
+};
+
+typedef NS_ENUM(NSInteger, ApolloGalleryTopWindow) {
+    ApolloGalleryTopWindowDay = 0,
+    ApolloGalleryTopWindowWeek,
+    ApolloGalleryTopWindowMonth,
+    ApolloGalleryTopWindowYear,
+    ApolloGalleryTopWindowAll,
+};
+
+// A subreddit's media feed. Not thread-safe: drive it from the main thread
+// (completions are always delivered there).
+@interface ApolloGalleryFeed : NSObject
+
+- (instancetype)initWithSubreddit:(NSString *)subreddit NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+@property (nonatomic, readonly, copy) NSString *subreddit;
+@property (nonatomic, readonly) NSArray<ApolloGalleryItem *> *items;
+
+// Changing either resets the feed (items cleared, cursor dropped). Use
+// -setSort:topWindow: to change both at once so only one reset happens.
+@property (nonatomic) ApolloGallerySort sort;
+@property (nonatomic) ApolloGalleryTopWindow topWindow;
+- (void)setSort:(ApolloGallerySort)sort topWindow:(ApolloGalleryTopWindow)topWindow;
+
+@property (nonatomic, readonly, getter=isLoading) BOOL loading;
+// YES once Reddit stops handing back a cursor, or after enough consecutive
+// media-free pages that continuing is pointless.
+@property (nonatomic, readonly, getter=isExhausted) BOOL exhausted;
+// Set when the last load failed; cleared by the next successful load.
+@property (nonatomic, readonly, copy, nullable) NSString *lastErrorMessage;
+
+// Human-readable label for the current sort, e.g. "Top: This Week".
+@property (nonatomic, readonly) NSString *sortDisplayName;
+
+// Loads the next batch, walking as many listing pages as it takes to gather a
+// batch worth of pictures (image posts are sparse in mixed subreddits). The
+// completion runs on the main thread with the index range appended to `items`;
+// `addedCount` is 0 when the batch found nothing new. A call made while a load
+// is already in flight, or after the feed is exhausted, completes immediately
+// with addedCount 0 and does not start a second request.
+- (void)loadNextBatchWithCompletion:(nullable void (^)(NSRange addedRange, NSString *_Nullable errorMessage))completion;
+
+// Drops every item and the cursor so the next load starts from the top.
+- (void)reset;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ApolloGalleryFeed.h
+++ b/src/ApolloGalleryFeed.h
@@ -54,9 +54,9 @@ static ApolloGalleryMediaKind const ApolloGalleryMediaKindAll =
 // backed by an actual animated .gif file (those animate through the image
 // loader instead). May be HLS (.m3u8) or a progressive mp4.
 @property (nonatomic, copy, nullable) NSURL *videoURL;
-// A self-contained mp4 that can be written to Photos, when one exists. Left nil
-// for v.redd.it, whose mp4 fallback carries no audio — saving it would silently
-// produce a mute copy, so Save is hidden there rather than lying.
+// The mp4 to save from. For v.redd.it this is the video-only fallback, which
+// ApolloGalleryVideoExport recognises and re-unites with the separate DASH
+// audio before writing to Photos; everywhere else it's already self-contained.
 @property (nonatomic, copy, nullable) NSURL *videoDownloadURL;
 // Runtime in seconds; 0 when Reddit didn't report one.
 @property (nonatomic) NSTimeInterval duration;

--- a/src/ApolloGalleryFeed.h
+++ b/src/ApolloGalleryFeed.h
@@ -126,7 +126,9 @@ typedef NS_ENUM(NSInteger, ApolloGalleryTopWindow) {
 @property (nonatomic, readonly) NSArray<ApolloGalleryItem *> *allItems;
 
 // Which kinds `items` includes. Never 0 — clearing the last kind is rejected,
-// since an empty gallery is never what someone meant. Persisted across launches.
+// since an empty gallery is never what someone meant. Scoped to THIS feed (one
+// gallery visit): every gallery opens with all kinds on, and a filter chosen in
+// one subreddit never follows you into another.
 @property (nonatomic) ApolloGalleryMediaKind allowedKinds;
 // How many of everything fetched so far are of `kind`, for the filter menu's
 // subtitles.

--- a/src/ApolloGalleryFeed.m
+++ b/src/ApolloGalleryFeed.m
@@ -1,0 +1,567 @@
+// ApolloGalleryFeed.m — see ApolloGalleryFeed.h for the feature overview.
+
+#import "ApolloGalleryFeed.h"
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+
+// How many pictures one "batch" should try to gather before the UI is told to
+// stop. Reddit listings mix text/link/video posts in, so a batch usually spans
+// more than one listing page.
+static NSInteger const kApolloGalleryBatchSize = 24;
+// Listing page size asked of Reddit (its hard cap is 100).
+static NSInteger const kApolloGalleryListingLimit = 100;
+// Safety valve: never walk more than this many listing pages for one batch, so
+// a subreddit with almost no images can't turn a single scroll into a long
+// chain of requests.
+static NSInteger const kApolloGalleryMaxPagesPerBatch = 4;
+// Consecutive listing pages that yielded no pictures before we call the feed
+// exhausted. Reddit sometimes serves a media-free page mid-listing, so one
+// empty page alone isn't enough evidence to stop.
+static NSInteger const kApolloGalleryEmptyPageLimit = 3;
+
+static NSTimeInterval const kApolloGalleryRequestTimeout = 20.0;
+
+#pragma mark - Small JSON helpers
+
+static NSString *ApolloGalleryString(id value) {
+    return [value isKindOfClass:[NSString class]] ? (NSString *)value : nil;
+}
+
+static NSDictionary *ApolloGalleryDict(id value) {
+    return [value isKindOfClass:[NSDictionary class]] ? (NSDictionary *)value : nil;
+}
+
+static NSArray *ApolloGalleryArray(id value) {
+    return [value isKindOfClass:[NSArray class]] ? (NSArray *)value : nil;
+}
+
+static BOOL ApolloGalleryBool(id value) {
+    return [value isKindOfClass:[NSNumber class]] && ((NSNumber *)value).boolValue;
+}
+
+static CGFloat ApolloGalleryNumber(id value) {
+    return [value isKindOfClass:[NSNumber class]] ? (CGFloat)((NSNumber *)value).doubleValue : 0.0;
+}
+
+static NSURL *ApolloGalleryURL(id value) {
+    NSString *string = ApolloGalleryString(value);
+    if (string.length == 0) return nil;
+    // raw_json=1 suppresses HTML entity escaping, but gallery `media_metadata`
+    // URLs have been observed to keep &amp; regardless, so unescape defensively.
+    if ([string containsString:@"&amp;"]) {
+        string = [string stringByReplacingOccurrencesOfString:@"&amp;" withString:@"&"];
+    }
+    NSURL *url = [NSURL URLWithString:string];
+    NSString *scheme = url.scheme.lowercaseString;
+    if (![scheme isEqualToString:@"http"] && ![scheme isEqualToString:@"https"]) return nil;
+    return url;
+}
+
+// YES for a URL whose path looks like a still image we can decode.
+static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
+    NSString *extension = url.pathExtension.lowercaseString;
+    if (extension.length == 0) return NO;
+    static NSSet<NSString *> *extensions;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        extensions = [NSSet setWithArray:@[@"jpg", @"jpeg", @"png", @"gif", @"webp", @"bmp", @"heic"]];
+    });
+    return [extensions containsObject:extension];
+}
+
+#pragma mark - ApolloGalleryItem
+
+@implementation ApolloGalleryItem
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _galleryCount = 1;
+    }
+    return self;
+}
+
+- (NSURL *)postURL {
+    if (self.permalink.length == 0) return nil;
+    NSString *path = self.permalink;
+    if (![path hasPrefix:@"/"]) path = [@"/" stringByAppendingString:path];
+    return [NSURL URLWithString:[@"https://www.reddit.com" stringByAppendingString:path]];
+}
+
+- (BOOL)shouldBlurThumbnail {
+    // Mirrors what the feed itself does for flagged posts: obscure the picture
+    // in the grid, show it plainly once the user opens it deliberately.
+    return self.isNSFW || self.isSpoiler;
+}
+
+@end
+
+#pragma mark - ApolloGalleryFeed
+
+@interface ApolloGalleryFeed ()
+@property (nonatomic, copy) NSString *subreddit;
+@property (nonatomic, strong) NSMutableArray<ApolloGalleryItem *> *mutableItems;
+// Full-size image URLs already emitted, so a post that resurfaces on a later
+// listing page (or a repost of the same file) doesn't duplicate a tile.
+@property (nonatomic, strong) NSMutableSet<NSString *> *seenImageKeys;
+@property (nonatomic, copy, nullable) NSString *afterCursor;
+@property (nonatomic, getter=isLoading) BOOL loading;
+@property (nonatomic, getter=isExhausted) BOOL exhausted;
+@property (nonatomic, copy, nullable) NSString *lastErrorMessage;
+@property (nonatomic) NSInteger consecutiveEmptyPages;
+// Bumped by -reset and by a sort change; an in-flight load whose generation no
+// longer matches drops its results instead of appending them to a feed the
+// user has already re-pointed somewhere else.
+@property (nonatomic) NSUInteger generation;
+@end
+
+@implementation ApolloGalleryFeed
+
+- (instancetype)initWithSubreddit:(NSString *)subreddit {
+    self = [super init];
+    if (self) {
+        _subreddit = [subreddit copy] ?: @"";
+        _mutableItems = [NSMutableArray array];
+        _seenImageKeys = [NSMutableSet set];
+        _sort = ApolloGallerySortHot;
+        _topWindow = ApolloGalleryTopWindowWeek;
+    }
+    return self;
+}
+
+- (NSArray<ApolloGalleryItem *> *)items {
+    return self.mutableItems;
+}
+
+- (void)setSort:(ApolloGallerySort)sort {
+    if (_sort == sort) return;
+    _sort = sort;
+    [self reset];
+}
+
+- (void)setTopWindow:(ApolloGalleryTopWindow)topWindow {
+    if (_topWindow == topWindow) return;
+    _topWindow = topWindow;
+    // The window only affects the "top" listing, so changing it under any other
+    // sort costs nothing and shouldn't throw the loaded pictures away.
+    if (_sort == ApolloGallerySortTop) [self reset];
+}
+
+- (void)setSort:(ApolloGallerySort)sort topWindow:(ApolloGalleryTopWindow)topWindow {
+    BOOL sortChanged = (_sort != sort);
+    BOOL windowChanged = (_topWindow != topWindow);
+    if (!sortChanged && !windowChanged) return;
+    // Assign the ivars directly, then reset once — going through the property
+    // setters would reset twice when both change.
+    _sort = sort;
+    _topWindow = topWindow;
+    if (sortChanged || sort == ApolloGallerySortTop) [self reset];
+}
+
+- (void)reset {
+    self.generation += 1;
+    [self.mutableItems removeAllObjects];
+    [self.seenImageKeys removeAllObjects];
+    self.afterCursor = nil;
+    self.exhausted = NO;
+    self.loading = NO;
+    self.lastErrorMessage = nil;
+    self.consecutiveEmptyPages = 0;
+}
+
+#pragma mark Sort plumbing
+
+- (NSString *)sortPathComponent {
+    switch (self.sort) {
+        case ApolloGallerySortNew:    return @"new";
+        case ApolloGallerySortTop:    return @"top";
+        case ApolloGallerySortRising: return @"rising";
+        case ApolloGallerySortHot:
+        default:                      return @"hot";
+    }
+}
+
+- (NSString *)topWindowParameter {
+    switch (self.topWindow) {
+        case ApolloGalleryTopWindowDay:   return @"day";
+        case ApolloGalleryTopWindowMonth: return @"month";
+        case ApolloGalleryTopWindowYear:  return @"year";
+        case ApolloGalleryTopWindowAll:   return @"all";
+        case ApolloGalleryTopWindowWeek:
+        default:                          return @"week";
+    }
+}
+
+- (NSString *)sortDisplayName {
+    switch (self.sort) {
+        case ApolloGallerySortNew:    return @"New";
+        case ApolloGallerySortRising: return @"Rising";
+        case ApolloGallerySortTop: {
+            switch (self.topWindow) {
+                case ApolloGalleryTopWindowDay:   return @"Top: Today";
+                case ApolloGalleryTopWindowMonth: return @"Top: This Month";
+                case ApolloGalleryTopWindowYear:  return @"Top: This Year";
+                case ApolloGalleryTopWindowAll:   return @"Top: All Time";
+                case ApolloGalleryTopWindowWeek:
+                default:                          return @"Top: This Week";
+            }
+        }
+        case ApolloGallerySortHot:
+        default:                      return @"Hot";
+    }
+}
+
+#pragma mark Requests
+
+- (NSString *)escapedSubreddit {
+    NSMutableCharacterSet *allowed = [[NSCharacterSet alphanumericCharacterSet] mutableCopy];
+    [allowed addCharactersInString:@"_-"];
+    return [self.subreddit stringByAddingPercentEncodingWithAllowedCharacters:allowed] ?: self.subreddit;
+}
+
+// `useOAuthHost` picks the transport:
+//   YES -> oauth.reddit.com + Authorization: Bearer (real API-key accounts)
+//   NO  -> www.reddit.com/....json, which the Tweak.xm session chokepoint
+//          rewrites onto the harvested web-session cookie for keyless accounts
+//          and leaves alone (public JSON) when nobody is signed in.
+- (NSURLRequest *)requestForCursor:(NSString *)after useOAuthHost:(BOOL)useOAuthHost {
+    NSString *escaped = [self escapedSubreddit];
+    NSMutableString *query = [NSMutableString stringWithFormat:@"limit=%ld&raw_json=1",
+                              (long)kApolloGalleryListingLimit];
+    if (self.sort == ApolloGallerySortTop) {
+        [query appendFormat:@"&t=%@", [self topWindowParameter]];
+    }
+    if (after.length > 0) {
+        [query appendFormat:@"&after=%@", after];
+    }
+
+    NSString *urlString = useOAuthHost
+        ? [NSString stringWithFormat:@"https://oauth.reddit.com/r/%@/%@?%@", escaped, [self sortPathComponent], query]
+        : [NSString stringWithFormat:@"https://www.reddit.com/r/%@/%@.json?%@", escaped, [self sortPathComponent], query];
+
+    NSURL *url = [NSURL URLWithString:urlString];
+    if (!url) return nil;
+
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+    request.timeoutInterval = kApolloGalleryRequestTimeout;
+    if (useOAuthHost) {
+        NSString *token = [sLatestRedditBearerToken copy];
+        if (token.length > 0) {
+            [request setValue:[@"Bearer " stringByAppendingString:token] forHTTPHeaderField:@"Authorization"];
+        }
+    }
+    [request setValue:(sUserAgent.length > 0 ? sUserAgent : @"ApolloGallery/1.0") forHTTPHeaderField:@"User-Agent"];
+    return request;
+}
+
+// One listing page. Calls back on an arbitrary queue with the parsed listing
+// `data` dictionary, or nil plus an error message.
+- (void)fetchPageWithCursor:(NSString *)after
+                 completion:(void (^)(NSDictionary *_Nullable listing, NSString *_Nullable errorMessage))completion {
+    // A real captured bearer means this install is running API keys; without
+    // one we're either keyless (cookie rewrite downstream) or signed out.
+    BOOL preferOAuth = sLatestRedditBearerToken.length > 0;
+    [self fetchPageWithCursor:after useOAuthHost:preferOAuth allowRetry:YES completion:completion];
+}
+
+- (void)fetchPageWithCursor:(NSString *)after
+               useOAuthHost:(BOOL)useOAuthHost
+                 allowRetry:(BOOL)allowRetry
+                 completion:(void (^)(NSDictionary *_Nullable listing, NSString *_Nullable errorMessage))completion {
+    NSURLRequest *request = [self requestForCursor:after useOAuthHost:useOAuthHost];
+    if (!request) {
+        completion(nil, @"Couldn't build the request for this subreddit.");
+        return;
+    }
+
+    // No retain cycle to avoid here (self never holds the task), but staying
+    // weak means a torn-down feed's in-flight page can't keep it alive; the
+    // completion is still always invoked so callers never hang.
+    __weak typeof(self) weakSelf = self;
+    [[[NSURLSession sharedSession] dataTaskWithRequest:request
+                                    completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) {
+            completion(nil, nil);
+            return;
+        }
+        NSInteger status = [response isKindOfClass:[NSHTTPURLResponse class]]
+            ? ((NSHTTPURLResponse *)response).statusCode : -1;
+
+        // An auth failure on one transport is worth one attempt on the other:
+        // a captured bearer can be stale, and a cookie session can be missing.
+        if (allowRetry && (status == 401 || status == 403)) {
+            ApolloLog(@"[Gallery] listing %ld on %@ host; retrying on the other host",
+                      (long)status, useOAuthHost ? @"oauth" : @"www");
+            [strongSelf fetchPageWithCursor:after
+                               useOAuthHost:!useOAuthHost
+                                 allowRetry:NO
+                                 completion:completion];
+            return;
+        }
+
+        if (error) {
+            ApolloLog(@"[Gallery] listing r/%@ failed: %@", strongSelf.subreddit, error.localizedDescription);
+            completion(nil, error.localizedDescription ?: @"Network error.");
+            return;
+        }
+        if (status < 200 || status >= 300) {
+            ApolloLog(@"[Gallery] listing r/%@ HTTP %ld", strongSelf.subreddit, (long)status);
+            completion(nil, [NSString stringWithFormat:@"Reddit returned HTTP %ld.", (long)status]);
+            return;
+        }
+
+        id json = data.length > 0 ? [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL] : nil;
+        NSDictionary *listing = ApolloGalleryDict(ApolloGalleryDict(json)[@"data"]);
+        if (!listing) {
+            ApolloLog(@"[Gallery] listing r/%@ unparseable (%lu bytes)", strongSelf.subreddit, (unsigned long)data.length);
+            completion(nil, @"Couldn't read Reddit's response.");
+            return;
+        }
+        completion(listing, nil);
+    }] resume];
+}
+
+#pragma mark Batch loading
+
+- (void)loadNextBatchWithCompletion:(void (^)(NSRange addedRange, NSString *_Nullable errorMessage))completion {
+    if (self.loading || self.exhausted) {
+        if (completion) completion(NSMakeRange(self.mutableItems.count, 0), nil);
+        return;
+    }
+    self.loading = YES;
+    self.lastErrorMessage = nil;
+
+    NSUInteger startIndex = self.mutableItems.count;
+    NSUInteger generation = self.generation;
+    [self continueBatchFromIndex:startIndex
+                      generation:generation
+                       pagesLeft:kApolloGalleryMaxPagesPerBatch
+                      completion:completion];
+}
+
+- (void)continueBatchFromIndex:(NSUInteger)startIndex
+                    generation:(NSUInteger)generation
+                     pagesLeft:(NSInteger)pagesLeft
+                    completion:(void (^)(NSRange addedRange, NSString *_Nullable errorMessage))completion {
+    __weak typeof(self) weakSelf = self;
+    [self fetchPageWithCursor:self.afterCursor completion:^(NSDictionary *listing, NSString *errorMessage) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            typeof(self) strongSelf = weakSelf;
+            if (!strongSelf) return;
+            // The feed was reset (or re-sorted) while this page was in flight —
+            // its contents belong to a listing nobody is looking at any more.
+            if (strongSelf.generation != generation) return;
+
+            if (!listing) {
+                strongSelf.loading = NO;
+                strongSelf.lastErrorMessage = errorMessage;
+                if (completion) completion(NSMakeRange(startIndex, 0), errorMessage);
+                return;
+            }
+
+            NSUInteger before = strongSelf.mutableItems.count;
+            [strongSelf appendItemsFromListing:listing];
+            NSUInteger gainedThisPage = strongSelf.mutableItems.count - before;
+
+            strongSelf.consecutiveEmptyPages = (gainedThisPage == 0)
+                ? strongSelf.consecutiveEmptyPages + 1
+                : 0;
+
+            NSString *nextCursor = ApolloGalleryString(listing[@"after"]);
+            strongSelf.afterCursor = nextCursor;
+
+            NSUInteger gainedThisBatch = strongSelf.mutableItems.count - startIndex;
+            BOOL noMorePages = (nextCursor.length == 0);
+            BOOL tooManyEmptyPages = (strongSelf.consecutiveEmptyPages >= kApolloGalleryEmptyPageLimit);
+            BOOL batchSatisfied = (gainedThisBatch >= (NSUInteger)kApolloGalleryBatchSize);
+            BOOL outOfPageBudget = (pagesLeft <= 1);
+
+            if (noMorePages || tooManyEmptyPages) {
+                strongSelf.exhausted = YES;
+                ApolloLog(@"[Gallery] r/%@ exhausted (cursor=%@ emptyPages=%ld total=%lu)",
+                          strongSelf.subreddit, nextCursor ?: @"nil",
+                          (long)strongSelf.consecutiveEmptyPages,
+                          (unsigned long)strongSelf.mutableItems.count);
+            }
+
+            if (strongSelf.exhausted || batchSatisfied || outOfPageBudget) {
+                strongSelf.loading = NO;
+                NSRange added = NSMakeRange(startIndex, gainedThisBatch);
+                ApolloLog(@"[Gallery] r/%@ %@ batch: +%lu (total %lu)",
+                          strongSelf.subreddit, [strongSelf sortDisplayName],
+                          (unsigned long)gainedThisBatch,
+                          (unsigned long)strongSelf.mutableItems.count);
+                if (completion) completion(added, nil);
+                return;
+            }
+
+            // Not enough pictures yet and pages left in the budget — keep going.
+            [strongSelf continueBatchFromIndex:startIndex
+                                    generation:generation
+                                     pagesLeft:pagesLeft - 1
+                                    completion:completion];
+        });
+    }];
+}
+
+#pragma mark Listing -> items
+
+- (void)appendItemsFromListing:(NSDictionary *)listing {
+    for (id child in ApolloGalleryArray(listing[@"children"]) ?: @[]) {
+        NSDictionary *post = ApolloGalleryDict(ApolloGalleryDict(child)[@"data"]);
+        if (!post) continue;
+        for (ApolloGalleryItem *item in [self itemsFromPost:post]) {
+            NSString *key = item.imageURL.absoluteString;
+            if (key.length == 0 || [self.seenImageKeys containsObject:key]) continue;
+            [self.seenImageKeys addObject:key];
+            [self.mutableItems addObject:item];
+        }
+    }
+}
+
+// Stamps the post-level fields every item from a post shares.
+static void ApolloGalleryApplyPostMetadata(ApolloGalleryItem *item, NSDictionary *post) {
+    item.postTitle = ApolloGalleryString(post[@"title"]);
+    item.author = ApolloGalleryString(post[@"author"]);
+    item.subreddit = ApolloGalleryString(post[@"subreddit"]);
+    item.permalink = ApolloGalleryString(post[@"permalink"]);
+    item.postFullname = ApolloGalleryString(post[@"name"]);
+    item.isNSFW = ApolloGalleryBool(post[@"over_18"]);
+    item.isSpoiler = ApolloGalleryBool(post[@"spoiler"]);
+}
+
+// Picks the smallest offered resolution at least `minWidth` wide, so the grid
+// downloads thumbnails rather than 4000px originals. Falls back to the largest
+// available when every option is smaller than the target.
+static NSURL *ApolloGalleryBestThumbnail(NSArray *resolutions, NSString *urlKey, CGFloat minWidth) {
+    NSURL *best = nil;
+    CGFloat bestWidth = 0.0;
+    NSURL *largest = nil;
+    CGFloat largestWidth = 0.0;
+    for (id entry in resolutions ?: @[]) {
+        NSDictionary *resolution = ApolloGalleryDict(entry);
+        if (!resolution) continue;
+        NSURL *url = ApolloGalleryURL(resolution[urlKey]);
+        if (!url) continue;
+        CGFloat width = ApolloGalleryNumber(resolution[@"x"]) ?: ApolloGalleryNumber(resolution[@"width"]);
+        if (width > largestWidth) { largestWidth = width; largest = url; }
+        if (width >= minWidth && (!best || width < bestWidth)) { bestWidth = width; best = url; }
+    }
+    return best ?: largest;
+}
+
+// Target thumbnail width in pixels: roughly a half-screen-wide tile at 3x.
+static CGFloat const kApolloGalleryThumbnailTargetWidth = 640.0;
+
+- (NSArray<ApolloGalleryItem *> *)itemsFromPost:(NSDictionary *)post {
+    // Crossposts carry no media of their own; the pictures live on the parent.
+    NSArray *crosspostParents = ApolloGalleryArray(post[@"crosspost_parent_list"]);
+    NSDictionary *mediaSource = post;
+    if (crosspostParents.count > 0) {
+        NSDictionary *parent = ApolloGalleryDict(crosspostParents.firstObject);
+        if (parent) mediaSource = parent;
+    }
+
+    NSArray<ApolloGalleryItem *> *items = [self galleryItemsFromPost:mediaSource];
+    if (items.count == 0) {
+        ApolloGalleryItem *single = [self singleImageItemFromPost:mediaSource];
+        if (single) items = @[single];
+    }
+    // Titles/permalinks/flags always come from the post the user would open,
+    // not from the crossposted original.
+    for (ApolloGalleryItem *item in items) {
+        ApolloGalleryApplyPostMetadata(item, post);
+        // NSFW/spoiler is worth honouring from either side of a crosspost.
+        if (ApolloGalleryBool(mediaSource[@"over_18"])) item.isNSFW = YES;
+        if (ApolloGalleryBool(mediaSource[@"spoiler"])) item.isSpoiler = YES;
+    }
+    return items;
+}
+
+// Multi-image ("gallery") posts: gallery_data gives the display order,
+// media_metadata the actual files.
+- (NSArray<ApolloGalleryItem *> *)galleryItemsFromPost:(NSDictionary *)post {
+    if (!ApolloGalleryBool(post[@"is_gallery"])) return @[];
+    NSDictionary *metadata = ApolloGalleryDict(post[@"media_metadata"]);
+    NSArray *order = ApolloGalleryArray(ApolloGalleryDict(post[@"gallery_data"])[@"items"]);
+    if (metadata.count == 0 || order.count == 0) return @[];
+
+    NSMutableArray<ApolloGalleryItem *> *items = [NSMutableArray array];
+    for (id entry in order) {
+        NSString *mediaID = ApolloGalleryString(ApolloGalleryDict(entry)[@"media_id"]);
+        NSDictionary *media = mediaID.length > 0 ? ApolloGalleryDict(metadata[mediaID]) : nil;
+        if (!media) continue;
+        NSString *status = ApolloGalleryString(media[@"status"]);
+        if (status.length > 0 && ![status isEqualToString:@"valid"]) continue;
+        // "Image" and "AnimatedImage" are pictures; "RedditVideo" is not.
+        NSString *kind = ApolloGalleryString(media[@"e"]);
+        if (kind.length > 0 && ![kind isEqualToString:@"Image"] && ![kind isEqualToString:@"AnimatedImage"]) continue;
+
+        NSDictionary *source = ApolloGalleryDict(media[@"s"]);
+        if (!source) continue;
+        BOOL animated = [kind isEqualToString:@"AnimatedImage"] || source[@"gif"] != nil;
+        // For animated entries `u` is a still preview and `gif` the real thing.
+        NSURL *full = animated ? (ApolloGalleryURL(source[@"gif"]) ?: ApolloGalleryURL(source[@"u"]))
+                               : ApolloGalleryURL(source[@"u"]);
+        if (!full) continue;
+
+        ApolloGalleryItem *item = [[ApolloGalleryItem alloc] init];
+        item.imageURL = full;
+        item.isAnimated = animated;
+        item.pixelSize = CGSizeMake(ApolloGalleryNumber(source[@"x"]), ApolloGalleryNumber(source[@"y"]));
+        // `p` holds the still previews; use one even for animated entries so the
+        // grid doesn't pull a multi-megabyte GIF per tile.
+        item.thumbnailURL = ApolloGalleryBestThumbnail(ApolloGalleryArray(media[@"p"]), @"u",
+                                                       kApolloGalleryThumbnailTargetWidth)
+                            ?: (animated ? ApolloGalleryURL(source[@"u"]) : full);
+        item.galleryIndex = (NSInteger)items.count;
+        [items addObject:item];
+    }
+    for (ApolloGalleryItem *item in items) {
+        item.galleryCount = (NSInteger)items.count;
+    }
+    return items;
+}
+
+// Ordinary single-image posts, including direct links to external image hosts.
+- (ApolloGalleryItem *)singleImageItemFromPost:(NSDictionary *)post {
+    NSDictionary *previewImage = ApolloGalleryDict(ApolloGalleryArray(ApolloGalleryDict(post[@"preview"])[@"images"]).firstObject);
+    NSDictionary *previewSource = ApolloGalleryDict(previewImage[@"source"]);
+    NSDictionary *gifVariantSource = ApolloGalleryDict(ApolloGalleryDict(ApolloGalleryDict(previewImage[@"variants"])[@"gif"])[@"source"]);
+
+    NSURL *direct = ApolloGalleryURL(post[@"url_overridden_by_dest"]) ?: ApolloGalleryURL(post[@"url"]);
+    NSString *hint = ApolloGalleryString(post[@"post_hint"]);
+    BOOL directIsImage = direct && ApolloGalleryURLLooksLikeImage(direct);
+    BOOL hintedImage = [hint isEqualToString:@"image"];
+
+    // Reddit-hosted animated GIFs arrive as an .gif `url` with an mp4/gif
+    // preview variant; keep the GIF so the viewer can animate it.
+    BOOL animated = (direct && [direct.pathExtension.lowercaseString isEqualToString:@"gif"]) || gifVariantSource != nil;
+
+    NSURL *full = nil;
+    if (directIsImage) {
+        full = direct;
+    } else if (animated && gifVariantSource) {
+        full = ApolloGalleryURL(gifVariantSource[@"url"]);
+    } else if (hintedImage && previewSource) {
+        // e.g. an imgur page link that Reddit resolved into a preview.
+        full = ApolloGalleryURL(previewSource[@"url"]);
+    }
+    if (!full) return nil;
+
+    ApolloGalleryItem *item = [[ApolloGalleryItem alloc] init];
+    item.imageURL = full;
+    item.isAnimated = animated;
+    if (previewSource) {
+        item.pixelSize = CGSizeMake(ApolloGalleryNumber(previewSource[@"width"]),
+                                    ApolloGalleryNumber(previewSource[@"height"]));
+    }
+    item.thumbnailURL = ApolloGalleryBestThumbnail(ApolloGalleryArray(previewImage[@"resolutions"]), @"url",
+                                                   kApolloGalleryThumbnailTargetWidth)
+                        ?: (previewSource ? ApolloGalleryURL(previewSource[@"url"]) : full)
+                        ?: full;
+    return item;
+}
+
+@end

--- a/src/ApolloGalleryFeed.m
+++ b/src/ApolloGalleryFeed.m
@@ -21,22 +21,6 @@ static NSInteger const kApolloGalleryEmptyPageLimit = 3;
 
 static NSTimeInterval const kApolloGalleryRequestTimeout = 20.0;
 
-// The media-kind filter is a per-view preference rather than a Settings toggle,
-// so it lives on its own key here instead of in UserDefaultConstants.h.
-static NSString *const kApolloGalleryAllowedKindsKey = @"ApolloGalleryAllowedKinds";
-
-static ApolloGalleryMediaKind ApolloGalleryPersistedAllowedKinds(void) {
-    id stored = [[NSUserDefaults standardUserDefaults] objectForKey:kApolloGalleryAllowedKindsKey];
-    if (![stored isKindOfClass:[NSNumber class]]) return ApolloGalleryMediaKindAll;
-    ApolloGalleryMediaKind kinds = (ApolloGalleryMediaKind)((NSNumber *)stored).unsignedIntegerValue;
-    kinds &= ApolloGalleryMediaKindAll;
-    return kinds ?: ApolloGalleryMediaKindAll;
-}
-
-static void ApolloGallerySetPersistedAllowedKinds(ApolloGalleryMediaKind kinds) {
-    [[NSUserDefaults standardUserDefaults] setInteger:(NSInteger)kinds forKey:kApolloGalleryAllowedKindsKey];
-}
-
 #pragma mark - Small JSON helpers
 
 static NSString *ApolloGalleryString(id value) {
@@ -159,7 +143,11 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
         _seenImageKeys = [NSMutableSet set];
         _sort = ApolloGallerySortHot;
         _topWindow = ApolloGalleryTopWindowWeek;
-        _allowedKinds = ApolloGalleryPersistedAllowedKinds();
+        // Every gallery opens showing everything. The filter is deliberately
+        // NOT persisted: it lives on this feed object, and each gallery visit
+        // creates a fresh feed — so "videos only" in one subreddit can't leak
+        // into the next, or into next week.
+        _allowedKinds = ApolloGalleryMediaKindAll;
         _filteredItems = @[];
     }
     return self;
@@ -179,7 +167,6 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
     allowedKinds &= ApolloGalleryMediaKindAll;
     if (allowedKinds == 0 || allowedKinds == _allowedKinds) return;
     _allowedKinds = allowedKinds;
-    ApolloGallerySetPersistedAllowedKinds(allowedKinds);
 
     // Invalidate any in-flight batch BEFORE rebuilding: its append accounting
     // is anchored to a startIndex in the OLD filtered array, so letting it

--- a/src/ApolloGalleryFeed.m
+++ b/src/ApolloGalleryFeed.m
@@ -658,18 +658,17 @@ static NSURL *ApolloGalleryDirectVideoURL(NSURL *url) {
     if (redditVideo) {
         stream = ApolloGalleryVideoStreamURL(redditVideo);
         duration = ApolloGalleryNumber(redditVideo[@"duration"]);
-        if (ApolloGalleryVideoIsSilentLoop(redditVideo)) {
-            kind = ApolloGalleryMediaKindGIF;
-            // Silent by definition, so the mp4 fallback is the whole thing and
-            // is safe to offer for Save.
-            downloadable = ApolloGalleryURL(redditVideo[@"fallback_url"]);
-        }
+        // The fallback mp4 is the video track only for anything with sound, but
+        // it's still the right handle to save from: ApolloGalleryVideoExport
+        // recognises a v.redd.it URL and muxes the DASH audio back in.
+        downloadable = ApolloGalleryURL(redditVideo[@"fallback_url"]);
+        if (ApolloGalleryVideoIsSilentLoop(redditVideo)) kind = ApolloGalleryMediaKindGIF;
     } else if (previewVideo) {
         // An external GIF/short clip Reddit re-hosted; nearly always silent.
         stream = ApolloGalleryVideoStreamURL(previewVideo);
         duration = ApolloGalleryNumber(previewVideo[@"duration"]);
         kind = ApolloGalleryVideoIsSilentLoop(previewVideo) ? ApolloGalleryMediaKindGIF : ApolloGalleryMediaKindVideo;
-        if (kind == ApolloGalleryMediaKindGIF) downloadable = ApolloGalleryURL(previewVideo[@"fallback_url"]);
+        downloadable = ApolloGalleryURL(previewVideo[@"fallback_url"]);
     } else {
         NSURL *direct = ApolloGalleryURL(post[@"url_overridden_by_dest"]) ?: ApolloGalleryURL(post[@"url"]);
         NSURL *directVideo = direct ? ApolloGalleryDirectVideoURL(direct) : nil;

--- a/src/ApolloGalleryFeed.m
+++ b/src/ApolloGalleryFeed.m
@@ -180,6 +180,17 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
     if (allowedKinds == 0 || allowedKinds == _allowedKinds) return;
     _allowedKinds = allowedKinds;
     ApolloGallerySetPersistedAllowedKinds(allowedKinds);
+
+    // Invalidate any in-flight batch BEFORE rebuilding: its append accounting
+    // is anchored to a startIndex in the OLD filtered array, so letting it
+    // complete against the new one could compute a bogus (even underflowed)
+    // appended range for the UI to insert. The stale completion drops out on
+    // the generation check without advancing the cursor, so its page is simply
+    // refetched by the next load — nothing is lost, and `seenImageKeys` keeps
+    // the refetch from duplicating tiles.
+    self.generation += 1;
+    self.loading = NO;
+
     [self rebuildFilteredItems];
 }
 
@@ -436,6 +447,20 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
             [strongSelf rebuildFilteredItems];
             NSUInteger gainedThisPage = strongSelf.filteredItems.count - before;
 
+            // Defensive: the generation check above should make this
+            // impossible, but if the filtered count ever ends up below the
+            // batch's start index (these are NSUIntegers — a bare subtraction
+            // would underflow to ~2^64 and the UI would try to insert it as a
+            // range), fail the batch closed instead.
+            if (strongSelf.filteredItems.count < startIndex) {
+                ApolloLog(@"[Gallery] r/%@ batch start %lu is beyond filtered count %lu; dropping batch",
+                          strongSelf.subreddit, (unsigned long)startIndex,
+                          (unsigned long)strongSelf.filteredItems.count);
+                strongSelf.loading = NO;
+                if (completion) completion(NSMakeRange(strongSelf.filteredItems.count, 0), nil);
+                return;
+            }
+
             strongSelf.consecutiveEmptyPages = (gainedThisPage == 0)
                 ? strongSelf.consecutiveEmptyPages + 1
                 : 0;
@@ -628,14 +653,22 @@ static BOOL ApolloGalleryVideoIsSilentLoop(NSDictionary *video) {
 // and plain .mp4/.webm links.
 static NSURL *ApolloGalleryDirectVideoURL(NSURL *url) {
     NSString *extension = url.pathExtension.lowercaseString;
-    if ([extension isEqualToString:@"mp4"] || [extension isEqualToString:@"webm"]) return url;
+    if ([extension isEqualToString:@"mp4"]) return url;
     if ([extension isEqualToString:@"gifv"]) {
-        // .gifv is an HTML page; the mp4 sits at the same path.
-        NSString *absolute = url.absoluteString;
-        NSString *swapped = [absolute stringByReplacingCharactersInRange:
-                             NSMakeRange(absolute.length - 4, 4) withString:@"m.mp4"];
-        return [NSURL URLWithString:swapped] ?: nil;
+        // imgur's .gifv is an HTML wrapper; the real file is the same path with
+        // the extension swapped: i.imgur.com/foo.gifv -> i.imgur.com/foo.mp4.
+        // Swap it on the PATH component (not the raw absolute string, where a
+        // clumsy character-range splice once produced "foo.m.mp4").
+        NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+        NSString *path = components.path;
+        if (![path.pathExtension.lowercaseString isEqualToString:@"gifv"]) return nil;
+        components.path = [[path stringByDeletingPathExtension] stringByAppendingPathExtension:@"mp4"];
+        return components.URL;
     }
+    // .webm is deliberately NOT admitted: AVPlayer can't decode it, so the tile
+    // would be an unplayable poster. Most webm posts still surface through
+    // preview.reddit_video_preview (Reddit's own mp4 transcode) upstream of
+    // this fallback.
     return nil;
 }
 

--- a/src/ApolloGalleryFeed.m
+++ b/src/ApolloGalleryFeed.m
@@ -21,6 +21,22 @@ static NSInteger const kApolloGalleryEmptyPageLimit = 3;
 
 static NSTimeInterval const kApolloGalleryRequestTimeout = 20.0;
 
+// The media-kind filter is a per-view preference rather than a Settings toggle,
+// so it lives on its own key here instead of in UserDefaultConstants.h.
+static NSString *const kApolloGalleryAllowedKindsKey = @"ApolloGalleryAllowedKinds";
+
+static ApolloGalleryMediaKind ApolloGalleryPersistedAllowedKinds(void) {
+    id stored = [[NSUserDefaults standardUserDefaults] objectForKey:kApolloGalleryAllowedKindsKey];
+    if (![stored isKindOfClass:[NSNumber class]]) return ApolloGalleryMediaKindAll;
+    ApolloGalleryMediaKind kinds = (ApolloGalleryMediaKind)((NSNumber *)stored).unsignedIntegerValue;
+    kinds &= ApolloGalleryMediaKindAll;
+    return kinds ?: ApolloGalleryMediaKindAll;
+}
+
+static void ApolloGallerySetPersistedAllowedKinds(ApolloGalleryMediaKind kinds) {
+    [[NSUserDefaults standardUserDefaults] setInteger:(NSInteger)kinds forKey:kApolloGalleryAllowedKindsKey];
+}
+
 #pragma mark - Small JSON helpers
 
 static NSString *ApolloGalleryString(id value) {
@@ -77,8 +93,23 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
     self = [super init];
     if (self) {
         _galleryCount = 1;
+        _kind = ApolloGalleryMediaKindPhoto;
     }
     return self;
+}
+
+- (BOOL)playsAsVideo {
+    return self.videoURL != nil;
+}
+
+- (NSString *)durationText {
+    NSTimeInterval seconds = self.duration;
+    if (seconds <= 0.0) return nil;
+    NSInteger total = (NSInteger)llround(seconds);
+    NSInteger hours = total / 3600, minutes = (total % 3600) / 60, secs = total % 60;
+    return hours > 0
+        ? [NSString stringWithFormat:@"%ld:%02ld:%02ld", (long)hours, (long)minutes, (long)secs]
+        : [NSString stringWithFormat:@"%ld:%02ld", (long)minutes, (long)secs];
 }
 
 - (NSURL *)postURL {
@@ -101,8 +132,11 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
 @interface ApolloGalleryFeed ()
 @property (nonatomic, copy) NSString *subreddit;
 @property (nonatomic, strong) NSMutableArray<ApolloGalleryItem *> *mutableItems;
-// Full-size image URLs already emitted, so a post that resurfaces on a later
-// listing page (or a repost of the same file) doesn't duplicate a tile.
+// `mutableItems` filtered by allowedKinds, rebuilt whenever either changes.
+@property (nonatomic, strong) NSArray<ApolloGalleryItem *> *filteredItems;
+// Media already emitted (stream URL for playables, image URL otherwise), so a
+// post that resurfaces on a later listing page — or a repost of the same file —
+// doesn't duplicate a tile.
 @property (nonatomic, strong) NSMutableSet<NSString *> *seenImageKeys;
 @property (nonatomic, copy, nullable) NSString *afterCursor;
 @property (nonatomic, getter=isLoading) BOOL loading;
@@ -125,12 +159,48 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
         _seenImageKeys = [NSMutableSet set];
         _sort = ApolloGallerySortHot;
         _topWindow = ApolloGalleryTopWindowWeek;
+        _allowedKinds = ApolloGalleryPersistedAllowedKinds();
+        _filteredItems = @[];
     }
     return self;
 }
 
 - (NSArray<ApolloGalleryItem *> *)items {
+    return self.filteredItems;
+}
+
+- (NSArray<ApolloGalleryItem *> *)allItems {
     return self.mutableItems;
+}
+
+- (void)setAllowedKinds:(ApolloGalleryMediaKind)allowedKinds {
+    // Refuse to turn everything off: an empty gallery is never the intent, and
+    // it would also make the loader spin forever looking for admissible media.
+    allowedKinds &= ApolloGalleryMediaKindAll;
+    if (allowedKinds == 0 || allowedKinds == _allowedKinds) return;
+    _allowedKinds = allowedKinds;
+    ApolloGallerySetPersistedAllowedKinds(allowedKinds);
+    [self rebuildFilteredItems];
+}
+
+- (void)rebuildFilteredItems {
+    if (self.allowedKinds == ApolloGalleryMediaKindAll) {
+        self.filteredItems = [self.mutableItems copy];
+        return;
+    }
+    NSMutableArray<ApolloGalleryItem *> *visible = [NSMutableArray array];
+    for (ApolloGalleryItem *item in self.mutableItems) {
+        if (item.kind & self.allowedKinds) [visible addObject:item];
+    }
+    self.filteredItems = visible;
+}
+
+- (NSUInteger)countOfKind:(ApolloGalleryMediaKind)kind {
+    NSUInteger count = 0;
+    for (ApolloGalleryItem *item in self.mutableItems) {
+        if (item.kind & kind) count++;
+    }
+    return count;
 }
 
 - (void)setSort:(ApolloGallerySort)sort {
@@ -161,6 +231,7 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
 - (void)reset {
     self.generation += 1;
     [self.mutableItems removeAllObjects];
+    self.filteredItems = @[];
     [self.seenImageKeys removeAllObjects];
     self.afterCursor = nil;
     self.exhausted = NO;
@@ -326,13 +397,13 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
 
 - (void)loadNextBatchWithCompletion:(void (^)(NSRange addedRange, NSString *_Nullable errorMessage))completion {
     if (self.loading || self.exhausted) {
-        if (completion) completion(NSMakeRange(self.mutableItems.count, 0), nil);
+        if (completion) completion(NSMakeRange(self.filteredItems.count, 0), nil);
         return;
     }
     self.loading = YES;
     self.lastErrorMessage = nil;
 
-    NSUInteger startIndex = self.mutableItems.count;
+    NSUInteger startIndex = self.filteredItems.count;
     NSUInteger generation = self.generation;
     [self continueBatchFromIndex:startIndex
                       generation:generation
@@ -360,9 +431,10 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
                 return;
             }
 
-            NSUInteger before = strongSelf.mutableItems.count;
+            NSUInteger before = strongSelf.filteredItems.count;
             [strongSelf appendItemsFromListing:listing];
-            NSUInteger gainedThisPage = strongSelf.mutableItems.count - before;
+            [strongSelf rebuildFilteredItems];
+            NSUInteger gainedThisPage = strongSelf.filteredItems.count - before;
 
             strongSelf.consecutiveEmptyPages = (gainedThisPage == 0)
                 ? strongSelf.consecutiveEmptyPages + 1
@@ -371,7 +443,7 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
             NSString *nextCursor = ApolloGalleryString(listing[@"after"]);
             strongSelf.afterCursor = nextCursor;
 
-            NSUInteger gainedThisBatch = strongSelf.mutableItems.count - startIndex;
+            NSUInteger gainedThisBatch = strongSelf.filteredItems.count - startIndex;
             BOOL noMorePages = (nextCursor.length == 0);
             BOOL tooManyEmptyPages = (strongSelf.consecutiveEmptyPages >= kApolloGalleryEmptyPageLimit);
             BOOL batchSatisfied = (gainedThisBatch >= (NSUInteger)kApolloGalleryBatchSize);
@@ -379,19 +451,24 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
 
             if (noMorePages || tooManyEmptyPages) {
                 strongSelf.exhausted = YES;
-                ApolloLog(@"[Gallery] r/%@ exhausted (cursor=%@ emptyPages=%ld total=%lu)",
+                ApolloLog(@"[Gallery] r/%@ exhausted (cursor=%@ emptyPages=%ld shown=%lu of %lu)",
                           strongSelf.subreddit, nextCursor ?: @"nil",
                           (long)strongSelf.consecutiveEmptyPages,
+                          (unsigned long)strongSelf.filteredItems.count,
                           (unsigned long)strongSelf.mutableItems.count);
             }
 
             if (strongSelf.exhausted || batchSatisfied || outOfPageBudget) {
                 strongSelf.loading = NO;
                 NSRange added = NSMakeRange(startIndex, gainedThisBatch);
-                ApolloLog(@"[Gallery] r/%@ %@ batch: +%lu (total %lu)",
+                ApolloLog(@"[Gallery] r/%@ %@ batch: +%lu shown (%lu shown / %lu fetched; photo %lu gif %lu video %lu)",
                           strongSelf.subreddit, [strongSelf sortDisplayName],
                           (unsigned long)gainedThisBatch,
-                          (unsigned long)strongSelf.mutableItems.count);
+                          (unsigned long)strongSelf.filteredItems.count,
+                          (unsigned long)strongSelf.mutableItems.count,
+                          (unsigned long)[strongSelf countOfKind:ApolloGalleryMediaKindPhoto],
+                          (unsigned long)[strongSelf countOfKind:ApolloGalleryMediaKindGIF],
+                          (unsigned long)[strongSelf countOfKind:ApolloGalleryMediaKindVideo]);
                 if (completion) completion(added, nil);
                 return;
             }
@@ -412,7 +489,10 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
         NSDictionary *post = ApolloGalleryDict(ApolloGalleryDict(child)[@"data"]);
         if (!post) continue;
         for (ApolloGalleryItem *item in [self itemsFromPost:post]) {
-            NSString *key = item.imageURL.absoluteString;
+            // Key on the stream for playables: two posts of the same video can
+            // carry differently-signed poster URLs, and every v.redd.it poster
+            // is unique even when the clip isn't.
+            NSString *key = item.videoURL.absoluteString ?: item.imageURL.absoluteString;
             if (key.length == 0 || [self.seenImageKeys containsObject:key]) continue;
             [self.seenImageKeys addObject:key];
             [self.mutableItems addObject:item];
@@ -465,7 +545,10 @@ static CGFloat const kApolloGalleryThumbnailTargetWidth = 640.0;
 
     NSArray<ApolloGalleryItem *> *items = [self galleryItemsFromPost:mediaSource];
     if (items.count == 0) {
-        ApolloGalleryItem *single = [self singleImageItemFromPost:mediaSource];
+        // Video first: a v.redd.it post also carries a still preview, so the
+        // image parser would happily claim it and we'd lose the playback.
+        ApolloGalleryItem *single = [self videoItemFromPost:mediaSource]
+                                    ?: [self singleImageItemFromPost:mediaSource];
         if (single) items = @[single];
     }
     // Titles/permalinks/flags always come from the post the user would open,
@@ -508,7 +591,7 @@ static CGFloat const kApolloGalleryThumbnailTargetWidth = 640.0;
 
         ApolloGalleryItem *item = [[ApolloGalleryItem alloc] init];
         item.imageURL = full;
-        item.isAnimated = animated;
+        item.kind = animated ? ApolloGalleryMediaKindGIF : ApolloGalleryMediaKindPhoto;
         item.pixelSize = CGSizeMake(ApolloGalleryNumber(source[@"x"]), ApolloGalleryNumber(source[@"y"]));
         // `p` holds the still previews; use one even for animated entries so the
         // grid doesn't pull a multi-megabyte GIF per tile.
@@ -522,6 +605,100 @@ static CGFloat const kApolloGalleryThumbnailTargetWidth = 640.0;
         item.galleryCount = (NSInteger)items.count;
     }
     return items;
+}
+
+// A Reddit `reddit_video` blob (from media.reddit_video or
+// preview.reddit_video_preview) turned into a playable stream.
+//
+// HLS is preferred over `fallback_url` because for real v.redd.it videos the
+// mp4 fallback is the VIDEO track only — Reddit serves audio as a separate DASH
+// stream — so playing the fallback gives a silent clip. The .m3u8 muxes both.
+static NSURL *ApolloGalleryVideoStreamURL(NSDictionary *video) {
+    return ApolloGalleryURL(video[@"hls_url"]) ?: ApolloGalleryURL(video[@"fallback_url"]);
+}
+
+// YES for a clip Reddit itself considers a soundless loop — a GIF someone
+// uploaded that Reddit transcoded to mp4. These are GIFs to a reader even
+// though they play through AVPlayer.
+static BOOL ApolloGalleryVideoIsSilentLoop(NSDictionary *video) {
+    return ApolloGalleryBool(video[@"is_gif"]);
+}
+
+// Direct links that are really videos: imgur's .gifv (an mp4 wearing a costume)
+// and plain .mp4/.webm links.
+static NSURL *ApolloGalleryDirectVideoURL(NSURL *url) {
+    NSString *extension = url.pathExtension.lowercaseString;
+    if ([extension isEqualToString:@"mp4"] || [extension isEqualToString:@"webm"]) return url;
+    if ([extension isEqualToString:@"gifv"]) {
+        // .gifv is an HTML page; the mp4 sits at the same path.
+        NSString *absolute = url.absoluteString;
+        NSString *swapped = [absolute stringByReplacingCharactersInRange:
+                             NSMakeRange(absolute.length - 4, 4) withString:@"m.mp4"];
+        return [NSURL URLWithString:swapped] ?: nil;
+    }
+    return nil;
+}
+
+// Reddit-hosted video posts and anything with a transcoded video preview.
+// Returns nil when the post has no playable stream, so the caller can fall
+// through to the still-image parser.
+- (ApolloGalleryItem *)videoItemFromPost:(NSDictionary *)post {
+    NSDictionary *previewImage = ApolloGalleryDict(ApolloGalleryArray(ApolloGalleryDict(post[@"preview"])[@"images"]).firstObject);
+    NSDictionary *previewSource = ApolloGalleryDict(previewImage[@"source"]);
+
+    NSDictionary *redditVideo = ApolloGalleryDict(ApolloGalleryDict(post[@"media"])[@"reddit_video"])
+                                ?: ApolloGalleryDict(ApolloGalleryDict(post[@"secure_media"])[@"reddit_video"]);
+    NSDictionary *previewVideo = ApolloGalleryDict(ApolloGalleryDict(post[@"preview"])[@"reddit_video_preview"]);
+
+    NSURL *stream = nil;
+    NSURL *downloadable = nil;
+    NSTimeInterval duration = 0.0;
+    ApolloGalleryMediaKind kind = ApolloGalleryMediaKindVideo;
+
+    if (redditVideo) {
+        stream = ApolloGalleryVideoStreamURL(redditVideo);
+        duration = ApolloGalleryNumber(redditVideo[@"duration"]);
+        if (ApolloGalleryVideoIsSilentLoop(redditVideo)) {
+            kind = ApolloGalleryMediaKindGIF;
+            // Silent by definition, so the mp4 fallback is the whole thing and
+            // is safe to offer for Save.
+            downloadable = ApolloGalleryURL(redditVideo[@"fallback_url"]);
+        }
+    } else if (previewVideo) {
+        // An external GIF/short clip Reddit re-hosted; nearly always silent.
+        stream = ApolloGalleryVideoStreamURL(previewVideo);
+        duration = ApolloGalleryNumber(previewVideo[@"duration"]);
+        kind = ApolloGalleryVideoIsSilentLoop(previewVideo) ? ApolloGalleryMediaKindGIF : ApolloGalleryMediaKindVideo;
+        if (kind == ApolloGalleryMediaKindGIF) downloadable = ApolloGalleryURL(previewVideo[@"fallback_url"]);
+    } else {
+        NSURL *direct = ApolloGalleryURL(post[@"url_overridden_by_dest"]) ?: ApolloGalleryURL(post[@"url"]);
+        NSURL *directVideo = direct ? ApolloGalleryDirectVideoURL(direct) : nil;
+        if (directVideo) {
+            stream = directVideo;
+            // A standalone mp4 is self-contained, so it can be saved as-is.
+            downloadable = directVideo;
+            // imgur .gifv is a looping GIF in mp4 clothing.
+            kind = [direct.pathExtension.lowercaseString isEqualToString:@"gifv"]
+                ? ApolloGalleryMediaKindGIF : ApolloGalleryMediaKindVideo;
+        }
+    }
+    if (!stream) return nil;
+
+    ApolloGalleryItem *item = [[ApolloGalleryItem alloc] init];
+    item.kind = kind;
+    item.videoURL = stream;
+    item.videoDownloadURL = downloadable;
+    item.duration = duration;
+    // The poster frame. Video posts always carry a preview; without one there's
+    // nothing to draw in the grid, so skip the post entirely.
+    NSURL *poster = previewSource ? ApolloGalleryURL(previewSource[@"url"]) : nil;
+    if (!poster) return nil;
+    item.imageURL = poster;
+    item.pixelSize = CGSizeMake(ApolloGalleryNumber(previewSource[@"width"]),
+                                ApolloGalleryNumber(previewSource[@"height"]));
+    item.thumbnailURL = ApolloGalleryBestThumbnail(ApolloGalleryArray(previewImage[@"resolutions"]), @"url",
+                                                   kApolloGalleryThumbnailTargetWidth) ?: poster;
+    return item;
 }
 
 // Ordinary single-image posts, including direct links to external image hosts.
@@ -552,7 +729,7 @@ static CGFloat const kApolloGalleryThumbnailTargetWidth = 640.0;
 
     ApolloGalleryItem *item = [[ApolloGalleryItem alloc] init];
     item.imageURL = full;
-    item.isAnimated = animated;
+    item.kind = animated ? ApolloGalleryMediaKindGIF : ApolloGalleryMediaKindPhoto;
     if (previewSource) {
         item.pixelSize = CGSizeMake(ApolloGalleryNumber(previewSource[@"width"]),
                                     ApolloGalleryNumber(previewSource[@"height"]));

--- a/src/ApolloGalleryImageLoader.h
+++ b/src/ApolloGalleryImageLoader.h
@@ -1,0 +1,56 @@
+// ApolloGalleryImageLoader.h
+//
+// Shared image fetch + decode for Gallery View (grid tiles and the fullscreen
+// viewer). Kept separate from ApolloGalleryFeed so the network/JSON layer has
+// no UIKit dependency.
+//
+// Three things the grid and viewer both need and shouldn't each reimplement:
+//   • a bounded in-memory image cache, so scrolling back up doesn't re-download;
+//   • animated-GIF decoding (UIImage's plain +imageWithData: shows frame 0 only,
+//     which is why a GIF looks like a still everywhere it isn't handled);
+//   • the original bytes, so Save/Share exports the real file — a GIF stays a
+//     GIF instead of being flattened by a re-encode.
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Opaque handle for an in-flight load; hold it to cancel when a cell is reused
+// or a viewer page scrolls far enough away. Several requests for the same URL
+// share one download, so cancelling one never strands the others.
+@interface ApolloGalleryImageRequest : NSObject
+- (void)cancel;
+// 0…1 for the underlying download, for a determinate progress bar. Sampled by
+// the caller (the viewer polls it on a timer) rather than pushed.
+@property (nonatomic, readonly) double progressFraction;
+@end
+
+@interface ApolloGalleryImageLoader : NSObject
+
++ (instancetype)sharedLoader;
+
+// Cached image for `url`, or nil. Synchronous and cheap — call it before
+// starting a load so a warm tile renders in the same runloop turn (no flash).
+- (nullable UIImage *)cachedImageForURL:(NSURL *)url;
+
+// Original downloaded bytes for `url` while they're still cached, for Save and
+// Share. nil once evicted; callers fall back to re-encoding the UIImage.
+- (nullable NSData *)cachedDataForURL:(NSURL *)url;
+
+// Downloads (or returns from cache) and decodes. `completion` always runs on
+// the main thread, and is skipped entirely if the request was cancelled.
+// `progress` is optional and also runs on the main thread.
+// Animated GIFs come back as multi-frame UIImages ready for UIImageView.
+- (ApolloGalleryImageRequest *)loadImageAtURL:(NSURL *)url
+                                     progress:(nullable void (^)(double fraction))progress
+                                   completion:(void (^)(UIImage *_Nullable image, NSData *_Nullable data))completion;
+
+// Warm the cache without wiring up a UI callback (viewer look-ahead).
+- (void)prefetchImageAtURL:(NSURL *)url;
+
+// Drops decoded images but keeps nothing pinned; called on memory pressure.
+- (void)purge;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ApolloGalleryImageLoader.h
+++ b/src/ApolloGalleryImageLoader.h
@@ -32,21 +32,32 @@ NS_ASSUME_NONNULL_BEGIN
 // Cached image for `url`, or nil. Synchronous and cheap — call it before
 // starting a load so a warm tile renders in the same runloop turn (no flash).
 - (nullable UIImage *)cachedImageForURL:(NSURL *)url;
+// Cached THUMBNAIL-tier decode for `url` (see -loadThumbnailAtURL:…), or nil.
+- (nullable UIImage *)cachedThumbnailForURL:(NSURL *)url;
 
 // Original downloaded bytes for `url` while they're still cached, for Save and
 // Share. nil once evicted; callers fall back to re-encoding the UIImage.
 - (nullable NSData *)cachedDataForURL:(NSURL *)url;
 
-// Downloads (or returns from cache) and decodes. `completion` always runs on
-// the main thread, and is skipped entirely if the request was cancelled.
-// `progress` is optional and also runs on the main thread.
+// Downloads (or returns from cache) and decodes at full size. `completion`
+// always runs on the main thread, and is skipped entirely if the request was
+// cancelled. `progress` is optional and also runs on the main thread.
 // Animated GIFs come back as multi-frame UIImages ready for UIImageView.
 - (ApolloGalleryImageRequest *)loadImageAtURL:(NSURL *)url
                                      progress:(nullable void (^)(double fraction))progress
                                    completion:(void (^)(UIImage *_Nullable image, NSData *_Nullable data))completion;
 
-// Warm the cache without wiring up a UI callback (viewer look-ahead).
-- (void)prefetchImageAtURL:(NSURL *)url;
+// The grid tier: a single downsampled still frame, cached separately from the
+// full decode of the same URL. Cells use this so a reused tile never pays for
+// a multi-frame GIF decode or a full-resolution bitmap it will draw at 185pt.
+- (ApolloGalleryImageRequest *)loadThumbnailAtURL:(NSURL *)url
+                                       completion:(void (^)(UIImage *_Nullable image))completion;
+
+// Cache warmers. Return the request handle so look-ahead can be CANCELLED when
+// the target scrolls away (grid prefetch, viewer paging); nil when the decode
+// is already cached and there is nothing to do.
+- (nullable ApolloGalleryImageRequest *)prefetchImageAtURL:(NSURL *)url;
+- (nullable ApolloGalleryImageRequest *)prefetchThumbnailAtURL:(NSURL *)url;
 
 // Drops decoded images but keeps nothing pinned; called on memory pressure.
 - (void)purge;

--- a/src/ApolloGalleryImageLoader.m
+++ b/src/ApolloGalleryImageLoader.m
@@ -1,0 +1,302 @@
+// ApolloGalleryImageLoader.m — see ApolloGalleryImageLoader.h.
+
+#import "ApolloGalleryImageLoader.h"
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+
+#import <ImageIO/ImageIO.h>
+
+// Decoded-image cache budget, in bytes of backing store. Grid thumbnails are
+// small; a handful of fullscreen originals is what actually fills this.
+static NSUInteger const kApolloGalleryImageCacheCostLimit = 96 * 1024 * 1024;
+// Original-bytes cache. Smaller: it only has to survive long enough for the
+// user to hit Save/Share on something they're looking at.
+static NSUInteger const kApolloGalleryDataCacheCostLimit = 32 * 1024 * 1024;
+
+static NSTimeInterval const kApolloGalleryImageTimeout = 30.0;
+
+@class ApolloGalleryPendingDownload;
+
+#pragma mark - Request handle
+
+@interface ApolloGalleryImageRequest ()
+@property (nonatomic, weak) ApolloGalleryImageLoader *loader;
+@property (nonatomic, copy) NSString *key;
+@property (nonatomic, copy, nullable) void (^completion)(UIImage *_Nullable, NSData *_Nullable);
+@property (nonatomic, weak, nullable) ApolloGalleryPendingDownload *download;
+@property (nonatomic, getter=isCancelled) BOOL cancelled;
+@end
+
+#pragma mark - One in-flight download, shared by every request for that URL
+
+@interface ApolloGalleryPendingDownload : NSObject
+@property (nonatomic, strong, nullable) NSURLSessionDataTask *task;
+@property (nonatomic, strong) NSMutableArray<ApolloGalleryImageRequest *> *requests;
+@end
+
+@implementation ApolloGalleryPendingDownload
+- (instancetype)init {
+    self = [super init];
+    if (self) _requests = [NSMutableArray array];
+    return self;
+}
+@end
+
+#pragma mark - Animated GIF decoding
+
+// UIImage's +imageWithData: keeps only the first frame of a GIF. Walk the
+// source with ImageIO instead and build the multi-frame UIImage that
+// UIImageView animates on its own. Returns nil for single-frame data so the
+// caller falls through to the cheap decode.
+static UIImage *ApolloGalleryDecodeAnimatedImage(NSData *data) {
+    CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
+    if (!source) return nil;
+
+    size_t frameCount = CGImageSourceGetCount(source);
+    if (frameCount <= 1) {
+        CFRelease(source);
+        return nil;
+    }
+
+    NSMutableArray<UIImage *> *frames = [NSMutableArray arrayWithCapacity:frameCount];
+    NSTimeInterval totalDuration = 0.0;
+
+    for (size_t i = 0; i < frameCount; i++) {
+        CGImageRef cgImage = CGImageSourceCreateImageAtIndex(source, i, NULL);
+        if (!cgImage) continue;
+
+        NSTimeInterval frameDuration = 0.1; // GIF default when unspecified
+        CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(source, i, NULL);
+        if (properties) {
+            CFDictionaryRef gif = CFDictionaryGetValue(properties, kCGImagePropertyGIFDictionary);
+            if (gif) {
+                // Unclamped is the authored delay; DelayTime is the value
+                // browsers clamp. Prefer unclamped, fall back to clamped.
+                NSNumber *unclamped = (__bridge NSNumber *)CFDictionaryGetValue(gif, kCGImagePropertyGIFUnclampedDelayTime);
+                NSNumber *clamped = (__bridge NSNumber *)CFDictionaryGetValue(gif, kCGImagePropertyGIFDelayTime);
+                NSNumber *value = ([unclamped isKindOfClass:[NSNumber class]] && unclamped.doubleValue > 0.0)
+                    ? unclamped
+                    : ([clamped isKindOfClass:[NSNumber class]] ? clamped : nil);
+                if (value.doubleValue > 0.0) frameDuration = value.doubleValue;
+            }
+            CFRelease(properties);
+        }
+        // Matches what browsers do with pathologically short frame delays.
+        if (frameDuration < 0.011) frameDuration = 0.1;
+
+        totalDuration += frameDuration;
+        [frames addObject:[UIImage imageWithCGImage:cgImage]];
+        CGImageRelease(cgImage);
+    }
+    CFRelease(source);
+
+    if (frames.count == 0) return nil;
+    if (totalDuration <= 0.0) totalDuration = frames.count * 0.1;
+    return [UIImage animatedImageWithImages:frames duration:totalDuration];
+}
+
+// Rough backing-store cost so NSCache's byte budget means something.
+static NSUInteger ApolloGalleryImageCost(UIImage *image) {
+    if (!image) return 0;
+    NSUInteger frames = MAX((NSUInteger)1, (NSUInteger)image.images.count);
+    CGImageRef cgImage = image.CGImage ?: image.images.firstObject.CGImage;
+    if (!cgImage) {
+        return (NSUInteger)(image.size.width * image.size.height * 4.0) * frames;
+    }
+    return CGImageGetHeight(cgImage) * CGImageGetBytesPerRow(cgImage) * frames;
+}
+
+#pragma mark - Loader
+
+@interface ApolloGalleryImageLoader ()
+@property (nonatomic, strong) NSCache<NSString *, UIImage *> *imageCache;
+@property (nonatomic, strong) NSCache<NSString *, NSData *> *dataCache;
+@property (nonatomic, strong) NSURLSession *session;
+// key -> the single in-flight download for that URL. Main-thread only, so no
+// lock: every mutation happens from -loadImageAtURL:… , -cancelRequest: or the
+// task completion's main-queue hop.
+@property (nonatomic, strong) NSMutableDictionary<NSString *, ApolloGalleryPendingDownload *> *pending;
+// Called back from -[ApolloGalleryImageRequest cancel].
+- (void)apollo_cancelRequest:(ApolloGalleryImageRequest *)request;
+@end
+
+@implementation ApolloGalleryImageRequest
+
+- (void)cancel {
+    if (self.cancelled) return;
+    self.cancelled = YES;
+    self.completion = nil;
+    [self.loader apollo_cancelRequest:self];
+}
+
+- (double)progressFraction {
+    NSURLSessionDataTask *task = self.download.task;
+    if (!task) return 0.0;
+    if (task.state == NSURLSessionTaskStateCompleted) return 1.0;
+    return MAX(0.0, MIN(1.0, task.progress.fractionCompleted));
+}
+
+@end
+
+@implementation ApolloGalleryImageLoader
+
++ (instancetype)sharedLoader {
+    static ApolloGalleryImageLoader *loader;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        loader = [[ApolloGalleryImageLoader alloc] init];
+    });
+    return loader;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _imageCache = [[NSCache alloc] init];
+        _imageCache.totalCostLimit = kApolloGalleryImageCacheCostLimit;
+        _dataCache = [[NSCache alloc] init];
+        _dataCache.totalCostLimit = kApolloGalleryDataCacheCostLimit;
+        _pending = [NSMutableDictionary dictionary];
+
+        NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+        // Reddit's image CDN is a single host, so the default per-host cap is
+        // what actually paces a fast grid scroll.
+        configuration.HTTPMaximumConnectionsPerHost = 8;
+        configuration.timeoutIntervalForRequest = kApolloGalleryImageTimeout;
+        _session = [NSURLSession sessionWithConfiguration:configuration];
+
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(apollo_didReceiveMemoryWarning)
+                                                     name:UIApplicationDidReceiveMemoryWarningNotification
+                                                   object:nil];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)apollo_didReceiveMemoryWarning {
+    [self purge];
+}
+
+- (void)purge {
+    [self.imageCache removeAllObjects];
+    [self.dataCache removeAllObjects];
+}
+
+- (UIImage *)cachedImageForURL:(NSURL *)url {
+    NSString *key = url.absoluteString;
+    return key.length > 0 ? [self.imageCache objectForKey:key] : nil;
+}
+
+- (NSData *)cachedDataForURL:(NSURL *)url {
+    NSString *key = url.absoluteString;
+    return key.length > 0 ? [self.dataCache objectForKey:key] : nil;
+}
+
+- (void)prefetchImageAtURL:(NSURL *)url {
+    if (!url || [self cachedImageForURL:url]) return;
+    [self loadImageAtURL:url progress:nil completion:^(UIImage *image, NSData *data) {
+        (void)image;
+        (void)data;
+    }];
+}
+
+// Called from -[ApolloGalleryImageRequest cancel]. The shared download only
+// dies once nobody is waiting on it any more — otherwise a recycled grid cell
+// would cancel a picture the viewer is still waiting for.
+- (void)apollo_cancelRequest:(ApolloGalleryImageRequest *)request {
+    NSString *key = request.key;
+    if (key.length == 0) return;
+    ApolloGalleryPendingDownload *download = self.pending[key];
+    if (!download) return;
+    [download.requests removeObjectIdenticalTo:request];
+    if (download.requests.count == 0) {
+        [download.task cancel];
+        [self.pending removeObjectForKey:key];
+    }
+}
+
+- (ApolloGalleryImageRequest *)loadImageAtURL:(NSURL *)url
+                                     progress:(void (^)(double fraction))progress
+                                   completion:(void (^)(UIImage *image, NSData *data))completion {
+    NSAssert(NSThread.isMainThread, @"ApolloGalleryImageLoader must be driven from the main thread");
+
+    ApolloGalleryImageRequest *request = [[ApolloGalleryImageRequest alloc] init];
+    request.loader = self;
+    request.completion = completion;
+
+    NSString *key = url.absoluteString;
+    if (key.length == 0) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (!request.isCancelled && request.completion) request.completion(nil, nil);
+        });
+        return request;
+    }
+    request.key = key;
+
+    UIImage *cached = [self.imageCache objectForKey:key];
+    if (cached) {
+        NSData *cachedData = [self.dataCache objectForKey:key];
+        // Async even on a cache hit: callers set up their view state after this
+        // returns, and a synchronous callback would run before that.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (!request.isCancelled && request.completion) request.completion(cached, cachedData);
+        });
+        return request;
+    }
+
+    ApolloGalleryPendingDownload *existing = self.pending[key];
+    if (existing) {
+        [existing.requests addObject:request];
+        request.download = existing;
+        if (progress) progress(request.progressFraction);
+        return request;
+    }
+
+    ApolloGalleryPendingDownload *download = [[ApolloGalleryPendingDownload alloc] init];
+    [download.requests addObject:request];
+    request.download = download;
+    self.pending[key] = download;
+
+    NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:url];
+    urlRequest.timeoutInterval = kApolloGalleryImageTimeout;
+    [urlRequest setValue:(sUserAgent.length > 0 ? sUserAgent : @"ApolloGallery/1.0") forHTTPHeaderField:@"User-Agent"];
+
+    __weak typeof(self) weakSelf = self;
+    download.task = [self.session dataTaskWithRequest:urlRequest
+                                    completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        UIImage *image = nil;
+        if (!error && data.length > 0) {
+            // Decoding happens here, off the main thread, so a big animated GIF
+            // never stalls a scroll.
+            image = ApolloGalleryDecodeAnimatedImage(data) ?: [UIImage imageWithData:data];
+        }
+        BOOL wasCancelled = [error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled;
+        if (!image && error && !wasCancelled) {
+            ApolloLog(@"[Gallery] image load failed (%@): %@", url.host ?: @"?", error.localizedDescription);
+        }
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            typeof(self) strongSelf = weakSelf;
+            if (!strongSelf) return;
+            if (image) {
+                [strongSelf.imageCache setObject:image forKey:key cost:ApolloGalleryImageCost(image)];
+                if (data.length > 0) [strongSelf.dataCache setObject:data forKey:key cost:data.length];
+            }
+            ApolloGalleryPendingDownload *finished = strongSelf.pending[key];
+            [strongSelf.pending removeObjectForKey:key];
+            for (ApolloGalleryImageRequest *waiter in finished.requests) {
+                if (!waiter.isCancelled && waiter.completion) waiter.completion(image, data);
+            }
+        });
+    }];
+
+    if (progress) progress(0.0);
+    [download.task resume];
+    return request;
+}
+
+@end

--- a/src/ApolloGalleryImageLoader.m
+++ b/src/ApolloGalleryImageLoader.m
@@ -42,6 +42,40 @@ static NSTimeInterval const kApolloGalleryImageTimeout = 30.0;
 }
 @end
 
+// Cap for the thumbnail decode tier. Grid tiles render at ~185pt (~555px @3x);
+// Reddit's preview variants are mostly ≤640px wide anyway, so this only bites
+// on the fallback cases where the tile URL is an original.
+static CGFloat const kApolloGalleryThumbnailDecodeMaxPixel = 800.0;
+
+// Thumbnail-tier decodes cache under their own key: the same URL can also be
+// decoded at full size by the viewer, and the two products must not shadow
+// each other. '#' can't appear un-escaped in an absolute URL string, so the
+// suffix is collision-safe.
+static NSString *ApolloGalleryThumbnailKey(NSURL *url) {
+    NSString *absolute = url.absoluteString;
+    return absolute.length > 0 ? [absolute stringByAppendingString:@"#thumb"] : nil;
+}
+
+// First-frame, downsampled decode for grid tiles. Never builds a multi-frame
+// animation and never inflates a full-resolution bitmap, so fast scrolling
+// through GIF-heavy grids costs bounded CPU/memory regardless of source size.
+static UIImage *ApolloGalleryDecodeStillThumbnail(NSData *data, CGFloat maxPixelSize) {
+    CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
+    if (!source) return nil;
+    NSDictionary *options = @{
+        (id)kCGImageSourceCreateThumbnailFromImageAlways: @YES,
+        (id)kCGImageSourceCreateThumbnailWithTransform: @YES,   // bake in EXIF orientation
+        (id)kCGImageSourceShouldCacheImmediately: @YES,         // decode here, not on first draw
+        (id)kCGImageSourceThumbnailMaxPixelSize: @(maxPixelSize),
+    };
+    CGImageRef cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, (__bridge CFDictionaryRef)options);
+    CFRelease(source);
+    if (!cgImage) return nil;
+    UIImage *image = [UIImage imageWithCGImage:cgImage];
+    CGImageRelease(cgImage);
+    return image;
+}
+
 #pragma mark - Animated GIF decoding
 
 // UIImage's +imageWithData: keeps only the first frame of a GIF. Walk the
@@ -196,11 +230,34 @@ static NSUInteger ApolloGalleryImageCost(UIImage *image) {
     return key.length > 0 ? [self.dataCache objectForKey:key] : nil;
 }
 
-- (void)prefetchImageAtURL:(NSURL *)url {
-    if (!url || [self cachedImageForURL:url]) return;
-    [self loadImageAtURL:url progress:nil completion:^(UIImage *image, NSData *data) {
+- (UIImage *)cachedThumbnailForURL:(NSURL *)url {
+    NSString *key = ApolloGalleryThumbnailKey(url);
+    return key.length > 0 ? [self.imageCache objectForKey:key] : nil;
+}
+
+- (ApolloGalleryImageRequest *)prefetchImageAtURL:(NSURL *)url {
+    if (!url || [self cachedImageForURL:url]) return nil;
+    return [self loadImageAtURL:url progress:nil completion:^(UIImage *image, NSData *data) {
         (void)image;
         (void)data;
+    }];
+}
+
+- (ApolloGalleryImageRequest *)prefetchThumbnailAtURL:(NSURL *)url {
+    if (!url || [self cachedThumbnailForURL:url]) return nil;
+    return [self loadThumbnailAtURL:url completion:^(UIImage *image) {
+        (void)image;
+    }];
+}
+
+- (ApolloGalleryImageRequest *)loadThumbnailAtURL:(NSURL *)url
+                                       completion:(void (^)(UIImage *_Nullable image))completion {
+    return [self apollo_loadURL:url
+                   thumbnailMax:kApolloGalleryThumbnailDecodeMaxPixel
+                       progress:nil
+                     completion:^(UIImage *image, NSData *data) {
+        (void)data;
+        completion(image);
     }];
 }
 
@@ -222,13 +279,24 @@ static NSUInteger ApolloGalleryImageCost(UIImage *image) {
 - (ApolloGalleryImageRequest *)loadImageAtURL:(NSURL *)url
                                      progress:(void (^)(double fraction))progress
                                    completion:(void (^)(UIImage *image, NSData *data))completion {
+    return [self apollo_loadURL:url thumbnailMax:0.0 progress:progress completion:completion];
+}
+
+// The one loading core. `thumbnailMax` > 0 selects the thumbnail tier: a
+// first-frame, downsampled decode cached under its own key, so grid tiles
+// never pay for multi-frame GIF decodes or full-resolution bitmaps, and never
+// collide with the viewer's full decode of the same URL.
+- (ApolloGalleryImageRequest *)apollo_loadURL:(NSURL *)url
+                                 thumbnailMax:(CGFloat)thumbnailMax
+                                     progress:(void (^)(double fraction))progress
+                                   completion:(void (^)(UIImage *image, NSData *data))completion {
     NSAssert(NSThread.isMainThread, @"ApolloGalleryImageLoader must be driven from the main thread");
 
     ApolloGalleryImageRequest *request = [[ApolloGalleryImageRequest alloc] init];
     request.loader = self;
     request.completion = completion;
 
-    NSString *key = url.absoluteString;
+    NSString *key = thumbnailMax > 0.0 ? ApolloGalleryThumbnailKey(url) : url.absoluteString;
     if (key.length == 0) {
         dispatch_async(dispatch_get_main_queue(), ^{
             if (!request.isCancelled && request.completion) request.completion(nil, nil);
@@ -270,9 +338,12 @@ static NSUInteger ApolloGalleryImageCost(UIImage *image) {
                                     completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         UIImage *image = nil;
         if (!error && data.length > 0) {
-            // Decoding happens here, off the main thread, so a big animated GIF
-            // never stalls a scroll.
-            image = ApolloGalleryDecodeAnimatedImage(data) ?: [UIImage imageWithData:data];
+            // Decoding happens here, off the main thread, so a big decode never
+            // stalls a scroll. The thumbnail tier decodes ONE downsampled frame;
+            // the full tier keeps animations intact.
+            image = thumbnailMax > 0.0
+                ? ApolloGalleryDecodeStillThumbnail(data, thumbnailMax)
+                : (ApolloGalleryDecodeAnimatedImage(data) ?: [UIImage imageWithData:data]);
         }
         BOOL wasCancelled = [error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled;
         if (!image && error && !wasCancelled) {
@@ -284,11 +355,22 @@ static NSUInteger ApolloGalleryImageCost(UIImage *image) {
             if (!strongSelf) return;
             if (image) {
                 [strongSelf.imageCache setObject:image forKey:key cost:ApolloGalleryImageCost(image)];
-                if (data.length > 0) [strongSelf.dataCache setObject:data forKey:key cost:data.length];
+                // Original bytes are only kept for full-tier loads — they exist
+                // for Save/Share, which never exports a thumbnail.
+                if (thumbnailMax <= 0.0 && data.length > 0) {
+                    [strongSelf.dataCache setObject:data forKey:key cost:data.length];
+                }
             }
-            ApolloGalleryPendingDownload *finished = strongSelf.pending[key];
-            [strongSelf.pending removeObjectForKey:key];
-            for (ApolloGalleryImageRequest *waiter in finished.requests) {
+            // Only touch the registry if this download still owns its slot. A
+            // cancelled task's completion can land AFTER a fresh download for
+            // the same URL has replaced pending[key]; removing and notifying
+            // blindly here would kill that newer download and hand its waiters
+            // this task's nil. Notifying the CAPTURED download is safe either
+            // way — when it was superseded, its waiters are all cancelled.
+            if (strongSelf.pending[key] == download) {
+                [strongSelf.pending removeObjectForKey:key];
+            }
+            for (ApolloGalleryImageRequest *waiter in download.requests) {
                 if (!waiter.isCancelled && waiter.completion) waiter.completion(image, data);
             }
         });

--- a/src/ApolloGalleryImageViewer.h
+++ b/src/ApolloGalleryImageViewer.h
@@ -1,0 +1,46 @@
+// ApolloGalleryImageViewer.h
+//
+// Gallery View's fullscreen pager: one picture at a time, swipe left/right for
+// the neighbours, pinch to zoom, swipe up or down to flick it away, tap to
+// toggle the chrome (post title / u/author / r/subreddit bottom-left, position
+// counter top-right, share top-right, Done top-left).
+//
+// It reads directly from the live ApolloGalleryFeed rather than a snapshot, so
+// paging past the last loaded picture pulls the next batch in place and the
+// counter's total grows — the same feed the grid behind it is showing, so the
+// two never disagree about what has been loaded.
+
+#import <UIKit/UIKit.h>
+
+@class ApolloGalleryFeed;
+@class ApolloGalleryImageViewer;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol ApolloGalleryImageViewerDelegate <NSObject>
+@optional
+// The viewer pulled another batch out of the shared feed; the grid should pick
+// the new items up. `addedRange` indexes into the feed's `items`.
+- (void)galleryViewer:(ApolloGalleryImageViewer *)viewer didAppendItemsInRange:(NSRange)addedRange;
+// Closing on `index` — the grid scrolls that tile into view so the user lands
+// back where they left off.
+- (void)galleryViewer:(ApolloGalleryImageViewer *)viewer willDismissAtIndex:(NSInteger)index;
+@end
+
+@interface ApolloGalleryImageViewer : UIViewController
+
+- (instancetype)initWithFeed:(ApolloGalleryFeed *)feed initialIndex:(NSInteger)initialIndex NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithNibName:(nullable NSString *)nibName bundle:(nullable NSBundle *)bundle NS_UNAVAILABLE;
+- (instancetype)initWithCoder:(NSCoder *)coder NS_UNAVAILABLE;
+
+@property (nonatomic, weak, nullable) id<ApolloGalleryImageViewerDelegate> galleryDelegate;
+// Index of the picture currently on screen.
+@property (nonatomic, readonly) NSInteger currentIndex;
+
+// Called by the grid when IT loaded more, so the pager picks up the same items
+// without a second request.
+- (void)feedDidAppendItems;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ApolloGalleryImageViewer.m
+++ b/src/ApolloGalleryImageViewer.m
@@ -10,8 +10,12 @@
 #import <AVFoundation/AVFoundation.h>
 #import <objc/message.h>
 
-// Pages either side of the current one kept warm.
-static NSInteger const kApolloGalleryViewerPrefetchRadius = 2;
+// Pages either side of the current one kept warm with their FULL-SIZE image.
+// Deliberately shallow — full-res warm-up is the expensive kind of prefetch on
+// image-heavy subreddits — and it drops to 0 for the session after a memory
+// warning (the poster/thumbnail still shows instantly; only the sharpening
+// waits for the page to become current).
+static NSInteger const kApolloGalleryViewerPrefetchRadius = 1;
 // Vertical drag (points) or flick velocity that commits the dismissal.
 static CGFloat const kApolloGalleryViewerDismissDistance = 120.0;
 static CGFloat const kApolloGalleryViewerDismissVelocity = 850.0;
@@ -66,6 +70,10 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
 @property (nonatomic, strong, nullable) id playerEndObserver;
 @property (nonatomic, copy, nullable) NSURL *videoURL;
 @property (nonatomic, readonly) BOOL hasVideo;
+// YES once the FULL-SIZE image is what's on screen. While it's NO, the image
+// view is showing the grid's downsampled thumbnail as a placeholder — which
+// Save/Share must never export.
+@property (nonatomic) BOOL fullImageLoaded;
 // Raised while a zoom is active so the pager and the dismiss pan stay out of
 // the way (a zoomed page must pan its own content, not turn the page).
 @property (nonatomic, readonly) BOOL isZoomed;
@@ -130,6 +138,7 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
     self.imageURL = nil;
     [self teardownPlayer];
     self.imageView.image = nil;
+    self.fullImageLoaded = NO;
     self.zoomView.zoomScale = 1.0;
     self.zoomView.contentInset = UIEdgeInsetsZero;
     self.zoomView.panGestureRecognizer.enabled = NO;
@@ -234,6 +243,12 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
 }
 
 - (void)playIfPossible {
+    // Players are created LAZILY, for the current page only: adjacent pages a
+    // paging collection view keeps materialized show their poster frame and
+    // cost no AVPlayer, no buffering, no decoder session. The player appears
+    // the moment its page becomes current (this method) and disappears with
+    // cell reuse.
+    if (!self.player && self.videoURL) [self prepareVideo:self.videoURL];
     if (!self.player) return;
     // Playback needs the session on a category that isn't silenced by the
     // ringer switch; Apollo parks it on Ambient, which mutes everything.
@@ -249,14 +264,17 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
 - (void)configureWithItem:(ApolloGalleryItem *)item {
     NSURL *url = item.imageURL;
     self.imageURL = url;
-    if (item.playsAsVideo) [self prepareVideo:item.videoURL];
+    // Stash the stream URL only; playIfPossible builds the player when this
+    // page actually becomes current.
+    self.videoURL = item.playsAsVideo ? item.videoURL : nil;
 
     // A grid thumbnail for this post is usually already decoded — show it
     // immediately so the page is never a black rectangle, then swap in the
     // full-size version when it lands.
-    UIImage *placeholder = item.thumbnailURL ? [[ApolloGalleryImageLoader sharedLoader] cachedImageForURL:item.thumbnailURL] : nil;
+    UIImage *placeholder = item.thumbnailURL ? [[ApolloGalleryImageLoader sharedLoader] cachedThumbnailForURL:item.thumbnailURL] : nil;
     UIImage *full = url ? [[ApolloGalleryImageLoader sharedLoader] cachedImageForURL:url] : nil;
     self.imageView.image = full ?: placeholder;
+    self.fullImageLoaded = (full != nil);
     // The fit rect depends on the image's proportions, so re-derive it whenever
     // the displayed image changes — including the placeholder→full swap, which
     // can have a different aspect if Reddit's preview was cropped.
@@ -280,6 +298,7 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
         [strongSelf.spinner stopAnimating];
         if (image) {
             strongSelf.imageView.image = image;
+            strongSelf.fullImageLoaded = YES;
             [strongSelf apollo_resetZoomGeometry];
         }
         (void)data;
@@ -458,6 +477,11 @@ static UIButton *ApolloGalleryChromeButton(UIImage *symbol, NSString *title, UIV
 
 @property (nonatomic, strong) UIPanGestureRecognizer *dismissPan;
 @property (nonatomic) BOOL isDismissing;
+// Full-res look-ahead: how deep (see kApolloGalleryViewerPrefetchRadius), and
+// the outstanding warm-up handles keyed by item index so paging can cancel the
+// ones that fell outside the window.
+@property (nonatomic) NSInteger prefetchRadius;
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, ApolloGalleryImageRequest *> *viewerPrefetches;
 @property (nonatomic) CGSize lastLaidOutSize;
 @end
 
@@ -470,6 +494,8 @@ static UIButton *ApolloGalleryChromeButton(UIImage *symbol, NSString *title, UIV
         _pendingInitialIndex = MAX(0, MIN(initialIndex, (NSInteger)feed.items.count - 1));
         _currentIndex = _pendingInitialIndex;
         _chromeVisible = YES;
+        _prefetchRadius = kApolloGalleryViewerPrefetchRadius;
+        _viewerPrefetches = [NSMutableDictionary dictionary];
         self.modalPresentationStyle = UIModalPresentationFullScreen;
         self.modalPresentationCapturesStatusBarAppearance = YES;
     }
@@ -541,6 +567,18 @@ static UIButton *ApolloGalleryChromeButton(UIImage *symbol, NSString *title, UIV
             [(ApolloGalleryViewerCell *)cell pausePlayback];
         }
     }
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // The loader is already dropping its caches; stop feeding it. Look-ahead
+    // stays off for the rest of this viewer session — the current page still
+    // loads full-res on demand, neighbours just wait until they're current.
+    self.prefetchRadius = 0;
+    for (ApolloGalleryImageRequest *request in self.viewerPrefetches.allValues) {
+        [request cancel];
+    }
+    [self.viewerPrefetches removeAllObjects];
 }
 
 - (void)viewDidLayoutSubviews {
@@ -842,11 +880,28 @@ static UIButton *ApolloGalleryChromeButton(UIImage *symbol, NSString *title, UIV
 }
 
 - (void)apollo_prefetchAroundIndex:(NSInteger)index {
+    NSInteger radius = self.prefetchRadius;
+
+    // Paging moved the window: transfers warming pages now outside it are
+    // spent bandwidth and decode pressure, so stop them instead of letting
+    // them run to completion behind the user.
+    NSMutableArray<NSNumber *> *stale = [NSMutableArray array];
+    [self.viewerPrefetches enumerateKeysAndObjectsUsingBlock:^(NSNumber *key, ApolloGalleryImageRequest *request, BOOL *stop) {
+        if (llabs(key.integerValue - index) > radius) {
+            [request cancel];
+            [stale addObject:key];
+        }
+    }];
+    [self.viewerPrefetches removeObjectsForKeys:stale];
+
     NSArray<ApolloGalleryItem *> *items = self.feed.items;
-    for (NSInteger offset = -kApolloGalleryViewerPrefetchRadius; offset <= kApolloGalleryViewerPrefetchRadius; offset++) {
+    for (NSInteger offset = -radius; offset <= radius; offset++) {
         NSInteger neighbour = index + offset;
         if (offset == 0 || neighbour < 0 || neighbour >= (NSInteger)items.count) continue;
-        [[ApolloGalleryImageLoader sharedLoader] prefetchImageAtURL:items[neighbour].imageURL];
+        if (self.viewerPrefetches[@(neighbour)]) continue;
+        ApolloGalleryImageRequest *request =
+            [[ApolloGalleryImageLoader sharedLoader] prefetchImageAtURL:items[neighbour].imageURL];
+        if (request) self.viewerPrefetches[@(neighbour)] = request;
     }
 }
 
@@ -869,7 +924,7 @@ static UIButton *ApolloGalleryChromeButton(UIImage *symbol, NSString *title, UIV
             if (strongSelf.feed.isExhausted) [strongSelf apollo_showToast:@"That's everything"];
             return;
         }
-        [strongSelf apollo_appendItemsInRange:addedRange];
+        [strongSelf feedDidAppendItems];
         id<ApolloGalleryImageViewerDelegate> delegate = strongSelf.galleryDelegate;
         if ([delegate respondsToSelector:@selector(galleryViewer:didAppendItemsInRange:)]) {
             [delegate galleryViewer:strongSelf didAppendItemsInRange:addedRange];
@@ -877,26 +932,24 @@ static UIButton *ApolloGalleryChromeButton(UIImage *symbol, NSString *title, UIV
     }];
 }
 
-- (void)apollo_appendItemsInRange:(NSRange)range {
-    if (range.length == 0) return;
-    NSMutableArray<NSIndexPath *> *indexPaths = [NSMutableArray arrayWithCapacity:range.length];
-    for (NSUInteger i = range.location; i < NSMaxRange(range); i++) {
-        [indexPaths addObject:[NSIndexPath indexPathForItem:(NSInteger)i inSection:0]];
-    }
-    // Appending past the end never disturbs the visible page's offset, so this
-    // is safe to do while the user is mid-swipe.
-    [self.collectionView performBatchUpdates:^{
-        [self.collectionView insertItemsAtIndexPaths:indexPaths];
-    } completion:nil];
-    [self apollo_updateChromeContent];
-}
-
+// Appends are derived by diffing the collection view's committed count against
+// the feed rather than trusting a callback range — the counts are the truth,
+// and a stale range (a filter/sort change landing mid-batch) then can't be
+// inserted. Appending past the end never disturbs the visible page's offset,
+// so this is safe mid-swipe.
 - (void)feedDidAppendItems {
     if (!self.isViewLoaded) return;
     NSInteger known = [self.collectionView numberOfItemsInSection:0];
     NSInteger total = (NSInteger)self.feed.items.count;
     if (total <= known) return;
-    [self apollo_appendItemsInRange:NSMakeRange((NSUInteger)known, (NSUInteger)(total - known))];
+    NSMutableArray<NSIndexPath *> *indexPaths = [NSMutableArray arrayWithCapacity:(NSUInteger)(total - known)];
+    for (NSInteger i = known; i < total; i++) {
+        [indexPaths addObject:[NSIndexPath indexPathForItem:i inSection:0]];
+    }
+    [self.collectionView performBatchUpdates:^{
+        [self.collectionView insertItemsAtIndexPaths:indexPaths];
+    } completion:nil];
+    [self apollo_updateChromeContent];
 }
 
 #pragma mark Gestures
@@ -1152,13 +1205,19 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
 }
 
 // Original bytes when we still have them (a GIF stays animated), otherwise a
-// PNG re-encode of what's on screen.
+// PNG re-encode of the on-screen image — but ONLY once the full-size image is
+// the thing on screen. While the full load is still in flight the image view
+// is showing the grid's downsampled thumbnail, and exporting that would
+// silently save a low-res copy; returning nil instead routes the action to
+// the "Still loading" toast.
 - (NSData *)apollo_dataForCurrentItem {
     ApolloGalleryItem *item = [self apollo_currentItem];
     if (!item) return nil;
     NSData *data = [[ApolloGalleryImageLoader sharedLoader] cachedDataForURL:item.imageURL];
     if (data.length > 0) return data;
-    UIImage *image = [self apollo_currentCell].imageView.image;
+    ApolloGalleryViewerCell *cell = [self apollo_currentCell];
+    if (!cell.fullImageLoaded) return nil;
+    UIImage *image = cell.imageView.image;
     return image ? UIImagePNGRepresentation(image) : nil;
 }
 

--- a/src/ApolloGalleryImageViewer.m
+++ b/src/ApolloGalleryImageViewer.m
@@ -8,6 +8,7 @@
 
 #import <Photos/Photos.h>
 #import <AVFoundation/AVFoundation.h>
+#import <objc/message.h>
 
 // Pages either side of the current one kept warm.
 static NSInteger const kApolloGalleryViewerPrefetchRadius = 2;
@@ -313,6 +314,16 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
 
 @end
 
+// Chrome glyphs at a fixed point size. Left unconfigured, an SF Symbol scales
+// to the button's font and filled the capsule edge to edge — which is what made
+// the share button look cramped and off-centre (its arrow overshoots the glyph
+// box, so tight bounds read as badly aligned rather than merely tight).
+static UIImage *ApolloGalleryChromeSymbol(NSString *name) {
+    UIImageSymbolConfiguration *configuration =
+        [UIImageSymbolConfiguration configurationWithPointSize:15.0 weight:UIImageSymbolWeightSemibold];
+    return [UIImage systemImageNamed:name withConfiguration:configuration];
+}
+
 // A chrome capsule: the material underneath, one content view (label or button)
 // filling it.
 //
@@ -336,6 +347,11 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
     [super layoutSubviews];
     self.materialView.frame = self.bounds;
     self.pillContentView.frame = self.bounds;
+    // Fully rounded, always: that makes a square icon button a circle and a
+    // text pill a capsule, which is the shape Apple's own glass controls use.
+    // A fixed radius on a 40x32 rect is what made these read as "tight boxes"
+    // rather than iOS 26 controls.
+    self.layer.cornerRadius = MIN(CGRectGetWidth(self.bounds), CGRectGetHeight(self.bounds)) / 2.0;
 }
 @end
 
@@ -343,16 +359,20 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
 // real UIGlassEffect, so the viewer's controls match the rest of the iOS 26 app
 // instead of reading as flat pre-26 pills; older builds keep translucent black,
 // which is what stays legible over an arbitrary photo.
-static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGFloat cornerRadius, CGFloat legacyAlpha) {
+static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGFloat legacyAlpha) {
     ApolloGalleryChromePillView *pill = [[ApolloGalleryChromePillView alloc] initWithFrame:CGRectZero];
-    pill.layer.cornerRadius = cornerRadius;
-    pill.layer.cornerCurve = kCACornerCurveContinuous;
     pill.clipsToBounds = YES;
 
     Class glassClass = NSClassFromString(@"UIGlassEffect");
     if (IsLiquidGlass() && glassClass) {
         pill.backgroundColor = UIColor.clearColor;
-        UIVisualEffectView *glass = [[UIVisualEffectView alloc] initWithEffect:[[glassClass alloc] init]];
+        id effect = [[glassClass alloc] init];
+        // Interactive glass is what gives Apple's controls their press
+        // response; without it the capsule is inert decoration.
+        if ([effect respondsToSelector:@selector(setInteractive:)]) {
+            ((void (*)(id, SEL, BOOL))objc_msgSend)(effect, @selector(setInteractive:), YES);
+        }
+        UIVisualEffectView *glass = [[UIVisualEffectView alloc] initWithEffect:(UIVisualEffect *)effect];
         glass.userInteractionEnabled = NO;
         [pill addSubview:glass];
         pill.materialView = glass;
@@ -525,7 +545,7 @@ static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGF
     [self.doneButton setTitle:@"Done" forState:UIControlStateNormal];
     self.doneButton.tintColor = UIColor.whiteColor;
     self.doneButton.titleLabel.font = [UIFont systemFontOfSize:16.0 weight:UIFontWeightSemibold];
-    self.donePill = ApolloGalleryChromePill(self.doneButton, 16.0, 0.55);
+    self.donePill = ApolloGalleryChromePill(self.doneButton, 0.55);
     [self.doneButton addTarget:self action:@selector(apollo_donePressed) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:self.donePill];
 
@@ -533,20 +553,20 @@ static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGF
     self.counterLabel.textColor = UIColor.whiteColor;
     self.counterLabel.font = [UIFont monospacedDigitSystemFontOfSize:14.0 weight:UIFontWeightSemibold];
     self.counterLabel.textAlignment = NSTextAlignmentCenter;
-    self.counterPill = ApolloGalleryChromePill(self.counterLabel, 14.0, 0.55);
+    self.counterPill = ApolloGalleryChromePill(self.counterLabel, 0.55);
     [self.view addSubview:self.counterPill];
 
     self.shareButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    [self.shareButton setImage:[UIImage systemImageNamed:@"square.and.arrow.up"] forState:UIControlStateNormal];
+    [self.shareButton setImage:ApolloGalleryChromeSymbol(@"square.and.arrow.up") forState:UIControlStateNormal];
     self.shareButton.tintColor = UIColor.whiteColor;
-    self.sharePill = ApolloGalleryChromePill(self.shareButton, 16.0, 0.55);
+    self.sharePill = ApolloGalleryChromePill(self.shareButton, 0.55);
     [self.shareButton addTarget:self action:@selector(apollo_sharePressed:) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:self.sharePill];
 
     // Only shown while a video/GIF page is up; still images have nothing to mute.
     self.muteButton = [UIButton buttonWithType:UIButtonTypeSystem];
     self.muteButton.tintColor = UIColor.whiteColor;
-    self.mutePill = ApolloGalleryChromePill(self.muteButton, 16.0, 0.55);
+    self.mutePill = ApolloGalleryChromePill(self.muteButton, 0.55);
     [self.muteButton addTarget:self action:@selector(apollo_muteTapped) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:self.mutePill];
 
@@ -594,7 +614,7 @@ static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGF
     self.statusLabel.textColor = UIColor.whiteColor;
     self.statusLabel.font = [UIFont systemFontOfSize:12.0 weight:UIFontWeightSemibold];
     self.statusLabel.textAlignment = NSTextAlignmentCenter;
-    self.statusPill = ApolloGalleryChromePill(self.statusLabel, 12.0, 0.55);
+    self.statusPill = ApolloGalleryChromePill(self.statusLabel, 0.55);
     self.statusPill.alpha = 0.0;
     [self.view addSubview:self.statusPill];
 
@@ -602,7 +622,7 @@ static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGF
     self.toastLabel.textColor = UIColor.whiteColor;
     self.toastLabel.font = [UIFont systemFontOfSize:14.0 weight:UIFontWeightSemibold];
     self.toastLabel.textAlignment = NSTextAlignmentCenter;
-    self.toastPill = ApolloGalleryChromePill(self.toastLabel, 14.0, 0.7);
+    self.toastPill = ApolloGalleryChromePill(self.toastLabel, 0.7);
     self.toastPill.alpha = 0.0;
     [self.view addSubview:self.toastPill];
 }
@@ -616,16 +636,23 @@ static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGF
     CGFloat side = MAX(16.0, safe.left + 16.0);
     CGFloat rightSide = MAX(16.0, safe.right + 16.0);
 
-    self.donePill.frame = CGRectMake(side, top, 72.0, 32.0);
-    self.sharePill.frame = CGRectMake(bounds.size.width - rightSide - 40.0, top, 40.0, 32.0);
+    // Icon buttons are SQUARE, so the capsule renders as a circle — the shape
+    // Apple uses for single-glyph glass controls. The old 40x32 rect with a
+    // fixed 16pt radius is what made them read as tight little boxes.
+    CGFloat const controlHeight = 36.0;
+    CGFloat const iconSize = controlHeight;
+    CGFloat const controlGap = 8.0;
+
+    self.donePill.frame = CGRectMake(side, top, 74.0, controlHeight);
+    self.sharePill.frame = CGRectMake(bounds.size.width - rightSide - iconSize, top, iconSize, controlHeight);
     CGFloat trailing = CGRectGetMinX(self.sharePill.frame);
     if (!self.mutePill.hidden) {
-        self.mutePill.frame = CGRectMake(trailing - 8.0 - 40.0, top, 40.0, 32.0);
+        self.mutePill.frame = CGRectMake(trailing - controlGap - iconSize, top, iconSize, controlHeight);
         trailing = CGRectGetMinX(self.mutePill.frame);
     }
-    CGFloat counterWidth = 84.0;
-    self.counterPill.frame = CGRectMake(trailing - 8.0 - counterWidth, top, counterWidth, 32.0);
-    self.statusPill.frame = CGRectMake((bounds.size.width - 150.0) / 2.0, CGRectGetMaxY(self.counterPill.frame) + 8.0, 150.0, 24.0);
+    CGFloat counterWidth = 88.0;
+    self.counterPill.frame = CGRectMake(trailing - controlGap - counterWidth, top, counterWidth, controlHeight);
+    self.statusPill.frame = CGRectMake((bounds.size.width - 156.0) / 2.0, CGRectGetMaxY(self.counterPill.frame) + 8.0, 156.0, 28.0);
 
     CGFloat bottom = safe.bottom + 16.0;
     CGFloat panelWidth = MIN(bounds.size.width - side - rightSide, 460.0);
@@ -650,8 +677,8 @@ static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGF
     self.subtitleLabel.frame = CGRectMake(12.0, 10.0 + titleSize.height + gap, subtitleSize.width, subtitleSize.height);
 
     self.toastPill.frame = CGRectMake((bounds.size.width - 220.0) / 2.0,
-                                       CGRectGetMinY(self.infoPanel.frame) - 44.0,
-                                       220.0, 30.0);
+                                       CGRectGetMinY(self.infoPanel.frame) - 46.0,
+                                       220.0, 32.0);
 }
 
 - (void)apollo_updateChromeContent {
@@ -975,7 +1002,7 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
     self.mutePill.hidden = !showsMute;
     if (showsMute) {
         BOOL muted = ApolloGalleryViewerVideosMuted();
-        [self.muteButton setImage:[UIImage systemImageNamed:(muted ? @"speaker.slash.fill" : @"speaker.wave.2.fill")]
+        [self.muteButton setImage:ApolloGalleryChromeSymbol(muted ? @"speaker.slash.fill" : @"speaker.wave.2.fill")
                          forState:UIControlStateNormal];
         self.muteButton.accessibilityLabel = muted ? @"Unmute" : @"Mute";
         self.mutePill.alpha = self.chromeVisible ? 1.0 : 0.0;

--- a/src/ApolloGalleryImageViewer.m
+++ b/src/ApolloGalleryImageViewer.m
@@ -6,6 +6,7 @@
 #import "ApolloCommon.h"
 
 #import <Photos/Photos.h>
+#import <AVFoundation/AVFoundation.h>
 
 // Pages either side of the current one kept warm.
 static NSInteger const kApolloGalleryViewerPrefetchRadius = 2;
@@ -18,6 +19,36 @@ static NSInteger const kApolloGalleryViewerLoadAheadSlack = 4;
 
 static NSString *const kApolloGalleryViewerCellID = @"ApolloGalleryViewerCell";
 
+// Mute state is sticky across pages and launches: someone browsing a video
+// subreddit in public wants it to stay off, and re-muting every clip by hand
+// would be miserable.
+static NSString *const kApolloGalleryViewerMutedKey = @"ApolloGalleryVideosMuted";
+
+static BOOL ApolloGalleryViewerVideosMuted(void) {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    // Default to muted — audio starting unprompted in a scrolling gallery is
+    // the worse surprise.
+    id stored = [defaults objectForKey:kApolloGalleryViewerMutedKey];
+    return stored ? [defaults boolForKey:kApolloGalleryViewerMutedKey] : YES;
+}
+
+static void ApolloGalleryViewerSetVideosMuted(BOOL muted) {
+    [[NSUserDefaults standardUserDefaults] setBool:muted forKey:kApolloGalleryViewerMutedKey];
+}
+
+// Apollo parks the shared session on Ambient, which is silenced by the ringer
+// switch — so an unmuted clip would still play silently without this.
+static void ApolloGalleryViewerActivateAudioSession(void) {
+    if (ApolloGalleryViewerVideosMuted()) return;
+    AVAudioSession *session = [AVAudioSession sharedInstance];
+    NSError *error = nil;
+    if (![session setCategory:AVAudioSessionCategoryPlayback error:&error]) {
+        ApolloLog(@"[Gallery] audio session category failed: %@", error.localizedDescription);
+        return;
+    }
+    [session setActive:YES error:NULL];
+}
+
 #pragma mark - Page cell
 
 @interface ApolloGalleryViewerCell : UICollectionViewCell <UIScrollViewDelegate>
@@ -26,6 +57,13 @@ static NSString *const kApolloGalleryViewerCellID = @"ApolloGalleryViewerCell";
 @property (nonatomic, strong) UIActivityIndicatorView *spinner;
 @property (nonatomic, strong, nullable) ApolloGalleryImageRequest *request;
 @property (nonatomic, copy, nullable) NSURL *imageURL;
+// Video side. The poster image stays underneath until the first frame is ready,
+// so paging onto a clip never flashes black.
+@property (nonatomic, strong, nullable) AVPlayer *player;
+@property (nonatomic, strong, nullable) AVPlayerLayer *playerLayer;
+@property (nonatomic, strong, nullable) id playerEndObserver;
+@property (nonatomic, copy, nullable) NSURL *videoURL;
+@property (nonatomic, readonly) BOOL hasVideo;
 // Raised while a zoom is active so the pager and the dismiss pan stay out of
 // the way (a zoomed page must pan its own content, not turn the page).
 @property (nonatomic, readonly) BOOL isZoomed;
@@ -79,11 +117,16 @@ static NSString *const kApolloGalleryViewerCellID = @"ApolloGalleryViewerCell";
     return self.zoomView.zoomScale > self.zoomView.minimumZoomScale + 0.01;
 }
 
+- (BOOL)hasVideo {
+    return self.player != nil;
+}
+
 - (void)prepareForReuse {
     [super prepareForReuse];
     [self.request cancel];
     self.request = nil;
     self.imageURL = nil;
+    [self teardownPlayer];
     self.imageView.image = nil;
     self.zoomView.zoomScale = 1.0;
     self.zoomView.contentInset = UIEdgeInsetsZero;
@@ -91,11 +134,23 @@ static NSString *const kApolloGalleryViewerCellID = @"ApolloGalleryViewerCell";
     [self.spinner stopAnimating];
 }
 
+- (void)dealloc {
+    [self teardownPlayer];
+}
+
 - (void)layoutSubviews {
     [super layoutSubviews];
     CGRect bounds = self.contentView.bounds;
     BOOL boundsChanged = !CGSizeEqualToSize(bounds.size, self.zoomView.frame.size);
     self.zoomView.frame = bounds;
+    // The player sits above the poster and fills the page; AVPlayerLayer's own
+    // aspect-fit gravity handles letterboxing, so it doesn't ride the zoom view.
+    if (self.playerLayer) {
+        [CATransaction begin];
+        [CATransaction setDisableActions:YES];
+        self.playerLayer.frame = bounds;
+        [CATransaction commit];
+    }
     self.spinner.center = CGPointMake(CGRectGetMidX(bounds), CGRectGetMidY(bounds));
     // A bounds change (rotation, first layout) invalidates the zoom geometry.
     if (boundsChanged) [self apollo_resetZoomGeometry];
@@ -135,9 +190,64 @@ static NSString *const kApolloGalleryViewerCellID = @"ApolloGalleryViewerCell";
     self.zoomView.contentInset = UIEdgeInsetsMake(vertical, horizontal, vertical, horizontal);
 }
 
+// Setting up / tearing down playback ----------------------------------------
+
+- (void)teardownPlayer {
+    if (self.playerEndObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:self.playerEndObserver];
+        self.playerEndObserver = nil;
+    }
+    [self.player pause];
+    [self.playerLayer removeFromSuperlayer];
+    self.playerLayer = nil;
+    self.player = nil;
+    self.videoURL = nil;
+}
+
+- (void)prepareVideo:(NSURL *)url {
+    if (!url) return;
+    self.videoURL = url;
+
+    AVPlayer *player = [AVPlayer playerWithURL:url];
+    player.muted = ApolloGalleryViewerVideosMuted();
+    // Clips are short and usually watched more than once; looping is what a
+    // gallery reader expects and matches how Apollo plays GIF-ish media.
+    __weak typeof(self) weakSelf = self;
+    self.playerEndObserver =
+        [[NSNotificationCenter defaultCenter] addObserverForName:AVPlayerItemDidPlayToEndTimeNotification
+                                                          object:player.currentItem
+                                                           queue:[NSOperationQueue mainQueue]
+                                                      usingBlock:^(NSNotification *note) {
+        [weakSelf.player seekToTime:kCMTimeZero];
+        [weakSelf.player play];
+    }];
+
+    AVPlayerLayer *layer = [AVPlayerLayer playerLayerWithPlayer:player];
+    layer.videoGravity = AVLayerVideoGravityResizeAspect;
+    layer.frame = self.contentView.bounds;
+    [self.contentView.layer addSublayer:layer];
+
+    self.player = player;
+    self.playerLayer = layer;
+}
+
+- (void)playIfPossible {
+    if (!self.player) return;
+    // Playback needs the session on a category that isn't silenced by the
+    // ringer switch; Apollo parks it on Ambient, which mutes everything.
+    ApolloGalleryViewerActivateAudioSession();
+    self.player.muted = ApolloGalleryViewerVideosMuted();
+    [self.player play];
+}
+
+- (void)pausePlayback {
+    [self.player pause];
+}
+
 - (void)configureWithItem:(ApolloGalleryItem *)item {
     NSURL *url = item.imageURL;
     self.imageURL = url;
+    if (item.playsAsVideo) [self prepareVideo:item.videoURL];
 
     // A grid thumbnail for this post is usually already decoded — show it
     // immediately so the page is never a black rectangle, then swap in the
@@ -218,6 +328,7 @@ static NSString *const kApolloGalleryViewerCellID = @"ApolloGalleryViewerCell";
 @property (nonatomic, strong) UIView *topChrome;
 @property (nonatomic, strong) UIButton *doneButton;
 @property (nonatomic, strong) UIButton *shareButton;
+@property (nonatomic, strong) UIButton *muteButton;
 @property (nonatomic, strong) UILabel *counterLabel;
 @property (nonatomic, strong) UIView *infoPanel;
 @property (nonatomic, strong) UILabel *titleLabel;
@@ -303,6 +414,16 @@ static NSString *const kApolloGalleryViewerCellID = @"ApolloGalleryViewerCell";
     [self apollo_updateChromeContent];
 }
 
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    // Nothing should keep playing behind or after the viewer.
+    for (UICollectionViewCell *cell in self.collectionView.visibleCells) {
+        if ([cell isKindOfClass:[ApolloGalleryViewerCell class]]) {
+            [(ApolloGalleryViewerCell *)cell pausePlayback];
+        }
+    }
+}
+
 - (void)viewDidLayoutSubviews {
     [super viewDidLayoutSubviews];
     CGSize size = self.view.bounds.size;
@@ -322,6 +443,7 @@ static NSString *const kApolloGalleryViewerCellID = @"ApolloGalleryViewerCell";
         [self.collectionView setContentOffset:CGPointMake(size.width * index, 0.0) animated:NO];
         self.currentIndex = index;
         [self apollo_updateChromeContent];
+        [self apollo_syncPlayback];
         [self apollo_prefetchAroundIndex:index];
     } else if (self.hasAppliedInitialIndex) {
         // Rotation moves the page boundaries; re-anchor on the current picture.
@@ -378,6 +500,17 @@ static UIView *ApolloGalleryChromeCapsule(CGFloat cornerRadius) {
     [self.shareButton addTarget:self action:@selector(apollo_sharePressed:) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:self.shareButton];
 
+    // Only shown while a video/GIF page is up; still images have nothing to mute.
+    self.muteButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    self.muteButton.tintColor = UIColor.whiteColor;
+    self.muteButton.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.55];
+    self.muteButton.layer.cornerRadius = 16.0;
+    self.muteButton.layer.cornerCurve = kCACornerCurveContinuous;
+    self.muteButton.clipsToBounds = YES;
+    self.muteButton.hidden = YES;
+    [self.muteButton addTarget:self action:@selector(apollo_muteTapped) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:self.muteButton];
+
     // Bottom-left post details. Tapping it leaves the gallery for the real post.
     self.infoPanel = ApolloGalleryChromeCapsule(14.0);
     [self.view addSubview:self.infoPanel];
@@ -432,8 +565,13 @@ static UIView *ApolloGalleryChromeCapsule(CGFloat cornerRadius) {
 
     self.doneButton.frame = CGRectMake(side, top, 72.0, 32.0);
     self.shareButton.frame = CGRectMake(bounds.size.width - rightSide - 40.0, top, 40.0, 32.0);
+    CGFloat trailing = CGRectGetMinX(self.shareButton.frame);
+    if (!self.muteButton.hidden) {
+        self.muteButton.frame = CGRectMake(trailing - 8.0 - 40.0, top, 40.0, 32.0);
+        trailing = CGRectGetMinX(self.muteButton.frame);
+    }
     CGFloat counterWidth = 84.0;
-    self.counterLabel.frame = CGRectMake(CGRectGetMinX(self.shareButton.frame) - 8.0 - counterWidth, top, counterWidth, 32.0);
+    self.counterLabel.frame = CGRectMake(trailing - 8.0 - counterWidth, top, counterWidth, 32.0);
     self.statusLabel.frame = CGRectMake((bounds.size.width - 150.0) / 2.0, CGRectGetMaxY(self.counterLabel.frame) + 8.0, 150.0, 24.0);
 
     CGFloat bottom = safe.bottom + 16.0;
@@ -479,6 +617,7 @@ static UIView *ApolloGalleryChromeCapsule(CGFloat cornerRadius) {
 
     ApolloGalleryItem *item = (index >= 0 && index < total) ? items[index] : nil;
     self.titleLabel.text = item.postTitle ?: @"";
+    [self apollo_updateMuteButton];
 
     NSMutableArray<NSString *> *parts = [NSMutableArray array];
     if (item.author.length > 0) [parts addObject:[@"u/" stringByAppendingString:item.author]];
@@ -498,11 +637,13 @@ static UIView *ApolloGalleryChromeCapsule(CGFloat cornerRadius) {
     void (^changes)(void) = ^{
         self.doneButton.alpha = alpha;
         self.shareButton.alpha = alpha;
+        self.muteButton.alpha = alpha;
         self.counterLabel.alpha = alpha;
         self.infoPanel.alpha = alpha;
     };
     self.doneButton.userInteractionEnabled = visible;
     self.shareButton.userInteractionEnabled = visible;
+    self.muteButton.userInteractionEnabled = visible;
     self.infoPanel.userInteractionEnabled = visible;
     if (animated) {
         [UIView animateWithDuration:0.22 animations:changes];
@@ -562,8 +703,25 @@ static UIView *ApolloGalleryChromeCapsule(CGFloat cornerRadius) {
     if (page == self.currentIndex) return;
     self.currentIndex = page;
     [self apollo_updateChromeContent];
+    [self apollo_syncPlayback];
     [self apollo_prefetchAroundIndex:page];
     [self apollo_loadMoreIfNeeded];
+}
+
+// Exactly one page plays at a time: every other visible cell (the neighbours a
+// paging collection view keeps alive) gets paused, so audio can't stack up.
+- (void)apollo_syncPlayback {
+    for (UICollectionViewCell *cell in self.collectionView.visibleCells) {
+        if (![cell isKindOfClass:[ApolloGalleryViewerCell class]]) continue;
+        ApolloGalleryViewerCell *viewerCell = (ApolloGalleryViewerCell *)cell;
+        NSIndexPath *indexPath = [self.collectionView indexPathForCell:cell];
+        if (indexPath.item == self.currentIndex) {
+            [viewerCell playIfPossible];
+        } else {
+            [viewerCell pausePlayback];
+        }
+    }
+    [self apollo_updateMuteButton];
 }
 
 - (void)apollo_prefetchAroundIndex:(NSInteger)index {
@@ -652,6 +810,7 @@ static UIView *ApolloGalleryChromeCapsule(CGFloat cornerRadius) {
                     [UIView animateWithDuration:0.15 animations:^{
                 self.doneButton.alpha = 0.0;
                 self.shareButton.alpha = 0.0;
+                self.muteButton.alpha = 0.0;
                 self.counterLabel.alpha = 0.0;
                 self.infoPanel.alpha = 0.0;
             }];
@@ -756,6 +915,26 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
     return items[self.currentIndex];
 }
 
+// The mute control only makes sense on a page that can make noise.
+- (void)apollo_updateMuteButton {
+    ApolloGalleryItem *item = [self apollo_currentItem];
+    BOOL showsMute = item.playsAsVideo && item.kind == ApolloGalleryMediaKindVideo;
+    self.muteButton.hidden = !showsMute;
+    if (showsMute) {
+        BOOL muted = ApolloGalleryViewerVideosMuted();
+        [self.muteButton setImage:[UIImage systemImageNamed:(muted ? @"speaker.slash.fill" : @"speaker.wave.2.fill")]
+                         forState:UIControlStateNormal];
+        self.muteButton.accessibilityLabel = muted ? @"Unmute" : @"Mute";
+        self.muteButton.alpha = self.chromeVisible ? 1.0 : 0.0;
+    }
+    [self.view setNeedsLayout];
+}
+
+- (void)apollo_muteTapped {
+    ApolloGalleryViewerSetVideosMuted(!ApolloGalleryViewerVideosMuted());
+    [self apollo_syncPlayback];
+}
+
 - (void)apollo_sharePressed:(UIButton *)sender {
     [self apollo_presentActionsFromView:sender];
 }
@@ -772,12 +951,26 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
                                                                    message:nil
                                                             preferredStyle:UIAlertControllerStyleActionSheet];
     __weak typeof(self) weakSelf = self;
-    [sheet addAction:[UIAlertAction actionWithTitle:@"Save Image" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-        [weakSelf apollo_saveCurrentImage];
-    }]];
-    [sheet addAction:[UIAlertAction actionWithTitle:@"Share Image" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-        [weakSelf apollo_shareCurrentImageFromView:sourceView];
-    }]];
+    if (item.playsAsVideo) {
+        // Only offer Save when there's a self-contained file to write. A
+        // v.redd.it "fallback" mp4 is the video track alone — saving it would
+        // hand back a silent copy, so it's left out rather than disappointing.
+        if (item.videoDownloadURL) {
+            [sheet addAction:[UIAlertAction actionWithTitle:@"Save Video" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+                [weakSelf apollo_saveCurrentVideo];
+            }]];
+        }
+        [sheet addAction:[UIAlertAction actionWithTitle:@"Share Video Link" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+            [weakSelf apollo_presentActivityWithItems:@[item.videoURL] fromView:sourceView];
+        }]];
+    } else {
+        [sheet addAction:[UIAlertAction actionWithTitle:@"Save Image" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+            [weakSelf apollo_saveCurrentImage];
+        }]];
+        [sheet addAction:[UIAlertAction actionWithTitle:@"Share Image" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+            [weakSelf apollo_shareCurrentImageFromView:sourceView];
+        }]];
+    }
     if (item.postURL) {
         [sheet addAction:[UIAlertAction actionWithTitle:@"Share Post Link" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
             [weakSelf apollo_sharePostLinkFromView:sourceView];
@@ -842,6 +1035,70 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
                 } else {
                     [weakSelf apollo_showToast:@"Photos access denied"];
                 }
+            });
+        }];
+    } else if (status == PHAuthorizationStatusAuthorized || status == PHAuthorizationStatusLimited) {
+        performSave();
+    } else {
+        [self apollo_showToast:@"Photos access denied"];
+    }
+}
+
+// Videos aren't held in the image cache, so this pulls the mp4 down before
+// handing it to Photos.
+- (void)apollo_saveCurrentVideo {
+    NSURL *source = [self apollo_currentItem].videoDownloadURL;
+    if (!source) return;
+    [self apollo_showToast:@"Saving…"];
+
+    __weak typeof(self) weakSelf = self;
+    NSURLSessionDownloadTask *task =
+        [[NSURLSession sharedSession] downloadTaskWithURL:source
+                                        completionHandler:^(NSURL *location, NSURLResponse *response, NSError *error) {
+        if (!location || error) {
+            ApolloLog(@"[Gallery] video download failed: %@", error.localizedDescription);
+            dispatch_async(dispatch_get_main_queue(), ^{ [weakSelf apollo_showToast:@"Save failed"]; });
+            return;
+        }
+        // Photos needs a file with a real video extension; the download lands
+        // at a temp path with none.
+        NSString *name = source.lastPathComponent.length > 0 ? source.lastPathComponent : @"video.mp4";
+        if (name.pathExtension.length == 0) name = [name stringByAppendingPathExtension:@"mp4"];
+        NSURL *fileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:name]];
+        [[NSFileManager defaultManager] removeItemAtURL:fileURL error:NULL];
+        if (![[NSFileManager defaultManager] moveItemAtURL:location toURL:fileURL error:NULL]) {
+            dispatch_async(dispatch_get_main_queue(), ^{ [weakSelf apollo_showToast:@"Save failed"]; });
+            return;
+        }
+        [weakSelf apollo_writeVideoFileToPhotos:fileURL];
+    }];
+    [task resume];
+}
+
+- (void)apollo_writeVideoFileToPhotos:(NSURL *)fileURL {
+    __weak typeof(self) weakSelf = self;
+    void (^performSave)(void) = ^{
+        [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+            PHAssetCreationRequest *request = [PHAssetCreationRequest creationRequestForAsset];
+            [request addResourceWithType:PHAssetResourceTypeVideo fileURL:fileURL options:nil];
+        } completionHandler:^(BOOL success, NSError *error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (success) {
+                    [weakSelf apollo_showToast:@"Saved"];
+                } else {
+                    ApolloLog(@"[Gallery] video save failed: %@", error.localizedDescription);
+                    [weakSelf apollo_showToast:@"Save failed"];
+                }
+            });
+        }];
+    };
+
+    PHAuthorizationStatus status = [PHPhotoLibrary authorizationStatusForAccessLevel:PHAccessLevelAddOnly];
+    if (status == PHAuthorizationStatusNotDetermined) {
+        [PHPhotoLibrary requestAuthorizationForAccessLevel:PHAccessLevelAddOnly handler:^(PHAuthorizationStatus newStatus) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (newStatus == PHAuthorizationStatusAuthorized || newStatus == PHAuthorizationStatusLimited) performSave();
+                else [weakSelf apollo_showToast:@"Photos access denied"];
             });
         }];
     } else if (status == PHAuthorizationStatusAuthorized || status == PHAuthorizationStatusLimited) {

--- a/src/ApolloGalleryImageViewer.m
+++ b/src/ApolloGalleryImageViewer.m
@@ -386,6 +386,44 @@ static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGF
     return pill;
 }
 
+// Builds a chrome button and the view that should be positioned for it.
+//
+// On Liquid Glass we hand the whole job to UIKit's own glass button
+// configuration rather than wrapping our own capsule around a plain button.
+// That's what gets Apple's metrics — UIKit sizes the glass around the glyph, so
+// the symbol is padded and optically centred instead of us guessing — and it's
+// also what lets a button-attached UIMenu play the iOS 26 morph, since the
+// button itself becomes the morph source. Elsewhere we fall back to the
+// hand-rolled pill.
+//
+// Returns the button; `outHost` is what -apollo_layoutChrome should position
+// (the button itself on glass, its pill otherwise).
+static UIButton *ApolloGalleryChromeButton(UIImage *symbol, NSString *title, UIView *__strong *outHost) {
+    if (IsLiquidGlass()) {
+        if (@available(iOS 26.0, *)) {
+            UIButtonConfiguration *configuration = [UIButtonConfiguration glassButtonConfiguration];
+            configuration.image = symbol;
+            configuration.title = title;
+            configuration.cornerStyle = UIButtonConfigurationCornerStyleCapsule;
+            UIButton *button = [UIButton buttonWithConfiguration:configuration primaryAction:nil];
+            button.tintColor = UIColor.whiteColor;
+            if (outHost) *outHost = button;
+            return button;
+        }
+    }
+
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+    button.tintColor = UIColor.whiteColor;
+    if (symbol) [button setImage:symbol forState:UIControlStateNormal];
+    if (title) {
+        [button setTitle:title forState:UIControlStateNormal];
+        button.titleLabel.font = [UIFont systemFontOfSize:16.0 weight:UIFontWeightSemibold];
+    }
+    ApolloGalleryChromePillView *pill = ApolloGalleryChromePill(button, 0.55);
+    if (outHost) *outHost = pill;
+    return button;
+}
+
 #pragma mark - Viewer
 
 @interface ApolloGalleryImageViewer () <UICollectionViewDataSource, UICollectionViewDelegateFlowLayout,
@@ -401,11 +439,11 @@ static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGF
 
 @property (nonatomic, strong) UIView *topChrome;
 @property (nonatomic, strong) UIButton *doneButton;
-@property (nonatomic, strong) ApolloGalleryChromePillView *donePill;
+@property (nonatomic, strong) UIView *doneHost;
 @property (nonatomic, strong) UIButton *shareButton;
-@property (nonatomic, strong) ApolloGalleryChromePillView *sharePill;
+@property (nonatomic, strong) UIView *shareHost;
 @property (nonatomic, strong) UIButton *muteButton;
-@property (nonatomic, strong) ApolloGalleryChromePillView *mutePill;
+@property (nonatomic, strong) UIView *muteHost;
 @property (nonatomic, strong) UILabel *counterLabel;
 @property (nonatomic, strong) ApolloGalleryChromePillView *counterPill;
 @property (nonatomic, strong) UIView *infoPanel;
@@ -541,13 +579,9 @@ static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGF
 // over an arbitrary photo — the same treatment in Liquid Glass and legacy
 // builds, since the backdrop here is the picture, not app chrome.
 - (void)apollo_buildChrome {
-    self.doneButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    [self.doneButton setTitle:@"Done" forState:UIControlStateNormal];
-    self.doneButton.tintColor = UIColor.whiteColor;
-    self.doneButton.titleLabel.font = [UIFont systemFontOfSize:16.0 weight:UIFontWeightSemibold];
-    self.donePill = ApolloGalleryChromePill(self.doneButton, 0.55);
+    self.doneButton = ApolloGalleryChromeButton(nil, @"Done", &_doneHost);
     [self.doneButton addTarget:self action:@selector(apollo_donePressed) forControlEvents:UIControlEventTouchUpInside];
-    [self.view addSubview:self.donePill];
+    [self.view addSubview:self.doneHost];
 
     self.counterLabel = [[UILabel alloc] initWithFrame:CGRectZero];
     self.counterLabel.textColor = UIColor.whiteColor;
@@ -556,19 +590,20 @@ static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGF
     self.counterPill = ApolloGalleryChromePill(self.counterLabel, 0.55);
     [self.view addSubview:self.counterPill];
 
-    self.shareButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    [self.shareButton setImage:ApolloGalleryChromeSymbol(@"square.and.arrow.up") forState:UIControlStateNormal];
-    self.shareButton.tintColor = UIColor.whiteColor;
-    self.sharePill = ApolloGalleryChromePill(self.shareButton, 0.55);
-    [self.shareButton addTarget:self action:@selector(apollo_sharePressed:) forControlEvents:UIControlEventTouchUpInside];
-    [self.view addSubview:self.sharePill];
+    self.shareButton = ApolloGalleryChromeButton(ApolloGalleryChromeSymbol(@"square.and.arrow.up"), nil, &_shareHost);
+    // A button-attached UIMenu, NOT a presented action sheet. That's what plays
+    // the iOS 26 morph out of the button; an alert-controller popover gets no
+    // such animation, which is why this felt unlike the rest of the app. The
+    // menu itself is rebuilt per page in -apollo_updateChromeContent.
+    self.shareButton.showsMenuAsPrimaryAction = YES;
+    [self.view addSubview:self.shareHost];
 
     // Only shown while a video/GIF page is up; still images have nothing to mute.
-    self.muteButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    self.muteButton.tintColor = UIColor.whiteColor;
-    self.mutePill = ApolloGalleryChromePill(self.muteButton, 0.55);
+    self.muteButton = ApolloGalleryChromeButton(ApolloGalleryChromeSymbol(@"speaker.slash.fill"), nil, &_muteHost);
     [self.muteButton addTarget:self action:@selector(apollo_muteTapped) forControlEvents:UIControlEventTouchUpInside];
-    [self.view addSubview:self.mutePill];
+    // Hidden until a page that can actually make noise is on screen.
+    self.muteHost.hidden = YES;
+    [self.view addSubview:self.muteHost];
 
     // Bottom-left post details. Tapping it leaves the gallery for the real post.
     // The info panel positions its own labels, so it gets the material directly
@@ -643,12 +678,12 @@ static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGF
     CGFloat const iconSize = controlHeight;
     CGFloat const controlGap = 8.0;
 
-    self.donePill.frame = CGRectMake(side, top, 74.0, controlHeight);
-    self.sharePill.frame = CGRectMake(bounds.size.width - rightSide - iconSize, top, iconSize, controlHeight);
-    CGFloat trailing = CGRectGetMinX(self.sharePill.frame);
-    if (!self.mutePill.hidden) {
-        self.mutePill.frame = CGRectMake(trailing - controlGap - iconSize, top, iconSize, controlHeight);
-        trailing = CGRectGetMinX(self.mutePill.frame);
+    self.doneHost.frame = CGRectMake(side, top, 74.0, controlHeight);
+    self.shareHost.frame = CGRectMake(bounds.size.width - rightSide - iconSize, top, iconSize, controlHeight);
+    CGFloat trailing = CGRectGetMinX(self.shareHost.frame);
+    if (!self.muteHost.hidden) {
+        self.muteHost.frame = CGRectMake(trailing - controlGap - iconSize, top, iconSize, controlHeight);
+        trailing = CGRectGetMinX(self.muteHost.frame);
     }
     CGFloat counterWidth = 88.0;
     self.counterPill.frame = CGRectMake(trailing - controlGap - counterWidth, top, counterWidth, controlHeight);
@@ -707,6 +742,8 @@ static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGF
                           (long)item.galleryIndex + 1, (long)item.galleryCount]];
     }
     self.subtitleLabel.text = [parts componentsJoinedByString:@" · "];
+    // The actions depend on the current item, so rebuild per page.
+    self.shareButton.menu = [self apollo_buildActionsMenu];
 
     [self.view setNeedsLayout];
 }
@@ -715,15 +752,15 @@ static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGF
     self.chromeVisible = visible;
     CGFloat alpha = visible ? 1.0 : 0.0;
     void (^changes)(void) = ^{
-        self.donePill.alpha = alpha;
-        self.sharePill.alpha = alpha;
-        self.mutePill.alpha = alpha;
+        self.doneHost.alpha = alpha;
+        self.shareHost.alpha = alpha;
+        self.muteHost.alpha = alpha;
         self.counterPill.alpha = alpha;
         self.infoPanel.alpha = alpha;
     };
-    self.donePill.userInteractionEnabled = visible;
-    self.sharePill.userInteractionEnabled = visible;
-    self.mutePill.userInteractionEnabled = visible;
+    self.doneHost.userInteractionEnabled = visible;
+    self.shareHost.userInteractionEnabled = visible;
+    self.muteHost.userInteractionEnabled = visible;
     self.infoPanel.userInteractionEnabled = visible;
     if (animated) {
         [UIView animateWithDuration:0.22 animations:changes];
@@ -888,9 +925,9 @@ static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGF
             // on the same touch, so a diagonal flick can't page AND dismiss.
             self.collectionView.scrollEnabled = NO;
                     [UIView animateWithDuration:0.15 animations:^{
-                self.donePill.alpha = 0.0;
-                self.sharePill.alpha = 0.0;
-                self.mutePill.alpha = 0.0;
+                self.doneHost.alpha = 0.0;
+                self.shareHost.alpha = 0.0;
+                self.muteHost.alpha = 0.0;
                 self.counterPill.alpha = 0.0;
                 self.infoPanel.alpha = 0.0;
             }];
@@ -999,13 +1036,13 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
 - (void)apollo_updateMuteButton {
     ApolloGalleryItem *item = [self apollo_currentItem];
     BOOL showsMute = item.playsAsVideo && item.kind == ApolloGalleryMediaKindVideo;
-    self.mutePill.hidden = !showsMute;
+    self.muteHost.hidden = !showsMute;
     if (showsMute) {
         BOOL muted = ApolloGalleryViewerVideosMuted();
         [self.muteButton setImage:ApolloGalleryChromeSymbol(muted ? @"speaker.slash.fill" : @"speaker.wave.2.fill")
                          forState:UIControlStateNormal];
         self.muteButton.accessibilityLabel = muted ? @"Unmute" : @"Mute";
-        self.mutePill.alpha = self.chromeVisible ? 1.0 : 0.0;
+        self.muteHost.alpha = self.chromeVisible ? 1.0 : 0.0;
     }
     [self.view setNeedsLayout];
 }
@@ -1015,12 +1052,58 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
     [self apollo_syncPlayback];
 }
 
-- (void)apollo_sharePressed:(UIButton *)sender {
-    [self apollo_presentActionsFromView:sender];
-}
-
 - (void)apollo_infoPanelTapped {
     [self apollo_openCurrentPost];
+}
+
+// The share button's actions as a UIMenu. Same set as the long-press sheet;
+// as a menu it gets the iOS 26 morph out of the button for free, and on older
+// releases it's still a native menu rather than a modal sheet.
+- (UIMenu *)apollo_buildActionsMenu {
+    ApolloGalleryItem *item = [self apollo_currentItem];
+    if (!item) return [UIMenu menuWithTitle:@"" children:@[]];
+
+    __weak typeof(self) weakSelf = self;
+    NSMutableArray<UIMenuElement *> *children = [NSMutableArray array];
+
+    if (item.playsAsVideo) {
+        if (item.videoDownloadURL) {
+            [children addObject:[UIAction actionWithTitle:@"Save Video"
+                                                    image:[UIImage systemImageNamed:@"arrow.down.to.line"]
+                                               identifier:nil
+                                                  handler:^(__kindof UIAction *a) { [weakSelf apollo_saveCurrentVideo]; }]];
+        }
+        [children addObject:[UIAction actionWithTitle:@"Share Video Link"
+                                                image:[UIImage systemImageNamed:@"square.and.arrow.up"]
+                                           identifier:nil
+                                              handler:^(__kindof UIAction *a) {
+            [weakSelf apollo_presentActivityWithItems:@[item.videoURL] fromView:weakSelf.shareButton];
+        }]];
+    } else {
+        [children addObject:[UIAction actionWithTitle:@"Save Image"
+                                                image:[UIImage systemImageNamed:@"arrow.down.to.line"]
+                                           identifier:nil
+                                              handler:^(__kindof UIAction *a) { [weakSelf apollo_saveCurrentImage]; }]];
+        [children addObject:[UIAction actionWithTitle:@"Share Image"
+                                                image:[UIImage systemImageNamed:@"square.and.arrow.up"]
+                                           identifier:nil
+                                              handler:^(__kindof UIAction *a) {
+            [weakSelf apollo_shareCurrentImageFromView:weakSelf.shareButton];
+        }]];
+    }
+    if (item.postURL) {
+        [children addObject:[UIAction actionWithTitle:@"Share Post Link"
+                                                image:[UIImage systemImageNamed:@"link"]
+                                           identifier:nil
+                                              handler:^(__kindof UIAction *a) {
+            [weakSelf apollo_sharePostLinkFromView:weakSelf.shareButton];
+        }]];
+        [children addObject:[UIAction actionWithTitle:@"Open Post"
+                                                image:[UIImage systemImageNamed:@"arrow.up.right.square"]
+                                           identifier:nil
+                                              handler:^(__kindof UIAction *a) { [weakSelf apollo_openCurrentPost]; }]];
+    }
+    return [UIMenu menuWithTitle:item.postTitle ?: @"" children:children];
 }
 
 - (void)apollo_presentActionsFromView:(UIView *)sourceView {

--- a/src/ApolloGalleryImageViewer.m
+++ b/src/ApolloGalleryImageViewer.m
@@ -313,6 +313,59 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
 
 @end
 
+// A chrome capsule: the material underneath, one content view (label or button)
+// filling it.
+//
+// It lays out by frame rather than Auto Layout on purpose. These pills are
+// frame-positioned from -apollo_layoutChrome and some start hidden, and
+// constraints inside that subtree proved unreliable — a button pinned to all
+// four edges stayed 0x0, so its symbol never drew.
+//
+// A container is also why the material isn't just inserted into the control:
+//   • UILabel draws text into its own layer contents, which any subview covers;
+//   • UIButton re-orders its subviews during layout on iOS 26, so a backdrop
+//     inserted at index 0 ends up ON TOP of the image, leaving a blurred ghost
+//     (the title escapes, which makes the bug look inconsistent).
+@interface ApolloGalleryChromePillView : UIView
+@property (nonatomic, strong, nullable) UIView *materialView;
+@property (nonatomic, strong) UIView *pillContentView;
+@end
+
+@implementation ApolloGalleryChromePillView
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    self.materialView.frame = self.bounds;
+    self.pillContentView.frame = self.bounds;
+}
+@end
+
+// Builds a capsule around `content`. On Liquid Glass builds the backing is a
+// real UIGlassEffect, so the viewer's controls match the rest of the iOS 26 app
+// instead of reading as flat pre-26 pills; older builds keep translucent black,
+// which is what stays legible over an arbitrary photo.
+static ApolloGalleryChromePillView *ApolloGalleryChromePill(UIView *content, CGFloat cornerRadius, CGFloat legacyAlpha) {
+    ApolloGalleryChromePillView *pill = [[ApolloGalleryChromePillView alloc] initWithFrame:CGRectZero];
+    pill.layer.cornerRadius = cornerRadius;
+    pill.layer.cornerCurve = kCACornerCurveContinuous;
+    pill.clipsToBounds = YES;
+
+    Class glassClass = NSClassFromString(@"UIGlassEffect");
+    if (IsLiquidGlass() && glassClass) {
+        pill.backgroundColor = UIColor.clearColor;
+        UIVisualEffectView *glass = [[UIVisualEffectView alloc] initWithEffect:[[glassClass alloc] init]];
+        glass.userInteractionEnabled = NO;
+        [pill addSubview:glass];
+        pill.materialView = glass;
+    } else {
+        pill.backgroundColor = [UIColor colorWithWhite:0.0 alpha:legacyAlpha];
+    }
+
+    content.backgroundColor = UIColor.clearColor;
+    [pill addSubview:content];
+    pill.pillContentView = content;
+    return pill;
+}
+
 #pragma mark - Viewer
 
 @interface ApolloGalleryImageViewer () <UICollectionViewDataSource, UICollectionViewDelegateFlowLayout,
@@ -328,14 +381,21 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
 
 @property (nonatomic, strong) UIView *topChrome;
 @property (nonatomic, strong) UIButton *doneButton;
+@property (nonatomic, strong) ApolloGalleryChromePillView *donePill;
 @property (nonatomic, strong) UIButton *shareButton;
+@property (nonatomic, strong) ApolloGalleryChromePillView *sharePill;
 @property (nonatomic, strong) UIButton *muteButton;
+@property (nonatomic, strong) ApolloGalleryChromePillView *mutePill;
 @property (nonatomic, strong) UILabel *counterLabel;
+@property (nonatomic, strong) ApolloGalleryChromePillView *counterPill;
 @property (nonatomic, strong) UIView *infoPanel;
+@property (nonatomic, strong, nullable) UIView *infoPanelMaterial;
 @property (nonatomic, strong) UILabel *titleLabel;
 @property (nonatomic, strong) UILabel *subtitleLabel;
 @property (nonatomic, strong) UILabel *statusLabel;
+@property (nonatomic, strong) ApolloGalleryChromePillView *statusPill;
 @property (nonatomic, strong) UILabel *toastLabel;
+@property (nonatomic, strong) ApolloGalleryChromePillView *toastPill;
 @property (nonatomic) BOOL chromeVisible;
 
 @property (nonatomic, strong) UIPanGestureRecognizer *dismissPan;
@@ -460,62 +520,60 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
 // Every overlay control sits on a translucent black capsule so it stays legible
 // over an arbitrary photo — the same treatment in Liquid Glass and legacy
 // builds, since the backdrop here is the picture, not app chrome.
-static UIView *ApolloGalleryChromeCapsule(CGFloat cornerRadius) {
-    UIView *capsule = [[UIView alloc] initWithFrame:CGRectZero];
-    capsule.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.55];
-    capsule.layer.cornerRadius = cornerRadius;
-    capsule.layer.cornerCurve = kCACornerCurveContinuous;
-    capsule.clipsToBounds = YES;
-    return capsule;
-}
-
 - (void)apollo_buildChrome {
     self.doneButton = [UIButton buttonWithType:UIButtonTypeSystem];
     [self.doneButton setTitle:@"Done" forState:UIControlStateNormal];
     self.doneButton.tintColor = UIColor.whiteColor;
     self.doneButton.titleLabel.font = [UIFont systemFontOfSize:16.0 weight:UIFontWeightSemibold];
-    self.doneButton.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.55];
-    self.doneButton.layer.cornerRadius = 16.0;
-    self.doneButton.layer.cornerCurve = kCACornerCurveContinuous;
-    self.doneButton.clipsToBounds = YES;
+    self.donePill = ApolloGalleryChromePill(self.doneButton, 16.0, 0.55);
     [self.doneButton addTarget:self action:@selector(apollo_donePressed) forControlEvents:UIControlEventTouchUpInside];
-    [self.view addSubview:self.doneButton];
+    [self.view addSubview:self.donePill];
 
     self.counterLabel = [[UILabel alloc] initWithFrame:CGRectZero];
     self.counterLabel.textColor = UIColor.whiteColor;
     self.counterLabel.font = [UIFont monospacedDigitSystemFontOfSize:14.0 weight:UIFontWeightSemibold];
     self.counterLabel.textAlignment = NSTextAlignmentCenter;
-    self.counterLabel.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.55];
-    self.counterLabel.layer.cornerRadius = 14.0;
-    self.counterLabel.layer.cornerCurve = kCACornerCurveContinuous;
-    self.counterLabel.clipsToBounds = YES;
-    [self.view addSubview:self.counterLabel];
+    self.counterPill = ApolloGalleryChromePill(self.counterLabel, 14.0, 0.55);
+    [self.view addSubview:self.counterPill];
 
     self.shareButton = [UIButton buttonWithType:UIButtonTypeSystem];
     [self.shareButton setImage:[UIImage systemImageNamed:@"square.and.arrow.up"] forState:UIControlStateNormal];
     self.shareButton.tintColor = UIColor.whiteColor;
-    self.shareButton.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.55];
-    self.shareButton.layer.cornerRadius = 16.0;
-    self.shareButton.layer.cornerCurve = kCACornerCurveContinuous;
-    self.shareButton.clipsToBounds = YES;
+    self.sharePill = ApolloGalleryChromePill(self.shareButton, 16.0, 0.55);
     [self.shareButton addTarget:self action:@selector(apollo_sharePressed:) forControlEvents:UIControlEventTouchUpInside];
-    [self.view addSubview:self.shareButton];
+    [self.view addSubview:self.sharePill];
 
     // Only shown while a video/GIF page is up; still images have nothing to mute.
     self.muteButton = [UIButton buttonWithType:UIButtonTypeSystem];
     self.muteButton.tintColor = UIColor.whiteColor;
-    self.muteButton.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.55];
-    self.muteButton.layer.cornerRadius = 16.0;
-    self.muteButton.layer.cornerCurve = kCACornerCurveContinuous;
-    self.muteButton.clipsToBounds = YES;
-    self.muteButton.hidden = YES;
+    self.mutePill = ApolloGalleryChromePill(self.muteButton, 16.0, 0.55);
     [self.muteButton addTarget:self action:@selector(apollo_muteTapped) forControlEvents:UIControlEventTouchUpInside];
-    [self.view addSubview:self.muteButton];
+    [self.view addSubview:self.mutePill];
 
     // Bottom-left post details. Tapping it leaves the gallery for the real post.
-    self.infoPanel = ApolloGalleryChromeCapsule(14.0);
+    // The info panel positions its own labels, so it gets the material directly
+    // rather than through a pill; a plain UIView doesn't reorder subviews.
+    self.infoPanel = [[UIView alloc] initWithFrame:CGRectZero];
+    self.infoPanel.layer.cornerRadius = 14.0;
+    self.infoPanel.layer.cornerCurve = kCACornerCurveContinuous;
+    self.infoPanel.clipsToBounds = YES;
+    {
+        Class glassClass = NSClassFromString(@"UIGlassEffect");
+        if (IsLiquidGlass() && glassClass) {
+            self.infoPanel.backgroundColor = UIColor.clearColor;
+            UIVisualEffectView *glass = [[UIVisualEffectView alloc] initWithEffect:[[glassClass alloc] init]];
+            glass.userInteractionEnabled = NO;
+            glass.frame = self.infoPanel.bounds;
+            glass.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+            [self.infoPanel addSubview:glass];
+            self.infoPanelMaterial = glass;
+        } else {
+            self.infoPanel.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.55];
+        }
+    }
     [self.view addSubview:self.infoPanel];
 
+    // (material added above sits at index 0, behind these labels)
     self.titleLabel = [[UILabel alloc] initWithFrame:CGRectZero];
     self.titleLabel.textColor = UIColor.whiteColor;
     self.titleLabel.font = [UIFont systemFontOfSize:14.0 weight:UIFontWeightSemibold];
@@ -536,23 +594,17 @@ static UIView *ApolloGalleryChromeCapsule(CGFloat cornerRadius) {
     self.statusLabel.textColor = UIColor.whiteColor;
     self.statusLabel.font = [UIFont systemFontOfSize:12.0 weight:UIFontWeightSemibold];
     self.statusLabel.textAlignment = NSTextAlignmentCenter;
-    self.statusLabel.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.55];
-    self.statusLabel.layer.cornerRadius = 12.0;
-    self.statusLabel.layer.cornerCurve = kCACornerCurveContinuous;
-    self.statusLabel.clipsToBounds = YES;
-    self.statusLabel.alpha = 0.0;
-    [self.view addSubview:self.statusLabel];
+    self.statusPill = ApolloGalleryChromePill(self.statusLabel, 12.0, 0.55);
+    self.statusPill.alpha = 0.0;
+    [self.view addSubview:self.statusPill];
 
     self.toastLabel = [[UILabel alloc] initWithFrame:CGRectZero];
     self.toastLabel.textColor = UIColor.whiteColor;
     self.toastLabel.font = [UIFont systemFontOfSize:14.0 weight:UIFontWeightSemibold];
     self.toastLabel.textAlignment = NSTextAlignmentCenter;
-    self.toastLabel.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.7];
-    self.toastLabel.layer.cornerRadius = 14.0;
-    self.toastLabel.layer.cornerCurve = kCACornerCurveContinuous;
-    self.toastLabel.clipsToBounds = YES;
-    self.toastLabel.alpha = 0.0;
-    [self.view addSubview:self.toastLabel];
+    self.toastPill = ApolloGalleryChromePill(self.toastLabel, 14.0, 0.7);
+    self.toastPill.alpha = 0.0;
+    [self.view addSubview:self.toastPill];
 }
 
 - (void)apollo_layoutChrome {
@@ -564,16 +616,16 @@ static UIView *ApolloGalleryChromeCapsule(CGFloat cornerRadius) {
     CGFloat side = MAX(16.0, safe.left + 16.0);
     CGFloat rightSide = MAX(16.0, safe.right + 16.0);
 
-    self.doneButton.frame = CGRectMake(side, top, 72.0, 32.0);
-    self.shareButton.frame = CGRectMake(bounds.size.width - rightSide - 40.0, top, 40.0, 32.0);
-    CGFloat trailing = CGRectGetMinX(self.shareButton.frame);
-    if (!self.muteButton.hidden) {
-        self.muteButton.frame = CGRectMake(trailing - 8.0 - 40.0, top, 40.0, 32.0);
-        trailing = CGRectGetMinX(self.muteButton.frame);
+    self.donePill.frame = CGRectMake(side, top, 72.0, 32.0);
+    self.sharePill.frame = CGRectMake(bounds.size.width - rightSide - 40.0, top, 40.0, 32.0);
+    CGFloat trailing = CGRectGetMinX(self.sharePill.frame);
+    if (!self.mutePill.hidden) {
+        self.mutePill.frame = CGRectMake(trailing - 8.0 - 40.0, top, 40.0, 32.0);
+        trailing = CGRectGetMinX(self.mutePill.frame);
     }
     CGFloat counterWidth = 84.0;
-    self.counterLabel.frame = CGRectMake(trailing - 8.0 - counterWidth, top, counterWidth, 32.0);
-    self.statusLabel.frame = CGRectMake((bounds.size.width - 150.0) / 2.0, CGRectGetMaxY(self.counterLabel.frame) + 8.0, 150.0, 24.0);
+    self.counterPill.frame = CGRectMake(trailing - 8.0 - counterWidth, top, counterWidth, 32.0);
+    self.statusPill.frame = CGRectMake((bounds.size.width - 150.0) / 2.0, CGRectGetMaxY(self.counterPill.frame) + 8.0, 150.0, 24.0);
 
     CGFloat bottom = safe.bottom + 16.0;
     CGFloat panelWidth = MIN(bounds.size.width - side - rightSide, 460.0);
@@ -597,7 +649,7 @@ static UIView *ApolloGalleryChromeCapsule(CGFloat cornerRadius) {
     self.titleLabel.frame = CGRectMake(12.0, 10.0, titleSize.width, titleSize.height);
     self.subtitleLabel.frame = CGRectMake(12.0, 10.0 + titleSize.height + gap, subtitleSize.width, subtitleSize.height);
 
-    self.toastLabel.frame = CGRectMake((bounds.size.width - 220.0) / 2.0,
+    self.toastPill.frame = CGRectMake((bounds.size.width - 220.0) / 2.0,
                                        CGRectGetMinY(self.infoPanel.frame) - 44.0,
                                        220.0, 30.0);
 }
@@ -636,15 +688,15 @@ static UIView *ApolloGalleryChromeCapsule(CGFloat cornerRadius) {
     self.chromeVisible = visible;
     CGFloat alpha = visible ? 1.0 : 0.0;
     void (^changes)(void) = ^{
-        self.doneButton.alpha = alpha;
-        self.shareButton.alpha = alpha;
-        self.muteButton.alpha = alpha;
-        self.counterLabel.alpha = alpha;
+        self.donePill.alpha = alpha;
+        self.sharePill.alpha = alpha;
+        self.mutePill.alpha = alpha;
+        self.counterPill.alpha = alpha;
         self.infoPanel.alpha = alpha;
     };
-    self.doneButton.userInteractionEnabled = visible;
-    self.shareButton.userInteractionEnabled = visible;
-    self.muteButton.userInteractionEnabled = visible;
+    self.donePill.userInteractionEnabled = visible;
+    self.sharePill.userInteractionEnabled = visible;
+    self.mutePill.userInteractionEnabled = visible;
     self.infoPanel.userInteractionEnabled = visible;
     if (animated) {
         [UIView animateWithDuration:0.22 animations:changes];
@@ -657,16 +709,16 @@ static UIView *ApolloGalleryChromeCapsule(CGFloat cornerRadius) {
     self.statusLabel.text = status;
     BOOL show = status.length > 0;
     [UIView animateWithDuration:0.2 animations:^{
-        self.statusLabel.alpha = show ? 1.0 : 0.0;
+        self.statusPill.alpha = show ? 1.0 : 0.0;
     }];
 }
 
 - (void)apollo_showToast:(NSString *)text {
     self.toastLabel.text = text;
-    [self.view bringSubviewToFront:self.toastLabel];
-    [UIView animateWithDuration:0.2 animations:^{ self.toastLabel.alpha = 1.0; }];
+    [self.view bringSubviewToFront:self.toastPill];
+    [UIView animateWithDuration:0.2 animations:^{ self.toastPill.alpha = 1.0; }];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.6 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        [UIView animateWithDuration:0.3 animations:^{ self.toastLabel.alpha = 0.0; }];
+        [UIView animateWithDuration:0.3 animations:^{ self.toastPill.alpha = 0.0; }];
     });
 }
 
@@ -809,10 +861,10 @@ static UIView *ApolloGalleryChromeCapsule(CGFloat cornerRadius) {
             // on the same touch, so a diagonal flick can't page AND dismiss.
             self.collectionView.scrollEnabled = NO;
                     [UIView animateWithDuration:0.15 animations:^{
-                self.doneButton.alpha = 0.0;
-                self.shareButton.alpha = 0.0;
-                self.muteButton.alpha = 0.0;
-                self.counterLabel.alpha = 0.0;
+                self.donePill.alpha = 0.0;
+                self.sharePill.alpha = 0.0;
+                self.mutePill.alpha = 0.0;
+                self.counterPill.alpha = 0.0;
                 self.infoPanel.alpha = 0.0;
             }];
             break;
@@ -920,13 +972,13 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
 - (void)apollo_updateMuteButton {
     ApolloGalleryItem *item = [self apollo_currentItem];
     BOOL showsMute = item.playsAsVideo && item.kind == ApolloGalleryMediaKindVideo;
-    self.muteButton.hidden = !showsMute;
+    self.mutePill.hidden = !showsMute;
     if (showsMute) {
         BOOL muted = ApolloGalleryViewerVideosMuted();
         [self.muteButton setImage:[UIImage systemImageNamed:(muted ? @"speaker.slash.fill" : @"speaker.wave.2.fill")]
                          forState:UIControlStateNormal];
         self.muteButton.accessibilityLabel = muted ? @"Unmute" : @"Mute";
-        self.muteButton.alpha = self.chromeVisible ? 1.0 : 0.0;
+        self.mutePill.alpha = self.chromeVisible ? 1.0 : 0.0;
     }
     [self.view setNeedsLayout];
 }

--- a/src/ApolloGalleryImageViewer.m
+++ b/src/ApolloGalleryImageViewer.m
@@ -1,0 +1,912 @@
+// ApolloGalleryImageViewer.m — see ApolloGalleryImageViewer.h.
+
+#import "ApolloGalleryImageViewer.h"
+#import "ApolloGalleryFeed.h"
+#import "ApolloGalleryImageLoader.h"
+#import "ApolloCommon.h"
+
+#import <Photos/Photos.h>
+
+// Pages either side of the current one kept warm.
+static NSInteger const kApolloGalleryViewerPrefetchRadius = 2;
+// Vertical drag (points) or flick velocity that commits the dismissal.
+static CGFloat const kApolloGalleryViewerDismissDistance = 120.0;
+static CGFloat const kApolloGalleryViewerDismissVelocity = 850.0;
+// Start pulling the next batch once the user is within this many pictures of
+// the end, so paging rarely stalls on the network.
+static NSInteger const kApolloGalleryViewerLoadAheadSlack = 4;
+
+static NSString *const kApolloGalleryViewerCellID = @"ApolloGalleryViewerCell";
+
+#pragma mark - Page cell
+
+@interface ApolloGalleryViewerCell : UICollectionViewCell <UIScrollViewDelegate>
+@property (nonatomic, strong) UIScrollView *zoomView;
+@property (nonatomic, strong) UIImageView *imageView;
+@property (nonatomic, strong) UIActivityIndicatorView *spinner;
+@property (nonatomic, strong, nullable) ApolloGalleryImageRequest *request;
+@property (nonatomic, copy, nullable) NSURL *imageURL;
+// Raised while a zoom is active so the pager and the dismiss pan stay out of
+// the way (a zoomed page must pan its own content, not turn the page).
+@property (nonatomic, readonly) BOOL isZoomed;
+- (void)configureWithItem:(ApolloGalleryItem *)item;
+@end
+
+@implementation ApolloGalleryViewerCell
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.backgroundColor = UIColor.blackColor;
+        self.contentView.backgroundColor = UIColor.blackColor;
+
+        _zoomView = [[UIScrollView alloc] initWithFrame:self.contentView.bounds];
+        _zoomView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        _zoomView.delegate = self;
+        _zoomView.minimumZoomScale = 1.0;
+        _zoomView.maximumZoomScale = 5.0;
+        _zoomView.showsHorizontalScrollIndicator = NO;
+        _zoomView.showsVerticalScrollIndicator = NO;
+        _zoomView.backgroundColor = UIColor.blackColor;
+        _zoomView.bouncesZoom = YES;
+        // Panning is only meaningful once zoomed in; while at 1x the paging
+        // scroll view and the dismiss gesture own the touch.
+        _zoomView.panGestureRecognizer.enabled = NO;
+        if (@available(iOS 11.0, *)) {
+            _zoomView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+        }
+        [self.contentView addSubview:_zoomView];
+
+        _imageView = [[UIImageView alloc] initWithFrame:_zoomView.bounds];
+        _imageView.contentMode = UIViewContentModeScaleAspectFit;
+        _imageView.backgroundColor = UIColor.blackColor;
+        [_zoomView addSubview:_imageView];
+
+        _spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+        _spinner.color = UIColor.whiteColor;
+        _spinner.hidesWhenStopped = YES;
+        [self.contentView addSubview:_spinner];
+
+        UITapGestureRecognizer *doubleTap = [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                                                    action:@selector(apollo_doubleTapped:)];
+        doubleTap.numberOfTapsRequired = 2;
+        [self.contentView addGestureRecognizer:doubleTap];
+    }
+    return self;
+}
+
+- (BOOL)isZoomed {
+    return self.zoomView.zoomScale > self.zoomView.minimumZoomScale + 0.01;
+}
+
+- (void)prepareForReuse {
+    [super prepareForReuse];
+    [self.request cancel];
+    self.request = nil;
+    self.imageURL = nil;
+    self.imageView.image = nil;
+    self.zoomView.zoomScale = 1.0;
+    self.zoomView.contentInset = UIEdgeInsetsZero;
+    self.zoomView.panGestureRecognizer.enabled = NO;
+    [self.spinner stopAnimating];
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGRect bounds = self.contentView.bounds;
+    BOOL boundsChanged = !CGSizeEqualToSize(bounds.size, self.zoomView.frame.size);
+    self.zoomView.frame = bounds;
+    self.spinner.center = CGPointMake(CGRectGetMidX(bounds), CGRectGetMidY(bounds));
+    // A bounds change (rotation, first layout) invalidates the zoom geometry.
+    if (boundsChanged) [self apollo_resetZoomGeometry];
+}
+
+// The zoom view's content is the PICTURE, not the page. Sizing the image view
+// to the whole page instead would make the letterbox bars zoomable too, so a
+// zoomed-in drag could pan off the photo into empty black.
+- (void)apollo_resetZoomGeometry {
+    UIImage *image = self.imageView.image;
+    CGSize bounds = self.zoomView.bounds.size;
+    if (bounds.width <= 0.0 || bounds.height <= 0.0) return;
+
+    self.zoomView.zoomScale = 1.0;
+    if (!image || image.size.width <= 0.0 || image.size.height <= 0.0) {
+        self.imageView.frame = CGRectMake(0.0, 0.0, bounds.width, bounds.height);
+        self.zoomView.contentSize = bounds;
+        self.zoomView.contentInset = UIEdgeInsetsZero;
+        return;
+    }
+
+    CGFloat scale = MIN(bounds.width / image.size.width, bounds.height / image.size.height);
+    CGSize fitted = CGSizeMake(floor(image.size.width * scale), floor(image.size.height * scale));
+    self.imageView.frame = CGRectMake(0.0, 0.0, fitted.width, fitted.height);
+    self.zoomView.contentSize = fitted;
+    self.zoomView.panGestureRecognizer.enabled = NO;
+    [self apollo_centerContent];
+}
+
+// Centres the picture with insets rather than by moving its frame, so the
+// scroll view's own content bounds stay honest and panning clamps to the edges.
+- (void)apollo_centerContent {
+    CGSize bounds = self.zoomView.bounds.size;
+    CGSize content = self.zoomView.contentSize;
+    CGFloat vertical = MAX(0.0, (bounds.height - content.height) / 2.0);
+    CGFloat horizontal = MAX(0.0, (bounds.width - content.width) / 2.0);
+    self.zoomView.contentInset = UIEdgeInsetsMake(vertical, horizontal, vertical, horizontal);
+}
+
+- (void)configureWithItem:(ApolloGalleryItem *)item {
+    NSURL *url = item.imageURL;
+    self.imageURL = url;
+
+    // A grid thumbnail for this post is usually already decoded — show it
+    // immediately so the page is never a black rectangle, then swap in the
+    // full-size version when it lands.
+    UIImage *placeholder = item.thumbnailURL ? [[ApolloGalleryImageLoader sharedLoader] cachedImageForURL:item.thumbnailURL] : nil;
+    UIImage *full = url ? [[ApolloGalleryImageLoader sharedLoader] cachedImageForURL:url] : nil;
+    self.imageView.image = full ?: placeholder;
+    // The fit rect depends on the image's proportions, so re-derive it whenever
+    // the displayed image changes — including the placeholder→full swap, which
+    // can have a different aspect if Reddit's preview was cropped.
+    [self apollo_resetZoomGeometry];
+
+    if (full || !url) {
+        [self.spinner stopAnimating];
+        return;
+    }
+    [self.spinner startAnimating];
+
+    __weak typeof(self) weakSelf = self;
+    self.request = [[ApolloGalleryImageLoader sharedLoader] loadImageAtURL:url
+                                                                  progress:nil
+                                                                completion:^(UIImage *image, NSData *data) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        // The cell may have been recycled onto a different picture while this
+        // download was in flight.
+        if (![strongSelf.imageURL isEqual:url]) return;
+        [strongSelf.spinner stopAnimating];
+        if (image) {
+            strongSelf.imageView.image = image;
+            [strongSelf apollo_resetZoomGeometry];
+        }
+        (void)data;
+    }];
+}
+
+- (void)apollo_doubleTapped:(UITapGestureRecognizer *)recognizer {
+    if (self.isZoomed) {
+        [self.zoomView setZoomScale:self.zoomView.minimumZoomScale animated:YES];
+        return;
+    }
+    CGPoint point = [recognizer locationInView:self.imageView];
+    CGFloat scale = MIN(self.zoomView.maximumZoomScale, 3.0);
+    CGSize size = self.zoomView.bounds.size;
+    CGRect target = CGRectMake(point.x - (size.width / scale) / 2.0,
+                               point.y - (size.height / scale) / 2.0,
+                               size.width / scale,
+                               size.height / scale);
+    [self.zoomView zoomToRect:target animated:YES];
+}
+
+#pragma mark UIScrollViewDelegate
+
+- (UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView {
+    return self.imageView;
+}
+
+- (void)scrollViewDidZoom:(UIScrollView *)scrollView {
+    scrollView.panGestureRecognizer.enabled = self.isZoomed;
+    [self apollo_centerContent];
+}
+
+@end
+
+#pragma mark - Viewer
+
+@interface ApolloGalleryImageViewer () <UICollectionViewDataSource, UICollectionViewDelegateFlowLayout,
+                                        UIGestureRecognizerDelegate>
+@property (nonatomic, strong) ApolloGalleryFeed *feed;
+@property (nonatomic, strong) UICollectionView *collectionView;
+@property (nonatomic, strong) UICollectionViewFlowLayout *layout;
+@property (nonatomic) NSInteger currentIndex;
+// Applied in -viewDidLayoutSubviews once the collection view has a real size;
+// setting the offset before that lands on the wrong page.
+@property (nonatomic) BOOL hasAppliedInitialIndex;
+@property (nonatomic) NSInteger pendingInitialIndex;
+
+@property (nonatomic, strong) UIView *topChrome;
+@property (nonatomic, strong) UIButton *doneButton;
+@property (nonatomic, strong) UIButton *shareButton;
+@property (nonatomic, strong) UILabel *counterLabel;
+@property (nonatomic, strong) UIView *infoPanel;
+@property (nonatomic, strong) UILabel *titleLabel;
+@property (nonatomic, strong) UILabel *subtitleLabel;
+@property (nonatomic, strong) UILabel *statusLabel;
+@property (nonatomic, strong) UILabel *toastLabel;
+@property (nonatomic) BOOL chromeVisible;
+
+@property (nonatomic, strong) UIPanGestureRecognizer *dismissPan;
+@property (nonatomic) BOOL isDismissing;
+@property (nonatomic) CGSize lastLaidOutSize;
+@end
+
+@implementation ApolloGalleryImageViewer
+
+- (instancetype)initWithFeed:(ApolloGalleryFeed *)feed initialIndex:(NSInteger)initialIndex {
+    self = [super initWithNibName:nil bundle:nil];
+    if (self) {
+        _feed = feed;
+        _pendingInitialIndex = MAX(0, MIN(initialIndex, (NSInteger)feed.items.count - 1));
+        _currentIndex = _pendingInitialIndex;
+        _chromeVisible = YES;
+        self.modalPresentationStyle = UIModalPresentationFullScreen;
+        self.modalPresentationCapturesStatusBarAppearance = YES;
+    }
+    return self;
+}
+
+- (BOOL)prefersStatusBarHidden {
+    return YES;
+}
+
+- (BOOL)shouldAutorotate {
+    return YES;
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskAllButUpsideDown;
+}
+
+#pragma mark Lifecycle
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.backgroundColor = UIColor.blackColor;
+
+    self.layout = [[UICollectionViewFlowLayout alloc] init];
+    self.layout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
+    self.layout.minimumLineSpacing = 0.0;
+    self.layout.minimumInteritemSpacing = 0.0;
+    self.layout.sectionInset = UIEdgeInsetsZero;
+
+    self.collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds collectionViewLayout:self.layout];
+    self.collectionView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.collectionView.dataSource = self;
+    self.collectionView.delegate = self;
+    self.collectionView.pagingEnabled = YES;
+    self.collectionView.backgroundColor = UIColor.blackColor;
+    self.collectionView.showsHorizontalScrollIndicator = NO;
+    self.collectionView.alwaysBounceVertical = NO;
+    if (@available(iOS 11.0, *)) {
+        self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+    }
+    [self.collectionView registerClass:[ApolloGalleryViewerCell class] forCellWithReuseIdentifier:kApolloGalleryViewerCellID];
+    [self.view addSubview:self.collectionView];
+
+    [self apollo_buildChrome];
+
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(apollo_singleTapped:)];
+    tap.numberOfTapsRequired = 1;
+    tap.delegate = self;
+    [self.view addGestureRecognizer:tap];
+
+    UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self
+                                                                                            action:@selector(apollo_longPressed:)];
+    longPress.delegate = self;
+    [self.view addGestureRecognizer:longPress];
+
+    self.dismissPan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(apollo_dismissPanned:)];
+    self.dismissPan.delegate = self;
+    [self.view addGestureRecognizer:self.dismissPan];
+
+    [self apollo_updateChromeContent];
+}
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    CGSize size = self.view.bounds.size;
+    if (size.width <= 0.0 || size.height <= 0.0) return;
+
+    if (!CGSizeEqualToSize(size, self.lastLaidOutSize)) {
+        self.lastLaidOutSize = size;
+        [self.layout invalidateLayout];
+    }
+    [self apollo_layoutChrome];
+
+    // First real layout: jump to the tapped picture without an animation.
+    if (!self.hasAppliedInitialIndex && self.feed.items.count > 0) {
+        self.hasAppliedInitialIndex = YES;
+        NSInteger index = MAX(0, MIN(self.pendingInitialIndex, (NSInteger)self.feed.items.count - 1));
+        [self.collectionView layoutIfNeeded];
+        [self.collectionView setContentOffset:CGPointMake(size.width * index, 0.0) animated:NO];
+        self.currentIndex = index;
+        [self apollo_updateChromeContent];
+        [self apollo_prefetchAroundIndex:index];
+    } else if (self.hasAppliedInitialIndex) {
+        // Rotation moves the page boundaries; re-anchor on the current picture.
+        CGFloat expected = size.width * self.currentIndex;
+        if (fabs(self.collectionView.contentOffset.x - expected) > 1.0 && !self.collectionView.isDragging) {
+            [self.collectionView setContentOffset:CGPointMake(expected, 0.0) animated:NO];
+        }
+    }
+}
+
+#pragma mark Chrome
+
+// Every overlay control sits on a translucent black capsule so it stays legible
+// over an arbitrary photo — the same treatment in Liquid Glass and legacy
+// builds, since the backdrop here is the picture, not app chrome.
+static UIView *ApolloGalleryChromeCapsule(CGFloat cornerRadius) {
+    UIView *capsule = [[UIView alloc] initWithFrame:CGRectZero];
+    capsule.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.55];
+    capsule.layer.cornerRadius = cornerRadius;
+    capsule.layer.cornerCurve = kCACornerCurveContinuous;
+    capsule.clipsToBounds = YES;
+    return capsule;
+}
+
+- (void)apollo_buildChrome {
+    self.doneButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.doneButton setTitle:@"Done" forState:UIControlStateNormal];
+    self.doneButton.tintColor = UIColor.whiteColor;
+    self.doneButton.titleLabel.font = [UIFont systemFontOfSize:16.0 weight:UIFontWeightSemibold];
+    self.doneButton.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.55];
+    self.doneButton.layer.cornerRadius = 16.0;
+    self.doneButton.layer.cornerCurve = kCACornerCurveContinuous;
+    self.doneButton.clipsToBounds = YES;
+    [self.doneButton addTarget:self action:@selector(apollo_donePressed) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:self.doneButton];
+
+    self.counterLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+    self.counterLabel.textColor = UIColor.whiteColor;
+    self.counterLabel.font = [UIFont monospacedDigitSystemFontOfSize:14.0 weight:UIFontWeightSemibold];
+    self.counterLabel.textAlignment = NSTextAlignmentCenter;
+    self.counterLabel.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.55];
+    self.counterLabel.layer.cornerRadius = 14.0;
+    self.counterLabel.layer.cornerCurve = kCACornerCurveContinuous;
+    self.counterLabel.clipsToBounds = YES;
+    [self.view addSubview:self.counterLabel];
+
+    self.shareButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.shareButton setImage:[UIImage systemImageNamed:@"square.and.arrow.up"] forState:UIControlStateNormal];
+    self.shareButton.tintColor = UIColor.whiteColor;
+    self.shareButton.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.55];
+    self.shareButton.layer.cornerRadius = 16.0;
+    self.shareButton.layer.cornerCurve = kCACornerCurveContinuous;
+    self.shareButton.clipsToBounds = YES;
+    [self.shareButton addTarget:self action:@selector(apollo_sharePressed:) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:self.shareButton];
+
+    // Bottom-left post details. Tapping it leaves the gallery for the real post.
+    self.infoPanel = ApolloGalleryChromeCapsule(14.0);
+    [self.view addSubview:self.infoPanel];
+
+    self.titleLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+    self.titleLabel.textColor = UIColor.whiteColor;
+    self.titleLabel.font = [UIFont systemFontOfSize:14.0 weight:UIFontWeightSemibold];
+    self.titleLabel.numberOfLines = 2;
+    [self.infoPanel addSubview:self.titleLabel];
+
+    self.subtitleLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+    self.subtitleLabel.textColor = [UIColor colorWithWhite:1.0 alpha:0.75];
+    self.subtitleLabel.font = [UIFont systemFontOfSize:12.0 weight:UIFontWeightRegular];
+    self.subtitleLabel.numberOfLines = 1;
+    [self.infoPanel addSubview:self.subtitleLabel];
+
+    UITapGestureRecognizer *infoTap = [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                                              action:@selector(apollo_infoPanelTapped)];
+    [self.infoPanel addGestureRecognizer:infoTap];
+
+    self.statusLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+    self.statusLabel.textColor = UIColor.whiteColor;
+    self.statusLabel.font = [UIFont systemFontOfSize:12.0 weight:UIFontWeightSemibold];
+    self.statusLabel.textAlignment = NSTextAlignmentCenter;
+    self.statusLabel.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.55];
+    self.statusLabel.layer.cornerRadius = 12.0;
+    self.statusLabel.layer.cornerCurve = kCACornerCurveContinuous;
+    self.statusLabel.clipsToBounds = YES;
+    self.statusLabel.alpha = 0.0;
+    [self.view addSubview:self.statusLabel];
+
+    self.toastLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+    self.toastLabel.textColor = UIColor.whiteColor;
+    self.toastLabel.font = [UIFont systemFontOfSize:14.0 weight:UIFontWeightSemibold];
+    self.toastLabel.textAlignment = NSTextAlignmentCenter;
+    self.toastLabel.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.7];
+    self.toastLabel.layer.cornerRadius = 14.0;
+    self.toastLabel.layer.cornerCurve = kCACornerCurveContinuous;
+    self.toastLabel.clipsToBounds = YES;
+    self.toastLabel.alpha = 0.0;
+    [self.view addSubview:self.toastLabel];
+}
+
+- (void)apollo_layoutChrome {
+    CGRect bounds = self.view.bounds;
+    UIEdgeInsets safe = UIEdgeInsetsZero;
+    if (@available(iOS 11.0, *)) safe = self.view.safeAreaInsets;
+
+    CGFloat top = safe.top + 12.0;
+    CGFloat side = MAX(16.0, safe.left + 16.0);
+    CGFloat rightSide = MAX(16.0, safe.right + 16.0);
+
+    self.doneButton.frame = CGRectMake(side, top, 72.0, 32.0);
+    self.shareButton.frame = CGRectMake(bounds.size.width - rightSide - 40.0, top, 40.0, 32.0);
+    CGFloat counterWidth = 84.0;
+    self.counterLabel.frame = CGRectMake(CGRectGetMinX(self.shareButton.frame) - 8.0 - counterWidth, top, counterWidth, 32.0);
+    self.statusLabel.frame = CGRectMake((bounds.size.width - 150.0) / 2.0, CGRectGetMaxY(self.counterLabel.frame) + 8.0, 150.0, 24.0);
+
+    CGFloat bottom = safe.bottom + 16.0;
+    CGFloat panelWidth = MIN(bounds.size.width - side - rightSide, 460.0);
+    CGFloat textWidth = panelWidth - 24.0;
+
+    CGSize titleSize = CGSizeZero;
+    if (self.titleLabel.text.length > 0) {
+        titleSize = [self.titleLabel sizeThatFits:CGSizeMake(textWidth, CGFLOAT_MAX)];
+        titleSize.width = textWidth;
+    }
+    CGSize subtitleSize = CGSizeZero;
+    if (self.subtitleLabel.text.length > 0) {
+        subtitleSize = [self.subtitleLabel sizeThatFits:CGSizeMake(textWidth, CGFLOAT_MAX)];
+        subtitleSize.width = textWidth;
+    }
+    CGFloat gap = (titleSize.height > 0.0 && subtitleSize.height > 0.0) ? 3.0 : 0.0;
+    CGFloat panelHeight = 20.0 + titleSize.height + gap + subtitleSize.height;
+    BOOL hasText = (titleSize.height + subtitleSize.height) > 0.0;
+    self.infoPanel.hidden = !hasText;
+    self.infoPanel.frame = CGRectMake(side, bounds.size.height - bottom - panelHeight, panelWidth, panelHeight);
+    self.titleLabel.frame = CGRectMake(12.0, 10.0, titleSize.width, titleSize.height);
+    self.subtitleLabel.frame = CGRectMake(12.0, 10.0 + titleSize.height + gap, subtitleSize.width, subtitleSize.height);
+
+    self.toastLabel.frame = CGRectMake((bounds.size.width - 220.0) / 2.0,
+                                       CGRectGetMinY(self.infoPanel.frame) - 44.0,
+                                       220.0, 30.0);
+}
+
+- (void)apollo_updateChromeContent {
+    NSArray<ApolloGalleryItem *> *items = self.feed.items;
+    NSInteger total = (NSInteger)items.count;
+    NSInteger index = MAX(0, MIN(self.currentIndex, total - 1));
+
+    if (total > 0) {
+        // Running position out of everything loaded so far. The total grows as
+        // batches land, which is the honest read on "how much is there" — more
+        // useful than restarting the count at every batch boundary.
+        self.counterLabel.text = [NSString stringWithFormat:@"%ld / %ld", (long)index + 1, (long)total];
+    } else {
+        self.counterLabel.text = @"";
+    }
+
+    ApolloGalleryItem *item = (index >= 0 && index < total) ? items[index] : nil;
+    self.titleLabel.text = item.postTitle ?: @"";
+
+    NSMutableArray<NSString *> *parts = [NSMutableArray array];
+    if (item.author.length > 0) [parts addObject:[@"u/" stringByAppendingString:item.author]];
+    if (item.subreddit.length > 0) [parts addObject:[@"r/" stringByAppendingString:item.subreddit]];
+    if (item.galleryCount > 1) {
+        [parts addObject:[NSString stringWithFormat:@"%ld of %ld in post",
+                          (long)item.galleryIndex + 1, (long)item.galleryCount]];
+    }
+    self.subtitleLabel.text = [parts componentsJoinedByString:@" · "];
+
+    [self.view setNeedsLayout];
+}
+
+- (void)apollo_setChromeVisible:(BOOL)visible animated:(BOOL)animated {
+    self.chromeVisible = visible;
+    CGFloat alpha = visible ? 1.0 : 0.0;
+    void (^changes)(void) = ^{
+        self.doneButton.alpha = alpha;
+        self.shareButton.alpha = alpha;
+        self.counterLabel.alpha = alpha;
+        self.infoPanel.alpha = alpha;
+    };
+    self.doneButton.userInteractionEnabled = visible;
+    self.shareButton.userInteractionEnabled = visible;
+    self.infoPanel.userInteractionEnabled = visible;
+    if (animated) {
+        [UIView animateWithDuration:0.22 animations:changes];
+    } else {
+        changes();
+    }
+}
+
+- (void)apollo_setStatus:(NSString *)status {
+    self.statusLabel.text = status;
+    BOOL show = status.length > 0;
+    [UIView animateWithDuration:0.2 animations:^{
+        self.statusLabel.alpha = show ? 1.0 : 0.0;
+    }];
+}
+
+- (void)apollo_showToast:(NSString *)text {
+    self.toastLabel.text = text;
+    [self.view bringSubviewToFront:self.toastLabel];
+    [UIView animateWithDuration:0.2 animations:^{ self.toastLabel.alpha = 1.0; }];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.6 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [UIView animateWithDuration:0.3 animations:^{ self.toastLabel.alpha = 0.0; }];
+    });
+}
+
+#pragma mark Data source
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+    return (NSInteger)self.feed.items.count;
+}
+
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
+                  cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+    ApolloGalleryViewerCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:kApolloGalleryViewerCellID
+                                                                             forIndexPath:indexPath];
+    NSArray<ApolloGalleryItem *> *items = self.feed.items;
+    if (indexPath.item < (NSInteger)items.count) {
+        [cell configureWithItem:items[indexPath.item]];
+    }
+    return cell;
+}
+
+- (CGSize)collectionView:(UICollectionView *)collectionView
+                  layout:(UICollectionViewLayout *)collectionViewLayout
+  sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
+    CGSize size = self.view.bounds.size;
+    return CGSizeMake(MAX(size.width, 1.0), MAX(size.height, 1.0));
+}
+
+#pragma mark Paging
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
+    if (scrollView != self.collectionView) return;
+    CGFloat width = MAX(self.collectionView.bounds.size.width, 1.0);
+    NSInteger page = (NSInteger)llround(scrollView.contentOffset.x / width);
+    page = MAX(0, MIN(page, (NSInteger)self.feed.items.count - 1));
+    if (page == self.currentIndex) return;
+    self.currentIndex = page;
+    [self apollo_updateChromeContent];
+    [self apollo_prefetchAroundIndex:page];
+    [self apollo_loadMoreIfNeeded];
+}
+
+- (void)apollo_prefetchAroundIndex:(NSInteger)index {
+    NSArray<ApolloGalleryItem *> *items = self.feed.items;
+    for (NSInteger offset = -kApolloGalleryViewerPrefetchRadius; offset <= kApolloGalleryViewerPrefetchRadius; offset++) {
+        NSInteger neighbour = index + offset;
+        if (offset == 0 || neighbour < 0 || neighbour >= (NSInteger)items.count) continue;
+        [[ApolloGalleryImageLoader sharedLoader] prefetchImageAtURL:items[neighbour].imageURL];
+    }
+}
+
+- (void)apollo_loadMoreIfNeeded {
+    NSInteger total = (NSInteger)self.feed.items.count;
+    if (self.feed.isExhausted || self.feed.isLoading) return;
+    if (self.currentIndex < total - kApolloGalleryViewerLoadAheadSlack) return;
+
+    [self apollo_setStatus:@"Loading more…"];
+    __weak typeof(self) weakSelf = self;
+    [self.feed loadNextBatchWithCompletion:^(NSRange addedRange, NSString *errorMessage) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        [strongSelf apollo_setStatus:nil];
+        if (errorMessage.length > 0) {
+            [strongSelf apollo_showToast:@"Couldn't load more"];
+            return;
+        }
+        if (addedRange.length == 0) {
+            if (strongSelf.feed.isExhausted) [strongSelf apollo_showToast:@"That's everything"];
+            return;
+        }
+        [strongSelf apollo_appendItemsInRange:addedRange];
+        id<ApolloGalleryImageViewerDelegate> delegate = strongSelf.galleryDelegate;
+        if ([delegate respondsToSelector:@selector(galleryViewer:didAppendItemsInRange:)]) {
+            [delegate galleryViewer:strongSelf didAppendItemsInRange:addedRange];
+        }
+    }];
+}
+
+- (void)apollo_appendItemsInRange:(NSRange)range {
+    if (range.length == 0) return;
+    NSMutableArray<NSIndexPath *> *indexPaths = [NSMutableArray arrayWithCapacity:range.length];
+    for (NSUInteger i = range.location; i < NSMaxRange(range); i++) {
+        [indexPaths addObject:[NSIndexPath indexPathForItem:(NSInteger)i inSection:0]];
+    }
+    // Appending past the end never disturbs the visible page's offset, so this
+    // is safe to do while the user is mid-swipe.
+    [self.collectionView performBatchUpdates:^{
+        [self.collectionView insertItemsAtIndexPaths:indexPaths];
+    } completion:nil];
+    [self apollo_updateChromeContent];
+}
+
+- (void)feedDidAppendItems {
+    if (!self.isViewLoaded) return;
+    NSInteger known = [self.collectionView numberOfItemsInSection:0];
+    NSInteger total = (NSInteger)self.feed.items.count;
+    if (total <= known) return;
+    [self apollo_appendItemsInRange:NSMakeRange((NSUInteger)known, (NSUInteger)(total - known))];
+}
+
+#pragma mark Gestures
+
+- (void)apollo_singleTapped:(UITapGestureRecognizer *)recognizer {
+    if (recognizer.state != UIGestureRecognizerStateRecognized) return;
+    [self apollo_setChromeVisible:!self.chromeVisible animated:YES];
+}
+
+- (void)apollo_longPressed:(UILongPressGestureRecognizer *)recognizer {
+    if (recognizer.state != UIGestureRecognizerStateBegan) return;
+    [self apollo_presentActionsFromView:self.view];
+}
+
+- (ApolloGalleryViewerCell *)apollo_currentCell {
+    NSIndexPath *indexPath = [NSIndexPath indexPathForItem:self.currentIndex inSection:0];
+    UICollectionViewCell *cell = [self.collectionView cellForItemAtIndexPath:indexPath];
+    return [cell isKindOfClass:[ApolloGalleryViewerCell class]] ? (ApolloGalleryViewerCell *)cell : nil;
+}
+
+- (void)apollo_dismissPanned:(UIPanGestureRecognizer *)recognizer {
+    CGPoint translation = [recognizer translationInView:self.view];
+    switch (recognizer.state) {
+        case UIGestureRecognizerStateBegan: {
+            // Toggling scrollEnabled cancels any paging drag UIKit had started
+            // on the same touch, so a diagonal flick can't page AND dismiss.
+            self.collectionView.scrollEnabled = NO;
+                    [UIView animateWithDuration:0.15 animations:^{
+                self.doneButton.alpha = 0.0;
+                self.shareButton.alpha = 0.0;
+                self.counterLabel.alpha = 0.0;
+                self.infoPanel.alpha = 0.0;
+            }];
+            break;
+        }
+        case UIGestureRecognizerStateChanged: {
+            CGFloat progress = MIN(fabs(translation.y) / 400.0, 1.0);
+            self.collectionView.transform = CGAffineTransformMakeTranslation(0.0, translation.y);
+            self.view.backgroundColor = [UIColor colorWithWhite:0.0 alpha:1.0 - progress * 0.65];
+            break;
+        }
+        case UIGestureRecognizerStateEnded:
+        case UIGestureRecognizerStateCancelled:
+        case UIGestureRecognizerStateFailed: {
+            CGFloat velocity = [recognizer velocityInView:self.view].y;
+            BOOL commit = recognizer.state == UIGestureRecognizerStateEnded &&
+                          (fabs(translation.y) > kApolloGalleryViewerDismissDistance ||
+                           fabs(velocity) > kApolloGalleryViewerDismissVelocity);
+            if (commit) {
+                // Keep flying in the direction the finger was already going.
+                CGFloat direction = (translation.y != 0.0 ? translation.y : velocity) < 0.0 ? -1.0 : 1.0;
+                [self apollo_dismissWithFlickDirection:direction];
+            } else {
+                self.collectionView.scrollEnabled = YES;
+                [UIView animateWithDuration:0.28
+                                      delay:0.0
+                     usingSpringWithDamping:0.85
+                      initialSpringVelocity:0.0
+                                    options:UIViewAnimationOptionAllowUserInteraction
+                                 animations:^{
+                    self.collectionView.transform = CGAffineTransformIdentity;
+                    self.view.backgroundColor = UIColor.blackColor;
+                } completion:nil];
+                [self apollo_setChromeVisible:self.chromeVisible animated:YES];
+            }
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+- (void)apollo_dismissWithFlickDirection:(CGFloat)direction {
+    if (self.isDismissing) return;
+    self.isDismissing = YES;
+    [self apollo_notifyWillDismiss];
+    CGFloat offscreen = direction * (self.view.bounds.size.height + 80.0);
+    [UIView animateWithDuration:0.22
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseOut
+                     animations:^{
+        self.collectionView.transform = CGAffineTransformMakeTranslation(0.0, offscreen);
+        self.view.backgroundColor = UIColor.clearColor;
+    } completion:^(BOOL finished) {
+        [self dismissViewControllerAnimated:NO completion:nil];
+    }];
+}
+
+- (void)apollo_notifyWillDismiss {
+    id<ApolloGalleryImageViewerDelegate> delegate = self.galleryDelegate;
+    if ([delegate respondsToSelector:@selector(galleryViewer:willDismissAtIndex:)]) {
+        [delegate galleryViewer:self willDismissAtIndex:self.currentIndex];
+    }
+}
+
+- (void)apollo_donePressed {
+    if (self.isDismissing) return;
+    self.isDismissing = YES;
+    [self apollo_notifyWillDismiss];
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+#pragma mark UIGestureRecognizerDelegate
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
+    if (gestureRecognizer != self.dismissPan) return YES;
+    // A zoomed-in page pans its own content instead.
+    if ([self apollo_currentCell].isZoomed) return NO;
+    CGPoint velocity = [self.dismissPan velocityInView:self.view];
+    return fabs(velocity.y) > fabs(velocity.x);
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return YES;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+       shouldReceiveTouch:(UITouch *)touch {
+    // Let the info panel's own tap handle taps that land on it.
+    if ([touch.view isDescendantOfView:self.infoPanel] && self.chromeVisible) {
+        return ![gestureRecognizer isKindOfClass:[UITapGestureRecognizer class]];
+    }
+    return YES;
+}
+
+#pragma mark Actions
+
+- (ApolloGalleryItem *)apollo_currentItem {
+    NSArray<ApolloGalleryItem *> *items = self.feed.items;
+    if (self.currentIndex < 0 || self.currentIndex >= (NSInteger)items.count) return nil;
+    return items[self.currentIndex];
+}
+
+- (void)apollo_sharePressed:(UIButton *)sender {
+    [self apollo_presentActionsFromView:sender];
+}
+
+- (void)apollo_infoPanelTapped {
+    [self apollo_openCurrentPost];
+}
+
+- (void)apollo_presentActionsFromView:(UIView *)sourceView {
+    ApolloGalleryItem *item = [self apollo_currentItem];
+    if (!item) return;
+
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:item.postTitle
+                                                                   message:nil
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+    __weak typeof(self) weakSelf = self;
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Save Image" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        [weakSelf apollo_saveCurrentImage];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Share Image" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        [weakSelf apollo_shareCurrentImageFromView:sourceView];
+    }]];
+    if (item.postURL) {
+        [sheet addAction:[UIAlertAction actionWithTitle:@"Share Post Link" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+            [weakSelf apollo_sharePostLinkFromView:sourceView];
+        }]];
+        [sheet addAction:[UIAlertAction actionWithTitle:@"Open Post" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+            [weakSelf apollo_openCurrentPost];
+        }]];
+    }
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    if (popover) {
+        popover.sourceView = sourceView ?: self.view;
+        popover.sourceRect = (sourceView && sourceView != self.view)
+            ? sourceView.bounds
+            : CGRectMake(CGRectGetMidX(self.view.bounds), CGRectGetMidY(self.view.bounds), 1.0, 1.0);
+    }
+    [self presentViewController:sheet animated:YES completion:nil];
+}
+
+// Original bytes when we still have them (a GIF stays animated), otherwise a
+// PNG re-encode of what's on screen.
+- (NSData *)apollo_dataForCurrentItem {
+    ApolloGalleryItem *item = [self apollo_currentItem];
+    if (!item) return nil;
+    NSData *data = [[ApolloGalleryImageLoader sharedLoader] cachedDataForURL:item.imageURL];
+    if (data.length > 0) return data;
+    UIImage *image = [self apollo_currentCell].imageView.image;
+    return image ? UIImagePNGRepresentation(image) : nil;
+}
+
+- (void)apollo_saveCurrentImage {
+    NSData *data = [self apollo_dataForCurrentItem];
+    if (data.length == 0) {
+        [self apollo_showToast:@"Still loading"];
+        return;
+    }
+
+    __weak typeof(self) weakSelf = self;
+    void (^performSave)(void) = ^{
+        [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+            PHAssetCreationRequest *request = [PHAssetCreationRequest creationRequestForAsset];
+            [request addResourceWithType:PHAssetResourceTypePhoto data:data options:nil];
+        } completionHandler:^(BOOL success, NSError *error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (success) {
+                    [weakSelf apollo_showToast:@"Saved"];
+                } else {
+                    ApolloLog(@"[Gallery] save failed: %@", error.localizedDescription);
+                    [weakSelf apollo_showToast:@"Save failed"];
+                }
+            });
+        }];
+    };
+
+    PHAuthorizationStatus status = [PHPhotoLibrary authorizationStatusForAccessLevel:PHAccessLevelAddOnly];
+    if (status == PHAuthorizationStatusNotDetermined) {
+        [PHPhotoLibrary requestAuthorizationForAccessLevel:PHAccessLevelAddOnly handler:^(PHAuthorizationStatus newStatus) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (newStatus == PHAuthorizationStatusAuthorized || newStatus == PHAuthorizationStatusLimited) {
+                    performSave();
+                } else {
+                    [weakSelf apollo_showToast:@"Photos access denied"];
+                }
+            });
+        }];
+    } else if (status == PHAuthorizationStatusAuthorized || status == PHAuthorizationStatusLimited) {
+        performSave();
+    } else {
+        [self apollo_showToast:@"Photos access denied"];
+    }
+}
+
+- (void)apollo_shareCurrentImageFromView:(UIView *)sourceView {
+    ApolloGalleryItem *item = [self apollo_currentItem];
+    NSData *data = [self apollo_dataForCurrentItem];
+    NSArray *activityItems = nil;
+
+    if (data.length > 0) {
+        // Write with the source filename so the receiving app sees a real .gif
+        // / .jpg rather than a generic blob.
+        NSString *name = item.imageURL.lastPathComponent.length > 0
+            ? item.imageURL.lastPathComponent
+            : [NSString stringWithFormat:@"image-%ld.jpg", (long)self.currentIndex + 1];
+        NSURL *fileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:name]];
+        if ([data writeToURL:fileURL atomically:YES]) activityItems = @[fileURL];
+    }
+    if (!activityItems && item.imageURL) activityItems = @[item.imageURL];
+    if (!activityItems) {
+        [self apollo_showToast:@"Still loading"];
+        return;
+    }
+    [self apollo_presentActivityWithItems:activityItems fromView:sourceView];
+}
+
+- (void)apollo_sharePostLinkFromView:(UIView *)sourceView {
+    NSURL *postURL = [self apollo_currentItem].postURL;
+    if (!postURL) return;
+    [self apollo_presentActivityWithItems:@[postURL] fromView:sourceView];
+}
+
+- (void)apollo_presentActivityWithItems:(NSArray *)activityItems fromView:(UIView *)sourceView {
+    UIActivityViewController *activity = [[UIActivityViewController alloc] initWithActivityItems:activityItems
+                                                                           applicationActivities:nil];
+    UIPopoverPresentationController *popover = activity.popoverPresentationController;
+    if (popover) {
+        popover.sourceView = sourceView ?: self.view;
+        popover.sourceRect = (sourceView && sourceView != self.view)
+            ? sourceView.bounds
+            : CGRectMake(CGRectGetMidX(self.view.bounds), CGRectGetMidY(self.view.bounds), 1.0, 1.0);
+    }
+    [self presentViewController:activity animated:YES completion:nil];
+}
+
+// Hand off to Apollo's own post view. The viewer has to get out of the way
+// first: routing a URL while a fullscreen modal is up would push the post
+// behind it.
+- (void)apollo_openCurrentPost {
+    NSURL *postURL = [self apollo_currentItem].postURL;
+    if (!postURL) return;
+    if (!self.isDismissing) {
+        self.isDismissing = YES;
+        [self apollo_notifyWillDismiss];
+    }
+    [self dismissViewControllerAnimated:YES completion:^{
+        if (!ApolloRouteURLThroughApp(postURL)) {
+            ApolloLog(@"[Gallery] couldn't route %@ through the app", postURL.absoluteString);
+        }
+    }];
+}
+
+@end

--- a/src/ApolloGalleryImageViewer.m
+++ b/src/ApolloGalleryImageViewer.m
@@ -4,6 +4,7 @@
 #import "ApolloGalleryFeed.h"
 #import "ApolloGalleryImageLoader.h"
 #import "ApolloCommon.h"
+#import "ApolloGalleryVideoExport.h"
 
 #import <Photos/Photos.h>
 #import <AVFoundation/AVFoundation.h>
@@ -952,9 +953,6 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
                                                             preferredStyle:UIAlertControllerStyleActionSheet];
     __weak typeof(self) weakSelf = self;
     if (item.playsAsVideo) {
-        // Only offer Save when there's a self-contained file to write. A
-        // v.redd.it "fallback" mp4 is the video track alone — saving it would
-        // hand back a silent copy, so it's left out rather than disappointing.
         if (item.videoDownloadURL) {
             [sheet addAction:[UIAlertAction actionWithTitle:@"Save Video" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
                 [weakSelf apollo_saveCurrentVideo];
@@ -1044,68 +1042,18 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
     }
 }
 
-// Videos aren't held in the image cache, so this pulls the mp4 down before
-// handing it to Photos.
+// Handed off to ApolloGalleryVideoExport, which knows that a v.redd.it save
+// needs the separate DASH audio muxed back in before it's worth keeping.
 - (void)apollo_saveCurrentVideo {
     NSURL *source = [self apollo_currentItem].videoDownloadURL;
     if (!source) return;
-    [self apollo_showToast:@"Saving…"];
 
     __weak typeof(self) weakSelf = self;
-    NSURLSessionDownloadTask *task =
-        [[NSURLSession sharedSession] downloadTaskWithURL:source
-                                        completionHandler:^(NSURL *location, NSURLResponse *response, NSError *error) {
-        if (!location || error) {
-            ApolloLog(@"[Gallery] video download failed: %@", error.localizedDescription);
-            dispatch_async(dispatch_get_main_queue(), ^{ [weakSelf apollo_showToast:@"Save failed"]; });
-            return;
-        }
-        // Photos needs a file with a real video extension; the download lands
-        // at a temp path with none.
-        NSString *name = source.lastPathComponent.length > 0 ? source.lastPathComponent : @"video.mp4";
-        if (name.pathExtension.length == 0) name = [name stringByAppendingPathExtension:@"mp4"];
-        NSURL *fileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:name]];
-        [[NSFileManager defaultManager] removeItemAtURL:fileURL error:NULL];
-        if (![[NSFileManager defaultManager] moveItemAtURL:location toURL:fileURL error:NULL]) {
-            dispatch_async(dispatch_get_main_queue(), ^{ [weakSelf apollo_showToast:@"Save failed"]; });
-            return;
-        }
-        [weakSelf apollo_writeVideoFileToPhotos:fileURL];
-    }];
-    [task resume];
-}
-
-- (void)apollo_writeVideoFileToPhotos:(NSURL *)fileURL {
-    __weak typeof(self) weakSelf = self;
-    void (^performSave)(void) = ^{
-        [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
-            PHAssetCreationRequest *request = [PHAssetCreationRequest creationRequestForAsset];
-            [request addResourceWithType:PHAssetResourceTypeVideo fileURL:fileURL options:nil];
-        } completionHandler:^(BOOL success, NSError *error) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                if (success) {
-                    [weakSelf apollo_showToast:@"Saved"];
-                } else {
-                    ApolloLog(@"[Gallery] video save failed: %@", error.localizedDescription);
-                    [weakSelf apollo_showToast:@"Save failed"];
-                }
-            });
-        }];
-    };
-
-    PHAuthorizationStatus status = [PHPhotoLibrary authorizationStatusForAccessLevel:PHAccessLevelAddOnly];
-    if (status == PHAuthorizationStatusNotDetermined) {
-        [PHPhotoLibrary requestAuthorizationForAccessLevel:PHAccessLevelAddOnly handler:^(PHAuthorizationStatus newStatus) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                if (newStatus == PHAuthorizationStatusAuthorized || newStatus == PHAuthorizationStatusLimited) performSave();
-                else [weakSelf apollo_showToast:@"Photos access denied"];
-            });
-        }];
-    } else if (status == PHAuthorizationStatusAuthorized || status == PHAuthorizationStatusLimited) {
-        performSave();
-    } else {
-        [self apollo_showToast:@"Photos access denied"];
-    }
+    ApolloGallerySaveVideoToPhotos(source, ^(NSString *text) {
+        [weakSelf apollo_showToast:text];
+    }, ^(BOOL success, NSString *message) {
+        [weakSelf apollo_showToast:message];
+    });
 }
 
 - (void)apollo_shareCurrentImageFromView:(UIView *)sourceView {

--- a/src/ApolloGalleryImageViewer.m
+++ b/src/ApolloGalleryImageViewer.m
@@ -903,6 +903,10 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
         [self apollo_notifyWillDismiss];
     }
     [self dismissViewControllerAnimated:YES completion:^{
+        // Apollo's URL handler only acts on apollo:// URLs — handing it the raw
+        // https reddit.com link is silently ignored. The scheme conversion is
+        // what every other in-app route in the tweak goes through.
+        if (ApolloRouteResolvedURLViaApolloScheme(postURL)) return;
         if (!ApolloRouteURLThroughApp(postURL)) {
             ApolloLog(@"[Gallery] couldn't route %@ through the app", postURL.absoluteString);
         }

--- a/src/ApolloGalleryMenu.xm
+++ b/src/ApolloGalleryMenu.xm
@@ -1,0 +1,399 @@
+// ApolloGalleryMenu.xm
+//
+// Puts "Gallery View" in a subreddit's nav-bar "..." menu, and opens
+// ApolloGalleryViewController when it's picked.
+//
+// Apollo draws that menu two different ways, so the row has to be added twice:
+//
+//   • Liquid Glass — the tweak's own ApolloNativeActionMenus module converts
+//     Apollo's ActionController sheet into a real UIKit UIMenu. It calls
+//     ApolloInjectGalleryViewMenuItemIfNeeded() while building the children, the
+//     same seam ApolloDeletedCommentsMenu and ApolloPublicStickyAsSubreddit use.
+//     We insert an inline single-item section at the top so the row reads as its
+//     own group instead of shuffling every native row down by one.
+//
+//   • Everything else — the ActionController presents itself as a table sheet.
+//     We append a row to the END of its data source and grow the presentation
+//     frame by one row height so the taller table still fits, mirroring what
+//     ApolloPublicStickyAsSubreddit does for the removal "Notify user via…"
+//     sheet. Appending (rather than inserting at the top, where it would match
+//     the glass menu) is forced: Apollo's own cellForRow calls
+//     -dequeueReusableCellWithIdentifier:forIndexPath: with the index path it
+//     was handed, and UIKit asserts if a shifted path is passed through, so the
+//     native rows have to keep their own indices. (On Liquid Glass these hooks
+//     still run, because the sheet is built before ApolloNativeActionMenus
+//     hides and swaps it — harmless, since that view never reaches the screen
+//     and the UIMenu is built from Apollo's Swift `actions` array, not from the
+//     table.)
+//
+// Which sheet is ours: the "..." menu has no header title to match on, so we
+// arm on -[PostsViewController moreOptionsBarButtonItemTappedWithSender:] and
+// let the first ActionController built inside a short grace window claim the
+// arm — the same one-shot claim ApolloDeletedCommentsMenu uses for the comments
+// "..." menu. The claim is recorded on the controller so repeat builds of the
+// same sheet re-inject, and no later, unrelated sheet can pick it up.
+//
+// Multireddits, Popular/All, profile feeds and search results never get the row:
+// the subreddit is resolved through ApolloSubredditNameFromViewController
+// (ApolloSubredditHeaders.xm), which gates on Apollo's own PostsType tag.
+
+#import <UIKit/UIKit.h>
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+#import "ApolloCommon.h"
+#import "ApolloGalleryViewController.h"
+#import "ApolloThemeRuntime.h"
+
+// Defined in ApolloSubredditHeaders.xm — resolves the slug for a genuine
+// single-subreddit feed, and nil for anything else (multireddit, Popular/All,
+// profile/special feeds).
+extern NSString *ApolloSubredditNameFromViewController(UIViewController *viewController);
+
+static NSString *const kApolloGalleryMenuTitle = @"Gallery View";
+static NSString *const kApolloGalleryMenuSymbol = @"square.grid.2x2";
+
+// How long after the "..." tap an ActionController may still claim the arm.
+static const CFTimeInterval kApolloGalleryMenuArmGraceSeconds = 1.5;
+
+// The PostsViewController whose "..." was just tapped, and when.
+static __weak UIViewController *sApolloGalleryArmedVC = nil;
+static CFTimeInterval sApolloGalleryArmedAt = 0.0;
+
+// Set on an ActionController once it has claimed the arm: an NSHashTable
+// holding the owning PostsViewController weakly (a plain associated object
+// would keep the view controller alive).
+static char kApolloGalleryMenuOwnerKey;
+// Row count the sheet reported before we appended ours, per controller.
+static char kApolloGalleryMenuOrigRowCountKey;
+
+#pragma mark - Claiming
+
+// The PostsViewController this ActionController belongs to, claiming the
+// pending arm the first time it's asked. Returns nil for every sheet that isn't
+// the subreddit "..." menu.
+static UIViewController *ApolloGalleryMenuOwnerForController(id actionController) {
+    if (!actionController) return nil;
+
+    NSHashTable *holder = objc_getAssociatedObject(actionController, &kApolloGalleryMenuOwnerKey);
+    if (holder) return holder.anyObject;
+
+    UIViewController *armed = sApolloGalleryArmedVC;
+    if (!armed) return nil;
+    if (CACurrentMediaTime() - sApolloGalleryArmedAt > kApolloGalleryMenuArmGraceSeconds) {
+        sApolloGalleryArmedVC = nil;
+        return nil;
+    }
+
+    holder = [NSHashTable weakObjectsHashTable];
+    [holder addObject:armed];
+    objc_setAssociatedObject(actionController, &kApolloGalleryMenuOwnerKey, holder, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    // One-shot: consumed here so a second sheet opened later can't also claim it.
+    sApolloGalleryArmedVC = nil;
+    return armed;
+}
+
+// Subreddit slug for a claimed controller, or nil when this sheet isn't ours or
+// the feed isn't a single subreddit.
+static NSString *ApolloGalleryMenuSubredditForController(id actionController) {
+    UIViewController *owner = ApolloGalleryMenuOwnerForController(actionController);
+    if (!owner) return nil;
+    return ApolloSubredditNameFromViewController(owner);
+}
+
+static void ApolloGalleryMenuOpenForController(id actionController) {
+    UIViewController *owner = ApolloGalleryMenuOwnerForController(actionController);
+    NSString *subreddit = owner ? ApolloSubredditNameFromViewController(owner) : nil;
+    if (subreddit.length == 0 || !owner) {
+        ApolloLog(@"[GalleryMenu] Gallery View tapped but the subreddit could not be resolved");
+        return;
+    }
+    [ApolloGalleryViewController presentGalleryForSubreddit:subreddit fromViewController:owner];
+}
+
+#pragma mark - Liquid Glass menu injection
+
+// Called from ApolloNativeActionMenuBuildMenu as it converts an ActionController
+// into a UIMenu. No-op for every sheet that isn't a subreddit "..." menu.
+void ApolloInjectGalleryViewMenuItemIfNeeded(NSMutableArray *children, NSString *menuTitle, id actionController) {
+    (void)menuTitle;
+    if (![children isKindOfClass:[NSMutableArray class]] || children.count == 0) return;
+
+    NSString *subreddit = ApolloGalleryMenuSubredditForController(actionController);
+    if (subreddit.length == 0) return;
+
+    // The builder runs more than once per presentation; the claim persists on
+    // the controller, so guard against inserting our section twice.
+    for (UIMenuElement *element in children) {
+        if ([element isKindOfClass:[UIMenu class]] &&
+            [((UIMenu *)element).children.firstObject isKindOfClass:[UIAction class]] &&
+            [((UIAction *)((UIMenu *)element).children.firstObject).title isEqualToString:kApolloGalleryMenuTitle]) {
+            return;
+        }
+    }
+
+    __weak id weakController = actionController;
+    UIAction *action = [UIAction actionWithTitle:kApolloGalleryMenuTitle
+                                           image:[UIImage systemImageNamed:kApolloGalleryMenuSymbol]
+                                      identifier:nil
+                                         handler:^(__unused __kindof UIAction *sender) {
+        ApolloGalleryMenuOpenForController(weakController);
+    }];
+
+    // An inline single-item menu renders as its own separated group above the
+    // native rows, rather than sitting inside them.
+    UIMenu *section = [UIMenu menuWithTitle:@""
+                                      image:nil
+                                 identifier:nil
+                                    options:UIMenuOptionsDisplayInline
+                                   children:@[action]];
+    [children insertObject:section atIndex:0];
+    ApolloLog(@"[GalleryMenu] Injected '%@' for r/%@ (glass menu)", kApolloGalleryMenuTitle, subreddit);
+}
+
+#pragma mark - Arming
+
+%hook _TtC6Apollo19PostsViewController
+
+- (void)moreOptionsBarButtonItemTappedWithSender:(id)sender {
+    // Only arm for feeds a gallery makes sense for; that keeps every other
+    // sheet (and every other feed type) completely untouched.
+    if (ApolloSubredditNameFromViewController((UIViewController *)self).length > 0) {
+        sApolloGalleryArmedVC = (UIViewController *)self;
+        sApolloGalleryArmedAt = CACurrentMediaTime();
+    } else {
+        sApolloGalleryArmedVC = nil;
+    }
+    %orig;
+}
+
+%end
+
+#pragma mark - Action-sheet row injection (non-Liquid-Glass)
+
+static NSInteger ApolloGalleryMenuOriginalRowCount(id actionController) {
+    NSNumber *stored = objc_getAssociatedObject(actionController, &kApolloGalleryMenuOrigRowCountKey);
+    return stored ? stored.integerValue : -1;
+}
+
+// Takes `id` so callers inside %hook blocks don't have to message a
+// forward-declared Swift class (clang rejects -class on one).
+static id ApolloGalleryMenuIvarObject(id object, const char *name) {
+    if (!object || !name) return nil;
+    Ivar ivar = class_getInstanceVariable(object_getClass(object), name);
+    return ivar ? object_getIvar(object, ivar) : nil;
+}
+
+// The sheet's own row height, asked of Apollo rather than guessed. 0 when it
+// can't be determined.
+static CGFloat ApolloGalleryMenuRowHeight(id actionController) {
+    id tableView = ApolloGalleryMenuIvarObject(actionController, "tableView");
+    if (![tableView isKindOfClass:[UITableView class]]) return 0.0;
+    if (![actionController respondsToSelector:@selector(tableView:heightForRowAtIndexPath:)]) return 0.0;
+    @try {
+        return [(id<UITableViewDelegate>)actionController
+                    tableView:(UITableView *)tableView
+                    heightForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
+    } @catch (__unused NSException *exception) {
+        return 0.0;
+    }
+}
+
+#pragma mark Row-0 styling capture
+
+// Apollo's action-sheet rows are custom-built (icon + accent-tinted label at
+// their own insets), so a stock UITableViewCell's textLabel lands in the wrong
+// place with the wrong colour — under a dark custom theme it renders as an
+// apparently blank row. Instead of guessing, mirror row 0: find its label and
+// icon by walking the cell (rather than by ivar name, which isn't stable) and
+// reuse their geometry and styling verbatim.
+static UIView *ApolloGalleryMenuFirstSubviewOfClass(UIView *root, Class cls, BOOL requireLabelText) {
+    for (UIView *subview in root.subviews) {
+        if ([subview isKindOfClass:cls]) {
+            if (!requireLabelText) return subview;
+            if ([subview isKindOfClass:[UILabel class]] && ((UILabel *)subview).text.length > 0) return subview;
+        }
+        UIView *nested = ApolloGalleryMenuFirstSubviewOfClass(subview, cls, requireLabelText);
+        if (nested) return nested;
+    }
+    return nil;
+}
+
+// Captured from row 0 the first time it builds. Frames are in the cell's own
+// coordinate space; only the x/height parts are reused (our row has the same
+// height, and the width comes from our own cell).
+static UIColor *sApolloGalleryRowTitleColor = nil;
+static UIFont *sApolloGalleryRowTitleFont = nil;
+static NSTextAlignment sApolloGalleryRowTitleAlignment = NSTextAlignmentLeft;
+static CGRect sApolloGalleryRowTitleFrame = CGRectZero;
+static CGRect sApolloGalleryRowIconFrame = CGRectZero;
+static UIColor *sApolloGalleryRowIconTint = nil;
+
+static void ApolloGalleryMenuCaptureRowStyle(UITableViewCell *cell) {
+    if (![cell isKindOfClass:[UITableViewCell class]]) return;
+    // Force a layout pass so the captured frames are real, not CGRectZero.
+    [cell layoutIfNeeded];
+
+    UILabel *label = (UILabel *)ApolloGalleryMenuFirstSubviewOfClass(cell, [UILabel class], YES);
+    if (!label) return;
+    sApolloGalleryRowTitleColor = label.textColor;
+    sApolloGalleryRowTitleFont = label.font;
+    sApolloGalleryRowTitleAlignment = label.textAlignment;
+    sApolloGalleryRowTitleFrame = [label convertRect:label.bounds toView:cell];
+
+    UIImageView *icon = (UIImageView *)ApolloGalleryMenuFirstSubviewOfClass(cell, [UIImageView class], NO);
+    if (icon && icon.bounds.size.width > 1.0) {
+        sApolloGalleryRowIconFrame = [icon convertRect:icon.bounds toView:cell];
+        sApolloGalleryRowIconTint = icon.tintColor;
+    }
+    ApolloLog(@"[GalleryMenu] Captured sheet row style: title=%@ icon=%@",
+              NSStringFromCGRect(sApolloGalleryRowTitleFrame), NSStringFromCGRect(sApolloGalleryRowIconFrame));
+}
+
+// Our appended row, laid out to match the captured native row.
+@interface ApolloGalleryMenuRowCell : UITableViewCell
+@property (nonatomic, strong) UILabel *rowTitleLabel;
+@property (nonatomic, strong) UIImageView *rowIconView;
+@end
+
+@implementation ApolloGalleryMenuRowCell
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        self.backgroundColor = UIColor.clearColor;
+        self.contentView.backgroundColor = UIColor.clearColor;
+        self.selectionStyle = UITableViewCellSelectionStyleDefault;
+
+        // The accent is the right last resort: Apollo tints these rows with the
+        // theme accent, so it matches even when the capture came up empty.
+        UIColor *tint = sApolloGalleryRowTitleColor ?: ApolloThemeAccentColor() ?: UIColor.labelColor;
+
+        _rowIconView = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:kApolloGalleryMenuSymbol]];
+        _rowIconView.contentMode = UIViewContentModeScaleAspectFit;
+        _rowIconView.tintColor = sApolloGalleryRowIconTint ?: tint;
+        [self.contentView addSubview:_rowIconView];
+
+        _rowTitleLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+        _rowTitleLabel.text = kApolloGalleryMenuTitle;
+        _rowTitleLabel.textColor = tint;
+        _rowTitleLabel.font = sApolloGalleryRowTitleFont ?: [UIFont systemFontOfSize:17.0];
+        _rowTitleLabel.textAlignment = sApolloGalleryRowTitleAlignment;
+        [self.contentView addSubview:_rowTitleLabel];
+    }
+    return self;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGRect bounds = self.contentView.bounds;
+
+    if (!CGRectIsEmpty(sApolloGalleryRowIconFrame)) {
+        CGRect iconFrame = sApolloGalleryRowIconFrame;
+        iconFrame.origin.y = (bounds.size.height - iconFrame.size.height) / 2.0;
+        self.rowIconView.frame = iconFrame;
+        self.rowIconView.hidden = NO;
+    } else {
+        self.rowIconView.hidden = YES;
+    }
+
+    CGFloat titleLeft = CGRectIsEmpty(sApolloGalleryRowTitleFrame) ? 16.0 : CGRectGetMinX(sApolloGalleryRowTitleFrame);
+    CGFloat titleHeight = CGRectIsEmpty(sApolloGalleryRowTitleFrame) ? 22.0 : CGRectGetHeight(sApolloGalleryRowTitleFrame);
+    self.rowTitleLabel.frame = CGRectMake(titleLeft,
+                                          (bounds.size.height - titleHeight) / 2.0,
+                                          MAX(0.0, bounds.size.width - titleLeft - 16.0),
+                                          titleHeight);
+}
+
+@end
+
+%hook _TtC6Apollo16ActionController
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    NSInteger count = %orig;
+    NSString *subreddit = ApolloGalleryMenuSubredditForController(self);
+    if (subreddit.length == 0) return count;
+    // Only the first section grows; Apollo's "..." sheet is single-section, but
+    // being explicit keeps a multi-section sheet from sprouting extra rows.
+    if (section != 0) return count;
+    if (ApolloGalleryMenuOriginalRowCount(self) != count) {
+        ApolloLog(@"[GalleryMenu] Added '%@' row for r/%@ (sheet, after %ld native rows)",
+                  kApolloGalleryMenuTitle, subreddit, (long)count);
+    }
+    objc_setAssociatedObject(self, &kApolloGalleryMenuOrigRowCountKey, @(count), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return count + 1;
+}
+
+// Our row is the LAST row, never inserted in the middle: Apollo's own
+// cellForRow calls -dequeueReusableCellWithIdentifier:forIndexPath: with the
+// index path it was handed, and UIKit asserts if that doesn't match the row the
+// table is currently asking for. So the native rows must keep their own indices
+// and only an appended row is safe.
+static BOOL ApolloGalleryMenuIsOurRow(id actionController, NSIndexPath *indexPath) {
+    NSInteger originalCount = ApolloGalleryMenuOriginalRowCount(actionController);
+    return originalCount >= 0 && indexPath.section == 0 && indexPath.row == originalCount;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (!ApolloGalleryMenuIsOurRow(self, indexPath)) {
+        UITableViewCell *cell = %orig;
+        // Apollo's first row is our style reference; re-capture on every sheet
+        // build so a theme change mid-session can't leave us on stale colours.
+        if (ApolloGalleryMenuOriginalRowCount(self) >= 0 && indexPath.section == 0 && indexPath.row == 0) {
+            ApolloGalleryMenuCaptureRowStyle(cell);
+        }
+        return cell;
+    }
+
+    // Built by hand with its own reuse identifier: dequeuing Apollo's cell class
+    // for an index its data source doesn't know about is what throws.
+    return [[ApolloGalleryMenuRowCell alloc] initWithStyle:UITableViewCellStyleDefault
+                                           reuseIdentifier:@"ApolloGalleryViewRow"];
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (!ApolloGalleryMenuIsOurRow(self, indexPath)) return %orig;
+    // Ask Apollo how tall its own rows are rather than guessing.
+    return %orig(tableView, [NSIndexPath indexPathForRow:0 inSection:indexPath.section]);
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (!ApolloGalleryMenuIsOurRow(self, indexPath)) { %orig; return; }
+
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    __strong id actionController = self;
+    // The sheet is modal over the subreddit; push only once it's gone.
+    [(UIViewController *)self dismissViewControllerAnimated:YES completion:^{
+        ApolloGalleryMenuOpenForController(actionController);
+    }];
+}
+
+%end
+
+// The sheet's height comes from Apollo's own row count, so it has to grow by a
+// row or the extra row is clipped. Only the presentation frame is touched —
+// growing the inner table view as well pushed its last row underneath the
+// Cancel button, where it couldn't be scrolled into view.
+%hook _TtC6Apollo38ActionControllerPresentationController
+
+- (CGRect)frameOfPresentedViewInContainerView {
+    CGRect frame = %orig;
+    UIViewController *presented = [(UIPresentationController *)self presentedViewController];
+    if (frame.size.height <= 0.0 || !presented) return frame;
+    NSInteger originalCount = ApolloGalleryMenuOriginalRowCount(presented);
+    if (originalCount < 0) return frame;
+
+    CGFloat rowHeight = ApolloGalleryMenuRowHeight(presented);
+    if (rowHeight <= 0.0) return frame;
+
+    frame.origin.y -= rowHeight;
+    frame.size.height += rowHeight;
+    return frame;
+}
+
+%end
+
+%ctor {
+    %init;
+    ApolloLog(@"[GalleryMenu] Gallery View menu hooks installed");
+}

--- a/src/ApolloGalleryMenu.xm
+++ b/src/ApolloGalleryMenu.xm
@@ -9,8 +9,9 @@
 //     Apollo's ActionController sheet into a real UIKit UIMenu. It calls
 //     ApolloInjectGalleryViewMenuItemIfNeeded() while building the children, the
 //     same seam ApolloDeletedCommentsMenu and ApolloPublicStickyAsSubreddit use.
-//     We insert an inline single-item section at the top so the row reads as its
-//     own group instead of shuffling every native row down by one.
+//     We insert an inline single-item section just below the leading "submit a
+//     post" affordance, so the row reads as its own group without displacing
+//     the composer that leads the menu.
 //
 //   • Everything else — the ActionController presents itself as a table sheet.
 //     We append a row to the END of its data source and grow the presentation
@@ -113,6 +114,24 @@ static void ApolloGalleryMenuOpenForController(id actionController) {
 
 #pragma mark - Liquid Glass menu injection
 
+// Where our section goes: after whatever "submit a post" affordance leads the
+// menu, never above it. That affordance has two shapes in the wild — a plain
+// "Submit Post" row (what stock Apollo's action list produces), and a leading
+// inline UIMenu that renders as a small row of post-type icons (image / link /
+// text) at the top of the menu. Skipping both keeps the composer where muscle
+// memory expects it and puts Gallery View directly underneath.
+static NSUInteger ApolloGalleryMenuInsertionIndex(NSArray<UIMenuElement *> *children) {
+    NSUInteger index = 0;
+    while (index < children.count) {
+        UIMenuElement *element = children[index];
+        if ([element isKindOfClass:[UIMenu class]]) { index++; continue; }
+        if ([element isKindOfClass:[UIAction class]] &&
+            [((UIAction *)element).title hasPrefix:@"Submit"]) { index++; continue; }
+        break;
+    }
+    return index;
+}
+
 // Called from ApolloNativeActionMenuBuildMenu as it converts an ActionController
 // into a UIMenu. No-op for every sheet that isn't a subreddit "..." menu.
 void ApolloInjectGalleryViewMenuItemIfNeeded(NSMutableArray *children, NSString *menuTitle, id actionController) {
@@ -140,15 +159,17 @@ void ApolloInjectGalleryViewMenuItemIfNeeded(NSMutableArray *children, NSString 
         ApolloGalleryMenuOpenForController(weakController);
     }];
 
-    // An inline single-item menu renders as its own separated group above the
-    // native rows, rather than sitting inside them.
+    // An inline single-item menu renders as its own separated group rather than
+    // sitting inside the native rows.
     UIMenu *section = [UIMenu menuWithTitle:@""
                                       image:nil
                                  identifier:nil
                                     options:UIMenuOptionsDisplayInline
                                    children:@[action]];
-    [children insertObject:section atIndex:0];
-    ApolloLog(@"[GalleryMenu] Injected '%@' for r/%@ (glass menu)", kApolloGalleryMenuTitle, subreddit);
+    NSUInteger index = ApolloGalleryMenuInsertionIndex(children);
+    [children insertObject:section atIndex:index];
+    ApolloLog(@"[GalleryMenu] Injected '%@' for r/%@ at index %lu (glass menu)",
+              kApolloGalleryMenuTitle, subreddit, (unsigned long)index);
 }
 
 #pragma mark - Arming

--- a/src/ApolloGalleryVideoExport.h
+++ b/src/ApolloGalleryVideoExport.h
@@ -1,0 +1,43 @@
+// ApolloGalleryVideoExport.h
+//
+// "Save Video" for Gallery View.
+//
+// Saving a v.redd.it clip is not just a download: Reddit serves the video and
+// audio as separate DASH representations, so the progressive `fallback_url`
+// everyone reaches for first is the video track ALONE. Writing that to Photos
+// hands back a silent copy of something the user watched with sound.
+//
+// So the reddit path is: read the DASH manifest, pull the video and audio
+// representations, and mux them into one mp4 with AVFoundation before saving.
+// The export uses the passthrough preset — both tracks are already H.264/AAC,
+// so nothing is re-encoded and nothing is lost. Self-contained sources (imgur
+// mp4, Reddit's silent GIF transcodes) skip all of that and download directly.
+//
+// The DASH manifest parsing is shared with Share as Video rather than copied
+// (see ApolloSVLowestDashURL / ApolloSVRedditAssetID in ApolloShareAsVideo.xm).
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// C linkage: this is defined in a .xm (ObjC++) but called from plain-ObjC .m
+// files, which would otherwise look for an unmangled symbol and fail to link.
+__BEGIN_DECLS
+
+// Downloads (muxing first when the source needs it) and writes the result to
+// the photo library.
+//
+// `progressiveURL` is a directly-downloadable mp4 — for v.redd.it that's the
+// video-only fallback, used both to identify the asset and as the fallback if
+// the manifest can't be read.
+//
+// `status` fires on the main thread with short user-facing progress text
+// ("Saving…", "Merging audio…"); `completion` fires on the main thread once,
+// with a message suitable for a toast.
+void ApolloGallerySaveVideoToPhotos(NSURL *progressiveURL,
+                                    void (^_Nullable status)(NSString *text),
+                                    void (^completion)(BOOL success, NSString *message));
+
+__END_DECLS
+
+NS_ASSUME_NONNULL_END

--- a/src/ApolloGalleryVideoExport.xm
+++ b/src/ApolloGalleryVideoExport.xm
@@ -1,0 +1,325 @@
+// ApolloGalleryVideoExport.xm — see ApolloGalleryVideoExport.h.
+//
+// Compiled as ObjC++ (.xm) purely so it links directly against the DASH helpers
+// in ApolloShareAsVideo.xm; there are no Logos hooks in here.
+
+#import "ApolloGalleryVideoExport.h"
+#import "ApolloCommon.h"
+
+#import <AVFoundation/AVFoundation.h>
+#import <Photos/Photos.h>
+
+static NSTimeInterval const kApolloGalleryExportManifestTimeout = 10.0;
+
+#pragma mark - DASH manifest
+
+// The v.redd.it asset id — the first path component of the URL.
+static NSString *ApolloGalleryExportRedditAssetID(NSURL *url) {
+    if (![url isKindOfClass:[NSURL class]]) return nil;
+    if ([url.host.lowercaseString rangeOfString:@"v.redd.it"].location == NSNotFound) return nil;
+    for (NSString *component in url.pathComponents) {
+        if (component.length > 0 && ![component isEqualToString:@"/"]) return component;
+    }
+    return nil;
+}
+
+// Picks the HIGHEST-bitrate video and audio representations out of a Reddit DASH
+// manifest.
+//
+// Deliberately not shared with Share as Video's parser, for two reasons. That
+// one wants the LOWEST bitrate (it's building a share card, where small wins);
+// a save wants the best copy available. And it keys off `contentType="video"`
+// with a `<BaseURL>*.mp4</BaseURL>` pattern, which only matches Reddit's newer
+// manifests — older ones carry no contentType at all, put mimeType on the
+// Representation, and use extension-less BaseURLs ("DASH_720", "audio"). Those
+// extension-less paths are the ONLY ones that serve: the .mp4 spellings 403.
+//
+// Returns absolute URLs; either may be nil.
+static void ApolloGalleryExportParseManifest(NSData *mpdData, NSURL *mpdURL,
+                                             NSURL *__strong *outVideo, NSURL *__strong *outAudio) {
+    if (outVideo) *outVideo = nil;
+    if (outAudio) *outAudio = nil;
+    NSString *xml = mpdData.length > 0 ? [[NSString alloc] initWithData:mpdData encoding:NSUTF8StringEncoding] : nil;
+    if (xml.length == 0) return;
+
+    // Each <Representation …> carries its own mimeType/bandwidth, and its
+    // <BaseURL> is the next one in document order.
+    // NOTE the doubled backslash: in an ObjC string literal "\b" is a BACKSPACE
+    // character, so a single one would compile into a pattern that matches
+    // nothing at all (and every track would silently fall back).
+    NSRegularExpression *representations =
+        [NSRegularExpression regularExpressionWithPattern:@"<Representation\\b([^>]*)>(.*?)</Representation>"
+                                                  options:NSRegularExpressionDotMatchesLineSeparators
+                                                    error:nil];
+    NSRegularExpression *baseURL =
+        [NSRegularExpression regularExpressionWithPattern:@"<BaseURL>([^<]+)</BaseURL>" options:0 error:nil];
+    if (!representations || !baseURL) return;
+
+    long long bestVideoBandwidth = -1, bestAudioBandwidth = -1;
+
+    for (NSTextCheckingResult *match in [representations matchesInString:xml options:0
+                                                                   range:NSMakeRange(0, xml.length)]) {
+        NSString *attributes = [xml substringWithRange:[match rangeAtIndex:1]];
+        NSString *body = [xml substringWithRange:[match rangeAtIndex:2]];
+
+        NSTextCheckingResult *base = [baseURL firstMatchInString:body options:0
+                                                           range:NSMakeRange(0, body.length)];
+        if (!base || base.numberOfRanges < 2) continue;
+        NSString *relative = [[body substringWithRange:[base rangeAtIndex:1]]
+                              stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        if (relative.length == 0) continue;
+        NSURL *resolved = [NSURL URLWithString:relative relativeToURL:mpdURL].absoluteURL;
+        if (!resolved) continue;
+
+        BOOL isAudio = [attributes rangeOfString:@"audio/" options:NSCaseInsensitiveSearch].location != NSNotFound ||
+                       [attributes rangeOfString:@"contentType=\"audio\"" options:NSCaseInsensitiveSearch].location != NSNotFound;
+
+        long long bandwidth = 0;
+        NSRange bandwidthRange = [attributes rangeOfString:@"bandwidth=\""];
+        if (bandwidthRange.location != NSNotFound) {
+            NSString *tail = [attributes substringFromIndex:NSMaxRange(bandwidthRange)];
+            bandwidth = [tail longLongValue];
+        }
+
+        if (isAudio) {
+            if (bandwidth > bestAudioBandwidth) { bestAudioBandwidth = bandwidth; if (outAudio) *outAudio = resolved; }
+        } else {
+            if (bandwidth > bestVideoBandwidth) { bestVideoBandwidth = bandwidth; if (outVideo) *outVideo = resolved; }
+        }
+    }
+}
+
+#pragma mark - Small helpers
+
+static void ApolloGalleryExportMain(void (^block)(void)) {
+    if (NSThread.isMainThread) block();
+    else dispatch_async(dispatch_get_main_queue(), block);
+}
+
+// Downloads `url` to a temp file with `extension`, because AVFoundation is far
+// happier composing from local files than from remote assets, and Photos needs
+// a real file with a real extension either way.
+static void ApolloGalleryExportDownload(NSURL *url, NSString *extension,
+                                        void (^completion)(NSURL *_Nullable fileURL)) {
+    NSURLSessionDownloadTask *task =
+        [[NSURLSession sharedSession] downloadTaskWithURL:url
+                                        completionHandler:^(NSURL *location, NSURLResponse *response, NSError *error) {
+        NSInteger status = [response isKindOfClass:[NSHTTPURLResponse class]]
+            ? ((NSHTTPURLResponse *)response).statusCode : 0;
+        if (!location || error || (status > 0 && (status < 200 || status >= 300))) {
+            ApolloLog(@"[GalleryExport] download failed (%ld) %@: %@",
+                      (long)status, url.lastPathComponent, error.localizedDescription ?: @"");
+            completion(nil);
+            return;
+        }
+        NSString *name = [[NSUUID UUID].UUIDString stringByAppendingPathExtension:extension];
+        NSURL *fileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:name]];
+        [[NSFileManager defaultManager] removeItemAtURL:fileURL error:NULL];
+        NSError *moveError = nil;
+        if (![[NSFileManager defaultManager] moveItemAtURL:location toURL:fileURL error:&moveError]) {
+            ApolloLog(@"[GalleryExport] move failed: %@", moveError.localizedDescription);
+            completion(nil);
+            return;
+        }
+        completion(fileURL);
+    }];
+    [task resume];
+}
+
+static void ApolloGalleryExportRemove(NSURL *_Nullable fileURL) {
+    if (fileURL) [[NSFileManager defaultManager] removeItemAtURL:fileURL error:NULL];
+}
+
+#pragma mark - Photos
+
+static void ApolloGalleryExportWriteToPhotos(NSURL *fileURL, NSArray<NSURL *> *scratch,
+                                             void (^completion)(BOOL success, NSString *message)) {
+    void (^finish)(BOOL, NSString *) = ^(BOOL ok, NSString *message) {
+        for (NSURL *url in scratch) ApolloGalleryExportRemove(url);
+        ApolloGalleryExportRemove(fileURL);
+        ApolloGalleryExportMain(^{ completion(ok, message); });
+    };
+
+    void (^performSave)(void) = ^{
+        [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+            PHAssetCreationRequest *request = [PHAssetCreationRequest creationRequestForAsset];
+            [request addResourceWithType:PHAssetResourceTypeVideo fileURL:fileURL options:nil];
+        } completionHandler:^(BOOL success, NSError *error) {
+            ApolloLog(@"[GalleryExport] Photos write %@%@", success ? @"OK" : @"FAILED",
+                      success ? @"" : [@": " stringByAppendingString:error.localizedDescription ?: @"?"]);
+            finish(success, success ? @"Saved" : @"Save failed");
+        }];
+    };
+
+    PHAuthorizationStatus status = [PHPhotoLibrary authorizationStatusForAccessLevel:PHAccessLevelAddOnly];
+    if (status == PHAuthorizationStatusNotDetermined) {
+        [PHPhotoLibrary requestAuthorizationForAccessLevel:PHAccessLevelAddOnly handler:^(PHAuthorizationStatus newStatus) {
+            if (newStatus == PHAuthorizationStatusAuthorized || newStatus == PHAuthorizationStatusLimited) performSave();
+            else finish(NO, @"Photos access denied");
+        }];
+    } else if (status == PHAuthorizationStatusAuthorized || status == PHAuthorizationStatusLimited) {
+        performSave();
+    } else {
+        finish(NO, @"Photos access denied");
+    }
+}
+
+#pragma mark - Muxing
+
+// Splices a video-only file and an audio-only file into a single mp4.
+// Passthrough preset: both tracks are already H.264/AAC, so this is a remux —
+// no re-encode, no quality loss, and fast enough to feel like a plain save.
+static void ApolloGalleryExportMux(NSURL *videoFile, NSURL *audioFile,
+                                   void (^completion)(NSURL *_Nullable muxedFile)) {
+    AVURLAsset *videoAsset = [AVURLAsset URLAssetWithURL:videoFile
+        options:@{AVURLAssetPreferPreciseDurationAndTimingKey: @YES}];
+    AVURLAsset *audioAsset = [AVURLAsset URLAssetWithURL:audioFile
+        options:@{AVURLAssetPreferPreciseDurationAndTimingKey: @YES}];
+
+    AVAssetTrack *sourceVideo = [videoAsset tracksWithMediaType:AVMediaTypeVideo].firstObject;
+    AVAssetTrack *sourceAudio = [audioAsset tracksWithMediaType:AVMediaTypeAudio].firstObject;
+    if (!sourceVideo) {
+        ApolloLog(@"[GalleryExport] mux: no video track");
+        completion(nil);
+        return;
+    }
+    if (!sourceAudio) {
+        // Audio side unusable — the caller still has a perfectly good silent
+        // video file, so hand that back rather than failing the whole save.
+        ApolloLog(@"[GalleryExport] mux: no audio track; keeping video only");
+        completion(videoFile);
+        return;
+    }
+
+    // Trim to the shorter track: Reddit's two representations can differ by a
+    // frame or two, and an over-long audio track would tail off into silence.
+    CMTime duration = CMTimeMinimum(videoAsset.duration, audioAsset.duration);
+    if (!CMTIME_IS_NUMERIC(duration) || CMTimeGetSeconds(duration) <= 0.0) {
+        duration = videoAsset.duration;
+    }
+    CMTimeRange range = CMTimeRangeMake(kCMTimeZero, duration);
+
+    AVMutableComposition *composition = [AVMutableComposition composition];
+    AVMutableCompositionTrack *videoTrack =
+        [composition addMutableTrackWithMediaType:AVMediaTypeVideo preferredTrackID:kCMPersistentTrackID_Invalid];
+    NSError *error = nil;
+    if (![videoTrack insertTimeRange:range ofTrack:sourceVideo atTime:kCMTimeZero error:&error]) {
+        ApolloLog(@"[GalleryExport] mux: video insert failed: %@", error.localizedDescription);
+        completion(nil);
+        return;
+    }
+    videoTrack.preferredTransform = sourceVideo.preferredTransform;
+
+    AVMutableCompositionTrack *audioTrack =
+        [composition addMutableTrackWithMediaType:AVMediaTypeAudio preferredTrackID:kCMPersistentTrackID_Invalid];
+    if (![audioTrack insertTimeRange:range ofTrack:sourceAudio atTime:kCMTimeZero error:&error]) {
+        // Losing the audio is better than losing the save.
+        ApolloLog(@"[GalleryExport] mux: audio insert failed: %@", error.localizedDescription);
+    }
+
+    NSString *name = [[NSUUID UUID].UUIDString stringByAppendingPathExtension:@"mp4"];
+    NSURL *outputURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:name]];
+    [[NSFileManager defaultManager] removeItemAtURL:outputURL error:NULL];
+
+    // `export` is a reserved word in C++, and this file is ObjC++.
+    AVAssetExportSession *session =
+        [[AVAssetExportSession alloc] initWithAsset:composition presetName:AVAssetExportPresetPassthrough];
+    session.outputURL = outputURL;
+    session.outputFileType = AVFileTypeMPEG4;
+    [session exportAsynchronouslyWithCompletionHandler:^{
+        if (session.status != AVAssetExportSessionStatusCompleted) {
+            ApolloLog(@"[GalleryExport] mux export %ld: %@",
+                      (long)session.status, session.error.localizedDescription ?: @"");
+            ApolloGalleryExportRemove(outputURL);
+            // Fall back to the silent video rather than dropping the save.
+            completion(videoFile);
+            return;
+        }
+        completion(outputURL);
+    }];
+}
+
+#pragma mark - Entry point
+
+void ApolloGallerySaveVideoToPhotos(NSURL *progressiveURL,
+                                    void (^status)(NSString *text),
+                                    void (^completion)(BOOL success, NSString *message)) {
+    if (!progressiveURL) {
+        ApolloGalleryExportMain(^{ completion(NO, @"Nothing to save"); });
+        return;
+    }
+    void (^report)(NSString *) = ^(NSString *text) {
+        if (status) ApolloGalleryExportMain(^{ status(text); });
+    };
+    report(@"Saving…");
+
+    NSString *assetID = ApolloGalleryExportRedditAssetID(progressiveURL);
+    if (assetID.length == 0) {
+        // Self-contained file (imgur mp4, Reddit's silent GIF transcode): the
+        // download IS the finished article.
+        ApolloGalleryExportDownload(progressiveURL, @"mp4", ^(NSURL *fileURL) {
+            if (!fileURL) {
+                ApolloGalleryExportMain(^{ completion(NO, @"Save failed"); });
+                return;
+            }
+            ApolloGalleryExportWriteToPhotos(fileURL, @[], completion);
+        });
+        return;
+    }
+
+    // v.redd.it: resolve the manifest so the audio representation can be muxed
+    // back in, otherwise the save is silent.
+    NSURL *manifestURL = [NSURL URLWithString:
+        [NSString stringWithFormat:@"https://v.redd.it/%@/DASHPlaylist.mpd", assetID]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:manifestURL
+                                                          cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                      timeoutInterval:kApolloGalleryExportManifestTimeout];
+    [[[NSURLSession sharedSession] dataTaskWithRequest:request
+                                     completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        NSInteger httpStatus = [response isKindOfClass:[NSHTTPURLResponse class]]
+            ? ((NSHTTPURLResponse *)response).statusCode : 0;
+        NSURL *videoURL = nil, *audioURL = nil;
+        if (!error && httpStatus >= 200 && httpStatus < 300 && data.length > 0) {
+            ApolloGalleryExportParseManifest(data, manifestURL, &videoURL, &audioURL);
+        }
+        // Manifest unreadable: the progressive fallback still gives a (silent)
+        // video, which beats refusing to save at all.
+        if (!videoURL) videoURL = progressiveURL;
+        ApolloLog(@"[GalleryExport] v.redd.it %@ manifest=%ld video=%@ audio=%@",
+                  assetID, (long)httpStatus,
+                  videoURL.lastPathComponent ?: @"none", audioURL.lastPathComponent ?: @"none");
+
+        ApolloGalleryExportDownload(videoURL, @"mp4", ^(NSURL *videoFile) {
+            if (!videoFile) {
+                ApolloGalleryExportMain(^{ completion(NO, @"Save failed"); });
+                return;
+            }
+            if (!audioURL) {
+                ApolloGalleryExportWriteToPhotos(videoFile, @[], completion);
+                return;
+            }
+            report(@"Merging audio…");
+            ApolloGalleryExportDownload(audioURL, @"mp4", ^(NSURL *audioFile) {
+                if (!audioFile) {
+                    // No audio to merge; save what we have.
+                    ApolloGalleryExportWriteToPhotos(videoFile, @[], completion);
+                    return;
+                }
+                ApolloGalleryExportMux(videoFile, audioFile, ^(NSURL *muxedFile) {
+                    if (!muxedFile) {
+                        ApolloGalleryExportRemove(videoFile);
+                        ApolloGalleryExportRemove(audioFile);
+                        ApolloGalleryExportMain(^{ completion(NO, @"Save failed"); });
+                        return;
+                    }
+                    // The mux can hand back the video file itself as a fallback;
+                    // don't list it as scratch in that case or it'd be deleted
+                    // before Photos reads it.
+                    NSMutableArray<NSURL *> *scratch = [NSMutableArray arrayWithObject:audioFile];
+                    if (![muxedFile isEqual:videoFile]) [scratch addObject:videoFile];
+                    ApolloGalleryExportWriteToPhotos(muxedFile, scratch, completion);
+                });
+            });
+        });
+    }] resume];
+}

--- a/src/ApolloGalleryViewController.h
+++ b/src/ApolloGalleryViewController.h
@@ -1,0 +1,35 @@
+// ApolloGalleryViewController.h
+//
+// Gallery View's grid: every picture in a subreddit's listing laid out as a
+// waterfall of tiles, loading more as you scroll. Tapping a tile opens
+// ApolloGalleryImageViewer on that picture, where you can swipe between them
+// full screen.
+//
+// Pushed onto the subreddit's own UINavigationController rather than presented,
+// so it inherits Apollo's nav bar appearance (Liquid Glass or legacy) and the
+// standard swipe-back for free.
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ApolloGalleryViewController : UIViewController
+
+// `subreddit` is the bare slug, no "r/" prefix.
+- (instancetype)initWithSubreddit:(NSString *)subreddit NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithNibName:(nullable NSString *)nibName bundle:(nullable NSBundle *)bundle NS_UNAVAILABLE;
+- (instancetype)initWithCoder:(NSCoder *)coder NS_UNAVAILABLE;
+
+// Background to sit behind the tiles. Apollo's themes repaint their own views,
+// so the caller passes the colour from the screen the gallery was opened from;
+// nil falls back to the system background.
+@property (nonatomic, copy, nullable) UIColor *gridBackgroundColor;
+
+// Convenience: builds the gallery for `subreddit` and pushes it onto
+// `sourceViewController`'s navigation controller. Returns NO (and does nothing)
+// when there's no navigation controller to push onto or the slug is empty.
++ (BOOL)presentGalleryForSubreddit:(NSString *)subreddit fromViewController:(UIViewController *)sourceViewController;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ApolloGalleryViewController.m
+++ b/src/ApolloGalleryViewController.m
@@ -7,6 +7,8 @@
 #import "ApolloCommon.h"
 #import "ApolloThemeRuntime.h"
 
+#import <objc/message.h>
+
 // Target tile width. The column count is derived from it so the grid widens
 // sensibly on iPad and in landscape instead of stretching two huge columns.
 static CGFloat const kApolloGalleryTargetTileWidth = 185.0;
@@ -217,10 +219,14 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
     }
     // No badge for an image's position within a multi-image post — every image
     // gets its own tile, so it only clutters the grid, and the viewer already
-    // spells it out ("7 of 20 in post") once you've opened one. GIF is a
-    // different case: a still thumbnail gives no hint that the tile animates,
-    // and nothing downstream says so either.
-    if (item.isAnimated) {
+    // spells it out ("7 of 20 in post") once you've opened one. Playables are a
+    // different case: a poster frame gives no hint that the tile moves, and
+    // nothing downstream says so either.
+    if (item.kind == ApolloGalleryMediaKindVideo) {
+        NSString *duration = item.durationText;
+        self.badgeLabel.text = duration.length > 0 ? [@"▶ " stringByAppendingString:duration] : @"▶";
+        self.badgeLabel.hidden = NO;
+    } else if (item.kind == ApolloGalleryMediaKindGIF) {
         self.badgeLabel.text = @"GIF";
         self.badgeLabel.hidden = NO;
     }
@@ -272,6 +278,7 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
 @property (nonatomic, strong) UILabel *footerLabel;
 @property (nonatomic, strong) UIRefreshControl *refreshControl;
 @property (nonatomic, weak, nullable) ApolloGalleryImageViewer *activeViewer;
+@property (nonatomic, strong, nullable) UIBarButtonItem *filterBarButtonItem;
 @end
 
 @implementation ApolloGalleryViewController
@@ -367,7 +374,7 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
     self.footerLabel.alpha = 0.0;
     [self.view addSubview:self.footerLabel];
 
-    [self apollo_installSortButton];
+    [self apollo_installNavigationButtons];
     [self apollo_beginInitialLoad];
 }
 
@@ -410,14 +417,92 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
 
 #pragma mark Sort
 
-- (void)apollo_installSortButton {
-    UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithImage:[UIImage systemImageNamed:@"arrow.up.arrow.down"]
+- (void)apollo_installNavigationButtons {
+    UIBarButtonItem *sort = [[UIBarButtonItem alloc] initWithImage:[UIImage systemImageNamed:@"arrow.up.arrow.down"]
                                                              style:UIBarButtonItemStylePlain
                                                             target:nil
                                                             action:nil];
-    item.accessibilityLabel = @"Sort";
-    item.menu = [self apollo_buildSortMenu];
-    self.navigationItem.rightBarButtonItem = item;
+    sort.accessibilityLabel = @"Sort";
+    sort.menu = [self apollo_buildSortMenu];
+
+    self.filterBarButtonItem = [[UIBarButtonItem alloc] initWithImage:[self apollo_filterButtonImage]
+                                                                style:UIBarButtonItemStylePlain
+                                                               target:nil
+                                                               action:nil];
+    self.filterBarButtonItem.accessibilityLabel = @"Filter media";
+    self.filterBarButtonItem.menu = [self apollo_buildFilterMenu];
+
+    // Rightmost first in this array, so: [filter] [sort].
+    self.navigationItem.rightBarButtonItems = @[sort, self.filterBarButtonItem];
+}
+
+// A filled glyph while a filter is narrowing things down, so it's obvious at a
+// glance that the grid isn't showing everything.
+- (UIImage *)apollo_filterButtonImage {
+    BOOL filtering = self.feed.allowedKinds != ApolloGalleryMediaKindAll;
+    return [UIImage systemImageNamed:(filtering ? @"line.3.horizontal.decrease.circle.fill"
+                                                : @"line.3.horizontal.decrease.circle")];
+}
+
+- (UIMenu *)apollo_buildFilterMenu {
+    NSArray<NSDictionary *> *kinds = @[
+        @{ @"title": @"Photos", @"icon": @"photo",           @"kind": @(ApolloGalleryMediaKindPhoto) },
+        @{ @"title": @"GIFs",   @"icon": @"square.stack.3d.forward.dottedline", @"kind": @(ApolloGalleryMediaKindGIF) },
+        @{ @"title": @"Videos", @"icon": @"play.rectangle",  @"kind": @(ApolloGalleryMediaKindVideo) },
+    ];
+
+    __weak typeof(self) weakSelf = self;
+    NSMutableArray<UIMenuElement *> *children = [NSMutableArray array];
+    for (NSDictionary *entry in kinds) {
+        ApolloGalleryMediaKind kind = (ApolloGalleryMediaKind)((NSNumber *)entry[@"kind"]).unsignedIntegerValue;
+        BOOL on = (self.feed.allowedKinds & kind) != 0;
+        BOOL isOnlyOneOn = on && (self.feed.allowedKinds == kind);
+
+        NSUInteger count = [self.feed countOfKind:kind];
+        UIAction *action = [UIAction actionWithTitle:entry[@"title"]
+                                               image:[UIImage systemImageNamed:entry[@"icon"]]
+                                          identifier:nil
+                                             handler:^(__kindof UIAction *a) {
+            [weakSelf apollo_toggleKind:kind];
+        }];
+        action.state = on ? UIMenuElementStateOn : UIMenuElementStateOff;
+        // Turning off the only remaining kind would empty the gallery, so that
+        // one row is disabled rather than silently doing nothing.
+        if (isOnlyOneOn) action.attributes = UIMenuElementAttributesDisabled;
+        if (count > 0 && [action respondsToSelector:@selector(setSubtitle:)]) {
+            ((void (*)(id, SEL, id))objc_msgSend)(action, @selector(setSubtitle:),
+                                                  [NSString stringWithFormat:@"%lu loaded", (unsigned long)count]);
+        }
+        // iOS 16+ can keep the menu up between taps, which is what makes a
+        // multi-select menu feel right; older releases just close each time.
+        if (@available(iOS 16.0, *)) {
+            action.attributes |= UIMenuElementAttributesKeepsMenuPresented;
+        }
+        [children addObject:action];
+    }
+    return [UIMenu menuWithTitle:@"Show" children:children];
+}
+
+- (void)apollo_toggleKind:(ApolloGalleryMediaKind)kind {
+    ApolloGalleryMediaKind updated = self.feed.allowedKinds ^ kind;
+    if (updated == 0) return;   // never leave the gallery with nothing to show
+
+    self.feed.allowedKinds = updated;
+    self.filterBarButtonItem.image = [self apollo_filterButtonImage];
+    self.filterBarButtonItem.menu = [self apollo_buildFilterMenu];
+    [self apollo_setFooterText:nil];
+    [self.collectionView reloadData];
+    [self.collectionView setContentOffset:CGPointMake(0.0, -self.collectionView.adjustedContentInset.top) animated:NO];
+    [self apollo_updateEmptyStateWithError:nil];
+    ApolloLog(@"[Gallery] filter -> photo:%d gif:%d video:%d (%lu of %lu shown)",
+              (updated & ApolloGalleryMediaKindPhoto) != 0,
+              (updated & ApolloGalleryMediaKindGIF) != 0,
+              (updated & ApolloGalleryMediaKindVideo) != 0,
+              (unsigned long)self.feed.items.count, (unsigned long)self.feed.allItems.count);
+
+    // The visible list just shrank; it may no longer fill the screen, so top it
+    // up rather than leaving the user on a stub of a grid.
+    [self apollo_loadMoreIfNeededForIndex:(NSInteger)self.feed.items.count - 1];
 }
 
 - (UIMenu *)apollo_buildSortMenu {
@@ -464,7 +549,7 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
     [self apollo_setFooterText:nil];
     [self.collectionView reloadData];
     [self.collectionView setContentOffset:CGPointMake(0.0, -self.collectionView.adjustedContentInset.top) animated:NO];
-    self.navigationItem.rightBarButtonItem.menu = [self apollo_buildSortMenu];
+    self.navigationItem.rightBarButtonItems.firstObject.menu = [self apollo_buildSortMenu];
     [self apollo_beginInitialLoad];
 }
 
@@ -483,6 +568,9 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
         [strongSelf.refreshControl endRefreshing];
         [strongSelf.collectionView reloadData];
         [strongSelf apollo_updateEmptyStateWithError:errorMessage];
+        // Built before the first fetch, so its "N loaded" subtitles were all
+        // zero until now.
+        strongSelf.filterBarButtonItem.menu = [strongSelf apollo_buildFilterMenu];
         (void)addedRange;
     }];
 }
@@ -506,8 +594,15 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
     if (errorMessage.length > 0) {
         self.messageLabel.text = [NSString stringWithFormat:@"Couldn't load r/%@.\n%@", self.subreddit, errorMessage];
         self.retryButton.hidden = NO;
+    } else if (self.feed.allItems.count > 0) {
+        // Media was found, the filter just excluded all of it — say so, rather
+        // than implying the subreddit is empty.
+        self.messageLabel.text = [NSString stringWithFormat:
+            @"Nothing matches the current filter.\n%lu items are loaded — tap the filter button to widen it.",
+            (unsigned long)self.feed.allItems.count];
+        self.retryButton.hidden = YES;
     } else {
-        self.messageLabel.text = [NSString stringWithFormat:@"No pictures found in r/%@ (%@).",
+        self.messageLabel.text = [NSString stringWithFormat:@"No media found in r/%@ (%@).",
                                   self.subreddit, self.feed.sortDisplayName];
         self.retryButton.hidden = YES;
     }

--- a/src/ApolloGalleryViewController.m
+++ b/src/ApolloGalleryViewController.m
@@ -237,7 +237,9 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
     self.thumbnailURL = url;
     if (!url) return;
 
-    UIImage *cached = [[ApolloGalleryImageLoader sharedLoader] cachedImageForURL:url];
+    // Thumbnail tier: one downsampled still frame. A tile must never pay for a
+    // multi-frame GIF decode or a full-resolution bitmap it draws at ~185pt.
+    UIImage *cached = [[ApolloGalleryImageLoader sharedLoader] cachedThumbnailForURL:url];
     if (cached) {
         self.imageView.image = cached;
         return;
@@ -245,9 +247,8 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
 
     __weak typeof(self) weakSelf = self;
     self.imageView.alpha = 0.0;
-    self.request = [[ApolloGalleryImageLoader sharedLoader] loadImageAtURL:url
-                                                                  progress:nil
-                                                                completion:^(UIImage *image, NSData *data) {
+    self.request = [[ApolloGalleryImageLoader sharedLoader] loadThumbnailAtURL:url
+                                                                    completion:^(UIImage *image) {
         typeof(self) strongSelf = weakSelf;
         if (!strongSelf || ![strongSelf.thumbnailURL isEqual:url]) return;
         if (!image) {
@@ -256,7 +257,6 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
         }
         strongSelf.imageView.image = image;
         [UIView animateWithDuration:0.18 animations:^{ strongSelf.imageView.alpha = 1.0; }];
-        (void)data;
     }];
 }
 
@@ -279,6 +279,9 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
 @property (nonatomic, strong) UIRefreshControl *refreshControl;
 @property (nonatomic, weak, nullable) ApolloGalleryImageViewer *activeViewer;
 @property (nonatomic, strong, nullable) UIBarButtonItem *filterBarButtonItem;
+// Outstanding look-ahead loads keyed by index path, so UIKit's cancel callback
+// can actually stop them (see collectionView:cancelPrefetchingForItemsAtIndexPaths:).
+@property (nonatomic, strong) NSMutableDictionary<NSIndexPath *, ApolloGalleryImageRequest *> *prefetchRequests;
 @end
 
 @implementation ApolloGalleryViewController
@@ -288,6 +291,7 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
     if (self) {
         _subreddit = [subreddit copy] ?: @"";
         _feed = [[ApolloGalleryFeed alloc] initWithSubreddit:_subreddit];
+        _prefetchRequests = [NSMutableDictionary dictionary];
     }
     return self;
 }
@@ -483,9 +487,21 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
     return [UIMenu menuWithTitle:@"Show" children:children];
 }
 
+
+// Index paths shift or vanish on any wholesale reload (filter toggle, sort
+// change, refresh) — the outstanding look-aheads keyed on them are stale, so
+// stop the transfers rather than let them finish into nothing.
+- (void)apollo_cancelAllPrefetches {
+    for (ApolloGalleryImageRequest *request in self.prefetchRequests.allValues) {
+        [request cancel];
+    }
+    [self.prefetchRequests removeAllObjects];
+}
+
 - (void)apollo_toggleKind:(ApolloGalleryMediaKind)kind {
     ApolloGalleryMediaKind updated = self.feed.allowedKinds ^ kind;
     if (updated == 0) return;   // never leave the gallery with nothing to show
+    [self apollo_cancelAllPrefetches];
 
     self.feed.allowedKinds = updated;
     self.filterBarButtonItem.image = [self apollo_filterButtonImage];
@@ -649,7 +665,7 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
             return;
         }
         if (addedRange.length > 0) {
-            [strongSelf apollo_appendItemsInRange:addedRange];
+            [strongSelf apollo_syncAppendedItems];
         }
         if (strongSelf.feed.isExhausted) {
             [strongSelf apollo_setFooterText:@"That's everything"];
@@ -660,10 +676,19 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
     }];
 }
 
-- (void)apollo_appendItemsInRange:(NSRange)range {
-    NSMutableArray<NSIndexPath *> *indexPaths = [NSMutableArray arrayWithCapacity:range.length];
-    for (NSUInteger i = range.location; i < NSMaxRange(range); i++) {
-        [indexPaths addObject:[NSIndexPath indexPathForItem:(NSInteger)i inSection:0]];
+// Appends are derived by diffing the collection view's committed count against
+// the feed, never by trusting a callback-supplied range: a filter toggle can
+// land between a batch starting and finishing, and inserting a stale range is
+// exactly the corruption that NSInternalInconsistencyExceptions are made of.
+// The count can only have GROWN here — shrinks happen solely in
+// apollo_toggleKind, which reloads wholesale.
+- (void)apollo_syncAppendedItems {
+    NSInteger known = [self.collectionView numberOfItemsInSection:0];
+    NSInteger total = (NSInteger)self.feed.items.count;
+    if (total <= known) return;
+    NSMutableArray<NSIndexPath *> *indexPaths = [NSMutableArray arrayWithCapacity:(NSUInteger)(total - known)];
+    for (NSInteger i = known; i < total; i++) {
+        [indexPaths addObject:[NSIndexPath indexPathForItem:i inSection:0]];
     }
     // The waterfall layout rebuilds every frame in -prepareLayout, so it always
     // agrees with the data source after an append.
@@ -712,7 +737,19 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
     for (NSIndexPath *indexPath in indexPaths) {
         if (indexPath.item >= (NSInteger)items.count) continue;
         ApolloGalleryItem *item = items[indexPath.item];
-        [[ApolloGalleryImageLoader sharedLoader] prefetchImageAtURL:(item.thumbnailURL ?: item.imageURL)];
+        // Handles are retained so the matching cancel callback can actually
+        // stop the download — fire-and-forget prefetch kept stale transfers
+        // alive through fast scrolls.
+        ApolloGalleryImageRequest *request =
+            [[ApolloGalleryImageLoader sharedLoader] prefetchThumbnailAtURL:(item.thumbnailURL ?: item.imageURL)];
+        if (request) self.prefetchRequests[indexPath] = request;
+    }
+}
+
+- (void)collectionView:(UICollectionView *)collectionView cancelPrefetchingForItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths {
+    for (NSIndexPath *indexPath in indexPaths) {
+        [self.prefetchRequests[indexPath] cancel];
+        [self.prefetchRequests removeObjectForKey:indexPath];
     }
 }
 

--- a/src/ApolloGalleryViewController.m
+++ b/src/ApolloGalleryViewController.m
@@ -216,7 +216,11 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
         [self.contentView bringSubviewToFront:self.blurView];
     }
     if (item.galleryCount > 1) {
-        self.badgeLabel.text = [NSString stringWithFormat:@"%ld", (long)item.galleryCount];
+        // Position within the post, not just its size: every image of a
+        // 20-image post gets its own tile, so a bare "20" on each of twenty
+        // tiles in a row reads as "20 images here" twenty times over.
+        self.badgeLabel.text = [NSString stringWithFormat:@"%ld/%ld",
+                                (long)item.galleryIndex + 1, (long)item.galleryCount];
         self.badgeLabel.hidden = NO;
     } else if (item.isAnimated) {
         self.badgeLabel.text = @"GIF";

--- a/src/ApolloGalleryViewController.m
+++ b/src/ApolloGalleryViewController.m
@@ -215,14 +215,12 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
         self.blurLabel.text = item.isNSFW ? @"NSFW" : @"SPOILER";
         [self.contentView bringSubviewToFront:self.blurView];
     }
-    if (item.galleryCount > 1) {
-        // Position within the post, not just its size: every image of a
-        // 20-image post gets its own tile, so a bare "20" on each of twenty
-        // tiles in a row reads as "20 images here" twenty times over.
-        self.badgeLabel.text = [NSString stringWithFormat:@"%ld/%ld",
-                                (long)item.galleryIndex + 1, (long)item.galleryCount];
-        self.badgeLabel.hidden = NO;
-    } else if (item.isAnimated) {
+    // No badge for an image's position within a multi-image post — every image
+    // gets its own tile, so it only clutters the grid, and the viewer already
+    // spells it out ("7 of 20 in post") once you've opened one. GIF is a
+    // different case: a still thumbnail gives no hint that the tile animates,
+    // and nothing downstream says so either.
+    if (item.isAnimated) {
         self.badgeLabel.text = @"GIF";
         self.badgeLabel.hidden = NO;
     }

--- a/src/ApolloGalleryViewController.m
+++ b/src/ApolloGalleryViewController.m
@@ -1,0 +1,657 @@
+// ApolloGalleryViewController.m — see ApolloGalleryViewController.h.
+
+#import "ApolloGalleryViewController.h"
+#import "ApolloGalleryFeed.h"
+#import "ApolloGalleryImageLoader.h"
+#import "ApolloGalleryImageViewer.h"
+#import "ApolloCommon.h"
+#import "ApolloThemeRuntime.h"
+
+// Target tile width. The column count is derived from it so the grid widens
+// sensibly on iPad and in landscape instead of stretching two huge columns.
+static CGFloat const kApolloGalleryTargetTileWidth = 185.0;
+static NSInteger const kApolloGalleryMinColumns = 2;
+// An enum, not a `static const NSInteger`: the waterfall layout sizes a
+// fixed-length C array with it, which needs a compile-time constant.
+enum { kApolloGalleryMaxColumns = 5 };
+static CGFloat const kApolloGalleryTileSpacing = 3.0;
+// Aspect clamp: a 1:8 panorama would otherwise produce a tile taller than the
+// screen, and a very wide one collapses to a sliver.
+static CGFloat const kApolloGalleryMinAspect = 0.5;   // height/width
+static CGFloat const kApolloGalleryMaxAspect = 2.2;
+static CGFloat const kApolloGalleryDefaultAspect = 1.25;
+// Rows from the bottom at which the next batch starts loading.
+static NSInteger const kApolloGalleryLoadAheadRows = 3;
+
+static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
+
+#pragma mark - Waterfall layout
+
+@protocol ApolloGalleryWaterfallLayoutDelegate <UICollectionViewDelegate>
+// height/width for the tile at `index`.
+- (CGFloat)galleryLayout:(UICollectionViewLayout *)layout aspectRatioForItemAtIndex:(NSInteger)index;
+@end
+
+// Column-balanced waterfall: each tile keeps its picture's real proportions and
+// goes into whichever column is currently shortest, which is what stops a grid
+// of mixed portrait/landscape photos from looking like a broken table.
+@interface ApolloGalleryWaterfallLayout : UICollectionViewLayout
+@property (nonatomic) NSInteger columnCount;
+@property (nonatomic) CGFloat spacing;
+@property (nonatomic, strong) NSMutableArray<UICollectionViewLayoutAttributes *> *attributesCache;
+@property (nonatomic) CGFloat contentHeight;
+@property (nonatomic) CGFloat lastPreparedWidth;
+@end
+
+@implementation ApolloGalleryWaterfallLayout
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _columnCount = kApolloGalleryMinColumns;
+        _spacing = kApolloGalleryTileSpacing;
+        _attributesCache = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void)prepareLayout {
+    [super prepareLayout];
+    UICollectionView *collectionView = self.collectionView;
+    if (!collectionView) return;
+
+    CGFloat width = collectionView.bounds.size.width;
+    if (width <= 0.0) return;
+
+    [self.attributesCache removeAllObjects];
+    self.contentHeight = 0.0;
+    self.lastPreparedWidth = width;
+
+    // Clamped here too, not just at the call site: columnHeights below is a
+    // fixed-size C array.
+    NSInteger columns = MAX(1, MIN(self.columnCount, (NSInteger)kApolloGalleryMaxColumns));
+    CGFloat totalSpacing = self.spacing * (columns - 1);
+    CGFloat columnWidth = floor((width - totalSpacing) / columns);
+
+    CGFloat columnHeights[kApolloGalleryMaxColumns];
+    for (NSInteger i = 0; i < columns && i < kApolloGalleryMaxColumns; i++) columnHeights[i] = 0.0;
+
+    id<ApolloGalleryWaterfallLayoutDelegate> delegate =
+        (id<ApolloGalleryWaterfallLayoutDelegate>)collectionView.delegate;
+    BOOL canAskDelegate = [delegate respondsToSelector:@selector(galleryLayout:aspectRatioForItemAtIndex:)];
+
+    NSInteger count = [collectionView numberOfItemsInSection:0];
+    for (NSInteger item = 0; item < count; item++) {
+        // Shortest column wins; ties go to the leftmost so the first row fills
+        // left-to-right in listing order.
+        NSInteger targetColumn = 0;
+        for (NSInteger column = 1; column < columns; column++) {
+            if (columnHeights[column] < columnHeights[targetColumn] - 0.5) targetColumn = column;
+        }
+
+        CGFloat aspect = canAskDelegate ? [delegate galleryLayout:self aspectRatioForItemAtIndex:item]
+                                        : kApolloGalleryDefaultAspect;
+        aspect = MAX(kApolloGalleryMinAspect, MIN(kApolloGalleryMaxAspect, aspect));
+        CGFloat height = round(columnWidth * aspect);
+
+        CGFloat x = targetColumn * (columnWidth + self.spacing);
+        CGFloat y = columnHeights[targetColumn];
+
+        UICollectionViewLayoutAttributes *attributes =
+            [UICollectionViewLayoutAttributes layoutAttributesForCellWithIndexPath:[NSIndexPath indexPathForItem:item inSection:0]];
+        attributes.frame = CGRectMake(x, y, columnWidth, height);
+        [self.attributesCache addObject:attributes];
+
+        columnHeights[targetColumn] = y + height + self.spacing;
+        self.contentHeight = MAX(self.contentHeight, columnHeights[targetColumn]);
+    }
+    if (self.contentHeight > 0.0) self.contentHeight -= self.spacing;
+}
+
+- (CGSize)collectionViewContentSize {
+    return CGSizeMake(self.collectionView.bounds.size.width, MAX(self.contentHeight, 0.0));
+}
+
+- (NSArray<UICollectionViewLayoutAttributes *> *)layoutAttributesForElementsInRect:(CGRect)rect {
+    NSMutableArray<UICollectionViewLayoutAttributes *> *visible = [NSMutableArray array];
+    for (UICollectionViewLayoutAttributes *attributes in self.attributesCache) {
+        if (CGRectIntersectsRect(attributes.frame, rect)) [visible addObject:attributes];
+    }
+    return visible;
+}
+
+- (UICollectionViewLayoutAttributes *)layoutAttributesForItemAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.item < 0 || indexPath.item >= (NSInteger)self.attributesCache.count) return nil;
+    return self.attributesCache[indexPath.item];
+}
+
+- (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds {
+    return fabs(newBounds.size.width - self.lastPreparedWidth) > 0.5;
+}
+
+@end
+
+#pragma mark - Tile
+
+@interface ApolloGalleryTileCell : UICollectionViewCell
+@property (nonatomic, strong) UIImageView *imageView;
+@property (nonatomic, strong) UIVisualEffectView *blurView;
+@property (nonatomic, strong) UILabel *blurLabel;
+@property (nonatomic, strong) UILabel *badgeLabel;
+@property (nonatomic, strong, nullable) ApolloGalleryImageRequest *request;
+@property (nonatomic, copy, nullable) NSURL *thumbnailURL;
+- (void)configureWithItem:(ApolloGalleryItem *)item;
+@end
+
+@implementation ApolloGalleryTileCell
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.contentView.clipsToBounds = YES;
+        self.contentView.layer.cornerRadius = 6.0;
+        self.contentView.layer.cornerCurve = kCACornerCurveContinuous;
+        self.contentView.backgroundColor = [UIColor colorWithWhite:0.5 alpha:0.14];
+
+        _imageView = [[UIImageView alloc] initWithFrame:self.contentView.bounds];
+        _imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        _imageView.contentMode = UIViewContentModeScaleAspectFill;
+        _imageView.clipsToBounds = YES;
+        [self.contentView addSubview:_imageView];
+
+        // NSFW / spoiler cover. Blurring the tile keeps the grid scannable
+        // without putting the picture on screen unasked.
+        _blurView = [[UIVisualEffectView alloc] initWithEffect:[UIBlurEffect effectWithStyle:UIBlurEffectStyleSystemThickMaterialDark]];
+        _blurView.frame = self.contentView.bounds;
+        _blurView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        _blurView.hidden = YES;
+        [self.contentView addSubview:_blurView];
+
+        _blurLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+        _blurLabel.textColor = UIColor.whiteColor;
+        _blurLabel.font = [UIFont systemFontOfSize:12.0 weight:UIFontWeightBold];
+        _blurLabel.textAlignment = NSTextAlignmentCenter;
+        [_blurView.contentView addSubview:_blurLabel];
+
+        // "4" for a multi-image post, "GIF" for an animation.
+        _badgeLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+        _badgeLabel.textColor = UIColor.whiteColor;
+        _badgeLabel.font = [UIFont systemFontOfSize:11.0 weight:UIFontWeightBold];
+        _badgeLabel.textAlignment = NSTextAlignmentCenter;
+        _badgeLabel.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.55];
+        _badgeLabel.layer.cornerRadius = 7.0;
+        _badgeLabel.layer.cornerCurve = kCACornerCurveContinuous;
+        _badgeLabel.clipsToBounds = YES;
+        _badgeLabel.hidden = YES;
+        [self.contentView addSubview:_badgeLabel];
+    }
+    return self;
+}
+
+- (void)prepareForReuse {
+    [super prepareForReuse];
+    [self.request cancel];
+    self.request = nil;
+    self.thumbnailURL = nil;
+    self.imageView.image = nil;
+    self.imageView.alpha = 1.0;
+    self.blurView.hidden = YES;
+    self.badgeLabel.hidden = YES;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    self.blurLabel.frame = self.contentView.bounds;
+    CGSize badgeSize = [self.badgeLabel sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)];
+    CGFloat badgeWidth = MAX(22.0, badgeSize.width + 10.0);
+    self.badgeLabel.frame = CGRectMake(CGRectGetWidth(self.contentView.bounds) - badgeWidth - 6.0,
+                                       CGRectGetHeight(self.contentView.bounds) - 20.0 - 6.0,
+                                       badgeWidth, 20.0);
+}
+
+- (void)configureWithItem:(ApolloGalleryItem *)item {
+    if (item.shouldBlurThumbnail) {
+        self.blurView.hidden = NO;
+        self.blurLabel.text = item.isNSFW ? @"NSFW" : @"SPOILER";
+        [self.contentView bringSubviewToFront:self.blurView];
+    }
+    if (item.galleryCount > 1) {
+        self.badgeLabel.text = [NSString stringWithFormat:@"%ld", (long)item.galleryCount];
+        self.badgeLabel.hidden = NO;
+    } else if (item.isAnimated) {
+        self.badgeLabel.text = @"GIF";
+        self.badgeLabel.hidden = NO;
+    }
+    [self.contentView bringSubviewToFront:self.badgeLabel];
+    [self setNeedsLayout];
+
+    NSURL *url = item.thumbnailURL ?: item.imageURL;
+    self.thumbnailURL = url;
+    if (!url) return;
+
+    UIImage *cached = [[ApolloGalleryImageLoader sharedLoader] cachedImageForURL:url];
+    if (cached) {
+        self.imageView.image = cached;
+        return;
+    }
+
+    __weak typeof(self) weakSelf = self;
+    self.imageView.alpha = 0.0;
+    self.request = [[ApolloGalleryImageLoader sharedLoader] loadImageAtURL:url
+                                                                  progress:nil
+                                                                completion:^(UIImage *image, NSData *data) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf || ![strongSelf.thumbnailURL isEqual:url]) return;
+        if (!image) {
+            strongSelf.imageView.alpha = 1.0;
+            return;
+        }
+        strongSelf.imageView.image = image;
+        [UIView animateWithDuration:0.18 animations:^{ strongSelf.imageView.alpha = 1.0; }];
+        (void)data;
+    }];
+}
+
+@end
+
+#pragma mark - Grid view controller
+
+@interface ApolloGalleryViewController () <UICollectionViewDataSource, UICollectionViewDelegate,
+                                           UICollectionViewDataSourcePrefetching,
+                                           ApolloGalleryWaterfallLayoutDelegate,
+                                           ApolloGalleryImageViewerDelegate>
+@property (nonatomic, copy) NSString *subreddit;
+@property (nonatomic, strong) ApolloGalleryFeed *feed;
+@property (nonatomic, strong) UICollectionView *collectionView;
+@property (nonatomic, strong) ApolloGalleryWaterfallLayout *waterfallLayout;
+@property (nonatomic, strong) UIActivityIndicatorView *initialSpinner;
+@property (nonatomic, strong) UILabel *messageLabel;
+@property (nonatomic, strong) UIButton *retryButton;
+@property (nonatomic, strong) UILabel *footerLabel;
+@property (nonatomic, strong) UIRefreshControl *refreshControl;
+@property (nonatomic, weak, nullable) ApolloGalleryImageViewer *activeViewer;
+@end
+
+@implementation ApolloGalleryViewController
+
+- (instancetype)initWithSubreddit:(NSString *)subreddit {
+    self = [super initWithNibName:nil bundle:nil];
+    if (self) {
+        _subreddit = [subreddit copy] ?: @"";
+        _feed = [[ApolloGalleryFeed alloc] initWithSubreddit:_subreddit];
+    }
+    return self;
+}
+
++ (BOOL)presentGalleryForSubreddit:(NSString *)subreddit fromViewController:(UIViewController *)sourceViewController {
+    NSString *slug = [subreddit stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@" \t/"]];
+    if ([slug.lowercaseString hasPrefix:@"r/"]) slug = [slug substringFromIndex:2];
+    if (slug.length == 0 || !sourceViewController) {
+        ApolloLog(@"[Gallery] refusing to open: subreddit=%@ source=%@", subreddit, sourceViewController);
+        return NO;
+    }
+
+    UINavigationController *navigationController = sourceViewController.navigationController;
+    if (!navigationController) {
+        ApolloLog(@"[Gallery] no navigation controller to push onto from %@", sourceViewController);
+        return NO;
+    }
+
+    ApolloGalleryViewController *gallery = [[ApolloGalleryViewController alloc] initWithSubreddit:slug];
+    // Apollo's themes paint their own backgrounds; borrow the colour from the
+    // screen we came from so the gallery doesn't flash system white/black.
+    gallery.gridBackgroundColor = sourceViewController.view.backgroundColor ?: navigationController.view.backgroundColor;
+    [navigationController pushViewController:gallery animated:YES];
+    ApolloLog(@"[Gallery] opened for r/%@", slug);
+    return YES;
+}
+
+#pragma mark Lifecycle
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Gallery";
+    self.view.backgroundColor = self.gridBackgroundColor ?: UIColor.systemBackgroundColor;
+
+    self.waterfallLayout = [[ApolloGalleryWaterfallLayout alloc] init];
+    self.waterfallLayout.spacing = kApolloGalleryTileSpacing;
+    self.waterfallLayout.columnCount = [self apollo_columnCountForWidth:self.view.bounds.size.width];
+
+    self.collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds
+                                           collectionViewLayout:self.waterfallLayout];
+    self.collectionView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.collectionView.backgroundColor = UIColor.clearColor;
+    self.collectionView.dataSource = self;
+    self.collectionView.delegate = self;
+    self.collectionView.prefetchDataSource = self;
+    self.collectionView.alwaysBounceVertical = YES;
+    [self.collectionView registerClass:[ApolloGalleryTileCell class] forCellWithReuseIdentifier:kApolloGalleryCellID];
+    [self.view addSubview:self.collectionView];
+
+    self.refreshControl = [[UIRefreshControl alloc] init];
+    [self.refreshControl addTarget:self action:@selector(apollo_pullToRefresh) forControlEvents:UIControlEventValueChanged];
+    self.collectionView.refreshControl = self.refreshControl;
+
+    self.initialSpinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
+    self.initialSpinner.hidesWhenStopped = YES;
+    [self.view addSubview:self.initialSpinner];
+
+    self.messageLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+    self.messageLabel.textAlignment = NSTextAlignmentCenter;
+    self.messageLabel.numberOfLines = 0;
+    self.messageLabel.textColor = UIColor.secondaryLabelColor;
+    self.messageLabel.font = [UIFont systemFontOfSize:15.0];
+    self.messageLabel.hidden = YES;
+    [self.view addSubview:self.messageLabel];
+
+    self.retryButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.retryButton setTitle:@"Try Again" forState:UIControlStateNormal];
+    self.retryButton.titleLabel.font = [UIFont systemFontOfSize:16.0 weight:UIFontWeightSemibold];
+    self.retryButton.tintColor = [self apollo_accentColor];
+    [self.retryButton addTarget:self action:@selector(apollo_retryPressed) forControlEvents:UIControlEventTouchUpInside];
+    self.retryButton.hidden = YES;
+    [self.view addSubview:self.retryButton];
+
+    // Floating "loading more" pill; a supplementary footer would have to be
+    // threaded through the custom layout for the same result.
+    self.footerLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+    self.footerLabel.textAlignment = NSTextAlignmentCenter;
+    self.footerLabel.font = [UIFont systemFontOfSize:12.0 weight:UIFontWeightSemibold];
+    self.footerLabel.textColor = UIColor.whiteColor;
+    self.footerLabel.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.6];
+    self.footerLabel.layer.cornerRadius = 13.0;
+    self.footerLabel.layer.cornerCurve = kCACornerCurveContinuous;
+    self.footerLabel.clipsToBounds = YES;
+    self.footerLabel.alpha = 0.0;
+    [self.view addSubview:self.footerLabel];
+
+    [self apollo_installSortButton];
+    [self apollo_beginInitialLoad];
+}
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    CGRect bounds = self.view.bounds;
+    self.initialSpinner.center = CGPointMake(CGRectGetMidX(bounds), CGRectGetMidY(bounds));
+
+    CGFloat messageWidth = MIN(bounds.size.width - 64.0, 420.0);
+    CGSize messageSize = [self.messageLabel sizeThatFits:CGSizeMake(messageWidth, CGFLOAT_MAX)];
+    self.messageLabel.frame = CGRectMake((bounds.size.width - messageWidth) / 2.0,
+                                         CGRectGetMidY(bounds) - messageSize.height / 2.0 - 20.0,
+                                         messageWidth, messageSize.height);
+    self.retryButton.frame = CGRectMake((bounds.size.width - 160.0) / 2.0,
+                                        CGRectGetMaxY(self.messageLabel.frame) + 12.0,
+                                        160.0, 40.0);
+
+    CGFloat safeBottom = 0.0;
+    if (@available(iOS 11.0, *)) safeBottom = self.view.safeAreaInsets.bottom;
+    self.footerLabel.frame = CGRectMake((bounds.size.width - 150.0) / 2.0,
+                                        bounds.size.height - safeBottom - 46.0,
+                                        150.0, 26.0);
+
+    NSInteger columns = [self apollo_columnCountForWidth:bounds.size.width];
+    if (columns != self.waterfallLayout.columnCount) {
+        self.waterfallLayout.columnCount = columns;
+        [self.waterfallLayout invalidateLayout];
+    }
+}
+
+- (NSInteger)apollo_columnCountForWidth:(CGFloat)width {
+    if (width <= 0.0) return kApolloGalleryMinColumns;
+    NSInteger columns = (NSInteger)floor(width / kApolloGalleryTargetTileWidth);
+    return MAX(kApolloGalleryMinColumns, MIN(kApolloGalleryMaxColumns, columns));
+}
+
+- (UIColor *)apollo_accentColor {
+    return ApolloThemeAccentColor() ?: self.view.tintColor ?: UIColor.systemBlueColor;
+}
+
+#pragma mark Sort
+
+- (void)apollo_installSortButton {
+    UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithImage:[UIImage systemImageNamed:@"arrow.up.arrow.down"]
+                                                             style:UIBarButtonItemStylePlain
+                                                            target:nil
+                                                            action:nil];
+    item.accessibilityLabel = @"Sort";
+    item.menu = [self apollo_buildSortMenu];
+    self.navigationItem.rightBarButtonItem = item;
+}
+
+- (UIMenu *)apollo_buildSortMenu {
+    __weak typeof(self) weakSelf = self;
+    UIAction * (^makeSort)(NSString *, ApolloGallerySort) = ^UIAction *(NSString *title, ApolloGallerySort sort) {
+        UIAction *action = [UIAction actionWithTitle:title image:nil identifier:nil handler:^(__kindof UIAction *a) {
+            [weakSelf apollo_applySort:sort topWindow:weakSelf.feed.topWindow];
+        }];
+        if (weakSelf.feed.sort == sort) action.state = UIMenuElementStateOn;
+        return action;
+    };
+
+    NSArray<UIAction *> *topWindows = @[
+        [self apollo_topWindowActionWithTitle:@"Today" window:ApolloGalleryTopWindowDay],
+        [self apollo_topWindowActionWithTitle:@"This Week" window:ApolloGalleryTopWindowWeek],
+        [self apollo_topWindowActionWithTitle:@"This Month" window:ApolloGalleryTopWindowMonth],
+        [self apollo_topWindowActionWithTitle:@"This Year" window:ApolloGalleryTopWindowYear],
+        [self apollo_topWindowActionWithTitle:@"All Time" window:ApolloGalleryTopWindowAll],
+    ];
+    UIMenu *topMenu = [UIMenu menuWithTitle:@"Top" image:nil identifier:nil options:0 children:topWindows];
+
+    return [UIMenu menuWithTitle:@"Sort" children:@[
+        makeSort(@"Hot", ApolloGallerySortHot),
+        makeSort(@"New", ApolloGallerySortNew),
+        makeSort(@"Rising", ApolloGallerySortRising),
+        topMenu,
+    ]];
+}
+
+- (UIAction *)apollo_topWindowActionWithTitle:(NSString *)title window:(ApolloGalleryTopWindow)window {
+    __weak typeof(self) weakSelf = self;
+    UIAction *action = [UIAction actionWithTitle:title image:nil identifier:nil handler:^(__kindof UIAction *a) {
+        [weakSelf apollo_applySort:ApolloGallerySortTop topWindow:window];
+    }];
+    if (self.feed.sort == ApolloGallerySortTop && self.feed.topWindow == window) {
+        action.state = UIMenuElementStateOn;
+    }
+    return action;
+}
+
+- (void)apollo_applySort:(ApolloGallerySort)sort topWindow:(ApolloGalleryTopWindow)window {
+    if (self.feed.sort == sort && (sort != ApolloGallerySortTop || self.feed.topWindow == window)) return;
+    [self.feed setSort:sort topWindow:window];
+    [self apollo_setFooterText:nil];
+    [self.collectionView reloadData];
+    [self.collectionView setContentOffset:CGPointMake(0.0, -self.collectionView.adjustedContentInset.top) animated:NO];
+    self.navigationItem.rightBarButtonItem.menu = [self apollo_buildSortMenu];
+    [self apollo_beginInitialLoad];
+}
+
+#pragma mark Loading
+
+- (void)apollo_beginInitialLoad {
+    self.messageLabel.hidden = YES;
+    self.retryButton.hidden = YES;
+    [self.initialSpinner startAnimating];
+
+    __weak typeof(self) weakSelf = self;
+    [self.feed loadNextBatchWithCompletion:^(NSRange addedRange, NSString *errorMessage) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        [strongSelf.initialSpinner stopAnimating];
+        [strongSelf.refreshControl endRefreshing];
+        [strongSelf.collectionView reloadData];
+        [strongSelf apollo_updateEmptyStateWithError:errorMessage];
+        (void)addedRange;
+    }];
+}
+
+- (void)apollo_pullToRefresh {
+    [self.feed reset];
+    [self.collectionView reloadData];
+    [self apollo_beginInitialLoad];
+}
+
+- (void)apollo_retryPressed {
+    [self apollo_beginInitialLoad];
+}
+
+- (void)apollo_updateEmptyStateWithError:(NSString *)errorMessage {
+    if (self.feed.items.count > 0) {
+        self.messageLabel.hidden = YES;
+        self.retryButton.hidden = YES;
+        return;
+    }
+    if (errorMessage.length > 0) {
+        self.messageLabel.text = [NSString stringWithFormat:@"Couldn't load r/%@.\n%@", self.subreddit, errorMessage];
+        self.retryButton.hidden = NO;
+    } else {
+        self.messageLabel.text = [NSString stringWithFormat:@"No pictures found in r/%@ (%@).",
+                                  self.subreddit, self.feed.sortDisplayName];
+        self.retryButton.hidden = YES;
+    }
+    self.messageLabel.hidden = NO;
+    self.retryButton.tintColor = [self apollo_accentColor];
+    [self.view setNeedsLayout];
+}
+
+- (void)apollo_setFooterText:(NSString *)text {
+    self.footerLabel.text = text;
+    [UIView animateWithDuration:0.2 animations:^{
+        self.footerLabel.alpha = text.length > 0 ? 1.0 : 0.0;
+    }];
+}
+
+// Transient footer states ("That's everything", "Couldn't load more") fade out
+// on their own; the persistent "Loading more…" is cleared by its completion.
+- (void)apollo_clearFooterAfterDelay {
+    NSString *shown = self.footerLabel.text;
+    __weak typeof(self) weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        typeof(self) strongSelf = weakSelf;
+        // Only clear if nothing else has claimed the footer since.
+        if (strongSelf && [strongSelf.footerLabel.text isEqualToString:shown]) {
+            [strongSelf apollo_setFooterText:nil];
+        }
+    });
+}
+
+- (void)apollo_loadMoreIfNeededForIndex:(NSInteger)index {
+    if (self.feed.isLoading || self.feed.isExhausted) return;
+    NSInteger total = (NSInteger)self.feed.items.count;
+    NSInteger slack = self.waterfallLayout.columnCount * kApolloGalleryLoadAheadRows;
+    if (index < total - slack) return;
+
+    [self apollo_setFooterText:@"Loading more…"];
+    __weak typeof(self) weakSelf = self;
+    [self.feed loadNextBatchWithCompletion:^(NSRange addedRange, NSString *errorMessage) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        if (errorMessage.length > 0) {
+            [strongSelf apollo_setFooterText:@"Couldn't load more"];
+            [strongSelf apollo_clearFooterAfterDelay];
+            return;
+        }
+        if (addedRange.length > 0) {
+            [strongSelf apollo_appendItemsInRange:addedRange];
+        }
+        if (strongSelf.feed.isExhausted) {
+            [strongSelf apollo_setFooterText:@"That's everything"];
+            [strongSelf apollo_clearFooterAfterDelay];
+        } else {
+            [strongSelf apollo_setFooterText:nil];
+        }
+    }];
+}
+
+- (void)apollo_appendItemsInRange:(NSRange)range {
+    NSMutableArray<NSIndexPath *> *indexPaths = [NSMutableArray arrayWithCapacity:range.length];
+    for (NSUInteger i = range.location; i < NSMaxRange(range); i++) {
+        [indexPaths addObject:[NSIndexPath indexPathForItem:(NSInteger)i inSection:0]];
+    }
+    // The waterfall layout rebuilds every frame in -prepareLayout, so it always
+    // agrees with the data source after an append.
+    [self.collectionView performBatchUpdates:^{
+        [self.collectionView insertItemsAtIndexPaths:indexPaths];
+    } completion:nil];
+    // The open viewer reads the same feed; let it pick the new pages up.
+    [self.activeViewer feedDidAppendItems];
+}
+
+#pragma mark Collection view
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+    return (NSInteger)self.feed.items.count;
+}
+
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
+                  cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+    ApolloGalleryTileCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:kApolloGalleryCellID
+                                                                           forIndexPath:indexPath];
+    NSArray<ApolloGalleryItem *> *items = self.feed.items;
+    if (indexPath.item < (NSInteger)items.count) {
+        [cell configureWithItem:items[indexPath.item]];
+    }
+    return cell;
+}
+
+- (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)cell
+    forItemAtIndexPath:(NSIndexPath *)indexPath {
+    [self apollo_loadMoreIfNeededForIndex:indexPath.item];
+}
+
+- (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
+    [collectionView deselectItemAtIndexPath:indexPath animated:NO];
+    if (indexPath.item >= (NSInteger)self.feed.items.count) return;
+
+    ApolloGalleryImageViewer *viewer = [[ApolloGalleryImageViewer alloc] initWithFeed:self.feed
+                                                                        initialIndex:indexPath.item];
+    viewer.galleryDelegate = self;
+    self.activeViewer = viewer;
+    [self presentViewController:viewer animated:YES completion:nil];
+}
+
+- (void)collectionView:(UICollectionView *)collectionView prefetchItemsAtIndexPaths:(NSArray<NSIndexPath *> *)indexPaths {
+    NSArray<ApolloGalleryItem *> *items = self.feed.items;
+    for (NSIndexPath *indexPath in indexPaths) {
+        if (indexPath.item >= (NSInteger)items.count) continue;
+        ApolloGalleryItem *item = items[indexPath.item];
+        [[ApolloGalleryImageLoader sharedLoader] prefetchImageAtURL:(item.thumbnailURL ?: item.imageURL)];
+    }
+}
+
+#pragma mark ApolloGalleryWaterfallLayoutDelegate
+
+- (CGFloat)galleryLayout:(UICollectionViewLayout *)layout aspectRatioForItemAtIndex:(NSInteger)index {
+    NSArray<ApolloGalleryItem *> *items = self.feed.items;
+    if (index < 0 || index >= (NSInteger)items.count) return kApolloGalleryDefaultAspect;
+    CGSize size = items[index].pixelSize;
+    if (size.width <= 0.0 || size.height <= 0.0) return kApolloGalleryDefaultAspect;
+    return size.height / size.width;
+}
+
+#pragma mark ApolloGalleryImageViewerDelegate
+
+- (void)galleryViewer:(ApolloGalleryImageViewer *)viewer didAppendItemsInRange:(NSRange)addedRange {
+    // The viewer paged past the end and pulled the batch itself; mirror it into
+    // the grid so the two stay in step.
+    NSInteger known = [self.collectionView numberOfItemsInSection:0];
+    NSInteger total = (NSInteger)self.feed.items.count;
+    if (total <= known) return;
+    NSMutableArray<NSIndexPath *> *indexPaths = [NSMutableArray array];
+    for (NSInteger i = known; i < total; i++) {
+        [indexPaths addObject:[NSIndexPath indexPathForItem:i inSection:0]];
+    }
+    [self.collectionView performBatchUpdates:^{
+        [self.collectionView insertItemsAtIndexPaths:indexPaths];
+    } completion:nil];
+}
+
+- (void)galleryViewer:(ApolloGalleryImageViewer *)viewer willDismissAtIndex:(NSInteger)index {
+    // Land back on whatever the user was last looking at, Photos-style.
+    if (index < 0 || index >= [self.collectionView numberOfItemsInSection:0]) return;
+    [self.collectionView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:index inSection:0]
+                                atScrollPosition:UICollectionViewScrollPositionCenteredVertically
+                                        animated:NO];
+}
+
+@end

--- a/src/ApolloNativeActionMenus.xm
+++ b/src/ApolloNativeActionMenus.xm
@@ -841,6 +841,9 @@ static UIMenu *ApolloNativeActionMenuBuildMenu(id actionController, BOOL moderat
     // Append "Show/Hide Deleted Comments" when this is a comments view's "..."
     // menu (no-op otherwise; see ApolloDeletedCommentsMenu.xm).
     ApolloInjectDeletedCommentsMenuItemIfNeeded(children, title, actionController);
+    // Prepend "Gallery View" when this is a subreddit's "..." menu (no-op
+    // otherwise; see ApolloGalleryMenu.xm).
+    ApolloInjectGalleryViewMenuItemIfNeeded(children, title, actionController);
     return [UIMenu menuWithTitle:title children:children];
 }
 

--- a/src/ApolloSubredditHeaders.xm
+++ b/src/ApolloSubredditHeaders.xm
@@ -1107,7 +1107,10 @@ static BOOL ApolloSubredditPostsTypeTag(id viewController, uint8_t *tag) {
 // fall back to the nav title so the header still appears instantly on
 // navigation instead of waiting for that async object.
 // Apollo's search-results VC is a different class and never reaches this hook.
-static NSString *ApolloSubredditNameFromViewController(UIViewController *viewController) {
+// Non-static: ApolloGalleryMenu.xm needs the same "is this really a single
+// subreddit, and which one" answer to decide whether the subreddit "..." menu
+// gets a Gallery View row.
+NSString *ApolloSubredditNameFromViewController(UIViewController *viewController) {
     if (!viewController) return nil;
 
     uint8_t tag = 0;


### PR DESCRIPTION
Lots of subreddits are basically just media feeds, and browsing them post by post is tedious — every picture is a tap into comments and a tap back out. This adds a **Gallery View** entry to a subreddit's nav-bar `...` menu that flattens the listing into a grid of just the media, and taps straight through to a fullscreen pager.

It covers photos, GIFs and videos, with a multi-select filter for mixed subreddits — show any one, two, or all three.

### Screenshots

| Subreddit `...` menu | The grid | Media filter | Fullscreen viewer | Save |
|:--:|:--:|:--:|:--:|:--:|
| <img src="https://github.com/user-attachments/assets/5f5e6dee-75b7-44cd-bdd5-e58a77708332" alt="Gallery View in the subreddit ... menu" width="180"> | <img src="https://github.com/user-attachments/assets/2716c5d6-b0e9-4735-8512-78aae3d1ff52" alt="Waterfall grid with video runtimes on the tiles" width="180"> | <img src="https://github.com/user-attachments/assets/56ff6cab-1312-410b-aff8-ed7b84ac3cf3" alt="Multi-select media filter with per-kind counts" width="180"> | <img src="https://github.com/user-attachments/assets/ddcb5c76-7aa5-4d55-bca4-49ded76726e9" alt="Fullscreen viewer playing a video, with counter and mute" width="180"> | <img src="https://github.com/user-attachments/assets/fe0eaacf-d73f-4ff9-8af8-02a3488b97b8" alt="Save Video and share actions" width="180"> |

### The grid

Column-balanced waterfall layout so mixed portrait/landscape photos keep their real proportions — tiles are sized from the dimensions Reddit reports, before the image has loaded, so nothing jumps around. Column count comes from the width, so it widens on iPad and in landscape instead of stretching two huge columns.

- scrolls endlessly, next batch starts loading a few rows from the bottom
- pull to refresh
- its own Hot / New / Rising / Top (day…all time) sort menu
- NSFW and spoiler tiles blurred, badges for multi-image posts and GIFs
- pushed onto the subreddit's own nav controller, so it inherits Apollo's nav bar appearance and swipe-back for free on both glass and legacy

### The viewer

Swipe left/right between pictures, pinch and double-tap to zoom, swipe **up or down** to flick it away, tap to toggle the chrome.

- post title + `u/author` · `r/subreddit` bottom-left, tap it to open the actual post
- position counter and share button top-right
- long-press (or the share button) → Save Image / Share Image / Share Post Link / Open Post
- paging past the last loaded picture pulls the next batch in place; the counter's total grows with it
- closing drops you back on the tile you were looking at

Zoom pans the picture itself rather than the page, so you can't drag off into empty black.

### Media types and the filter

Every item carries a kind, so video and GIF subreddits work the same way image ones do:

- **Videos** — v.redd.it plays from the **HLS** stream, not the mp4 `fallback_url`. The fallback is the video track alone (Reddit serves audio as a separate DASH stream), so playing it would be silently mute.
- **GIFs** — Reddit's transcoded clips (`preview.reddit_video_preview`) and imgur `.gifv`/`.mp4`, plus real animated `.gif` files. Anything Reddit marks `is_gif` counts as a GIF rather than a video, since to a reader a silent loop is a GIF whichever container it arrives in.
- Video posts are parsed **before** the still parser gets a look — otherwise the poster frame gets claimed as a photo and the playback is lost.

The filter is a multi-select menu in the nav bar with live per-kind counts. It's applied when items are handed to the UI rather than at parse time, so toggling is instant and never costs a refetch. Every gallery opens with all three on — the selection is scoped to that gallery visit, so a filter chosen in one subreddit never follows you into another. Turning off the last remaining kind is disabled rather than silently ignored. Batch loading counts what the filter *admits*, so a video-only filter on a mostly-photo subreddit keeps paging until it actually has videos instead of returning a screen of nothing — and narrowing the filter tops the grid back up.

In the viewer, playables run through AVPlayer: current page only, looping, poster frame underneath so paging never flashes black. Mute is sticky across pages and launches (default on), and unmuting moves the audio session off Apollo's `Ambient` category, which the ringer switch silences. Tiles show a play glyph and runtime.

**Saving videos** works for everything playable, including v.redd.it. Reddit splits video and audio into separate DASH representations, so the progressive `fallback_url` is the video track alone — saving that would hand back a silent copy. `ApolloGalleryVideoExport` reads the manifest, takes the best video and audio representations, and muxes them with `AVAssetExportSession` on the **passthrough** preset: both tracks are already H.264/AAC, so nothing is re-encoded. Self-contained sources skip all of it and download directly. It degrades instead of failing — unreadable manifest still saves the fallback, missing audio still saves the video, failed mux still saves the video.

The manifest parser is deliberately *not* shared with Share as Video's. That one wants the lowest bitrate (it's building a share card); a save wants the best copy. It also keys off `contentType="video"` with a `<BaseURL>*.mp4</BaseURL>` pattern, which only matches Reddit's newer manifests — older ones carry no `contentType`, put `mimeType` on the `Representation`, and use extension-less BaseURLs (`DASH_720`, `audio`). Those extension-less paths are the only ones that serve; every `.mp4` spelling of them 403s.

### Data + auth

`ApolloGalleryFeed` pages the listing, walking as many pages as it takes to gather a batch of pictures (image posts are sparse in mixed subreddits, so a fixed "20 posts" would often return almost nothing). Handles direct image posts, multi-image gallery posts (one tile per image), crossposts and animated GIFs; videos are skipped.

**Both auth modes work with no special-casing.** With API keys the request goes to `oauth.reddit.com` with the captured bearer. Keyless installs never have a real bearer, so it addresses `www.reddit.com/...json` instead and the existing `__NSCFLocalSessionTask` chokepoint rewrites that onto the harvested session cookie — listing reads are already a routable path there. A 401/403 retries once on the other host so a stale captured bearer can't strand the gallery.

Images share one loader with a bounded cache, coalesced downloads (N tiles wanting the same picture share one request) and real animated-GIF decoding via ImageIO — `+[UIImage imageWithData:]` only keeps frame 0, which is why GIFs look like stills anywhere that isn't handled. It also keeps the original bytes so Save/Share exports the real file rather than a PNG re-encode, so a GIF stays a GIF.

### Menu plumbing

The row has to be added twice because Apollo draws that menu two ways:

- **Liquid Glass** — an inline single-item section at the top of the converted `UIMenu`, via the same `ApolloNativeActionMenuBuildMenu` seam `ApolloDeletedCommentsMenu` and `ApolloPublicStickyAsSubreddit` already use.
- **Legacy** — an appended row on the `ActionController` table sheet, styled from Apollo's own first row (icon inset, accent colour, font) so it doesn't look foreign under a custom theme.

It has to be *appended* rather than inserted at the top on the legacy path: Apollo's own `cellForRow` calls `-dequeueReusableCellWithIdentifier:forIndexPath:` with the index path it was handed, and UIKit asserts if a shifted path is passed through — so the native rows keep their own indices.

Which sheet is ours is resolved by arming on `moreOptionsBarButtonItemTappedWithSender:` and letting the first `ActionController` inside a short grace window claim it — the same one-shot claim the deleted-comments menu uses. Multireddits, Popular/All, profile feeds and search results never get the row, since the subreddit is resolved through `ApolloSubredditNameFromViewController`, which gates on Apollo's own PostsType tag.

### Notes

- One deliberate deviation from the original idea: the counter shows a running `12 / 161` that grows as batches land, rather than restarting at `1/20` per batch. Same purpose (you can see more is loading) but you don't lose your absolute position.
- Diff to existing files is 18 lines across 4 files (Makefile, one declaration in `ApolloCommon.h`, one call in `ApolloNativeActionMenus.xm`, and dropping `static` from `ApolloSubredditNameFromViewController`) — everything else is new files, to keep it out of the way of the other open PRs.
- No settings toggle for now; the row is additive and only shows up on real subreddits.

### Testing

Simulator, both glass and non-glass builds (legacy verified by patching the shell's linked SDK back down to 16.0 so `IsLiquidGlass()` reports NO):

- grid loads, scrolls through several batches (99 → 197 → 297 → 397 on r/EarthPorn), masonry stays balanced
- media classification: r/aww split 145 photos + 8 videos, r/gifs 99/99 GIFs
- video and GIF playback + looping confirmed by frame sampling; filter narrowing and auto-top-up confirmed
- re-verified **signed out**, which also exercises the keyless/public-JSON fallback
- video saving verified end to end on an r/FunnyClips v.redd.it clip: the written asset went from 1 track / 3,375,187 bytes (video only) to 2 tracks / 3,565,469 bytes with audio present
- multi-image posts expand to one page each ("1 of 3 in post"), badges correct
- viewer: swipe paging, counter, post details, pinch zoom + pan bounds, swipe-up and swipe-down dismiss, tap-to-toggle chrome
- Save Image writes the real 2.2 MB original to Photos
- Home feed's `...` menu is untouched (no row, no height change)
- device build against the shipped `iphone:clang:26.0:14.0` target is clean

Not covered in the sim: a real keyless *account* (signed-out public JSON is now exercised, but the cookie-rewrite path for a harvested web session is not), iPad/landscape column counts, and third-party video hosts that need a resolver (redgifs/streamable are skipped rather than shown as unplayable tiles).



