### PR TITLE
Add option to use Apple's Translate sheet for the Translate button

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,8 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloShareAsImagePreviewFix.xm \
     $(SRC_DIR)/ApolloTranslation.xm \
     $(SRC_DIR)/ApolloAppleTranslation.swift \
+    $(SRC_DIR)/ApolloAppleTranslateSheet.swift \
+    $(SRC_DIR)/ApolloAppleTranslateSheet.xm \
     $(SRC_DIR)/ApolloVideoUnmute.xm \
     $(SRC_DIR)/ApolloVideoSwipeFix.xm \
     $(SRC_DIR)/ApolloVideoPlaybackSpeed.xm \

--- a/src/ApolloAppleTranslateSheet.swift
+++ b/src/ApolloAppleTranslateSheet.swift
@@ -1,0 +1,152 @@
+//
+//  ApolloAppleTranslateSheet.swift
+//  Apollo-Reborn
+//
+//  Presents iOS's native Translate sheet (Translation.framework) as an
+//  alternative to Apollo's OWN Translate button, which normally opens
+//  `_TtC6Apollo24TranslatorViewController` — a `WKWebView` loading
+//  translate.google.com. `ApolloAppleTranslateSheet.xm` intercepts that
+//  presentation and calls into this file when the user has opted in.
+//
+//  NOT guaranteed on-device. Unlike ApolloAppleTranslationCoordinator below,
+//  which only ever drives a headless `TranslationSession` against already-
+//  installed models, `.translationPresentation` is a system UI that may, by
+//  default, send the text to Apple's servers to translate (confirmed on-device:
+//  the sheet shows its own one-time "will be sent to Apple to process" consent
+//  prompt) unless the user has enabled offline-only translation in the system
+//  Translate app's settings. Don't describe this feature as private in any
+//  user-facing copy.
+//
+//  Why a hidden SwiftUI host? Same reason as ApolloAppleTranslation.swift: Apple's
+//  Translate UI has no UIKit entry point. It's exposed ONLY as the SwiftUI view
+//  modifier `.translationPresentation(isPresented:text:)`, so a real (if invisible)
+//  SwiftUI view has to exist in the hierarchy to carry it.
+//
+//  This is deliberately a SEPARATE host from ApolloAppleTranslationCoordinator's
+//  (ApolloAppleTranslation.swift) — that one is a long-lived singleton whose
+//  re-renders are load-bearing for vending `TranslationSession`s for the bulk
+//  in-place pipeline. This one is short-lived: it exists only for the duration of
+//  one Translate-button tap and tears itself down when the sheet is dismissed.
+//
+//  `.translationPresentation` is available from iOS 17.4 — earlier than the iOS
+//  18.0 floor `TranslationSession`/`.translationTask` need in the other file — so
+//  this feature has its own, lower availability gate.
+//
+
+import Foundation
+
+#if canImport(Translation) && canImport(SwiftUI) && canImport(UIKit)
+import UIKit
+import SwiftUI
+import Translation
+import os
+
+@available(iOS 17.4, *)
+private let appleTranslateSheetLog = Logger(subsystem: "apollofix", category: "AppleTranslateSheet")
+
+// MARK: - Hidden host
+
+/// Sized to fill the presenter's view (not a 1x1 pixel) so that on iPad — where
+/// `.translationPresentation` shows a POPOVER rather than a sheet — it anchors
+/// somewhere reasonable instead of the top-left corner.
+@available(iOS 17.4, *)
+private struct ApolloTranslateSheetHost: View {
+    let text: String
+    let onDismiss: () -> Void
+    @State private var isPresented = false
+
+    var body: some View {
+        Color.clear
+            .translationPresentation(isPresented: $isPresented, text: text)
+            .onAppear { isPresented = true }
+            .onChange(of: isPresented) { _, presented in
+                if !presented { onDismiss() }
+            }
+    }
+}
+
+/// Owns the hidden host's lifecycle. Not actor-isolated: every entry point here is
+/// only ever reached synchronously from the main-thread `presentViewController:`
+/// hook in ApolloAppleTranslateSheet.xm, and touches only UIKit view-hierarchy
+/// APIs (no async Translation-framework calls happen in this file).
+@available(iOS 17.4, *)
+private final class ApolloTranslateSheetPresentation {
+    private weak var hosting: UIHostingController<ApolloTranslateSheetHost>?
+
+    /// Only one sheet host at a time — a second tap while one is already up
+    /// declines, so the caller falls back to Apollo's web view rather than this
+    /// file stacking a second hidden host.
+    private var isActive: Bool { hosting != nil }
+
+    func present(_ text: String, from presenter: UIViewController) -> Bool {
+        guard !isActive else {
+            appleTranslateSheetLog.log("Apple translate sheet already active; declining second presentation")
+            return false
+        }
+
+        let host = UIHostingController(
+            rootView: ApolloTranslateSheetHost(text: text, onDismiss: { [weak self] in
+                self?.teardown()
+            })
+        )
+        host.view.frame = presenter.view.bounds
+        host.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        host.view.backgroundColor = .clear
+        host.view.isUserInteractionEnabled = false
+
+        presenter.addChild(host)
+        presenter.view.addSubview(host.view)
+        host.didMove(toParent: presenter)
+
+        hosting = host
+        appleTranslateSheetLog.log("presented Apple translate sheet for \(text.count, privacy: .public) chars")
+        return true
+    }
+
+    private func teardown() {
+        guard let host = hosting else { return }
+        host.willMove(toParent: nil)
+        host.view.removeFromSuperview()
+        host.removeFromParent()
+        hosting = nil
+        appleTranslateSheetLog.log("Apple translate sheet dismissed")
+    }
+}
+
+@available(iOS 17.4, *)
+private let sharedPresentation = ApolloTranslateSheetPresentation()
+
+#endif
+
+// MARK: - Objective-C bridge
+
+/// Stable, always-present Objective-C entry point — defined unconditionally (no
+/// `@available` on the class) so the generated `ApolloReborn-Swift.h` always
+/// declares it; the iOS-17.4 gate lives inside each method. Mirrors
+/// `ApolloAppleTranslator` in ApolloAppleTranslation.swift.
+@objc(ApolloAppleTranslateSheet)
+public final class ApolloAppleTranslateSheet: NSObject {
+
+    /// Whether the native Translate sheet (Translation.framework's
+    /// `.translationPresentation`) can be presented on this OS.
+    @objc public static func isSupported() -> Bool {
+        #if canImport(Translation) && canImport(SwiftUI) && canImport(UIKit)
+        if #available(iOS 17.4, *) { return true }
+        #endif
+        return false
+    }
+
+    /// Presents the native Translate sheet for `text`, hosted as a hidden child of
+    /// `presenter`. Returns NO (declining) when unsupported, `text` is empty, or a
+    /// sheet is already active — the caller should fall back to Apollo's own web
+    /// view in that case.
+    @objc public static func present(_ text: String, from presenter: UIViewController) -> Bool {
+        guard !text.isEmpty else { return false }
+        #if canImport(Translation) && canImport(SwiftUI) && canImport(UIKit)
+        if #available(iOS 17.4, *) {
+            return sharedPresentation.present(text, from: presenter)
+        }
+        #endif
+        return false
+    }
+}

