### PR TITLE
Prevent keychain enumeration passcode prompt loops

### DIFF
--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -186,10 +186,18 @@ static OSStatus ApolloRealSecItemDelete(NSDictionary *q) {
     return ((OSStatus (*)(CFDictionaryRef))SecItemDelete_orig)((__bridge CFDictionaryRef)q);
 }
 
-// One enumeration of every generic-password keychain item (all access groups, synced included),
-// returned as attribute+data dicts (nil on failure; the status is reported via outStatus). Shared
-// by the recovery cache, the destructive-write guard, and the account diagnostics so they don't
-// each re-declare the same MatchLimitAll query.
+// One NON-INTERACTIVE enumeration of every generic-password keychain item (all access groups,
+// synced included), returned as attribute+data dicts (nil on failure; the status is reported via
+// outStatus). Shared by the recovery cache, the destructive-write guard, and the account
+// diagnostics so they don't each re-declare the same MatchLimitAll query.
+//
+// kSecUseAuthenticationUISkip is essential here. This is an internal recovery/diagnostic sweep,
+// not a user-requested secret access. Without it, Security.framework defaults to allowing UI and
+// kSecReturnData makes an unscoped MatchLimitAll query attempt to decrypt ANY visible generic
+// password. A stale or unrelated item protected by user-presence then presents "Enter iPhone
+// Passcode for Apollo". Lifecycle snapshots run this sweep more than once, so approving one
+// operation immediately led to another prompt (#770). Skipping protected rows preserves all
+// ordinary Valet recovery data while guaranteeing this background path can never authenticate.
 static NSArray<NSDictionary *> *ApolloCopyAllGenericPasswords(OSStatus *outStatus) {
     NSDictionary *q = @{
         (__bridge id)kSecClass:              (__bridge id)kSecClassGenericPassword,
@@ -197,6 +205,7 @@ static NSArray<NSDictionary *> *ApolloCopyAllGenericPasswords(OSStatus *outStatu
         (__bridge id)kSecReturnAttributes:   @YES,
         (__bridge id)kSecReturnData:         @YES,
         (__bridge id)kSecAttrSynchronizable: (__bridge id)kSecAttrSynchronizableAny,
+        (__bridge id)kSecUseAuthenticationUI: (__bridge id)kSecUseAuthenticationUISkip,
     };
     CFTypeRef result = NULL;
     OSStatus st = ApolloRealSecItemCopyMatching(q, &result);

--- a/src/settings/ApolloBackupRestore.m
+++ b/src/settings/ApolloBackupRestore.m
@@ -24,10 +24,16 @@ static NSString *const kValetServiceSubstring = @"com.christianselig.Apollo";
 // in the simulator, with the tweak's keychain shim (which serves these on launch).
 static NSArray<NSDictionary *> *ApolloCaptureValetKeychainItems(void) {
     NSDictionary *query = @{
-        (__bridge id)kSecClass:            (__bridge id)kSecClassGenericPassword,
-        (__bridge id)kSecMatchLimit:       (__bridge id)kSecMatchLimitAll,
-        (__bridge id)kSecReturnAttributes: @YES,
-        (__bridge id)kSecReturnData:       @YES,
+        (__bridge id)kSecClass:               (__bridge id)kSecClassGenericPassword,
+        (__bridge id)kSecMatchLimit:          (__bridge id)kSecMatchLimitAll,
+        (__bridge id)kSecReturnAttributes:    @YES,
+        (__bridge id)kSecReturnData:          @YES,
+        // Backup is an Apollo/Valet export, not permission to unlock some other protected
+        // generic-password item visible to this signing identity. MatchLimitAll otherwise
+        // defaults to allowing authentication UI and can unexpectedly request the device
+        // passcode. Protected rows are unrelated to Apollo's ordinary Valet stores, so skip
+        // them silently just like the recovery/diagnostic enumeration in Tweak.xm.
+        (__bridge id)kSecUseAuthenticationUI: (__bridge id)kSecUseAuthenticationUISkip,
     };
     // Keyed by service+account so mirror-only items can be merged in without duplicating a key.
     NSMutableDictionary<NSString *, NSDictionary *> *byKey = [NSMutableDictionary dictionary];


### PR DESCRIPTION
## Summary

- make login-recovery and account-diagnostic keychain enumerations non-interactive
- prevent Settings Backup from authenticating unrelated protected keychain records
- preserve the existing Valet recovery, self-healing, and account-mirror behavior

## Root cause

The 3.4.2 login-persistence work introduced an unscoped `kSecMatchLimitAll` query that requested both attributes and secret data for every generic-password item visible to Apollo's signing identity.

Security.framework allows authentication UI by default. If any visible record is protected by user presence, the background recovery/diagnostic sweep can therefore present `Enter iPhone Passcode for Apollo`. Lifecycle snapshots perform the sweep more than once, and recovery can perform it again, producing the immediate prompt loop reported in #770. Apollo's own Face ID/passcode setting is not involved.

This sets `kSecUseAuthenticationUI` to `kSecUseAuthenticationUISkip` on both broad enumeration paths. Items requiring authentication are silently omitted, while Apollo's ordinary `AccessibleAfterFirstUnlock` Valet account records remain available to login recovery.

## Validation

- `THEOS=/Users/Jordan.Earle/theos make package`
- `THEOS=/Users/Jordan.Earle/theos scripts/run-in-sim.sh --glass --logs`
- confirmed the Liquid Glass simulator launch completed with the tweak loaded
- confirmed the existing signed-in simulator account remained active
- `git diff --check`

Physical-device confirmation is still required because the simulator cannot reproduce hardware-backed user-presence keychain records.

Closes #770
