### PR TITLE
Honor Apollo’s NSFW blur preference in Gallery View

### DIFF
--- a/src/ApolloGalleryFeed.m
+++ b/src/ApolloGalleryFeed.m
@@ -105,10 +105,11 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
 }
 
 - (BOOL)shouldBlurThumbnail {
-    // Match Apollo's active-account adult-content choice rather than covering
-    // every mature tile unconditionally. Spoilers keep their independent
-    // reveal gate regardless of that preference.
-    return self.isSpoiler || (self.isNSFW && ApolloShouldBlurNSFWMedia());
+    // Spoilers keep their independent reveal gate unconditionally. NSFW blurs
+    // when either the account's Reddit adult-content pref or the tweak's own
+    // Tag Filters setting says to — resolved against this ITEM's subreddit
+    // (not the feed's) so per-subreddit overrides apply to every tile.
+    return self.isSpoiler || (self.isNSFW && ApolloShouldBlurNSFWMediaInSubreddit(self.subreddit));
 }
 
 @end

--- a/src/ApolloGalleryFeed.m
+++ b/src/ApolloGalleryFeed.m
@@ -1,6 +1,7 @@
 // ApolloGalleryFeed.m — see ApolloGalleryFeed.h for the feature overview.
 
 #import "ApolloGalleryFeed.h"
+#import "ApolloTagFilters.h"
 #import "ApolloCommon.h"
 #import "ApolloState.h"
 
@@ -104,9 +105,10 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
 }
 
 - (BOOL)shouldBlurThumbnail {
-    // Mirrors what the feed itself does for flagged posts: obscure the picture
-    // in the grid, show it plainly once the user opens it deliberately.
-    return self.isNSFW || self.isSpoiler;
+    // Match Apollo's active-account adult-content choice rather than covering
+    // every mature tile unconditionally. Spoilers keep their independent
+    // reveal gate regardless of that preference.
+    return self.isSpoiler || (self.isNSFW && ApolloShouldBlurNSFWMedia());
 }
 
 @end

--- a/src/ApolloGalleryViewController.m
+++ b/src/ApolloGalleryViewController.m
@@ -7,6 +7,7 @@
 #import "ApolloCommon.h"
 #import "ApolloTagFilters.h"
 #import "ApolloThemeRuntime.h"
+#import "TagFiltersViewController.h"
 
 #import <objc/message.h>
 
@@ -382,8 +383,13 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
     [self apollo_installNavigationButtons];
     [[NSNotificationCenter defaultCenter]
         addObserver:self
-           selector:@selector(apollo_adultContentBlurPreferenceChanged:)
+           selector:@selector(apollo_nsfwBlurInputsChanged:)
                name:ApolloAdultContentBlurPreferenceDidChangeNotification
+             object:nil];
+    [[NSNotificationCenter defaultCenter]
+        addObserver:self
+           selector:@selector(apollo_nsfwBlurInputsChanged:)
+               name:ApolloTagFiltersChangedNotification
              object:nil];
     [self apollo_beginInitialLoad];
 }