--- a/src/ApolloAppleTranslateSheet.xm
+++ b/src/ApolloAppleTranslateSheet.xm
@@ -1,0 +1,133 @@
+// ApolloAppleTranslateSheet
+//
+// Lets the user redirect Apollo's OWN Translate button (the native action-sheet
+// item shown on comment/post long-press) to iOS's native Translate sheet
+// instead of Apollo's built-in Google Translate web view.
+//
+// NOTE: unlike the headless TranslationSession API the bulk in-place pipeline
+// uses (ApolloAppleTranslation.swift), this sheet is NOT guaranteed on-device.
+// `.translationPresentation` may send the text to Apple's servers to translate
+// by default — Apple's own sheet shows a one-time "will be sent to Apple"
+// consent prompt for this — unless the user has turned on offline-only
+// translation in the system Translate app's settings. Don't describe this
+// setting as private/on-device in UI copy; see the Settings footer for the
+// user-facing wording.
+//
+// How Apollo's Translate button works (confirmed in Hopper): it presents
+// `_TtC6Apollo24TranslatorViewController`, whose `viewDidLoad` reads its
+// `textToTranslate` Swift String ivar, builds a translate.google.com URL from it,
+// and loads that into a WKWebView (`webView` ivar) inside a custom
+// pan-to-dismiss presentation (TranslatorPresentationController/
+// TranslatorAnimationController). There's no override point inside that flow —
+// the URL construction and web load both happen in one Swift-compiled function
+// (sub_100661c68 in the class-dump build) with no ObjC-visible seam.
+//
+// Instead we intercept one level up, at the PRESENTATION boundary: %hook
+// UIViewController -presentViewController:animated:completion: (the same
+// suppression pattern as ApolloHideSubscribePrompt.xm), detect that Apollo is
+// about to present a TranslatorViewController, read its still-untranslated
+// textToTranslate ivar off the not-yet-loaded instance, and — when the setting
+// is on and the OS supports it — present Apple's native Translate sheet from the
+// same presenter instead of letting Apollo's web view go up. Falls back to
+// %orig (Apollo's own web view) whenever the Apple sheet isn't available, so
+// this is always safe on older iOS.
+//
+// The actual sheet lives in ApolloAppleTranslateSheet.swift (Translation.framework
+// has no ObjC surface — `.translationPresentation` is a SwiftUI-only modifier).
+// This intentionally does NOT touch the separate bulk in-place translation
+// pipeline (ApolloTranslation.xm) or its own Apple-backed provider
+// (ApolloAppleTranslation.swift) — those already have their own on-device path;
+// this file only concerns Apollo's own Translate action-sheet button.
+
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#include <dlfcn.h>
+#include <string.h>
+
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+
+// Generated umbrella header for this module's Swift compilation units
+// (ApolloAppleTranslation.swift, ApolloAppleTranslateSheet.swift), which vends
+// the @objc ApolloAppleTranslateSheet class used below. Guarded with
+// __has_include so this file still builds if Swift output isn't present yet.
+#if __has_include("ApolloReborn-Swift.h")
+#import "ApolloReborn-Swift.h"
+#define APOLLO_HAS_APPLE_TRANSLATE_SHEET 1
+#else
+#define APOLLO_HAS_APPLE_TRANSLATE_SHEET 0
+#endif
+
+// Local copy of the small-Swift-string decoder, matching the copies already
+// living independently in ApolloTranslation.xm and ApolloNativeActionMenus.xm —
+// this codebase duplicates this helper per-file rather than sharing it.
+// Strings <=15 bytes are packed inline across two registers/words; longer
+// strings fall back to Swift's _bridgeToObjectiveC bridging thunk.
+static NSString *ApolloAppleSheetDecodeSwiftString(uint64_t w0, uint64_t w1) {
+    if (w1 == 0) return nil;
+
+    uint8_t disc = (uint8_t)(w1 >> 56);
+    if (disc >= 0xE0 && disc <= 0xEF) {
+        NSUInteger len = disc - 0xE0;
+        if (len == 0) return @"";
+
+        char buf[16] = {0};
+        memcpy(buf, &w0, 8);
+        uint64_t w1clean = w1 & 0x00FFFFFFFFFFFFFFULL;
+        memcpy(buf + 8, &w1clean, 7);
+        return [[NSString alloc] initWithBytes:buf length:len encoding:NSUTF8StringEncoding];
+    }
+
+    typedef NSString *(*BridgeFn)(uint64_t, uint64_t);
+    static BridgeFn sBridge = NULL;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sBridge = (BridgeFn)dlsym(RTLD_DEFAULT, "$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF");
+    });
+
+    return sBridge ? sBridge(w0, w1) : nil;
+}
+
+// Reads TranslatorViewController's `textToTranslate` Swift String ivar directly
+// off the not-yet-presented instance. Safe to call before -viewDidLoad runs:
+// the ivar is set in -initWithCoder:/-initWithNibName:bundle: (Hopper confirms
+// the class-dump-visible initializers take the text), well before viewDidLoad
+// builds the Google Translate URL from it.
+static NSString *ApolloTranslatorTextToTranslate(id translatorVC) {
+    if (!translatorVC) return nil;
+    Ivar ivar = class_getInstanceVariable(object_getClass(translatorVC), "textToTranslate");
+    if (!ivar) return nil;
+
+    ptrdiff_t offset = ivar_getOffset(ivar);
+    uint8_t *base = (uint8_t *)(__bridge void *)translatorVC;
+    uint64_t w0 = *(uint64_t *)(base + offset);
+    uint64_t w1 = *(uint64_t *)(base + offset + 0x08);
+    return ApolloAppleSheetDecodeSwiftString(w0, w1);
+}
+
+%hook UIViewController
+
+- (void)presentViewController:(UIViewController *)viewControllerToPresent
+                     animated:(BOOL)animated
+                   completion:(void (^)(void))completion {
+    if (sAppleTranslateSheet &&
+        [viewControllerToPresent isKindOfClass:objc_getClass("_TtC6Apollo24TranslatorViewController")]) {
+#if APOLLO_HAS_APPLE_TRANSLATE_SHEET
+        NSString *text = ApolloTranslatorTextToTranslate(viewControllerToPresent);
+        if (text.length > 0 && [ApolloAppleTranslateSheet isSupported] &&
+            [ApolloAppleTranslateSheet present:text from:self]) {
+            ApolloLog(@"[AppleTranslateSheet] Presented Apple's Translate sheet for %lu chars instead of Apollo's Google web view",
+                       (unsigned long)text.length);
+            // Honor the presentation contract: Apollo passes nil here, but a
+            // future/other caller might not, and we're standing in for a real
+            // presentation.
+            if (completion) completion();
+            return;
+        }
+        ApolloLog(@"[AppleTranslateSheet] Falling back to Apollo's Google Translate web view (unsupported OS, empty text, or a sheet is already up)");
+#endif
+    }
+    %orig;
+}
+
+%end

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -366,6 +366,9 @@ extern NSString *sLibreTranslateURL;
 extern NSString *sLibreTranslateAPIKey;
 // Lowercased 2-letter language codes the user has opted out of translating.
 extern NSArray<NSString *> *sTranslationSkipLanguages;
