### PR TITLE
Fix iOS 27 Gallery menu dismissal crash

### DIFF
--- a/src/ApolloGalleryMenu.xm
+++ b/src/ApolloGalleryMenu.xm
@@ -44,6 +44,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloGalleryViewController.h"
+#import "ApolloNativeActionMenus.h"
 #import "ApolloThemeRuntime.h"
 
 // Defined in ApolloSubredditHeaders.xm — resolves the slug for a genuine
@@ -109,7 +110,17 @@ static void ApolloGalleryMenuOpenForController(id actionController) {
         ApolloLog(@"[GalleryMenu] Gallery View tapped but the subreddit could not be resolved");
         return;
     }
-    [ApolloGalleryViewController presentGalleryForSubreddit:subreddit fromViewController:owner];
+
+    dispatch_block_t openGallery = ^{
+        [ApolloGalleryViewController presentGalleryForSubreddit:subreddit
+                                             fromViewController:owner];
+    };
+    if (ApolloNativeActionMenuPerformAfterDismissal(actionController, openGallery)) {
+        ApolloLog(@"[GalleryMenu] Waiting for the glass menu to dismiss before opening r/%@",
+                  subreddit);
+        return;
+    }
+    openGallery();
 }
 
 #pragma mark - Liquid Glass menu injection

--- a/src/ApolloNativeActionMenus.h
+++ b/src/ApolloNativeActionMenus.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Runs `action` after the tweak-owned Liquid Glass context menu that was built
+// from `actionController` has completely dismissed. Returns NO when the
+// controller is using Apollo's ordinary action sheet, so callers can perform
+// the action through that sheet's own dismissal completion instead.
+BOOL ApolloNativeActionMenuPerformAfterDismissal(id actionController,
+                                                  dispatch_block_t action);
+
+NS_ASSUME_NONNULL_END

--- a/src/ApolloNativeActionMenus.xm
+++ b/src/ApolloNativeActionMenus.xm
@@ -46,17 +46,46 @@ static BOOL sApolloNativeActionMenuNextPresentationModeratorStyle = NO;
 @property (nonatomic, strong) UIView *morphStandInView;
 @end
 
