### PR TITLE
Fix Modern Chat/Modmail: let every account choose, instead of locking the switches

### DIFF
--- a/src/ApolloChatUnreadPoller.h
+++ b/src/ApolloChatUnreadPoller.h
@@ -27,10 +27,10 @@ __BEGIN_DECLS
 // Incremental polls (with a `since` token) are ~2 KB, so a 30 s foreground
 // cadence is cheaper than a single feed image.
 //
-// The poller only runs when the modern Chat surface is actually in use
-// (ApolloModernChatShouldOpen() — forced on for API-key-free accounts, opt-in
-// for API-key accounts) and the active account has a stored web session. With
-// the feature off it never fires, so stock Apollo behavior is untouched.
+// The poller only runs when the modern Chat surface is actually in use (the
+// Use Modern Reddit Chat preference, which applies to API-key and API-key-free
+// accounts alike) and the active account has a stored web session. With the
+// feature off it never fires, so stock Apollo behavior is untouched.
 
 // Ask the poller to refresh soon (coalesced; safe from any thread). Used by
 // UI that wants a fresher count than the periodic cadence, e.g. when the

--- a/src/ApolloChatUnreadPoller.m
+++ b/src/ApolloChatUnreadPoller.m
@@ -626,8 +626,7 @@ static void ApolloChatPollTick(void) {
     NSString *username = ApolloActiveWebSessionUsername();
     ApolloWebSessionEntry *entry = username.length > 0 ? ApolloWebSessionPollFor(username) : nil;
     BOOL available = username.length > 0 && entry != nil;
-    BOOL shouldOpen = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseModernRedditChat]
-        || ApolloModernChatIsRequiredForSession(entry);
+    BOOL shouldOpen = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseModernRedditChat];
     NSString *gateState = [NSString stringWithFormat:@"open=%d avail=%d user=%@ cookie=%d",
                            shouldOpen, available, username ?: @"-", entry.cookieHeader.length > 0];
     static NSString *sLastGateState = nil;

--- a/src/ApolloDirectChatWeb.h
+++ b/src/ApolloDirectChatWeb.h
@@ -22,14 +22,15 @@ __BEGIN_DECLS
 // Apollo's stock (dormant) chat UI instead of a blank web page.
 BOOL ApolloModernMailboxOSSupported(void);
 BOOL ApolloModernChatIsAvailable(void);
-BOOL ApolloModernChatIsRequiredForActiveAccount(void);
-// Per-session variant for callers that already resolved the active account's
-// web-session entry (the 30s unread poller): identical verdict to
-// ApolloModernChatIsRequiredForActiveAccount without re-unarchiving the
-// account blob or re-reading the keychain.
-BOOL ApolloModernChatIsRequiredForSession(ApolloWebSessionEntry * _Nullable entry);
+// Both surfaces are a plain user preference — they work for API-key and
+// API-key-free accounts alike, and off means Apollo's own Direct Chat /
+// Moderator Mail, which need Reddit API credentials.
 BOOL ApolloModernChatShouldOpen(void);
 BOOL ApolloModernModmailShouldOpen(void);
+// One-time: records the previously implied "on" for setups that were getting
+// modern Chat/Modmail from the old forced gate, so switching to a plain
+// preference cannot silently remove either surface. Safe to call repeatedly.
+void ApolloMigrateModernMailboxPreferences(void);
 // YES iff `controller` (a modern mailbox controller) was cookie-seeded for
 // the account that is active RIGHT NOW. The persistent Inbox Chat hub uses
 // this to detect account switches and cookie rotations, so a retained hub can

--- a/src/ApolloDirectChatWeb.xm
+++ b/src/ApolloDirectChatWeb.xm
@@ -2893,46 +2893,54 @@ BOOL ApolloModernChatIsAvailable(void) {
     return username.length > 0 && ApolloWebSessionPollFor(username) != nil;
 }
 
