### PR TITLE
Add visionOS gaze hover and multiwindow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,8 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloFeedTextPostThumbnails.xm \
     $(SRC_DIR)/ApolloTweetBuddy.xm \
 	$(SRC_DIR)/ApolloVisionOSFix.xm \
+    $(SRC_DIR)/ApolloVisionOSHover.xm \
+    $(SRC_DIR)/ApolloVisionOSMultiwindow.xm \
     $(SRC_DIR)/ApolloWebAuthViewController.m \
     $(SRC_DIR)/ApolloWebJSON.m \
     $(SRC_DIR)/ApolloWebJSONIdentity.xm \

--- a/src/ApolloVisionOSHover.xm
+++ b/src/ApolloVisionOSHover.xm
@@ -1,0 +1,650 @@
+// ApolloVisionOSHover.xm
+//
+// Pointer- and gaze-hover highlights for Apollo's feed and controls when it
+// runs as an iOS app in compatibility mode on visionOS (Apple Vision Pro).
+// iPhone and iPad are a strict no-op — the %ctor bails unless running on
+// visionOS.
+//
+// Apollo draws its feed with AsyncDisplayKit (Texture) nodes. Pointer hover
+// (the Mac Virtual Display cursor) is covered by attaching UIHoverStyle to the
+// cells. Gaze hover is different: the visionOS compositor resolves it out of
+// process against regions the app exports, and content inside a Texture layer
+// subtree is never addressable for gaze no matter what the app publishes on
+// its layers — while any window-direct view over the same screen region glows
+// normally. So each on-screen cell, and each nav/toolbar/comment control, gets
+// a pooled, hit-test-transparent "ghost" parented to the window that tracks
+// its frame from a display link: the target visibly glows on gaze and pinches
+// pass straight through to the content underneath.
+
+#import <UIKit/UIKit.h>
+#import <objc/message.h>
+#import <objc/runtime.h>
+#import "ApolloCommon.h"
+
+// Minimal Texture surface used here. Classes are resolved at runtime via
+// NSClassFromString because ApolloReborn.dylib is injected rather than linked
+// against Apollo, so a direct class reference would fail at link time.
+@interface ASDisplayNode : NSObject
+- (id)supernode;
+@end
+
+@interface UIView (ApolloVisionOSTexture)
+- (ASDisplayNode *)asyncdisplaykit_node;
+@end
+
+@interface _ASTableViewCell : UITableViewCell
+@end
+
+@interface _ASCollectionViewCell : UICollectionViewCell
+@end
+
+#pragma mark - Tunables
+
+// Row hover effect. Highlight renders behind the view's content, which Texture
+// hides by rasterising its nodes opaquely; lift scales and shadows the row
+// instead and stays visible however the cell paints itself.
+static const NSInteger kApolloRowHoverEffect = 1;   // 0 highlight, 1 lift, 2 automatic
+static const CGFloat kApolloRowCornerRadius = 12.0;
+
+// A ghost sits over EVERY on-screen row (the app never learns which row the
+// user looks at, so all are covered), so any non-zero resting fill tiles
+// across the feed as a faint all-over wash — most visible in dark mode. 0
+// leaves the ghosts invisible at rest; the on-gaze glow is the system's remote
+// hover effect, which targets the ghost's region rather than its pixels, so it
+// survives a clear fill.
+static const CGFloat kApolloGhostRestAlpha = 0.0;
+
+// How long a scroll view must hold still before its rows re-acquire ghosts.
+static const CFTimeInterval kApolloGhostSettleDelay = 0.15;
+
+#pragma mark - visionOS gate
+
+// YES only when this process is an iOS app running on visionOS in compatibility
+// mode. Prefers the official API added in visionOS 26.1
+// (-[NSProcessInfo isiOSAppOnVision]); falls back to a visionOS-only class
+// check on earlier releases. Guarded so it can never raise
+// doesNotRecognizeSelector.
+static BOOL ApolloIsRunningOnVisionOS(void) {
+    static BOOL result = NO;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+        SEL sel = NSSelectorFromString(@"isiOSAppOnVision");
+        if ([processInfo respondsToSelector:sel]) {
+            BOOL (*msgSend)(id, SEL) = (BOOL (*)(id, SEL))objc_msgSend;
+            if (msgSend(processInfo, sel)) {
+                result = YES;
+                return;
+            }
+        }
+        if (NSClassFromString(@"UIWindowSceneGeometryPreferencesVision") != nil) {
+            result = YES;
+        }
+    });
+    return result;
+}
+
+#pragma mark - Hover styles
+
+// Resolved at runtime rather than linked: a linked class reference is bound by
+// dyld at load time and would abort on an OS lacking the class, whereas a
+// runtime lookup simply returns nil and the feature quietly does nothing.
+static id ApolloHoverEffect(NSInteger kind) {
+    NSString *name = @"UIHoverAutomaticEffect";
+    if (kind == 0) {
+        name = @"UIHoverHighlightEffect";
+    } else if (kind == 1) {
+        name = @"UIHoverLiftEffect";
+    }
+    Class effectClass = NSClassFromString(name);
+    if (!effectClass) return nil;
+    id (*msgSend)(Class, SEL) = (id (*)(Class, SEL))objc_msgSend;
+    return msgSend(effectClass, @selector(effect));
+}
+
+static id ApolloRectShape(CGFloat cornerRadius) {
+    Class shapeClass = NSClassFromString(@"UIShape");
+    if (!shapeClass) return nil;
+    id (*msgSend)(Class, SEL, CGFloat) = (id (*)(Class, SEL, CGFloat))objc_msgSend;
+    return msgSend(shapeClass, @selector(rectShapeWithCornerRadius:), cornerRadius);
+}
+
+static id ApolloRowHoverStyle(void) {
+    static id style = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class styleClass = NSClassFromString(@"UIHoverStyle");
+        id effect = ApolloHoverEffect(kApolloRowHoverEffect);
+        if (!styleClass || !effect) return;
+        id (*msgSend)(Class, SEL, id, id) = (id (*)(Class, SEL, id, id))objc_msgSend;
+        style = msgSend(styleClass, @selector(styleWithEffect:shape:),
+                        effect, ApolloRectShape(kApolloRowCornerRadius));
+    });
+    return style;
+}
+
+// Bar and comment buttons read as capsules, not rows; falls back to a rounded
+// rect when +[UIShape capsuleShape] is missing.
+static id ApolloControlHoverStyle(void) {
+    static id style = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class styleClass = NSClassFromString(@"UIHoverStyle");
+        id effect = ApolloHoverEffect(kApolloRowHoverEffect);
+        if (!styleClass || !effect) return;
+        id shape = nil;
+        Class shapeClass = NSClassFromString(@"UIShape");
+        if ([shapeClass respondsToSelector:@selector(capsuleShape)]) {
+            id (*msgSend)(Class, SEL) = (id (*)(Class, SEL))objc_msgSend;
+            shape = msgSend(shapeClass, @selector(capsuleShape));
+        }
+        if (!shape) shape = ApolloRectShape(8.0);
+        id (*msgSend)(Class, SEL, id, id) = (id (*)(Class, SEL, id, id))objc_msgSend;
+        style = msgSend(styleClass, @selector(styleWithEffect:shape:), effect, shape);
+    });
+    return style;
+}
+
+// Cells are reused and the style outlives reuse, so each view needs it once.
+// The marker also keeps the deliberately overlapping cell hooks idempotent.
+static const void *kApolloHoverAppliedKey = &kApolloHoverAppliedKey;
+
+static void ApolloApplyHoverStyle(UIView *view, id style) {
+    if (!view || !style) return;
+    if (objc_getAssociatedObject(view, kApolloHoverAppliedKey)) return;
+    if (![view respondsToSelector:@selector(setHoverStyle:)]) return;
+    objc_setAssociatedObject(view, kApolloHoverAppliedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    void (*msgSend)(id, SEL, id) = (void (*)(id, SEL, id))objc_msgSend;
+    msgSend(view, @selector(setHoverStyle:), style);
+}
+
+static void ApolloApplyRowHoverStyle(UIView *view) {
+    ApolloApplyHoverStyle(view, ApolloRowHoverStyle());
+}
+
+#pragma mark - Gaze eligibility
+
+// Gaze glow in a compatibility app comes from the hit-testing remote effect,
+// whose gate accepts any view carrying a UITapGestureRecognizer. Attaching one
+// with no target so it recognises nothing (and steals nothing) is enough to
+// qualify a view; public API only.
+static const void *kApolloGazeTapKey = &kApolloGazeTapKey;
+
+static void ApolloGazeEnroll(UIView *view) {
+    if (!view || objc_getAssociatedObject(view, kApolloGazeTapKey)) return;
+    objc_setAssociatedObject(view, kApolloGazeTapKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] init];
+    tap.cancelsTouchesInView = NO;
+    tap.delaysTouchesBegan = NO;
+    tap.delaysTouchesEnded = NO;
+    [view addGestureRecognizer:tap];
+}
+
+// UIScrollView hides gaze for its subtree while it scrolls by writing a hide
+// blend factor onto its outermost layer, restoring it only from its
+// end-of-scroll callbacks. A scroll animation cancelled before those fire
+// (Texture's interrupted programmatic scrolling does this) strands the hidden
+// state forever. -_setRemoteHoverInteractionEnabled: is a registered selector,
+// so calling it with YES lets UIKit's own code clear the correct layer; a hook
+// keeps ordinary scrolling from re-sticking it.
+static void ApolloUnstickScrollGaze(void) {
+    SEL sel = NSSelectorFromString(@"_setRemoteHoverInteractionEnabled:");
+    void (*msgSend)(id, SEL, BOOL) = (void (*)(id, SEL, BOOL))objc_msgSend;
+    for (UIWindow *window in ApolloAllWindows()) {
+        NSMutableArray<UIView *> *stack = [NSMutableArray arrayWithObject:window];
+        while (stack.count) {
+            UIView *view = stack.lastObject;
+            [stack removeLastObject];
+            if ([view isKindOfClass:[UIScrollView class]] &&
+                [view respondsToSelector:sel]) {
+                msgSend(view, sel, YES);
+            }
+            [stack addObjectsFromArray:view.subviews];
+        }
+    }
+}
+
+%group ApolloVisionOSHoverKeepAlive
+%hook UIScrollView
+- (void)_setRemoteHoverInteractionEnabled:(__unused BOOL)enabled {
+    %orig(YES);
+}
+%end
+%end
+
+#pragma mark - Texture node helpers
+
+static ASDisplayNode *ApolloNodeOfView(UIView *view) {
+    if (![view respondsToSelector:@selector(asyncdisplaykit_node)]) return nil;
+    return [view asyncdisplaykit_node];
+}
+
+static ASDisplayNode *ApolloSupernode(ASDisplayNode *node) {
+    return [node respondsToSelector:@selector(supernode)] ? [node supernode] : nil;
+}
+
+// A node whose enclosing cell node is a *PostCellNode belongs to a feed row,
+// which keeps its whole-row ghost rather than sprouting a capsule per control.
+static BOOL ApolloNodeIsInsidePostCell(ASDisplayNode *node) {
+    NSUInteger hops = 0;
+    for (ASDisplayNode *n = node; n && hops < 40; n = ApolloSupernode(n), hops++) {
+        if ([NSStringFromClass([n class]) hasSuffix:@"PostCellNode"]) return YES;
+    }
+    return NO;
+}
+
+#pragma mark - Ghost overlays
+
+// Invisible to touch: pinches land on the Apollo content underneath, while gaze
+// targeting is layer-based and unaffected.
+@interface ApolloGazeGhost : UIView
+@end
+
+@implementation ApolloGazeGhost
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    return nil;
+}
+@end
+
+// Ghosts are pooled and reassigned each frame, so cell reuse and deallocation
+// need no bookkeeping. Pools are PER WINDOW (weak keys, purged with the
+// window): keying them to the key window made ghosting on a second window a
+// focus-race coin flip.
+static NSHashTable<UIView *> *gApolloGhostCells = nil;
+static NSHashTable<UIView *> *gApolloGhostControls = nil;
+static NSMapTable<UIWindow *, NSMutableArray<ApolloGazeGhost *> *> *gApolloRowPools = nil;
+static NSMapTable<UIWindow *, NSMutableArray<ApolloGazeGhost *> *> *gApolloControlPools = nil;
+static NSMapTable<UIScrollView *, NSValue *> *gApolloGhostOffsets = nil;
+static NSMapTable<UIScrollView *, NSNumber *> *gApolloGhostStillSince = nil;
+static NSHashTable<UIView *> *gApolloTopBars = nil;
+
+// hidden/alpha on the view alone misses a hidden ancestor — a faded-out toolbar
+// that is still on screen must not leave a glowing ghost behind.
+static BOOL ApolloViewVisibleInWindow(UIView *view) {
+    for (UIView *v = view; v; v = v.superview) {
+        if (v.hidden || v.alpha < 0.01) return NO;
+        if ([v isKindOfClass:[UIWindow class]]) return YES;
+    }
+    return NO;
+}
+
+// Top-of-window bars that float OVER the feed (the Liquid Glass build renders
+// the Posts/Inbox/Search tab bar and the nav bar at the top, so scrolled rows
+// slide underneath them). Their items glow natively, but a row ghost is a
+// window-direct view above the whole app UI, so where it overlaps a bar it
+// steals the gaze ray and the row glows instead of the bar item. Row ghosts are
+// clipped to below these bars. Cached on the 1 Hz timer rather than re-walked
+// per frame; a bar's window frame is fixed as the feed scrolls.
+static void ApolloRefreshTopBars(void) {
+    if (!gApolloTopBars) gApolloTopBars = [NSHashTable weakObjectsHashTable];
+    [gApolloTopBars removeAllObjects];
+    for (UIWindow *window in ApolloAllWindows()) {
+        NSMutableArray<UIView *> *stack = [NSMutableArray arrayWithObject:window];
+        while (stack.count) {
+            UIView *view = stack.lastObject;
+            [stack removeLastObject];
+            if ([view isKindOfClass:[UITabBar class]] ||
+                [view isKindOfClass:[UINavigationBar class]]) {
+                CGRect frame = [view convertRect:view.bounds toView:window];
+                // Only bars anchored near the TOP — a bottom tab bar never
+                // overlaps a scrolled row, so it must not clip anything.
+                if (CGRectGetMinY(frame) < window.bounds.size.height * 0.4) {
+                    [gApolloTopBars addObject:view];
+                }
+                continue;   // no interactive rows live inside a bar
+            }
+            [stack addObjectsFromArray:view.subviews];
+        }
+    }
+}
+
+// Bottom edge (window coords) of the lowest top-anchored visible bar in a
+// window, or 0 if none.
+static CGFloat ApolloTopOverlayBottom(UIWindow *window) {
+    if (!gApolloTopBars || !window) return 0.0;
+    CGFloat bottom = 0.0;
+    for (UIView *bar in gApolloTopBars) {
+        if (bar.window != window || !ApolloViewVisibleInWindow(bar)) continue;
+        CGFloat maxY = CGRectGetMaxY([bar convertRect:bar.bounds toView:window]);
+        if (maxY > bottom) bottom = maxY;
+    }
+    return bottom;
+}
+
+// Ghosts vanish while a scroll view moves and return once it has been still for
+// a beat, mirroring how UIKit itself suppresses gaze during a scroll. Watching
+// the offset (rather than isDragging/isDecelerating) covers finger drags,
+// deceleration and Texture's programmatic scrolls with one signal.
+static BOOL ApolloGhostScrollerSettled(UIView *cell, CFTimeInterval now) {
+    UIView *ancestor = cell.superview;
+    while (ancestor && ![ancestor isKindOfClass:[UIScrollView class]]) {
+        ancestor = ancestor.superview;
+    }
+    UIScrollView *scroller = (UIScrollView *)ancestor;
+    if (!scroller) return YES;
+
+    if (!gApolloGhostOffsets) gApolloGhostOffsets = [NSMapTable weakToStrongObjectsMapTable];
+    if (!gApolloGhostStillSince) gApolloGhostStillSince = [NSMapTable weakToStrongObjectsMapTable];
+
+    CGPoint offset = scroller.contentOffset;
+    NSValue *last = [gApolloGhostOffsets objectForKey:scroller];
+    if (!last || !CGPointEqualToPoint(last.CGPointValue, offset)) {
+        [gApolloGhostOffsets setObject:[NSValue valueWithCGPoint:offset] forKey:scroller];
+        [gApolloGhostStillSince setObject:@(now) forKey:scroller];
+        return NO;
+    }
+    return (now - [gApolloGhostStillSince objectForKey:scroller].doubleValue) >= kApolloGhostSettleDelay;
+}
+
+static void ApolloGhostRegisterCell(UIView *cell) {
+    if (!gApolloGhostCells) gApolloGhostCells = [NSHashTable weakObjectsHashTable];
+    [gApolloGhostCells addObject:cell];
+}
+
+#pragma mark - Bar / comment control registration
+
+// The bars' internal button classes are private and churn between UIKit
+// releases, while "a reasonably sized UIControl under a bar" is stable, so bar
+// controls are gathered by a sweep from the 1 Hz timer rather than by hooks.
+// The size caps keep a bar's full-width background control from acquiring a
+// capsule ghost. Tab-bar buttons are deliberately excluded: they glow natively
+// in compatibility mode, so ghosting them would double the effect.
+static BOOL ApolloControlSizeFits(UIView *view) {
+    return view.bounds.size.height >= 8.0 && view.bounds.size.height <= 96.0 &&
+           view.bounds.size.width <= 400.0;
+}
+
+static void ApolloRegisterGhostControl(UIView *view) {
+    if (!gApolloGhostControls) gApolloGhostControls = [NSHashTable weakObjectsHashTable];
+    [gApolloGhostControls addObject:view];
+}
+
+static void ApolloRegisterBarControlsIn(UIView *bar) {
+    NSMutableArray<UIView *> *stack = [NSMutableArray arrayWithObject:bar];
+    while (stack.count) {
+        UIView *view = stack.lastObject;
+        [stack removeLastObject];
+        if ([view isKindOfClass:[UIControl class]] && ApolloControlSizeFits(view)) {
+            ApolloRegisterGhostControl(view);
+            continue;   // a control's internals never need their own ghost
+        }
+        [stack addObjectsFromArray:view.subviews];
+    }
+}
+
+// Apollo's own tappables — the upvote/downvote/save/reply/share bar above the
+// comments, per-comment option buttons, inline link buttons — are ASControlNode
+// descendants, not UIControls, so the bar sweep can't see them. Anything whose
+// backing node is an ASControlNode qualifies, except inside a *PostCellNode
+// subtree.
+static BOOL ApolloIsGhostableADKControl(UIView *view) {
+    Class controlNodeClass = NSClassFromString(@"ASControlNode");
+    if (!controlNodeClass || !view.userInteractionEnabled) return NO;
+    ASDisplayNode *node = ApolloNodeOfView(view);
+    if (![node isKindOfClass:controlNodeClass]) return NO;
+    return !ApolloNodeIsInsidePostCell(node);
+}
+
+static void ApolloRegisterBarControls(void) {
+    for (UIWindow *window in ApolloAllWindows()) {
+        NSMutableArray<UIView *> *stack = [NSMutableArray arrayWithObject:window];
+        while (stack.count) {
+            UIView *view = stack.lastObject;
+            [stack removeLastObject];
+            if ([view isKindOfClass:[UINavigationBar class]] ||
+                [view isKindOfClass:[UIToolbar class]]) {
+                ApolloRegisterBarControlsIn(view);
+                continue;
+            }
+            if (ApolloControlSizeFits(view) && ApolloIsGhostableADKControl(view)) {
+                ApolloRegisterGhostControl(view);
+                continue;
+            }
+            [stack addObjectsFromArray:view.subviews];
+        }
+    }
+}
+
+#pragma mark - Ghost driver
+
+@interface ApolloGhostDriver : NSObject
++ (instancetype)shared;
+- (void)tick:(CADisplayLink *)link;
+@end
+
+@implementation ApolloGhostDriver
+
++ (instancetype)shared {
+    static ApolloGhostDriver *shared = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ shared = [[ApolloGhostDriver alloc] init]; });
+    return shared;
+}
+
+// One window's frame update for one pool. `controls` selects the capsule
+// treatment: the control hover style at creation, and a per-frame corner radius
+// because bar buttons come in many sizes while the ghost is pooled and reshaped
+// freely.
+static void ApolloGhostLayoutPass(NSArray<UIView *> *targets,
+                                  NSMutableArray<ApolloGazeGhost *> *pool,
+                                  UIWindow *window, CFTimeInterval now,
+                                  BOOL controls) {
+    // Row ghosts yield the top-bar band to the bars (whose items glow
+    // natively); control ghosts ARE the bar items, so they are never clipped.
+    CGFloat topClip = controls ? 0.0 : ApolloTopOverlayBottom(window);
+    NSUInteger used = 0;
+    for (UIView *target in targets) {
+        if (target.window != window || target.bounds.size.height < 8.0) continue;
+        if (!ApolloViewVisibleInWindow(target)) continue;
+        if (!ApolloGhostScrollerSettled(target, now)) continue;
+        CGRect frame = [target convertRect:target.bounds toView:window];
+        if (!CGRectIntersectsRect(frame, window.bounds)) continue;
+
+        if (topClip > 0.0) {
+            if (CGRectGetMaxY(frame) <= topClip + 1.0) continue;   // fully under the bar
+            if (CGRectGetMinY(frame) < topClip) {                  // partly under — clip to the exposed part
+                CGFloat delta = topClip - CGRectGetMinY(frame);
+                frame.origin.y += delta;
+                frame.size.height -= delta;
+            }
+        }
+
+        ApolloGazeGhost *ghost = nil;
+        if (used < pool.count) {
+            ghost = pool[used];
+        } else {
+            ghost = [[ApolloGazeGhost alloc] initWithFrame:CGRectZero];
+            ghost.userInteractionEnabled = YES;
+            ghost.backgroundColor = [UIColor colorWithWhite:1.0 alpha:kApolloGhostRestAlpha];
+            ghost.layer.cornerRadius = kApolloRowCornerRadius;
+            ApolloApplyHoverStyle(ghost, controls ? ApolloControlHoverStyle()
+                                                  : ApolloRowHoverStyle());
+            ApolloGazeEnroll(ghost);
+            [pool addObject:ghost];
+        }
+        used++;
+
+        if (ghost.superview != window) [window addSubview:ghost];
+        ghost.hidden = NO;
+        ghost.frame = frame;
+        if (controls) {
+            ghost.layer.cornerRadius = MIN(frame.size.height, frame.size.width) / 2.0;
+        }
+    }
+    for (NSUInteger i = used; i < pool.count; i++) {
+        pool[i].hidden = YES;
+    }
+}
+
+// Partition one target table by each target's OWN window and run a pass per
+// window. Windows that had a pool but no targets this frame still get a pass so
+// their leftover ghosts hide rather than linger.
+static void ApolloGhostLayoutAllWindows(
+    NSHashTable<UIView *> *targets,
+    NSMapTable<UIWindow *, NSMutableArray<ApolloGazeGhost *> *> *pools,
+    CFTimeInterval now, BOOL controls) {
+    NSMapTable<UIWindow *, NSMutableArray<UIView *> *> *byWindow =
+        [NSMapTable weakToStrongObjectsMapTable];
+    for (UIView *target in targets.allObjects) {
+        UIWindow *window = target.window;
+        if (!window) continue;
+        NSMutableArray<UIView *> *group = [byWindow objectForKey:window];
+        if (!group) {
+            group = [NSMutableArray array];
+            [byWindow setObject:group forKey:window];
+        }
+        [group addObject:target];
+    }
+    NSMutableSet<UIWindow *> *windows = [NSMutableSet set];
+    for (UIWindow *window in byWindow.keyEnumerator) [windows addObject:window];
+    for (UIWindow *window in pools.keyEnumerator) [windows addObject:window];
+    for (UIWindow *window in windows) {
+        NSMutableArray<ApolloGazeGhost *> *pool = [pools objectForKey:window];
+        if (!pool) {
+            pool = [NSMutableArray array];
+            [pools setObject:pool forKey:window];
+        }
+        ApolloGhostLayoutPass([byWindow objectForKey:window] ?: @[], pool, window, now, controls);
+    }
+}
+
+// YES while any window shows a context menu (its container is a direct window
+// subview). Ghosts vanish for the duration: a pooled ghost created after the
+// menu presented would sit above the platter and fight its rows for the pinch.
+static BOOL ApolloContextMenuIsUp(void) {
+    for (UIWindow *window in ApolloAllWindows()) {
+        for (UIView *view in window.subviews) {
+            if ([NSStringFromClass([view class]) containsString:@"ContextMenu"]) return YES;
+        }
+    }
+    return NO;
+}
+
+static void ApolloGhostHideAll(NSMapTable<UIWindow *, NSMutableArray<ApolloGazeGhost *> *> *pools) {
+    for (UIWindow *window in pools.keyEnumerator) {
+        for (ApolloGazeGhost *ghost in [pools objectForKey:window]) ghost.hidden = YES;
+    }
+}
+
+- (void)tick:(CADisplayLink *)link {
+    if (ApolloContextMenuIsUp()) {
+        if (gApolloRowPools) ApolloGhostHideAll(gApolloRowPools);
+        if (gApolloControlPools) ApolloGhostHideAll(gApolloControlPools);
+        return;
+    }
+    if (gApolloGhostCells) {
+        if (!gApolloRowPools) gApolloRowPools = [NSMapTable weakToStrongObjectsMapTable];
+        ApolloGhostLayoutAllWindows(gApolloGhostCells, gApolloRowPools, link.timestamp, NO);
+    }
+    if (gApolloGhostControls) {
+        if (!gApolloControlPools) gApolloControlPools = [NSMapTable weakToStrongObjectsMapTable];
+        ApolloGhostLayoutAllWindows(gApolloGhostControls, gApolloControlPools, link.timestamp, YES);
+    }
+}
+
+@end
+
+#pragma mark - Cell hooks
+
+// Hooking the UIKit base classes covers Apollo's plain cells (settings, menus)
+// and, by inheritance, Texture's; the explicit _AS* hooks are the safety net
+// for subclasses that override -didMoveToWindow without chaining to super.
+//
+// System-private cells keep their native interaction machinery: a context
+// menu's rows are _UI* collection cells, and a foreign tap recogniser on one
+// forces the menu's own selection recogniser to fail — the menu neither fires
+// nor dismisses. Apollo's cells are _AS* or unprefixed, so the _UI test cuts
+// exactly the system chrome.
+static BOOL ApolloIsSystemPrivateCell(UIView *cell) {
+    return [NSStringFromClass([cell class]) hasPrefix:@"_UI"];
+}
+
+%group ApolloVisionOSCellHover
+
+%hook UITableViewCell
+- (void)didMoveToWindow {
+    %orig;
+    if (self.window && !ApolloIsSystemPrivateCell(self)) {
+        ApolloApplyRowHoverStyle(self);
+        ApolloGazeEnroll(self);
+    }
+}
+%end
+
+%hook UICollectionViewCell
+- (void)didMoveToWindow {
+    %orig;
+    if (self.window && !ApolloIsSystemPrivateCell(self)) {
+        ApolloApplyRowHoverStyle(self);
+        ApolloGazeEnroll(self);
+    }
+}
+%end
+
+%end
+
+%group ApolloVisionOSASCellHover
+
+%hook _ASTableViewCell
+- (void)didMoveToWindow {
+    %orig;
+    if (self.window) {
+        ApolloApplyRowHoverStyle(self);
+        ApolloGazeEnroll(self);
+        ApolloGhostRegisterCell(self);
+    }
+}
+%end
+
+%hook _ASCollectionViewCell
+- (void)didMoveToWindow {
+    %orig;
+    if (self.window) {
+        ApolloApplyRowHoverStyle(self);
+        ApolloGazeEnroll(self);
+        ApolloGhostRegisterCell(self);
+    }
+}
+%end
+
+%end
+
+#pragma mark - Timers
+
+// Apollo replaces window contents freely and scroll views come and go with
+// navigation, so the unstick sweep, top-bar cache and bar-control sweep run on
+// a slow repeating timer.
+static void ApolloStartHoverTimers(void) {
+    [[NSNotificationCenter defaultCenter]
+        addObserverForName:UIApplicationDidBecomeActiveNotification
+                    object:nil
+                     queue:[NSOperationQueue mainQueue]
+                usingBlock:^(__unused NSNotification *note) {
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            [NSTimer scheduledTimerWithTimeInterval:1.0 repeats:YES block:^(__unused NSTimer *timer) {
+                ApolloUnstickScrollGaze();
+                ApolloRefreshTopBars();
+                ApolloRegisterBarControls();
+            }];
+
+            CADisplayLink *link =
+                [CADisplayLink displayLinkWithTarget:[ApolloGhostDriver shared]
+                                            selector:@selector(tick:)];
+            [link addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+        });
+    }];
+}
+
+%ctor {
+    if (!ApolloIsRunningOnVisionOS()) return;
+
+    %init(ApolloVisionOSCellHover);
+    %init(ApolloVisionOSHoverKeepAlive);
+    if (NSClassFromString(@"_ASTableViewCell")) {
+        %init(ApolloVisionOSASCellHover);
+    }
+    ApolloStartHoverTimers();
+
+    ApolloLog(@"[VisionOSHover] active on visionOS");
+}

