### PR TITLE
Fix link preview images not loading in feeds and bot-walled sites stuck compact

### DIFF
--- a/src/ApolloInlineLinkPreviews.xm
+++ b/src/ApolloInlineLinkPreviews.xm
@@ -57,6 +57,9 @@ typedef NS_ENUM(unsigned char, ApolloLinkPreviewStackAlignItems) {
 - (BOOL)isNodeLoaded;
 - (void)setNeedsDisplay;
 - (void)onDidLoad:(void(^)(__kindof ASDisplayNode *node))body;
+// Texture ASInterfaceState bitmask: MeasureLayout=1<<0, Preload=1<<1,
+// Display=1<<2, Visible=1<<3. Thread-safe accessor (lock-guarded in Texture).
+@property (nonatomic, readonly) NSUInteger interfaceState;
 @property (nullable, nonatomic, copy) UIColor *backgroundColor;
 @property (nonatomic) CGFloat cornerRadius;
 @property (nonatomic) BOOL clipsToBounds;
@@ -1119,6 +1122,70 @@ static BOOL ApolloLPImageURLIsDead(NSURL *url) {
     }
 }
 
+// V25: TRANSIENT image-fetch failures (timeout, 5xx, offline, non-image body
+// on a 2xx) used to be terminal for the card: the one-shot scheduled marker
+// was never cleared, so a single failed fetch left the node image-less for its
+// whole life — the "hero image missing until you open the post and come back"
+// report (opening the post worked only because the comments-view card
+// re-fetched into the shared bitmap cache). Failures now clear the marker and
+// stamp a short per-URL cooldown; retries are event-driven — the next
+// didEnterPreloadState / didEnterVisibleState / card build past the cooldown
+// re-kicks the fetch — never polled.
+static const NSTimeInterval kApolloLPImageTransientRetryCooldown = 8.0;
+
+static NSMutableDictionary<NSString *, NSDate *> *ApolloLPTransientImageFailures(void) {
+    static NSMutableDictionary *map;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ map = [NSMutableDictionary dictionary]; });
+    return map;
+}
+
+static void ApolloLPMarkImageURLTransientFailure(NSURL *url) {
+    NSString *key = url.absoluteString;
+    if (key.length == 0) return;
+    @synchronized (ApolloLPTransientImageFailures()) {
+        ApolloLPTransientImageFailures()[key] = [NSDate date];
+    }
+}
+
+static void ApolloLPClearImageURLTransientFailure(NSURL *url) {
+    NSString *key = url.absoluteString;
+    if (key.length == 0) return;
+    @synchronized (ApolloLPTransientImageFailures()) {
+        [ApolloLPTransientImageFailures() removeObjectForKey:key];
+    }
+}
+
+static BOOL ApolloLPImageURLInTransientCooldown(NSURL *url) {
+    NSString *key = url.absoluteString;
+    if (key.length == 0) return NO;
+    @synchronized (ApolloLPTransientImageFailures()) {
+        NSDate *failedAt = ApolloLPTransientImageFailures()[key];
+        if (!failedAt) return NO;
+        if ([[NSDate date] timeIntervalSinceDate:failedAt] > kApolloLPImageTransientRetryCooldown) {
+            [ApolloLPTransientImageFailures() removeObjectForKey:key];
+            return NO;
+        }
+        return YES;
+    }
+}
+
+// Is the node inside Texture's data range (preload/display/visible)? Cards are
+// measured for WHOLE insert batches at once — rows many screens below the fold
+// included — and firing a network fetch for every measured card front-loaded
+// dozens of concurrent requests whose timeouts were this bug's main trigger.
+// Fetch only near-range cards; didEnterPreloadState kicks the rest as they
+// approach. Nodes that can't report a state keep the old fetch-always behavior.
+static BOOL ApolloLPNodeIsInFetchRange(ASDisplayNode *node) {
+    if (![node respondsToSelector:@selector(interfaceState)]) return YES;
+    @try {
+        NSUInteger state = node.interfaceState;
+        return (state & (0x2 | 0x4 | 0x8)) != 0; // Preload | Display | Visible
+    } @catch (__unused NSException *exception) {
+        return YES;
+    }
+}
+
 // Tail of the fallback apply — displayImage must already be display-sized.
 // Re-runs the liveness guards because it also fires after an async resize,
 // by which point the node may have moved to another URL or grown an image.
