### PR TITLE
Fix just-posted comments rendering blank (no username/flair, score 0, 56.6y timestamp)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,13 @@ ApolloReborn_CFLAGS += -Wno-deprecated-declarations
 # screenshots. Only ever compiled into the simulator build, never the device/
 # release build (this branch is under the APOLLO_SIM_BUILD ifeq).
 ApolloReborn_FILES += $(SRC_DIR)/ApolloSimOpenRoute.m
+# Opt-in /api/comment write diagnostics + legacy-response-shape simulator
+# (APOLLO_COMMENT_DEBUG=1 scripts/run-in-sim.sh). Used to reproduce Reddit's
+# 2026-08 legacy write-response regression against the OAuth path on demand —
+# see src/ApolloCommentDebug.xm.
+ifeq ($(APOLLO_COMMENT_DEBUG),1)
+ApolloReborn_FILES += $(SRC_DIR)/ApolloCommentDebug.xm
+endif
 else
 ApolloReborn_OBJ_FILES = $(shell find $(FFMPEG_KIT_DIR) -name '*.a')
 

--- a/src/ApolloCommentDebug.xm
+++ b/src/ApolloCommentDebug.xm
@@ -1,0 +1,191 @@
+// Opt-in sim-only diagnostics for the "just-posted comment renders blank"
+// bug class (missing author/avatar/flair, score 0, epoch timestamp until
+// reload — Reddit intermittently serves the legacy old-reddit write-response
+// shape, 2026-08 even to OAuth clients). Build with:
+//   APOLLO_COMMENT_DEBUG=1 scripts/run-in-sim.sh
+// Logs, for /api/comment writes:
+//   1. the outgoing request path + parameters (postPath:parameters:completion:)
+//   2. the raw response body handed to the serializer
+//   3. the parsed objects delivered to the submitComment completion, with the
+//      fields the comment cell renders (author/created/score/fullname)
+// Plus a legacy-response-shape simulator to exercise the repair while Reddit
+// happens to be returning the modern shape: launch the app with
+//   -ApolloSimulateLegacyCommentResponse YES
+// (argument domain) and every modern /api/comment write response is converted
+// back into the legacy {parent, content, contentText, …} shape before parsing.
+// Compiled ONLY under APOLLO_SIM_BUILD + APOLLO_COMMENT_DEBUG (see Makefile) —
+// never ships to devices.
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import "ApolloCommon.h"
+
+typedef void (^ApolloCommentDebugCompletion)(id objects, NSError *error);
+
+// os_log clips a single message around 1KB; chunk long payloads.
+static void ApolloCommentDebugLogChunked(NSString *tag, NSString *payload) {
+    if (payload.length == 0) {
+        ApolloLog(@"[CommentDebug] %@ (empty)", tag);
+        return;
+    }
+    NSUInteger chunk = 700;
+    NSUInteger count = (payload.length + chunk - 1) / chunk;
+    for (NSUInteger i = 0; i < count; i++) {
+        NSRange range = NSMakeRange(i * chunk, MIN(chunk, payload.length - i * chunk));
+        ApolloLog(@"[CommentDebug] %@ [%lu/%lu] %@", tag, (unsigned long)(i + 1), (unsigned long)count,
+                  [payload substringWithRange:range]);
+    }
+}
+
+// KVC (valueForKey:) rather than objc_msgSend-as-id: several RDK getters
+// (score, scoreHidden) return primitives, and retaining a raw BOOL crashes.
+// KVC boxes primitives into NSNumber for free.
+static NSString *ApolloCommentDebugString(id model, NSString *key) {
+    if (![model respondsToSelector:NSSelectorFromString(key)]) return @"(no-sel)";
+    id value = nil;
+    @try { value = [model valueForKey:key]; }
+    @catch (__unused NSException *e) { return @"(threw)"; }
+    if (!value) return @"(nil)";
+    return [NSString stringWithFormat:@"%@", value];
+}
+
+static NSString *ApolloCommentDebugDescribeModel(id model) {
+    if (!model) return @"(nil model)";
+    NSMutableString *s = [NSMutableString stringWithFormat:@"<%@ %p", NSStringFromClass([model class]), model];
+    [s appendFormat:@" fullname=%@", ApolloCommentDebugString(model, @"fullName")];
+    [s appendFormat:@" author=%@", ApolloCommentDebugString(model, @"author")];
+    [s appendFormat:@" createdUTC=%@", ApolloCommentDebugString(model, @"createdUTC")];
+    [s appendFormat:@" score=%@", ApolloCommentDebugString(model, @"score")];
+    [s appendFormat:@" scoreHidden=%@", ApolloCommentDebugString(model, @"scoreHidden")];
+    [s appendFormat:@" subreddit=%@", ApolloCommentDebugString(model, @"subreddit")];
+    NSString *body = ApolloCommentDebugString(model, @"body");
+    [s appendFormat:@" bodyLen=%lu", (unsigned long)body.length];
+    [s appendString:@">"];
+    return s;
+}
+
+static ApolloCommentDebugCompletion ApolloCommentDebugWrapCompletion(NSString *label, ApolloCommentDebugCompletion completion) {
+    if (!completion) {
+        ApolloLog(@"[CommentDebug] %@ called with nil completion", label);
+        return completion;
+    }
+    return ^(id objects, NSError *error) {
+        ApolloLog(@"[CommentDebug] %@ completion: objectsClass=%@ count=%@ error=%@",
+                  label, NSStringFromClass([objects class]),
+                  [objects respondsToSelector:@selector(count)] ? @([objects count]) : @"n/a",
+                  error);
+        if ([objects isKindOfClass:[NSArray class]]) {
+            for (id model in (NSArray *)objects) {
+                ApolloLog(@"[CommentDebug] %@ parsed model: %@", label, ApolloCommentDebugDescribeModel(model));
+            }
+        } else if (objects) {
+            ApolloLog(@"[CommentDebug] %@ parsed model (non-array): %@", label, ApolloCommentDebugDescribeModel(objects));
+        }
+        completion(objects, error);
+    };
+}
+
+%hook RDKClient
+
+- (id)postPath:(NSString *)path parameters:(id)parameters completion:(id)completion {
+    if ([path isKindOfClass:[NSString class]] &&
+        [path rangeOfString:@"api/comment"].location != NSNotFound) {
+        ApolloCommentDebugLogChunked(@"postPath", [NSString stringWithFormat:@"%@ params=%@", path, parameters]);
+    }
+    return %orig;
+}
+
+- (id)submitComment:(id)body onLink:(id)link completion:(ApolloCommentDebugCompletion)completion {
+    ApolloCommentDebugCompletion wrapped = ApolloCommentDebugWrapCompletion(@"submitComment:onLink:", completion);
+    return %orig(body, link, wrapped);
+}
+
+- (id)submitComment:(id)body asReplyToComment:(id)parent completion:(ApolloCommentDebugCompletion)completion {
+    ApolloCommentDebugCompletion wrapped = ApolloCommentDebugWrapCompletion(@"submitComment:asReplyToComment:", completion);
+    return %orig(body, parent, wrapped);
+}
+
+- (id)submitComment:(id)body onThingWithFullName:(id)fullName completion:(ApolloCommentDebugCompletion)completion {
+    ApolloCommentDebugCompletion wrapped = ApolloCommentDebugWrapCompletion(@"submitComment:onThingWithFullName:", completion);
+    return %orig(body, fullName, wrapped);
+}
+
+%end
+
+// Rebuilds a modern /api/comment response as the legacy old-reddit shape that
+// Reddit intermittently serves (2026-08, OAuth included) — {parent, content,
+// contentText, contentHTML, id, link, replies} with the data-* attributes the
+// repair's extractors read. Lets the fix be exercised on the OAuth path while
+// Reddit happens to be returning the modern shape. Enabled per-launch with
+// `-ApolloSimulateLegacyCommentResponse YES` (argument domain).
+static NSData *ApolloCommentDebugLegacyData(NSData *data) {
+    if (data.length == 0) return nil;
+    NSDictionary *root = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+    if (![root isKindOfClass:[NSDictionary class]]) return nil;
+    NSDictionary *json = [root[@"json"] isKindOfClass:[NSDictionary class]] ? root[@"json"] : nil;
+    NSArray *things = [json[@"data"] isKindOfClass:[NSDictionary class]] ? json[@"data"][@"things"] : nil;
+    if (![things isKindOfClass:[NSArray class]] || things.count == 0) return nil;
+
+    NSMutableArray *legacyThings = [NSMutableArray array];
+    for (NSDictionary *thing in things) {
+        NSDictionary *td = [thing isKindOfClass:[NSDictionary class]] ? thing[@"data"] : nil;
+        NSString *body = [td[@"body"] isKindOfClass:[NSString class]] ? td[@"body"] : nil;
+        if (!body) return nil; // already legacy or unexpected — don't simulate
+        NSString *fullname = [NSString stringWithFormat:@"t1_%@", td[@"id"]];
+        NSString *permalink = [td[@"permalink"] isKindOfClass:[NSString class]] ? td[@"permalink"]
+            : [NSString stringWithFormat:@"/r/%@/comments/%@/x/%@/", td[@"subreddit"],
+               [[td[@"link_id"] description] stringByReplacingOccurrencesOfString:@"t3_" withString:@""], td[@"id"]];
+        NSString *content = [NSString stringWithFormat:
+            @"<div class=\" thing id-%@ comment \" data-fullname=\"%@\" data-type=\"comment\" "
+            @"data-subreddit=\"%@\" data-author=\"%@\" data-permalink=\"%@\">"
+            @"<div class=\"md\"><p>%@</p></div></div>",
+            fullname, fullname, td[@"subreddit"], td[@"author"], permalink, body];
+        [legacyThings addObject:@{
+            @"kind": @"t1",
+            @"data": @{
+                @"parent": td[@"parent_id"] ?: @"",
+                @"content": content,
+                @"contentText": body,
+                @"contentHTML": td[@"body_html"] ?: @"",
+                @"link": td[@"link_id"] ?: @"",
+                @"replies": @"",
+                @"id": fullname,
+            },
+        }];
+    }
+    NSDictionary *legacyRoot = @{ @"json": @{ @"errors": @[], @"data": @{ @"things": legacyThings } } };
+    return [NSJSONSerialization dataWithJSONObject:legacyRoot options:0 error:NULL];
+}
+
+%hook RDKResponseSerializer
+
+- (id)responseObjectForResponse:(NSURLResponse *)response data:(NSData *)data error:(NSError **)error {
+    NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
+    NSString *path = http.URL.path ?: @"";
+    BOOL isCommentWrite = [path rangeOfString:@"/api/comment"].location != NSNotFound;
+    if (isCommentWrite && http.statusCode == 200 &&
+        [[NSUserDefaults standardUserDefaults] boolForKey:@"ApolloSimulateLegacyCommentResponse"]) {
+        NSData *legacy = ApolloCommentDebugLegacyData(data);
+        if (legacy) {
+            ApolloLog(@"[CommentDebug] SIMULATING legacy /api/comment response shape (%lu -> %lu bytes)",
+                      (unsigned long)data.length, (unsigned long)legacy.length);
+            data = legacy;
+        }
+    }
+    id obj = %orig(response, data, error);
+    if (isCommentWrite) {
+        NSString *raw = data.length > 0 ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] : nil;
+        ApolloCommentDebugLogChunked(
+            [NSString stringWithFormat:@"/api/comment response status=%ld bytes=%lu", (long)http.statusCode, (unsigned long)data.length],
+            raw ?: @"(binary/undecodable)");
+    }
+    return obj;
+}
+
+%end
+
+%ctor {
+    %init;
+    ApolloLog(@"[CommentDebug] diagnostics module loaded");
+}