-BOOL ApolloModernChatIsRequiredForSession(ApolloWebSessionEntry *entry) {
-    if (!ApolloModernMailboxOSSupported()) return NO;
-    // Only a PRIMARY (API-key-free) session can force the modern surface —
-    // an auxiliary poll-only entry rides along an OAuth account that keeps
-    // Apollo's stock chat unless the user opts in via the settings toggle.
-    if (!entry || entry.pollOnly) return NO;
-    // API-key-free synthesized RDKClient accounts deliberately carry an empty
-    // authorizationCredential.clientIdentifier. Inspect the active client
-    // itself instead of the global default API key, which may belong to a
-    // different account in a mixed API/web-session setup.
-    Class clientClass = objc_getClass("RDKClient");
-    id client = [clientClass respondsToSelector:@selector(sharedClient)]
-        ? ((id (*)(id, SEL))objc_msgSend)(clientClass, @selector(sharedClient)) : nil;
-    id credential = [client respondsToSelector:@selector(authorizationCredential)]
-        ? ((id (*)(id, SEL))objc_msgSend)(client, @selector(authorizationCredential)) : nil;
-    NSString *clientIdentifier = [credential respondsToSelector:@selector(clientIdentifier)]
-        ? ((id (*)(id, SEL))objc_msgSend)(credential, @selector(clientIdentifier)) : nil;
-    return clientIdentifier.length == 0;
-}
-
-BOOL ApolloModernChatIsRequiredForActiveAccount(void) {
-    if (!ApolloModernMailboxOSSupported()) return NO;
-    // A poll-only entry reports pollOnly=YES and is rejected by the session
-    // helper, so resolving via PollFor is equivalent to the primary-only
-    // ApolloActiveWebSession() != nil check at half the account-blob cost.
-    NSString *username = ApolloActiveWebSessionUsername();
-    return ApolloModernChatIsRequiredForSession(
-        username.length > 0 ? ApolloWebSessionPollFor(username) : nil);
-}
-
+// Both surfaces are a straight user preference now. They used to be
+// force-enabled — with the settings switches greyed out — whenever the active
+// account had a primary reddit.com web session and no client identifier on the
+// shared RDKClient, which was read as "this account is API-key-free, so it has
+// no other option". But holding a web session is exactly what modern Chat and
+// Modmail require, and an account can hold one *and* an API key: sign a keyed
+// account into reddit.com to use these surfaces and the lock fired for it too,
+// leaving no way back to Apollo's own Chat / Moderator Mail even though its
+// credentials work fine. Because the preference is app-wide, one such account
+// took the choice away from every account on the device.
+//
+// Modern Chat and Modmail work for keyed and keyless accounts alike, so the
+// preference alone decides. Off means Apollo's own Direct Chat / Moderator
+// Mail, which need Reddit API credentials — an account with no API key that
+// turns these off simply has no Chat or Modmail, the same as before either
+// modern surface existed. ApolloMigrateModernMailboxPreferences below makes
+// sure nobody loses a surface they were relying on when the stored preference
+// took over from the forced gate.
 BOOL ApolloModernChatShouldOpen(void) {
     if (!ApolloModernMailboxOSSupported()) return NO;
-    if (ApolloModernChatIsRequiredForActiveAccount()) return YES;
     return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseModernRedditChat];
 }
 
 BOOL ApolloModernModmailShouldOpen(void) {
     if (!ApolloModernMailboxOSSupported()) return NO;
-    if (ApolloModernChatIsRequiredForActiveAccount()) return YES;
     return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseModernRedditModmail];
