### PR TITLE
Restore audio for hosted Gallery videos

### DIFF
--- a/src/ApolloGalleryFeed.h
+++ b/src/ApolloGalleryFeed.h
@@ -58,6 +58,15 @@ static ApolloGalleryMediaKind const ApolloGalleryMediaKindAll =
 // ApolloGalleryVideoExport recognises and re-unites with the separate DASH
 // audio before writing to Photos; everywhere else it's already self-contained.
 @property (nonatomic, copy, nullable) NSURL *videoDownloadURL;
+// External video page (currently Redgifs / Streamable / supported sports
+// hosts). Reddit commonly supplies a convenient but silent re-encoded preview
+// for these posts; Gallery keeps that preview as a fallback, then resolves the
+// host's original audio-bearing MP4 only when the item is opened.
+@property (nonatomic, readonly, copy, nullable) NSURL *hostedVideoPageURL;
+// YES until the one lazy host lookup has completed. The lookup is coalesced per
+// item, so repeated playback/layout passes never duplicate API requests.
+@property (nonatomic, readonly) BOOL needsHostedVideoResolution;
+@property (nonatomic, readonly, getter=isHostedVideoResolving) BOOL hostedVideoResolving;
 // Runtime in seconds; 0 when Reddit didn't report one.
 @property (nonatomic) NSTimeInterval duration;
 // Smaller preview used by the grid; falls back to imageURL when Reddit gave
@@ -90,6 +99,11 @@ static ApolloGalleryMediaKind const ApolloGalleryMediaKindAll =
 @property (nonatomic, readonly) BOOL playsAsVideo;
 // "0:42" / "1:23:45", or nil when the duration is unknown.
 @property (nonatomic, readonly, nullable) NSString *durationText;
+
+// Resolves hostedVideoPageURL once, preferring the original combined MP4 over
+// Reddit's silent preview. On failure videoURL remains/restores the Reddit
+// fallback. Completion is delivered on the main queue.
+- (void)resolveHostedVideoWithCompletion:(nullable void (^)(BOOL resolvedOriginal))completion;
 
 @end
 

--- a/src/ApolloGalleryFeed.m
+++ b/src/ApolloGalleryFeed.m
@@ -2,6 +2,7 @@
 
 #import "ApolloGalleryFeed.h"
 #import "ApolloCommon.h"
+#import "ApolloHostedVideo.h"
 #import "ApolloState.h"
 
 // How many pictures one "batch" should try to gather before the UI is told to
@@ -71,6 +72,15 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
 
 #pragma mark - ApolloGalleryItem
 