--- a/src/ApolloCommentDebug.xm
+++ b/src/ApolloCommentDebug.xm
@@ -170,10 +170,19 @@ static NSData *ApolloCommentDebugPartialData(NSData *data) {
     NSArray *things = [json[@"data"] isKindOfClass:[NSDictionary class]] ? json[@"data"][@"things"] : nil;
     if (![things isKindOfClass:[NSArray class]] || things.count == 0) return nil;
 
+    // Matches the wild degraded payload observed on-device 2026-08 (36 keys of
+    // the healthy ~86): identity, timestamps, votes, flair AND the thing's
+    // location (subreddit/link/permalink) are all stripped. The location keys
+    // are the ones whose absence blanks the own-flair pill and the moderator
+    // shield even after author/created/score are filled.
     NSArray *stripKeys = @[ @"author", @"author_fullname", @"created", @"created_utc",
                             @"score", @"ups", @"downs", @"likes",
                             @"author_flair_richtext", @"author_flair_text", @"author_flair_type",
-                            @"author_flair_template_id", @"author_flair_css_class" ];
+                            @"author_flair_template_id", @"author_flair_css_class",
+                            @"subreddit", @"subreddit_id", @"subreddit_name_prefixed", @"subreddit_type",
+                            @"link_id", @"parent_id", @"permalink",
+                            @"distinguished", @"is_submitter", @"author_premium", @"author_patreon_flair",
+                            @"total_awards_received", @"gilded", @"all_awardings" ];
     NSMutableArray *strippedThings = [NSMutableArray array];
     for (NSDictionary *thing in things) {
         NSDictionary *td = [thing isKindOfClass:[NSDictionary class]] ? thing[@"data"] : nil;

--- a/src/ApolloCommentDebug.xm
+++ b/src/ApolloCommentDebug.xm
@@ -8,11 +8,12 @@
 //   2. the raw response body handed to the serializer
 //   3. the parsed objects delivered to the submitComment completion, with the
 //      fields the comment cell renders (author/created/score/fullname)
-// Plus a legacy-response-shape simulator to exercise the repair while Reddit
-// happens to be returning the modern shape: launch the app with
-//   -ApolloSimulateLegacyCommentResponse YES
-// (argument domain) and every modern /api/comment write response is converted
-// back into the legacy {parent, content, contentText, …} shape before parsing.
+// Plus simulators for both degraded response shapes, to exercise the repair
+// while Reddit happens to be returning healthy responses (argument domain):
+//   -ApolloSimulateLegacyCommentResponse YES   — full legacy old-reddit shape
+//     ({parent, content:"<html>", contentText, …})
+//   -ApolloSimulatePartialCommentResponse YES  — modern shape with the
+//     render-critical fields (author/created/score/vote/flair) stripped
 // Compiled ONLY under APOLLO_SIM_BUILD + APOLLO_COMMENT_DEBUG (see Makefile) —
 // never ships to devices.
 
@@ -158,6 +159,35 @@ static NSData *ApolloCommentDebugLegacyData(NSData *data) {
     return [NSJSONSerialization dataWithJSONObject:legacyRoot options:0 error:NULL];
 }
 
+// Strips the render-critical fields (author/created/score/vote state/flair)
+// from each modern thing while keeping the modern shape — the milder degraded
+// variant. Enabled per-launch with `-ApolloSimulatePartialCommentResponse YES`.
+static NSData *ApolloCommentDebugPartialData(NSData *data) {
+    if (data.length == 0) return nil;
+    NSDictionary *root = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+    if (![root isKindOfClass:[NSDictionary class]]) return nil;
+    NSDictionary *json = [root[@"json"] isKindOfClass:[NSDictionary class]] ? root[@"json"] : nil;
+    NSArray *things = [json[@"data"] isKindOfClass:[NSDictionary class]] ? json[@"data"][@"things"] : nil;
+    if (![things isKindOfClass:[NSArray class]] || things.count == 0) return nil;
+
+    NSArray *stripKeys = @[ @"author", @"author_fullname", @"created", @"created_utc",
+                            @"score", @"ups", @"downs", @"likes",
+                            @"author_flair_richtext", @"author_flair_text", @"author_flair_type",
+                            @"author_flair_template_id", @"author_flair_css_class" ];
+    NSMutableArray *strippedThings = [NSMutableArray array];
+    for (NSDictionary *thing in things) {
+        NSDictionary *td = [thing isKindOfClass:[NSDictionary class]] ? thing[@"data"] : nil;
+        if (![td isKindOfClass:[NSDictionary class]] || td[@"body"] == nil) return nil; // not modern — don't simulate
+        NSMutableDictionary *stripped = [td mutableCopy];
+        [stripped removeObjectsForKeys:stripKeys];
+        NSMutableDictionary *newThing = [thing mutableCopy];
+        newThing[@"data"] = stripped;
+        [strippedThings addObject:newThing];
+    }
+    NSDictionary *newRoot = @{ @"json": @{ @"errors": @[], @"data": @{ @"things": strippedThings } } };
+    return [NSJSONSerialization dataWithJSONObject:newRoot options:0 error:NULL];
+}
+
 %hook RDKResponseSerializer
 
 - (id)responseObjectForResponse:(NSURLResponse *)response data:(NSData *)data error:(NSError **)error {
@@ -171,6 +201,15 @@ static NSData *ApolloCommentDebugLegacyData(NSData *data) {
             ApolloLog(@"[CommentDebug] SIMULATING legacy /api/comment response shape (%lu -> %lu bytes)",
                       (unsigned long)data.length, (unsigned long)legacy.length);
             data = legacy;
+        }
+    }
+    if (isCommentWrite && http.statusCode == 200 &&
+        [[NSUserDefaults standardUserDefaults] boolForKey:@"ApolloSimulatePartialCommentResponse"]) {
+        NSData *partial = ApolloCommentDebugPartialData(data);
+        if (partial) {
+            ApolloLog(@"[CommentDebug] SIMULATING partial modern /api/comment response (%lu -> %lu bytes)",
+                      (unsigned long)data.length, (unsigned long)partial.length);
+            data = partial;
         }
     }
     id obj = %orig(response, data, error);

--- a/src/ApolloWebJSON.h
+++ b/src/ApolloWebJSON.h
@@ -46,13 +46,14 @@ void ApolloWebJSONNoteResponse(NSURLRequest *request, NSURLResponse *response);
 // preview URL and aspect ratio instead of fabricating dimensions.
 NSData *ApolloWebJSONFixupListingMediaResponseData(NSURLResponse *response, NSData *data);
 
-// Fixes up the parsed response object for cookie-routed comment writes
-// (/api/editusertext, /api/comment). www.reddit.com returns each thing's data in
-// the legacy old-reddit {parent, content:"<html>"} shape, which Apollo can't
-// render (the just-edited/posted comment shows empty with 0 upvotes); this swaps
-// in the modern comment JSON re-fetched via info.json. Returns the input
-// unchanged outside Web JSON mode or when the shape is already modern. Called
-// from the RDKResponseSerializer hook with the serializer's output.
+// Fixes up the parsed response object for comment writes (/api/editusertext,
+// /api/comment) in EVERY auth mode. www.reddit.com always returns each thing's
+// data in the legacy old-reddit {parent, content:"<html>"} shape, and since
+// 2026-08 oauth.reddit.com has intermittently done the same to API-key (OAuth)
+// clients; Apollo renders such a comment with no author/score/timestamp. This
+// swaps in the modern comment JSON (info.json refetch, else local synthesis).
+// Returns the input unchanged when the shape is already modern. Called from the
+// RDKResponseSerializer hook with the serializer's output.
 id ApolloWebJSONFixupWriteResponseObject(NSURLResponse *response, id responseObject);
 
 // Fixes up the parsed response object for the cookie-routed moderators-list

--- a/src/ApolloWebJSON.h
+++ b/src/ApolloWebJSON.h
@@ -122,7 +122,16 @@ NSString *ApolloWebJSONKeylessOAuthBearer(NSString *username);
 // lives under, and parentFullName is the t1 being replied to (nil for
 // top-level comments and edits). Any argument may be nil — the repair fills
 // only what it has.
-void ApolloWebJSONNoteCommentWriteContext(id client, NSString *subreddit, NSString *subredditFullName,
+//
+// `body` is the submitted markdown and is what keys this capture to its own
+// response: writes can overlap (a second comment submitted while the first is
+// still in flight), and Reddit echoes the markdown back as the response thing's
+// body/contentText, so the repair can tell which outstanding write a degraded
+// response belongs to instead of taking whichever was captured last. Pass it
+// whenever the call site has it; a capture with no body still participates, it
+// just can't be matched exactly.
+void ApolloWebJSONNoteCommentWriteContext(id client, NSString *body, NSString *subreddit,
+                                          NSString *subredditFullName,
                                           NSString *linkFullName, NSString *parentFullName);
 
 // Fetch-outcome feedback for ApolloWebJSONKeylessOAuthBearer callers: report a

--- a/src/ApolloWebJSON.h
+++ b/src/ApolloWebJSON.h
@@ -111,6 +111,13 @@ BOOL ApolloWebJSONRequestIsInternal(NSURL *url);
 // request with ApolloWebJSONProbeURL so the transport hooks leave it alone.
 NSString *ApolloWebJSONKeylessOAuthBearer(NSString *username);
 
+// Captures the posting identity for the write-response repair. Called from the
+// identity module's RDKClient submit/edit hooks with the client that issued the
+// write; the repair reads it (TTL-bounded) when a degraded response is missing
+// its author — each account owns its own RDKClient, so the submitting client's
+// currentUser is the true posting identity even for temporaryPostingAccount.
+void ApolloWebJSONNoteCommentWriteClient(id client);
+
 // Fetch-outcome feedback for ApolloWebJSONKeylessOAuthBearer callers: report a
 // 401/403 so a minted bearer proven dead (an anonymous token from a signed-out
 // session) is dropped and its account backs off instead of re-minting a doomed

--- a/src/ApolloWebJSON.h
+++ b/src/ApolloWebJSON.h
@@ -111,12 +111,19 @@ BOOL ApolloWebJSONRequestIsInternal(NSURL *url);
 // request with ApolloWebJSONProbeURL so the transport hooks leave it alone.
 NSString *ApolloWebJSONKeylessOAuthBearer(NSString *username);
 
-// Captures the posting identity for the write-response repair. Called from the
+// Captures the write context for the write-response repair. Called from the
 // identity module's RDKClient submit/edit hooks with the client that issued the
-// write; the repair reads it (TTL-bounded) when a degraded response is missing
-// its author — each account owns its own RDKClient, so the submitting client's
-// currentUser is the true posting identity even for temporaryPostingAccount.
-void ApolloWebJSONNoteCommentWriteClient(id client);
+// write plus everything the call site knows about WHERE the write landed; the
+// repair reads it (TTL-bounded) when a degraded response is missing those
+// fields. The client resolves the posting identity (each account owns its own
+// RDKClient, so the submitting client's currentUser is the true posting
+// identity even for temporaryPostingAccount); subreddit/subredditFullName come
+// from the target link/parent comment, linkFullName is the t3 the comment
+// lives under, and parentFullName is the t1 being replied to (nil for
+// top-level comments and edits). Any argument may be nil — the repair fills
+// only what it has.
+void ApolloWebJSONNoteCommentWriteContext(id client, NSString *subreddit, NSString *subredditFullName,
+                                          NSString *linkFullName, NSString *parentFullName);
 
 // Fetch-outcome feedback for ApolloWebJSONKeylessOAuthBearer callers: report a
 // 401/403 so a minted bearer proven dead (an anonymous token from a signed-out

--- a/src/ApolloWebJSON.m
+++ b/src/ApolloWebJSON.m
@@ -3,6 +3,7 @@
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
 #import "Defaults.h"
+#import "ApolloAccountCredentials.h" // ApolloActiveAccountUsername() — write-fixup author for API-key actives
 #import "ApolloWebSessionStore.h"
 #import "ApolloWebSessionLoginViewController.h" // silent re-harvest before the expiry prompt
 
@@ -1159,16 +1160,22 @@ static NSString *ApolloWebJSONFullnameFromLegacyContent(NSString *html) {
 }
 
 // Synchronously fetch the modern JSON `data` dict for a single thing via
-// info.json (cookie-authed, tagged so it bypasses our own rewrite + the expiry
-// counter). Called off the main thread from the response serializer.
+// info.json (tagged so it bypasses our own rewrite + the expiry counter).
+// Called off the main thread from the response serializer. Auth follows the
+// active account's mode: web-session actives use their cookie against www;
+// API-key (OAuth) actives use the captured bearer against oauth.reddit.com.
 static NSDictionary *ApolloWebJSONFetchModernThingData(NSString *fullname) {
+    if (fullname.length == 0) return nil;
     NSString *cookie = ApolloActiveWebSession().cookieHeader;
-    if (cookie.length == 0 || fullname.length == 0) return nil;
+    NSString *bearer = cookie.length == 0 ? [sLatestRedditBearerToken copy] : nil;
+    if (cookie.length == 0 && bearer.length == 0) return nil;
 
-    NSString *urlStr = [NSString stringWithFormat:@"https://www.reddit.com/api/info.json?id=%@&raw_json=1", fullname];
+    NSString *host = cookie.length > 0 ? @"https://www.reddit.com" : @"https://oauth.reddit.com";
+    NSString *urlStr = [NSString stringWithFormat:@"%@/api/info.json?id=%@&raw_json=1", host, fullname];
     NSURL *probeURL = ApolloWebJSONURLWithFragment([NSURL URLWithString:urlStr], kApolloWebJSONProbeMarker);
     NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:probeURL];
-    [req setValue:cookie forHTTPHeaderField:@"Cookie"];
+    if (cookie.length > 0) [req setValue:cookie forHTTPHeaderField:@"Cookie"];
+    else [req setValue:[@"Bearer " stringByAppendingString:bearer] forHTTPHeaderField:@"Authorization"];
     [req setValue:([sUserAgent length] > 0 ? sUserAgent : defaultUserAgent) forHTTPHeaderField:@"User-Agent"];
     req.HTTPShouldHandleCookies = NO;
     req.timeoutInterval = 15.0;
@@ -1214,6 +1221,22 @@ static BOOL ApolloWebJSONPermalinkPartsFromLegacyContent(NSString *html, NSStrin
     return YES;
 }
 
+// Extracts the comment author from an old-reddit content blob's data-author
+// attribute. Authoritative when present — it is Reddit's own record of who the
+// write ran as, with the account's canonical capitalization.
+static NSString *ApolloWebJSONAuthorFromLegacyContent(NSString *html) {
+    if (html.length == 0) return nil;
+    static NSRegularExpression *re;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        re = [NSRegularExpression regularExpressionWithPattern:@"data-author=\"([^\"]+)\"" options:0 error:NULL];
+    });
+    NSTextCheckingResult *m = [re firstMatchInString:html options:0 range:NSMakeRange(0, html.length)];
+    if (!m || m.numberOfRanges < 2) return nil;
+    NSString *author = [html substringWithRange:[m rangeAtIndex:1]];
+    return author.length > 0 ? author : nil;
+}
+
 // Minimal HTML-escape for synthesizing a body_html when the legacy response
 // carries no contentHTML. Reddit's own body_html wraps in <div class="md">.
 static NSString *ApolloWebJSONEscapedBodyHTML(NSString *body) {
@@ -1241,10 +1264,14 @@ static NSDictionary *ApolloWebJSONSynthesizeModernThingData(NSString *fullname, 
     NSString *bodyHTML = [legacy[@"contentHTML"] isKindOfClass:[NSString class]] ? legacy[@"contentHTML"] : nil;
     if (body.length == 0 && bodyHTML.length == 0) return nil; // nothing renderable to show
 
-    // ApolloActiveWebSessionUsername() preserves the stored capitalization,
-    // which matters because Apollo gates the Edit affordance on
-    // comment.author == currentUser.username.
-    NSString *author = ApolloActiveWebSessionUsername();
+    // Author, in trust order: Reddit's own data-author attribute in the legacy
+    // content blob, then the active web-session account, then the active
+    // API-key (OAuth) account — a comment write always runs as the foreground
+    // account. Capitalization matters because Apollo gates the Edit affordance
+    // on comment.author == currentUser.username.
+    NSString *author = ApolloWebJSONAuthorFromLegacyContent(content);
+    if (author.length == 0) author = ApolloActiveWebSessionUsername();
+    if (author.length == 0) author = ApolloActiveAccountUsername();
     if (author.length == 0) return nil;
 
     NSMutableDictionary *modern = [NSMutableDictionary dictionary];
@@ -1285,20 +1312,22 @@ static NSDictionary *ApolloWebJSONSynthesizeModernThingData(NSString *fullname, 
     return modern;
 }
 
-// www.reddit.com's old-reddit /api/editusertext and /api/comment responses return
-// each thing's `data` in the legacy shape {parent, content:"<html>"} instead of
-// the modern comment JSON ({body, body_html, score, author, …}) that
-// oauth.reddit.com returns. Apollo parses things[0].data into an RDKComment, finds
-// no body/score, and re-renders the just-edited comment empty — or, for a fresh
-// /api/comment post, inserts nothing at all (the new comment only appears after a
-// manual refresh). We detect the legacy shape and swap in the modern object:
-// primary source is an info.json refetch (authoritative fields); when that isn't
-// possible (serializer on the main thread — no sync network allowed) or comes up
-// empty (info.json can lag a seconds-old comment), we synthesize the modern dict
-// locally from the legacy fields, which always carry the submitted text. No-op
-// outside Web JSON mode, on API errors, or on the modern shape.
+// Old-reddit /api/editusertext and /api/comment responses return each thing's
+// `data` in the legacy shape {parent, content:"<html>"} instead of the modern
+// comment JSON ({body, body_html, score, author, …}). Apollo's RedditKit maps
+// only the body-ish fields from that shape (data.contentText/contentHTML), so
+// the just-posted comment renders with no author/avatar/flair, score 0, and an
+// epoch-1970 timestamp until the thread is reloaded. www.reddit.com always
+// answers this way (Web JSON mode), and since 2026-08 oauth.reddit.com has
+// intermittently served the SAME legacy shape to API-key (OAuth) clients — it
+// also hit Narwhal — so this repair runs in EVERY auth mode; it is a strict
+// no-op for the modern shape and on API errors. We detect the legacy shape and
+// swap in the modern object: primary source is an info.json refetch
+// (authoritative fields); when that isn't possible (serializer on the main
+// thread — no sync network allowed) or comes up empty (info.json can lag a
+// seconds-old comment), we synthesize the modern dict locally from the legacy
+// fields, which always carry the submitted text.
 id ApolloWebJSONFixupWriteResponseObject(NSURLResponse *response, id responseObject) {
-    if (!ApolloWebJSONHasUsableSession()) return responseObject;
     if (![response isKindOfClass:[NSHTTPURLResponse class]]) return responseObject;
 
     NSString *path = [((NSHTTPURLResponse *)response).URL.path lowercaseString] ?: @"";

--- a/src/ApolloWebJSON.m
+++ b/src/ApolloWebJSON.m
@@ -1224,6 +1224,14 @@ static BOOL ApolloWebJSONPermalinkPartsFromLegacyContent(NSString *html, NSStrin
 }
 
 // Defined with the write-repair helpers below; used by the legacy synthesis too.
+typedef struct {
+    NSString *username;
+    NSString *subreddit;
+    NSString *subredditFullName;
+    NSString *linkFullName;
+    NSString *parentFullName;
+} ApolloWebJSONWriteContext;
+static ApolloWebJSONWriteContext ApolloWebJSONRecentCommentWriteContext(void);
 static NSString *ApolloWebJSONRecentCommentWriteUsername(void);
 
 // Extracts the comment author from an old-reddit content blob's data-author
@@ -1296,6 +1304,23 @@ static NSDictionary *ApolloWebJSONSynthesizeModernThingData(NSString *fullname, 
     if (subreddit.length > 0) modern[@"subreddit"] = subreddit;
     if (!modern[@"link_id"] && linkId36.length > 0) modern[@"link_id"] = [@"t3_" stringByAppendingString:linkId36];
 
+    // Legacy blobs without a data-permalink (or with the link/parent fields
+    // stripped) still need the thing's location — an empty subreddit disables
+    // the own-flair backfill and the moderator shield on the inserted cell.
+    // The write context captured at submit time knows it.
+    ApolloWebJSONWriteContext ctx = ApolloWebJSONRecentCommentWriteContext();
+    if (!modern[@"subreddit"] && ctx.subreddit) modern[@"subreddit"] = ctx.subreddit;
+    if (ctx.subredditFullName) modern[@"subreddit_id"] = ctx.subredditFullName;
+    if (!modern[@"link_id"] && ctx.linkFullName) modern[@"link_id"] = ctx.linkFullName;
+    if (!modern[@"parent_id"] && !isEdit && (ctx.parentFullName ?: ctx.linkFullName)) {
+        modern[@"parent_id"] = ctx.parentFullName ?: ctx.linkFullName;
+    }
+    if (!modern[@"permalink"] && modern[@"subreddit"] && [modern[@"link_id"] isKindOfClass:[NSString class]]
+        && [modern[@"link_id"] hasPrefix:@"t3_"]) {
+        modern[@"permalink"] = [NSString stringWithFormat:@"/r/%@/comments/%@/_/%@/",
+                                modern[@"subreddit"], [modern[@"link_id"] substringFromIndex:3], modern[@"id"]];
+    }
+
     NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
     modern[@"created"] = @(now);
     modern[@"created_utc"] = @(now);
@@ -1325,41 +1350,68 @@ static BOOL ApolloWebJSONIsNonEmptyString(id value) {
     return [value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0;
 }
 
-// The username the most recent comment/edit write ran as, captured at submit
-// time from the RDKClient that issued it (ApolloWebJSONNoteCommentWriteClient,
-// called from the identity module's submit hooks). The ACTIVE account is the
-// wrong answer when the composer's account chooser posted as someone else
-// (temporaryPostingAccount): each account owns its own RDKClient, so the
-// submitting client's currentUser IS the posting identity. TTL-bounded so a
-// stale capture can never label an unrelated later repair.
-static NSString *sApolloWebJSONLastWriteUsername = nil;
+// The context of the most recent comment/edit write, captured at submit time
+// (ApolloWebJSONNoteCommentWriteContext, called from the identity module's
+// submit hooks). The username comes from the RDKClient that issued the write —
+// the ACTIVE account is the wrong answer when the composer's account chooser
+// posted as someone else (temporaryPostingAccount): each account owns its own
+// RDKClient, so the submitting client's currentUser IS the posting identity.
+// The subreddit/link/parent fields come from the submit call's typed target
+// (link or parent comment) — the wild degraded /api/comment payload observed
+// on-device (2026-08, 36 keys) strips those alongside author/created/score,
+// and an empty model.subreddit silently disables both the own-flair backfill
+// and the moderator shield on the freshly inserted cell. TTL-bounded so a
+// stale capture can never label an unrelated later repair; single-slot, so two
+// overlapping degraded writes in different subreddits within the TTL could
+// mislabel the earlier one — the response's own fields always win when
+// present, and the same tradeoff already applies to the username capture.
+// (ApolloWebJSONWriteContext is typedef'd above the legacy synthesis, which
+// consumes the same capture.)
+static ApolloWebJSONWriteContext sApolloWebJSONLastWrite;
 static NSTimeInterval sApolloWebJSONLastWriteAt = 0;
 static os_unfair_lock sApolloWebJSONLastWriteLock = OS_UNFAIR_LOCK_INIT;
 
-void ApolloWebJSONNoteCommentWriteClient(id client) {
+static NSString *ApolloWebJSONCopiedNonEmptyString(id value) {
+    return ([value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0) ? [value copy] : nil;
+}
+
+void ApolloWebJSONNoteCommentWriteContext(id client, NSString *subreddit, NSString *subredditFullName,
+                                          NSString *linkFullName, NSString *parentFullName) {
     NSString *name = nil;
     @try {
         id user = [client respondsToSelector:@selector(currentUser)]
             ? ((id (*)(id, SEL))objc_msgSend)(client, @selector(currentUser)) : nil;
         id value = [user respondsToSelector:@selector(username)]
             ? ((id (*)(id, SEL))objc_msgSend)(user, @selector(username)) : nil;
-        if ([value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0) name = [value copy];
-    } @catch (__unused NSException *e) { return; }
-    if (!name) return;
+        name = ApolloWebJSONCopiedNonEmptyString(value);
+    } @catch (__unused NSException *e) {}
     os_unfair_lock_lock(&sApolloWebJSONLastWriteLock);
-    sApolloWebJSONLastWriteUsername = name;
+    sApolloWebJSONLastWrite.username = name;
+    sApolloWebJSONLastWrite.subreddit = ApolloWebJSONCopiedNonEmptyString(subreddit);
+    sApolloWebJSONLastWrite.subredditFullName = ApolloWebJSONCopiedNonEmptyString(subredditFullName);
+    sApolloWebJSONLastWrite.linkFullName = ApolloWebJSONCopiedNonEmptyString(linkFullName);
+    sApolloWebJSONLastWrite.parentFullName = ApolloWebJSONCopiedNonEmptyString(parentFullName);
     sApolloWebJSONLastWriteAt = [NSDate timeIntervalSinceReferenceDate];
     os_unfair_lock_unlock(&sApolloWebJSONLastWriteLock);
 }
 
-// nil when no write was captured recently — callers fall back to the active
-// account. 60s comfortably covers submit -> response -> serializer.
-static NSString *ApolloWebJSONRecentCommentWriteUsername(void) {
+// Zeroed struct when no write was captured recently — callers fall back to the
+// active account / leave fields unfilled. 60s comfortably covers
+// submit -> response -> serializer.
+static ApolloWebJSONWriteContext ApolloWebJSONRecentCommentWriteContext(void) {
     os_unfair_lock_lock(&sApolloWebJSONLastWriteLock);
-    NSString *name = sApolloWebJSONLastWriteUsername;
-    BOOL fresh = name.length > 0 && ([NSDate timeIntervalSinceReferenceDate] - sApolloWebJSONLastWriteAt) < 60.0;
+    ApolloWebJSONWriteContext ctx = sApolloWebJSONLastWrite;
+    BOOL fresh = ([NSDate timeIntervalSinceReferenceDate] - sApolloWebJSONLastWriteAt) < 60.0 && sApolloWebJSONLastWriteAt > 0;
     os_unfair_lock_unlock(&sApolloWebJSONLastWriteLock);
-    return fresh ? name : nil;
+    if (!fresh) {
+        ApolloWebJSONWriteContext empty = {nil, nil, nil, nil, nil};
+        return empty;
+    }
+    return ctx;
+}
+
+static NSString *ApolloWebJSONRecentCommentWriteUsername(void) {
+    return ApolloWebJSONRecentCommentWriteContext().username;
 }
 
 // A timestamp-ish numeric field that's absent, JSON-null, the wrong type, or
@@ -1371,13 +1423,17 @@ static BOOL ApolloWebJSONTimestampMissing(id value) {
 }
 
 // The milder variant of the same degraded write response: a MODERN-shaped thing
-// (body present) that is missing the render-critical fields — author,
-// created/created_utc, score. RedditKit then parses a comment with no
-// author/avatar/flair, an epoch-1970 timestamp and score 0: the identical blank
-// cell the legacy shape produces. Fill ONLY the missing fields, with the same
-// optimistic values the legacy synthesis uses; anything present is never
-// overwritten. Returns nil when the thing is already complete — the
-// overwhelmingly common case, making this a strict no-op for healthy responses.
+// (body present) that is missing render-critical fields — author,
+// created/created_utc, score, and (in the wild 36-key payload observed
+// 2026-08) the thing's location: subreddit/link_id/parent_id/permalink.
+// RedditKit then parses a comment with no author/avatar, an epoch-1970
+// timestamp, score 0 — and an empty subreddit, which silently disables the
+// own-flair backfill and the moderator shield on the inserted cell. Fill ONLY
+// the missing fields — identity/score with the same optimistic values the
+// legacy synthesis uses, location from the write context captured at submit
+// time; anything present is never overwritten. Returns nil when the thing is
+// already complete — the overwhelmingly common case, making this a strict
+// no-op for healthy responses.
 static NSDictionary *ApolloWebJSONCompleteModernThingData(NSDictionary *td, BOOL isEdit, NSArray<NSString *> **outFilled) {
     NSMutableArray<NSString *> *filled = [NSMutableArray array];
     NSMutableDictionary *patched = [td mutableCopy];
@@ -1424,6 +1480,45 @@ static NSDictionary *ApolloWebJSONCompleteModernThingData(NSDictionary *td, BOOL
         }
         if (!isEdit && ![td[@"likes"] isKindOfClass:[NSNumber class]]) {
             patched[@"likes"] = @YES;
+        }
+    }
+
+    // Location fields, from the write context captured at submit time. An empty
+    // model.subreddit is what silently kills the own-flair backfill and the
+    // moderator shield on the fresh cell (both key off the comment's
+    // subreddit), so this is as render-critical as author/created/score.
+    ApolloWebJSONWriteContext ctx = ApolloWebJSONRecentCommentWriteContext();
+    if (!ApolloWebJSONIsNonEmptyString(td[@"subreddit"]) && ctx.subreddit) {
+        patched[@"subreddit"] = ctx.subreddit;
+        [filled addObject:@"subreddit"];
+    }
+    if (!ApolloWebJSONIsNonEmptyString(td[@"subreddit_id"]) && ctx.subredditFullName) {
+        patched[@"subreddit_id"] = ctx.subredditFullName;
+        [filled addObject:@"subreddit_id"];
+    }
+    if (!ApolloWebJSONIsNonEmptyString(td[@"link_id"]) && ctx.linkFullName) {
+        patched[@"link_id"] = ctx.linkFullName;
+        [filled addObject:@"link_id"];
+    }
+    // A top-level comment's parent IS the link; a reply's is the parent t1.
+    // Only creates: an edit's parent is not in the context (the edited comment
+    // could be nested anywhere), and edits prefer the info.json refetch anyway.
+    if (!isEdit && !ApolloWebJSONIsNonEmptyString(td[@"parent_id"])) {
+        NSString *parent = ctx.parentFullName ?: ctx.linkFullName;
+        if (parent) {
+            patched[@"parent_id"] = parent;
+            [filled addObject:@"parent_id"];
+        }
+    }
+    if (!ApolloWebJSONIsNonEmptyString(td[@"permalink"]) && ctx.subreddit && ctx.linkFullName) {
+        // "/_/" is old-reddit's wildcard slug — Reddit resolves it for any post.
+        NSString *link36 = [ctx.linkFullName hasPrefix:@"t3_"] ? [ctx.linkFullName substringFromIndex:3] : nil;
+        NSString *own = ApolloWebJSONIsNonEmptyString(td[@"id"]) ? td[@"id"]
+                      : (ApolloWebJSONIsNonEmptyString(td[@"name"]) && [td[@"name"] hasPrefix:@"t1_"]
+                         ? [td[@"name"] substringFromIndex:3] : nil);
+        if (link36 && own) {
+            patched[@"permalink"] = [NSString stringWithFormat:@"/r/%@/comments/%@/_/%@/", ctx.subreddit, link36, own];
+            [filled addObject:@"permalink"];
         }
     }
 

--- a/src/ApolloWebJSON.m
+++ b/src/ApolloWebJSON.m
@@ -6,6 +6,8 @@
 #import "ApolloAccountCredentials.h" // ApolloActiveAccountUsername() — write-fixup author for API-key actives
 #import "ApolloWebSessionStore.h"
 #import "ApolloWebSessionLoginViewController.h" // silent re-harvest before the expiry prompt
+#import <objc/message.h>
+#import <os/lock.h>
 
 #import <Security/Security.h>
 
@@ -1221,6 +1223,9 @@ static BOOL ApolloWebJSONPermalinkPartsFromLegacyContent(NSString *html, NSStrin
     return YES;
 }
 
+// Defined with the write-repair helpers below; used by the legacy synthesis too.
+static NSString *ApolloWebJSONRecentCommentWriteUsername(void);
+
 // Extracts the comment author from an old-reddit content blob's data-author
 // attribute. Authoritative when present — it is Reddit's own record of who the
 // write ran as, with the account's canonical capitalization.
@@ -1265,11 +1270,13 @@ static NSDictionary *ApolloWebJSONSynthesizeModernThingData(NSString *fullname, 
     if (body.length == 0 && bodyHTML.length == 0) return nil; // nothing renderable to show
 
     // Author, in trust order: Reddit's own data-author attribute in the legacy
-    // content blob, then the active web-session account, then the active
-    // API-key (OAuth) account — a comment write always runs as the foreground
-    // account. Capitalization matters because Apollo gates the Edit affordance
-    // on comment.author == currentUser.username.
+    // content blob, then the identity captured from the submitting RDKClient
+    // (correct for non-active posting accounts), then the active web-session
+    // account, then the active API-key (OAuth) account. Capitalization matters
+    // because Apollo gates the Edit affordance on
+    // comment.author == currentUser.username.
     NSString *author = ApolloWebJSONAuthorFromLegacyContent(content);
+    if (author.length == 0) author = ApolloWebJSONRecentCommentWriteUsername();
     if (author.length == 0) author = ApolloActiveWebSessionUsername();
     if (author.length == 0) author = ApolloActiveAccountUsername();
     if (author.length == 0) return nil;
@@ -1312,6 +1319,119 @@ static NSDictionary *ApolloWebJSONSynthesizeModernThingData(NSString *fullname, 
     return modern;
 }
 
+// YES for a usable non-empty string. JSON null arrives as NSNull, which must
+// count as missing everywhere in the write-response repair.
+static BOOL ApolloWebJSONIsNonEmptyString(id value) {
+    return [value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0;
+}
+
+// The username the most recent comment/edit write ran as, captured at submit
+// time from the RDKClient that issued it (ApolloWebJSONNoteCommentWriteClient,
+// called from the identity module's submit hooks). The ACTIVE account is the
+// wrong answer when the composer's account chooser posted as someone else
+// (temporaryPostingAccount): each account owns its own RDKClient, so the
+// submitting client's currentUser IS the posting identity. TTL-bounded so a
+// stale capture can never label an unrelated later repair.
+static NSString *sApolloWebJSONLastWriteUsername = nil;
+static NSTimeInterval sApolloWebJSONLastWriteAt = 0;
+static os_unfair_lock sApolloWebJSONLastWriteLock = OS_UNFAIR_LOCK_INIT;
+
+void ApolloWebJSONNoteCommentWriteClient(id client) {
+    NSString *name = nil;
+    @try {
+        id user = [client respondsToSelector:@selector(currentUser)]
+            ? ((id (*)(id, SEL))objc_msgSend)(client, @selector(currentUser)) : nil;
+        id value = [user respondsToSelector:@selector(username)]
+            ? ((id (*)(id, SEL))objc_msgSend)(user, @selector(username)) : nil;
+        if ([value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0) name = [value copy];
+    } @catch (__unused NSException *e) { return; }
+    if (!name) return;
+    os_unfair_lock_lock(&sApolloWebJSONLastWriteLock);
+    sApolloWebJSONLastWriteUsername = name;
+    sApolloWebJSONLastWriteAt = [NSDate timeIntervalSinceReferenceDate];
+    os_unfair_lock_unlock(&sApolloWebJSONLastWriteLock);
+}
+
+// nil when no write was captured recently — callers fall back to the active
+// account. 60s comfortably covers submit -> response -> serializer.
+static NSString *ApolloWebJSONRecentCommentWriteUsername(void) {
+    os_unfair_lock_lock(&sApolloWebJSONLastWriteLock);
+    NSString *name = sApolloWebJSONLastWriteUsername;
+    BOOL fresh = name.length > 0 && ([NSDate timeIntervalSinceReferenceDate] - sApolloWebJSONLastWriteAt) < 60.0;
+    os_unfair_lock_unlock(&sApolloWebJSONLastWriteLock);
+    return fresh ? name : nil;
+}
+
+// A timestamp-ish numeric field that's absent, JSON-null, the wrong type, or
+// non-positive counts as missing (RedditKit turns all of those into the
+// epoch-1970 date the blank cell shows).
+static BOOL ApolloWebJSONTimestampMissing(id value) {
+    if (![value isKindOfClass:[NSNumber class]]) return YES;
+    return [(NSNumber *)value doubleValue] <= 0;
+}
+
+// The milder variant of the same degraded write response: a MODERN-shaped thing
+// (body present) that is missing the render-critical fields — author,
+// created/created_utc, score. RedditKit then parses a comment with no
+// author/avatar/flair, an epoch-1970 timestamp and score 0: the identical blank
+// cell the legacy shape produces. Fill ONLY the missing fields, with the same
+// optimistic values the legacy synthesis uses; anything present is never
+// overwritten. Returns nil when the thing is already complete — the
+// overwhelmingly common case, making this a strict no-op for healthy responses.
+static NSDictionary *ApolloWebJSONCompleteModernThingData(NSDictionary *td, BOOL isEdit, NSArray<NSString *> **outFilled) {
+    NSMutableArray<NSString *> *filled = [NSMutableArray array];
+    NSMutableDictionary *patched = [td mutableCopy];
+
+    if (!ApolloWebJSONIsNonEmptyString(td[@"author"])) {
+        // Trust order (no content HTML exists here, so no data-author): the
+        // identity captured from the submitting RDKClient — correct even when
+        // the composer posted as a non-active account (temporaryPostingAccount)
+        // — then the active web session, then the active account. Stored
+        // capitalization matters because the Edit affordance gates on
+        // comment.author == currentUser.username.
+        NSString *author = ApolloWebJSONRecentCommentWriteUsername();
+        if (author.length == 0) author = ApolloActiveWebSessionUsername();
+        if (author.length == 0) author = ApolloActiveAccountUsername();
+        if (author.length > 0) {
+            patched[@"author"] = author;
+            [filled addObject:@"author"];
+        }
+    }
+
+    NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
+    if (ApolloWebJSONTimestampMissing(td[@"created_utc"])) {
+        patched[@"created_utc"] = @(now);
+        [filled addObject:@"created_utc"];
+    }
+    if (ApolloWebJSONTimestampMissing(td[@"created"])) {
+        patched[@"created"] = @(now);
+        [filled addObject:@"created"];
+    }
+
+    // A freshly created own comment always starts at score 1 with the author's
+    // self-upvote, so on /api/comment a missing score — or an explicit 0 with no
+    // vote state — is the degraded payload, not a real value. Edits keep an
+    // explicit 0: a genuinely downvoted comment can legitimately sit there.
+    id score = td[@"score"];
+    BOOL scoreMissing = ![score isKindOfClass:[NSNumber class]];
+    BOOL scoreZeroOnCreate = !isEdit && [score isKindOfClass:[NSNumber class]] && [(NSNumber *)score integerValue] == 0
+                             && ![td[@"likes"] isKindOfClass:[NSNumber class]];
+    if (scoreMissing || scoreZeroOnCreate) {
+        patched[@"score"] = @1;
+        [filled addObject:@"score"];
+        if (![td[@"ups"] isKindOfClass:[NSNumber class]] || (!isEdit && [(NSNumber *)td[@"ups"] integerValue] == 0)) {
+            patched[@"ups"] = @1;
+        }
+        if (!isEdit && ![td[@"likes"] isKindOfClass:[NSNumber class]]) {
+            patched[@"likes"] = @YES;
+        }
+    }
+
+    if (filled.count == 0) return nil;
+    if (outFilled) *outFilled = filled;
+    return patched;
+}
+
 // Old-reddit /api/editusertext and /api/comment responses return each thing's
 // `data` in the legacy shape {parent, content:"<html>"} instead of the modern
 // comment JSON ({body, body_html, score, author, …}). Apollo's RedditKit maps
@@ -1321,12 +1441,14 @@ static NSDictionary *ApolloWebJSONSynthesizeModernThingData(NSString *fullname, 
 // answers this way (Web JSON mode), and since 2026-08 oauth.reddit.com has
 // intermittently served the SAME legacy shape to API-key (OAuth) clients — it
 // also hit Narwhal — so this repair runs in EVERY auth mode; it is a strict
-// no-op for the modern shape and on API errors. We detect the legacy shape and
-// swap in the modern object: primary source is an info.json refetch
-// (authoritative fields); when that isn't possible (serializer on the main
-// thread — no sync network allowed) or comes up empty (info.json can lag a
-// seconds-old comment), we synthesize the modern dict locally from the legacy
-// fields, which always carry the submitted text.
+// no-op for the modern shape and on API errors. Two degraded variants are
+// handled: the full legacy shape is swapped for a modern object (primary source
+// is an info.json refetch — authoritative fields; when that isn't possible
+// (serializer on the main thread — no sync network allowed) or comes up empty
+// (info.json can lag a seconds-old comment), we synthesize the modern dict
+// locally from the legacy fields, which always carry the submitted text), and a
+// modern-shaped thing missing its render-critical fields gets just those fields
+// filled in place (ApolloWebJSONCompleteModernThingData above).
 id ApolloWebJSONFixupWriteResponseObject(NSURLResponse *response, id responseObject) {
     if (![response isKindOfClass:[NSHTTPURLResponse class]]) return responseObject;
 
@@ -1372,7 +1494,51 @@ id ApolloWebJSONFixupWriteResponseObject(NSURLResponse *response, id responseObj
         if (![thing isKindOfClass:[NSDictionary class]]) continue;
         NSDictionary *td = thing[@"data"];
         if (![td isKindOfClass:[NSDictionary class]]) continue;
-        if (td[@"body"] != nil || ![td[@"content"] isKindOfClass:[NSString class]]) continue; // already modern
+
+        // JSON null (NSNull) counts as body-missing: a body:null + content thing
+        // is the legacy shape (synthesis rebuilds the body from contentText).
+        BOOL hasBody = [td[@"body"] isKindOfClass:[NSString class]];
+        BOOL isLegacyShape = (!hasBody && [td[@"content"] isKindOfClass:[NSString class]]);
+        if (!isLegacyShape) {
+            if (!hasBody) continue; // neither shape — leave untouched
+            // Modern shape: fill any missing render-critical fields in place —
+            // but only on actual COMMENTS. Private-message replies also flow
+            // through /api/comment as t4 things whose healthy data legitimately
+            // carries score:0/likes:null, and they must stay untouched. Skip
+            // only on explicit evidence of a non-comment: a degraded comment
+            // payload could lose kind AND name, and missing the repair there is
+            // the costlier error (skipping re-blanks the just-posted comment).
+            NSString *kind = [thing[@"kind"] isKindOfClass:[NSString class]] ? thing[@"kind"] : nil;
+            NSString *name = ApolloWebJSONIsNonEmptyString(td[@"name"]) ? td[@"name"] : nil;
+            BOOL notComment = (kind && ![kind isEqualToString:@"t1"]) ||
+                              (name && [name rangeOfString:@"_"].location != NSNotFound && ![name hasPrefix:@"t1_"]);
+            if (notComment) continue;
+
+            NSArray<NSString *> *filledKeys = nil;
+            NSDictionary *completed = ApolloWebJSONCompleteModernThingData(td, isEdit, &filledKeys);
+            if (!completed) continue; // already complete — the common case
+
+            NSString *source = @"optimistic fill";
+            // An edited comment already exists with a real score/created —
+            // prefer the authoritative refetch over optimistic values, exactly
+            // like the legacy path does for edits.
+            if (isEdit && allowNetwork) {
+                NSString *fullname = name ?: (td[@"id"] ? [@"t1_" stringByAppendingFormat:@"%@", td[@"id"]] : nil);
+                NSDictionary *fetched = fullname.length > 0 ? ApolloWebJSONFetchModernThingData(fullname) : nil;
+                if ([fetched isKindOfClass:[NSDictionary class]]) {
+                    completed = fetched;
+                    source = @"info.json refetch";
+                }
+            }
+
+            newThings[i] = @{ @"kind": kind ?: @"t1", @"data": completed };
+            changed = YES;
+            ApolloLog(@"[WebJSON] Filled missing %@ on modern %@ thing %@ via %@ (%lu keys present)",
+                      [filledKeys componentsJoinedByString:@"+"], path,
+                      name ?: [NSString stringWithFormat:@"(id %@)", td[@"id"] ?: @"?"],
+                      source, (unsigned long)td.count);
+            continue;
+        }
 
         NSString *fullname = ApolloWebJSONFullnameFromLegacyContent(td[@"content"]);
         // The legacy dict's own "id" field is the fullname too — use it when the

--- a/src/ApolloWebJSON.m
+++ b/src/ApolloWebJSON.m
@@ -1231,9 +1231,14 @@ typedef struct {
     NSString *linkFullName;
     NSString *parentFullName;
 } ApolloWebJSONWriteContext;
-// Resolved from the markdown Reddit echoed back, so overlapping writes can't
-// cross-contaminate each other's repairs. See the pending-write store below.
-static ApolloWebJSONWriteContext ApolloWebJSONWriteContextForBody(id responseBody);
+// Resolved from the markdown Reddit echoed back, plus any location fields the
+// degraded payload happened to keep (they distinguish two overlapping writes
+// whose markdown is identical), so overlapping writes can't cross-contaminate
+// each other's repairs. See the pending-write store below.
+static ApolloWebJSONWriteContext ApolloWebJSONWriteContextForResponse(id responseBody,
+                                                                      NSString *subredditHint,
+                                                                      NSString *linkHint,
+                                                                      NSString *parentHint);
 
 // Extracts the comment author from an old-reddit content blob's data-author
 // attribute. Authoritative when present — it is Reddit's own record of who the
@@ -1278,10 +1283,26 @@ static NSDictionary *ApolloWebJSONSynthesizeModernThingData(NSString *fullname, 
     NSString *bodyHTML = [legacy[@"contentHTML"] isKindOfClass:[NSString class]] ? legacy[@"contentHTML"] : nil;
     if (body.length == 0 && bodyHTML.length == 0) return nil; // nothing renderable to show
 
+    NSString *legacyParent = ([legacy[@"parent"] isKindOfClass:[NSString class]]
+                              && [(NSString *)legacy[@"parent"] length] > 0) ? legacy[@"parent"] : nil;
+    NSString *legacyLink = ([legacy[@"link"] isKindOfClass:[NSString class]]
+                            && [(NSString *)legacy[@"link"] length] > 0) ? legacy[@"link"] : nil;
+    NSString *permalink = nil, *subreddit = nil, *linkId36 = nil;
+    ApolloWebJSONPermalinkPartsFromLegacyContent(content, &permalink, &subreddit, &linkId36);
+
     // The submitted markdown identifies WHICH outstanding write this response
     // belongs to, so a second comment posted while this one was in flight can't
-    // lend it its author or its thread. Resolve once and reuse below.
-    ApolloWebJSONWriteContext ctx = ApolloWebJSONWriteContextForBody(body);
+    // lend it its author or its thread. Whatever location the legacy dict still
+    // carries goes along as identity hints — they are what tells two
+    // overlapping writes apart when their markdown is identical. The parent
+    // hint is creates-only: an edited comment's real parent was never captured
+    // (the edit context has no parentFullName), so it could only contradict
+    // falsely. Resolve once and reuse below.
+    NSString *linkHint = legacyLink ?: (linkId36.length > 0 ? [@"t3_" stringByAppendingString:linkId36] : nil);
+    ApolloWebJSONWriteContext ctx = ApolloWebJSONWriteContextForResponse(body,
+                                                                         subreddit.length > 0 ? subreddit : nil,
+                                                                         linkHint,
+                                                                         isEdit ? nil : legacyParent);
 
     // Author, in trust order: Reddit's own data-author attribute in the legacy
     // content blob, then the identity captured from the submitting RDKClient
@@ -1301,11 +1322,9 @@ static NSDictionary *ApolloWebJSONSynthesizeModernThingData(NSString *fullname, 
     modern[@"author"] = author;
     modern[@"body"] = body.length > 0 ? body : @"";
     modern[@"body_html"] = bodyHTML.length > 0 ? bodyHTML : ApolloWebJSONEscapedBodyHTML(body ?: @"");
-    if ([legacy[@"parent"] isKindOfClass:[NSString class]]) modern[@"parent_id"] = legacy[@"parent"];
-    if ([legacy[@"link"] isKindOfClass:[NSString class]]) modern[@"link_id"] = legacy[@"link"];
+    if (legacyParent) modern[@"parent_id"] = legacyParent;
+    if (legacyLink) modern[@"link_id"] = legacyLink;
 
-    NSString *permalink = nil, *subreddit = nil, *linkId36 = nil;
-    ApolloWebJSONPermalinkPartsFromLegacyContent(content, &permalink, &subreddit, &linkId36);
     if (permalink.length > 0) modern[@"permalink"] = permalink;
     if (subreddit.length > 0) modern[@"subreddit"] = subreddit;
     if (!modern[@"link_id"] && linkId36.length > 0) modern[@"link_id"] = [@"t3_" stringByAppendingString:linkId36];
@@ -1377,11 +1396,17 @@ static BOOL ApolloWebJSONIsNonEmptyString(id value) {
 //
 // The correlation key is the submitted markdown, which Reddit echoes back as
 // `body` (modern shape) / `contentText` (legacy shape) — no plumbing through
-// RedditKit's request internals required. When a response can't be matched
-// (body absent or normalized beyond recognition) we fall back to the single
-// outstanding write if there is exactly one, and otherwise to only those fields
-// every outstanding write agrees on — an unmatched response never adopts one
-// candidate's thread over another's.
+// RedditKit's request internals required. Duplicate bodies are PRESERVED, not
+// deduped: two overlapping writes can legitimately carry identical markdown
+// (a "Thanks" posted in two different threads), and evicting the earlier
+// capture would hand the first response the second write's context. An
+// ambiguous key is resolved only by response-side identity — location fields
+// the degraded payload happened to keep that positively contradict a candidate
+// rule it out — and when that can't narrow the set to one, the repair uses
+// only the fields every remaining candidate agrees on. The same unanimity
+// fallback covers a response that can't be matched at all (body absent or
+// normalized beyond recognition): a response never adopts one candidate's
+// thread over another's.
 @interface ApolloWebJSONPendingWrite : NSObject
 @property (nonatomic, copy, nullable) NSString *username;
 @property (nonatomic, copy, nullable) NSString *subreddit;
@@ -1460,15 +1485,13 @@ void ApolloWebJSONNoteCommentWriteContext(id client, NSString *body, NSString *s
     os_unfair_lock_lock(&sApolloWebJSONLastWriteLock);
     if (!sApolloWebJSONPendingWrites) sApolloWebJSONPendingWrites = [NSMutableArray array];
     ApolloWebJSONPruneWritesLocked();
-    // Resubmitting identical text (the user retried a failed post) replaces the
-    // earlier capture rather than leaving two entries fighting over one body.
-    if (write.bodyKey) {
-        NSUInteger existing = [sApolloWebJSONPendingWrites indexOfObjectPassingTest:
-                               ^BOOL(ApolloWebJSONPendingWrite *w, NSUInteger idx, BOOL *stop) {
-            return [w.bodyKey isEqualToString:write.bodyKey];
-        }];
-        if (existing != NSNotFound) [sApolloWebJSONPendingWrites removeObjectAtIndex:existing];
-    }
+    // An entry with the same body may already be pending — keep BOTH. Evicting
+    // it would hand the earlier write's response the newer write's context
+    // whenever two overlapping writes carry identical markdown (a "Thanks"
+    // posted in two different threads); the resolver treats a duplicated key
+    // as ambiguous instead. The retry case the old eviction served (user
+    // resubmitted a failed post) still repairs fully: identical retries carry
+    // identical context, so the unanimity fallback returns every field.
     [sApolloWebJSONPendingWrites addObject:write];
     while (sApolloWebJSONPendingWrites.count > kApolloWebJSONMaxPendingWrites) {
         [sApolloWebJSONPendingWrites removeObjectAtIndex:0];
@@ -1502,35 +1525,81 @@ static ApolloWebJSONWriteContext ApolloWebJSONUnanimousContext(NSArray<ApolloWeb
     return ctx;
 }
 
+// YES when the response-side identity hints positively rule this candidate
+// out: a location field the degraded payload kept that differs from what was
+// captured at submit time cannot belong to this write. A nil on either side
+// proves nothing and never disqualifies — silence is not evidence.
+static BOOL ApolloWebJSONWriteContradictsHints(ApolloWebJSONPendingWrite *w,
+                                               NSString *subredditHint,
+                                               NSString *linkHint,
+                                               NSString *parentHint) {
+    if (subredditHint && w.subreddit
+        && [subredditHint caseInsensitiveCompare:w.subreddit] != NSOrderedSame) return YES;
+    if (linkHint && w.linkFullName && ![linkHint isEqualToString:w.linkFullName]) return YES;
+    // What the repair itself would write as parent_id for a create: the parent
+    // comment for a reply, the link itself for a top-level comment. Callers
+    // pass a nil parentHint for edits — an edited comment's real parent was
+    // never captured, so it could only contradict falsely.
+    NSString *effectiveParent = w.parentFullName ?: w.linkFullName;
+    if (parentHint && effectiveParent && ![parentHint isEqualToString:effectiveParent]) return YES;
+    return NO;
+}
+
 // The write context for the response now being repaired, resolved from the
-// markdown Reddit echoed back. Zeroed struct when nothing usable is
-// outstanding — callers fall back to the active account / leave fields unfilled.
-static ApolloWebJSONWriteContext ApolloWebJSONWriteContextForBody(id responseBody) {
+// markdown Reddit echoed back plus whatever location fields the payload kept
+// (the identity hints). Zeroed struct when nothing usable is outstanding —
+// callers fall back to the active account / leave fields unfilled.
+static ApolloWebJSONWriteContext ApolloWebJSONWriteContextForResponse(id responseBody,
+                                                                      NSString *subredditHint,
+                                                                      NSString *linkHint,
+                                                                      NSString *parentHint) {
     NSString *key = ApolloWebJSONWriteBodyKey(responseBody);
     ApolloWebJSONWriteContext ctx = {nil, nil, nil, nil, nil};
 
     os_unfair_lock_lock(&sApolloWebJSONLastWriteLock);
     ApolloWebJSONPruneWritesLocked();
-    ApolloWebJSONPendingWrite *match = nil;
-    if (key) {
-        // Newest first: a resubmit of the same text should win over an older
-        // capture that somehow survived the dedupe above.
-        for (ApolloWebJSONPendingWrite *w in [sApolloWebJSONPendingWrites reverseObjectEnumerator]) {
-            if (w.bodyKey && [w.bodyKey isEqualToString:key]) { match = w; break; }
-        }
-    }
+
+    // Candidate set, narrowest first: every entry whose captured markdown
+    // matches the echoed body — duplicates included, and consumed entries too,
+    // so a re-serialized retry of the same response still resolves. When
+    // nothing matches by body, every write still awaiting its response; when
+    // all of those have already repaired something, everything outstanding
+    // (most likely one of those responses being serialized again).
     NSArray<ApolloWebJSONPendingWrite *> *candidates = nil;
-    if (!match) {
+    BOOL matchedByBody = NO;
+    if (key) {
+        candidates = [sApolloWebJSONPendingWrites filteredArrayUsingPredicate:
+                      [NSPredicate predicateWithBlock:^BOOL(ApolloWebJSONPendingWrite *w, NSDictionary *b) {
+            return w.bodyKey && [w.bodyKey isEqualToString:key];
+        }]];
+        matchedByBody = candidates.count > 0;
+    }
+    if (!matchedByBody) {
         candidates = [sApolloWebJSONPendingWrites filteredArrayUsingPredicate:
                       [NSPredicate predicateWithBlock:^BOOL(ApolloWebJSONPendingWrite *w, NSDictionary *b) {
             return !w.consumed;
         }]];
-        // Everything outstanding has already repaired something: this is most
-        // likely that same response being serialized again, so still prefer the
-        // captured values over nothing.
         if (candidates.count == 0) candidates = [sApolloWebJSONPendingWrites copy];
-        if (candidates.count == 1) match = candidates.firstObject;
     }
+
+    // Response-side identity narrows further: drop candidates the kept
+    // location fields positively contradict. This is what tells apart two
+    // overlapping writes whose markdown is identical (a "Thanks" posted in two
+    // different threads) when the payload retained any of its location.
+    if (candidates.count > 0 && (subredditHint || linkHint || parentHint)) {
+        candidates = [candidates filteredArrayUsingPredicate:
+                      [NSPredicate predicateWithBlock:^BOOL(ApolloWebJSONPendingWrite *w, NSDictionary *b) {
+            return !ApolloWebJSONWriteContradictsHints(w, subredditHint, linkHint, parentHint);
+        }]];
+    }
+
+    // Adopt a candidate's full context only when exactly one is left. Anything
+    // else — an ambiguous duplicated body the hints couldn't split, or no
+    // survivors at all — never picks one: only the fields every survivor
+    // agrees on are used, so identical retries still repair fully and two
+    // same-body writes from one account still get the right author, while the
+    // fields that differ stay empty. A weaker repair, never a wrong one.
+    ApolloWebJSONPendingWrite *match = candidates.count == 1 ? candidates.firstObject : nil;
     if (match) {
         match.consumed = YES;
         ctx.username = match.username;
@@ -1546,7 +1615,8 @@ static ApolloWebJSONWriteContext ApolloWebJSONWriteContextForBody(id responseBod
 
     if (outstanding > 1) {
         ApolloLog(@"[WebJSON] Write context for repair: %@ (%lu writes outstanding)",
-                  match ? @"matched by body" : @"unmatched — unanimous fields only",
+                  match ? (matchedByBody ? @"uniquely matched by body" : @"sole surviving candidate")
+                        : @"ambiguous — unanimous fields only",
                   (unsigned long)outstanding);
     }
     return ctx;
@@ -1578,10 +1648,18 @@ static NSDictionary *ApolloWebJSONCompleteModernThingData(NSDictionary *td, BOOL
 
     // Which outstanding write is this? The degraded payload keeps `body` (that
     // is what makes it "modern-shaped"), and body IS the submitted markdown, so
-    // it identifies the write even when everything else was stripped. Resolved
-    // once here and reused for both the author and the location fields — two
-    // lookups could otherwise disagree if a write landed in between.
-    ApolloWebJSONWriteContext ctx = ApolloWebJSONWriteContextForBody(td[@"body"]);
+    // it identifies the write even when everything else was stripped. Any
+    // location field it DID keep goes along as an identity hint — that is what
+    // tells two overlapping writes apart when their markdown is identical
+    // (parent hint creates-only: an edited comment's real parent was never
+    // captured, so it could only contradict falsely). Resolved once here and
+    // reused for both the author and the location fields — two lookups could
+    // otherwise disagree if a write landed in between.
+    ApolloWebJSONWriteContext ctx = ApolloWebJSONWriteContextForResponse(
+        td[@"body"],
+        ApolloWebJSONIsNonEmptyString(td[@"subreddit"]) ? td[@"subreddit"] : nil,
+        ApolloWebJSONIsNonEmptyString(td[@"link_id"]) ? td[@"link_id"] : nil,
+        (!isEdit && ApolloWebJSONIsNonEmptyString(td[@"parent_id"])) ? td[@"parent_id"] : nil);
 
     if (!ApolloWebJSONIsNonEmptyString(td[@"author"])) {
         // Trust order (no content HTML exists here, so no data-author): the

--- a/src/ApolloWebJSON.m
+++ b/src/ApolloWebJSON.m
@@ -1231,8 +1231,9 @@ typedef struct {
     NSString *linkFullName;
     NSString *parentFullName;
 } ApolloWebJSONWriteContext;
-static ApolloWebJSONWriteContext ApolloWebJSONRecentCommentWriteContext(void);
-static NSString *ApolloWebJSONRecentCommentWriteUsername(void);
+// Resolved from the markdown Reddit echoed back, so overlapping writes can't
+// cross-contaminate each other's repairs. See the pending-write store below.
+static ApolloWebJSONWriteContext ApolloWebJSONWriteContextForBody(id responseBody);
 
 // Extracts the comment author from an old-reddit content blob's data-author
 // attribute. Authoritative when present — it is Reddit's own record of who the
@@ -1277,6 +1278,11 @@ static NSDictionary *ApolloWebJSONSynthesizeModernThingData(NSString *fullname, 
     NSString *bodyHTML = [legacy[@"contentHTML"] isKindOfClass:[NSString class]] ? legacy[@"contentHTML"] : nil;
     if (body.length == 0 && bodyHTML.length == 0) return nil; // nothing renderable to show
 
+    // The submitted markdown identifies WHICH outstanding write this response
+    // belongs to, so a second comment posted while this one was in flight can't
+    // lend it its author or its thread. Resolve once and reuse below.
+    ApolloWebJSONWriteContext ctx = ApolloWebJSONWriteContextForBody(body);
+
     // Author, in trust order: Reddit's own data-author attribute in the legacy
     // content blob, then the identity captured from the submitting RDKClient
     // (correct for non-active posting accounts), then the active web-session
@@ -1284,7 +1290,7 @@ static NSDictionary *ApolloWebJSONSynthesizeModernThingData(NSString *fullname, 
     // because Apollo gates the Edit affordance on
     // comment.author == currentUser.username.
     NSString *author = ApolloWebJSONAuthorFromLegacyContent(content);
-    if (author.length == 0) author = ApolloWebJSONRecentCommentWriteUsername();
+    if (author.length == 0) author = ctx.username;
     if (author.length == 0) author = ApolloActiveWebSessionUsername();
     if (author.length == 0) author = ApolloActiveAccountUsername();
     if (author.length == 0) return nil;
@@ -1308,7 +1314,6 @@ static NSDictionary *ApolloWebJSONSynthesizeModernThingData(NSString *fullname, 
     // stripped) still need the thing's location — an empty subreddit disables
     // the own-flair backfill and the moderator shield on the inserted cell.
     // The write context captured at submit time knows it.
-    ApolloWebJSONWriteContext ctx = ApolloWebJSONRecentCommentWriteContext();
     if (!modern[@"subreddit"] && ctx.subreddit) modern[@"subreddit"] = ctx.subreddit;
     if (ctx.subredditFullName) modern[@"subreddit_id"] = ctx.subredditFullName;
     if (!modern[@"link_id"] && ctx.linkFullName) modern[@"link_id"] = ctx.linkFullName;
@@ -1350,7 +1355,7 @@ static BOOL ApolloWebJSONIsNonEmptyString(id value) {
     return [value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0;
 }
 
-// The context of the most recent comment/edit write, captured at submit time
+// The context of a comment/edit write, captured at submit time
 // (ApolloWebJSONNoteCommentWriteContext, called from the identity module's
 // submit hooks). The username comes from the RDKClient that issued the write —
 // the ACTIVE account is the wrong answer when the composer's account chooser
@@ -1360,22 +1365,79 @@ static BOOL ApolloWebJSONIsNonEmptyString(id value) {
 // (link or parent comment) — the wild degraded /api/comment payload observed
 // on-device (2026-08, 36 keys) strips those alongside author/created/score,
 // and an empty model.subreddit silently disables both the own-flair backfill
-// and the moderator shield on the freshly inserted cell. TTL-bounded so a
-// stale capture can never label an unrelated later repair; single-slot, so two
-// overlapping degraded writes in different subreddits within the TTL could
-// mislabel the earlier one — the response's own fields always win when
-// present, and the same tradeoff already applies to the username capture.
-// (ApolloWebJSONWriteContext is typedef'd above the legacy synthesis, which
-// consumes the same capture.)
-static ApolloWebJSONWriteContext sApolloWebJSONLastWrite;
-static NSTimeInterval sApolloWebJSONLastWriteAt = 0;
+// and the moderator shield on the freshly inserted cell.
+//
+// These are KEYED PER WRITE, not a single global slot. Apollo lets a comment be
+// submitted while an earlier one is still in flight (different thread, different
+// subreddit, even a different account), and the response serializer runs well
+// after submit — with one slot the second submit overwrote the first before the
+// first's degraded response was repaired, so the earlier comment could be
+// synthesized with the later post's subreddit/link/parent/permalink/author and
+// render or navigate as if it belonged to another thread.
+//
+// The correlation key is the submitted markdown, which Reddit echoes back as
+// `body` (modern shape) / `contentText` (legacy shape) — no plumbing through
+// RedditKit's request internals required. When a response can't be matched
+// (body absent or normalized beyond recognition) we fall back to the single
+// outstanding write if there is exactly one, and otherwise to only those fields
+// every outstanding write agrees on — an unmatched response never adopts one
+// candidate's thread over another's.
+@interface ApolloWebJSONPendingWrite : NSObject
+@property (nonatomic, copy, nullable) NSString *username;
+@property (nonatomic, copy, nullable) NSString *subreddit;
+@property (nonatomic, copy, nullable) NSString *subredditFullName;
+@property (nonatomic, copy, nullable) NSString *linkFullName;
+@property (nonatomic, copy, nullable) NSString *parentFullName;
+// Normalized submitted markdown; nil when the submit call had no usable text.
+@property (nonatomic, copy, nullable) NSString *bodyKey;
+@property (nonatomic) NSTimeInterval capturedAt;
+// Set once this entry has repaired a response. Kept around (not deleted) for
+// the rest of the TTL so a re-serialized retry of the same response still
+// matches it exactly, but excluded from the ambiguity set so a finished write
+// can't keep suppressing fields for a later one.
+@property (nonatomic) BOOL consumed;
+@end
+
+@implementation ApolloWebJSONPendingWrite
+@end
+
+// Bounded so a burst of writes can't grow this without limit; comment writes
+// are user-paced, so a handful of slots is far more than enough overlap.
+static NSUInteger const kApolloWebJSONMaxPendingWrites = 8;
+// Comfortably covers submit -> response -> serializer.
+static NSTimeInterval const kApolloWebJSONWriteContextTTL = 60.0;
+static NSMutableArray<ApolloWebJSONPendingWrite *> *sApolloWebJSONPendingWrites = nil;
 static os_unfair_lock sApolloWebJSONLastWriteLock = OS_UNFAIR_LOCK_INIT;
 
 static NSString *ApolloWebJSONCopiedNonEmptyString(id value) {
     return ([value isKindOfClass:[NSString class]] && [(NSString *)value length] > 0) ? [value copy] : nil;
 }
 
-void ApolloWebJSONNoteCommentWriteContext(id client, NSString *subreddit, NSString *subredditFullName,
+// Reddit round-trips the submitted markdown, but not always byte-for-byte: line
+// endings come back normalized and trailing whitespace trimmed. Compare on a
+// canonical form so a legitimate match isn't missed (a missed match is not
+// wrong, only weaker — it drops to the unanimous-fields path).
+static NSString *ApolloWebJSONWriteBodyKey(id text) {
+    NSString *string = [text isKindOfClass:[NSString class]] ? (NSString *)text : nil;
+    if (string.length == 0) return nil;
+    NSString *normalized = [[string stringByReplacingOccurrencesOfString:@"\r\n" withString:@"\n"]
+                            stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    return normalized.length > 0 ? normalized : nil;
+}
+
+// Caller must hold sApolloWebJSONLastWriteLock. Drops entries past the TTL.
+static void ApolloWebJSONPruneWritesLocked(void) {
+    if (sApolloWebJSONPendingWrites.count == 0) return;
+    NSTimeInterval now = [NSDate timeIntervalSinceReferenceDate];
+    NSIndexSet *stale = [sApolloWebJSONPendingWrites indexesOfObjectsPassingTest:
+                         ^BOOL(ApolloWebJSONPendingWrite *w, NSUInteger idx, BOOL *stop) {
+        return (now - w.capturedAt) >= kApolloWebJSONWriteContextTTL;
+    }];
+    if (stale.count > 0) [sApolloWebJSONPendingWrites removeObjectsAtIndexes:stale];
+}
+
+void ApolloWebJSONNoteCommentWriteContext(id client, NSString *body, NSString *subreddit,
+                                          NSString *subredditFullName,
                                           NSString *linkFullName, NSString *parentFullName) {
     NSString *name = nil;
     @try {
@@ -1385,33 +1447,109 @@ void ApolloWebJSONNoteCommentWriteContext(id client, NSString *subreddit, NSStri
             ? ((id (*)(id, SEL))objc_msgSend)(user, @selector(username)) : nil;
         name = ApolloWebJSONCopiedNonEmptyString(value);
     } @catch (__unused NSException *e) {}
+
+    ApolloWebJSONPendingWrite *write = [ApolloWebJSONPendingWrite new];
+    write.username = name;
+    write.subreddit = ApolloWebJSONCopiedNonEmptyString(subreddit);
+    write.subredditFullName = ApolloWebJSONCopiedNonEmptyString(subredditFullName);
+    write.linkFullName = ApolloWebJSONCopiedNonEmptyString(linkFullName);
+    write.parentFullName = ApolloWebJSONCopiedNonEmptyString(parentFullName);
+    write.bodyKey = ApolloWebJSONWriteBodyKey(body);
+    write.capturedAt = [NSDate timeIntervalSinceReferenceDate];
+
     os_unfair_lock_lock(&sApolloWebJSONLastWriteLock);
-    sApolloWebJSONLastWrite.username = name;
-    sApolloWebJSONLastWrite.subreddit = ApolloWebJSONCopiedNonEmptyString(subreddit);
-    sApolloWebJSONLastWrite.subredditFullName = ApolloWebJSONCopiedNonEmptyString(subredditFullName);
-    sApolloWebJSONLastWrite.linkFullName = ApolloWebJSONCopiedNonEmptyString(linkFullName);
-    sApolloWebJSONLastWrite.parentFullName = ApolloWebJSONCopiedNonEmptyString(parentFullName);
-    sApolloWebJSONLastWriteAt = [NSDate timeIntervalSinceReferenceDate];
+    if (!sApolloWebJSONPendingWrites) sApolloWebJSONPendingWrites = [NSMutableArray array];
+    ApolloWebJSONPruneWritesLocked();
+    // Resubmitting identical text (the user retried a failed post) replaces the
+    // earlier capture rather than leaving two entries fighting over one body.
+    if (write.bodyKey) {
+        NSUInteger existing = [sApolloWebJSONPendingWrites indexOfObjectPassingTest:
+                               ^BOOL(ApolloWebJSONPendingWrite *w, NSUInteger idx, BOOL *stop) {
+            return [w.bodyKey isEqualToString:write.bodyKey];
+        }];
+        if (existing != NSNotFound) [sApolloWebJSONPendingWrites removeObjectAtIndex:existing];
+    }
+    [sApolloWebJSONPendingWrites addObject:write];
+    while (sApolloWebJSONPendingWrites.count > kApolloWebJSONMaxPendingWrites) {
+        [sApolloWebJSONPendingWrites removeObjectAtIndex:0];
+    }
     os_unfair_lock_unlock(&sApolloWebJSONLastWriteLock);
 }
 
-// Zeroed struct when no write was captured recently — callers fall back to the
-// active account / leave fields unfilled. 60s comfortably covers
-// submit -> response -> serializer.
-static ApolloWebJSONWriteContext ApolloWebJSONRecentCommentWriteContext(void) {
-    os_unfair_lock_lock(&sApolloWebJSONLastWriteLock);
-    ApolloWebJSONWriteContext ctx = sApolloWebJSONLastWrite;
-    BOOL fresh = ([NSDate timeIntervalSinceReferenceDate] - sApolloWebJSONLastWriteAt) < 60.0 && sApolloWebJSONLastWriteAt > 0;
-    os_unfair_lock_unlock(&sApolloWebJSONLastWriteLock);
-    if (!fresh) {
-        ApolloWebJSONWriteContext empty = {nil, nil, nil, nil, nil};
-        return empty;
+// Only the fields on which every candidate agrees. Two overlapping writes into
+// the same subreddit still get their subreddit filled; ones that disagree leave
+// the field empty, which is exactly the pre-location-fill behavior — a weaker
+// repair, never a wrong one.
+static ApolloWebJSONWriteContext ApolloWebJSONUnanimousContext(NSArray<ApolloWebJSONPendingWrite *> *writes) {
+    ApolloWebJSONWriteContext ctx = {nil, nil, nil, nil, nil};
+    if (writes.count == 0) return ctx;
+    ApolloWebJSONPendingWrite *first = writes.firstObject;
+    NSString *username = first.username, *subreddit = first.subreddit;
+    NSString *subredditFullName = first.subredditFullName;
+    NSString *linkFullName = first.linkFullName, *parentFullName = first.parentFullName;
+    for (ApolloWebJSONPendingWrite *w in writes) {
+        if (username && ![username isEqualToString:w.username ?: @""]) username = nil;
+        if (subreddit && ![subreddit isEqualToString:w.subreddit ?: @""]) subreddit = nil;
+        if (subredditFullName && ![subredditFullName isEqualToString:w.subredditFullName ?: @""]) subredditFullName = nil;
+        if (linkFullName && ![linkFullName isEqualToString:w.linkFullName ?: @""]) linkFullName = nil;
+        if (parentFullName && ![parentFullName isEqualToString:w.parentFullName ?: @""]) parentFullName = nil;
     }
+    ctx.username = username;
+    ctx.subreddit = subreddit;
+    ctx.subredditFullName = subredditFullName;
+    ctx.linkFullName = linkFullName;
+    ctx.parentFullName = parentFullName;
     return ctx;
 }
 
-static NSString *ApolloWebJSONRecentCommentWriteUsername(void) {
-    return ApolloWebJSONRecentCommentWriteContext().username;
+// The write context for the response now being repaired, resolved from the
+// markdown Reddit echoed back. Zeroed struct when nothing usable is
+// outstanding — callers fall back to the active account / leave fields unfilled.
+static ApolloWebJSONWriteContext ApolloWebJSONWriteContextForBody(id responseBody) {
+    NSString *key = ApolloWebJSONWriteBodyKey(responseBody);
+    ApolloWebJSONWriteContext ctx = {nil, nil, nil, nil, nil};
+
+    os_unfair_lock_lock(&sApolloWebJSONLastWriteLock);
+    ApolloWebJSONPruneWritesLocked();
+    ApolloWebJSONPendingWrite *match = nil;
+    if (key) {
+        // Newest first: a resubmit of the same text should win over an older
+        // capture that somehow survived the dedupe above.
+        for (ApolloWebJSONPendingWrite *w in [sApolloWebJSONPendingWrites reverseObjectEnumerator]) {
+            if (w.bodyKey && [w.bodyKey isEqualToString:key]) { match = w; break; }
+        }
+    }
+    NSArray<ApolloWebJSONPendingWrite *> *candidates = nil;
+    if (!match) {
+        candidates = [sApolloWebJSONPendingWrites filteredArrayUsingPredicate:
+                      [NSPredicate predicateWithBlock:^BOOL(ApolloWebJSONPendingWrite *w, NSDictionary *b) {
+            return !w.consumed;
+        }]];
+        // Everything outstanding has already repaired something: this is most
+        // likely that same response being serialized again, so still prefer the
+        // captured values over nothing.
+        if (candidates.count == 0) candidates = [sApolloWebJSONPendingWrites copy];
+        if (candidates.count == 1) match = candidates.firstObject;
+    }
+    if (match) {
+        match.consumed = YES;
+        ctx.username = match.username;
+        ctx.subreddit = match.subreddit;
+        ctx.subredditFullName = match.subredditFullName;
+        ctx.linkFullName = match.linkFullName;
+        ctx.parentFullName = match.parentFullName;
+    } else {
+        ctx = ApolloWebJSONUnanimousContext(candidates);
+    }
+    NSUInteger outstanding = sApolloWebJSONPendingWrites.count;
+    os_unfair_lock_unlock(&sApolloWebJSONLastWriteLock);
+
+    if (outstanding > 1) {
+        ApolloLog(@"[WebJSON] Write context for repair: %@ (%lu writes outstanding)",
+                  match ? @"matched by body" : @"unmatched — unanimous fields only",
+                  (unsigned long)outstanding);
+    }
+    return ctx;
 }
 
 // A timestamp-ish numeric field that's absent, JSON-null, the wrong type, or
@@ -1438,6 +1576,13 @@ static NSDictionary *ApolloWebJSONCompleteModernThingData(NSDictionary *td, BOOL
     NSMutableArray<NSString *> *filled = [NSMutableArray array];
     NSMutableDictionary *patched = [td mutableCopy];
 
+    // Which outstanding write is this? The degraded payload keeps `body` (that
+    // is what makes it "modern-shaped"), and body IS the submitted markdown, so
+    // it identifies the write even when everything else was stripped. Resolved
+    // once here and reused for both the author and the location fields — two
+    // lookups could otherwise disagree if a write landed in between.
+    ApolloWebJSONWriteContext ctx = ApolloWebJSONWriteContextForBody(td[@"body"]);
+
     if (!ApolloWebJSONIsNonEmptyString(td[@"author"])) {
         // Trust order (no content HTML exists here, so no data-author): the
         // identity captured from the submitting RDKClient — correct even when
@@ -1445,7 +1590,7 @@ static NSDictionary *ApolloWebJSONCompleteModernThingData(NSDictionary *td, BOOL
         // — then the active web session, then the active account. Stored
         // capitalization matters because the Edit affordance gates on
         // comment.author == currentUser.username.
-        NSString *author = ApolloWebJSONRecentCommentWriteUsername();
+        NSString *author = ctx.username;
         if (author.length == 0) author = ApolloActiveWebSessionUsername();
         if (author.length == 0) author = ApolloActiveAccountUsername();
         if (author.length > 0) {
@@ -1487,7 +1632,6 @@ static NSDictionary *ApolloWebJSONCompleteModernThingData(NSDictionary *td, BOOL
     // model.subreddit is what silently kills the own-flair backfill and the
     // moderator shield on the fresh cell (both key off the comment's
     // subreddit), so this is as render-critical as author/created/score.
-    ApolloWebJSONWriteContext ctx = ApolloWebJSONRecentCommentWriteContext();
     if (!ApolloWebJSONIsNonEmptyString(td[@"subreddit"]) && ctx.subreddit) {
         patched[@"subreddit"] = ctx.subreddit;
         [filled addObject:@"subreddit"];

--- a/src/ApolloWebJSONIdentity.xm
+++ b/src/ApolloWebJSONIdentity.xm
@@ -772,11 +772,12 @@ void ApolloWebJSONRepairPoisonedAccountBlobs(void) {
 
 %end
 
-// Cookie-routed comment writes (/api/editusertext, /api/comment) come back from
-// www.reddit.com in the old-reddit {parent, content:"<html>"} shape, which Apollo
-// can't render (the edited/posted comment shows empty with 0 upvotes). Rewrite the
-// serializer's output into the modern shape Apollo expects. No-op outside Web JSON
-// mode / for the modern shape — see ApolloWebJSONFixupWriteResponseObject.
+// Comment writes (/api/editusertext, /api/comment) can come back in the legacy
+// old-reddit {parent, content:"<html>"} shape — always from www.reddit.com
+// (Web JSON mode), and intermittently from oauth.reddit.com for API-key
+// accounts too — which Apollo renders as a blank comment (no author/score/
+// timestamp). Rewrite the serializer's output into the modern shape Apollo
+// expects. No-op for the modern shape — see ApolloWebJSONFixupWriteResponseObject.
 %hook RDKResponseSerializer
 - (id)responseObjectForResponse:(id)response data:(id)data error:(id *)error {
     id serializerData = data;
@@ -785,9 +786,14 @@ void ApolloWebJSONRepairPoisonedAccountBlobs(void) {
         @catch (NSException *e) { ApolloLog(@"[WebJSON] listing-media fixup failed: %@", e); }
     }
     id obj = %orig(response, serializerData, error);
+    // The write fixup runs in EVERY auth mode, not just Web JSON: since 2026-08
+    // oauth.reddit.com has intermittently returned the legacy old-reddit
+    // write-response shape to API-key (OAuth) clients too (also hit Narwhal),
+    // which renders the just-posted comment with no author/score/timestamp.
+    // The repair is a strict no-op for the modern shape.
+    @try { obj = ApolloWebJSONFixupWriteResponseObject(response, obj); }
+    @catch (NSException *e) { ApolloLog(@"[WebJSON] write-response fixup failed: %@", e); }
     if (sWebJSONEnabled) {
-        @try { obj = ApolloWebJSONFixupWriteResponseObject(response, obj); }
-        @catch (NSException *e) { ApolloLog(@"[WebJSON] write-response fixup failed: %@", e); }
         @try { obj = ApolloWebJSONFixupModeratorsResponseObject(response, obj); }
         @catch (NSException *e) { ApolloLog(@"[WebJSON] moderators-response fixup failed: %@", e); }
         // No legacy equivalent exists for this endpoint at all (see

--- a/src/ApolloWebJSONIdentity.xm
+++ b/src/ApolloWebJSONIdentity.xm
@@ -770,6 +770,33 @@ void ApolloWebJSONRepairPoisonedAccountBlobs(void) {
     return %orig;
 }
 
+// The write-response repair (ApolloWebJSONFixupWriteResponseObject) may need to
+// know WHO a degraded /api/comment / /api/editusertext response belongs to.
+// The active account is the wrong answer when the composer posted as a
+// different account (temporaryPostingAccount), so capture the identity at
+// submit time from the client itself — each account owns its own RDKClient,
+// making self.currentUser the true posting identity.
+
+- (id)submitComment:(id)text onLink:(id)link completion:(id)completion {
+    ApolloWebJSONNoteCommentWriteClient(self);
+    return %orig;
+}
+
+- (id)submitComment:(id)text asReplyToComment:(id)parent completion:(id)completion {
+    ApolloWebJSONNoteCommentWriteClient(self);
+    return %orig;
+}
+
+- (id)submitComment:(id)text onThingWithFullName:(id)fullName completion:(id)completion {
+    ApolloWebJSONNoteCommentWriteClient(self);
+    return %orig;
+}
+
+- (id)editComment:(id)comment newText:(id)text completion:(id)completion {
+    ApolloWebJSONNoteCommentWriteClient(self);
+    return %orig;
+}
+
 %end
 
 // Comment writes (/api/editusertext, /api/comment) can come back in the legacy

--- a/src/ApolloWebJSONIdentity.xm
+++ b/src/ApolloWebJSONIdentity.xm
@@ -796,7 +796,7 @@ static id ApolloWebJSONThingProperty(id thing, SEL selector) {
 // the typed target (link / parent comment).
 
 - (id)submitComment:(id)text onLink:(id)link completion:(id)completion {
-    ApolloWebJSONNoteCommentWriteContext(self,
+    ApolloWebJSONNoteCommentWriteContext(self, text,
                                          ApolloWebJSONThingProperty(link, @selector(subreddit)),
                                          ApolloWebJSONThingProperty(link, @selector(subredditFullName)),
                                          ApolloWebJSONThingProperty(link, @selector(fullName)),
@@ -808,7 +808,7 @@ static id ApolloWebJSONThingProperty(id thing, SEL selector) {
 }
 
 - (id)submitComment:(id)text asReplyToComment:(id)parent completion:(id)completion {
-    ApolloWebJSONNoteCommentWriteContext(self,
+    ApolloWebJSONNoteCommentWriteContext(self, text,
                                          ApolloWebJSONThingProperty(parent, @selector(subreddit)),
                                          ApolloWebJSONThingProperty(parent, @selector(subredditID)),
                                          ApolloWebJSONThingProperty(parent, @selector(linkID)),
@@ -825,7 +825,7 @@ static id ApolloWebJSONThingProperty(id thing, SEL selector) {
     if (![[NSThread currentThread].threadDictionary[kApolloWebJSONTypedWriteScopeKey] boolValue]) {
         NSString *target = [fullName isKindOfClass:[NSString class]] ? fullName : nil;
         BOOL targetIsLink = [target hasPrefix:@"t3_"];
-        ApolloWebJSONNoteCommentWriteContext(self, nil, nil,
+        ApolloWebJSONNoteCommentWriteContext(self, text, nil, nil,
                                              targetIsLink ? target : nil,
                                              targetIsLink ? nil : target);
     }
@@ -833,7 +833,7 @@ static id ApolloWebJSONThingProperty(id thing, SEL selector) {
 }
 
 - (id)editComment:(id)comment newText:(id)text completion:(id)completion {
-    ApolloWebJSONNoteCommentWriteContext(self,
+    ApolloWebJSONNoteCommentWriteContext(self, text,
                                          ApolloWebJSONThingProperty(comment, @selector(subreddit)),
                                          ApolloWebJSONThingProperty(comment, @selector(subredditID)),
                                          ApolloWebJSONThingProperty(comment, @selector(linkID)),

--- a/src/ApolloWebJSONIdentity.xm
+++ b/src/ApolloWebJSONIdentity.xm
@@ -692,6 +692,21 @@ void ApolloWebJSONRepairPoisonedAccountBlobs(void) {
               (unsigned long)repaired);
 }
 
+// The typed submit entry points tail-call submitComment:onThingWithFullName:
+// on the same thread; this flag keeps that inner call from clobbering the
+// richer write-context capture (same pattern as ApolloOwnCommentFlair's
+// typed-submit scope).
+static NSString *const kApolloWebJSONTypedWriteScopeKey = @"ApolloWebJSONTypedWriteScope";
+
+// String-typed property read tolerant of foreign/odd objects.
+static id ApolloWebJSONThingProperty(id thing, SEL selector) {
+    if (![thing respondsToSelector:selector]) return nil;
+    id value = nil;
+    @try { value = ((id (*)(id, SEL))objc_msgSend)(thing, selector); }
+    @catch (__unused NSException *e) { return nil; }
+    return [value isKindOfClass:[NSString class]] ? value : nil;
+}
+
 %hook RDKClient
 
 // When the loaded account installs its currentUser (RDKMe) without a username,
@@ -771,29 +786,58 @@ void ApolloWebJSONRepairPoisonedAccountBlobs(void) {
 }
 
 // The write-response repair (ApolloWebJSONFixupWriteResponseObject) may need to
-// know WHO a degraded /api/comment / /api/editusertext response belongs to.
+// know WHO a degraded /api/comment / /api/editusertext response belongs to and
+// WHERE it landed (the wild degraded payload strips subreddit/link_id too,
+// which blanks the own-flair pill and the moderator shield on the fresh cell).
 // The active account is the wrong answer when the composer posted as a
 // different account (temporaryPostingAccount), so capture the identity at
 // submit time from the client itself — each account owns its own RDKClient,
-// making self.currentUser the true posting identity.
+// making self.currentUser the true posting identity — and the location from
+// the typed target (link / parent comment).
 
 - (id)submitComment:(id)text onLink:(id)link completion:(id)completion {
-    ApolloWebJSONNoteCommentWriteClient(self);
-    return %orig;
+    ApolloWebJSONNoteCommentWriteContext(self,
+                                         ApolloWebJSONThingProperty(link, @selector(subreddit)),
+                                         ApolloWebJSONThingProperty(link, @selector(subredditFullName)),
+                                         ApolloWebJSONThingProperty(link, @selector(fullName)),
+                                         nil);
+    [NSThread currentThread].threadDictionary[kApolloWebJSONTypedWriteScopeKey] = @YES;
+    id result = %orig;
+    [[NSThread currentThread].threadDictionary removeObjectForKey:kApolloWebJSONTypedWriteScopeKey];
+    return result;
 }
 
 - (id)submitComment:(id)text asReplyToComment:(id)parent completion:(id)completion {
-    ApolloWebJSONNoteCommentWriteClient(self);
-    return %orig;
+    ApolloWebJSONNoteCommentWriteContext(self,
+                                         ApolloWebJSONThingProperty(parent, @selector(subreddit)),
+                                         ApolloWebJSONThingProperty(parent, @selector(subredditID)),
+                                         ApolloWebJSONThingProperty(parent, @selector(linkID)),
+                                         ApolloWebJSONThingProperty(parent, @selector(fullName)));
+    [NSThread currentThread].threadDictionary[kApolloWebJSONTypedWriteScopeKey] = @YES;
+    id result = %orig;
+    [[NSThread currentThread].threadDictionary removeObjectForKey:kApolloWebJSONTypedWriteScopeKey];
+    return result;
 }
 
 - (id)submitComment:(id)text onThingWithFullName:(id)fullName completion:(id)completion {
-    ApolloWebJSONNoteCommentWriteClient(self);
+    // Only when reached directly: the typed entry points above already captured
+    // a richer context and tail-call through here on the same thread.
+    if (![[NSThread currentThread].threadDictionary[kApolloWebJSONTypedWriteScopeKey] boolValue]) {
+        NSString *target = [fullName isKindOfClass:[NSString class]] ? fullName : nil;
+        BOOL targetIsLink = [target hasPrefix:@"t3_"];
+        ApolloWebJSONNoteCommentWriteContext(self, nil, nil,
+                                             targetIsLink ? target : nil,
+                                             targetIsLink ? nil : target);
+    }
     return %orig;
 }
 
 - (id)editComment:(id)comment newText:(id)text completion:(id)completion {
-    ApolloWebJSONNoteCommentWriteClient(self);
+    ApolloWebJSONNoteCommentWriteContext(self,
+                                         ApolloWebJSONThingProperty(comment, @selector(subreddit)),
+                                         ApolloWebJSONThingProperty(comment, @selector(subredditID)),
+                                         ApolloWebJSONThingProperty(comment, @selector(linkID)),
+                                         nil);
     return %orig;
 }
 


### PR DESCRIPTION
when you post a comment it shows up basically blank until you leave the page and come back - no avatar/username, no flair, score shows 0 instead of 1 and the timestamp says 56.6y lol. happens in both api key mode and api-key-free mode, and it seems to favor the **first comment after a cold app start** (reddit throws "please wait for verification" challenges at fresh sessions, and the degraded responses show up in that same window). narwhal got hit by the same thing so it's a reddit side thing that comes and goes.

turns out reddit degrades the `/api/comment` (and `/api/editusertext`) write response in **two different ways**, and apollo's redditkit renders a blank comment for both:

1. **full legacy shape** - the old-reddit `{parent, content:"<html>", contentText...}` payload with no author/created/score fields at all. www always answers this way (api-key-free mode), and since aug 2026 oauth.reddit.com intermittently does it too. we already had a repair for this but it was gated to web-session accounts only, so api key accounts never got it.
2. **partial modern shape** - looks normal (body present) but stripped down to ~36 of the healthy ~86 keys: author/created_utc/score AND the thing's location (subreddit/subreddit_id/link_id/parent_id/permalink) are all missing. caught in the wild on device twice: first as the blank comment (build with fix 1 only), then as a comment that rendered fine except the flair pill and mod shield - an empty subreddit silently disables both.

what this PR does:

- runs the write-response repair in **every auth mode**, not just web-session accounts
- **legacy shape**: rebuilt into the modern object via local synthesis (creates) or authoritative info.json refetch (edits), author taken from reddit's own `data-author` attribute in the legacy html
- **partial modern shape**: merge-fills ONLY the missing render-critical fields (author / created / score-with-self-upvote on creates, plus subreddit/link_id/parent_id/permalink from the write context captured at submit time - the flair backfill and mod shield both need the comment's subreddit). fields that are present are never touched, so healthy responses stay byte-identical - strict no-op
- gated to actual comments: PM/chat replies flow through `/api/comment` as t4 things whose healthy data legitimately carries `score:0`/`likes:null`, and they stay untouched
- `body:null` routes to the legacy synthesis (rebuilds the body from contentText); edits prefer the info.json refetch over optimistic values
- the author used for a repair is captured from the submitting RDKClient at write time, so posting as a non-active account via the composer's account chooser still labels correctly
- **every repair logs** (`Filled missing ...` / `Rebuilt ...`) so if reddit ever invents a third shape, one log export shows exactly what arrived instead of failing silently
- test tooling (sim-only, opt-in): `APOLLO_COMMENT_DEBUG=1 scripts/run-in-sim.sh` + launch args `-ApolloSimulateLegacyCommentResponse YES` / `-ApolloSimulatePartialCommentResponse YES` replay either degraded shape against real responses on demand

tested in the sim across the full matrix (api key mode with each degraded shape replayed over the real oauth response, api-key-free against the genuine www legacy response, plus a healthy-response run confirming the strict no-op): comment renders fully right away every time - avatar, username, flair backfill, score 1, proper timestamp. top-level comments and replies both covered.

| before (main, api key + legacy response) | after (this PR, same setup) |
|---|---|
| <img width="380" alt="before" src="https://github.com/user-attachments/assets/e789c296-2765-4360-a935-93e5406caa3c" /> | <img width="380" alt="after" src="https://github.com/user-attachments/assets/086e520d-bbda-4c03-9812-b0b7ca416dd3" /> |

both screenshots are the same thread on the sim, api key mode, posting a fresh comment with the degraded response active - fun detail: on plain main the fieldless comment even gets picked up by the deleted comments feature and renders as "DELETED BY USER".

device test of the partial-modern repair is pending (it needs reddit to be in one of its moods, which is exactly why the repair logs now - a cold start + first comment + log export settles it either way).