--- a/src/ApolloVisionOSHover.xm
+++ b/src/ApolloVisionOSHover.xm
@@ -268,6 +268,29 @@ static BOOL ApolloViewVisibleInWindow(UIView *view) {
     return NO;
 }
 
+static BOOL ApolloViewIsWithin(UIView *view, UIView *ancestor) {
+    for (UIView *v = view; v; v = v.superview) {
+        if (v == ancestor) return YES;
+    }
+    return NO;
+}
+
+// The topmost modally presented view in a window, or nil. A page/form sheet
+// (the iPad idiom visionOS compatibility runs) keeps the presenting view in the
+// window, so feed cells behind it stay visible to the pass; ghosts, appended to
+// the window last, would otherwise glow on top of a compose/share/settings
+// sheet. Targets not within this view are suppressed while it is up, so a
+// presented sheet with its own Texture content still ghosts but the feed behind
+// does not.
+static UIView *ApolloWindowPresentedView(UIWindow *window) {
+    UIViewController *presented = nil;
+    for (UIViewController *vc = window.rootViewController; vc.presentedViewController;
+         vc = vc.presentedViewController) {
+        presented = vc.presentedViewController;
+    }
+    return presented.viewIfLoaded;
+}
+
 // Top-of-window bars that float OVER the feed (the Liquid Glass build renders
 // the Posts/Inbox/Search tab bar and the nav bar at the top, so scrolled rows
 // slide underneath them). Their items glow natively, but a row ghost is a