@@ -392,9 +398,10 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (void)apollo_adultContentBlurPreferenceChanged:(NSNotification *)notification {
+- (void)apollo_nsfwBlurInputsChanged:(NSNotification *)notification {
     // The captured Reddit preference can arrive after Gallery's initial cells
-    // were configured, or change when the active account switches.
+    // were configured, or change when the active account switches; the Tag
+    // Filters settings can be edited while a Gallery sits in the nav stack.
     [self.collectionView reloadData];
     (void)notification;
 }

--- a/src/ApolloGalleryViewController.m
+++ b/src/ApolloGalleryViewController.m
@@ -5,6 +5,7 @@
 #import "ApolloGalleryImageLoader.h"
 #import "ApolloGalleryImageViewer.h"
 #import "ApolloCommon.h"
+#import "ApolloTagFilters.h"
 #import "ApolloThemeRuntime.h"
 
 #import <objc/message.h>
@@ -161,8 +162,8 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
         _imageView.clipsToBounds = YES;
         [self.contentView addSubview:_imageView];
 
-        // NSFW / spoiler cover. Blurring the tile keeps the grid scannable
-        // without putting the picture on screen unasked.
+        // NSFW / spoiler cover. NSFW follows Apollo's active-account adult
+        // content preference; spoilers always keep their reveal gate.
         _blurView = [[UIVisualEffectView alloc] initWithEffect:[UIBlurEffect effectWithStyle:UIBlurEffectStyleSystemThickMaterialDark]];
         _blurView.frame = self.contentView.bounds;
         _blurView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
@@ -214,7 +215,7 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
 - (void)configureWithItem:(ApolloGalleryItem *)item {
     if (item.shouldBlurThumbnail) {
         self.blurView.hidden = NO;
-        self.blurLabel.text = item.isNSFW ? @"NSFW" : @"SPOILER";
+        self.blurLabel.text = item.isSpoiler ? @"SPOILER" : @"NSFW";
         [self.contentView bringSubviewToFront:self.blurView];
     }
     // No badge for an image's position within a multi-image post — every image
@@ -379,7 +380,23 @@ static NSString *const kApolloGalleryCellID = @"ApolloGalleryTile";
     [self.view addSubview:self.footerLabel];
 
     [self apollo_installNavigationButtons];
+    [[NSNotificationCenter defaultCenter]
+        addObserver:self
+           selector:@selector(apollo_adultContentBlurPreferenceChanged:)
+               name:ApolloAdultContentBlurPreferenceDidChangeNotification
+             object:nil];
     [self apollo_beginInitialLoad];
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)apollo_adultContentBlurPreferenceChanged:(NSNotification *)notification {
+    // The captured Reddit preference can arrive after Gallery's initial cells
+    // were configured, or change when the active account switches.
+    [self.collectionView reloadData];
+    (void)notification;
 }
 
 - (void)viewDidLayoutSubviews {

--- a/src/ApolloTagFilters.h
+++ b/src/ApolloTagFilters.h
@@ -1,0 +1,21 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Posted on the main thread when the active account's Reddit
+// "Blur mature (18+) images and media" preference becomes known or changes.
+FOUNDATION_EXPORT NSNotificationName const ApolloAdultContentBlurPreferenceDidChangeNotification;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Mirrors Apollo's active-account NSFW blur preference. Returns YES while the
+// value is still unknown, matching Apollo's conservative launch-time behavior.
+BOOL ApolloShouldBlurNSFWMedia(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/src/ApolloTagFilters.h
+++ b/src/ApolloTagFilters.h
@@ -10,9 +10,18 @@ FOUNDATION_EXPORT NSNotificationName const ApolloAdultContentBlurPreferenceDidCh
 extern "C" {
 #endif
 
-// Mirrors Apollo's active-account NSFW blur preference. Returns YES while the
-// value is still unknown, matching Apollo's conservative launch-time behavior.
-BOOL ApolloShouldBlurNSFWMedia(void);
+// Whether NSFW media from `subreddit` (no "r/" prefix) should be blurred.
+// ORs two independent user choices:
+//   1. The tweak's own Tag Filters NSFW setting — global toggle with the
+//      per-subreddit override winning — which the user opts into regardless
+//      of their Reddit account preference.
+//   2. Apollo's active-account Reddit "Blur mature (18+) images and media"
+//      preference. While that preference is still unknown it counts as
+//      "blur" (matching Apollo's conservative launch-time behavior), EXCEPT
+//      for keyless web-session accounts: no OAuth /me fetch ever runs for
+//      them, so unknown is permanent there and resolves to "don't blur" —
+//      the same thing Apollo's native feed shows in those sessions.
+BOOL ApolloShouldBlurNSFWMediaInSubreddit(NSString *_Nullable subreddit);
 
 #ifdef __cplusplus
 }

--- a/src/ApolloTagFilters.xm
+++ b/src/ApolloTagFilters.xm
@@ -22,9 +22,11 @@
 #import <objc/runtime.h>
 #import <objc/message.h>
 
+#import "ApolloAccountCredentials.h"
 #import "ApolloCommon.h"
 #import "ApolloState.h"
 #import "ApolloTagFilters.h"
+#import "ApolloWebJSON.h"
 #import "Tweak.h"
 #import "UIWindow+Apollo.h"
 #import "UserDefaultConstants.h"
@@ -76,6 +78,20 @@ static RDKLink *ApolloTagLinkFromCell(id cell) {
     return nil;
 }
 
+// Effective per-tag filter switch for `subreddit`: the per-subreddit override
+// when one is stored, else the global toggle. `tagKey` is @"nsfw" or
+// @"spoiler". Shared by the feed decision below and the Gallery's thumbnail
+// decision (ApolloShouldBlurNSFWMediaInSubreddit).
+static BOOL ApolloTagFilterTagOn(NSString *subreddit, NSString *tagKey, BOOL globalValue) {
+    NSString *subKey = [subreddit isKindOfClass:[NSString class]] ? subreddit.lowercaseString : nil;
+    NSDictionary *override = (subKey.length > 0) ? sTagFilterSubredditOverrides[subKey] : nil;
+    if ([override isKindOfClass:[NSDictionary class]]) {
+        id v = override[tagKey];
+        if ([v isKindOfClass:[NSNumber class]]) return [(NSNumber *)v boolValue];
+    }
+    return globalValue;
+}
+
 // Returns @"hide", @"blur", or @"none" given a link and (optional) subreddit context.
 // Per-subreddit overrides take precedence over global settings on a per-tag basis;
 // mode is also overridable per-sub.
@@ -91,17 +107,8 @@ static NSString *ApolloTagFilterDecisionForLink(RDKLink *link) {
 
     NSString *sub = nil;
     @try { sub = link.subreddit; } @catch (__unused id e) {}
-    NSString *subKey = [sub isKindOfClass:[NSString class]] ? sub.lowercaseString : nil;
-    NSDictionary *override = (subKey.length > 0) ? sTagFilterSubredditOverrides[subKey] : nil;
-
-    BOOL filterNSFW = sTagFilterNSFW;
-    BOOL filterSpoiler = sTagFilterSpoiler;
-    if ([override isKindOfClass:[NSDictionary class]]) {
-        id n = override[@"nsfw"];
-        if ([n isKindOfClass:[NSNumber class]]) filterNSFW = [(NSNumber *)n boolValue];
-        id s = override[@"spoiler"];
-        if ([s isKindOfClass:[NSNumber class]]) filterSpoiler = [(NSNumber *)s boolValue];
-    }
+    BOOL filterNSFW = ApolloTagFilterTagOn(sub, @"nsfw", sTagFilterNSFW);
+    BOOL filterSpoiler = ApolloTagFilterTagOn(sub, @"spoiler", sTagFilterSpoiler);
 
     BOOL match = (isNSFW && filterNSFW) || (isSpoiler && filterSpoiler);
     if (!match) return @"none";
@@ -223,10 +230,41 @@ static NSInteger sTagEffectiveNoProfanity = -1;
 NSNotificationName const ApolloAdultContentBlurPreferenceDidChangeNotification =
     @"ApolloAdultContentBlurPreferenceDidChangeNotification";
 
-BOOL ApolloShouldBlurNSFWMedia(void) {
-    // Unknown stays covered until Apollo finishes loading the active account,
-    // just as its native feed does during launch.
-    return sTagEffectiveNoProfanity != 0;
+// YES when the ACTIVE account authenticates through a cookie web session
+// (keyless mode): the identity layer installs a synthetic OAuth credential on
+// its client (ApolloWebJSONIdentity.xm), so no real /me fetch — and therefore
+// no pref_no_profanity capture — can ever happen for it through the OAuth
+// path. Read from the live client rather than disk so the answer tracks
+// whatever credential the transport is actually using right now.
+static BOOL ApolloTagActiveAccountIsKeyless(void) {
+    id client = ApolloActiveAccountClient();
+    SEL credentialSel = NSSelectorFromString(@"authorizationCredential");
+    SEL tokenSel = NSSelectorFromString(@"accessToken");
+    if (!client || ![client respondsToSelector:credentialSel]) return NO;
+    id credential = ((id (*)(id, SEL))objc_msgSend)(client, credentialSel);
+    if (!credential || ![credential respondsToSelector:tokenSel]) return NO;
+    // RDKOAuthCredential.accessToken is an RDKAccessToken; its own accessToken
+    // getter returns the raw bearer string.
+    id accessToken = ((id (*)(id, SEL))objc_msgSend)(credential, tokenSel);
+    if (!accessToken || ![accessToken respondsToSelector:tokenSel]) return NO;
+    id token = ((id (*)(id, SEL))objc_msgSend)(accessToken, tokenSel);
+    return [token isKindOfClass:[NSString class]] && ApolloWebJSONBearerIsSynthetic((NSString *)token);
+}
+
+BOOL ApolloShouldBlurNSFWMediaInSubreddit(NSString *subreddit) {
+    // The tweak's own Tag Filters choice is independent of the Reddit account
+    // pref: a user who opted into blurring NSFW (globally or for this
+    // subreddit) keeps that cover even with Reddit's mature-media blur off.
+    if (sTagFilterEnabled && ApolloTagFilterTagOn(subreddit, @"nsfw", sTagFilterNSFW)) return YES;
+    if (sTagEffectiveNoProfanity == 1) return YES;
+    if (sTagEffectiveNoProfanity == 0) return NO;
+    // Unknown: stay covered while Apollo is still loading the active account,
+    // just as its native feed does during launch — unless the account is
+    // keyless, where unknown is permanent (see above) and Apollo's native
+    // feed shows NSFW media uncovered (the synthesized user object carries
+    // noProfanity == NO). If a cookie-routed /me does land later and captures
+    // the real pref, the capture wins over this fallback.
+    return !ApolloTagActiveAccountIsKeyless();
 }
 
 static void ApolloTagRefreshAllVisibleCells(void);

--- a/src/ApolloTagFilters.xm
+++ b/src/ApolloTagFilters.xm
@@ -224,7 +224,7 @@ static BOOL ApolloTagMediaIsVideo(id richMediaNode) {
 // hop to main (where the parsed object is fully populated); decisions run
 // from cell didLoad/layout on main.
 static NSMutableDictionary<NSString *, NSNumber *> *sTagNoProfanityByUser = nil;
-static NSString *sTagActiveUsername = nil;
+static NSString *sTagEffectiveUsername = nil;
 static NSInteger sTagEffectiveNoProfanity = -1;
 
 NSNotificationName const ApolloAdultContentBlurPreferenceDidChangeNotification =
@@ -282,12 +282,12 @@ static NSString *ApolloTagNormalizedUsername(id userObject) {
     return name.length > 0 ? [name lowercaseString] : nil;
 }
 
-// Live lookup for sessions restored with a signed-in user before any
-// -[RDKClient setCurrentUser:] fires under our hook.
+// Resolve identity from AccountManager's SELECTED live client. RDKClient's
+// sharedClient is the application-only/bootstrap client, and remembering the
+// last client that received -setCurrentUser: lets background refreshes for an
+// inactive account overwrite the Gallery decision.
 static NSString *ApolloTagLiveActiveUsername(void) {
-    Class clientClass = objc_getClass("RDKClient");
-    if (!clientClass || ![clientClass respondsToSelector:@selector(sharedClient)]) return nil;
-    id client = ((id (*)(id, SEL))objc_msgSend)(clientClass, @selector(sharedClient));
+    id client = ApolloActiveAccountClient();
     if (!client || ![client respondsToSelector:@selector(currentUser)]) return nil;
     id currentUser = ((id (*)(id, SEL))objc_msgSend)(client, @selector(currentUser));
     return currentUser ? ApolloTagNormalizedUsername(currentUser) : nil;
@@ -297,14 +297,16 @@ static NSString *ApolloTagLiveActiveUsername(void) {
 // EFFECTIVE change (capture for the active account, or an account switch)
 // re-evaluates visible cells — a statically-visible feed gets no layout pass
 // of its own when /me lands or the account flips.
-static void ApolloTagRecomputeEffectiveNoProfanity(void) {
-    if (sTagActiveUsername.length == 0) sTagActiveUsername = ApolloTagLiveActiveUsername();
-    NSNumber *captured = sTagActiveUsername.length > 0 ? sTagNoProfanityByUser[sTagActiveUsername] : nil;
+static void ApolloTagRecomputeEffectiveNoProfanity(BOOL forceRefresh) {
+    NSString *activeUsername = ApolloTagLiveActiveUsername();
+    NSNumber *captured = activeUsername.length > 0 ? sTagNoProfanityByUser[activeUsername] : nil;
     NSInteger effective = captured ? (captured.boolValue ? 1 : 0) : -1;
-    if (effective == sTagEffectiveNoProfanity) return;
+    BOOL identityChanged = ![sTagEffectiveUsername isEqualToString:activeUsername];
+    if (!forceRefresh && !identityChanged && effective == sTagEffectiveNoProfanity) return;
+    sTagEffectiveUsername = [activeUsername copy];
     sTagEffectiveNoProfanity = effective;
     ApolloLog(@"[TagFilters] Effective pref_no_profanity=%ld for u/%@ (blur mature media)",
-              (long)effective, sTagActiveUsername ?: @"(unknown)");
+              (long)effective, activeUsername ?: @"(unknown)");
     [[NSNotificationCenter defaultCenter]
         postNotificationName:ApolloAdultContentBlurPreferenceDidChangeNotification
                       object:nil];
@@ -745,23 +747,22 @@ static void ApolloTagRefreshAllVisibleCells(void) {
             sTagNoProfanityByUser[username] = @(value);
             ApolloLog(@"[TagFilters] Captured pref_no_profanity=%d for u/%@ (blur mature media)", value, username);
         }
-        ApolloTagRecomputeEffectiveNoProfanity();
+        ApolloTagRecomputeEffectiveNoProfanity(NO);
     });
 }
 
 %end
 
-// Account switches move the effective pref to the new account's captured
-// value (or back to unknown if it was never captured for them).
+// A current-user install can belong to any stored client. Re-resolve through
+// AccountManager instead of treating the receiver as proof that it is active.
 %hook RDKClient
 
 - (void)setCurrentUser:(id)user {
     %orig;
-    id newUser = user;
     dispatch_async(dispatch_get_main_queue(), ^{
-        sTagActiveUsername = newUser ? ApolloTagNormalizedUsername(newUser) : nil;
-        ApolloTagRecomputeEffectiveNoProfanity();
+        ApolloTagRecomputeEffectiveNoProfanity(NO);
     });
+    (void)user;
 }
 
 %end
@@ -824,4 +825,22 @@ static void ApolloTagRefreshAllVisibleCells(void) {
                                                   usingBlock:^(NSNotification *note) {
         ApolloTagRefreshAllVisibleCells();
     }];
+
+    // Apollo posts these after selecting an existing AccountManager client.
+    // No -setCurrentUser: call is required for that path, so observe both
+    // native account-change names and force a refresh even when the two
+    // accounts happen to have the same captured preference. The forced pass
+    // also covers an unknown OAuth account <-> unknown keyless account switch,
+    // whose conservative fallback differs despite both caching as -1.
+    for (NSNotificationName name in @[
+        @"com.christianselig.RedditCurrentAccountChanged",
+        @"com.christianselig.RedditAccountChanged",
+    ]) {
+        [[NSNotificationCenter defaultCenter] addObserverForName:name
+                                                          object:nil
+                                                           queue:[NSOperationQueue mainQueue]
+                                                      usingBlock:^(__unused NSNotification *note) {
+            ApolloTagRecomputeEffectiveNoProfanity(YES);
+        }];
+    }
 }

--- a/src/ApolloTagFilters.xm
+++ b/src/ApolloTagFilters.xm
@@ -24,6 +24,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloState.h"
+#import "ApolloTagFilters.h"
 #import "Tweak.h"
 #import "UIWindow+Apollo.h"
 #import "UserDefaultConstants.h"
@@ -219,6 +220,15 @@ static NSMutableDictionary<NSString *, NSNumber *> *sTagNoProfanityByUser = nil;
 static NSString *sTagActiveUsername = nil;
 static NSInteger sTagEffectiveNoProfanity = -1;
 
+NSNotificationName const ApolloAdultContentBlurPreferenceDidChangeNotification =
+    @"ApolloAdultContentBlurPreferenceDidChangeNotification";
+
+BOOL ApolloShouldBlurNSFWMedia(void) {
+    // Unknown stays covered until Apollo finishes loading the active account,
+    // just as its native feed does during launch.
+    return sTagEffectiveNoProfanity != 0;
+}
+
 static void ApolloTagRefreshAllVisibleCells(void);
 
 static NSString *ApolloTagNormalizedUsername(id userObject) {
@@ -257,6 +267,9 @@ static void ApolloTagRecomputeEffectiveNoProfanity(void) {
     sTagEffectiveNoProfanity = effective;
     ApolloLog(@"[TagFilters] Effective pref_no_profanity=%ld for u/%@ (blur mature media)",
               (long)effective, sTagActiveUsername ?: @"(unknown)");
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:ApolloAdultContentBlurPreferenceDidChangeNotification
+                      object:nil];
     ApolloTagRefreshAllVisibleCells();
 }
 


### PR DESCRIPTION
## What changed

- Make Gallery View use Apollo/Reddit’s active-account “Blur mature (18+) images and media” preference for NSFW thumbnails.
- OR the tweak’s own Tag Filters NSFW setting into the decision (global toggle plus per-subreddit override, resolved against each item’s subreddit), so users who opted into Tag Filters keep their cover even with the Reddit preference off.
- Keep spoiler thumbnails obscured regardless of either preference.
- Refresh an open Gallery when the account preference becomes available, the active account changes, or the Tag Filters settings are edited.
- Preserve conservative launch behavior by keeping NSFW thumbnails covered while the account preference is still unknown — except for keyless web-session accounts, where the preference can never arrive (no OAuth `/me` fetch happens): there unknown resolves to “don’t blur”, matching Apollo’s native feed in those sessions. A later cookie-routed capture of the real preference still wins.

## Why

Gallery View previously blurred every NSFW thumbnail unconditionally because `shouldBlurThumbnail` treated NSFW and spoiler flags identically. This made adult-focused galleries effectively unusable even for users who had explicitly disabled mature-media blurring in Apollo.

The Gallery now follows the same per-account choice as Apollo’s native feed without changing the user’s Reddit preference, while still honoring the tweak’s own Tag Filters as an independent opt-in cover.

## Validation

- Built and launched successfully in the iOS simulator with Liquid Glass enabled.
- Confirmed runtime capture of `pref_no_profanity=0` for the active simulator account.
- Completed a full device-target `make package` build and a simulator-target build successfully.
- `git diff --check` passes.