+}
+
+void ApolloMigrateModernMailboxPreferences(void) {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    if ([defaults boolForKey:UDKeyModernMailboxChoiceMigrated]) return;
+    [defaults setBool:YES forKey:UDKeyModernMailboxChoiceMigrated];
+    // The old forced-on state lived only in the derived gate, never in the
+    // stored preference, so simply honouring the preference from now on would
+    // silently take Chat and Modmail away from everyone who had been getting
+    // them that way. Anyone running API-Key-Free Mode with a stored web session
+    // was in that population — write down what they already had, which they can
+    // now switch off if they would rather use Apollo's own surfaces.
+    if (![defaults boolForKey:UDKeyWebJSONEnabled]) return;
+    if (ApolloWebSessionUsernames().count == 0) return;
+    BOOL chat = [defaults boolForKey:UDKeyUseModernRedditChat];
+    BOOL modmail = [defaults boolForKey:UDKeyUseModernRedditModmail];
+    if (!chat) [defaults setBool:YES forKey:UDKeyUseModernRedditChat];
+    if (!modmail) [defaults setBool:YES forKey:UDKeyUseModernRedditModmail];
+    if (!chat || !modmail) {
+        ApolloLog(@"[DirectChatWeb] Recorded modern Chat/Modmail as on for this web-session setup "
+                  @"(previously implied); both are now switchable in Settings");
+    }
 }
 
 UIViewController *ApolloCreateModernChatViewController(void) {
@@ -3110,5 +3118,6 @@ UIViewController *ApolloCreateModernModmailViewControllerForPath(NSString *desti
 
 %ctor {
     %init;
+    ApolloMigrateModernMailboxPreferences();
     ApolloLog(@"[DirectChatWeb] module loaded");
 }

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -359,13 +359,17 @@ static NSString *const UDKeyPostFilterNameSubstrings = @"PostFilterNameSubstring
 // Web JSON spike (see ApolloWebJSON.m). Master switch for re-pointing
 // whitelisted listing reads at cookie-authenticated www.reddit.com JSON.
 static NSString *const UDKeyWebJSONEnabled = @"WebJSONEnabled";
-// API-key accounts may opt into Reddit's modern web Chat; API-key-free
-// accounts always use it because legacy /message no longer contains Chat.
+// Reddit's modern web Chat, for API-key and API-key-free accounts alike. Off
+// means Apollo's own Direct Chat, which needs Reddit API credentials.
 static NSString *const UDKeyUseModernRedditChat = @"UseModernRedditChat";
-// API-key accounts may independently opt into Reddit's current web Modmail;
-// API-key-free accounts always use it because Apollo's native new-Modmail
-// endpoints require OAuth credentials they deliberately do not have.
+// Independently, Reddit's current web Modmail. Off means Apollo's native
+// Moderator Mail, whose new-Modmail endpoints require OAuth credentials.
 static NSString *const UDKeyUseModernRedditModmail = @"UseModernRedditModmail";
+// One-shot marker: the two keys above became a plain user preference (they
+// used to be force-enabled for web-session accounts by a derived gate). Set
+// once ApolloMigrateModernMailboxPreferences has recorded the previously
+// implied value, so that never runs twice and re-flips a deliberate choice.
+static NSString *const UDKeyModernMailboxChoiceMigrated = @"ModernMailboxChoiceMigrated";
 // Modern Chat unread poller (ApolloChatUnreadPoller.m). Per-account high-water
 // marks of the unread/requests counts already announced through Bark, so a
 // relaunch doesn't re-push the same unread messages. Not user-facing.

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -479,8 +479,8 @@ typedef NS_ENUM(NSInteger, Tag) {
     // flow (signed-in user / write-token availability may have just changed).
     // No-ops while the row is hidden (API-Key-Free Mode off).
     [self reloadRowWithID:@"api.webSessionLogin"];
-    // The active account can change while this screen is off-screen, flipping
-    // modern Chat/Modmail between optional and mandatory — re-derive both.
+    // Modern Chat/Modmail can be switched from other surfaces (and the one-time
+    // migration writes them on first launch) — re-read both.
     [self reloadRowWithID:@"api.modernChat"];
     [self reloadRowWithID:@"api.modernModmail"];
     // Refresh the Apollo AI and Rich Link Previews status subtitles after returning
@@ -1032,41 +1032,34 @@ typedef NS_ENUM(NSInteger, Tag) {
     // Only exists while API-Key-Free Mode is on (see -_applyWebJSONEnabled:).
     webSessionLogin.visible = ^BOOL { return sWebJSONEnabled; };
 
-    // Modern Reddit Chat. API-key accounts may opt in; API-key-free accounts are
-    // forced on (and the switch disabled) because Reddit no longer exposes Direct
-    // Chat through the legacy message API. Uses the harvested web session.
+    // Modern Reddit Chat / Moderator Mail. Both work for API-key and
+    // API-key-free accounts alike, so both are a plain choice that stays
+    // switchable for everyone. These preferences are app-wide, like the rest of
+    // Apollo's settings, which is the other reason not to derive their state
+    // from whichever account happens to be active: they used to lock as soon as
+    // ONE signed-in account looked API-key-free, taking the choice away from the
+    // keyed accounts sharing the same device.
     ApolloSettingsRow *modernChat =
         [ApolloSettingsRow customRowWithID:@"api.modernChat"
                                       cell:^UITableViewCell *(__unused UITableView *tableView, __unused ApolloSettingsRow *row) {
-            BOOL required = ApolloModernChatIsRequiredForActiveAccount();
-            BOOL selected = required || [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseModernRedditChat];
             return [weakSelf switchCellWithIdentifier:@"Cell_API_ModernChat"
                                                 label:@"Use Modern Reddit Chat"
-                                               detail:required
-                                                      ? @"Required for the active API-key-free account because Reddit no longer exposes Direct Chat through the legacy message API."
-                                                      : @"Off keeps Apollo's legacy Direct Chat. On uses Reddit's current Chat with requests, group chats, and media. Requires a web-session sign-in."
-                                                   on:selected
-                                              enabled:!required
+                                               detail:@"On uses Reddit's current Chat — requests, group chats and media — for every account, and needs a web-session sign-in. Off keeps Apollo's own Direct Chat, which only works for accounts signed in with an API key."
+                                                   on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseModernRedditChat]
+                                              enabled:YES
                                                action:@selector(modernRedditChatSwitchToggled:)]
                 ?: [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
         }
                                   onSelect:nil];
 
-    // Modern Moderator Mail. Same shape as Chat: opt-in for API-key accounts,
-    // forced on for API-key-free ones (Apollo's native Modmail needs OAuth creds
-    // they deliberately don't have).
     ApolloSettingsRow *modernModmail =
         [ApolloSettingsRow customRowWithID:@"api.modernModmail"
                                       cell:^UITableViewCell *(__unused UITableView *tableView, __unused ApolloSettingsRow *row) {
-            BOOL required = ApolloModernChatIsRequiredForActiveAccount();
-            BOOL selected = required || [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseModernRedditModmail];
             return [weakSelf switchCellWithIdentifier:@"Cell_API_ModernModmail"
                                                 label:@"Use Modern Moderator Mail"
-                                               detail:required
-                                                      ? @"Required for the active API-key-free account because Apollo's native Moderator Mail requires Reddit API credentials."
-                                                      : @"Off keeps Apollo's native Moderator Mail. On uses Reddit's current Modmail with the active web-session account."
-                                                   on:selected
-                                              enabled:!required
+                                               detail:@"On uses Reddit's current Modmail with the active web-session account. Off keeps Apollo's native Moderator Mail, which only works for accounts signed in with an API key."
+                                                   on:[[NSUserDefaults standardUserDefaults] boolForKey:UDKeyUseModernRedditModmail]
+                                              enabled:YES
                                                action:@selector(modernRedditModmailSwitchToggled:)]
                 ?: [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
         }
@@ -3070,9 +3063,7 @@ typedef NS_ENUM(NSInteger, Tag) {
     [self visibilityDidChange];
 }
 
-// Modern Chat / Modmail opt-in for API-key accounts. API-key-free accounts are
-// forced on (the switch is disabled via -buildAPIKeysExperimentalSection), so
-// these only ever fire for a keyed account choosing to opt in or out.
+// Modern Chat / Modmail are a plain app-wide choice for every account.
 - (void)modernRedditChatSwitchToggled:(UISwitch *)sender {
     [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:UDKeyUseModernRedditChat];
     // The combined Inbox tab badge gates its chat contribution on this key —


### PR DESCRIPTION
## The problem

**Use Modern Reddit Chat** and **Use Modern Moderator Mail** were force-enabled, with both switches greyed out, whenever the active account had a primary reddit.com web session and no client identifier on the shared `RDKClient` — read as *"this account is API-key-free, so it has no other option"*.

But holding a web session is **exactly what those two surfaces require**, and an account can hold one *and* an API key. Sign a keyed account into reddit.com so it can use modern Chat or Modmail, and the lock fires for it too — even though its API credentials work fine and Apollo's own Direct Chat and Moderator Mail are perfectly usable.

And because the preference is **app-wide** (like the rest of Apollo's settings, not per-account), one such account takes the choice away from every account on the device. Reproduced on a device with one API-key account and one API-key-free account, both web-session signed in: the keyed account could not reach either switch.

## The rule this replaces it with

| | Modern **on** | Modern **off** |
|---|---|---|
| Account with an API key | Reddit's current Chat / Modmail | Apollo's own Direct Chat / Moderator Mail |
| Account with no API key | Reddit's current Chat / Modmail | no Chat / Modmail — Apollo's own need API credentials |

Both surfaces work for keyed and keyless accounts alike, so the preference alone decides and nothing is derived from whichever account happens to be active.

## Changes

- Both switches are **always enabled**, and their subtitles now say what off means: Apollo's own Direct Chat / Moderator Mail, *which only work for accounts signed in with an API key*.
- `ApolloModernChatShouldOpen` / `ApolloModernModmailShouldOpen` return the stored preference; the modern-Chat unread poller's gate follows.
- `ApolloModernChatIsRequiredForActiveAccount` and its per-session variant are **deleted** — nothing derives this from `RDKClient` any more.

## Migration

The old forced-on state lived only in the derived gate and was never written to the preference, so honouring the preference alone would have **silently taken Chat and Modmail away** from everyone who had been getting them that way.

`ApolloMigrateModernMailboxPreferences` runs once and records the previously implied "on" for anyone running API-Key-Free Mode with a stored web session — which they can now switch off. Guarded by a `ModernMailboxChoiceMigrated` marker so it can never re-flip a deliberate choice.

Note this does mean a mixed-setup user who had modern Chat/Modmail off for their keyed account gets it switched on once. That is the conservative direction: the alternative silently breaks Chat and Modmail for their keyless account, and it is now one tap to undo — which it was not before.

## Testing

Simulator (iOS 26, Liquid Glass), mixed setup — one API-key account and one API-key-free account, both web-session signed in:

- Both rows render enabled and switchable for the API-key account (previously greyed with "Required for the active API-key-free account").
- Moderator Mail **off** → Apollo's native Modmail opens and issues its `oauth.reddit.com/api/mod/conversations` request; **back on** → Reddit's web Modmail hydrates. State survives a relaunch.
- Migration verified from a cleared preference state: writes both keys once and logs it; does not run again.
- Device build (`make package FINALPACKAGE=1`, iOS 14 floor, `-Werror`) compiles clean.
- Not device-tested.

Independent of #749 (Modmail transition/flicker fixes); both touch `ApolloDirectChatWeb.xm` but in separate regions.