### PR TITLE
Fix trending limits and add refreshable subreddit discovery

### DIFF
--- a/src/ApolloSearchTabFixes.xm
+++ b/src/ApolloSearchTabFixes.xm
@@ -1,6 +1,6 @@
 // ApolloSearchTabFixes.xm
 //
-// Two Search-tab polish fixes for stock Apollo bugs (Apollo-Reborn issues #646 and #647):
+// Search-tab fixes and enhancements:
 //
 // ── #646: suggestions list rests flush against the search bar (legacy/non-Liquid-Glass) ──
 //
@@ -35,6 +35,14 @@
 // +0.33pt per side). Same glyph, same weave gaps, matched weight. The asset is referenced
 // only by SearchViewController's cell provider (xrefs: 0x1002b3ab4 / 0x1002b4d58 /
 // 0x1002b50e8), so patching it at the cell is complete coverage.
+//
+// ── Trending pull-to-refresh + Random NSFW action ──
+//
+// Hopper confirms the default state is section 2 = the Swift Optional<[String]>
+// `trendingSubreddits` ivar and section 3 = one Random Subreddit row. Pull-to-refresh
+// replaces that Swift value through ApolloSwiftIvarBridge, then reloads the native section.
+// Random NSFW extends section 3 to two rows and still routes through the tweak's custom
+// /r/randnsfw request rewrite; Reddit's original endpoint no longer exists.
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
@@ -42,9 +50,43 @@
 #import <objc/runtime.h>
 
 #import "ApolloCommon.h"
+#import "ApolloState.h"
+#import "ApolloToast.h"
+#import "Tweak.h"
+#import "UserDefaultConstants.h"
 
 @interface _TtC6Apollo20SearchViewController : UIViewController
+- (void)apollo_refreshTrendingSubreddits:(UIRefreshControl *)refreshControl;
 @end
+
+@interface ApolloSearchRefreshControl : UIRefreshControl
+@end
+
+@implementation ApolloSearchRefreshControl
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    if (!IsLiquidGlass()) return;
+
+    // UIRefreshControl owns its transform while spinning, so a caller-applied
+    // transform is reset. A negative bounds origin moves the rendered content
+    // down without changing the table's pull threshold or content geometry.
+    CGRect bounds = self.bounds;
+    if (fabs(bounds.origin.y + 16.0) > 0.5) {
+        bounds.origin.y = -16.0;
+        self.bounds = bounds;
+    }
+}
+
+@end
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern void ApolloSwiftAssignOptionalStringArray(void *storage, const void *arrayObject);
+#ifdef __cplusplus
+}
+#endif
 
 // MARK: - #646 helpers
 
@@ -53,6 +95,13 @@
 static const CGFloat kApolloSearchSuggestionsGap = 16.0;
 
 static const void *kApolloSearchBaselineInsetKey = &kApolloSearchBaselineInsetKey;
+static const void *kApolloSearchBaselineBounceKey = &kApolloSearchBaselineBounceKey;
+static const void *kApolloSearchRefreshControlKey = &kApolloSearchRefreshControlKey;
+static const void *kApolloSearchRefreshInFlightKey = &kApolloSearchRefreshInFlightKey;
+static const void *kApolloSearchRandomNSFWActiveKey = &kApolloSearchRandomNSFWActiveKey;
+static const void *kApolloSearchRandomNSFWSuppressedKey = &kApolloSearchRandomNSFWSuppressedKey;
+static const void *kApolloSearchRandomNSFWInFlightKey = &kApolloSearchRandomNSFWInFlightKey;
+static NSString *const kApolloRandomNSFWTitle = @"Random NSFW Subreddit";
 
 // The controller's grouped UITableView. SearchViewController subclasses
 // ApolloTableViewController, whose `tableView` ivar is ObjC-visible; fall back to a subview
@@ -70,6 +119,177 @@ static UITableView *ApolloSearchTabTableView(UIViewController *vc) {
         if ([v isKindOfClass:[UITableView class]]) return (UITableView *)v;
     }
     return nil;
