### PR TITLE
Fix release blockers and harden launch-time paths

### DIFF
--- a/src/ApolloAccountCredentials.h
+++ b/src/ApolloAccountCredentials.h
@@ -74,6 +74,11 @@ NSString *ApolloEffectiveRedirectURI(void);
 // ([[RDKClient sharedClient] currentUser].username), or nil if none/unavailable.
 NSString * _Nullable ApolloActiveAccountUsername(void);
 
+// Invalidate the cached active username after either side of Apollo's persisted
+// account selection changes. Tweak.xm calls this from narrowly-scoped
+// NSUserDefaults write hooks for RedditAccounts2 / CurrentRedditAccountIndex.
+void ApolloInvalidateActiveAccountUsernameCache(void);
+
 // The live RDKClient selected by Apollo's AccountManager, or nil when there is
 // no signed-in account. Do not use RDKClient.sharedClient for account mutations:
 // that singleton is Apollo's application-only/bootstrap client and normally has

--- a/src/ApolloAccountCredentials.m
+++ b/src/ApolloAccountCredentials.m
@@ -125,6 +125,47 @@ NSString *ApolloSecretForClientId(NSString *clientId) {
 // the primary (only) mechanism since the live signal can't be trusted at all.
 static NSString *const kApolloAccountCredsGroupSuite = @"group.com.christianselig.apollo";
 
+// Unarchiving RedditAccounts2 reconstructs every persisted RDKClient, including
+// its AFHTTPSessionManager/CFNetwork graph. That is far too expensive for a
+// username helper used from poll cells, headers, caches, chat, and request
+// routing. Keep one resolved value until either the archive or selected index is
+// written. A generation protects publication when a write lands while a decode
+// is in progress; the writer wins and the stale decode is never cached.
+static os_unfair_lock sApolloActiveUsernameCacheLock = OS_UNFAIR_LOCK_INIT;
+static NSString *sApolloActiveUsernameCache = nil;
+static BOOL sApolloActiveUsernameCacheValid = NO;
+static uint64_t sApolloActiveUsernameCacheGeneration = 1;
+
+void ApolloInvalidateActiveAccountUsernameCache(void) {
+    os_unfair_lock_lock(&sApolloActiveUsernameCacheLock);
+    sApolloActiveUsernameCache = nil;
+    sApolloActiveUsernameCacheValid = NO;
+    sApolloActiveUsernameCacheGeneration++;
+    os_unfair_lock_unlock(&sApolloActiveUsernameCacheLock);
+}
+
+static BOOL ApolloReadActiveUsernameCache(NSString **outUsername, uint64_t *outGeneration) {
+    os_unfair_lock_lock(&sApolloActiveUsernameCacheLock);
+    BOOL valid = sApolloActiveUsernameCacheValid;
+    NSString *username = sApolloActiveUsernameCache;
+    uint64_t generation = sApolloActiveUsernameCacheGeneration;
+    os_unfair_lock_unlock(&sApolloActiveUsernameCacheLock);
+    if (outUsername) *outUsername = username;
+    if (outGeneration) *outGeneration = generation;
+    return valid;
+}
+
+static BOOL ApolloPublishActiveUsernameCache(NSString *username, uint64_t generation) {
+    os_unfair_lock_lock(&sApolloActiveUsernameCacheLock);
+    BOOL current = generation == sApolloActiveUsernameCacheGeneration;
+    if (current) {
+        sApolloActiveUsernameCache = [username copy];
+        sApolloActiveUsernameCacheValid = YES; // nil is a valid cached result
+    }
+    os_unfair_lock_unlock(&sApolloActiveUsernameCacheLock);
+    return current;
+}
+
 // Apollo.AccountManager does not expose its Swift `accounts` array or
 // `currentAccountIndex` through ObjC. The live manager still registers both
 // fields as ivars, though, and this Apollo build uses the standard native Swift
@@ -221,36 +262,60 @@ static BOOL ApolloLogIfUsernameResultChanged(NSString *newResult) {
 }
 
 NSString *ApolloActiveAccountUsername(void) {
+    NSString *cached = nil;
+    uint64_t generation = 0;
+    if (ApolloReadActiveUsernameCache(&cached, &generation)) return cached;
+
     NSUserDefaults *group = [[NSUserDefaults alloc] initWithSuiteName:kApolloAccountCredsGroupSuite];
     id accounts = ApolloAccountCredsUnarchive([group objectForKey:@"RedditAccounts2"]);
     if (![accounts isKindOfClass:[NSArray class]]) {
         if (ApolloLogIfUsernameResultChanged(nil))
             ApolloLog(@"[AccountCredentials] ApolloActiveAccountUsername: no RedditAccounts2 array");
-        return nil;
+        return ApolloPublishActiveUsernameCache(nil, generation)
+            ? nil
+            : ApolloActiveAccountUsername();
     }
     NSInteger index = [group integerForKey:@"CurrentRedditAccountIndex"];
     if (index < 0 || (NSUInteger)index >= [(NSArray *)accounts count]) {
         NSString *msg = [NSString stringWithFormat:@"index %ld out of range (count %lu)", (long)index, (unsigned long)[(NSArray *)accounts count]];
         if (ApolloLogIfUsernameResultChanged(msg))
             ApolloLog(@"[AccountCredentials] ApolloActiveAccountUsername: %@", msg);
-        return nil;
+        return ApolloPublishActiveUsernameCache(nil, generation)
+            ? nil
+            : ApolloActiveAccountUsername();
     }
     id client = ((NSArray *)accounts)[(NSUInteger)index];
     id user = nil;
     @try { user = [client valueForKey:@"currentUser"]; }
-    @catch (__unused NSException *e) { return nil; }
+    @catch (__unused NSException *e) {
+        return ApolloPublishActiveUsernameCache(nil, generation)
+            ? nil
+            : ApolloActiveAccountUsername();
+    }
     if (!user) {
         if (ApolloLogIfUsernameResultChanged(@"currentUser nil"))
             ApolloLog(@"[AccountCredentials] ApolloActiveAccountUsername: currentUser nil at index %ld", (long)index);
-        return nil;
+        return ApolloPublishActiveUsernameCache(nil, generation)
+            ? nil
+            : ApolloActiveAccountUsername();
     }
     NSString *username = nil;
     @try { username = [user valueForKey:@"username"]; }
-    @catch (__unused NSException *e) { return nil; }
+    @catch (__unused NSException *e) {
+        return ApolloPublishActiveUsernameCache(nil, generation)
+            ? nil
+            : ApolloActiveAccountUsername();
+    }
     BOOL valid = [username isKindOfClass:[NSString class]] && username.length > 0;
     if (valid && ApolloLogIfUsernameResultChanged(username))
         ApolloLog(@"[AccountCredentials] ApolloActiveAccountUsername: resolved u/%@ (index %ld)", username, (long)index);
-    return valid ? username : nil;
+    NSString *result = valid ? username : nil;
+    // If an account write raced this decode, do not publish or return the stale
+    // identity. Resolve once more against the new generation instead.
+    if (!ApolloPublishActiveUsernameCache(result, generation)) {
+        return ApolloActiveAccountUsername();
+    }
+    return result;
 }
 
 NSString *ApolloEffectiveRedditClientId(void) {
@@ -277,8 +342,8 @@ NSString *ApolloEffectiveRedirectURI(void) {
 // (the RDKClient user-install hooks in ApolloUserAvatars.xm) fires far more
 // often than "a sign-in just completed": -setCurrentUser: is invoked by
 // NSKeyedUnarchiver's KVC decode of RedditAccounts2 — which
-// ApolloActiveAccountUsername() above performs on every call, including for
-// the sign-in's own token-exchange request — and
+// ApolloActiveAccountUsername() performs whenever its invalidated cache must
+// be rebuilt, including during the sign-in's own archive/index writes — and
 // -updateCurrentUserWithNewUser: fires for every background identity refresh
 // of every stored account. A naive "first install after arming consumes"
 // design therefore spends the flag on whatever stored account decodes first

--- a/src/ApolloDeletedCommentsMenu.xm
+++ b/src/ApolloDeletedCommentsMenu.xm
@@ -462,12 +462,20 @@ static void ApolloDCMenuCaptureLegacyRowStyle(UITableViewCell *cell) {
     }
 
     BOOL effective = NO;
-    if (!ApolloDCMenuResolveState(self, NULL, NULL, &effective)) return nil;
+    BOOL hasOwner = ApolloDCMenuResolveState(self, NULL, NULL, &effective);
     ApolloDeletedCommentsMenuRowCell *cell =
         [[ApolloDeletedCommentsMenuRowCell alloc]
             initWithStyle:UITableViewCellStyleDefault
           reuseIdentifier:@"ApolloDeletedCommentsMenuRow"];
     [cell configureEffective:effective];
+    // UITableView requires a non-nil cell for every row previously reported by
+    // the data source. The presenting comments controller should stay alive for
+    // the sheet's lifetime, but if UIKit asks during teardown after that weak
+    // owner disappears, return an inert row rather than violating the contract.
+    if (!hasOwner) {
+        cell.userInteractionEnabled = NO;
+        cell.selectionStyle = UITableViewCellSelectionStyleNone;
+    }
     return cell;
 }
 

--- a/src/ApolloDeletedCommentsMenu.xm
+++ b/src/ApolloDeletedCommentsMenu.xm
@@ -1,9 +1,9 @@
 // Deleted-comments shortcut in the comments "..." menu + passive per-thread mode.
 //
 // Adds a "Show Deleted Comments" / "Hide Deleted Comments" item to the comments
-// view's overflow menu (the native Liquid Glass UIMenu built by
-// ApolloNativeActionMenus.xm, which calls ApolloInjectDeletedCommentsMenuItemIfNeeded()
-// while it assembles the children — same pattern as the Public Sticky item).
+// view's overflow menu. Liquid Glass uses the native UIMenu assembled by
+// ApolloNativeActionMenus.xm; Standard/pre-Liquid-Glass builds append an
+// equivalent row to Apollo's legacy ActionController table.
 //
 // Two behaviors, decided by the "Passive Deleted Comments" setting:
 //   - Passive OFF: the item is a plain shortcut for the global Show Deleted
@@ -24,7 +24,11 @@
 #import "ApolloCommon.h"
 #import "ApolloState.h"
 #import "ApolloDeletedCommentsData.h"
+#import "ApolloThemeRuntime.h"
 #import "UserDefaultConstants.h"
+
+static NSString *const kApolloDCMenuShowTitle = @"Show Deleted Comments";
+static NSString *const kApolloDCMenuHideTitle = @"Hide Deleted Comments";
 
 // The comments VC currently presenting its "..." menu. Armed in the tap hook
 // below; menu construction happens synchronously inside that tap (see
@@ -40,6 +44,8 @@ static CFAbsoluteTime sApolloDCMenuArmedAt = 0;
 // hash table holding the owning CommentsViewController (a plain weak assoc
 // isn't possible with objc_setAssociatedObject).
 static char kApolloDCMenuOwnerVCKey;
+// Row count before our appended legacy ActionController row.
+static char kApolloDCMenuOrigRowCountKey;
 
 // linkFullName key -> weak set of CommentsViewController instances currently
 // showing that post's thread. Main-thread only. When the last live VC for an
@@ -61,6 +67,29 @@ static id ApolloDCMenuIvarObject(id object, const char *name) {
         if (ivar) return object_getIvar(object, ivar);
     }
     return nil;
+}
+
+// Resolve and permanently tag the ActionController presenting the armed
+// comments menu. Both the Liquid Glass UIMenu builder and the legacy table
+// sheet use this same one-shot claim, whichever asks first.
+static id ApolloDCMenuOwnerForController(id actionController) {
+    if (!actionController) return nil;
+    NSHashTable *holder = objc_getAssociatedObject(actionController, &kApolloDCMenuOwnerVCKey);
+    if (holder) return holder.anyObject;
+
+    id vc = sApolloDCMenuArmedVC;
+    if (!vc) return nil;
+    if (CFAbsoluteTimeGetCurrent() - sApolloDCMenuArmedAt > 1.5) {
+        sApolloDCMenuArmedVC = nil;
+        return nil;
+    }
+
+    holder = [NSHashTable weakObjectsHashTable];
+    [holder addObject:vc];
+    objc_setAssociatedObject(actionController, &kApolloDCMenuOwnerVCKey,
+                             holder, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    sApolloDCMenuArmedVC = nil;
+    return vc;
 }
 
 // Post fullName (t3_xxx, lowercased) for a CommentsViewController, from its
@@ -194,19 +223,8 @@ void ApolloInjectDeletedCommentsMenuItemIfNeeded(NSMutableArray *children, NSStr
     // once per presentation) reuse the tag; otherwise the FIRST menu built
     // while armed claims the armed VC and consumes the arm, so a different
     // menu opened within the grace window can never pick up the item.
-    NSHashTable *ownerHolder = actionController ? objc_getAssociatedObject(actionController, &kApolloDCMenuOwnerVCKey) : nil;
-    id vc = ownerHolder.anyObject;
-    if (!vc) {
-        vc = sApolloDCMenuArmedVC;
-        if (!vc) return;
-        if (CFAbsoluteTimeGetCurrent() - sApolloDCMenuArmedAt > 1.5) return;
-        if (actionController) {
-            NSHashTable *holder = [NSHashTable weakObjectsHashTable];
-            [holder addObject:vc];
-            objc_setAssociatedObject(actionController, &kApolloDCMenuOwnerVCKey, holder, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        }
-        sApolloDCMenuArmedVC = nil;
-    }
+    id vc = ApolloDCMenuOwnerForController(actionController);
+    if (!vc) return;
 
     NSString *linkKey = ApolloDCMenuLinkKeyForVC(vc);
     BOOL passive = sPassiveDeletedComments && !sShowDeletedComments;
@@ -214,7 +232,7 @@ void ApolloInjectDeletedCommentsMenuItemIfNeeded(NSMutableArray *children, NSStr
     if (passive && linkKey.length == 0) return;
 
     BOOL effective = sShowDeletedComments || (linkKey.length > 0 && ApolloDeletedCommentsHasThreadOverride(linkKey));
-    NSString *title = effective ? @"Hide Deleted Comments" : @"Show Deleted Comments";
+    NSString *title = effective ? kApolloDCMenuHideTitle : kApolloDCMenuShowTitle;
     UIImage *image = [UIImage systemImageNamed:(effective ? @"eye.slash" : @"eye")];
 
     __weak id weakVC = vc;
@@ -265,6 +283,234 @@ void ApolloInjectDeletedCommentsMenuItemIfNeeded(NSMutableArray *children, NSStr
     NSString *linkKey = ApolloDCMenuLinkKeyForVC(self);
     if (linkKey.length == 0 || !ApolloDeletedCommentsHasThreadOverride(linkKey)) return;
     ApolloDCMenuUntrackVCAndMaybeClear(linkKey, self);
+}
+
+%end
+
+#pragma mark - Legacy ActionController row (Standard / pre-Liquid-Glass)
+
+// Apollo's non-Liquid-Glass overflow menu is an ActionController-backed table
+// sheet. Keep every native row at its original index and append ours: Apollo's
+// own cell builder dequeues with the supplied index path and will assert if
+// native rows are shifted.
+static NSInteger ApolloDCMenuOriginalRowCount(id actionController) {
+    NSNumber *stored = objc_getAssociatedObject(actionController, &kApolloDCMenuOrigRowCountKey);
+    return stored ? stored.integerValue : -1;
+}
+
+static BOOL ApolloDCMenuResolveState(id actionController, id *outVC,
+                                     NSString **outLinkKey, BOOL *outEffective) {
+    id vc = ApolloDCMenuOwnerForController(actionController);
+    if (!vc) return NO;
+    NSString *linkKey = ApolloDCMenuLinkKeyForVC(vc);
+    BOOL passive = sPassiveDeletedComments && !sShowDeletedComments;
+    if (passive && linkKey.length == 0) return NO;
+    BOOL effective = sShowDeletedComments ||
+        (linkKey.length > 0 && ApolloDeletedCommentsHasThreadOverride(linkKey));
+    if (outVC) *outVC = vc;
+    if (outLinkKey) *outLinkKey = linkKey;
+    if (outEffective) *outEffective = effective;
+    return YES;
+}
+
+static BOOL ApolloDCMenuIsLegacyRow(id actionController, NSIndexPath *indexPath) {
+    NSInteger originalCount = ApolloDCMenuOriginalRowCount(actionController);
+    return originalCount >= 0 && indexPath.section == 0 && indexPath.row == originalCount;
+}
+
+static CGFloat ApolloDCMenuLegacyRowHeight(id actionController) {
+    id tableView = ApolloDCMenuIvarObject(actionController, "tableView");
+    if (![tableView isKindOfClass:[UITableView class]] ||
+        ![actionController respondsToSelector:@selector(tableView:heightForRowAtIndexPath:)]) {
+        return 0.0;
+    }
+    @try {
+        return [(id<UITableViewDelegate>)actionController
+                    tableView:(UITableView *)tableView
+                    heightForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
+    } @catch (__unused NSException *exception) {
+        return 0.0;
+    }
+}
+
+// Apollo's sheet rows use custom labels/icons rather than UITableViewCell's
+// stock textLabel geometry. Capture row 0 and mirror its presentation so the
+// appended row remains readable under stock and custom themes.
+static UIView *ApolloDCMenuFirstSubviewOfClass(UIView *root, Class cls, BOOL requireText) {
+    for (UIView *subview in root.subviews) {
+        if ([subview isKindOfClass:cls]) {
+            if (!requireText) return subview;
+            if ([subview isKindOfClass:[UILabel class]] &&
+                ((UILabel *)subview).text.length > 0) {
+                return subview;
+            }
+        }
+        UIView *nested = ApolloDCMenuFirstSubviewOfClass(subview, cls, requireText);
+        if (nested) return nested;
+    }
+    return nil;
+}
+
+static UIColor *sApolloDCMenuTitleColor = nil;
+static UIFont *sApolloDCMenuTitleFont = nil;
+static NSTextAlignment sApolloDCMenuTitleAlignment = NSTextAlignmentLeft;
+static CGRect sApolloDCMenuTitleFrame = CGRectZero;
+static CGRect sApolloDCMenuIconFrame = CGRectZero;
+static UIColor *sApolloDCMenuIconTint = nil;
+
+static void ApolloDCMenuCaptureLegacyRowStyle(UITableViewCell *cell) {
+    if (![cell isKindOfClass:[UITableViewCell class]]) return;
+    [cell layoutIfNeeded];
+    UILabel *label =
+        (UILabel *)ApolloDCMenuFirstSubviewOfClass(cell, [UILabel class], YES);
+    if (!label) return;
+    sApolloDCMenuTitleColor = label.textColor;
+    sApolloDCMenuTitleFont = label.font;
+    sApolloDCMenuTitleAlignment = label.textAlignment;
+    sApolloDCMenuTitleFrame = [label convertRect:label.bounds toView:cell];
+
+    UIImageView *icon =
+        (UIImageView *)ApolloDCMenuFirstSubviewOfClass(cell, [UIImageView class], NO);
+    if (icon.bounds.size.width > 1.0) {
+        sApolloDCMenuIconFrame = [icon convertRect:icon.bounds toView:cell];
+        sApolloDCMenuIconTint = icon.tintColor;
+    }
+}
+
+@interface ApolloDeletedCommentsMenuRowCell : UITableViewCell
+@property (nonatomic, strong) UILabel *apolloTitleLabel;
+@property (nonatomic, strong) UIImageView *apolloIconView;
+- (void)configureEffective:(BOOL)effective;
+@end
+
+@implementation ApolloDeletedCommentsMenuRowCell
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        self.backgroundColor = UIColor.clearColor;
+        self.contentView.backgroundColor = UIColor.clearColor;
+        UIColor *accent =
+            sApolloDCMenuTitleColor ?: ApolloThemeAccentColor() ?: UIColor.labelColor;
+
+        _apolloIconView = [[UIImageView alloc] initWithFrame:CGRectZero];
+        _apolloIconView.contentMode = UIViewContentModeScaleAspectFit;
+        _apolloIconView.tintColor = sApolloDCMenuIconTint ?: accent;
+        [self.contentView addSubview:_apolloIconView];
+
+        _apolloTitleLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+        _apolloTitleLabel.textColor = accent;
+        _apolloTitleLabel.font = sApolloDCMenuTitleFont ?: [UIFont systemFontOfSize:17.0];
+        _apolloTitleLabel.textAlignment = sApolloDCMenuTitleAlignment;
+        [self.contentView addSubview:_apolloTitleLabel];
+    }
+    return self;
+}
+
+- (void)configureEffective:(BOOL)effective {
+    self.apolloTitleLabel.text =
+        effective ? kApolloDCMenuHideTitle : kApolloDCMenuShowTitle;
+    self.apolloIconView.image =
+        [UIImage systemImageNamed:(effective ? @"eye.slash" : @"eye")];
+    self.accessibilityLabel = self.apolloTitleLabel.text;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    CGRect bounds = self.contentView.bounds;
+    if (!CGRectIsEmpty(sApolloDCMenuIconFrame)) {
+        CGRect iconFrame = sApolloDCMenuIconFrame;
+        iconFrame.origin.y = (bounds.size.height - iconFrame.size.height) / 2.0;
+        self.apolloIconView.frame = iconFrame;
+        self.apolloIconView.hidden = NO;
+    } else {
+        self.apolloIconView.hidden = YES;
+    }
+
+    CGFloat left = CGRectIsEmpty(sApolloDCMenuTitleFrame)
+        ? 16.0
+        : CGRectGetMinX(sApolloDCMenuTitleFrame);
+    CGFloat height = CGRectIsEmpty(sApolloDCMenuTitleFrame)
+        ? 22.0
+        : CGRectGetHeight(sApolloDCMenuTitleFrame);
+    self.apolloTitleLabel.frame =
+        CGRectMake(left, (bounds.size.height - height) / 2.0,
+                   MAX(0.0, bounds.size.width - left - 16.0), height);
+}
+
+@end
+
+%hook _TtC6Apollo16ActionController
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    NSInteger count = %orig;
+    if (section != 0 || !ApolloDCMenuResolveState(self, NULL, NULL, NULL)) return count;
+    objc_setAssociatedObject(self, &kApolloDCMenuOrigRowCountKey,
+                             @(count), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return count + 1;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (!ApolloDCMenuIsLegacyRow(self, indexPath)) {
+        UITableViewCell *cell = %orig;
+        if (ApolloDCMenuOriginalRowCount(self) >= 0 &&
+            indexPath.section == 0 && indexPath.row == 0) {
+            ApolloDCMenuCaptureLegacyRowStyle(cell);
+        }
+        return cell;
+    }
+
+    BOOL effective = NO;
+    if (!ApolloDCMenuResolveState(self, NULL, NULL, &effective)) return nil;
+    ApolloDeletedCommentsMenuRowCell *cell =
+        [[ApolloDeletedCommentsMenuRowCell alloc]
+            initWithStyle:UITableViewCellStyleDefault
+          reuseIdentifier:@"ApolloDeletedCommentsMenuRow"];
+    [cell configureEffective:effective];
+    return cell;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView
+ heightForRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (!ApolloDCMenuIsLegacyRow(self, indexPath)) return %orig;
+    return %orig(tableView, [NSIndexPath indexPathForRow:0 inSection:indexPath.section]);
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (!ApolloDCMenuIsLegacyRow(self, indexPath)) {
+        %orig;
+        return;
+    }
+
+    id vc = nil;
+    NSString *linkKey = nil;
+    BOOL effective = NO;
+    if (!ApolloDCMenuResolveState(self, &vc, &linkKey, &effective)) return;
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    [(UIViewController *)self dismissViewControllerAnimated:YES completion:^{
+        ApolloDCMenuHandleToggle(vc, linkKey, effective);
+    }];
+}
+
+%end
+
+// Apollo sizes the sheet from its original data-source row count. Grow only
+// the presentation frame so the appended row is reachable above Cancel.
+%hook _TtC6Apollo38ActionControllerPresentationController
+
+- (CGRect)frameOfPresentedViewInContainerView {
+    CGRect frame = %orig;
+    UIViewController *presented =
+        [(UIPresentationController *)self presentedViewController];
+    if (frame.size.height <= 0.0 || ApolloDCMenuOriginalRowCount(presented) < 0) {
+        return frame;
+    }
+    CGFloat rowHeight = ApolloDCMenuLegacyRowHeight(presented);
+    if (rowHeight <= 0.0) return frame;
+    frame.origin.y -= rowHeight;
+    frame.size.height += rowHeight;
+    return frame;
 }
 
 %end

--- a/src/ApolloFoundationModels.swift
+++ b/src/ApolloFoundationModels.swift
@@ -50,6 +50,26 @@ public final class ApolloFoundationModels: NSObject {
     private var preparedSessions: [String: Any] = [:]
     private var preparedInstructions: [String: String] = [:]
     private var activeTasks: [String: Task<Void, Never>] = [:]
+    // A cancelled task can finish after its replacement has already been
+    // stored. Cleanup must remove the registry entry only when the finishing
+    // task still owns it; otherwise the old task makes the replacement
+    // unreachable to later cancellation. Monotonic generations provide that
+    // ownership check without comparing opaque Task values.
+    private var activeTaskGenerations: [String: UInt64] = [:]
+    private var nextTaskGeneration: UInt64 = 0
+
+    private func beginTaskGeneration(_ identifier: String) -> UInt64 {
+        nextTaskGeneration &+= 1
+        let generation = nextTaskGeneration
+        activeTaskGenerations[identifier] = generation
+        return generation
+    }
+
+    private func finishTask(_ identifier: String, generation: UInt64) {
+        guard activeTaskGenerations[identifier] == generation else { return }
+        activeTasks.removeValue(forKey: identifier)
+        activeTaskGenerations.removeValue(forKey: identifier)
+    }
 
     /// The on-device model used for every summary. We deliberately do NOT use
     /// `SystemLanguageModel.default`: its default safety guardrail frequently
@@ -141,6 +161,7 @@ public final class ApolloFoundationModels: NSObject {
     @objc public func cancelRequest(_ identifier: String) {
         preparedSessions.removeValue(forKey: identifier)
         preparedInstructions.removeValue(forKey: identifier)
+        activeTaskGenerations.removeValue(forKey: identifier)
         activeTasks.removeValue(forKey: identifier)?.cancel()
     }
 
@@ -171,6 +192,8 @@ public final class ApolloFoundationModels: NSObject {
         // Run the async generation on the main actor: the framework does the
         // heavy work on its own executor and only resumes here to deliver
         // snapshots, so the callbacks land on the main thread for free.
+        activeTasks[identifier]?.cancel()
+        let generation = beginTaskGeneration(identifier)
         let task = Task { @MainActor in
             // A fresh, permissive-guardrail session built from `instructions`.
             // Used when no prepared session was staged, and for the single
@@ -234,9 +257,8 @@ public final class ApolloFoundationModels: NSObject {
                     onComplete(nil, Self.classify(error))
                 }
             }
-            activeTasks.removeValue(forKey: identifier)
+            finishTask(identifier, generation: generation)
         }
-        activeTasks[identifier]?.cancel()
         activeTasks[identifier] = task
         #else
         onComplete(nil, Self.makeError(code: 4, message: "FoundationModels not available in this build"))
@@ -278,6 +300,8 @@ public final class ApolloFoundationModels: NSObject {
         // (empty-string instructions sentinel — never an instructed one).
         let prepared = preparedSessions.removeValue(forKey: identifier) as? LanguageModelSession
         let preparedIsPlain = preparedInstructions.removeValue(forKey: identifier) == ""
+        activeTasks[identifier]?.cancel()
+        let generation = beginTaskGeneration(identifier)
         let task = Task { @MainActor in
             do {
                 if Task.isCancelled { throw CancellationError() }
@@ -298,9 +322,8 @@ public final class ApolloFoundationModels: NSObject {
                     onComplete(nil, Self.classify(error))
                 }
             }
-            activeTasks.removeValue(forKey: identifier)
+            finishTask(identifier, generation: generation)
         }
-        activeTasks[identifier]?.cancel()
         activeTasks[identifier] = task
         #else
         onComplete(nil, Self.makeError(code: 4, message: "FoundationModels not available in this build"))

--- a/src/ApolloFoundationModels.swift
+++ b/src/ApolloFoundationModels.swift
@@ -233,7 +233,12 @@ public final class ApolloFoundationModels: NSObject {
                             let elapsed = ContinuousClock.now - startedAt
                             aiLog.debug("first text \(identifier, privacy: .public) after \(String(describing: elapsed), privacy: .public)")
                         }
-                        onPartial(latest)
+                        // A replaced task can yield one last buffered snapshot
+                        // after cancellation. Never let that stale generation
+                        // overwrite the replacement's UI.
+                        if activeTaskGenerations[identifier] == generation {
+                            onPartial(latest)
+                        }
                     }
                     if !latest.isEmpty || Task.isCancelled { break }
                 }
@@ -246,14 +251,24 @@ public final class ApolloFoundationModels: NSObject {
                 // marks the post failed/suppressed (and won't regenerate on reopen,
                 // since `onComplete` lands after `viewDidDisappear` clears the set).
                 if Task.isCancelled { throw CancellationError() }
-                aiLog.debug("completed \(identifier, privacy: .public) after \(String(describing: ContinuousClock.now - startedAt), privacy: .public)")
-                onComplete(latest, nil)
+                if activeTaskGenerations[identifier] == generation {
+                    aiLog.debug("completed \(identifier, privacy: .public) after \(String(describing: ContinuousClock.now - startedAt), privacy: .public)")
+                    onComplete(latest, nil)
+                }
             } catch {
-                preparedSessions.removeValue(forKey: identifier)
-                preparedInstructions.removeValue(forKey: identifier)
-                if Task.isCancelled {
+                let currentGeneration = activeTaskGenerations[identifier]
+                let stillOwnsIdentifier = currentGeneration == generation
+                let wasReplaced = currentGeneration != nil && !stillOwnsIdentifier
+                // A predecessor must not discard a prepared session staged by
+                // its replacement. Explicit cancelRequest already clears these
+                // dictionaries synchronously, so cleanup is owner-only.
+                if stillOwnsIdentifier {
+                    preparedSessions.removeValue(forKey: identifier)
+                    preparedInstructions.removeValue(forKey: identifier)
+                }
+                if Task.isCancelled && !wasReplaced {
                     onComplete(nil, Self.makeError(code: 6, message: "Generation cancelled"))
-                } else {
+                } else if stillOwnsIdentifier {
                     onComplete(nil, Self.classify(error))
                 }
             }
@@ -313,12 +328,19 @@ public final class ApolloFoundationModels: NSObject {
                 let response = try await session.respond(to: prompt, options: options)
                 aiLog.debug("plain completion RESPONSE \(identifier, privacy: .public) after \(String(describing: ContinuousClock.now - startedAt), privacy: .public): \(response.content, privacy: .public)")
                 if Task.isCancelled { throw CancellationError() }
-                onComplete(response.content, nil)
+                if activeTaskGenerations[identifier] == generation {
+                    onComplete(response.content, nil)
+                }
             } catch {
-                aiLog.debug("plain completion ERROR \(identifier, privacy: .public): \(String(describing: error), privacy: .public)")
-                if Task.isCancelled {
+                let currentGeneration = activeTaskGenerations[identifier]
+                let stillOwnsIdentifier = currentGeneration == generation
+                let wasReplaced = currentGeneration != nil && !stillOwnsIdentifier
+                if !wasReplaced {
+                    aiLog.debug("plain completion ERROR \(identifier, privacy: .public): \(String(describing: error), privacy: .public)")
+                }
+                if Task.isCancelled && !wasReplaced {
                     onComplete(nil, Self.makeError(code: 6, message: "Generation cancelled"))
-                } else {
+                } else if stillOwnsIdentifier {
                     onComplete(nil, Self.classify(error))
                 }
             }

--- a/src/ApolloOwnCommentFlair.xm
+++ b/src/ApolloOwnCommentFlair.xm
@@ -75,9 +75,9 @@ static char kApolloOwnFlairSynthesizedKey;
 
 #pragma mark - Active account identity (cheap)
 
-// ApolloActiveAccountUsername() unarchives RedditAccounts2 on every call, which
-// is far too heavy for a funnel that fires for every model in every listing.
-// RDKClient holds the same identity in memory; memoize it briefly on top of that.
+// Prefer RDKClient's live identity in this especially hot per-model funnel.
+// ApolloActiveAccountUsername() is now cached too, but a live hit avoids even
+// its defaults/cache bookkeeping and keeps this path independent of disk state.
 static NSString *ApolloOwnFlairActiveUsername(void) {
     static NSString *cached = nil;
     static NSTimeInterval cachedAt = 0;

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -941,16 +941,41 @@ static dispatch_queue_t ApolloAccountSnapshotQueue(void) {
     static dispatch_queue_t queue;
     static dispatch_once_t once;
     dispatch_once(&once, ^{
-        queue = dispatch_queue_create("com.apolloreborn.account-snapshots",
-                                      DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
-        dispatch_set_target_queue(queue, dispatch_get_global_queue(QOS_CLASS_UTILITY, 0));
+        // Construct with the target atomically. Retargeting an already-active
+        // queue via dispatch_set_target_queue traps on newer libdispatch
+        // runtimes (including the Xcode 27 simulator).
+        queue = dispatch_queue_create_with_target(
+            "com.apolloreborn.account-snapshots",
+            DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL,
+            dispatch_get_global_queue(QOS_CLASS_UTILITY, 0));
     });
     return queue;
 }
 
+// Lifecycle notifications are delivered on the main queue (registration below).
+// A cold launch may emit willEnterForeground immediately before didBecomeActive;
+// skip that redundant first snapshot and take one delayed post-activation
+// baseline instead. Warm foreground transitions still retain both diagnostics.
+static BOOL sApolloAccountSnapshotCompletedFirstActivation = NO;
+
 static void ApolloScheduleAccountSnapshot(NSString *reason) {
     NSString *capturedReason = [reason copy] ?: @"unknown";
-    dispatch_async(ApolloAccountSnapshotQueue(), ^{
+    BOOL didBecomeActive = [capturedReason isEqualToString:@"didBecomeActive"];
+    if (!sApolloAccountSnapshotCompletedFirstActivation &&
+        [capturedReason isEqualToString:@"willEnterForeground"]) {
+        return;
+    }
+    BOOL firstActivation = didBecomeActive && !sApolloAccountSnapshotCompletedFirstActivation;
+    if (didBecomeActive) sApolloAccountSnapshotCompletedFirstActivation = YES;
+
+    // didBecomeActive is delivered while the process-launch watchdog can still
+    // be sensitive on older devices. Give Apollo's first frame and native
+    // CFNetwork setup a clear runway before diagnostics reconstruct archived
+    // AFHTTPSessionManager objects. Warm lifecycle snapshots are already
+    // outside cold launch and can run immediately.
+    NSTimeInterval delay = firstActivation ? 5.0 : 0.0;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)),
+                   ApolloAccountSnapshotQueue(), ^{
         ApolloLogAccountSnapshot(capturedReason);
     });
 }
@@ -1415,9 +1440,9 @@ static NSArray *const blockedUrls = @[
 
 // Cache storing subreddit list source URLs -> response body
 static NSCache<NSString *, NSString *> *subredditListCache;
-// Source URLs currently being refreshed. Access only under @synchronized; the
-// cache itself is NSCache and is safe to read from Apollo's request paths while
-// NSURLSession completions populate it in the background.
+// Source URLs currently being refreshed. Access is confined to the serial
+// source queue; the cache itself is NSCache and is safe to read from Apollo's
+// request paths while NSURLSession completions populate it in the background.
 static NSMutableSet<NSString *> *subredditListFetchesInFlight;
 
 static NSArray<NSString *> *ApolloSubredditListLines(NSString *content) {
@@ -1427,43 +1452,60 @@ static NSArray<NSString *> *ApolloSubredditListLines(NSString *content) {
     return [lines filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"length > 0"]];
 }
 
+static dispatch_queue_t ApolloSubredditSourceQueue(void) {
+    static dispatch_queue_t queue;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        queue = dispatch_queue_create_with_target(
+            "com.apolloreborn.subreddit-sources",
+            DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL,
+            dispatch_get_global_queue(QOS_CLASS_UTILITY, 0));
+    });
+    return queue;
+}
+
 // Warm a remote subreddit-list source without ever waiting for it. Callers use
 // the last cached value (or their local/native fallback) immediately. The
 // in-flight set prevents a burst of resource/request hooks from starting the
-// same download repeatedly while the first fetch is outstanding.
+// same download repeatedly while the first fetch is outstanding. Crucially,
+// URL/session/request construction also happens on the utility queue: merely
+// creating NSURLSession.sharedSession can initialize CFNetwork, so doing that
+// synchronously from the bundle-resource hook or dylib constructor would leave
+// CFNetwork work on Apollo's launch-critical main thread even without a wait.
 static void ApolloRefreshSubredditListSourceAsync(NSString *source) {
     if (source.length == 0) return;
-    NSURL *url = [NSURL URLWithString:source];
-    NSString *key = url.absoluteString;
-    if (!url || key.length == 0 || [subredditListCache objectForKey:key]) return;
-
-    @synchronized (subredditListFetchesInFlight) {
+    NSString *capturedSource = [source copy];
+    dispatch_async(ApolloSubredditSourceQueue(), ^{
+        NSURL *url = [NSURL URLWithString:capturedSource];
+        NSString *key = url.absoluteString;
+        if (!url || key.length == 0 || [subredditListCache objectForKey:key]) return;
         if ([subredditListFetchesInFlight containsObject:key]) return;
         [subredditListFetchesInFlight addObject:key];
-    }
 
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
-                                                           cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                       timeoutInterval:8.0];
-    [[[NSURLSession sharedSession] dataTaskWithRequest:request
-                                    completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        NSString *content = data.length > 0
-            ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]
-            : nil;
-        NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]]
-            ? (NSHTTPURLResponse *)response
-            : nil;
-        if (!error && http.statusCode == 200 && ApolloSubredditListLines(content).count > 0) {
-            [subredditListCache setObject:content forKey:key];
-            ApolloLog(@"[RandomSources] Refreshed %@", key);
-        } else {
-            ApolloLog(@"[RandomSources] Refresh failed for %@: HTTP %ld error=%@",
-                      key, (long)http.statusCode, error.localizedDescription ?: @"invalid/empty response");
-        }
-        @synchronized (subredditListFetchesInFlight) {
-            [subredditListFetchesInFlight removeObject:key];
-        }
-    }] resume];
+        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
+                                                               cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                           timeoutInterval:8.0];
+        [[[NSURLSession sharedSession] dataTaskWithRequest:request
+                                        completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            NSString *content = data.length > 0
+                ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]
+                : nil;
+            NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]]
+                ? (NSHTTPURLResponse *)response
+                : nil;
+            if (!error && http.statusCode == 200 && ApolloSubredditListLines(content).count > 0) {
+                [subredditListCache setObject:content forKey:key];
+                ApolloLog(@"[RandomSources] Refreshed %@", key);
+            } else {
+                ApolloLog(@"[RandomSources] Refresh failed for %@: HTTP %ld error=%@",
+                          key, (long)http.statusCode,
+                          error.localizedDescription ?: @"invalid/empty response");
+            }
+            dispatch_async(ApolloSubredditSourceQueue(), ^{
+                [subredditListFetchesInFlight removeObject:key];
+            });
+        }] resume];
+    });
 }
 // Replace Reddit API client ID. Resolved per-account (see
 // ApolloAccountCredentials.{h,m}): a pending add-account choice, else the

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -932,6 +932,29 @@ static void ApolloLogAccountSnapshot(NSString *reason) {
     ApolloLoginDiag(@"[AccountBlobGroups] %@ | %@", reason, ApolloAccountsBlobGroupBreakdown());
 }
 
