### PR TITLE
Fix recent UI and moderation regressions

### DIFF
--- a/src/ApolloImmersiveHeaderBackground.h
+++ b/src/ApolloImmersiveHeaderBackground.h
@@ -2,11 +2,11 @@
 
 // Draws a profile or subreddit banner through the table's adjusted top inset
 // so the artwork continues behind the navigation bar without changing the
-// existing header's layout. Two layers: the sharp banner owns the chrome +
-// banner strip (`regionHeight`), then dissolves into a blurred continuation
-// of itself that sits behind the identity text and resolves to the theme
-// page color exactly at `extendedHeight` (the bottom of the identity header),
-// where the first opaque cells begin.
+// existing header's layout. Two layers: a blurred continuation owns the
+// chrome + identity region, while the sharp image uses the actual banner strip
+// inside `regionHeight` (below `topInset`) and dissolves into the blur. The blur
+// resolves to the theme page color exactly at `extendedHeight` (the bottom of
+// the identity header), where the first opaque cells begin.
 @interface ApolloImmersiveHeaderBackgroundView : UIView
 
 @property(nonatomic, assign) CGFloat contentTranslation;

--- a/src/ApolloImmersiveHeaderBackground.m
+++ b/src/ApolloImmersiveHeaderBackground.m
@@ -370,7 +370,11 @@ static void ApolloImmersiveRequestBackdrop(UIImage *banner, void (^completion)(U
     [_contentContainer.layer addSublayer:_veilLayer];
 
     // Top layer: the sharp banner, alpha-feathered at its bottom edge so it
-    // melts into the blur instead of a hard seam.
+    // melts into the blur instead of a hard seam. The clip spans the chrome +
+    // banner region, but layout sizes the image itself to the real banner
+    // strip; the chrome above shows the blurred continuation. Aspect-filling
+    // one tall chrome+banner rectangle made the crop depend on the search-bar
+    // inset and visibly jumped whenever that inset changed (#766).
     _sharpClip = [[UIView alloc] init];
     _sharpClip.clipsToBounds = YES;
     _sharpClip.userInteractionEnabled = NO;
@@ -481,7 +485,9 @@ static void ApolloImmersiveRequestBackdrop(UIImage *banner, void (^completion)(U
     self.backdropView.frame = CGRectMake(0.0, 0.0, width, extendedHeight);
 
     self.sharpClip.frame = CGRectMake(0.0, 0.0, width, regionHeight);
-    self.sharpView.frame = self.sharpClip.bounds;
+    CGFloat bannerTop = MIN(regionHeight, MAX(0.0, self.topInset));
+    CGFloat bannerHeight = MAX(1.0, regionHeight - bannerTop);
+    self.sharpView.frame = CGRectMake(0.0, bannerTop, width, bannerHeight);
     CGFloat featherStart = MAX(0.0, 1.0 - ApolloImmersiveSharpFeatherHeight / MAX(1.0, regionHeight));
     self.sharpFeatherMask.frame = self.sharpClip.bounds;
     self.sharpFeatherMask.locations = @[@(featherStart), @1.0];

--- a/src/ApolloNativeActionMenus.xm
+++ b/src/ApolloNativeActionMenus.xm
@@ -1170,6 +1170,87 @@ static UIViewController *ApolloNativeActionMenuViewControllerForView(UIView *vie
     return nil;
 }
 
+// Apollo's banned-user screen still presents its 2017-era Swift
+// ActionController when Liquid Glass is unavailable.  On some iOS 18 builds
+// that controller crashes while being presented, before the moderator can
+// choose "Edit Ban" (issue #765).  Keep Apollo's own row handlers—the code
+// that opens the contextual comment or pre-filled BanUserViewController—but
+// host those actions in UIKit's stable action sheet instead.  This is scoped
+// to this one screen and only runs when the iOS 26 native-menu replacement is
+// not active.
+static void ApolloLegacyBannedUserAppendActions(NSMutableArray<UIAction *> *actions,
+                                                 NSArray<UIMenuElement *> *elements) {
+    for (UIMenuElement *element in elements) {
+        if ([element isKindOfClass:[UIAction class]]) {
+            [actions addObject:(UIAction *)element];
+        } else if ([element isKindOfClass:[UIMenu class]]) {
+            ApolloLegacyBannedUserAppendActions(actions, ((UIMenu *)element).children);
+        }
+    }
+}
+
+static BOOL ApolloLegacyBannedUserActionMenuPresent(id presenter,
+                                                     id actionController,
+                                                     void (^completion)(void)) {
+    if (ApolloNativeActionMenusEnabled()) return NO;
+    if (![actionController isKindOfClass:objc_getClass("_TtC6Apollo16ActionController")]) return NO;
+
+    UIViewController *host = [presenter isKindOfClass:[UIViewController class]] ? presenter : nil;
+    UIViewController *content = [host isKindOfClass:[UINavigationController class]]
+        ? ((UINavigationController *)host).topViewController
+        : host;
+    if (![content isKindOfClass:objc_getClass("_TtC6Apollo34ModeratorBannedUsersViewController")]) return NO;
+    if (ApolloReadBoolIvar(actionController, "showKeyboardOnAppearanceForTextEntryView", NO)) return NO;
+    if (ApolloNativeActionMenuActionControllerHasCustomHeader(actionController)) return NO;
+
+    UIMenu *menu = ApolloNativeActionMenuBuildMenu(actionController, YES);
+    if (!menu) return NO;
+
+    NSMutableArray<UIAction *> *menuActions = [NSMutableArray array];
+    ApolloLegacyBannedUserAppendActions(menuActions, menu.children);
+    if (menuActions.count == 0) return NO;
+
+    UIView *sourceView = ApolloNativeActionMenuSelectedCellForPresenter(content)
+        ?: ApolloNativeActionMenuViewForObject(content);
+    if (!sourceView.window) return NO;
+    objc_setAssociatedObject(actionController, &kApolloNativeActionMenuSourceViewKey,
+                             sourceView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:nil
+                                                                   message:nil
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+    for (UIAction *menuAction in menuActions) {
+        UIAction *retainedMenuAction = menuAction;
+        UIAlertActionStyle style = (menuAction.attributes & UIMenuElementAttributesDestructive)
+            ? UIAlertActionStyleDestructive
+            : UIAlertActionStyleDefault;
+        UIAlertAction *alertAction = [UIAlertAction actionWithTitle:menuAction.title
+                                                              style:style
+                                                            handler:^(__unused UIAlertAction *selectedAction) {
+            ApolloNativeActionMenuActionHandler handler =
+                ((ApolloNativeActionMenuActionHandler (*)(id, SEL))objc_msgSend)(retainedMenuAction,
+                                                                                 @selector(handler));
+            if (handler) handler(retainedMenuAction);
+        }];
+        alertAction.enabled = !(menuAction.attributes & UIMenuElementAttributesDisabled);
+        [sheet addAction:alertAction];
+    }
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel"
+                                              style:UIAlertActionStyleCancel
+                                            handler:nil]];
+
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    if (popover) {
+        popover.sourceView = sourceView;
+        popover.sourceRect = sourceView.bounds;
+    }
+
+    ApolloLog(@"[NativeActionMenu] Using UIKit fallback for banned-user actions (%lu item(s))",
+              (unsigned long)menuActions.count);
+    [host presentViewController:sheet animated:YES completion:completion];
+    return YES;
+}
+
 // Walk down the presentedViewController chain to the top-most window-backed
 // controller that can legally present a new modal. Skips the window-less
 // ActionController (which the native-menu path never actually presents).
@@ -1722,6 +1803,9 @@ static BOOL ApolloNativeActionMenuCanFallbackPresent(id presenter, id actionCont
     if (ApolloNativeActionMenuPresent(self, viewControllerToPresent, completion)) {
         return;
     }
+    if (ApolloLegacyBannedUserActionMenuPresent(self, viewControllerToPresent, completion)) {
+        return;
+    }
     %orig;
 }
 %end
@@ -1730,6 +1814,9 @@ static BOOL ApolloNativeActionMenuCanFallbackPresent(id presenter, id actionCont
 
 - (void)presentViewController:(UIViewController *)viewControllerToPresent animated:(BOOL)flag completion:(void (^)(void))completion {
     if (ApolloNativeActionMenuPresent(self, viewControllerToPresent, completion)) {
+        return;
+    }
+    if (ApolloLegacyBannedUserActionMenuPresent(self, viewControllerToPresent, completion)) {
         return;
     }
 

--- a/src/ApolloPollCompose.xm
+++ b/src/ApolloPollCompose.xm
@@ -35,6 +35,48 @@ static id ApolloPollComposeIvar(id object, const char *name) {
     return ivar ? object_getIvar(object, ivar) : nil;
 }
 
+// Swift Optional<Array<Dictionary<String, Any>>> and Optional<Dictionary<…>>
+// store their bridged heap object in the first word. ComposePostViewController
+// does not expose ObjC getters for either flairOptions or selectedFlairOption,
+// so read that word directly (the same runtime representation used by
+// ApolloUserFlair.xm). Never use object_getIvar here: these are Swift value
+// types, not ObjC object ivars.
+static id ApolloPollComposeRawSwiftObjectIvar(id object, const char *name) {
+    if (!object) return nil;
+    Ivar ivar = class_getInstanceVariable(object_getClass(object), name);
+    if (!ivar) return nil;
+    void *rawValue = NULL;
+    memcpy(&rawValue,
+           (const uint8_t *)(__bridge const void *)object + ivar_getOffset(ivar),
+           sizeof(rawValue));
+    return (__bridge id)rawValue;
+}
+
+static NSString *ApolloPollComposeFlairString(NSDictionary *option, NSArray<NSString *> *keys) {
+    if (![option isKindOfClass:NSDictionary.class]) return nil;
+    for (NSString *key in keys) {
+        id value = option[key];
+        if ([value isKindOfClass:NSString.class] && [value length] > 0) return value;
+    }
+    return nil;
+}
+
+static NSString *ApolloPollComposeFlairTitle(NSDictionary *option) {
+    NSString *text = ApolloPollComposeFlairString(option, @[@"text", @"flair_text", @"name"]);
+    if (text.length > 0) return text;
+    id richText = option[@"richtext"] ?: option[@"flair_richtext"];
+    if ([richText isKindOfClass:NSArray.class]) {
+        NSMutableString *joined = [NSMutableString string];
+        for (id piece in (NSArray *)richText) {
+            if (![piece isKindOfClass:NSDictionary.class]) continue;
+            NSString *pieceText = ApolloPollComposeFlairString(piece, @[@"t", @"a"]);
+            if (pieceText.length > 0) [joined appendString:pieceText];
+        }
+        if (joined.length > 0) return joined;
+    }
+    return @"Untitled Flair";
+}
+
 // Decode a Swift String stored inline as a two-word struct ivar (Swift stored
 // properties have no ObjC getter). Small strings (≤15 UTF-8 bytes) decode from
 // the packed words; everything else goes through Swift's own
@@ -244,6 +286,8 @@ UIMenu *ApolloSubmitPostTypesMenu(__unused id actionController, void (^selectRow
 @property (nonatomic, copy) NSString *username;
 @property (nonatomic, strong) NSMutableArray<NSString *> *optionTexts;
 @property (nonatomic, copy) NSString *titleText;
+@property (nonatomic, copy) NSArray<NSDictionary *> *flairOptions;
+@property (nonatomic, copy) NSDictionary *selectedFlairOption;
 @property (nonatomic) NSInteger durationDays;
 @property (nonatomic) BOOL submitting;
 @end
@@ -274,7 +318,25 @@ UIMenu *ApolloSubmitPostTypesMenu(__unused id actionController, void (^selectRow
     UIColor *accent = ApolloThemeAccentColor();
     if (accent) self.navigationController.navigationBar.tintColor = accent;
     self.tableView.backgroundColor = self.composeBackgroundColor ?: self.composeHost.view.backgroundColor;
+    [self refreshFlairOptions];
     [self revalidate];
+}
+
+- (void)refreshFlairOptions {
+    id rawOptions = ApolloPollComposeRawSwiftObjectIvar(self.composeHost, "flairOptions");
+    if ([rawOptions isKindOfClass:NSArray.class]) {
+        NSMutableArray<NSDictionary *> *valid = [NSMutableArray array];
+        for (id option in (NSArray *)rawOptions) {
+            if ([option isKindOfClass:NSDictionary.class]) [valid addObject:option];
+        }
+        self.flairOptions = valid;
+    } else {
+        self.flairOptions = @[];
+    }
+    if (!self.selectedFlairOption) {
+        id selected = ApolloPollComposeRawSwiftObjectIvar(self.composeHost, "selectedFlairOption");
+        if ([selected isKindOfClass:NSDictionary.class]) self.selectedFlairOption = selected;
+    }
 }
 
 - (NSArray<NSString *> *)filledOptions {
@@ -294,7 +356,7 @@ UIMenu *ApolloSubmitPostTypesMenu(__unused id actionController, void (^selectRow
 
 #pragma mark Table
 
-- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView { return 3; }
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView { return 4; }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     if (section == 0) return 1;
@@ -305,12 +367,14 @@ UIMenu *ApolloSubmitPostTypesMenu(__unused id actionController, void (^selectRow
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
     if (section == 0) return @"Title";
     if (section == 1) return @"Options";
+    if (section == 2) return @"Flair";
     return @"Duration";
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {
     if (section == 1) return @"2 to 6 options. Empty ones are skipped.";
-    if (section == 2) return @"Voting closes this many days after posting.";
+    if (section == 2) return @"Required in communities that require post flair.";
+    if (section == 3) return @"Voting closes this many days after posting.";
     return nil;
 }
 
@@ -356,6 +420,12 @@ UIMenu *ApolloSubmitPostTypesMenu(__unused id actionController, void (^selectRow
             cell.textLabel.textColor = ApolloThemeAccentColor() ?: cell.textLabel.tintColor;
             cell.selectionStyle = UITableViewCellSelectionStyleDefault;
         }
+    } else if (indexPath.section == 2) {
+        cell.textLabel.text = @"Post Flair";
+        cell.detailTextLabel.text = self.selectedFlairOption
+            ? ApolloPollComposeFlairTitle(self.selectedFlairOption) : @"None";
+        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+        cell.selectionStyle = UITableViewCellSelectionStyleDefault;
     } else {
         cell.textLabel.text = @"Poll Duration";
         cell.detailTextLabel.text = [NSString stringWithFormat:@"%ld %@", (long)self.durationDays,
@@ -374,11 +444,49 @@ UIMenu *ApolloSubmitPostTypesMenu(__unused id actionController, void (^selectRow
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    if (indexPath.section == 2) {
+        [self presentFlairPickerFromCell:[tableView cellForRowAtIndexPath:indexPath]];
+        return;
+    }
     if (indexPath.section != 1 || (NSUInteger)indexPath.row != self.optionTexts.count) return;
     [self.optionTexts addObject:@""];
     // Reload the section rather than inserting: the "Add Option" row also moves
     // (or disappears at the 6-option cap), and these tiny tables reload cheaply.
     [tableView reloadSections:[NSIndexSet indexSetWithIndex:1] withRowAnimation:UITableViewRowAnimationAutomatic];
+}
+
+- (void)presentFlairPickerFromCell:(UITableViewCell *)cell {
+    [self refreshFlairOptions];
+    if (self.flairOptions.count == 0) {
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"No Post Flairs"
+            message:@"This community did not return any post flair choices. If its flairs are still loading, wait a moment and try again."
+            preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
+        [self presentViewController:alert animated:YES completion:nil];
+        return;
+    }
+
+    UIAlertController *picker = [UIAlertController alertControllerWithTitle:@"Post Flair"
+        message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+    __weak typeof(self) weakSelf = self;
+    [picker addAction:[UIAlertAction actionWithTitle:@"None" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        weakSelf.selectedFlairOption = nil;
+        [weakSelf.tableView reloadSections:[NSIndexSet indexSetWithIndex:2] withRowAnimation:UITableViewRowAnimationNone];
+    }]];
+    for (NSDictionary *option in self.flairOptions) {
+        NSString *title = ApolloPollComposeFlairTitle(option);
+        [picker addAction:[UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+            weakSelf.selectedFlairOption = option;
+            [weakSelf.tableView reloadSections:[NSIndexSet indexSetWithIndex:2] withRowAnimation:UITableViewRowAnimationNone];
+        }]];
+    }
+    [picker addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    UIPopoverPresentationController *popover = picker.popoverPresentationController;
+    if (popover) {
+        popover.sourceView = cell ?: self.view;
+        popover.sourceRect = cell ? cell.bounds : self.view.bounds;
+    }
+    [self presentViewController:picker animated:YES completion:nil];
 }
 
 - (void)textFieldChanged:(UITextField *)field {
@@ -397,7 +505,7 @@ UIMenu *ApolloSubmitPostTypesMenu(__unused id actionController, void (^selectRow
 
 - (void)durationChanged:(UIStepper *)stepper {
     self.durationDays = (NSInteger)stepper.value;
-    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:2] withRowAnimation:UITableViewRowAnimationNone];
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:3] withRowAnimation:UITableViewRowAnimationNone];
 }
 
 #pragma mark Submission
@@ -467,15 +575,21 @@ UIMenu *ApolloSubmitPostTypesMenu(__unused id actionController, void (^selectRow
         [self showError:@"The stored Reddit session has no modhash. Sign in again from the account switcher and retry."];
         return;
     }
-    NSDictionary *body = @{ @"sr": self.subredditName ?: @"",
-                            @"title": [self.titleText stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet],
-                            @"text": @"",
-                            @"options": self.filledOptions,
-                            @"duration": @(self.durationDays),
-                            @"api_type": @"json",
-                            @"kind": @"poll",
-                            @"resubmit": @YES,
-                            @"sendreplies": @YES };
+    NSMutableDictionary *body = [@{ @"sr": self.subredditName ?: @"",
+                                    @"title": [self.titleText stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet],
+                                    @"text": @"",
+                                    @"options": self.filledOptions,
+                                    @"duration": @(self.durationDays),
+                                    @"api_type": @"json",
+                                    @"kind": @"poll",
+                                    @"resubmit": @YES,
+                                    @"sendreplies": @YES } mutableCopy];
+    NSString *flairID = ApolloPollComposeFlairString(self.selectedFlairOption,
+        @[@"id", @"flair_id", @"template_id"]);
+    NSString *flairText = ApolloPollComposeFlairString(self.selectedFlairOption,
+        @[@"text", @"flair_text"]);
+    if (flairID.length > 0) body[@"flair_id"] = flairID;
+    if (flairText.length > 0) body[@"flair_text"] = flairText;
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:kApolloPollSubmitEndpoint]];
     request.HTTPMethod = @"POST";
     NSError *serializationError = nil;

--- a/src/ApolloSearchInPlace.xm
+++ b/src/ApolloSearchInPlace.xm
@@ -153,6 +153,12 @@ static BOOL sCancelNeedsIntro = NO;
 // Liquid Glass — the jump happens on stock Apollo too.
 static __weak UIScrollView *sFeedSearchTable     = nil;  // captured tableNode.view (ASTableView)
 static __weak UIView        *sFeedSearchToolbar   = nil;  // captured upperToolbar (the rest anchor)
+// The one ASTableViewController that owns every capture above. During an
+// interactive push/pop UIKit lays out both the source and destination
+// controllers; without an owner gate the off-screen controller can replace
+// these process-wide weak refs with its own table/toolbar and then tear down
+// the visible search session from viewWillDisappear:.
+static __weak UIViewController *sFeedSearchOwner = nil;
 static BOOL sFeedSearchActive         = NO;  // YES while a feed (!stick) search is editing
 static BOOL sFeedSearchDismissing     = NO;  // YES briefly during dismiss (relax clamp to a downward pull)
 static BOOL sFeedSearchScrolledByUser = NO;  // armed once the user drags → stop clamping so they can browse
@@ -472,6 +478,9 @@ static void recenterCancelButton(void) {
 
     // Offset stabilizer (runs regardless of Liquid Glass): arm the active flags and capture the feed
     // table + docked toolbar (the rest anchor) + field so the ASTableView inset/offset hooks engage.
+    UIViewController *owner = (UIViewController *)self;
+    if (sFeedSearchOwner && sFeedSearchOwner != owner) ApolloFeedSearchRestoreHeader();
+    sFeedSearchOwner = owner;
     sFeedSearchActive = YES;
     sFeedSearchDismissing = NO;
     sFeedSearchScrolledByUser = NO;
@@ -504,6 +513,9 @@ static void recenterCancelButton(void) {
 - (void)viewDidLayoutSubviews {
     %orig;
     if (MSHookIvar<BOOL>(self, "searchBarShouldStickToKeyboard")) return; // feed-only; skip comments search
+    // Navigation transitions lay out multiple ASTableViewControllers in the
+    // same frame. Only the focused/restored feed may refresh the shared refs.
+    if (sFeedSearchOwner != (UIViewController *)self) return;
     // Keep the offset-stabilizer refs current (runs regardless of Liquid Glass).
     id tableNode = ApolloObjectIvar(self, "tableNode");
     UIView *tv = [tableNode respondsToSelector:@selector(view)] ? [tableNode view] : nil;
@@ -532,6 +544,11 @@ static void recenterCancelButton(void) {
 }
 
 - (void)dismissSearchBarButtonTappedWithSender:(id)sender {
+    UIViewController *owner = (UIViewController *)self;
+    if (sFeedSearchOwner != owner) {
+        %orig;
+        return;
+    }
     // In-place: Apollo's teardown (sub_1002bf57c) animates the toolbar/field/button from the docked-top
     // geometry; since the nav bar never moved here, that reads as a "fly in from above". Keep our pins
     // live through the teardown (don't pre-clear), strip the implicit animations (in the toolbar hooks),
@@ -544,10 +561,13 @@ static void recenterCancelButton(void) {
         animateCancelOut();                           // fade the round-X out
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.45 * NSEC_PER_SEC)),
                        dispatch_get_main_queue(), ^{
-            if (gen != sFeedSearchDismissGen) return; // re-focused / re-dismissed meanwhile
+            if (gen != sFeedSearchDismissGen || sFeedSearchOwner != owner) return;
+            // Re-focused / re-dismissed or another feed took ownership.
             sFeedSearchActive = NO;
             sFeedSearchDismissing = NO;
+            sFeedSearchOwner = nil;
             sFeedSearchNavBar = nil;
+            sFeedSearchTable = nil;
             sFeedSearchToolbar = nil;
             sFeedSearchField = nil;
             sFeedSearchCancel = nil;
@@ -563,10 +583,19 @@ static void recenterCancelButton(void) {
     sFeedSearchNavBar = nil;
     sFeedSearchActive = NO;
     sFeedSearchDismissing = YES;
+    NSUInteger gen = ++sFeedSearchDismissGen;
     %orig;
     animateCancelOut(); // slide the round-X out
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.4 * NSEC_PER_SEC)),
-                   dispatch_get_main_queue(), ^{ sFeedSearchDismissing = NO; });
+                   dispatch_get_main_queue(), ^{
+        if (gen != sFeedSearchDismissGen || sFeedSearchOwner != owner) return;
+        sFeedSearchDismissing = NO;
+        sFeedSearchOwner = nil;
+        sFeedSearchTable = nil;
+        sFeedSearchToolbar = nil;
+        sFeedSearchField = nil;
+        sFeedSearchCancel = nil;
+    });
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -588,7 +617,12 @@ static void recenterCancelButton(void) {
     // flag) before the appear / re-focus, so the nav stays put and the toolbar docks below it from the
     // first pass. textFieldDidBeginEditing re-arms idempotently if/when the field actually focuses.
     if (sKeepSearchBarInPlace && txt.length > 0) {
+        sFeedSearchOwner = (UIViewController *)self;
+        ++sFeedSearchDismissGen;
         sFeedSearchNavBar = [(UIViewController *)self navigationController].navigationBar;
+        id tableNode = ApolloObjectIvar(self, "tableNode");
+        UIView *tableView = [tableNode respondsToSelector:@selector(view)] ? [tableNode view] : nil;
+        if ([tableView isKindOfClass:objc_getClass("ASTableView")]) sFeedSearchTable = (UIScrollView *)tableView;
         if ([field isKindOfClass:[UIView class]]) sFeedSearchField = (UIView *)field;
         id upper = ApolloObjectIvar(self, "upperToolbar");
         if ([upper isKindOfClass:[UIView class]]) sFeedSearchToolbar = (UIView *)upper;
@@ -627,20 +661,25 @@ static void recenterCancelButton(void) {
     }
 }
 
-- (void)viewWillDisappear:(BOOL)animated {
-    // If this controller owns the captured bar and is leaving, drop the capture so a stale reference
-    // can't affect an unrelated transform later.
-    if (sFeedSearchNavBar && [(UIViewController *)self navigationController].navigationBar == sFeedSearchNavBar) {
-        sFeedSearchNavBar = nil;
-    }
+- (void)viewDidDisappear:(BOOL)animated {
+    %orig;
+    // viewWillDisappear: also runs when an interactive swipe is cancelled.
+    // Waiting for viewDidDisappear: preserves the source feed in that case;
+    // owner scoping above prevents the destination's transition layouts from
+    // touching these refs while the gesture is in flight.
+    if (sFeedSearchOwner != (UIViewController *)self) return;
+    ApolloFeedSearchRestoreHeader();
+    sFeedSearchOwner = nil;
+    sFeedSearchNavBar = nil;
+    sFeedSearchTable = nil;
     sFeedSearchActive = NO;
     sFeedSearchDismissing = NO;
     sFeedSearchToolbar = nil;
     sFeedSearchField = nil;
     sFeedSearchCancel = nil;
+    sFeedSearchScrolledByUser = NO;
     sCancelNeedsIntro = NO;
     ++sFeedSearchDismissGen; // a pending dismiss release timer can't resurrect state after we leave
-    %orig;
 }
 
 %end

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -6310,7 +6310,13 @@ static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
             objc_setAssociatedObject(navItem, kApolloGlobeStandaloneItemKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         }
 
-        if (globe.superview == container) return;  // already merged — don't double-shift
+        if (globe.superview == container) {
+            // The visual pill may have been rebuilt around the same custom
+            // view. Keep the title invalidation alive even though the button
+            // geometry itself is already merged.
+            ApolloSubredditRequestTitleRelayout(navItem);
+            return;  // already merged — don't double-shift
+        }
 
         CGFloat gw = kApolloGlobeMergeSlotWidth;
         CGFloat h = container.bounds.size.height > 1.0 ? container.bounds.size.height : 44.0;
@@ -6387,6 +6393,19 @@ static void ApolloApplyGlobeMergeForNavItem(UINavigationItem *navItem) {
         container.bounds = CGRectMake(0.0, 0.0, newW, cf.size.height > 1.0 ? cf.size.height : h);
         objc_setAssociatedObject(container, kApolloGlobeMergeShiftKey, @(shift), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         [container setNeedsLayout];
+
+        // iOS 27 caches the UIBarButtonItem custom-view measurement more
+        // aggressively than iOS 26. Merely widening container.frame can leave
+        // the platter and title wrapper laid out for the pre-globe width, so a
+        // long subreddit title overlaps the new leading globe (#772). Re-set
+        // the item array under the merge guard to invalidate UIKit's cached
+        // measurement, then explicitly ask the subreddit title to remeasure.
+        // The platter-frame hook in ApolloLiquidGlass performs the final poke
+        // once UIKit publishes the resized visual capsule.
+        sApplyingGlobeMerge = YES;
+        navItem.rightBarButtonItems = [navItem.rightBarButtonItems copy];
+        sApplyingGlobeMerge = NO;
+        ApolloSubredditRequestTitleRelayout(navItem);
         return;
     }
 


### PR DESCRIPTION
## Summary

Fixes five regressions reported after 3.5.0:

- adds post-flair selection to the poll composer and forwards the selected flair with poll submissions
- replaces the crash-prone legacy banned-user action controller with a scoped UIKit action sheet while preserving Apollo's original View Comment and Edit Ban handlers
- keeps immersive subreddit banner artwork aligned when the search inset changes
- preserves in-place subreddit search ownership and state through completed and cancelled interactive navigation transitions
- invalidates the navigation item's cached width after merging the translation globe so long subreddit titles truncate before the control instead of overlapping it

## Root causes

- The custom poll flow skipped Apollo's already-loaded `flairOptions` and never sent `flair_id` / `flair_text`.
- The affected standard/iOS 18 moderation flow presents Apollo's old Swift `ActionController`; the selected banned-user model itself is bounds-checked and safely decoded, so the fallback bypasses only that presentation layer.
- The immersive sharp image aspect-filled the combined chrome-and-banner rectangle, making its crop depend on the changing top/search inset.
- Search state used process-wide weak references without tracking which feed owned them. UIKit lays out both sides of an interactive transition, allowing the wrong controller to replace or clear the active feed's state.
- Newer UIKit caches a `UIBarButtonItem` custom-view measurement after the translation globe is merged, leaving the title wrapper unaware of the control's wider footprint.

## Validation

- clean iOS 14 device package build against the pinned iOS 26 SDK
- clean iOS Simulator build and Liquid Glass launch
- poll composer: loaded real subreddit flair choices and updated the selected row
- banned users: selected a real banned user on both Glass and standard shells; the standard fallback showed View Comment/Edit Ban and Edit Ban opened Apollo's pre-filled editor
- immersive banner: compared normal and focused-search layouts; the sharp strip stayed aligned
- search: searched a subreddit, opened a result, swiped back, and confirmed the query, Current Posts mode, and rows remained; also exercised a cancelled edge swipe
- translation: verified a long subreddit title truncates before the merged globe without overlap

Fixes #764
Fixes #765
Fixes #766
Fixes #768
Fixes #772