+@interface ApolloGalleryItem ()
+@property (nonatomic, readwrite, copy, nullable) NSURL *hostedVideoPageURL;
+@property (nonatomic, readwrite, getter=isHostedVideoResolving) BOOL hostedVideoResolving;
+@property (nonatomic) BOOL hostedVideoResolutionAttempted;
+@property (nonatomic) BOOL hostedVideoResolvedOriginal;
+@property (nonatomic, copy, nullable) NSURL *hostedVideoFallbackDownloadURL;
+@property (nonatomic, strong) NSMutableArray *hostedVideoResolveCompletions;
+@end
+
 @implementation ApolloGalleryItem
 
 - (instancetype)init {
@@ -83,7 +93,65 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
 }
 
 - (BOOL)playsAsVideo {
-    return self.videoURL != nil;
+    return self.videoURL != nil || self.hostedVideoPageURL != nil;
+}
+
+- (BOOL)needsHostedVideoResolution {
+    return self.hostedVideoPageURL != nil && !self.hostedVideoResolutionAttempted;
+}
+
+- (void)resolveHostedVideoWithCompletion:(void (^)(BOOL resolvedOriginal))completion {
+    if (!self.hostedVideoPageURL) {
+        if (completion) completion(NO);
+        return;
+    }
+    if (self.hostedVideoResolutionAttempted) {
+        if (completion) completion(self.hostedVideoResolvedOriginal);
+        return;
+    }
+
+    if (!self.hostedVideoResolveCompletions) {
+        self.hostedVideoResolveCompletions = [NSMutableArray array];
+    }
+    if (completion) [self.hostedVideoResolveCompletions addObject:[completion copy]];
+    if (self.hostedVideoResolving) return;
+
+    self.hostedVideoResolving = YES;
+    NSURL *pageURL = self.hostedVideoPageURL;
+    ApolloLog(@"[Gallery] resolving original hosted video for %@", pageURL.host ?: @"unknown host");
+    __weak typeof(self) weakSelf = self;
+    ApolloHostedVideoResolve(pageURL, ^(NSURL *mp4URL, NSURL *posterURL,
+                                        CGSize pixelSize, BOOL hasAudio) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+
+        BOOL resolved = (mp4URL != nil);
+        if (resolved) {
+            // Hosted MP4s are self-contained, including their audio track.
+            strongSelf.videoURL = mp4URL;
+            strongSelf.videoDownloadURL = mp4URL;
+            if (!strongSelf.imageURL && posterURL) strongSelf.imageURL = posterURL;
+            if (CGSizeEqualToSize(strongSelf.pixelSize, CGSizeZero) &&
+                pixelSize.width > 0.0 && pixelSize.height > 0.0) {
+                strongSelf.pixelSize = pixelSize;
+            }
+        } else {
+            // Keep playback working even if the host API is unavailable. The
+            // Reddit preview may be silent, but it is still better than a dead
+            // tile; saving follows the same fallback after this attempt.
+            strongSelf.videoDownloadURL = strongSelf.hostedVideoFallbackDownloadURL;
+        }
+        strongSelf.hostedVideoResolvedOriginal = resolved;
+        strongSelf.hostedVideoResolutionAttempted = YES;
+        strongSelf.hostedVideoResolving = NO;
+
+        ApolloLog(@"[Gallery] hosted video %@ (original=%d audio=%d)",
+                  resolved ? @"ready" : @"fell back to Reddit preview",
+                  (int)resolved, (int)hasAudio);
+        NSArray *callbacks = [strongSelf.hostedVideoResolveCompletions copy];
+        [strongSelf.hostedVideoResolveCompletions removeAllObjects];
+        for (void (^callback)(BOOL) in callbacks) callback(resolved);
+    });
 }
 
 - (NSString *)durationText {
@@ -504,7 +572,9 @@ static BOOL ApolloGalleryURLLooksLikeImage(NSURL *url) {
             // Key on the stream for playables: two posts of the same video can
             // carry differently-signed poster URLs, and every v.redd.it poster
             // is unique even when the clip isn't.
-            NSString *key = item.videoURL.absoluteString ?: item.imageURL.absoluteString;
+            NSString *key = item.hostedVideoPageURL.absoluteString
+                ?: item.videoURL.absoluteString
+                ?: item.imageURL.absoluteString;
             if (key.length == 0 || [self.seenImageKeys containsObject:key]) continue;
             [self.seenImageKeys addObject:key];
             [self.mutableItems addObject:item];
@@ -665,6 +735,14 @@ static NSURL *ApolloGalleryDirectVideoURL(NSURL *url) {
 - (ApolloGalleryItem *)videoItemFromPost:(NSDictionary *)post {
     NSDictionary *previewImage = ApolloGalleryDict(ApolloGalleryArray(ApolloGalleryDict(post[@"preview"])[@"images"]).firstObject);
     NSDictionary *previewSource = ApolloGalleryDict(previewImage[@"source"]);
+    NSURL *direct = ApolloGalleryURL(post[@"url_overridden_by_dest"]) ?: ApolloGalleryURL(post[@"url"]);
+    NSURL *directVideo = direct ? ApolloGalleryDirectVideoURL(direct) : nil;
+    ApolloHostedVideoKind hostedKind = ApolloHostedVideoKindForURL(direct);
+    // A CDN URL can belong to a supported host while already pointing at a
+    // self-contained MP4. It needs no page/API resolution (and its path is not
+    // a valid host video ID), so only classify actual hosted pages here.
+    BOOL isHostedDirectVideo = directVideo && hostedKind != ApolloHostedVideoNone;
+    BOOL isHostedVideo = !directVideo && hostedKind != ApolloHostedVideoNone;
 
     NSDictionary *redditVideo = ApolloGalleryDict(ApolloGalleryDict(post[@"media"])[@"reddit_video"])
                                 ?: ApolloGalleryDict(ApolloGalleryDict(post[@"secure_media"])[@"reddit_video"]);
@@ -683,6 +761,12 @@ static NSURL *ApolloGalleryDirectVideoURL(NSURL *url) {
         // recognises a v.redd.it URL and muxes the DASH audio back in.
         downloadable = ApolloGalleryURL(redditVideo[@"fallback_url"]);
         if (ApolloGalleryVideoIsSilentLoop(redditVideo)) kind = ApolloGalleryMediaKindGIF;
+    } else if (isHostedDirectVideo) {
+        // Some host links already are the combined CDN MP4. Prefer it over
+        // Reddit's silent preview without spending an API request.
+        stream = directVideo;
+        downloadable = directVideo;
+        kind = ApolloGalleryMediaKindVideo;
     } else if (previewVideo) {
         // An external GIF/short clip Reddit re-hosted; nearly always silent.
         stream = ApolloGalleryVideoStreamURL(previewVideo);
@@ -690,8 +774,6 @@ static NSURL *ApolloGalleryDirectVideoURL(NSURL *url) {
         kind = ApolloGalleryVideoIsSilentLoop(previewVideo) ? ApolloGalleryMediaKindGIF : ApolloGalleryMediaKindVideo;
         downloadable = ApolloGalleryURL(previewVideo[@"fallback_url"]);
     } else {
-        NSURL *direct = ApolloGalleryURL(post[@"url_overridden_by_dest"]) ?: ApolloGalleryURL(post[@"url"]);
-        NSURL *directVideo = direct ? ApolloGalleryDirectVideoURL(direct) : nil;
         if (directVideo) {
             stream = directVideo;
             // A standalone mp4 is self-contained, so it can be saved as-is.
@@ -701,20 +783,41 @@ static NSURL *ApolloGalleryDirectVideoURL(NSURL *url) {
                 ? ApolloGalleryMediaKindGIF : ApolloGalleryMediaKindVideo;
         }
     }
-    if (!stream) return nil;
+    // Redgifs/Streamable links commonly include Reddit's convenient
+    // reddit_video_preview, but that preview is deliberately silent and
+    // re-encoded. Keep it only as an instant fallback; the viewer lazily asks
+    // ApolloHostedVideo for the host's original combined MP4 when opened.
+    if (!stream && !isHostedVideo) return nil;
 
     ApolloGalleryItem *item = [[ApolloGalleryItem alloc] init];
-    item.kind = kind;
+    item.kind = isHostedVideo ? ApolloGalleryMediaKindVideo : kind;
     item.videoURL = stream;
-    item.videoDownloadURL = downloadable;
+    if (isHostedVideo) {
+        item.hostedVideoPageURL = direct;
+        item.hostedVideoFallbackDownloadURL = downloadable;
+        // Do not expose "Save Video" until the audio-bearing original has
+        // resolved (or the one attempt fails and restores this fallback).
+        item.videoDownloadURL = nil;
+    } else {
+        item.videoDownloadURL = downloadable;
+    }
     item.duration = duration;
-    // The poster frame. Video posts always carry a preview; without one there's
-    // nothing to draw in the grid, so skip the post entirely.
+    // The poster frame. Reddit usually supplies preview.images; external hosts
+    // can instead put the still under oembed.thumbnail_url. Never resolve the
+    // host API just to populate the scrolling grid—that would fan one listing
+    // page out into dozens of requests.
     NSURL *poster = previewSource ? ApolloGalleryURL(previewSource[@"url"]) : nil;
+    NSDictionary *oembed = ApolloGalleryDict(ApolloGalleryDict(post[@"secure_media"])[@"oembed"])
+        ?: ApolloGalleryDict(ApolloGalleryDict(post[@"media"])[@"oembed"]);
+    if (!poster) poster = ApolloGalleryURL(oembed[@"thumbnail_url"]);
+    if (!poster) poster = ApolloGalleryURL(post[@"thumbnail"]);
     if (!poster) return nil;
     item.imageURL = poster;
-    item.pixelSize = CGSizeMake(ApolloGalleryNumber(previewSource[@"width"]),
-                                ApolloGalleryNumber(previewSource[@"height"]));
+    CGFloat posterWidth = ApolloGalleryNumber(previewSource[@"width"])
+        ?: ApolloGalleryNumber(oembed[@"thumbnail_width"]);
+    CGFloat posterHeight = ApolloGalleryNumber(previewSource[@"height"])
+        ?: ApolloGalleryNumber(oembed[@"thumbnail_height"]);
+    item.pixelSize = CGSizeMake(posterWidth, posterHeight);
     item.thumbnailURL = ApolloGalleryBestThumbnail(ApolloGalleryArray(previewImage[@"resolutions"]), @"url",
                                                    kApolloGalleryThumbnailTargetWidth) ?: poster;
     return item;

--- a/src/ApolloGalleryImageViewer.m
+++ b/src/ApolloGalleryImageViewer.m
@@ -78,6 +78,7 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
 // the way (a zoomed page must pan its own content, not turn the page).
 @property (nonatomic, readonly) BOOL isZoomed;
 - (void)configureWithItem:(ApolloGalleryItem *)item;
+- (void)replaceVideoURL:(nullable NSURL *)videoURL andPlay:(BOOL)play;
 @end
 
 @implementation ApolloGalleryViewerCell
@@ -266,7 +267,10 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
     self.imageURL = url;
     // Stash the stream URL only; playIfPossible builds the player when this
     // page actually becomes current.
-    self.videoURL = item.playsAsVideo ? item.videoURL : nil;
+    // A hosted post deliberately waits on its original MP4 instead of starting
+    // Reddit's silent preview while the host lookup is in flight.
+    self.videoURL = (item.playsAsVideo && !item.needsHostedVideoResolution)
+        ? item.videoURL : nil;
 
     // A grid thumbnail for this post is usually already decoded — show it
     // immediately so the page is never a black rectangle, then swap in the
@@ -303,6 +307,16 @@ static void ApolloGalleryViewerActivateAudioSession(void) {
         }
         (void)data;
     }];
+}
+
+- (void)replaceVideoURL:(NSURL *)videoURL andPlay:(BOOL)play {
+    if ([self.videoURL isEqual:videoURL]) {
+        if (play) [self playIfPossible];
+        return;
+    }
+    [self teardownPlayer];
+    self.videoURL = videoURL;
+    if (play) [self playIfPossible];
 }
 
 - (void)apollo_doubleTapped:(UITapGestureRecognizer *)recognizer {
@@ -866,6 +880,21 @@ static UIButton *ApolloGalleryChromeButton(UIImage *symbol, NSString *title, UIV
 // Exactly one page plays at a time: every other visible cell (the neighbours a
 // paging collection view keeps alive) gets paused, so audio can't stack up.
 - (void)apollo_syncPlayback {
+    ApolloGalleryItem *currentItem = [self apollo_currentItem];
+    if (currentItem.needsHostedVideoResolution && !currentItem.isHostedVideoResolving) {
+        __weak typeof(self) weakSelf = self;
+        [currentItem resolveHostedVideoWithCompletion:^(BOOL resolvedOriginal) {
+            typeof(self) strongSelf = weakSelf;
+            if (!strongSelf || [strongSelf apollo_currentItem] != currentItem) return;
+            ApolloGalleryViewerCell *currentCell = [strongSelf apollo_currentCell];
+            [currentCell replaceVideoURL:currentItem.videoURL andPlay:YES];
+            [strongSelf apollo_updateChromeContent];
+            if (!resolvedOriginal && !currentItem.videoURL) {
+                [strongSelf apollo_showToast:@"Couldn't load video"];
+            }
+        }];
+    }
+
     for (UICollectionViewCell *cell in self.collectionView.visibleCells) {
         if (![cell isKindOfClass:[ApolloGalleryViewerCell class]]) continue;
         ApolloGalleryViewerCell *viewerCell = (ApolloGalleryViewerCell *)cell;
@@ -1126,12 +1155,15 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
                                                identifier:nil
                                                   handler:^(__kindof UIAction *a) { [weakSelf apollo_saveCurrentVideo]; }]];
         }
-        [children addObject:[UIAction actionWithTitle:@"Share Video Link"
-                                                image:[UIImage systemImageNamed:@"square.and.arrow.up"]
-                                           identifier:nil
-                                              handler:^(__kindof UIAction *a) {
-            [weakSelf apollo_presentActivityWithItems:@[item.videoURL] fromView:weakSelf.shareButton];
-        }]];
+        NSURL *shareURL = item.videoURL ?: item.hostedVideoPageURL;
+        if (shareURL) {
+            [children addObject:[UIAction actionWithTitle:@"Share Video Link"
+                                                    image:[UIImage systemImageNamed:@"square.and.arrow.up"]
+                                               identifier:nil
+                                                  handler:^(__kindof UIAction *a) {
+                [weakSelf apollo_presentActivityWithItems:@[shareURL] fromView:weakSelf.shareButton];
+            }]];
+        }
     } else {
         [children addObject:[UIAction actionWithTitle:@"Save Image"
                                                 image:[UIImage systemImageNamed:@"arrow.down.to.line"]
@@ -1173,9 +1205,12 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
                 [weakSelf apollo_saveCurrentVideo];
             }]];
         }
-        [sheet addAction:[UIAlertAction actionWithTitle:@"Share Video Link" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [weakSelf apollo_presentActivityWithItems:@[item.videoURL] fromView:sourceView];
-        }]];
+        NSURL *shareURL = item.videoURL ?: item.hostedVideoPageURL;
+        if (shareURL) {
+            [sheet addAction:[UIAlertAction actionWithTitle:@"Share Video Link" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+                [weakSelf apollo_presentActivityWithItems:@[shareURL] fromView:sourceView];
+            }]];
+        }
     } else {
         [sheet addAction:[UIAlertAction actionWithTitle:@"Save Image" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
             [weakSelf apollo_saveCurrentImage];


### PR DESCRIPTION
## Summary

- Treat supported hosted-video posts as videos even when Reddit labels the silent preview as a GIF.
- Resolve the original combined MP4 only when the Gallery page becomes current, then swap it into the player so audio is available through Gallery’s mute control.
- Use direct host CDN MP4s immediately and retain Reddit’s preview as a graceful fallback when host resolution fails.
- Rebuild save/share actions after resolution without issuing host requests for scrolling grid tiles.

## Root cause

Gallery preferred `preview.reddit_video_preview` before the post’s Redgifs/Streamable URL. Reddit’s external-host preview is re-encoded without audio, so Gallery never reached the host’s original audio-bearing MP4 and also classified many clips as silent GIFs.

## Validation

- Sanitized synthetic hosted-video metadata fixture passed; no adult media was opened or fetched.
- iOS Simulator build, injection, Liquid Glass launch, and tweak-load logs passed.
- Full iOS device package build passed.
- Native Reddit HLS videos and ordinary GIF/direct-video parsing remain on their existing paths.