+// Redirects Apollo's own Translate button to iOS's on-device Translate sheet
+// instead of Apollo's Google Translate web view. See UDKeyAppleTranslateSheet.
+extern BOOL sAppleTranslateSheet;
 
 #ifdef __OBJC__
 // Whether the on-device Apple translation backend (ApolloAppleTranslation.swift,

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -109,6 +109,7 @@ NSString *sTranslationProvider = nil;
 NSString *sLibreTranslateURL = nil;
 NSString *sLibreTranslateAPIKey = nil;
 NSArray<NSString *> *sTranslationSkipLanguages = nil;
+BOOL sAppleTranslateSheet = NO;
 
 BOOL sWebJSONEnabled = NO;
 BOOL sPollsFeatureEnabled = NO;

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -3312,6 +3312,7 @@ static void initializeRandomSources() {
                                     UDKeyLibreTranslateURL: @"https://libretranslate.de/translate",
                                     UDKeyLibreTranslateAPIKey: @"",
                                     UDKeyTranslationSkipLanguages: @[],
+                                    UDKeyAppleTranslateSheet: @NO,
                                     UDKeyEnableAISummaries: @NO,
                                     UDKeyEnableAIPostSummaries: @YES,
                                     UDKeyEnableAICommentSummaries: @YES,
@@ -3602,6 +3603,8 @@ static void initializeRandomSources() {
         }
         sTranslationSkipLanguages = [clean copy];
     }