@@ -432,9 +455,13 @@ static void ApolloGhostLayoutPass(NSArray<UIView *> *targets,
     // Row ghosts yield the top-bar band to the bars (whose items glow
     // natively); control ghosts ARE the bar items, so they are never clipped.
     CGFloat topClip = controls ? 0.0 : ApolloTopOverlayBottom(window);
+    // While a sheet is presented, only its own content ghosts — the feed behind
+    // it is suppressed so no glow lands on top of the sheet.
+    UIView *presentedView = ApolloWindowPresentedView(window);
     NSUInteger used = 0;
     for (UIView *target in targets) {
         if (target.window != window || target.bounds.size.height < 8.0) continue;
+        if (presentedView && !ApolloViewIsWithin(target, presentedView)) continue;
         if (!ApolloViewVisibleInWindow(target)) continue;
         if (!ApolloGhostScrollerSettled(target, now)) continue;
         CGRect frame = [target convertRect:target.bounds toView:window];

--- a/src/ApolloVisionOSMultiwindow.xm
+++ b/src/ApolloVisionOSMultiwindow.xm
@@ -1,0 +1,489 @@
+// ApolloVisionOSMultiwindow.xm
+//
+// Multiwindow affordances for Apollo running as an iOS app in compatibility
+// mode on visionOS (Apple Vision Pro). iPhone and iPad are a strict no-op — the
+// %ctor bails unless running on visionOS.
+//
+// Apollo already declares UIApplicationSupportsMultipleScenes and a handoff
+// activity for iPad multiwindow, but offers no way to trigger it on visionOS.
+// This adds:
+//
+//   • Cmd-N (new window) and Cmd-Shift-N (duplicate the current window). A
+//     bottom-left floating button duplicates too, since the Vision Pro is
+//     usually driven without a keyboard and the window bar's menu only offers
+//     system commands.
+//
+//   • "Open in New Window" on a post or comment long-press: the thread opens in
+//     its own window beside the feed. Apollo's handoff opener accepts only its
+//     universal-link domain (openinapollo.com) and reads the reddit target from
+//     the URL's query items (subreddit / postID / commentID), so a new plain
+//     scene is activated and then handed a browsing-web NSUserActivity carrying
+//     that query URL through its scene delegate's -scene:continueUserActivity:.
+//     The pressed post/comment is identified from the cell's Texture node,
+//     located via the last touch point (gaze-and-pinch input does not report a
+//     usable gesture state mid-press, so the point is traced from
+//     -[UIWindow sendEvent:]).
+
+#import <UIKit/UIKit.h>
+#import <objc/message.h>
+#import <objc/runtime.h>
+#import "ApolloCommon.h"
+#import "Tweak.h"   // RDKLink, RDKComment
+
+// RedditKit accessors not in Tweak.h's shared surface; resolved at runtime
+// against Apollo's own classes.
+@interface RDKLink (ApolloVisionOS)
+@property (copy, nonatomic, readonly) NSString *identifier;
+@end
+
+@interface RDKComment (ApolloVisionOS)
+@property (copy, nonatomic, readonly) NSString *identifier;
+@property (copy, nonatomic, readonly) NSString *subreddit;
+@end
+
+// Minimal Texture surface, resolved at runtime (ApolloReborn.dylib is injected,
+// not linked against Apollo).
+@interface ASDisplayNode : NSObject
+- (id)supernode;
+@end
+
+@interface UIView (ApolloVisionOSTexture)
+- (ASDisplayNode *)asyncdisplaykit_node;
+@end
+
+#pragma mark - visionOS gate
+
+static BOOL ApolloIsRunningOnVisionOS(void) {
+    static BOOL result = NO;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+        SEL sel = NSSelectorFromString(@"isiOSAppOnVision");
+        if ([processInfo respondsToSelector:sel]) {
+            BOOL (*msgSend)(id, SEL) = (BOOL (*)(id, SEL))objc_msgSend;
+            if (msgSend(processInfo, sel)) {
+                result = YES;
+                return;
+            }
+        }
+        if (NSClassFromString(@"UIWindowSceneGeometryPreferencesVision") != nil) {
+            result = YES;
+        }
+    });
+    return result;
+}
+
+#pragma mark - Window / scene helpers
+
+static UIWindowScene *ApolloForegroundWindowScene(void) {
+    UIWindowScene *fallback = nil;
+    for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+        if (![scene isKindOfClass:[UIWindowScene class]]) continue;
+        UIWindowScene *windowScene = (UIWindowScene *)scene;
+        if (windowScene.activationState == UISceneActivationStateForegroundActive) {
+            return windowScene;
+        }
+        if (!fallback) fallback = windowScene;
+    }
+    return fallback;
+}
+
+static UIWindow *ApolloKeyWindow(void) {
+    for (UIWindow *window in ApolloAllWindows()) {
+        if (window.isKeyWindow) return window;
+    }
+    return nil;
+}
+
+// Reproduce the current window in a new scene. Apollo's SceneDelegate does not
+// implement -stateRestorationActivityForScene:, so this rides the
+// scene.userActivity fallback (Apollo's own handoff activity); nil activity
+// opens a fresh window.
+static NSUserActivity *ApolloCurrentStateActivity(void) {
+    UIWindowScene *scene = ApolloForegroundWindowScene();
+    if (!scene) return nil;
+    id<UISceneDelegate> delegate = scene.delegate;
+    if ([delegate respondsToSelector:@selector(stateRestorationActivityForScene:)]) {
+        NSUserActivity *activity = [delegate stateRestorationActivityForScene:scene];
+        if (activity) return activity;
+    }
+    return scene.userActivity;
+}
+
+static void ApolloOpenWindow(NSUserActivity *activity) {
+    [[UIApplication sharedApplication] requestSceneSessionActivation:nil
+                                                        userActivity:activity
+                                                             options:nil
+                                                        errorHandler:^(NSError *error) {
+        ApolloLog(@"[VisionOSMultiwindow] scene activation failed: %@", error);
+    }];
+}
+
+#pragma mark - Touch trace
+
+// Gaze-and-pinch input does not report a usable gesture-recogniser state
+// mid-press, so the pressed point is recorded at the source: every synthesized
+// touch funnels through -[UIWindow sendEvent:] regardless of input mechanism.
+static __weak UIWindow *gApolloLastTouchWindow = nil;
+static CGPoint gApolloLastTouchPoint;
+static CFAbsoluteTime gApolloLastTouchTime = 0;
+
+%group ApolloVisionOSTouchTrace
+%hook UIWindow
+- (void)sendEvent:(UIEvent *)event {
+    if (event.type == UIEventTypeTouches) {
+        for (UITouch *touch in event.allTouches) {
+            UITouchPhase phase = touch.phase;
+            if (phase == UITouchPhaseBegan || phase == UITouchPhaseMoved ||
+                phase == UITouchPhaseStationary) {
+                gApolloLastTouchWindow = self;
+                gApolloLastTouchPoint = [touch locationInView:self];
+                gApolloLastTouchTime = CFAbsoluteTimeGetCurrent();
+                break;
+            }
+        }
+    }
+    %orig;
+}
+%end
+%end
+
+#pragma mark - Deep-link resolution
+
+static ASDisplayNode *ApolloNodeOfView(UIView *view) {
+    if (![view respondsToSelector:@selector(asyncdisplaykit_node)]) return nil;
+    return [view asyncdisplaykit_node];
+}
+
+// The RedditKit model stored under ivar `ivarName` on a Swift cell node,
+// provided it is an instance of the named class.
+static id ApolloModelIvar(id node, const char *ivarName, NSString *className) {
+    Ivar ivar = class_getInstanceVariable(object_getClass(node), ivarName);
+    if (!ivar) return nil;
+    id value = object_getIvar(node, ivar);
+    Class modelClass = NSClassFromString(className);
+    return (value && modelClass && [value isKindOfClass:modelClass]) ? value : nil;
+}
+
+static NSString *ApolloID36FromFullName(NSString *fullName) {
+    NSRange underscore = [fullName rangeOfString:@"_"];
+    if (fullName && underscore.location != NSNotFound && underscore.location + 1 < fullName.length) {
+        return [fullName substringFromIndex:underscore.location + 1];
+    }
+    return nil;
+}
+
+static NSString *ApolloNonEmpty(NSString *value) {
+    return ([value isKindOfClass:[NSString class]] && value.length) ? value : nil;
+}
+
+// openinapollo.com deep link. Apollo's handoff opener gates on this host and
+// reads the reddit target from bare-id36 query items (it adds the t3_/t1_
+// prefixes itself), so the link is query-string encoded rather than a reddit
+// path.
+static NSURL *ApolloDeepLinkURL(NSString *subreddit, NSString *postID, NSString *commentID) {
+    if (!postID.length) return nil;
+    NSURLComponents *components = [[NSURLComponents alloc] init];
+    components.scheme = @"https";
+    components.host = @"openinapollo.com";
+    components.path = @"/";
+    NSMutableArray<NSURLQueryItem *> *items = [NSMutableArray array];
+    if (subreddit.length) [items addObject:[NSURLQueryItem queryItemWithName:@"subreddit" value:subreddit]];
+    [items addObject:[NSURLQueryItem queryItemWithName:@"postID" value:postID]];
+    if (commentID.length) [items addObject:[NSURLQueryItem queryItemWithName:@"commentID" value:commentID]];
+    components.queryItems = items;
+    return components.URL;
+}
+
+static NSURL *ApolloDeepLinkForLink(RDKLink *link) {
+    NSString *postID = ApolloNonEmpty(link.identifier) ?: ApolloID36FromFullName(link.fullName);
+    if (!postID) return nil;
+    return ApolloDeepLinkURL(ApolloNonEmpty(link.subreddit), postID, nil);
+}
+
+static NSURL *ApolloDeepLinkForComment(RDKComment *comment) {
+    NSString *postID = ApolloNonEmpty([comment linkIDWithoutTypePrefix]);
+    if (!postID) return nil;
+    return ApolloDeepLinkURL(ApolloNonEmpty(comment.subreddit), postID,
+                             ApolloNonEmpty(comment.identifier));
+}
+
+// Deep link for the post or comment displayed at or above `view`, walking each
+// view's Texture node chain.
+static NSURL *ApolloDeepLinkFromView(UIView *view) {
+    NSUInteger hops = 0;
+    for (UIView *v = view; v && ![v isKindOfClass:[UIWindow class]] && hops < 40;
+         v = v.superview, hops++) {
+        NSUInteger nodeHops = 0;
+        for (ASDisplayNode *n = ApolloNodeOfView(v); n && nodeHops < 40; nodeHops++) {
+            NSString *cls = NSStringFromClass([n class]);
+            if ([cls hasSuffix:@"PostCellNode"]) {
+                RDKLink *link = ApolloModelIvar(n, "link", @"RDKLink");
+                if (link) return ApolloDeepLinkForLink(link);
+            } else if ([cls hasSuffix:@"CommentCellNode"]) {
+                RDKComment *comment = ApolloModelIvar(n, "comment", @"RDKComment");
+                if (comment) return ApolloDeepLinkForComment(comment);
+            }
+            n = [n respondsToSelector:@selector(supernode)] ? [n supernode] : nil;
+        }
+    }
+    return nil;
+}
+
+// The view under a long-press about to show a context menu: it carries a
+// UIContextMenuInteraction and one of its recognisers is mid-recognition. Used
+// as a fallback when no recent touch was traced.
+static UIView *ApolloActiveContextMenuView(void) {
+    for (UIWindow *window in ApolloAllWindows()) {
+        NSMutableArray<UIView *> *stack = [NSMutableArray arrayWithObject:window];
+        while (stack.count) {
+            UIView *view = stack.lastObject;
+            [stack removeLastObject];
+            BOOL hasInteraction = NO;
+            for (id<UIInteraction> interaction in view.interactions) {
+                if ([interaction isKindOfClass:[UIContextMenuInteraction class]]) {
+                    hasInteraction = YES;
+                    break;
+                }
+            }
+            if (hasInteraction) {
+                for (UIGestureRecognizer *recognizer in view.gestureRecognizers) {
+                    BOOL live = recognizer.state == UIGestureRecognizerStateBegan ||
+                                recognizer.state == UIGestureRecognizerStateChanged ||
+                                recognizer.numberOfTouches > 0;
+                    if (!live) continue;
+                    CGPoint point = [recognizer locationInView:view];
+                    UIView *hit = [view hitTest:point withEvent:nil];
+                    return hit ?: view;
+                }
+            }
+            [stack addObjectsFromArray:view.subviews];
+        }
+    }
+    return nil;
+}
+
+// Deep link for whatever is under the active long-press, or nil when it isn't a
+// post/comment. Resolved eagerly at menu-configuration time — by the time a
+// menu action runs the touch is gone. The traced touch point is primary; the
+// interaction walk is the fallback.
+static NSURL *ApolloActiveDeepLink(void) {
+    UIWindow *window = gApolloLastTouchWindow;
+    if (window && CFAbsoluteTimeGetCurrent() - gApolloLastTouchTime < 5.0) {
+        UIView *hit = [window hitTest:gApolloLastTouchPoint withEvent:nil];
+        NSURL *url = ApolloDeepLinkFromView(hit ?: window);
+        if (url) return url;
+    }
+    UIView *view = ApolloActiveContextMenuView();
+    return view ? ApolloDeepLinkFromView(view) : nil;
+}
+
+#pragma mark - New-window delivery
+
+// Hand a URL to a scene through Apollo's handoff entry point. The activity type
+// is the Foundation browsing-web constant, which is the type Apollo's activity
+// handler gates its webpageURL branch on.
+static void ApolloDeliverURLToScene(UIWindowScene *scene, NSURL *url) {
+    id<UISceneDelegate> delegate = scene.delegate;
+    if (![delegate respondsToSelector:@selector(scene:continueUserActivity:)]) return;
+    NSUserActivity *activity =
+        [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
+    activity.webpageURL = url;
+    [delegate scene:scene continueUserActivity:activity];
+}
+
+// Poll for a scene that was not connected before the activation request, then
+// deliver once its UI is up. A scene-activation notification observer proved
+// unreliable; polling connectedScenes cannot miss.
+static void ApolloAwaitNewScene(NSHashTable<UIScene *> *existing, NSURL *url, int attemptsLeft) {
+    if (attemptsLeft <= 0) return;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+            if (![scene isKindOfClass:[UIWindowScene class]] || [existing containsObject:scene]) continue;
+            UIWindowScene *windowScene = (UIWindowScene *)scene;
+            if (windowScene.windows.count == 0) break;   // connected, UI not up yet
+            ApolloDeliverURLToScene(windowScene, url);
+            return;
+        }
+        ApolloAwaitNewScene(existing, url, attemptsLeft - 1);
+    });
+}
+
+// Passing the activity through requestSceneSessionActivation's userActivity:
+// parameter opens the window but drops the payload, so a plain scene is
+// activated and the deep link delivered in-process once the new scene exists.
+static void ApolloOpenDeepLinkInNewWindow(NSURL *url) {
+    if (!url) return;
+    NSHashTable<UIScene *> *existing = [NSHashTable weakObjectsHashTable];
+    for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+        [existing addObject:scene];
+    }
+    ApolloAwaitNewScene(existing, url, 32);
+    ApolloOpenWindow(nil);
+}
+
+#pragma mark - Keyboard shortcuts
+
+%group ApolloVisionOSKeyCommands
+
+%hook UIApplication
+
+- (NSArray<UIKeyCommand *> *)keyCommands {
+    NSArray<UIKeyCommand *> *existing = %orig ?: @[];
+
+    UIKeyCommand *newWindow =
+        [UIKeyCommand keyCommandWithInput:@"n"
+                            modifierFlags:UIKeyModifierCommand
+                                   action:@selector(apolloVisionOSNewWindow:)];
+    newWindow.discoverabilityTitle = @"New Window";
+
+    UIKeyCommand *duplicateWindow =
+        [UIKeyCommand keyCommandWithInput:@"n"
+                            modifierFlags:(UIKeyModifierCommand | UIKeyModifierShift)
+                                   action:@selector(apolloVisionOSDuplicateWindow:)];
+    duplicateWindow.discoverabilityTitle = @"Duplicate Window";
+
+    return [existing arrayByAddingObjectsFromArray:@[newWindow, duplicateWindow]];
+}
+
+%new
+- (void)apolloVisionOSNewWindow:(id)sender {
+    ApolloOpenWindow(nil);
+}
+
+%new
+- (void)apolloVisionOSDuplicateWindow:(id)sender {
+    ApolloOpenWindow(ApolloCurrentStateActivity());
+}
+
+%end
+
+%end
+
+#pragma mark - Context menu entry
+
+// Every context menu is built through this factory, so wrapping the action
+// provider appends the entry wherever Apollo offers a long-press menu. The
+// child-count test skips system menus (text selection and the like). The deep
+// link is resolved HERE, while the long-press touch is still down and the
+// pressed cell is findable. The action defers past the menu's dismissal, since
+// a scene activation requested mid-dismissal is dropped.
+%group ApolloVisionOSContextMenu
+
+%hook UIContextMenuConfiguration
+
++ (instancetype)configurationWithIdentifier:(id<NSCopying>)identifier
+                            previewProvider:(UIContextMenuContentPreviewProvider)previewProvider
+                             actionProvider:(UIContextMenuActionProvider)actionProvider {
+    if (!actionProvider) return %orig;
+
+    NSURL *deepLink = ApolloActiveDeepLink();
+    if (!deepLink) return %orig;
+
+    UIContextMenuActionProvider wrapped = ^UIMenu *(NSArray<UIMenuElement *> *suggestedActions) {
+        UIMenu *menu = actionProvider(suggestedActions);
+        if (![menu isKindOfClass:[UIMenu class]] || menu.children.count < 2) return menu;
+
+        UIAction *openInWindow =
+            [UIAction actionWithTitle:@"Open in New Window"
+                                image:[UIImage systemImageNamed:@"macwindow.badge.plus"]
+                           identifier:@"com.apollo-reborn.visionos.open-in-new-window"
+                              handler:^(__unused __kindof UIAction *action) {
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.45 * NSEC_PER_SEC)),
+                               dispatch_get_main_queue(), ^{
+                    ApolloOpenDeepLinkInNewWindow(deepLink);
+                });
+            }];
+
+        return [menu menuByReplacingChildren:[menu.children arrayByAddingObject:openInWindow]];
+    };
+
+    return %orig(identifier, previewProvider, wrapped);
+}
+
+%end
+
+%end
+
+#pragma mark - Floating button
+
+@interface ApolloVisionOSWindowButtonTarget : NSObject
++ (instancetype)shared;
+- (void)duplicate:(id)sender;
+@end
+
+@implementation ApolloVisionOSWindowButtonTarget
++ (instancetype)shared {
+    static ApolloVisionOSWindowButtonTarget *shared = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ shared = [[ApolloVisionOSWindowButtonTarget alloc] init]; });
+    return shared;
+}
+- (void)duplicate:(__unused id)sender {
+    ApolloOpenWindow(ApolloCurrentStateActivity());
+}
+@end
+
+static UIButton *gApolloWindowButton = nil;
+
+// Bottom-left: the top-right corner is Apollo's own overflow button. Left as a
+// stock UIButton with no hover style of ours — UIKit gives buttons their own
+// automatic gaze treatment.
+static void ApolloPlaceWindowButton(void) {
+    UIWindow *target = ApolloKeyWindow();
+    if (!target) return;
+
+    if (!gApolloWindowButton) {
+        UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+        UIImageSymbolConfiguration *config =
+            [UIImageSymbolConfiguration configurationWithPointSize:17.0
+                                                            weight:UIImageSymbolWeightSemibold];
+        [button setImage:[UIImage systemImageNamed:@"plus.rectangle.on.rectangle"
+                                 withConfiguration:config]
+                forState:UIControlStateNormal];
+        button.tintColor = [UIColor whiteColor];
+        button.backgroundColor = [UIColor colorWithWhite:0.15 alpha:0.85];
+        button.layer.cornerRadius = 22.0;
+        button.accessibilityLabel = @"Duplicate Window";
+        [button addTarget:[ApolloVisionOSWindowButtonTarget shared]
+                   action:@selector(duplicate:)
+         forControlEvents:UIControlEventTouchUpInside];
+        gApolloWindowButton = button;
+    }
+
+    if (gApolloWindowButton.superview != target) [target addSubview:gApolloWindowButton];
+    [target bringSubviewToFront:gApolloWindowButton];
+    gApolloWindowButton.frame =
+        CGRectMake(16.0,
+                   target.bounds.size.height - 44.0 - target.safeAreaInsets.bottom - 16.0,
+                   44.0, 44.0);
+}
+
+// Apollo replaces its window's contents freely, so the button is re-asserted on
+// a slow timer rather than added once.
+static void ApolloStartWindowButton(void) {
+    [[NSNotificationCenter defaultCenter]
+        addObserverForName:UIApplicationDidBecomeActiveNotification
+                    object:nil
+                     queue:[NSOperationQueue mainQueue]
+                usingBlock:^(__unused NSNotification *note) {
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            [NSTimer scheduledTimerWithTimeInterval:1.0 repeats:YES block:^(__unused NSTimer *timer) {
+                ApolloPlaceWindowButton();
+            }];
+        });
+    }];
+}
+
+%ctor {
+    if (!ApolloIsRunningOnVisionOS()) return;
+
+    %init(ApolloVisionOSKeyCommands);
+    %init(ApolloVisionOSTouchTrace);
+    %init(ApolloVisionOSContextMenu);
+    ApolloStartWindowButton();
+
+    ApolloLog(@"[VisionOSMultiwindow] active on visionOS");
+}

