### PR TITLE
Keep the "..." control visible while its glass context menu is open

### DIFF
--- a/src/ApolloNativeActionMenus.xm
+++ b/src/ApolloNativeActionMenus.xm
@@ -30,6 +30,10 @@ static BOOL sApolloNativeActionMenuNextPresentationModeratorStyle = NO;
 @property (nonatomic, weak) UIView *morphSourceView;
 @property (nonatomic, strong) UIContextMenuInteraction *interaction;
 @property (nonatomic, assign) BOOL removeSourceViewOnEnd;
+// Empty throwaway view pinned over morphSourceView; this is what UIKit portals
+// into the glass platter, so the real control keeps drawing. See
+// ApolloNativeActionMenuCreateMorphStandIn().
+@property (nonatomic, strong) UIView *morphStandInView;
 @end
 
 static BOOL ApolloNativeActionMenusEnabled(void) {
@@ -844,7 +848,66 @@ static UIMenu *ApolloNativeActionMenuBuildMenu(id actionController, BOOL moderat
     return [UIMenu menuWithTitle:title children:children];
 }
 
+// Keep the tapped "..." control on screen for the whole menu lifecycle.
+//
+// UIKit builds the liquid-glass platter by portaling the morph preview's view
+// (a CAPortalLayer pointed at its layer). CoreAnimation stops drawing a
+// portaled layer in its original position for as long as the portal is alive —
+// a render-server effect, so from the app's side the control still looks
+// perfectly healthy (hidden NO, alpha 1, contents set) while its *presentation*
+// layer reads opacity 0. Clearing the portal's hidesSourceLayer does not undo
+// it; only the portal going away does. And the portal outlives the dismissal
+// animation — by ~1s on device — so the control sat blank long after the menu
+// was gone, which reads as the dots vanishing and slowly popping back.
+//
+// So don't let UIKit portal the real thing. This pins an empty throwaway view
+// over the control, exactly its size, and hands UIKit that as the preview: the
+// stand-in absorbs the portaling and the control itself never stops drawing.
+//
+// The stand-in is deliberately *blank* rather than a snapshot. The preview's
+// frame is all the morph needs — it drives where the glass platter blooms from
+// and collapses back to — while any pixels in it get carried inside the platter
+// as a second copy of the icon that animates with the morph. With the control
+// now permanently visible underneath, that copy showed up as a duplicate set of
+// dots sliding into place at the end of the dismissal. Empty stand-in, empty
+// platter: the glass shape blooms out of the control and the control is the
+// only thing ever drawing the icon.
+static UIView *ApolloNativeActionMenuCreateMorphStandIn(UIView *sourceView) {
+    UIView *container = sourceView.superview;
+    if (!container || !sourceView.window || CGRectIsEmpty(sourceView.bounds)) return nil;
+
+    UIView *standIn = [[UIView alloc] initWithFrame:sourceView.frame];
+    standIn.backgroundColor = UIColor.clearColor;
+    standIn.opaque = NO;
+    standIn.userInteractionEnabled = NO;
+    standIn.accessibilityElementsHidden = YES;
+    [container insertSubview:standIn aboveSubview:sourceView];
+    ApolloLog(@"[NativeActionMenu] Morphing from a stand-in over %@ so it stays drawn", sourceView);
+    return standIn;
+}
+
+// Matches the treatment the invisible proxy anchor gets below: a contentless
+// preview must not pick up UIPreviewParameters' default platter background or
+// drop shadow, or the empty stand-in would render as a grey box.
+static UITargetedPreview *ApolloNativeActionMenuStandInPreview(UIView *standIn) {
+    UIPreviewParameters *parameters = [UIPreviewParameters new];
+    parameters.backgroundColor = UIColor.clearColor;
+    parameters.visiblePath = [UIBezierPath bezierPathWithRect:standIn.bounds];
+    SEL setAppliesShadowSelector = NSSelectorFromString(@"setAppliesShadow:");
+    if ([parameters respondsToSelector:setAppliesShadowSelector]) {
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(parameters, setAppliesShadowSelector, NO);
+    }
+    return [[UITargetedPreview alloc] initWithView:standIn parameters:parameters];
+}
+
 @implementation ApolloNativeActionMenuPresenter
+
+// Normally the teardown in -willEndForConfiguration: takes the stand-in out.
+// This catches the presentation that never got a dismissal (aborted before it
+// opened), so a stale copy can't ride along on a recycled cell.
+- (void)dealloc {
+    [_morphStandInView removeFromSuperview];
+}
 
 - (UIContextMenuConfiguration *)contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction configurationForMenuAtLocation:(__unused CGPoint)location {
     UIMenu *menu = self.menu;
@@ -900,6 +963,20 @@ static id ApolloNativeActionMenuCompactMenuStyle(void) {
         if ([morphSource respondsToSelector:morphViewSelector]) {
             UIView *resolved = ((id (*)(id, SEL))objc_msgSend)(morphSource, morphViewSelector);
             if (resolved.window) morphView = resolved;
+        }
+
+        // Hand UIKit a stand-in instead of the control itself, so the control
+        // survives being portaled (see ApolloNativeActionMenuCreateMorphStandIn).
+        // Both the highlight and the dismiss preview reuse the same stand-in;
+        // the teardown in -willEndForConfiguration: takes it back out.
+        UIView *standIn = self.morphStandInView;
+        if (!standIn.window) {
+            [standIn removeFromSuperview];
+            standIn = ApolloNativeActionMenuCreateMorphStandIn(morphView);
+            self.morphStandInView = standIn;
+        }
+        if (standIn) {
+            return ApolloNativeActionMenuStandInPreview(standIn);
         }
         return [[UITargetedPreview alloc] initWithView:morphView];
     }
@@ -966,12 +1043,17 @@ static id ApolloNativeActionMenuCompactMenuStyle(void) {
     if (!sourceView || !menuInteraction) return;
 
     BOOL removeSourceViewOnEnd = self.removeSourceViewOnEnd;
+    UIView *standInView = self.morphStandInView;
+    self.morphStandInView = nil;
     // Issue #249: tear down at dismissal END, not START — removing the anchor
     // (the interaction's host view) while the menu is still morphing back into
-    // the source button cuts the dismissal animation short.
+    // the source button cuts the dismissal animation short. The stand-in goes
+    // at the same point: it is what the collapsing platter is portaling, and
+    // pulling it early would empty the platter mid-animation.
     void (^teardown)(void) = ^{
         [sourceView removeInteraction:menuInteraction];
         objc_setAssociatedObject(sourceView, &kApolloNativeActionMenuControllerKey, nil, OBJC_ASSOCIATION_ASSIGN);
+        [standInView removeFromSuperview];
         if (removeSourceViewOnEnd) {
             [sourceView removeFromSuperview];
         }


### PR DESCRIPTION
Small cosmetic thing on Liquid Glass builds: after you close a post's "..." menu, the three dots stay gone for about a second and then pop back in. Same for any of the tweak's converted menus (sort, nav bar ellipsis, cell "...").

Watch the three dots on the post's info row as the menu closes:

| Before | After |
|:------:|:-----:|
| <img width="280" alt="before" src="https://github.com/user-attachments/assets/f74594e8-a694-4556-852b-4617524583fc" /> | <img width="280" alt="after" src="https://github.com/user-attachments/assets/65c4a031-f058-453c-b309-f339693536db" /> |
| dots blank out, then pop back a beat later | dots never leave |

### What's going on

UIKit builds the glass platter by *portaling* the morph preview's view — a `CAPortalLayer` pointed at its layer. CoreAnimation stops drawing a portaled layer in its original spot for as long as that portal object is alive, and the portal outlives the dismissal animation by roughly a second. The platter is invisible by then, so the button is just blank.

Annoying part is it's a render-server effect, so from the app side the control looks completely fine the whole time — `hidden` NO, `alpha` 1, `contents` set, no animations, nothing covering it. The only tell is `layer.presentationLayer.opacity` reading 0.

Forcing the portal's `hidesSourceLayer` back to NO doesn't help either — the suppression tracks the portal's existence, not that flag. `presentationLayer.opacity` flips back to 1 exactly when the portal deallocs, whatever the flag says.

### The fix

Don't let UIKit portal the real control. `-previewForHighlightingMenuWithConfiguration:` now pins an empty throwaway view over the control, exactly its size, and hands UIKit that as the `UITargetedPreview` instead. The stand-in absorbs the portaling and the control never stops drawing, so there's no teardown timing left to get wrong. It comes back out in the existing `-willEndForConfiguration:` animator completion (same point the proxy anchor is removed), with a `dealloc` net for a presentation that never opens.

The stand-in is deliberately **blank** rather than a snapshot of the control. The preview's frame is all the morph needs — it's what drives where the platter blooms from and collapses back to — but any pixels in it get carried inside the platter as a second copy of the icon that animates with the morph. That's invisible today because the real control isn't drawing; with this change it showed up as a duplicate set of dots sliding into place at the end of the dismissal. Empty stand-in, empty platter, one set of dots. It gets the same clear-background / no-shadow `UIPreviewParameters` the invisible proxy anchor already uses, otherwise a contentless preview picks up UIKit's default grey platter background.

Nothing about #249's morph setup changes — same compact style, same fallback driver style, same anchor. Only which view gets handed over as the preview.

### Testing

Simulator (iPhone 16 Pro, iOS 26, Liquid Glass, dark), frame-by-frame off a screen recording:

- Scanned every frame for a gap where the row is uncovered but the dots aren't drawn: **zero**. Before: two per cycle. The dots go visible → behind the menu → visible.
- Scanned every frame for more than one set of dots: **zero**.
- Bloom and collapse frames match the current animation — still the glass shape growing out of the button, not a fade.
- Menu actions still fire, nav bar ellipsis menu still fine, no leftover copy on the row afterwards (pixel diff before vs after a full cycle is just video compression noise).

Not device-tested yet.