+
+    sAppleTranslateSheet = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyAppleTranslateSheet];
 
     // Web JSON: read the flag here, but defer the keychain-backed
     // cookie/modhash/username hydration until AFTER the SecItem fishhooks are

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -271,6 +271,14 @@ static NSString *const UDKeyLibreTranslateURL = @"LibreTranslateURL";
 static NSString *const UDKeyLibreTranslateAPIKey = @"LibreTranslateAPIKey";
 // Array<String> of 2-letter language codes to leave untranslated (detected source language).
 static NSString *const UDKeyTranslationSkipLanguages = @"TranslationSkipLanguages";
+// Redirects Apollo's OWN Translate button (the native action-sheet item on
+// comments/posts, which normally opens Apollo's Google Translate web view) to
+// iOS's on-device Translate sheet instead. Independent of UDKeyTranslationProvider,
+// which governs the tweak's separate bulk in-place translation backend, not this
+// button. Requires iOS 17.4+ (Translation.framework's .translationPresentation);
+// has no effect while Bulk Translation is on, since that already removes the
+// native Translate action from the sheet. Default OFF via registerDefaults.
+static NSString *const UDKeyAppleTranslateSheet = @"AppleTranslateSheet";
 
 // On-device AI summaries (Apple FoundationModels, iOS 26+). Off by default.
 static NSString *const UDKeyEnableAISummaries = @"EnableAISummaries";