--- a/src/ApolloVisionOSMultiwindow.xm
+++ b/src/ApolloVisionOSMultiwindow.xm
@@ -88,19 +88,11 @@ static UIWindowScene *ApolloForegroundWindowScene(void) {
     return fallback;
 }
 
-static UIWindow *ApolloKeyWindow(void) {
-    for (UIWindow *window in ApolloAllWindows()) {
-        if (window.isKeyWindow) return window;
-    }
-    return nil;
-}
-
-// Reproduce the current window in a new scene. Apollo's SceneDelegate does not
+// Reproduce a scene's window in a new scene. Apollo's SceneDelegate does not
 // implement -stateRestorationActivityForScene:, so this rides the
-// scene.userActivity fallback (Apollo's own handoff activity); nil activity
+// scene.userActivity fallback (Apollo's own handoff activity); a nil result
 // opens a fresh window.
-static NSUserActivity *ApolloCurrentStateActivity(void) {
-    UIWindowScene *scene = ApolloForegroundWindowScene();
+static NSUserActivity *ApolloStateActivityForScene(UIWindowScene *scene) {
     if (!scene) return nil;
     id<UISceneDelegate> delegate = scene.delegate;
     if ([delegate respondsToSelector:@selector(stateRestorationActivityForScene:)]) {
@@ -108,6 +100,10 @@ static NSUserActivity *ApolloCurrentStateActivity(void) {
         if (activity) return activity;
     }
     return scene.userActivity;
+}
+
+static NSUserActivity *ApolloCurrentStateActivity(void) {
+    return ApolloStateActivityForScene(ApolloForegroundWindowScene());
 }
 
 static void ApolloOpenWindow(NSUserActivity *activity) {
@@ -420,48 +416,77 @@ static void ApolloOpenDeepLinkInNewWindow(NSURL *url) {
     dispatch_once(&onceToken, ^{ shared = [[ApolloVisionOSWindowButtonTarget alloc] init]; });
     return shared;
 }
-- (void)duplicate:(__unused id)sender {
-    ApolloOpenWindow(ApolloCurrentStateActivity());
+// Duplicates the sender's OWN window, so each window's button reproduces that
+// window rather than whichever scene is foreground.
+- (void)duplicate:(id)sender {
+    UIWindowScene *scene = nil;
+    if ([sender isKindOfClass:[UIView class]]) scene = ((UIView *)sender).window.windowScene;
+    ApolloOpenWindow(ApolloStateActivityForScene(scene ?: ApolloForegroundWindowScene()));
 }
 @end
 
-static UIButton *gApolloWindowButton = nil;
+// One button per window (weak keys, purged with the window), mirroring the
+// per-window hover ghost pools. A single shared button placed on the key window
+// would hop between scenes as focus changed, leaving the unfocused window
+// without one — the case this feature exists for.
+static NSMapTable<UIWindow *, UIButton *> *gApolloWindowButtons = nil;
+
+// The content window of a scene: its first normal-level window with a root view
+// controller (skips keyboard / alert overlay windows).
+static UIWindow *ApolloContentWindow(UIWindowScene *scene) {
+    for (UIWindow *window in scene.windows) {
+        if (window.rootViewController && !window.hidden &&
+            window.windowLevel == UIWindowLevelNormal) {
+            return window;
+        }
+    }
+    return nil;
+}
 
 // Bottom-left: the top-right corner is Apollo's own overflow button. Left as a
 // stock UIButton with no hover style of ours — UIKit gives buttons their own
 // automatic gaze treatment.
-static void ApolloPlaceWindowButton(void) {
-    UIWindow *target = ApolloKeyWindow();
-    if (!target) return;
-
-    if (!gApolloWindowButton) {
-        UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
-        UIImageSymbolConfiguration *config =
-            [UIImageSymbolConfiguration configurationWithPointSize:17.0
-                                                            weight:UIImageSymbolWeightSemibold];
-        [button setImage:[UIImage systemImageNamed:@"plus.rectangle.on.rectangle"
-                                 withConfiguration:config]
-                forState:UIControlStateNormal];
-        button.tintColor = [UIColor whiteColor];
-        button.backgroundColor = [UIColor colorWithWhite:0.15 alpha:0.85];
-        button.layer.cornerRadius = 22.0;
-        button.accessibilityLabel = @"Duplicate Window";
-        [button addTarget:[ApolloVisionOSWindowButtonTarget shared]
-                   action:@selector(duplicate:)
-         forControlEvents:UIControlEventTouchUpInside];
-        gApolloWindowButton = button;
-    }
-
-    if (gApolloWindowButton.superview != target) [target addSubview:gApolloWindowButton];
-    [target bringSubviewToFront:gApolloWindowButton];
-    gApolloWindowButton.frame =
-        CGRectMake(16.0,
-                   target.bounds.size.height - 44.0 - target.safeAreaInsets.bottom - 16.0,
-                   44.0, 44.0);
+static UIButton *ApolloMakeWindowButton(void) {
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+    UIImageSymbolConfiguration *config =
+        [UIImageSymbolConfiguration configurationWithPointSize:17.0
+                                                        weight:UIImageSymbolWeightSemibold];
+    [button setImage:[UIImage systemImageNamed:@"plus.rectangle.on.rectangle"
+                             withConfiguration:config]
+            forState:UIControlStateNormal];
+    button.tintColor = [UIColor whiteColor];
+    button.backgroundColor = [UIColor colorWithWhite:0.15 alpha:0.85];
+    button.layer.cornerRadius = 22.0;
+    button.accessibilityLabel = @"Duplicate Window";
+    [button addTarget:[ApolloVisionOSWindowButtonTarget shared]
+               action:@selector(duplicate:)
+     forControlEvents:UIControlEventTouchUpInside];
+    return button;
 }
 
-// Apollo replaces its window's contents freely, so the button is re-asserted on
-// a slow timer rather than added once.
+// Apollo replaces window contents freely, so the buttons are re-asserted on a
+// slow timer rather than added once.
+static void ApolloPlaceWindowButtons(void) {
+    if (!gApolloWindowButtons) gApolloWindowButtons = [NSMapTable weakToStrongObjectsMapTable];
+    for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+        if (![scene isKindOfClass:[UIWindowScene class]]) continue;
+        UIWindow *target = ApolloContentWindow((UIWindowScene *)scene);
+        if (!target) continue;
+
+        UIButton *button = [gApolloWindowButtons objectForKey:target];
+        if (!button) {
+            button = ApolloMakeWindowButton();
+            [gApolloWindowButtons setObject:button forKey:target];
+        }
+        if (button.superview != target) [target addSubview:button];
+        [target bringSubviewToFront:button];
+        button.frame =
+            CGRectMake(16.0,
+                       target.bounds.size.height - 44.0 - target.safeAreaInsets.bottom - 16.0,
+                       44.0, 44.0);
+    }
+}
+
 static void ApolloStartWindowButton(void) {
     [[NSNotificationCenter defaultCenter]
         addObserverForName:UIApplicationDidBecomeActiveNotification
@@ -471,7 +496,7 @@ static void ApolloStartWindowButton(void) {
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
             [NSTimer scheduledTimerWithTimeInterval:1.0 repeats:YES block:^(__unused NSTimer *timer) {
-                ApolloPlaceWindowButton();
+                ApolloPlaceWindowButtons();
             }];
         });
     }];

--- a/src/ApolloVisionOSMultiwindow.xm
+++ b/src/ApolloVisionOSMultiwindow.xm
@@ -75,17 +75,25 @@ static BOOL ApolloIsRunningOnVisionOS(void) {
 
 #pragma mark - Window / scene helpers
 
+// Multiple windows can stay foreground-active at once on visionOS, and
+// connectedScenes is unordered, so prefer the scene that owns the key window
+// before falling back to any foreground-active scene.
 static UIWindowScene *ApolloForegroundWindowScene(void) {
+    UIWindowScene *foreground = nil;
     UIWindowScene *fallback = nil;
     for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
         if (![scene isKindOfClass:[UIWindowScene class]]) continue;
         UIWindowScene *windowScene = (UIWindowScene *)scene;
-        if (windowScene.activationState == UISceneActivationStateForegroundActive) {
-            return windowScene;
+        for (UIWindow *window in windowScene.windows) {
+            if (window.isKeyWindow) return windowScene;
+        }
+        if (!foreground &&
+            windowScene.activationState == UISceneActivationStateForegroundActive) {
+            foreground = windowScene;
         }
         if (!fallback) fallback = windowScene;
     }
-    return fallback;
+    return foreground ?: fallback;
 }
 
 // Reproduce a scene's window in a new scene. Apollo's SceneDelegate does not


### PR DESCRIPTION
## What

Two visionOS-only quality-of-life features for Apollo running as an iPad-compatibility app on Apple Vision Pro. Both are strict no-ops on iPhone and iPad — each `%ctor` bails unless `-[NSProcessInfo isiOSAppOnVision]` (with a pre-26.1 class-check fallback), the same gate `ApolloVisionOSFix.xm` already uses — so nothing here is toggle-gated; it's simply active where it applies, like the existing visionOS fix.

**`ApolloVisionOSHover.xm` — gaze & pointer hover.** Apollo draws its feed with AsyncDisplayKit (Texture) nodes, which the visionOS gaze compositor can't address (content inside a Texture layer subtree never glows, no matter what the app publishes on its layers), so before this there was no highlight when you looked at a row. Pointer hover (Mac Virtual Display cursor) is covered by attaching `UIHoverStyle` to the cells. Gaze hover is covered by parenting a pooled, hit-test-transparent "ghost" over each on-screen cell — and each nav/toolbar button and Texture-backed comment control (upvote/downvote/save/reply/share, per-comment buttons) — that tracks the target's frame from a display link. A window-direct view over the same region *does* glow, so the row lights up on gaze while pinches pass straight through to the content underneath. Ghost pools are per-window; ghosts are clear at rest (a fill tiled across every row as a faint dark-mode wash); and row ghosts are clipped below the floating Liquid Glass top bars so the bars' native glow wins where a scrolled row slides under them. Tab-bar buttons are left to their native glow.

**`ApolloVisionOSMultiwindow.xm` — multiwindow.** Apollo already declares `UIApplicationSupportsMultipleScenes` but offers no way to open a second window on visionOS. This adds Cmd-N (new window), Cmd-Shift-N (duplicate), a bottom-left floating button (the Vision Pro is usually driven without a keyboard), and **Open in New Window** on a post/comment long-press so a thread opens in its own window beside the feed. The new window is deep-linked in-process: a plain scene is activated, then handed a browsing-web `NSUserActivity` through its scene delegate's `-scene:continueUserActivity:` carrying an `openinapollo.com` query URL (`?subreddit=…&postID=…&commentID=…`) — the form Apollo's own handoff opener accepts. The pressed post/comment is identified from the cell's Texture node's `RDKLink`/`RDKComment`, located via the last touch point (gaze-and-pinch input gives no usable gesture state mid-press, so the point is traced from `-[UIWindow sendEvent:]`).

## Notes

- Reuses `ApolloCommon` (`ApolloAllWindows`, `ApolloLog`) and `Tweak.h` (`RDKLink`/`RDKComment`); Texture/RedditKit surfaces beyond those are declared minimally and resolved at runtime, matching the codebase's injected-not-linked pattern.
- Registered in `Makefile`; `CHANGELOG.md` updated under Unreleased → Features.
- Device-tested on Apple Vision Pro (feed/comments hover, both windows, Open-in-New-Window on posts and comments). Compiles clean under the project's flags.
- Two experiments were tried and dropped as impossible in compatibility mode (recorded here so they aren't re-attempted): programmatic window geometry/orientation is refused by the windowing mode, and `+[AVPictureInPictureController isPictureInPictureSupported]` returns NO on visionOS compat.

The context-menu entry is added by wrapping `+[UIContextMenuConfiguration configurationWithIdentifier:previewProvider:actionProvider:]` so it needs no knowledge of Apollo's menu code; happy to route it through the native action-menu builder instead if that's preferred.