+// Account snapshots reconstruct Apollo's archived RDKClient objects and inspect
+// the keychain. They are diagnostics, never launch-critical work. Keep them on
+// a serial utility queue after lifecycle delivery so they cannot block the main
+// thread or contend with CFNetwork/Foundation initialization from the dylib
+// constructor (the rootless 0x8BADF00D launch watchdog in #718).
+static dispatch_queue_t ApolloAccountSnapshotQueue(void) {
+    static dispatch_queue_t queue;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        queue = dispatch_queue_create("com.apolloreborn.account-snapshots",
+                                      DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+        dispatch_set_target_queue(queue, dispatch_get_global_queue(QOS_CLASS_UTILITY, 0));
+    });
+    return queue;
+}
+
+static void ApolloScheduleAccountSnapshot(NSString *reason) {
+    NSString *capturedReason = [reason copy] ?: @"unknown";
+    dispatch_async(ApolloAccountSnapshotQueue(), ^{
+        ApolloLogAccountSnapshot(capturedReason);
+    });
+}
+
 // Fixes apollo-reborn#567: an iCloud-synced Valet item can miss a plain read
 // (errSecItemNotFound) but still collide on add (errSecDuplicateItem), and
 // AccountManager wipes the account instead of retrying. Broaden reads to include
@@ -1392,6 +1415,56 @@ static NSArray *const blockedUrls = @[
 
 // Cache storing subreddit list source URLs -> response body
 static NSCache<NSString *, NSString *> *subredditListCache;
+// Source URLs currently being refreshed. Access only under @synchronized; the
+// cache itself is NSCache and is safe to read from Apollo's request paths while
+// NSURLSession completions populate it in the background.
+static NSMutableSet<NSString *> *subredditListFetchesInFlight;
+
+static NSArray<NSString *> *ApolloSubredditListLines(NSString *content) {
+    if (content.length == 0) return @[];
+    NSArray<NSString *> *lines =
+        [content componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+    return [lines filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"length > 0"]];
+}
+
+// Warm a remote subreddit-list source without ever waiting for it. Callers use
+// the last cached value (or their local/native fallback) immediately. The
+// in-flight set prevents a burst of resource/request hooks from starting the
+// same download repeatedly while the first fetch is outstanding.
+static void ApolloRefreshSubredditListSourceAsync(NSString *source) {
+    if (source.length == 0) return;
+    NSURL *url = [NSURL URLWithString:source];
+    NSString *key = url.absoluteString;
+    if (!url || key.length == 0 || [subredditListCache objectForKey:key]) return;
+
+    @synchronized (subredditListFetchesInFlight) {
+        if ([subredditListFetchesInFlight containsObject:key]) return;
+        [subredditListFetchesInFlight addObject:key];
+    }
+
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
+                                                           cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                       timeoutInterval:8.0];
+    [[[NSURLSession sharedSession] dataTaskWithRequest:request
+                                    completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        NSString *content = data.length > 0
+            ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]
+            : nil;
+        NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]]
+            ? (NSHTTPURLResponse *)response
+            : nil;
+        if (!error && http.statusCode == 200 && ApolloSubredditListLines(content).count > 0) {
+            [subredditListCache setObject:content forKey:key];
+            ApolloLog(@"[RandomSources] Refreshed %@", key);
+        } else {
+            ApolloLog(@"[RandomSources] Refresh failed for %@: HTTP %ld error=%@",
+                      key, (long)http.statusCode, error.localizedDescription ?: @"invalid/empty response");
+        }
+        @synchronized (subredditListFetchesInFlight) {
+            [subredditListFetchesInFlight removeObject:key];
+        }
+    }] resume];
+}
 // Replace Reddit API client ID. Resolved per-account (see
 // ApolloAccountCredentials.{h,m}): a pending add-account choice, else the
 // active account's stored override, else the global default — instead of