@@ -1190,6 +1257,9 @@ static void ApolloLPStartFallbackImageFetch(ASNetworkImageNode *imageNode, NSURL
     // on every re-render loops: 404 -> reflow -> row reload -> re-render ->
     // fetch -> 404 ... (one reload per second, visible as flickering cells).
     if (ApolloLPImageURLIsDead(imageURL)) return;
+    // Transiently-failed URLs wait out a short cooldown so preload/visible
+    // re-entries can't hammer a struggling host or an offline link.
+    if (ApolloLPImageURLInTransientCooldown(imageURL)) return;
     NSString *key = imageURL.absoluteString;
     if (key.length == 0) return;
 
@@ -1209,7 +1279,6 @@ static void ApolloLPStartFallbackImageFetch(ASNetworkImageNode *imageNode, NSURL
     __weak ASNetworkImageNode *weakImageNode = imageNode;
     NSString *hostCopy = [host copy];
     [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        (void)error;
         UIImage *image = data.length > 0 ? [UIImage imageWithData:data scale:UIScreen.mainScreen.scale] : nil;
         BOOL definitivelyDead = NO;
         if (image) {
@@ -1223,6 +1292,7 @@ static void ApolloLPStartFallbackImageFetch(ASNetworkImageNode *imageNode, NSURL
             image = ApolloLPDisplaySizedImage(image);
             NSUInteger cost = (NSUInteger)(image.size.width * image.size.height * image.scale * image.scale * 4.0);
             [ApolloLPFallbackImageCache() setObject:image forKey:key cost:cost];
+            ApolloLPClearImageURLTransientFailure(imageURL);
         } else {
             NSHTTPURLResponse *httpResponse = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
             // 4xx = the file genuinely isn't there (clip hosts publish og:image
@@ -1230,12 +1300,25 @@ static void ApolloLPStartFallbackImageFetch(ASNetworkImageNode *imageNode, NSURL
             // 5xx don't dead-mark, so flaky connectivity can't compact-ify
             // every card.
             definitivelyDead = httpResponse.statusCode >= 400 && httpResponse.statusCode < 500;
+            if (!definitivelyDead) {
+                ApolloLPMarkImageURLTransientFailure(imageURL);
+            }
+            ApolloLog(@"[LinkPreviews] image fetch failed host=%@ status=%ld bytes=%lu err=%@ (%@)",
+                      hostCopy, (long)httpResponse.statusCode, (unsigned long)data.length,
+                      error.localizedDescription ?: @"decode",
+                      definitivelyDead ? @"dead-marked" : @"will retry on approach");
         }
 
         dispatch_async(dispatch_get_main_queue(), ^{
             ASNetworkImageNode *strongImageNode = weakImageNode;
             if (!strongImageNode) return;
             objc_setAssociatedObject(strongImageNode, &kApolloLinkPreviewImageFallbackInFlightKey, @NO, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            if (!image) {
+                // Failed fetch: release the one-shot scheduled marker so a
+                // later card build may schedule again — the marker's job is to
+                // dedupe PENDING work, not to make the first failure terminal.
+                objc_setAssociatedObject(strongImageNode, &kApolloLinkPreviewImageFallbackScheduledKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+            }
             ApolloLPApplyFallbackImage(strongImageNode, imageURL, image, hostCopy);
 
             if (definitivelyDead && !ApolloLPImageURLIsDead(imageURL)) {
@@ -1307,7 +1390,16 @@ static void ApolloLPScheduleImageFallbackIfNeeded(ASNetworkImageNode *imageNode,
             }
             return;
         }
-        ApolloLPStartFallbackImageFetch(strongImageNode, imageURLCopy, hostCopy);
+        if (ApolloLPNodeIsInFetchRange((ASDisplayNode *)strongImageNode)) {
+            ApolloLPStartFallbackImageFetch(strongImageNode, imageURLCopy, hostCopy);
+        } else {
+            // Below-fold card measured with the rest of its insert batch:
+            // don't spend a fetch (and possibly a burst timeout) on a row
+            // that may never scroll on screen. Clear the scheduled marker so
+            // the arm is spendable again; didEnterPreloadState kicks the
+            // fetch when the row actually approaches.
+            objc_setAssociatedObject(strongImageNode, &kApolloLinkPreviewImageFallbackScheduledKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+        }
         // One bounded late re-check: if Texture's loader lands the image after
         // the 900ms window (slow CDN) and no further layout pass happens, the
         // card would stay on the default anchor with no face scan. Not broken,
@@ -4417,6 +4509,67 @@ static void ApolloLPStackGuardReport(const char *where, size_t used, size_t size
 // untouched and still catches the actual failure regardless of cause.
 // ======================== END stack-guard sentinel ========================
 
+// V25: the recovery half of the retry design. For every card image/avatar node
+// that is still image-less, either repaint it from the shared bitmap cache
+// (another screen — typically the comments header card — may have fetched it
+// meanwhile) or re-kick the network fetch. Runs on preload/visible ENTRY only:
+// event-driven, at most one fetch per URL in flight, dead/cooldown-guarded
+// inside ApolloLPStartFallbackImageFetch.
+static void ApolloLPRecoverMissingCardImages(ASDisplayNode *hostNode) {
+    for (NSDictionary *bundle in ApolloLPNodeBundlesSnapshot(hostNode)) {
+        NSString *pageHost = ApolloLPHost(bundle[@"url"]);
+        for (NSString *key in @[@"image", @"avatar"]) {
+            ASNetworkImageNode *imageNode = bundle[key];
+            NSURL *fallbackURL = imageNode ? objc_getAssociatedObject(imageNode, &kApolloLinkPreviewImageFallbackURLKey) : nil;
+            if (!fallbackURL.absoluteString.length) continue;
+            if (ApolloLPNetworkImageNodeHasImage(imageNode)) continue;
+            UIImage *cached = [ApolloLPFallbackImageCache() objectForKey:fallbackURL.absoluteString];
+            if (cached) {
+                ApolloLPApplyFallbackImage(imageNode, fallbackURL, cached, pageHost);
+            } else {
+                ApolloLPStartFallbackImageFetch(imageNode, fallbackURL, pageHost);
+            }
+        }
+    }
+}
+
+// V25: one background refetch per URL per launch for cached previews that are
+// the residue of a blocked fetch (bot-wall title, or slug-title + favicon with
+// no description — reuters/wsj-style 401s used to cache these for their whole
+// 7-day TTL, pinning the host to a compact favicon card). The stale card still
+// renders this pass; when the refetch lands something better, the DidCache
+// notification + node invalidation re-render it in place.
+static BOOL ApolloLPMarkWeakCacheRefetchAttempted(NSURL *url) {
+    NSString *key = url.absoluteString;
+    if (key.length == 0) return NO;
+    static NSMutableSet<NSString *> *attempted;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ attempted = [NSMutableSet set]; });
+    @synchronized (attempted) {
+        if ([attempted containsObject:key]) return NO;
+        [attempted addObject:key];
+        return YES;
+    }
+}
+
+static void ApolloLPKickWeakCachedPreviewRefetch(NSURL *url, ApolloLinkPreview *cached) {
+    NSString *weakReason = [ApolloLinkPreviewFetcher refetchReasonForCachedPreview:cached url:url];
+    if (!weakReason) return;
+    if (!ApolloLPMarkWeakCacheRefetchAttempted(url)) return;
+    ApolloLog(@"[LinkPreviews] healing weak cached preview host=%@ reason=%@", ApolloLPHost(url), weakReason);
+    [ApolloLinkPreviewFetcher requestPreviewForURL:url completion:^(ApolloLinkPreview *preview) {
+        if (!preview || ![preview hasUsefulMetadata]) return;
+        // Same signal path as a first fetch: cached-preview consumers reload,
+        // registered link nodes re-measure against the healed cache entry.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:ApolloLinkPreviewDidCacheNotification
+                                                                object:nil
+                                                              userInfo:@{@"url": url}];
+            ApolloLPInvalidateRegisteredLinkPreviewNodesForURL(url, @"weak-cache-heal");
+        });
+    }];
+}
+
 %hook _TtC6Apollo14LinkButtonNode
 
 // Release the per-card bitmap pins when the card leaves the preload range, and
@@ -4440,15 +4593,7 @@ static void ApolloLPStackGuardReport(const char *where, size_t used, size_t size
 
 - (void)didEnterPreloadState {
     %orig;
-    for (NSDictionary *bundle in ApolloLPNodeBundlesSnapshot((ASDisplayNode *)self)) {
-        ASNetworkImageNode *imageNode = bundle[@"image"];
-        NSURL *fallbackURL = imageNode ? objc_getAssociatedObject(imageNode, &kApolloLinkPreviewImageFallbackURLKey) : nil;
-        if (!fallbackURL.absoluteString.length) continue;
-        UIImage *cached = [ApolloLPFallbackImageCache() objectForKey:fallbackURL.absoluteString];
-        if (cached && !ApolloLPNetworkImageNodeHasImage(imageNode)) {
-            ApolloLPApplyFallbackImage(imageNode, fallbackURL, cached, ApolloLPHost(fallbackURL));
-        }
-    }
+    ApolloLPRecoverMissingCardImages((ASDisplayNode *)self);
 }
 
 - (id)layoutSpecThatFits:(struct CDStruct_90e057aa)constrainedSize {
@@ -4491,7 +4636,9 @@ static void ApolloLPStackGuardReport(const char *where, size_t used, size_t size
     }
     ApolloLPPrefetchRedditUserProfileIfNeeded(url);
 
-    if (!url) {
+    // Empty-host URLs ("https:///message/compose/?to=...") can never fetch or
+    // render a meaningful card — let Apollo's native link UI handle them.
+    if (!url || url.host.length == 0) {
         ApolloLPRestoreHostShell((ASDisplayNode *)self);
         return %orig;
     }
@@ -4555,6 +4702,9 @@ static void ApolloLPStackGuardReport(const char *where, size_t used, size_t size
             }
             cached = nil;
         }
+    }
+    if (cached && [cached hasUsefulMetadata]) {
+        ApolloLPKickWeakCachedPreviewRefetch(url, cached);
     }
     if (!cached) {
         // Reserve a hero image box ONLY on positive evidence (see
@@ -4819,6 +4969,11 @@ static void ApolloLPStackGuardReport(const char *where, size_t used, size_t size
         });
     }
     ApolloLPScheduleOverflowHeightCheck((ASDisplayNode *)self, @"visible-check");
+    // V25: a card the user is LOOKING at with a blank image area is the
+    // reported bug — belt-and-suspenders recovery on top of the preload-entry
+    // kick (covers a fetch that failed while the row sat in the preload
+    // buffer). Cooldown-guarded, so this cannot loop.
+    ApolloLPRecoverMissingCardImages((ASDisplayNode *)self);
 }
 
 %end

--- a/src/ApolloInlineLinkPreviews.xm
+++ b/src/ApolloInlineLinkPreviews.xm
@@ -142,6 +142,8 @@ static char kApolloLinkPreviewSourceURLStringKey;
 static char kApolloLinkPreviewImageFallbackURLKey;
 static char kApolloLinkPreviewImageFallbackScheduledKey;
 static char kApolloLinkPreviewImageFallbackInFlightKey;
+// URL string this node has already spent its one self-scheduled retry on.
+static char kApolloLinkPreviewImageFallbackRetriedURLKey;
 static char kApolloLinkPreviewImageFallbackAppliedURLKey;
 static char kApolloLinkPreviewImageFallbackResizeInFlightURLKey;
 static char kApolloLinkPreviewRenderSignaturesKey;
@@ -1251,6 +1253,53 @@ static void ApolloLPApplyFallbackImage(ASNetworkImageNode *imageNode, NSURL *ima
     });
 }
 
+static void ApolloLPStartFallbackImageFetch(ASNetworkImageNode *imageNode, NSURL *imageURL, NSString *host);
+
+// One self-scheduled retry per (node, URL), fired just past the transient
+// cooldown so ApolloLPStartFallbackImageFetch's own cooldown guard lets it
+// through. This is the only non-event-driven fetch trigger in the module, and
+// it exists for exactly one case: the card was on screen when its fetch failed,
+// so no further preload/visible event is coming to re-kick it.
+//
+// Deliberately not a poll — the retry is armed once per URL, and if it also
+// fails the card returns to the event-driven path (scroll away and back, or a
+// rebuild) exactly as before. Everything is re-checked at fire time, so a node
+// that has been recycled onto a different URL, has since acquired an image, has
+// scrolled out of range, or whose URL got dead-marked in the meantime spends
+// nothing.
+static void ApolloLPScheduleOneFallbackImageRetry(ASNetworkImageNode *imageNode, NSURL *imageURL, NSString *host) {
+    if (!imageNode || !ApolloLPURLIsHTTP(imageURL)) return;
+    NSString *key = imageURL.absoluteString;
+    if (key.length == 0) return;
+
+    // Already spent this node's retry on this URL.
+    NSString *retriedURL = objc_getAssociatedObject(imageNode, &kApolloLinkPreviewImageFallbackRetriedURLKey);
+    if ([retriedURL isEqualToString:key]) return;
+    objc_setAssociatedObject(imageNode, &kApolloLinkPreviewImageFallbackRetriedURLKey, key, OBJC_ASSOCIATION_COPY_NONATOMIC);
+
+    __weak ASNetworkImageNode *weakImageNode = imageNode;
+    NSURL *imageURLCopy = imageURL;
+    NSString *hostCopy = [host copy];
+    int64_t delay = (int64_t)((kApolloLPImageTransientRetryCooldown + 0.5) * NSEC_PER_SEC);
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay), dispatch_get_main_queue(), ^{
+        ASNetworkImageNode *strongImageNode = weakImageNode;
+        if (!strongImageNode) return;
+        // The node may have been recycled onto another link since the failure.
+        NSURL *currentURL = objc_getAssociatedObject(strongImageNode, &kApolloLinkPreviewImageFallbackURLKey);
+        if (![currentURL.absoluteString isEqualToString:imageURLCopy.absoluteString]) return;
+        // Texture's own loader, or a sibling card sharing the fallback cache,
+        // may have landed the image while we waited.
+        if (ApolloLPNetworkImageNodeHasImage(strongImageNode)) return;
+        // Off-screen now: the ordinary preload/visible path owns it again, and
+        // spending a fetch on a row nobody is looking at is what the
+        // fetch-range guard exists to avoid.
+        if (!ApolloLPNodeIsInFetchRange((ASDisplayNode *)strongImageNode)) return;
+        ApolloLog(@"[LinkPreviews] retrying on-screen image fetch after cooldown host=%@", hostCopy);
+        // Dead-mark, cooldown and in-flight are all re-checked inside.
+        ApolloLPStartFallbackImageFetch(strongImageNode, imageURLCopy, hostCopy);
+    });
+}
+
 static void ApolloLPStartFallbackImageFetch(ASNetworkImageNode *imageNode, NSURL *imageURL, NSString *host) {
     if (!imageNode || !ApolloLPURLIsHTTP(imageURL)) return;
     // Dead-marked URLs don't get re-fetched during the cooldown — refetching
@@ -1318,6 +1367,18 @@ static void ApolloLPStartFallbackImageFetch(ASNetworkImageNode *imageNode, NSURL
                 // later card build may schedule again — the marker's job is to
                 // dedupe PENDING work, not to make the first failure terminal.
                 objc_setAssociatedObject(strongImageNode, &kApolloLinkPreviewImageFallbackScheduledKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+                // ...but clearing the marker only helps a card that gets ANOTHER
+                // lifecycle event. On a card already on screen when the fetch
+                // failed, didEnterPreloadState and didEnterVisibleState fired
+                // long before a 15s timeout resolved, and nothing re-enters
+                // after the cooldown — so the card stayed visibly blank until
+                // the user scrolled it away and back. Schedule exactly one
+                // retry for the cooldown deadline; every guard is re-evaluated
+                // when it fires, and a second failure falls back to the
+                // event-driven path rather than looping.
+                if (!definitivelyDead) {
+                    ApolloLPScheduleOneFallbackImageRetry(strongImageNode, imageURL, hostCopy);
+                }
             }
             ApolloLPApplyFallbackImage(strongImageNode, imageURL, image, hostCopy);
 
@@ -1355,6 +1416,12 @@ static void ApolloLPStartFallbackImageFetch(ASNetworkImageNode *imageNode, NSURL
 static void ApolloLPScheduleImageFallbackIfNeeded(ASNetworkImageNode *imageNode, NSURL *imageURL, NSString *host) {
     if (!imageNode || !ApolloLPURLIsHTTP(imageURL)) return;
     if (ApolloLPImageURLIsDead(imageURL)) return;
+    NSURL *previousURL = objc_getAssociatedObject(imageNode, &kApolloLinkPreviewImageFallbackURLKey);
+    if (previousURL && ![previousURL.absoluteString isEqualToString:imageURL.absoluteString]) {
+        // Recycled onto a different link: the new URL gets its own retry
+        // budget, and a marker left from the old one must not suppress it.
+        objc_setAssociatedObject(imageNode, &kApolloLinkPreviewImageFallbackRetriedURLKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    }
     objc_setAssociatedObject(imageNode, &kApolloLinkPreviewImageFallbackURLKey, imageURL, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
     NSString *cacheKey = imageURL.absoluteString;

--- a/src/ApolloLinkPreviewFetcher.h
+++ b/src/ApolloLinkPreviewFetcher.h
@@ -7,6 +7,16 @@
 + (void)requestPreviewForURL:(NSURL *)url completion:(void (^)(ApolloLinkPreview *preview))completion;
 + (BOOL)isTwitterURL:(NSURL *)url;
 
+// Non-nil when a CACHED preview is the residue of a fetch that never reached
+// the real page — a bot-wall interstitial title, a DOI page whose metadata is
+// just the DOI, or the slug-title + favicon fallback with no description — and
+// therefore deserves a background refetch rather than squatting in the cache
+// for its whole TTL. Returns a short reason slug for logging ("bot-wall",
+// "weak-academic", "weak-generic") or nil for a healthy preview. Shared by
+// requestPreviewForURL:'s own staleness gate and the render path's
+// once-per-launch cache-healing kick in ApolloInlineLinkPreviews.
++ (NSString *)refetchReasonForCachedPreview:(ApolloLinkPreview *)preview url:(NSURL *)url;
+
 @end
 
 // Decode HTML entities (named + numeric, e.g. &laquo;->«, &raquo;->», &#8230;->…)

--- a/src/ApolloLinkPreviewFetcher.m
+++ b/src/ApolloLinkPreviewFetcher.m
@@ -719,14 +719,38 @@ static NSString *ApolloLinkPreviewBrowserUserAgent(void) {
 + (void)fetchBlueskyPreviewForURL:(NSURL *)url completion:(ApolloLinkPreviewCompletion)completion;
 + (NSString *)crossrefSummaryFromMessage:(NSDictionary *)message;
 + (void)fetchCrossrefPreviewForURL:(NSURL *)url completion:(ApolloLinkPreviewCompletion)completion;
++ (void)fetchRedditInfoPreviewForURL:(NSURL *)url completion:(ApolloLinkPreviewCompletion)completion;
++ (void)fetchRedditInfoPreviewForExactURL:(NSURL *)url completion:(ApolloLinkPreviewCompletion)completion;
 + (void)fetchHTMLPreviewForURL:(NSURL *)url completion:(ApolloLinkPreviewCompletion)completion;
 + (void)fetchHTMLPreviewForURL:(NSURL *)url allowRange:(BOOL)allowRange browserFallback:(BOOL)browserFallback completion:(ApolloLinkPreviewCompletion)completion;
 @end
 
 @implementation ApolloLinkPreviewFetcher
 
++ (NSString *)refetchReasonForCachedPreview:(ApolloLinkPreview *)preview url:(NSURL *)url {
+    if (!preview) return nil;
+    if (ApolloLinkPreviewIsCachedBotWall(preview)) return @"bot-wall";
+    if (ApolloLinkPreviewIsWeakAcademicPreview(preview, url)) return @"weak-academic";
+    BOOL weakGeneric = preview.imageIsFallbackIcon
+        && preview.desc.length == 0
+        && [preview.title isEqualToString:ApolloLinkPreviewTitleFromURL(url)];
+    if (weakGeneric) return @"weak-generic";
+    return nil;
+}
+
 + (void)requestPreviewForURL:(NSURL *)url completion:(void (^)(ApolloLinkPreview *preview))completion {
     if (!ApolloLinkPreviewURLIsHTTP(url)) {
+        if (completion) completion(nil);
+        return;
+    }
+    // Scheme-relative garbage like "https:///message/compose/?to=/r/ios"
+    // (a site-relative link that never got resolved against its page) parses as
+    // an http(s) URL with an EMPTY host. It can never fetch — and worse, the
+    // failure path used to synthesize a slug-title card ("Message Compose")
+    // for it. Negative-cache it so the native link UI shows instead.
+    if (url.host.length == 0) {
+        ApolloLog(@"[LinkPreviews] rejecting empty-host URL %@", url.absoluteString);
+        [[ApolloLinkPreviewCache sharedCache] markNoMetadataForURL:url];
         if (completion) completion(nil);
         return;
     }
@@ -736,11 +760,7 @@ static NSString *ApolloLinkPreviewBrowserUserAgent(void) {
     if ([logHost hasPrefix:@"www."]) logHost = [logHost substringFromIndex:4];
     ApolloLog(@"[LinkPreviews] requestPreview host=%@ cached=%@", logHost, cached ? @"YES" : @"NO");
     if (cached) {
-        BOOL botWall = ApolloLinkPreviewIsCachedBotWall(cached);
-        BOOL weakAcademic = ApolloLinkPreviewIsWeakAcademicPreview(cached, url);
-        BOOL weakGeneric = cached.imageIsFallbackIcon
-            && cached.desc.length == 0
-            && [cached.title isEqualToString:ApolloLinkPreviewTitleFromURL(url)];
+        NSString *weakReason = [self refetchReasonForCachedPreview:cached url:url];
         BOOL staleBluesky = ApolloBlueskyPostPartsFromURL(url)
             && (![cached.previewKind isEqualToString:@"bluesky-post-v2"] || cached.postText.length == 0);
         BOOL staleRedditUser = ApolloRedditUsernameFromProfileURL(url).length > 0
@@ -756,12 +776,12 @@ static NSString *ApolloLinkPreviewBrowserUserAgent(void) {
             && [cached.previewKind isEqualToString:@"reddit-user-profile"]
             && ((redditProfileInfo && !redditProfileInfo.suspensionChecked)
                 || (ApolloBannedProfileCachedIsSuspended(redditUsername) != previewSaysBanned));
-        if (!botWall && !weakAcademic && !weakGeneric && !staleBluesky && !staleRedditUser && !staleRedditSubreddit && !staleRedditUserSuspension) {
+        if (!weakReason && !staleBluesky && !staleRedditUser && !staleRedditSubreddit && !staleRedditUserSuspension) {
             if (completion) completion(cached);
             return;
         }
         ApolloLog(@"[LinkPreviews] refetching cached preview host=%@ reason=%@",
-                  logHost, botWall ? @"bot-wall" : (weakAcademic ? @"weak-academic" : (weakGeneric ? @"weak-generic" : (staleBluesky ? @"stale-bluesky" : (staleRedditUserSuspension ? @"stale-reddit-user-suspension" : (staleRedditUser ? @"stale-reddit-user" : @"stale-reddit-subreddit"))))));
+                  logHost, weakReason ?: (staleBluesky ? @"stale-bluesky" : (staleRedditUserSuspension ? @"stale-reddit-user-suspension" : (staleRedditUser ? @"stale-reddit-user" : @"stale-reddit-subreddit"))));
         if (staleRedditUserSuspension && redditUsername.length > 0) {
             [[ApolloLinkPreviewCache sharedCache] removePreviewsForRedditUsername:redditUsername];
         }
@@ -1337,6 +1357,116 @@ static NSString *ApolloLinkPreviewBrowserUserAgent(void) {
     }] resume];
 }
 
+// The URL with its host's "www." prefix toggled (added when absent, stripped
+// when present), or nil when no meaningful sibling exists. The LinkButtonNode
+// URL is display-derived on iOS 26 — the rendered text drops the scheme and
+// "www." — while Reddit's api/info matches the SUBMITTED URL exactly, so a
+// bare-host lookup misses the www-host submission and vice versa.
+static NSURL *ApolloLinkPreviewWWWSiblingURL(NSURL *url) {
+    NSString *host = url.host;
+    if (host.length == 0) return nil;
+    NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:YES];
+    if (!components) return nil;
+    components.host = [host.lowercaseString hasPrefix:@"www."]
+        ? [host substringFromIndex:4]
+        : [@"www." stringByAppendingString:host];
+    return components.URL;
+}
+
+// Last-resort metadata for a page whose own fetch is bot-walled (reuters.com,
+// wsj.com, ... answer non-browser clients with 401/403): ask Reddit what IT
+// knows about the URL. api/info?url= returns every submission of that exact
+// URL, and each carries the preview image Reddit's own scraper captured
+// server-side at submit time — no client-side bot wall involved — plus the
+// submission title, which for news posts is normally the article headline.
++ (void)fetchRedditInfoPreviewForURL:(NSURL *)url completion:(ApolloLinkPreviewCompletion)completion {
+    if (ApolloLinkPreviewHostIs(url, @"reddit.com") || ApolloLinkPreviewHostIs(url, @"redd.it")) {
+        completion(nil);
+        return;
+    }
+    NSURL *sibling = ApolloLinkPreviewWWWSiblingURL(url);
+    [self fetchRedditInfoPreviewForExactURL:url completion:^(ApolloLinkPreview *preview) {
+        if (preview || !sibling) {
+            completion(preview);
+            return;
+        }
+        [self fetchRedditInfoPreviewForExactURL:sibling completion:completion];
+    }];
+}
+
++ (void)fetchRedditInfoPreviewForExactURL:(NSURL *)url completion:(ApolloLinkPreviewCompletion)completion {
+    // Form-strict escaping: the URL goes in a query VALUE, so its own '&', '=',
+    // '?' and '+' must all be percent-encoded (URLQueryAllowedCharacterSet
+    // would leave them bare and truncate the lookup at the first '&').
+    static NSCharacterSet *valueAllowed;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        NSMutableCharacterSet *allowed = [[NSCharacterSet alphanumericCharacterSet] mutableCopy];
+        [allowed addCharactersInString:@"-._~"];
+        valueAllowed = [allowed copy];
+    });
+    NSString *escaped = [url.absoluteString stringByAddingPercentEncodingWithAllowedCharacters:valueAllowed];
+    if (escaped.length == 0) {
+        completion(nil);
+        return;
+    }
+
+    NSString *urlString = sLatestRedditBearerToken.length > 0
+        ? [NSString stringWithFormat:@"https://oauth.reddit.com/api/info.json?raw_json=1&url=%@", escaped]
+        : [NSString stringWithFormat:@"https://www.reddit.com/api/info.json?raw_json=1&url=%@", escaped];
+    NSMutableURLRequest *request = ApolloLinkPreviewRequest([NSURL URLWithString:urlString], 10.0);
+    if (sLatestRedditBearerToken.length > 0) {
+        [request setValue:[@"Bearer " stringByAppendingString:sLatestRedditBearerToken] forHTTPHeaderField:@"Authorization"];
+    }
+
+    [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        NSHTTPURLResponse *httpResponse = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
+        if (error || !data || httpResponse.statusCode < 200 || httpResponse.statusCode >= 300) {
+            ApolloLog(@"[LinkPreviews] Reddit info lookup failed host=%@ status=%ld err=%@",
+                      ApolloLinkPreviewHost(url), (long)httpResponse.statusCode, error.localizedDescription);
+            completion(nil);
+            return;
+        }
+
+        NSDictionary *json = ApolloLinkPreviewDictionaryValue([NSJSONSerialization JSONObjectWithData:data options:0 error:nil]);
+        NSArray *children = ApolloLinkPreviewArrayValue(ApolloLinkPreviewDictionaryValue(json[@"data"])[@"children"]);
+        NSDictionary *bestPost = nil;
+        NSString *bestImage = nil;
+        for (id child in children) {
+            NSDictionary *post = ApolloLinkPreviewDictionaryValue(ApolloLinkPreviewDictionaryValue(child)[@"data"]);
+            if (!post) continue;
+            NSString *image = ApolloRedditPreviewImageStringFromPost(post);
+            if (image.length == 0) continue;
+            bestPost = post;
+            bestImage = image;
+            break;
+        }
+        if (!bestPost) {
+            ApolloLog(@"[LinkPreviews] Reddit info lookup: no submission with preview host=%@ children=%lu",
+                      ApolloLinkPreviewHost(url), (unsigned long)children.count);
+            completion(nil);
+            return;
+        }
+
+        ApolloLinkPreview *preview = [ApolloLinkPreview new];
+        preview.siteName = ApolloLinkPreviewHost(url);
+        preview.title = ApolloLinkPreviewCleanString(bestPost[@"title"]) ?: ApolloLinkPreviewTitleFromURL(url);
+        preview.imageURL = ApolloLinkPreviewURLFromString(bestImage, url);
+        NSDictionary *source = ApolloLinkPreviewDictionaryValue(ApolloLinkPreviewDictionaryValue(ApolloLinkPreviewArrayValue(ApolloLinkPreviewDictionaryValue(bestPost[@"preview"])[@"images"]).firstObject)[@"source"]);
+        if ([source[@"width"] respondsToSelector:@selector(doubleValue)] && [source[@"height"] respondsToSelector:@selector(doubleValue)]) {
+            preview.imageSize = CGSizeMake([source[@"width"] doubleValue], [source[@"height"] doubleValue]);
+        }
+        preview.fetchedAt = [NSDate date];
+        if (preview.imageURL.absoluteString.length == 0) {
+            completion(nil);
+            return;
+        }
+        ApolloLog(@"[LinkPreviews] Reddit info harvested preview host=%@ image=%.0fx%.0f",
+                  ApolloLinkPreviewHost(url), preview.imageSize.width, preview.imageSize.height);
+        completion(preview);
+    }] resume];
+}
+
 + (NSString *)crossrefSummaryFromMessage:(NSDictionary *)message {
     NSString *publisher = ApolloLinkPreviewFirstString(message[@"publisher"]);
     NSString *container = ApolloLinkPreviewFirstString(message[@"container-title"]);
@@ -1455,6 +1585,45 @@ static NSString *ApolloLinkPreviewBrowserUserAgent(void) {
     [self fetchHTMLPreviewForURL:url allowRange:YES browserFallback:NO completion:completion];
 }
 
+// The page itself is unreachable (bot wall, hard 4xx, challenge interstitial).
+// Try the Reddit-harvested preview before settling for the slug-title +
+// favicon fallback card.
++ (void)deliverUnreachablePagePreviewForURL:(NSURL *)url reason:(NSString *)reason completion:(ApolloLinkPreviewCompletion)completion {
+    [self fetchRedditInfoPreviewForURL:url completion:^(ApolloLinkPreview *harvested) {
+        completion(harvested ?: ApolloLinkPreviewFallbackPreviewForURL(url, reason));
+    }];
+}
+
+// Head-truncation for oversized pages: og/twitter/meta tags live in <head>, so
+// a 12MB page (indexca.se serves one) still yields full metadata from its
+// first slice — rejecting it outright threw the metadata away. Cutting at a
+// byte boundary can split a multi-byte UTF-8 sequence, and NSString's UTF-8
+// decode fails on ANY malformed byte, which would silently reroute the whole
+// page through the Latin-1 fallback (mojibake titles) — so back off past any
+// trailing partial sequence first.
+static NSData *ApolloLinkPreviewHeadSliceOfData(NSData *data) {
+    if (data.length <= ApolloLinkPreviewMaxHTMLBytes) return data;
+    NSUInteger length = ApolloLinkPreviewMaxHTMLBytes;
+    const uint8_t *bytes = data.bytes;
+    // Walk back over up to 3 continuation bytes (0b10xxxxxx); if the byte
+    // before them starts a sequence that the cut left incomplete, drop it too.
+    NSUInteger continuations = 0;
+    while (continuations < 3 && length > 0 && (bytes[length - 1] & 0xC0) == 0x80) {
+        continuations++;
+        length--;
+    }
+    if (length > 0) {
+        uint8_t lead = bytes[length - 1];
+        NSUInteger expected = (lead & 0xE0) == 0xC0 ? 1 : (lead & 0xF0) == 0xE0 ? 2 : (lead & 0xF8) == 0xF0 ? 3 : 0;
+        if (expected > 0 && expected != continuations) {
+            length--;
+        } else if (expected > 0 && expected == continuations) {
+            length += continuations; // the sequence was complete after all
+        }
+    }
+    return [data subdataWithRange:NSMakeRange(0, length)];
+}
+
 + (void)fetchHTMLPreviewForURL:(NSURL *)url allowRange:(BOOL)allowRange browserFallback:(BOOL)browserFallback completion:(ApolloLinkPreviewCompletion)completion {
     NSMutableURLRequest *request = ApolloLinkPreviewRequest(url, browserFallback ? 18.0 : 12.0);
     if (allowRange) {
@@ -1463,16 +1632,22 @@ static NSString *ApolloLinkPreviewBrowserUserAgent(void) {
     if (browserFallback) {
         [request setValue:ApolloLinkPreviewBrowserUserAgent() forHTTPHeaderField:@"User-Agent"];
         [request setValue:@"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8" forHTTPHeaderField:@"Accept"];
+        [request setValue:@"en-US,en;q=0.9" forHTTPHeaderField:@"Accept-Language"];
     }
 
     [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
         NSString *contentType = [[httpResponse allHeaderFields][@"Content-Type"] lowercaseString];
-        if (error || !data || httpResponse.statusCode < 200 || httpResponse.statusCode >= 300 || data.length > ApolloLinkPreviewMaxHTMLBytes || (contentType.length > 0 && ![contentType containsString:@"text/html"])) {
+        if (error || !data || httpResponse.statusCode < 200 || httpResponse.statusCode >= 300 || (contentType.length > 0 && ![contentType containsString:@"text/html"])) {
             ApolloLog(@"[LinkPreviews] HTML fetch failed %@ status=%ld type=%@ bytes=%lu err=%@",
                       url.absoluteString, (long)httpResponse.statusCode, contentType ?: @"",
                       (unsigned long)data.length, error.localizedDescription);
-            if (!browserFallback && (error || httpResponse.statusCode == 0 || data.length == 0)) {
+            // Bot walls answer non-browser clients with a live 4xx (reuters
+            // 401, wsj 401, jn.pt 403), not a dead connection — so any 4xx/5xx
+            // earns the browser-shaped retry too, not just connection-level
+            // failures. One retry total; the browser attempt's own failure
+            // falls through to the Reddit-harvest / favicon path below.
+            if (!browserFallback && (error || httpResponse.statusCode == 0 || httpResponse.statusCode >= 400 || data.length == 0)) {
                 ApolloLog(@"[LinkPreviews] HTML retrying full browser fetch host=%@", ApolloLinkPreviewHost(url));
                 [self fetchHTMLPreviewForURL:url allowRange:NO browserFallback:YES completion:completion];
                 return;
@@ -1481,15 +1656,18 @@ static NSString *ApolloLinkPreviewBrowserUserAgent(void) {
                 [self fetchCrossrefPreviewForURL:url completion:^(ApolloLinkPreview *preview) {
                     completion(preview ?: ApolloLinkPreviewFallbackPreviewForURL(url, nil));
                 }];
+            } else if (httpResponse.statusCode >= 400) {
+                [self deliverUnreachablePagePreviewForURL:url reason:nil completion:completion];
             } else {
                 completion(ApolloLinkPreviewFallbackPreviewForURL(url, contentType.length > 0 ? contentType : nil));
             }
             return;
         }
 
-        NSString *html = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        NSData *headSlice = ApolloLinkPreviewHeadSliceOfData(data);
+        NSString *html = [[NSString alloc] initWithData:headSlice encoding:NSUTF8StringEncoding];
         if (html.length == 0) {
-            html = [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding];
+            html = [[NSString alloc] initWithData:headSlice encoding:NSISOLatin1StringEncoding];
         }
 
         NSDictionary<NSString *, NSString *> *meta = [self metaValuesFromHTML:html];
@@ -1531,15 +1709,21 @@ static NSString *ApolloLinkPreviewBrowserUserAgent(void) {
 
         // If we landed on a Cloudflare / Reddit verification gate, treat the
         // result as empty so Apollo's native card paints instead of "Please
-        // wait for verification" everywhere.
+        // wait for verification" everywhere. A gate served to the app UA may
+        // still open for a browser-shaped client, so spend the one retry on it
+        // before falling back to Crossref / Reddit-harvest / favicon.
         if (ApolloLinkPreviewIsBlockedPage(preview.title, html)) {
             ApolloLog(@"[LinkPreviews] blocked-page sniff matched %@ title=%@", url.absoluteString, preview.title);
+            if (!browserFallback) {
+                [self fetchHTMLPreviewForURL:url allowRange:NO browserFallback:YES completion:completion];
+                return;
+            }
             if (ApolloLinkPreviewDOIFromURL(url).length > 0) {
                 [self fetchCrossrefPreviewForURL:url completion:^(ApolloLinkPreview *crossrefPreview) {
                     completion(crossrefPreview ?: ApolloLinkPreviewFallbackPreviewForURL(url, nil));
                 }];
             } else {
-                completion(ApolloLinkPreviewFallbackPreviewForURL(url, nil));
+                [self deliverUnreachablePagePreviewForURL:url reason:nil completion:completion];
             }
             return;
         }


### PR DESCRIPTION
## Summary

Scrolling a feed, some link preview cards would show their title/description but the image area stayed a blank color block — and stayed that way until you opened the post and came back (compact cards had the same thing with the site favicon). Separately, some sites that always have article images (reuters.com being the obvious one) were permanently stuck as compact favicon cards. Diagnosed from my own device log.

## Root causes

**Blank images:** each card image has two loaders — Texture's own `ASNetworkImageNode` loader and the tweak's fallback fetch. The fallback was armed exactly once per node+URL: every row of an insert batch scheduled its fetch at the same +900ms tick (dozens of concurrent requests), and if that single attempt failed (timeout in the burst, 403 on the app UA, one bar of signal) the scheduled marker was never cleared, so nothing ever retried for the life of the node. Opening the post "fixed" it because the comments header card runs its own fetch into the shared bitmap cache, which the feed card picks up on re-layout. Relaunching "fixed" it because fresh nodes get fresh attempts.

**Reuters stuck compact:** reuters/wsj-style bot walls answer non-browser clients with a live 401 + body, but the fetcher's browser-UA retry only triggered on connection-level failures (`error || status==0 || bytes==0`) — so the 401 skipped it, a slug-title + google-favicon fallback preview got cached for its full 7-day TTL, and each one taught the shape memory the host was "imageless". The layout path reads the cache directly, so poisoned entries never got a second chance.

Also from the log: a 12MB page (indexca.se) was rejected outright instead of parsing its head, and site-relative links that never resolved (`https:///message/compose/...`, empty host) produced garbage slug-title cards.

## Fixes

Image loading is now event-driven with bounded retry instead of fire-once:

- fallback fetches are range-gated — only cards in Texture's preload/display/visible range fetch, so an insert batch no longer front-loads dozens of requests (the burst timeouts were the main trigger)
- a failed fetch releases the one-shot marker and stamps a short per-URL cooldown (8s transient / existing 5min dead-mark for 4xx), and `didEnterPreloadState` / `didEnterVisibleState` re-kick any still-missing image — so a blank card you're looking at heals itself on approach, no polling anywhere

Metadata fetching got a proper failure ladder:

- browser-UA retry now also fires on live 4xx/5xx and on sniffed challenge pages, not just dead connections
- if both UAs fail, the fetcher asks Reddit what it knows about the URL (`api/info.json`) and uses the preview image Reddit's own scraper captured server-side at submit time — no client-side bot wall can block that. The lookup also tries the www-toggled sibling URL, because on iOS 26 the LinkButtonNode URL is display-derived (`www.` stripped) while api/info matches the submitted URL exactly
- oversized pages parse their first 2MB (UTF-8-safe truncation) instead of failing — the og/twitter tags live in `<head>` anyway
- empty-host URLs are negative-cached so the native link UI shows instead of a fake card
- weak cached previews (bot-wall titles, slug-title + favicon with no description) get one background refetch per URL per launch and re-render in place when the refetch lands something better — so already-poisoned caches heal instead of waiting out the TTL

Shape memory needed no changes — once real reuters previews flow, its sliding window flips the host verdict to imaged on its own.

## Screenshots

reuters posts now render as full hero cards with the real article image — the left one was a poisoned favicon compact card that healed in place, the right one is a brand-new post going straight to a hero card on its very first fetch:

| Healed cached post | Fresh post, first fetch |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/20d4942b-1dd0-4615-851c-dfb60b191055" width="360" alt="reuters hero card with real article image"> | <img src="https://github.com/user-attachments/assets/a35224f1-8a01-4436-a5c1-eeeac82c754b" width="360" alt="fresh reuters post rendering straight to a hero card"> |

## Testing

Sim-verified (glass, API-key mode): watched the full ladder in the logs — reuters 401 → browser retry → real og:image stored, six poisoned cache entries healed to hero cards in place, telegraph (unreachable from that network) rendered compact with its favicon instead of blank, no row-reload churn or layout regressions across heavy scrolling, comments-view cards intact. Device-tested on iOS 26.