+}
+
+static UISearchBar *ApolloSearchTabSearchBar(UIViewController *vc) {
+    UIView *titleView = vc.navigationItem.titleView;
+    if ([titleView isKindOfClass:[UISearchBar class]]) return (UISearchBar *)titleView;
+
+    for (Class cls = object_getClass(vc); cls; cls = class_getSuperclass(cls)) {
+        Ivar ivar = class_getInstanceVariable(cls, "searchBar");
+        if (!ivar) continue;
+        id value = object_getIvar(vc, ivar);
+        return [value isKindOfClass:[UISearchBar class]] ? value : nil;
+    }
+    return nil;
+}
+
+static UIRefreshControl *ApolloSearchTabRefreshControl(UIViewController *vc) {
+    UIRefreshControl *refresh =
+        objc_getAssociatedObject(vc, kApolloSearchRefreshControlKey);
+    if (refresh) return refresh;
+    return ApolloSearchTabTableView(vc).refreshControl;
+}
+
+static BOOL ApolloSearchTabIsDefaultState(UIViewController *vc) {
+    return ApolloSearchTabSearchBar(vc).text.length == 0;
+}
+
+static void ApolloSearchTabUpdateRefreshAvailability(UIViewController *vc) {
+    UIRefreshControl *refresh = ApolloSearchTabRefreshControl(vc);
+    BOOL defaultState = ApolloSearchTabIsDefaultState(vc);
+    if (refresh) refresh.enabled = defaultState;
+
+    UITableView *tableView = ApolloSearchTabTableView(vc);
+    NSNumber *baselineBounce =
+        objc_getAssociatedObject(vc, kApolloSearchBaselineBounceKey);
+    if (tableView && baselineBounce) {
+        tableView.alwaysBounceVertical =
+            defaultState ? YES : baselineBounce.boolValue;
+    }
+}
+
+static BOOL ApolloSearchTabAssignTrendingSubreddits(
+    UIViewController *vc,
+    NSArray<NSString *> *subreddits
+) {
+    if (!vc || !subreddits) return NO;
+    for (Class cls = object_getClass(vc); cls; cls = class_getSuperclass(cls)) {
+        Ivar ivar = class_getInstanceVariable(cls, "trendingSubreddits");
+        if (!ivar) continue;
+        uint8_t *base = (uint8_t *)(__bridge void *)vc;
+        void *storage = base + ivar_getOffset(ivar);
+        ApolloSwiftAssignOptionalStringArray(
+            storage, (__bridge const void *)subreddits);
+        return YES;
+    }
+    return NO;
+}
+
+static BOOL ApolloSearchTabRandomNSFWEnabled(void) {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowRandNsfw];
+}
+
+static BOOL ApolloSearchTabRandomNSFWActive(UIViewController *vc) {
+    NSNumber *active = objc_getAssociatedObject(vc, kApolloSearchRandomNSFWActiveKey);
+    return active ? active.boolValue : ApolloSearchTabRandomNSFWEnabled();
+}
+
+static BOOL ApolloSearchTabRandomNSFWSuppressed(UIViewController *vc) {
+    return [objc_getAssociatedObject(vc, kApolloSearchRandomNSFWSuppressedKey) boolValue];
+}
+
+static BOOL ApolloSearchTabIsRandomNSFWIndexPath(
+    UIViewController *vc,
+    NSIndexPath *indexPath
+) {
+    return indexPath.section == 3 &&
+           indexPath.row == 1 &&
+           ApolloSearchTabRandomNSFWActive(vc) &&
+           !ApolloSearchTabRandomNSFWSuppressed(vc);
+}
+
+static void ApolloSearchTabSyncRandomNSFWSection(UIViewController *vc) {
+    BOOL desired = ApolloSearchTabRandomNSFWEnabled();
+    BOOL active = ApolloSearchTabRandomNSFWActive(vc);
+    if (desired == active) return;
+    UITableView *tableView = ApolloSearchTabTableView(vc);
+    if (tableView.numberOfSections <= 3) return;
+
+    if (!ApolloSearchTabIsDefaultState(vc)) {
+        objc_setAssociatedObject(vc, kApolloSearchRandomNSFWActiveKey, @(desired),
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(vc, kApolloSearchRandomNSFWSuppressedKey, @YES,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return;
+    }
+
+    NSIndexPath *extraRow = [NSIndexPath indexPathForRow:1 inSection:3];
+    if (desired) {
+        objc_setAssociatedObject(vc, kApolloSearchRandomNSFWActiveKey, @YES,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(vc, kApolloSearchRandomNSFWSuppressedKey, nil,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        [tableView insertRowsAtIndexPaths:@[extraRow]
+                         withRowAnimation:UITableViewRowAnimationNone];
+    } else {
+        objc_setAssociatedObject(vc, kApolloSearchRandomNSFWSuppressedKey, @YES,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(vc, kApolloSearchRandomNSFWActiveKey, @NO,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        [tableView deleteRowsAtIndexPaths:@[extraRow]
+                         withRowAnimation:UITableViewRowAnimationNone];
+    }
+}
+
+static BOOL ApolloSearchTabNativeSearching(UIViewController *vc) {
+    for (Class cls = object_getClass(vc); cls; cls = class_getSuperclass(cls)) {
+        Ivar ivar = class_getInstanceVariable(cls, "searching");
+        if (!ivar) continue;
+        uint8_t value = 0;
+        memcpy(&value,
+               (uint8_t *)(__bridge void *)vc + ivar_getOffset(ivar),
+               sizeof(value));
+        return (value & 1) != 0;
+    }
+    return !ApolloSearchTabIsDefaultState(vc);
+}
+
+// Apollo's native text-change batch inserts/deletes exactly one section-3 row.
+// Remove our extra row before entering search, then restore it after Apollo has
+// inserted its native row when returning to the default state.
+static void ApolloSearchTabPrepareForModeTransition(
+    UIViewController *vc,
+    BOOL nextDefaultState
+) {
+    BOOL wasSearching = ApolloSearchTabNativeSearching(vc);
+    BOOL enteringSearch = !wasSearching && !nextDefaultState;
+    if (!enteringSearch ||
+        !ApolloSearchTabRandomNSFWActive(vc) ||
+        ApolloSearchTabRandomNSFWSuppressed(vc)) {
+        if (!nextDefaultState) {
+            objc_setAssociatedObject(vc, kApolloSearchRandomNSFWSuppressedKey, @YES,
+                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+        return;
+    }
+
+    UITableView *tableView = ApolloSearchTabTableView(vc);
+    if (tableView.numberOfSections <= 3) return;
+    objc_setAssociatedObject(vc, kApolloSearchRandomNSFWSuppressedKey, @YES,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [tableView deleteRowsAtIndexPaths:@[
+        [NSIndexPath indexPathForRow:1 inSection:3]
+    ] withRowAnimation:UITableViewRowAnimationNone];
+}
+
+static void ApolloSearchTabFinishModeTransition(
+    UIViewController *vc,
+    BOOL nextDefaultState
+) {
+    if (!nextDefaultState ||
+        !ApolloSearchTabRandomNSFWActive(vc) ||
+        !ApolloSearchTabRandomNSFWSuppressed(vc)) {
+        return;
+    }
+
+    UITableView *tableView = ApolloSearchTabTableView(vc);
+    if (tableView.numberOfSections <= 3) return;
+    objc_setAssociatedObject(vc, kApolloSearchRandomNSFWSuppressedKey, nil,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [tableView insertRowsAtIndexPaths:@[
+        [NSIndexPath indexPathForRow:1 inSection:3]
+    ] withRowAnimation:UITableViewRowAnimationNone];
 }
 
 // Re-anchor the table's top inset for the current mode. `searching` == the bar has text
@@ -169,23 +389,135 @@ static UIImage *ApolloThickenedTemplateIcon(UIImage *src) {
 
 %hook _TtC6Apollo20SearchViewController
 
+// MARK: Trending refresh
+
+- (void)viewDidLoad {
+    %orig;
+
+    UITableView *tableView = ApolloSearchTabTableView(self);
+    if (tableView && !ApolloSearchTabRefreshControl(self)) {
+        objc_setAssociatedObject(self, kApolloSearchBaselineBounceKey,
+                                 @(tableView.alwaysBounceVertical),
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        UIRefreshControl *refresh = [[ApolloSearchRefreshControl alloc] init];
+        [refresh addTarget:self
+                    action:@selector(apollo_refreshTrendingSubreddits:)
+          forControlEvents:UIControlEventValueChanged];
+        tableView.refreshControl = refresh;
+        objc_setAssociatedObject(self, kApolloSearchRefreshControlKey, refresh,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    objc_setAssociatedObject(self, kApolloSearchRandomNSFWActiveKey,
+                             @(ApolloSearchTabRandomNSFWEnabled()),
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(self, kApolloSearchRandomNSFWSuppressedKey, nil,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    ApolloSearchTabUpdateRefreshAvailability(self);
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    ApolloSearchTabSyncRandomNSFWSection(self);
+    ApolloSearchTabUpdateRefreshAvailability(self);
+}
+
+%new
+- (void)apollo_refreshTrendingSubreddits:(UIRefreshControl *)refreshControl {
+    if (!ApolloSearchTabIsDefaultState(self)) {
+        [refreshControl endRefreshing];
+        return;
+    }
+    if ([objc_getAssociatedObject(self, kApolloSearchRefreshInFlightKey) boolValue]) {
+        return;
+    }
+    objc_setAssociatedObject(self, kApolloSearchRefreshInFlightKey, @YES,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    __weak UIViewController *weakSelf = self;
+    __weak UIRefreshControl *weakRefresh = refreshControl;
+    ApolloRefreshTrendingSubreddits(
+        ^(NSArray<NSString *> *subreddits, NSError *error) {
+            UIViewController *controller = weakSelf;
+            [weakRefresh endRefreshing];
+            if (!controller) return;
+            objc_setAssociatedObject(controller, kApolloSearchRefreshInFlightKey, nil,
+                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+            if (error) {
+                ApolloLog(@"[SearchTabFixes] trending refresh failed: %@",
+                          error.localizedDescription);
+                ApolloShowToastWithStyle(
+                    @"Couldn't Refresh Trending Subreddits",
+                    error.localizedDescription,
+                    ApolloToastStyleError,
+                    nil);
+                return;
+            }
+
+            if (!ApolloSearchTabAssignTrendingSubreddits(controller, subreddits ?: @[])) {
+                ApolloLog(@"[SearchTabFixes] trendingSubreddits ivar unavailable");
+                ApolloShowToastWithStyle(
+                    @"Couldn't Refresh Trending Subreddits",
+                    @"Apollo's trending list storage was unavailable.",
+                    ApolloToastStyleError,
+                    nil);
+                return;
+            }
+
+            UITableView *tableView = ApolloSearchTabTableView(controller);
+            if (ApolloSearchTabIsDefaultState(controller) &&
+                tableView.numberOfSections > 2) {
+                [tableView reloadSections:[NSIndexSet indexSetWithIndex:2]
+                         withRowAnimation:UITableViewRowAnimationAutomatic];
+            }
+            ApolloLog(@"[SearchTabFixes] refreshed %lu trending subreddit(s)",
+                      (unsigned long)subreddits.count);
+        });
+}
+
 // MARK: #646 — re-anchor on every state change that swaps the table's content mode.
 
 - (void)searchBar:(UISearchBar *)bar textDidChange:(NSString *)text {
+    BOOL nextDefaultState = text.length == 0;
+    ApolloSearchTabPrepareForModeTransition(self, nextDefaultState);
     %orig;
+    ApolloSearchTabFinishModeTransition(self, nextDefaultState);
     ApolloSearchTabApplyTopInset(self, bar);
+    ApolloSearchTabUpdateRefreshAvailability(self);
 }
 
 - (void)searchBarCancelButtonClicked:(UISearchBar *)bar {
+    ApolloSearchTabPrepareForModeTransition(self, YES);
     %orig;
+    ApolloSearchTabFinishModeTransition(self, YES);
     ApolloSearchTabApplyTopInset(self, bar);
+    ApolloSearchTabUpdateRefreshAvailability(self);
 }
 
-// MARK: #647 — swap in the weight-matched icon on the Random Subreddit row.
+// MARK: Random action group
+
+- (NSInteger)tableView:(UITableView *)tableView
+ numberOfRowsInSection:(NSInteger)section {
+    NSInteger count = %orig;
+    if (section == 3 &&
+        count == 1 &&
+        ApolloSearchTabRandomNSFWActive(self) &&
+        !ApolloSearchTabRandomNSFWSuppressed(self)) {
+        return 2;
+    }
+    return count;
+}
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     UITableViewCell *cell = %orig;
+    if (ApolloSearchTabIsRandomNSFWIndexPath(self, indexPath)) {
+        cell.textLabel.text = kApolloRandomNSFWTitle;
+        cell.accessibilityLabel = kApolloRandomNSFWTitle;
+    }
+
+    // #647 — swap in the weight-matched icon on both random-action rows.
     if ([cell.reuseIdentifier isEqualToString:@"RandomSubredditCell"]) {
+        cell.accessibilityLabel = cell.textLabel.text;
         UIImage *src = cell.imageView.image;
         // Idempotent: a re-dequeued cell already showing our output is left alone.
         if (src && !objc_getAssociatedObject(src, kApolloThickenedIconMarkerKey)) {
@@ -199,6 +531,56 @@ static UIImage *ApolloThickenedTemplateIcon(UIImage *src) {
         }
     }
     return cell;
+}
+
+- (void)tableView:(UITableView *)tableView
+ didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (!ApolloSearchTabIsRandomNSFWIndexPath(self, indexPath)) {
+        %orig;
+        return;
+    }
+
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    if (sRandNsfwSubredditsSource.length == 0) {
+        ApolloShowToastWithStyle(
+            @"Random NSFW Source Required",
+            @"Configure a Random NSFW source in Apollo Reborn settings.",
+            ApolloToastStyleError,
+            nil);
+        return;
+    }
+    if ([objc_getAssociatedObject(self, kApolloSearchRandomNSFWInFlightKey) boolValue]) {
+        return;
+    }
+    objc_setAssociatedObject(self, kApolloSearchRandomNSFWInFlightKey, @YES,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    __weak UIViewController *weakSelf = self;
+    ApolloPrepareRandomNSFWSubredditSource(^(NSError *error) {
+        UIViewController *controller = weakSelf;
+        if (!controller) return;
+        objc_setAssociatedObject(controller, kApolloSearchRandomNSFWInFlightKey, nil,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        if (error) {
+            ApolloLog(@"[SearchTabFixes] Random NSFW source unavailable: %@",
+                      error.localizedDescription);
+            ApolloShowToastWithStyle(
+                @"Couldn't Load Random NSFW Subreddit",
+                error.localizedDescription,
+                ApolloToastStyleError,
+                nil);
+            return;
+        }
+
+        NSURL *url = [NSURL URLWithString:@"https://reddit.com/r/randnsfw"];
+        if (!ApolloRouteResolvedURLViaApolloScheme(url)) {
+            ApolloShowToastWithStyle(
+                @"Couldn't Open Random NSFW Subreddit",
+                @"Apollo's native subreddit router was unavailable.",
+                ApolloToastStyleError,
+                nil);
+        }
+    });
 }
 
 %end

--- a/src/ApolloSearchTabFixes.xm
+++ b/src/ApolloSearchTabFixes.xm
@@ -72,8 +72,8 @@
     // transform is reset. A negative bounds origin moves the rendered content
     // down without changing the table's pull threshold or content geometry.
     CGRect bounds = self.bounds;
-    if (fabs(bounds.origin.y + 16.0) > 0.5) {
-        bounds.origin.y = -16.0;
+    if (fabs(bounds.origin.y + 32.0) > 0.5) {
+        bounds.origin.y = -32.0;
         self.bounds = bounds;
     }
 }
@@ -148,9 +148,21 @@ static BOOL ApolloSearchTabIsDefaultState(UIViewController *vc) {
 static void ApolloSearchTabUpdateRefreshAvailability(UIViewController *vc) {
     UIRefreshControl *refresh = ApolloSearchTabRefreshControl(vc);
     BOOL defaultState = ApolloSearchTabIsDefaultState(vc);
-    if (refresh) refresh.enabled = defaultState;
-
     UITableView *tableView = ApolloSearchTabTableView(vc);
+    if (refresh && tableView) {
+        refresh.enabled = defaultState;
+        if (defaultState) {
+            if (tableView.refreshControl != refresh) {
+                tableView.refreshControl = refresh;
+            }
+        } else {
+            [refresh endRefreshing];
+            if (tableView.refreshControl == refresh) {
+                tableView.refreshControl = nil;
+            }
+        }
+    }
+
     NSNumber *baselineBounce =
         objc_getAssociatedObject(vc, kApolloSearchBaselineBounceKey);
     if (tableView && baselineBounce) {

--- a/src/ApolloSwiftIvarBridge.swift
+++ b/src/ApolloSwiftIvarBridge.swift
@@ -20,3 +20,19 @@ public func ApolloSwiftAssignOptionalString(
     let value = utf8Value.map { String(cString: $0) }
     storage.assumingMemoryBound(to: Optional<String>.self).pointee = value
 }
+
+@_cdecl("ApolloSwiftAssignOptionalStringArray")
+public func ApolloSwiftAssignOptionalStringArray(
+    _ storage: UnsafeMutableRawPointer?,
+    _ arrayObject: UnsafeRawPointer?
+) {
+    guard let storage else { return }
+    let value: [String]?
+    if let arrayObject {
+        let array = Unmanaged<NSArray>.fromOpaque(arrayObject).takeUnretainedValue()
+        value = array.compactMap { $0 as? String }
+    } else {
+        value = nil
+    }
+    storage.assumingMemoryBound(to: Optional<[String]>.self).pointee = value
+}

--- a/src/ApolloToast.m
+++ b/src/ApolloToast.m
@@ -61,18 +61,23 @@ static void ApolloToastShowImpl(NSString *message, NSString *detail, ApolloToast
     // Replace any visible toast so rapid actions don't stack bubbles.
     ApolloToastDismiss(sApolloActiveToast, NO);
 
-    UIVisualEffectView *bubble = [[UIVisualEffectView alloc]
-        initWithEffect:[UIBlurEffect effectWithStyle:UIBlurEffectStyleSystemThickMaterial]];
+    UIView *bubble = [[UIView alloc] init];
     bubble.translatesAutoresizingMaskIntoConstraints = NO;
-    // The effect view itself must NOT clip, so its drop shadow can show; the
-    // rounded-corner clipping happens on its contentView instead (set below).
     bubble.clipsToBounds = NO;
     bubble.alpha = 0.0;
     bubble.transform = CGAffineTransformMakeTranslation(0.0, 8.0);
     [window addSubview:bubble];
     sApolloActiveToast = bubble;
 
-    UIView *content = bubble.contentView;
+    UIVisualEffectView *material = [[UIVisualEffectView alloc]
+        initWithEffect:[UIBlurEffect effectWithStyle:UIBlurEffectStyleSystemThickMaterial]];
+    material.translatesAutoresizingMaskIntoConstraints = NO;
+    material.layer.cornerRadius = 20.0;
+    material.layer.cornerCurve = kCACornerCurveContinuous;
+    material.clipsToBounds = YES;
+    [bubble addSubview:material];
+
+    UIView *content = material.contentView;
 
     UIStackView *row = [[UIStackView alloc] init];
     row.axis = UILayoutConstraintAxisHorizontal;
@@ -116,6 +121,11 @@ static void ApolloToastShowImpl(NSString *message, NSString *detail, ApolloToast
     [row addArrangedSubview:textStack];
 
     [NSLayoutConstraint activateConstraints:@[
+        [material.topAnchor constraintEqualToAnchor:bubble.topAnchor],
+        [material.bottomAnchor constraintEqualToAnchor:bubble.bottomAnchor],
+        [material.leadingAnchor constraintEqualToAnchor:bubble.leadingAnchor],
+        [material.trailingAnchor constraintEqualToAnchor:bubble.trailingAnchor],
+
         [row.topAnchor constraintEqualToAnchor:content.topAnchor constant:12.0],
         [row.bottomAnchor constraintEqualToAnchor:content.bottomAnchor constant:-12.0],
         [row.leadingAnchor constraintEqualToAnchor:content.leadingAnchor constant:16.0],
@@ -129,13 +139,10 @@ static void ApolloToastShowImpl(NSString *message, NSString *detail, ApolloToast
         [bubble.bottomAnchor constraintEqualToAnchor:window.safeAreaLayoutGuide.bottomAnchor constant:-64.0],
     ]];
 
-    // Round the material via its contentView (the effect view is left unclipped
-    // so the shadow below can render outside its bounds).
-    content.layer.cornerRadius = 20.0;
-    content.layer.cornerCurve = kCACornerCurveContinuous;
-    content.clipsToBounds = YES;
-
-    // A subtle shadow lifts the material off busy content behind it.
+    // Keep shadow and clipping on separate layers: UIVisualEffectView's private
+    // backdrop ignores contentView clipping, so the material itself must clip.
+    bubble.layer.cornerRadius = 20.0;
+    bubble.layer.cornerCurve = kCACornerCurveContinuous;
     bubble.layer.shadowColor = UIColor.blackColor.CGColor;
     bubble.layer.shadowOpacity = 0.18;
     bubble.layer.shadowRadius = 12.0;
@@ -151,9 +158,9 @@ static void ApolloToastShowImpl(NSString *message, NSString *detail, ApolloToast
 
     // Auto-dismiss; longer messages linger a little longer.
     NSTimeInterval visible = 1.8 + MIN(2.0, (message.length + detail.length) / 40.0);
-    __weak UIVisualEffectView *weakBubble = bubble;
+    __weak UIView *weakBubble = bubble;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(visible * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        UIVisualEffectView *strong = weakBubble;
+        UIView *strong = weakBubble;
         if (strong && strong.superview) ApolloToastDismiss(strong, YES);
     });
 }

--- a/src/Tweak.h
+++ b/src/Tweak.h
@@ -1,5 +1,16 @@
 #import <Foundation/Foundation.h>
 
+typedef void (^ApolloTrendingSubredditsRefreshCompletion)(NSArray<NSString *> *subreddits,
+                                                          NSError *error);
+typedef void (^ApolloSubredditSourcePreparationCompletion)(NSError *error);
+
+__BEGIN_DECLS
+FOUNDATION_EXPORT void ApolloRefreshTrendingSubreddits(
+    ApolloTrendingSubredditsRefreshCompletion completion);
+FOUNDATION_EXPORT void ApolloPrepareRandomNSFWSubredditSource(
+    ApolloSubredditSourcePreparationCompletion completion);
+__END_DECLS
+
 @interface ShareUrlTask : NSObject
 
 @property (atomic, strong) dispatch_group_t dispatchGroup;

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1456,6 +1456,15 @@ static NSMutableDictionary<NSString *, NSString *> *subredditListPersistentCache
 // source queue; the cache itself is NSCache and is safe to read from Apollo's
 // request paths while NSURLSession completions populate it in the background.
 static NSMutableSet<NSString *> *subredditListFetchesInFlight;
+// Completion waiters for each in-flight source. A manual refresh can overlap
+// the constructor prefetch; coalescing them guarantees every caller finishes.
+static NSMutableDictionary<NSString *, NSMutableArray *> *subredditListFetchCompletions;
+// Whether the active request bypasses URLCache, plus forced waiters that must
+// receive a follow-up network request when they overlap a weaker prefetch.
+static NSMutableDictionary<NSString *, NSNumber *> *subredditListFetchBypassesCache;
+static NSMutableDictionary<NSString *, NSMutableArray *> *subredditListForcedFetchCompletions;
+
+typedef void (^ApolloSubredditSourceRefreshCompletion)(NSString *content, NSError *error);
 
 static NSArray<NSString *> *ApolloSubredditListLines(NSString *content) {
     if (content.length == 0) return @[];
@@ -1514,27 +1523,80 @@ static dispatch_queue_t ApolloSubredditSourceQueue(void) {
     return queue;
 }
 
+static NSError *ApolloSubredditSourceError(NSInteger code, NSString *description) {
+    return [NSError errorWithDomain:@"com.apolloreborn.subreddit-sources"
+                               code:code
+                           userInfo:@{NSLocalizedDescriptionKey:
+                                          description.length > 0
+                                              ? description
+                                              : @"The subreddit source could not be loaded."}];
+}
+
 // Warm a remote subreddit-list source without ever waiting for it. Callers use
 // the last cached value (or their local/native fallback) immediately. The
-// in-flight set prevents a burst of resource/request hooks from starting the
-// same download repeatedly while the first fetch is outstanding. Crucially,
+// in-flight coordinator prevents duplicate downloads and retains completion
+// waiters so a pull-to-refresh overlapping launch prefetch cannot hang.
 // URL/session/request construction also happens on the utility queue: merely
-// creating NSURLSession.sharedSession can initialize CFNetwork, so doing that
-// synchronously from the bundle-resource hook or dylib constructor would leave
-// CFNetwork work on Apollo's launch-critical main thread even without a wait.
-static void ApolloRefreshSubredditListSourceAsync(NSString *source, BOOL refreshCached) {
-    if (source.length == 0) return;
+// creating NSURLSession.sharedSession can initialize CFNetwork.
+static void ApolloRefreshSubredditListSourceAsync(
+    NSString *source,
+    BOOL forceRefresh,
+    NSURLRequestCachePolicy cachePolicy,
+    ApolloSubredditSourceRefreshCompletion completion
+) {
     NSString *capturedSource = [source copy];
     dispatch_async(ApolloSubredditSourceQueue(), ^{
+        if (capturedSource.length == 0) {
+            if (completion) {
+                completion(nil, ApolloSubredditSourceError(
+                    NSURLErrorBadURL, @"The subreddit source URL is empty."));
+            }
+            return;
+        }
+
         NSURL *url = [NSURL URLWithString:capturedSource];
         NSString *key = url.absoluteString;
-        if (!url || key.length == 0) return;
-        if (!refreshCached && [subredditListCache objectForKey:key]) return;
-        if ([subredditListFetchesInFlight containsObject:key]) return;
+        if (!url || key.length == 0 || url.scheme.length == 0 || url.host.length == 0) {
+            if (completion) {
+                completion(nil, ApolloSubredditSourceError(
+                    NSURLErrorBadURL, @"The subreddit source URL is invalid."));
+            }
+            return;
+        }
+
+        NSString *cached = [subredditListCache objectForKey:key];
+        if (!forceRefresh && cached.length > 0) {
+            if (completion) completion(cached, nil);
+            return;
+        }
+
+        if ([subredditListFetchesInFlight containsObject:key]) {
+            if (completion) {
+                BOOL activeBypassesCache =
+                    [subredditListFetchBypassesCache[key] boolValue];
+                if (forceRefresh && !activeBypassesCache) {
+                    NSMutableArray *forcedWaiters =
+                        subredditListForcedFetchCompletions[key];
+                    if (!forcedWaiters) {
+                        forcedWaiters = [NSMutableArray array];
+                        subredditListForcedFetchCompletions[key] = forcedWaiters;
+                    }
+                    [forcedWaiters addObject:[completion copy]];
+                } else {
+                    [subredditListFetchCompletions[key] addObject:[completion copy]];
+                }
+            }
+            return;
+        }
         [subredditListFetchesInFlight addObject:key];
+        subredditListFetchBypassesCache[key] =
+            @(cachePolicy == NSURLRequestReloadIgnoringLocalCacheData);
+        NSMutableArray *waiters = [NSMutableArray array];
+        if (completion) [waiters addObject:[completion copy]];
+        subredditListFetchCompletions[key] = waiters;
 
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
-                                                               cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                               cachePolicy:cachePolicy
                                                            timeoutInterval:8.0];
         [[[NSURLSession sharedSession] dataTaskWithRequest:request
                                         completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
@@ -1545,33 +1607,88 @@ static void ApolloRefreshSubredditListSourceAsync(NSString *source, BOOL refresh
                 ? (NSHTTPURLResponse *)response
                 : nil;
             dispatch_async(ApolloSubredditSourceQueue(), ^{
+                NSError *resultError = error;
                 if (!error && http.statusCode == 200 &&
                     ApolloSubredditListLines(content).count > 0) {
                     [subredditListCache setObject:content forKey:key];
                     ApolloPersistSubredditSource(key, content);
                     ApolloLog(@"[RandomSources] Refreshed %@", key);
                 } else {
+                    if (!resultError) {
+                        NSString *reason = http && http.statusCode != 200
+                            ? [NSString stringWithFormat:@"The source returned HTTP %ld.",
+                                                               (long)http.statusCode]
+                            : @"The source returned no valid subreddit entries.";
+                        resultError = ApolloSubredditSourceError(
+                            NSURLErrorBadServerResponse, reason);
+                    }
                     ApolloLog(@"[RandomSources] Refresh failed for %@: HTTP %ld error=%@",
                               key, (long)http.statusCode,
-                              error.localizedDescription ?: @"invalid/empty response");
+                              resultError.localizedDescription ?: @"invalid/empty response");
                 }
+
+                NSArray *completions = [subredditListFetchCompletions[key] copy] ?: @[];
+                NSArray *forcedCompletions =
+                    [subredditListForcedFetchCompletions[key] copy] ?: @[];
+                [subredditListFetchCompletions removeObjectForKey:key];
+                [subredditListForcedFetchCompletions removeObjectForKey:key];
+                [subredditListFetchBypassesCache removeObjectForKey:key];
                 [subredditListFetchesInFlight removeObject:key];
+                for (ApolloSubredditSourceRefreshCompletion waiter in completions) {
+                    waiter(resultError ? nil : content, resultError);
+                }
+
+                if (forcedCompletions.count > 0) {
+                    ApolloRefreshSubredditListSourceAsync(
+                        key,
+                        YES,
+                        NSURLRequestReloadIgnoringLocalCacheData,
+                        ^(NSString *forcedContent, NSError *forcedError) {
+                            for (ApolloSubredditSourceRefreshCompletion waiter
+                                    in forcedCompletions) {
+                                waiter(forcedContent, forcedError);
+                            }
+                        });
+                }
             });
         }] resume];
     });
 }
 
-static NSArray<NSString *> *ApolloTrendingFallbackSubreddits(NSDictionary *fallbackDict) {
+static NSArray<NSString *> *ApolloSampleTrendingSubreddits(
+    NSArray<NSString *> *subreddits,
+    NSString *limit
+) {
+    if (subreddits.count == 0) return @[];
+    if (limit.length == 0) return [subreddits copy];
+
+    NSInteger requestedCount = MAX(0, limit.integerValue);
+    if ((NSUInteger)requestedCount >= subreddits.count) return [subreddits copy];
+
+    NSMutableArray<NSString *> *pool = [subreddits mutableCopy];
+    NSMutableArray<NSString *> *result =
+        [NSMutableArray arrayWithCapacity:(NSUInteger)requestedCount];
+    for (NSInteger i = 0; i < requestedCount; i++) {
+        NSUInteger randomIndex = arc4random_uniform((uint32_t)pool.count);
+        [result addObject:pool[randomIndex]];
+        [pool removeObjectAtIndex:randomIndex];
+    }
+    return result;
+}
+
+static NSArray<NSString *> *ApolloTrendingFallbackSubreddits(
+    NSDictionary *fallbackDict,
+    NSString *limit
+) {
     NSArray *fallbackKeys = fallbackDict.allKeys;
     if (fallbackKeys.count == 0) return @[];
 
-    if (sTrendingSubredditsLimit.length == 0) {
+    if (limit.length == 0) {
         NSString *key = fallbackKeys[arc4random_uniform((uint32_t)fallbackKeys.count)];
         NSArray *subreddits = fallbackDict[key];
         return [subreddits isKindOfClass:[NSArray class]] ? subreddits : @[];
     }
 
-    NSInteger requestedCount = MAX(0, sTrendingSubredditsLimit.integerValue);
     NSMutableOrderedSet<NSString *> *uniqueSubreddits = [NSMutableOrderedSet orderedSet];
     for (id value in fallbackDict.allValues) {
         if (![value isKindOfClass:[NSArray class]]) continue;
@@ -1582,16 +1699,42 @@ static NSArray<NSString *> *ApolloTrendingFallbackSubreddits(NSDictionary *fallb
             }
         }
     }
+    return ApolloSampleTrendingSubreddits(uniqueSubreddits.array, limit);
+}
 
-    NSUInteger count = MIN((NSUInteger)requestedCount, uniqueSubreddits.count);
-    NSMutableArray<NSString *> *pool = [uniqueSubreddits.array mutableCopy];
-    NSMutableArray<NSString *> *result = [NSMutableArray arrayWithCapacity:count];
-    for (NSUInteger i = 0; i < count; i++) {
-        NSUInteger randomIndex = arc4random_uniform((uint32_t)pool.count);
-        [result addObject:pool[randomIndex]];
-        [pool removeObjectAtIndex:randomIndex];
-    }
-    return result;
+void ApolloRefreshTrendingSubreddits(
+    ApolloTrendingSubredditsRefreshCompletion completion
+) {
+    NSString *source = [sTrendingSubredditsSource copy];
+    NSString *limit = [sTrendingSubredditsLimit copy];
+    ApolloRefreshSubredditListSourceAsync(
+        source,
+        YES,
+        NSURLRequestReloadIgnoringLocalCacheData,
+        ^(NSString *content, NSError *error) {
+            NSArray<NSString *> *sample =
+                error ? nil
+                      : ApolloSampleTrendingSubreddits(
+                            ApolloSubredditListLines(content), limit);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (completion) completion(sample, error);
+            });
+        });
+}
+
+void ApolloPrepareRandomNSFWSubredditSource(
+    ApolloSubredditSourcePreparationCompletion completion
+) {
+    NSString *source = [sRandNsfwSubredditsSource copy];
+    ApolloRefreshSubredditListSourceAsync(
+        source,
+        NO,
+        NSURLRequestUseProtocolCachePolicy,
+        ^(__unused NSString *content, NSError *error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (completion) completion(error);
+            });
+        });
 }
 // Replace Reddit API client ID. Resolved per-account (see
 // ApolloAccountCredentials.{h,m}): a pending add-account choice, else the
@@ -1814,12 +1957,10 @@ static const char kARCompletion = '\0';
         // Build an immediate local fallback. For a configured limit, sample
         // across Apollo's historical lists so the fallback has that many rows
         // instead of silently reverting to one native five-item day.
-        NSArray *fallbackArray = ApolloTrendingFallbackSubreddits(fallbackDict);
+        NSArray *fallbackArray =
+            ApolloTrendingFallbackSubreddits(fallbackDict, sTrendingSubredditsLimit);
         if (fallbackArray.count == 0 && sTrendingSubredditsLimit.integerValue != 0) {
             return url;
-        }
-        if ([[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowRandNsfw]) {
-            fallbackArray = [fallbackArray arrayByAddingObject:@"RandNSFW"];
         }
         [fallbackDict setObject:fallbackArray forKey:[formatter stringFromDate:[NSDate date]]];
 
@@ -1839,36 +1980,28 @@ static const char kARCompletion = '\0';
             ? [subredditListCache objectForKey:cacheKey]
             : nil;
         if (subredditListContent.length == 0) {
-            ApolloRefreshSubredditListSourceAsync(sTrendingSubredditsSource, NO);
+            ApolloRefreshSubredditListSourceAsync(
+                sTrendingSubredditsSource,
+                NO,
+                NSURLRequestUseProtocolCachePolicy,
+                nil);
             ApolloLog(@"[RandomSources] Trending source not ready; using %lu bundled entries",
                       (unsigned long)fallbackArray.count);
             return writeDict(fallbackDict);
         }
 
         // Parse into array
-        NSMutableArray<NSString *> *subreddits = [ApolloSubredditListLines(subredditListContent) mutableCopy];
+        NSArray<NSString *> *subreddits =
+            ApolloSampleTrendingSubreddits(
+                ApolloSubredditListLines(subredditListContent),
+                sTrendingSubredditsLimit);
         if (subreddits.count == 0) {
-            return writeDict(fallbackDict);
+            if (sTrendingSubredditsLimit.integerValue != 0) {
+                return writeDict(fallbackDict);
+            }
         }
 
         NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-        // Randomize and limit subreddits
-        bool limitSubreddits = [sTrendingSubredditsLimit length] > 0;
-        if (limitSubreddits && [sTrendingSubredditsLimit integerValue] < subreddits.count) {
-            NSUInteger count = [sTrendingSubredditsLimit integerValue];
-            NSMutableArray<NSString *> *randomSubreddits = [NSMutableArray arrayWithCapacity:count];
-            for (NSUInteger i = 0; i < count; i++) {
-                NSUInteger randomIndex = arc4random_uniform((uint32_t)subreddits.count);
-                [randomSubreddits addObject:subreddits[randomIndex]];
-                // Remove to prevent duplicates
-                [subreddits removeObjectAtIndex:randomIndex];
-            }
-            subreddits = randomSubreddits;
-        }
-
-        if ([[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowRandNsfw]) {
-            [subreddits addObject:@"RandNSFW"];
-        }
         [dict setObject:subreddits forKey:[formatter stringFromDate:[NSDate date]]];
         return writeDict(dict);
     }
@@ -2245,7 +2378,11 @@ static void ApolloImgurRetryAlbumViaTextProxy(NSString *albumID,
         // The constructor normally prewarms this cache. If it did not finish
         // (offline/slow network), preserve Apollo's native request for this tap
         // and refresh asynchronously for the next one.
-        ApolloRefreshSubredditListSourceAsync(subredditListURL.absoluteString, NO);
+        ApolloRefreshSubredditListSourceAsync(
+            subredditListURL.absoluteString,
+            NO,
+            NSURLRequestUseProtocolCachePolicy,
+            nil);
         return %orig;
     }
 
@@ -3079,7 +3216,11 @@ static void initializeRandomSources() {
     for (NSString *source in @[sRandNsfwSubredditsSource ?: @"",
                                sRandomSubredditsSource ?: @"",
                                sTrendingSubredditsSource ?: @""]) {
-        ApolloRefreshSubredditListSourceAsync(source, YES);
+        ApolloRefreshSubredditListSourceAsync(
+            source,
+            YES,
+            NSURLRequestUseProtocolCachePolicy,
+            nil);
     }
 }
 
@@ -3088,6 +3229,9 @@ static void initializeRandomSources() {
     subredditListCache = [NSCache new];
     subredditListCache.countLimit = 16;
     subredditListFetchesInFlight = [NSMutableSet set];
+    subredditListFetchCompletions = [NSMutableDictionary dictionary];
+    subredditListFetchBypassesCache = [NSMutableDictionary dictionary];
+    subredditListForcedFetchCompletions = [NSMutableDictionary dictionary];
     ApolloLoadPersistedSubredditSources();
 
     NSDictionary *defaultValues = @{UDKeyBlockAnnouncements: @YES,

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1449,6 +1449,9 @@ static NSArray *const blockedUrls = @[
 
 // Cache storing subreddit list source URLs -> response body
 static NSCache<NSString *, NSString *> *subredditListCache;
+// Last successful source bodies survive process restarts so Apollo's one-shot
+// SearchViewController load never has to race the launch-time network refresh.
+static NSMutableDictionary<NSString *, NSString *> *subredditListPersistentCache;
 // Source URLs currently being refreshed. Access is confined to the serial
 // source queue; the cache itself is NSCache and is safe to read from Apollo's
 // request paths while NSURLSession completions populate it in the background.
@@ -1459,6 +1462,44 @@ static NSArray<NSString *> *ApolloSubredditListLines(NSString *content) {
     NSArray<NSString *> *lines =
         [content componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
     return [lines filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"length > 0"]];
+}
+
+static NSString *ApolloSubredditSourceCachePath(void) {
+    NSString *caches =
+        NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
+    if (caches.length == 0) {
+        caches = [NSHomeDirectory() stringByAppendingPathComponent:@"Library/Caches"];
+    }
+    return [caches stringByAppendingPathComponent:@"ApolloRebornSubredditSources.plist"];
+}
+
+static void ApolloLoadPersistedSubredditSources(void) {
+    NSDictionary *disk =
+        [NSDictionary dictionaryWithContentsOfFile:ApolloSubredditSourceCachePath()];
+    subredditListPersistentCache = [NSMutableDictionary dictionary];
+    if (![disk isKindOfClass:[NSDictionary class]]) return;
+
+    [disk enumerateKeysAndObjectsUsingBlock:^(id key, id value, __unused BOOL *stop) {
+        if (![key isKindOfClass:[NSString class]] ||
+            ![value isKindOfClass:[NSString class]] ||
+            ApolloSubredditListLines((NSString *)value).count == 0) {
+            return;
+        }
+        subredditListPersistentCache[key] = value;
+        [subredditListCache setObject:value forKey:key];
+    }];
+    ApolloLog(@"[RandomSources] Loaded %lu persisted source(s)",
+              (unsigned long)subredditListPersistentCache.count);
+}
+
+// Called only on ApolloSubredditSourceQueue().
+static void ApolloPersistSubredditSource(NSString *key, NSString *content) {
+    if (key.length == 0 || content.length == 0) return;
+    subredditListPersistentCache[key] = content;
+    if (![subredditListPersistentCache writeToFile:ApolloSubredditSourceCachePath()
+                                        atomically:YES]) {
+        ApolloLog(@"[RandomSources] Failed to persist %@", key);
+    }
 }
 
 static dispatch_queue_t ApolloSubredditSourceQueue(void) {
@@ -1481,13 +1522,14 @@ static dispatch_queue_t ApolloSubredditSourceQueue(void) {
 // creating NSURLSession.sharedSession can initialize CFNetwork, so doing that
 // synchronously from the bundle-resource hook or dylib constructor would leave
 // CFNetwork work on Apollo's launch-critical main thread even without a wait.
-static void ApolloRefreshSubredditListSourceAsync(NSString *source) {
+static void ApolloRefreshSubredditListSourceAsync(NSString *source, BOOL refreshCached) {
     if (source.length == 0) return;
     NSString *capturedSource = [source copy];
     dispatch_async(ApolloSubredditSourceQueue(), ^{
         NSURL *url = [NSURL URLWithString:capturedSource];
         NSString *key = url.absoluteString;
-        if (!url || key.length == 0 || [subredditListCache objectForKey:key]) return;
+        if (!url || key.length == 0) return;
+        if (!refreshCached && [subredditListCache objectForKey:key]) return;
         if ([subredditListFetchesInFlight containsObject:key]) return;
         [subredditListFetchesInFlight addObject:key];
 
@@ -1502,19 +1544,54 @@ static void ApolloRefreshSubredditListSourceAsync(NSString *source) {
             NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]]
                 ? (NSHTTPURLResponse *)response
                 : nil;
-            if (!error && http.statusCode == 200 && ApolloSubredditListLines(content).count > 0) {
-                [subredditListCache setObject:content forKey:key];
-                ApolloLog(@"[RandomSources] Refreshed %@", key);
-            } else {
-                ApolloLog(@"[RandomSources] Refresh failed for %@: HTTP %ld error=%@",
-                          key, (long)http.statusCode,
-                          error.localizedDescription ?: @"invalid/empty response");
-            }
             dispatch_async(ApolloSubredditSourceQueue(), ^{
+                if (!error && http.statusCode == 200 &&
+                    ApolloSubredditListLines(content).count > 0) {
+                    [subredditListCache setObject:content forKey:key];
+                    ApolloPersistSubredditSource(key, content);
+                    ApolloLog(@"[RandomSources] Refreshed %@", key);
+                } else {
+                    ApolloLog(@"[RandomSources] Refresh failed for %@: HTTP %ld error=%@",
+                              key, (long)http.statusCode,
+                              error.localizedDescription ?: @"invalid/empty response");
+                }
                 [subredditListFetchesInFlight removeObject:key];
             });
         }] resume];
     });
+}
+
+static NSArray<NSString *> *ApolloTrendingFallbackSubreddits(NSDictionary *fallbackDict) {
+    NSArray *fallbackKeys = fallbackDict.allKeys;
+    if (fallbackKeys.count == 0) return @[];
+
+    if (sTrendingSubredditsLimit.length == 0) {
+        NSString *key = fallbackKeys[arc4random_uniform((uint32_t)fallbackKeys.count)];
+        NSArray *subreddits = fallbackDict[key];
+        return [subreddits isKindOfClass:[NSArray class]] ? subreddits : @[];
+    }
+
+    NSInteger requestedCount = MAX(0, sTrendingSubredditsLimit.integerValue);
+    NSMutableOrderedSet<NSString *> *uniqueSubreddits = [NSMutableOrderedSet orderedSet];
+    for (id value in fallbackDict.allValues) {
+        if (![value isKindOfClass:[NSArray class]]) continue;
+        for (id subreddit in (NSArray *)value) {
+            if ([subreddit isKindOfClass:[NSString class]] &&
+                [(NSString *)subreddit length] > 0) {
+                [uniqueSubreddits addObject:subreddit];
+            }
+        }
+    }
+
+    NSUInteger count = MIN((NSUInteger)requestedCount, uniqueSubreddits.count);
+    NSMutableArray<NSString *> *pool = [uniqueSubreddits.array mutableCopy];
+    NSMutableArray<NSString *> *result = [NSMutableArray arrayWithCapacity:count];
+    for (NSUInteger i = 0; i < count; i++) {
+        NSUInteger randomIndex = arc4random_uniform((uint32_t)pool.count);
+        [result addObject:pool[randomIndex]];
+        [pool removeObjectAtIndex:randomIndex];
+    }
+    return result;
 }
 // Replace Reddit API client ID. Resolved per-account (see
 // ApolloAccountCredentials.{h,m}): a pending add-account choice, else the
@@ -1734,13 +1811,13 @@ static const char kARCompletion = '\0';
             - Return plist as a new file
         */
         NSMutableDictionary *fallbackDict = [[NSDictionary dictionaryWithContentsOfURL:url] mutableCopy];
-        // Select a random bundled list as an immediate fallback. Never make a
-        // resource lookup depend on the network: this hook runs on Apollo's
-        // launch/UI path.
-        NSArray *fallbackKeys = [fallbackDict allKeys];
-        if (fallbackKeys.count == 0) return url;
-        NSString *randomFallbackKey = fallbackKeys[arc4random_uniform((uint32_t)fallbackKeys.count)];
-        NSArray *fallbackArray = fallbackDict[randomFallbackKey];
+        // Build an immediate local fallback. For a configured limit, sample
+        // across Apollo's historical lists so the fallback has that many rows
+        // instead of silently reverting to one native five-item day.
+        NSArray *fallbackArray = ApolloTrendingFallbackSubreddits(fallbackDict);
+        if (fallbackArray.count == 0 && sTrendingSubredditsLimit.integerValue != 0) {
+            return url;
+        }
         if ([[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowRandNsfw]) {
             fallbackArray = [fallbackArray arrayByAddingObject:@"RandNSFW"];
         }
@@ -1762,7 +1839,9 @@ static const char kARCompletion = '\0';
             ? [subredditListCache objectForKey:cacheKey]
             : nil;
         if (subredditListContent.length == 0) {
-            ApolloRefreshSubredditListSourceAsync(sTrendingSubredditsSource);
+            ApolloRefreshSubredditListSourceAsync(sTrendingSubredditsSource, NO);
+            ApolloLog(@"[RandomSources] Trending source not ready; using %lu bundled entries",
+                      (unsigned long)fallbackArray.count);
             return writeDict(fallbackDict);
         }
 
@@ -2166,7 +2245,7 @@ static void ApolloImgurRetryAlbumViaTextProxy(NSString *albumID,
         // The constructor normally prewarms this cache. If it did not finish
         // (offline/slow network), preserve Apollo's native request for this tap
         // and refresh asynchronously for the next one.
-        ApolloRefreshSubredditListSourceAsync(subredditListURL.absoluteString);
+        ApolloRefreshSubredditListSourceAsync(subredditListURL.absoluteString, NO);
         return %orig;
     }
 
@@ -2995,19 +3074,21 @@ static BOOL ApolloDefaultsKeyChangesActiveAccount(NSString *key) {
 
 // Pre-fetches random subreddit lists in background
 static void initializeRandomSources() {
-    // Trending uses the same cache as Random/RandNSFW. Starting all three
-    // downloads here makes the launch-time resource hook a cache-only lookup.
+    // Persisted data serves launch immediately; refresh all configured sources
+    // in the background so a later launch gets current data too.
     for (NSString *source in @[sRandNsfwSubredditsSource ?: @"",
                                sRandomSubredditsSource ?: @"",
                                sTrendingSubredditsSource ?: @""]) {
-        ApolloRefreshSubredditListSourceAsync(source);
+        ApolloRefreshSubredditListSourceAsync(source, YES);
     }
 }
 
 // MARK: - Constructor
 %ctor {
     subredditListCache = [NSCache new];
+    subredditListCache.countLimit = 16;
     subredditListFetchesInFlight = [NSMutableSet set];
+    ApolloLoadPersistedSubredditSources();
 
     NSDictionary *defaultValues = @{UDKeyBlockAnnouncements: @YES,
                                     UDKeyEnableFLEX: @NO,


### PR DESCRIPTION
Fixes #779

### Summary

Fixes the trending-subreddit limit race and expands Apollo's default Search tab with:

- pull-to-refresh for fetching and resampling the configured trending source;
- a separate **Random NSFW Subreddit** row below **Random Subreddit**;
- reliable persisted source caching so cold launches do not fall back to Apollo's five-item bundled list.

https://github.com/user-attachments/assets/dbc937c1-67cf-49d6-9a35-39c6fc5f3f1f

### Changes

- Persists successful subreddit source responses and serves them immediately on later launches while refreshing them asynchronously.
- Centralizes trending limit behavior:
  - a numeric limit randomly samples without duplicates;
  - an empty limit keeps every source entry in source order.
- Adds pull-to-refresh only while the Search field is empty and safely replaces Apollo's Swift `trendingSubreddits` array through a Swift ABI bridge.
- Coalesces overlapping source requests while ensuring an explicit refresh still performs a cache-bypassing fetch.
- Removes the synthetic `RandNSFW` item from the trending section.
- Extends Apollo's native Random Subreddit group with a **Random NSFW Subreddit** row controlled by the existing `Show RandNSFW in Search` setting.
- Prepares the configured RandNSFW source before routing, avoiding Reddit's discontinued `/r/randnsfw` endpoint on a cold cache.
- Keeps Apollo's native Search batch updates balanced when entering or leaving search mode.
- Reuses the shared toast UI for refresh/source failures, correcting its rounded material clipping.
- Adjusts the Liquid Glass refresh indicator so it clears the floating search bar.

### Testing

- Built successfully with `make package` for the arm64 device target.
- Verified on device that entering search no longer triggers invalid UITableView batch updates.
- Verified the Random NSFW row and pull-to-refresh behavior on the default Search state.