@@ -1610,9 +1683,12 @@ static const char kARCompletion = '\0';
             - Return plist as a new file
         */
         NSMutableDictionary *fallbackDict = [[NSDictionary dictionaryWithContentsOfURL:url] mutableCopy];
-        // Select random array from dict
+        // Select a random bundled list as an immediate fallback. Never make a
+        // resource lookup depend on the network: this hook runs on Apollo's
+        // launch/UI path.
         NSArray *fallbackKeys = [fallbackDict allKeys];
-        NSString *randomFallbackKey = fallbackKeys[arc4random_uniform((uint32_t)[fallbackKeys count])];
+        if (fallbackKeys.count == 0) return url;
+        NSString *randomFallbackKey = fallbackKeys[arc4random_uniform((uint32_t)fallbackKeys.count)];
         NSArray *fallbackArray = fallbackDict[randomFallbackKey];
         if ([[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowRandNsfw]) {
             fallbackArray = [fallbackArray arrayByAddingObject:@"RandNSFW"];
@@ -1627,36 +1703,20 @@ static const char kARCompletion = '\0';
             return [NSURL fileURLWithPath:tempPath];
         };
 
-        __block NSError *error = nil;
-        __block NSString *subredditListContent = nil;
-
-        // Try fetching the subreddit list from the source URL, with timeout of 5 seconds
-        // FIXME: Blocks the UI during the splash screen
-        dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-        NSURLRequest *request = [NSURLRequest requestWithURL:subredditListURL cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:5.0];
-        NSURLSession *session = [NSURLSession sharedSession];
-        NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *e) {
-            if (e) {
-                error = e;
-            } else {
-                NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
-                if (httpResponse.statusCode == 200) {
-                    subredditListContent = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-                }
-            }
-            dispatch_semaphore_signal(semaphore);
-        }];
-        [dataTask resume];
-        dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-
-        // Use fallback dict if there was an error
-        if (error || ![subredditListContent length]) {
+        // Constructor prefetch normally has this ready. On a cold/slow network,
+        // return the bundled fallback now and let the async refresh benefit the
+        // next lookup instead of freezing the splash screen.
+        NSString *cacheKey = subredditListURL.absoluteString;
+        NSString *subredditListContent = cacheKey.length > 0
+            ? [subredditListCache objectForKey:cacheKey]
+            : nil;
+        if (subredditListContent.length == 0) {
+            ApolloRefreshSubredditListSourceAsync(sTrendingSubredditsSource);
             return writeDict(fallbackDict);
         }
 
         // Parse into array
-        NSMutableArray<NSString *> *subreddits = [[subredditListContent componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]] mutableCopy];
-        [subreddits filterUsingPredicate:[NSPredicate predicateWithFormat:@"length > 0"]];
+        NSMutableArray<NSString *> *subreddits = [ApolloSubredditListLines(subredditListContent) mutableCopy];
         if (subreddits.count == 0) {
             return writeDict(fallbackDict);
         }