--- a/src/settings/TranslationSettingsViewController.m
+++ b/src/settings/TranslationSettingsViewController.m
@@ -247,17 +247,42 @@ static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguag
         }
                                   onSelect:nil];
 
-    return @[
+    NSMutableArray<ApolloSettingsSection *> *sections = [NSMutableArray array];
+    [sections addObject:
         [ApolloSettingsSection sectionWithTitle:@"General"
                                          footer:@"Translates comments in place, and optionally post titles. Translation Mode sets how it kicks in:\n\n• Automatic — opens everything already translated.\n• Tap to Translate — keeps the original language and shows a tappable \"Translate\" line under comments plus a language marker next to post stats; tap to translate that item, tap again to switch back.\n• Manual (Globe) — nothing is translated until you tap the globe per feed or thread.\n\nThe Details toggles control the \"Translated from …\" lines and language markers. Match App Colour tints them with your theme's accent instead of green."
-                                           rows:@[ enableBulk, translationMode, translateTitles, showDetails, titleDetails, markerColor, targetLanguage, provider ]],
+                                           rows:@[ enableBulk, translationMode, translateTitles, showDetails, titleDetails, markerColor, targetLanguage, provider ]]];
+
+    // Apollo's own Translate button (the native action-sheet item on comment/post
+    // long-press) is unrelated to the bulk pipeline above, so it gets its own
+    // section rather than a row gated on sEnableBulkTranslation. Only built at
+    // all when the OS can present Apple's sheet (iOS 17.4+) — the framework has
+    // no way to hide a whole section, so an unsupported OS would otherwise leave
+    // a header/footer floating over zero rows.
+#if APOLLO_HAS_APPLE_TRANSLATE
+    if ([ApolloAppleTranslateSheet isSupported]) {
+        ApolloSettingsRow *appleSheet =
+            [ApolloSettingsRow switchRowWithID:@"appleSheet"
+                                         title:@"Use Apple Translate Sheet"
+                                          isOn:^BOOL { return sAppleTranslateSheet; }
+                                      onToggle:^(UISwitch *sender) { [weakSelf appleTranslateSheetSwitchToggled:sender]; }];
+        [sections addObject:
+            [ApolloSettingsSection sectionWithTitle:@"Context Menu"
+                                             footer:@"Opens iOS's native Translate sheet on the Translate action instead of a Google Translate page. Unlike the Apple provider above, this isn't always on-device; iOS may send text to Apple's servers unless offline-only translation is enabled in the system Translate app."
+                                               rows:@[ appleSheet ]]];
+    }
+#endif
+
+    [sections addObject:
         [ApolloSettingsSection sectionWithTitle:@"Don't Translate"
                                          footer:@"Posts and comments detected as one of these languages will be left in their original form. Mixed-language text is still translated so embedded foreign words come through."
-                                           rows:skipRows],
+                                           rows:skipRows]];
+    [sections addObject:
         [ApolloSettingsSection sectionWithTitle:@"LibreTranslate"
                                          footer:@"Google is the default provider. If Google or LibreTranslate fails, the tweak automatically falls back to the other one. Apple (On-Device) translates privately on your device with no network — it stays Apple (no fallback) and will ask you to download a language the first time it's needed (iOS 18+). The settings below configure the LibreTranslate endpoint."
-                                           rows:@[ libreURL, libreAPIKey ]],
-    ];
+                                           rows:@[ libreURL, libreAPIKey ]]];
+
+    return sections;
 }
 
 #pragma mark - Helpers