+// The anchor view owns the presenter for exactly as long as the menu can use
+// it. Keep the reverse lookup from ActionController non-owning: the presenter's
+// UIMenu actions retain that controller, so a direct RETAIN association here
+// would close a cycle and prevent the aborted-presentation -dealloc cleanup.
+static ApolloNativeActionMenuPresenter *ApolloNativeActionMenuPresenterForController(id actionController) {
+    NSHashTable *holder = objc_getAssociatedObject(actionController,
+                                                    &kApolloNativeActionMenuPresenterKey);
+    id presenter = holder.anyObject;
+    return [presenter isKindOfClass:[ApolloNativeActionMenuPresenter class]] ? presenter : nil;
+}
+
+static void ApolloNativeActionMenuSetPresenterForController(id actionController,
+                                                             ApolloNativeActionMenuPresenter *presenter) {
+    if (!actionController) return;
+    if (!presenter) {
+        objc_setAssociatedObject(actionController, &kApolloNativeActionMenuPresenterKey, nil,
+                                 OBJC_ASSOCIATION_ASSIGN);
+        return;
+    }
+
+    NSHashTable *holder = [NSHashTable weakObjectsHashTable];
+    [holder addObject:presenter];
+    objc_setAssociatedObject(actionController, &kApolloNativeActionMenuPresenterKey, holder,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 BOOL ApolloNativeActionMenuPerformAfterDismissal(id actionController,
                                                   dispatch_block_t action) {
     if (!actionController || !action) return NO;
 
     ApolloNativeActionMenuPresenter *presenter =
-        objc_getAssociatedObject(actionController, &kApolloNativeActionMenuPresenterKey);
-    if (![presenter isKindOfClass:[ApolloNativeActionMenuPresenter class]] ||
-        !presenter.interaction) {
+        ApolloNativeActionMenuPresenterForController(actionController);
+    if (!presenter.interaction) {
         return NO;
     }
 
+    // UIKit does not guarantee whether an action handler runs before or after
+    // -willEndForConfiguration:. The animator completion intentionally reads
+    // this property at dismissal END, so even a late handler stored after
+    // dismissal begins still cannot fall through the teardown window.
     presenter.afterDismissalAction = [action copy];
     return YES;
 }
@@ -1112,10 +1141,8 @@ static id ApolloNativeActionMenuCompactMenuStyle(void) {
     UIView *standInView = self.morphStandInView;
     UIView *dismissalFallbackView = self.dismissalFallbackView;
     id actionController = self.actionController;
-    dispatch_block_t afterDismissalAction = self.afterDismissalAction;
     self.morphStandInView = nil;
     self.dismissalFallbackView = nil;
-    self.afterDismissalAction = nil;
     // Issue #249: tear down at dismissal END, not START — removing the anchor
     // (the interaction's host view) while the menu is still morphing back into
     // the source button cuts the dismissal animation short. The stand-in goes
@@ -1126,16 +1153,19 @@ static id ApolloNativeActionMenuCompactMenuStyle(void) {
             [sourceView removeInteraction:menuInteraction];
             objc_setAssociatedObject(sourceView, &kApolloNativeActionMenuControllerKey, nil, OBJC_ASSOCIATION_ASSIGN);
         }
-        if (actionController &&
-            objc_getAssociatedObject(actionController, &kApolloNativeActionMenuPresenterKey) == self) {
-            objc_setAssociatedObject(actionController, &kApolloNativeActionMenuPresenterKey, nil,
-                                     OBJC_ASSOCIATION_ASSIGN);
+        if (ApolloNativeActionMenuPresenterForController(actionController) == self) {
+            ApolloNativeActionMenuSetPresenterForController(actionController, nil);
         }
         [standInView removeFromSuperview];
         [dismissalFallbackView removeFromSuperview];
         if (removeSourceViewOnEnd) {
             [sourceView removeFromSuperview];
         }
+        // Read at dismissal END rather than capturing at dismissal START. An
+        // action handler may run between those callbacks on a future UIKit and
+        // store its work after this method has already begun.
+        dispatch_block_t afterDismissalAction = self.afterDismissalAction;
+        self.afterDismissalAction = nil;
         if (afterDismissalAction) {
             dispatch_async(dispatch_get_main_queue(), afterDismissalAction);
         }
@@ -1325,8 +1355,7 @@ static BOOL ApolloNativeActionMenuPresent(id presenter, id actionController, voi
 
     [anchorView addInteraction:interaction];
     objc_setAssociatedObject(anchorView, &kApolloNativeActionMenuControllerKey, menuPresenter, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    objc_setAssociatedObject(actionController, &kApolloNativeActionMenuPresenterKey, menuPresenter,
-                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloNativeActionMenuSetPresenterForController(actionController, menuPresenter);
 
     // Issue #249: a programmatic presentation has no active click driver, so
     // -[UIContextMenuInteraction menuAppearance] falls back to the interaction's

--- a/src/ApolloNativeActionMenus.xm
+++ b/src/ApolloNativeActionMenus.xm
@@ -1,4 +1,5 @@
 #import "ApolloCommon.h"
+#import "ApolloNativeActionMenus.h"
 #import "ApolloNativeActionMetadata.h"
 #import "ApolloThemeRuntime.h"
 
@@ -11,6 +12,7 @@ static char kApolloNativeActionMenuControllerKey;
 static char kApolloNativeActionMenuInvokingActionKey;
 static char kApolloNativeActionMenuWrappedModeratorActionKey;
 static char kApolloNativeActionMenuLifecycleFallbackKey;
+static char kApolloNativeActionMenuPresenterKey;
 static char kApolloNativeActionMenuSourceViewKey;
 static char kApolloNativeActionMenuWrappedSourceActionKey;
 
@@ -30,11 +32,34 @@ static BOOL sApolloNativeActionMenuNextPresentationModeratorStyle = NO;
 @property (nonatomic, weak) UIView *morphSourceView;
 @property (nonatomic, strong) UIContextMenuInteraction *interaction;
 @property (nonatomic, assign) BOOL removeSourceViewOnEnd;
+@property (nonatomic, weak) id actionController;
+@property (nonatomic, copy) dispatch_block_t afterDismissalAction;
+// Keep the presentation window and anchor point for the menu's short lifetime.
+// A selected action may push another controller before UIKit asks for its
+// dismissal preview, detaching the nav-bar proxy from the window on iOS 27.
+@property (nonatomic, strong) UIWindow *presentationWindow;
+@property (nonatomic, assign) CGPoint presentationAnchorCenter;
+@property (nonatomic, strong) UIView *dismissalFallbackView;
 // Empty throwaway view pinned over morphSourceView; this is what UIKit portals
 // into the glass platter, so the real control keeps drawing. See
 // ApolloNativeActionMenuCreateMorphStandIn().
 @property (nonatomic, strong) UIView *morphStandInView;
 @end
+
+BOOL ApolloNativeActionMenuPerformAfterDismissal(id actionController,
+                                                  dispatch_block_t action) {
+    if (!actionController || !action) return NO;
+
+    ApolloNativeActionMenuPresenter *presenter =
+        objc_getAssociatedObject(actionController, &kApolloNativeActionMenuPresenterKey);
+    if (![presenter isKindOfClass:[ApolloNativeActionMenuPresenter class]] ||
+        !presenter.interaction) {
+        return NO;
+    }
+
+    presenter.afterDismissalAction = [action copy];
+    return YES;
+}
 
 static BOOL ApolloNativeActionMenusEnabled(void) {
     if (@available(iOS 26.0, *)) {
@@ -910,6 +935,7 @@ static UITargetedPreview *ApolloNativeActionMenuStandInPreview(UIView *standIn) 
 // opened), so a stale copy can't ride along on a recycled cell.
 - (void)dealloc {
     [_morphStandInView removeFromSuperview];
+    [_dismissalFallbackView removeFromSuperview];
 }
 
 - (UIContextMenuConfiguration *)contextMenuInteraction:(__unused UIContextMenuInteraction *)interaction configurationForMenuAtLocation:(__unused CGPoint)location {
@@ -1011,6 +1037,45 @@ static id ApolloNativeActionMenuCompactMenuStyle(void) {
     UIView *sourceView = self.sourceView;
     if (!sourceView) return nil;
 
+    // iOS 27 throws if initWithView:parameters: is handed a view that is no
+    // longer in a window. A menu action can legitimately navigate before UIKit
+    // requests this dismissal preview, which detaches a nav-bar source and its
+    // proxy. Preserve the invisible-preview behavior by substituting a
+    // temporary 1pt anchor in the original presentation window.
+    if (!sourceView.window) {
+        UIWindow *window = self.presentationWindow;
+        if (!window) {
+            for (UIWindow *candidate in ApolloAllWindows()) {
+                if (candidate.isKeyWindow) {
+                    window = candidate;
+                    break;
+                }
+            }
+        }
+        if (!window) {
+            ApolloLog(@"[NativeActionMenu] No window for dismissal preview");
+            return nil;
+        }
+
+        UIView *fallback = self.dismissalFallbackView;
+        if (!fallback.window) {
+            [fallback removeFromSuperview];
+            CGPoint center = self.presentationAnchorCenter;
+            fallback = [[UIView alloc] initWithFrame:CGRectMake(center.x - 0.5,
+                                                                center.y - 0.5,
+                                                                1.0,
+                                                                1.0)];
+            fallback.backgroundColor = UIColor.clearColor;
+            fallback.opaque = NO;
+            fallback.userInteractionEnabled = NO;
+            fallback.accessibilityElementsHidden = YES;
+            [window addSubview:fallback];
+            self.dismissalFallbackView = fallback;
+            ApolloLog(@"[NativeActionMenu] Original dismissal anchor detached; using window fallback");
+        }
+        sourceView = fallback;
+    }
+
     UIPreviewParameters *parameters = [UIPreviewParameters new];
     parameters.backgroundColor = UIColor.clearColor;
     parameters.visiblePath = [UIBezierPath bezierPathWithRect:CGRectZero];
@@ -1043,22 +1108,36 @@ static id ApolloNativeActionMenuCompactMenuStyle(void) {
 
     UIView *sourceView = self.sourceView;
     UIContextMenuInteraction *menuInteraction = self.interaction;
-    if (!sourceView || !menuInteraction) return;
-
     BOOL removeSourceViewOnEnd = self.removeSourceViewOnEnd;
     UIView *standInView = self.morphStandInView;
+    UIView *dismissalFallbackView = self.dismissalFallbackView;
+    id actionController = self.actionController;
+    dispatch_block_t afterDismissalAction = self.afterDismissalAction;
     self.morphStandInView = nil;
+    self.dismissalFallbackView = nil;
+    self.afterDismissalAction = nil;
     // Issue #249: tear down at dismissal END, not START — removing the anchor
     // (the interaction's host view) while the menu is still morphing back into
     // the source button cuts the dismissal animation short. The stand-in goes
     // at the same point: it is what the collapsing platter is portaling, and
     // pulling it early would empty the platter mid-animation.
     void (^teardown)(void) = ^{
-        [sourceView removeInteraction:menuInteraction];
-        objc_setAssociatedObject(sourceView, &kApolloNativeActionMenuControllerKey, nil, OBJC_ASSOCIATION_ASSIGN);
+        if (sourceView && menuInteraction) {
+            [sourceView removeInteraction:menuInteraction];
+            objc_setAssociatedObject(sourceView, &kApolloNativeActionMenuControllerKey, nil, OBJC_ASSOCIATION_ASSIGN);
+        }
+        if (actionController &&
+            objc_getAssociatedObject(actionController, &kApolloNativeActionMenuPresenterKey) == self) {
+            objc_setAssociatedObject(actionController, &kApolloNativeActionMenuPresenterKey, nil,
+                                     OBJC_ASSOCIATION_ASSIGN);
+        }
         [standInView removeFromSuperview];
+        [dismissalFallbackView removeFromSuperview];
         if (removeSourceViewOnEnd) {
             [sourceView removeFromSuperview];
+        }
+        if (afterDismissalAction) {
+            dispatch_async(dispatch_get_main_queue(), afterDismissalAction);
         }
     };
     if (animator) {
@@ -1222,6 +1301,12 @@ static BOOL ApolloNativeActionMenuPresent(id presenter, id actionController, voi
     ApolloNativeActionMenuPresenter *menuPresenter = [ApolloNativeActionMenuPresenter new];
     menuPresenter.menu = menu;
     menuPresenter.sourceView = anchorView;
+    menuPresenter.actionController = actionController;
+    menuPresenter.presentationWindow = anchorView.window;
+    menuPresenter.presentationAnchorCenter =
+        [anchorView convertPoint:CGPointMake(CGRectGetMidX(anchorView.bounds),
+                                             CGRectGetMidY(anchorView.bounds))
+                          toView:anchorView.window];
     BOOL morphable = ApolloNativeActionMenuViewShouldMorph(sourceView);
     menuPresenter.morphSourceView = morphable ? sourceView : nil;
     menuPresenter.removeSourceViewOnEnd = removeAnchorViewOnEnd;
@@ -1240,6 +1325,8 @@ static BOOL ApolloNativeActionMenuPresent(id presenter, id actionController, voi
 
     [anchorView addInteraction:interaction];
     objc_setAssociatedObject(anchorView, &kApolloNativeActionMenuControllerKey, menuPresenter, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(actionController, &kApolloNativeActionMenuPresenterKey, menuPresenter,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
     // Issue #249: a programmatic presentation has no active click driver, so
     // -[UIContextMenuInteraction menuAppearance] falls back to the interaction's


### PR DESCRIPTION
## Summary

- defer Gallery View navigation until the tweak-owned Liquid Glass context menu has fully dismissed
- retain a window-backed invisible fallback anchor for dismissal previews if another action detaches the original navigation-bar source
- leave Apollo's standard non-Glass action-sheet dismissal flow unchanged

Closes #763.

## Root cause

On iOS 27, selecting Gallery View could push the gallery controller before UIKit requested the Liquid Glass menu's dismissal preview. That push detached the source navigation-bar proxy from its window, and `UITargetedPreview` throws when initialized with a windowless view.

## Validation

- `make package` succeeds with the pinned iOS 26 device SDK / iOS 14 deployment target
- standard simulator build launches cleanly and the ordinary action-sheet path remains unchanged
- iOS 27 Liquid Glass simulator: selecting Gallery logs that it is waiting for menu dismissal, then opens Gallery after the dismissal completes; the process remains alive and no crash report is generated
- Settings root search is visible in both standard and Liquid Glass layouts; its index builds successfully with 430 entries