@@ -2048,30 +2108,21 @@ static void ApolloImgurRetryAlbumViaTextProxy(NSString *albumID,
         return %orig;
     }
 
-    NSError *error = nil;
     // Check cache
     NSString *subredditListContent = [subredditListCache objectForKey:subredditListURL.absoluteString];
-    bool updateCache = false;
 
     if (!subredditListContent) {
-        // Not in cache, so fetch subreddit list from source URL
-        // FIXME: The current implementation blocks the UI, but the prefetching in initializeRandomSources() should help
-        subredditListContent = [NSString stringWithContentsOfURL:subredditListURL encoding:NSUTF8StringEncoding error:&error];
-        if (error) {
-            return %orig;
-        }
-        updateCache = true;
-    }
-
-    // Parse the content into a list of strings
-    NSArray<NSString *> *subreddits = [subredditListContent componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
-    subreddits = [subreddits filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"length > 0"]];
-    if (subreddits.count == 0) {
+        // The constructor normally prewarms this cache. If it did not finish
+        // (offline/slow network), preserve Apollo's native request for this tap
+        // and refresh asynchronously for the next one.
+        ApolloRefreshSubredditListSourceAsync(subredditListURL.absoluteString);
         return %orig;
     }
 
-    if (updateCache) {
-        [subredditListCache setObject:subredditListContent forKey:subredditListURL.absoluteString];
+    // Parse the content into a list of strings
+    NSArray<NSString *> *subreddits = ApolloSubredditListLines(subredditListContent);
+    if (subreddits.count == 0) {
+        return %orig;
     }
 
     // Pick a random subreddit, then modify the request URL to use that subreddit, simulating a 302 redirect in Reddit's original API behaviour
@@ -2844,6 +2895,41 @@ static void ApolloInstallNotificationsUnavailableOverlay(UIViewController *contr
 }
 %end
 
+// ApolloActiveAccountUsername() caches the expensive RedditAccounts2 decode.
+// Invalidate it synchronously at the two persisted selection write points so a
+// request made immediately after an account switch cannot observe the previous
+// identity. These hooks are deliberately key-scoped and otherwise transparent;
+// they compose with the theme/auto-hide NSUserDefaults hooks in other modules.
+static BOOL ApolloDefaultsKeyChangesActiveAccount(NSString *key) {
+    return [key isEqualToString:@"RedditAccounts2"] ||
+           [key isEqualToString:@"CurrentRedditAccountIndex"];
+}
+
+%hook NSUserDefaults
+
+- (void)setObject:(id)value forKey:(NSString *)key {
+    %orig;
+    if (ApolloDefaultsKeyChangesActiveAccount(key)) {
+        ApolloInvalidateActiveAccountUsernameCache();
+    }
+}
+
+- (void)setInteger:(NSInteger)value forKey:(NSString *)key {
+    %orig;
+    if (ApolloDefaultsKeyChangesActiveAccount(key)) {
+        ApolloInvalidateActiveAccountUsernameCache();
+    }
+}
+
+- (void)removeObjectForKey:(NSString *)key {
+    %orig;
+    if (ApolloDefaultsKeyChangesActiveAccount(key)) {
+        ApolloInvalidateActiveAccountUsernameCache();
+    }
+}
+
+%end
+
 // Reddit API can returns "error" as a dict (e.g. {"reason":"UNAUTHORIZED",...})
 // instead of a numeric code. Multiple Apollo code paths call [dict[@"error"] integerValue]
 // on the response, including unhookable block invokes. Adding integerValue to NSDictionary
@@ -2858,33 +2944,19 @@ static void ApolloInstallNotificationsUnavailableOverlay(UIViewController *contr
 
 // Pre-fetches random subreddit lists in background
 static void initializeRandomSources() {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        NSArray *sources = @[sRandNsfwSubredditsSource, sRandomSubredditsSource];
-        for (NSString *source in sources) {
-            if (![source length]) {
-                continue;
-            }
-            NSURL *subredditListURL = [NSURL URLWithString:source];
-            NSError *error = nil;
-            NSString *subredditListContent = [NSString stringWithContentsOfURL:subredditListURL encoding:NSUTF8StringEncoding error:&error];
-            if (error) {
-                continue;
-            }
-
-            NSArray<NSString *> *subreddits = [subredditListContent componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
-            subreddits = [subreddits filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"length > 0"]];
-            if (subreddits.count == 0) {
-                continue;
-            }
-
-            [subredditListCache setObject:subredditListContent forKey:subredditListURL.absoluteString];
-        }
-    });
+    // Trending uses the same cache as Random/RandNSFW. Starting all three
+    // downloads here makes the launch-time resource hook a cache-only lookup.
+    for (NSString *source in @[sRandNsfwSubredditsSource ?: @"",
+                               sRandomSubredditsSource ?: @"",
+                               sTrendingSubredditsSource ?: @""]) {
+        ApolloRefreshSubredditListSourceAsync(source);
+    }
 }
 
 // MARK: - Constructor
 %ctor {
     subredditListCache = [NSCache new];
+    subredditListFetchesInFlight = [NSMutableSet set];
 
     NSDictionary *defaultValues = @{UDKeyBlockAnnouncements: @YES,
                                     UDKeyEnableFLEX: @NO,
@@ -3552,8 +3624,8 @@ static void initializeRandomSources() {
 
     // Login-persistence diagnostics: snapshot where the account lives at each lifecycle
     // transition so a warm sign-out (wiped while only backgrounded — the "signed out by the
-    // time I got to the store" reports) is pinned to an event and a storage layer. Cheap and
-    // low-frequency; cross-references with the [KeychainTrace] write sizes.
+    // time I got to the store" reports) is pinned to an event and a storage layer. Snapshot
+    // work is scheduled off-main because it decodes archived clients and reads the keychain.
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     NSDictionary<NSNotificationName, NSString *> *snapshotEvents = @{
         UIApplicationDidBecomeActiveNotification:   @"didBecomeActive",
@@ -3564,11 +3636,11 @@ static void initializeRandomSources() {
     for (NSNotificationName name in snapshotEvents) {
         NSString *reason = snapshotEvents[name];
         [nc addObserverForName:name object:nil queue:[NSOperationQueue mainQueue]
-                    usingBlock:^(NSNotification *note) { ApolloLogAccountSnapshot(reason); }];
+                    usingBlock:^(NSNotification *note) { ApolloScheduleAccountSnapshot(reason); }];
     }
-    // Session boundary in the persistent buffer so a force-quit + relaunch is legible, followed
-    // by a baseline snapshot of the on-disk state at launch (before AccountManager loads).
+    // A session boundary is safe in the constructor because it does no account
+    // decoding. The first full snapshot arrives from didBecomeActive, after
+    // Apollo/CFNetwork have finished launch initialization.
     NSString *appVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: @"?";
     ApolloLoginDiag(@"===== launch (Apollo %@, tweak %@) =====", appVersion, @TWEAK_VERSION);
-    ApolloLogAccountSnapshot(@"ctor");
 }


### PR DESCRIPTION
## Summary

This closes the two known 3.5.0 release blockers and folds in the stability/performance fixes found during the final audit.

- Move expensive account archive/keychain diagnostics out of the dylib constructor and off the main thread after lifecycle delivery, preventing the rootless launch watchdog path. Fixes #718.
- Add the Show/Hide Deleted Comments row to Apollo’s legacy ActionController sheet so Passive mode works in Standard and pre-Liquid-Glass builds. Fixes #757.
- Make Trending/Random subreddit source loading cache-first and fully asynchronous; cold or failed network requests now use bundled/native fallbacks immediately.
- Give Foundation Models tasks a monotonic ownership generation so a cancelled predecessor cannot remove, overwrite, complete, or clean up state belonging to its replacement.
- Cache the active account username instead of repeatedly unarchiving every RDKClient, with synchronous invalidation when RedditAccounts2 or CurrentRedditAccountIndex changes.

## Implementation notes

- The legacy deleted-comments row is appended after all native rows, mirrors Apollo’s native row styling/height, grows only the presentation frame, and retains UITableView’s non-nil cell contract during teardown.
- Subreddit downloads are deduplicated while in flight, validate HTTP 200 plus non-empty content, and perform URL/request/session construction on a serial utility queue. The queue is created atomically with its target to avoid the newer-libdispatch dispatch_set_target_queue trap.
- Cold-launch account diagnostics skip the redundant willEnterForeground event and delay the first background didBecomeActive snapshot until Apollo has reached its stable point.
- Account username cache publication is generation-checked, so an account write racing a decode cannot publish or return the stale identity.

## Validation

- Device/rootful debug package build
- Device/rootless debug package build
- Simulator arm64 build with internal Logos and APOLLO_SIM_BUILD=1
- Standard/non-glass simulator smoke launch with the injected tweak; Apollo remained running and produced no new crash report
- Verified subreddit source setup runs off-main and the first account snapshot runs on the utility queue after the launch-stable marker
- Clean synthetic merge and simulator build with the assumed 3.5.0 PRs #746 and #758 together
- git diff --check
- Confirmed no synchronous dispatch_semaphore_wait, DISPATCH_TIME_FOREVER, or stringWithContentsOfURL remains in the affected Tweak.xm paths