@@ -768,6 +793,14 @@ static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguag
     [[NSUserDefaults standardUserDefaults] setBool:sTranslationMarkerUseThemeColor forKey:UDKeyTranslationMarkerUseThemeColor];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"ApolloShowTranslationDetailsChanged" object:nil];
     [[NSNotificationCenter defaultCenter] postNotificationName:ApolloRichPreviewTranslationDidUpdateNotification object:nil userInfo:ApolloRichPreviewSettingsChangeUserInfo()];
+}
+
+- (void)appleTranslateSheetSwitchToggled:(UISwitch *)sender {
+    sAppleTranslateSheet = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sAppleTranslateSheet forKey:UDKeyAppleTranslateSheet];
+    // No live-update notification needed: ApolloAppleTranslateSheet.xm reads
+    // sAppleTranslateSheet fresh at the moment Apollo presents its Translate
+    // sheet, not at some earlier cached point.
 }
 
 - (void)translatePostTitlesSwitchToggled:(UISwitch *)sender {


### PR DESCRIPTION
## Summary
Adds an opt-in setting that redirects Apollo's own Translate action (long-press or click 3 dots on a comment or post) to iOS's native Translate sheet instead of Apollo's built-in Google Translate web view.

Implements https://request.apolloreborn.app/posts/40/re-enable-apollos-original-translate-post-comment-feature-and-support-apple-translate.

## Impact
- New "Use Apple Translate Sheet" toggle under Settings > Translation > Context Menu, shown only on iOS 17.4+.
- When enabled, tapping Translate on a comment or post opens the system Translate sheet instead of Apollo's Google Translate web view.
- Not guaranteed fully on-device: unlike the existing Apple provider used for bulk translation, this sheet may send text to Apple's servers by default (Apple shows its own one-time consent prompt for this) unless offline-only translation is enabled in the system Translate app.

## Changes
- `src/ApolloAppleTranslateSheet.swift`: new `@objc` bridge (`ApolloAppleTranslateSheet`) hosting a hidden SwiftUI view carrying `.translationPresentation(isPresented:text:)`, since Apple only exposes the sheet via SwiftUI.
- `src/ApolloAppleTranslateSheet.xm`: hooks `-[UIViewController presentViewController:animated:completion:]` to detect Apollo's `TranslatorViewController` before it presents, reads its `textToTranslate` ivar directly off the instance, and swaps in the Apple sheet when the setting is on and supported, falling back to Apollo's web view otherwise.
- `src/settings/TranslationSettingsViewController.m`: new "Context Menu" section with the toggle, built only when `ApolloAppleTranslateSheet.isSupported()` since the settings form has no per-section visibility gate.
- `UserDefaultConstants.h` / `ApolloState.h` / `ApolloState.m` / `Tweak.xm`: new `UDKeyAppleTranslateSheet` / `sAppleTranslateSheet` following the standard settings key/global/default pattern, off by default.
- `Makefile`: registers the two new source files.

## Reasoning
Apple's Translate sheet has no UIKit entry point (`.translationPresentation` is SwiftUI-only), so a hidden `UIHostingController` bridges it into the existing UIKit action-sheet flow, the same pattern already used for the bulk on-device translation provider. Interception happens at presentation time rather than patching `TranslatorViewController` itself, since its URL-building and web-load logic is compiled Swift with no ObjC-visible seam. The settings footer calls out that this sheet isn't guaranteed on-device: testing surfaced that `.translationPresentation` shows its own "will be sent to Apple to process" consent prompt and may use Apple's servers by default.

## Testing
Manually verified on device: toggling the setting redirects the comment/post Translate action to the native sheet, and falls back to Apollo's web view when off. Verified via `scripts/run-in-sim.sh --glass` that the module compiles and loads cleanly in the simulator.