### PR TITLE
Fix iOS 27 lists stuck under the tab bar (both IPA variants) and hide-bars stutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ liquid-glass/scripts/cartool
 
 AsyncDisplayKit.framework/
 docs/
-iPhone18-3_26.1_23B85_Restore/*
+iPhone18-3_26.1_23B85_Restore/
 iOS26-Runtime-Headers/
 
 # Reborn Widgets (xcodegen) — track project.yml + Sources/ only.

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloModmailLayout.xm \
     $(SRC_DIR)/ApolloModmailSubjectCounter.xm \
     $(SRC_DIR)/ApolloAutoHideTabBar.xm \
+    $(SRC_DIR)/ApolloListLayoutDiagnostics.xm \
     $(SRC_DIR)/ApolloTabBarCollapseSide.xm \
     $(SRC_DIR)/ApolloIPadTabBarBottom.xm \
     $(SRC_DIR)/ApolloScrollEdgeEffect.xm \

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,6 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloModmailSubjectCounter.xm \
     $(SRC_DIR)/ApolloAutoHideTabBar.xm \
     $(SRC_DIR)/ApolloListBottomInsetGuard.xm \
-    $(SRC_DIR)/ApolloListLayoutDiagnostics.xm \
     $(SRC_DIR)/ApolloTabBarCollapseSide.xm \
     $(SRC_DIR)/ApolloIPadTabBarBottom.xm \
     $(SRC_DIR)/ApolloScrollEdgeEffect.xm \

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloModmailLayout.xm \
     $(SRC_DIR)/ApolloModmailSubjectCounter.xm \
     $(SRC_DIR)/ApolloAutoHideTabBar.xm \
+    $(SRC_DIR)/ApolloListBottomInsetGuard.xm \
     $(SRC_DIR)/ApolloListLayoutDiagnostics.xm \
     $(SRC_DIR)/ApolloTabBarCollapseSide.xm \
     $(SRC_DIR)/ApolloIPadTabBarBottom.xm \

--- a/src/ApolloAutoHideTabBar.xm
+++ b/src/ApolloAutoHideTabBar.xm
@@ -477,6 +477,12 @@ static void ApolloHideTabBar(UITabBarController *tbc, BOOL animated) {
     UITabBar *tabBar = tbc.tabBar;
     if (tabBar.hidden) return;
 
+    // Preserve the stable visible-bar baseline before the legacy hide changes
+    // safe-area geometry. The settled show verifier can then restore exactly
+    // the prior list-specific value (including comments' extra), without a
+    // permanent setContentInset observer. This retains issue #809 protection.
+    ApolloListCaptureHealthyBottomForVisibleLists(@"legacyTabBarWillHide");
+
     ApolloLog(@"[AutoHideTabBarFix] Hide (animated=%d)", animated);
 
     SEL setHiddenSelector = NSSelectorFromString(@"setTabBarHidden:animated:");

--- a/src/ApolloAutoHideTabBar.xm
+++ b/src/ApolloAutoHideTabBar.xm
@@ -83,10 +83,22 @@ static BOOL ApolloSupportsNativeTabBarMinimize(void) {
     return supported;
 }
 
-static void ApolloApplyMinimizeBehavior(UITabBarController *tbc, ApolloTabBarMinimizeBehavior behavior) {
+static NSInteger ApolloCurrentMinimizeBehavior(UITabBarController *tbc) {
+    SEL getter = NSSelectorFromString(@"tabBarMinimizeBehavior");
+    if (!tbc || ![tbc respondsToSelector:getter]) return NSNotFound;
+    return ((NSInteger (*)(id, SEL))objc_msgSend)(tbc, getter);
+}
+
+static void ApolloApplyMinimizeBehaviorInternal(UITabBarController *tbc,
+                                                ApolloTabBarMinimizeBehavior behavior,
+                                                BOOL reconcileUIKitState) {
     if (!tbc || !ApolloSupportsNativeTabBarMinimize()) return;
     NSNumber *lastApplied = objc_getAssociatedObject(tbc, &kApolloAppliedMinimizeBehaviorKey);
-    if ([lastApplied isKindOfClass:[NSNumber class]] && lastApplied.integerValue == (NSInteger)behavior) return;
+    if ([lastApplied isKindOfClass:[NSNumber class]] &&
+        lastApplied.integerValue == (NSInteger)behavior) {
+        if (!reconcileUIKitState) return;
+        if (ApolloCurrentMinimizeBehavior(tbc) == (NSInteger)behavior) return;
+    }
 
     SEL sel = ApolloMinimizeBehaviorSetter();
     NSMethodSignature *sig = [tbc methodSignatureForSelector:sel];
@@ -98,8 +110,17 @@ static void ApolloApplyMinimizeBehavior(UITabBarController *tbc, ApolloTabBarMin
     [inv setArgument:&raw atIndex:2];
     [inv invoke];
     objc_setAssociatedObject(tbc, &kApolloAppliedMinimizeBehaviorKey, @(raw), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    ApolloLog(@"[AutoHideTabBarFix] Native tabBarMinimizeBehavior=%ld on %@",
-              (long)raw, NSStringFromClass([tbc class]));
+    ApolloLog(@"[AutoHideTabBarFix] Native tabBarMinimizeBehavior=%ld reconcile=%d on %@",
+              (long)raw, reconcileUIKitState, NSStringFromClass([tbc class]));
+}
+
+static void ApolloApplyMinimizeBehavior(UITabBarController *tbc,
+                                        ApolloTabBarMinimizeBehavior behavior) {
+    // This helper is reached from scroll callbacks and Apollo's repeated
+    // hidesBarsOnSwipe configuration. Trust our requested-value cache here:
+    // consulting UIKit's live property on every call made iOS 27 fight us
+    // between .never and .onScrollDown at display-link cadence.
+    ApolloApplyMinimizeBehaviorInternal(tbc, behavior, NO);
 }
 
 static ApolloTabBarMinimizeBehavior ApolloLastAppliedMinimizeBehavior(UITabBarController *tbc) {
@@ -203,6 +224,23 @@ static void ApolloReapplyNativeMinimizeBehavior(UITabBarController *tbc, NSStrin
     ApolloApplyMinimizeBehavior(tbc, behavior);
     ApolloLog(@"[AutoHideTabBarFix] Reapplied native minimize desired=%d idleMode=%d reason=%@",
               anyWantsMinimize, sAutoHideTabBarShowOnIdle, reason ?: @"unknown");
+}
+
+static void ApolloReconcileNativeMinimizeBehaviorAfterActivation(UITabBarController *tbc,
+                                                                 NSString *reason) {
+    if (!tbc || !ApolloSupportsNativeTabBarMinimize()) return;
+
+    BOOL anyWantsMinimize = ApolloTabBarControllerWantsNativeMinimize(tbc);
+    ApolloTabBarMinimizeBehavior behavior = anyWantsMinimize
+        ? ApolloTabBarMinimizeBehaviorOnScrollDown
+        : ApolloTabBarMinimizeBehaviorNever;
+
+    // This is the only path that compares against UIKit's live property. It
+    // runs once after activation, when iOS 27 may have restored stale policy,
+    // and never from scrolling/layout callbacks.
+    ApolloApplyMinimizeBehaviorInternal(tbc, behavior, YES);
+    ApolloLog(@"[AutoHideTabBarFix] Reconciled native minimize desired=%d reason=%@",
+              anyWantsMinimize, reason ?: @"unknown");
 }
 
 static NSString *const ApolloTabBarSlideDownAnimationKey = @"apolloTabBarSlideDown";
@@ -745,13 +783,31 @@ static BOOL sApolloInBarHideSwipeHandler = NO;
 %end
 
 %ctor {
-    [[NSNotificationCenter defaultCenter] addObserverForName:ApolloAutoHideTabBarShowOnIdleChangedNotification
-                                                      object:nil
-                                                       queue:[NSOperationQueue mainQueue]
-                                                  usingBlock:^(__unused NSNotification *notification) {
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    [center addObserverForName:ApolloAutoHideTabBarShowOnIdleChangedNotification
+                        object:nil
+                         queue:[NSOperationQueue mainQueue]
+                    usingBlock:^(__unused NSNotification *notification) {
         ApolloForEachVisibleTabBarController(^(UITabBarController *tbc) {
             ApolloCancelIdleRevealTimer(tbc);
             ApolloReapplyNativeMinimizeBehavior(tbc, @"idleModeChanged");
+        });
+    }];
+
+    // iOS 27 can restore stale tab-bar policy while foregrounding. Reconcile
+    // once, on the next main-queue turn after activation. Repeating this at
+    // will-enter, did-become, and next-turn made the glass transition restart;
+    // putting the live-property comparison in the general apply path was worse
+    // because scroll callbacks then fought UIKit every frame.
+    [center addObserverForName:UIApplicationDidBecomeActiveNotification
+                        object:nil
+                         queue:[NSOperationQueue mainQueue]
+                    usingBlock:^(__unused NSNotification *notification) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            ApolloForEachVisibleTabBarController(^(UITabBarController *tbc) {
+                ApolloReconcileNativeMinimizeBehaviorAfterActivation(
+                    tbc, @"didBecomeActive.nextTurn");
+            });
         });
     }];
 }

--- a/src/ApolloAutoHideTabBar.xm
+++ b/src/ApolloAutoHideTabBar.xm
@@ -4,6 +4,7 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 #import "ApolloCommon.h"
+#import "ApolloListLayoutSupport.h"
 #import "ApolloState.h"
 
 // MARK: - Tab Bar Auto-Hide Reveal Fix
@@ -20,11 +21,13 @@
 //   nav bar stays put (true Liquid Glass feel; native API only minimizes the
 //   tab bar). When the toggle is OFF we restore .never (raw value 1).
 //
-//   Mode B ("Tab Bar Re-Expands When Idle"): same .onScrollDown collapse as
-//   Mode A. A deliberate upward scroll flips to .never so the bar expands and
-//   stays open until the next downward scroll. If the user stops reading with
-//   the pill collapsed we wait a longer idle period before doing the same
-//   restore automatically.
+//   Mode B ("Tab Bar Re-Expands When Idle"): a deliberate short upward drag
+//   switches to .never to fully expand the bar. That reveal is owned by the
+//   gesture which requested it: direction noise within the same gesture cannot
+//   switch back and thrash the safe area. Once that gesture has completely
+//   ended, restore .onScrollDown exactly once so the next downward gesture is
+//   enrolled from its beginning. If the user leaves the pill collapsed, the
+//   longer idle timer still requests an automatic expansion.
 //
 // iOS <26 (legacy mirror):
 //   Apollo's hide-on-swipe hides the bottom UITabBar but never restores it.
@@ -34,6 +37,10 @@
 
 @interface UITabBarController (ApolloHideFix)
 - (void)setTabBarHidden:(BOOL)hidden animated:(BOOL)animated; // private
+@end
+
+@interface UIScrollView (ApolloAutoHidePan)
+- (void)_apolloAutoHideTabBarPanChanged:(UIPanGestureRecognizer *)pan;
 @end
 
 // iOS 26 SDK selector — declared via NSInteger to avoid hard SDK dependency.
@@ -52,15 +59,20 @@ static char kApolloRequestedHidesBarsOnSwipeKey;
 static char kApolloAppliedMinimizeBehaviorKey;
 static char kApolloIdleRevealTimerKey;
 static char kApolloIdleRevealTimerScheduledAtKey;
+static char kApolloCustomRevealActiveKey;
+static char kApolloCustomRevealGestureTokenKey;
+static char kApolloCustomRevealStartedAtKey;
+static char kApolloScrollGestureTokenKey;
 static char kApolloUpwardRevealDistanceKey;
-static char kApolloDownwardCollapseDistanceKey;
+static char kApolloAutoHidePanObserverAttachedKey;
 static char kApolloScrollViewTabBarControllerBoxKey;
 
 static NSString *const ApolloAutoHideTabBarShowOnIdleChangedNotification = @"ApolloAutoHideTabBarShowOnIdleChangedNotification";
 static const NSTimeInterval ApolloIdleRevealDelaySeconds = 30.0;
+static const NSTimeInterval ApolloIdleRevealRearmDelaySeconds = 0.5;
 static const NSTimeInterval ApolloIdleRevealRescheduleInterval = 0.25;
 static const CGFloat ApolloUpwardRevealDistanceThreshold = 120.0;
-static const CGFloat ApolloDownwardCollapseDistanceThreshold = 48.0;
+static NSUInteger sApolloScrollGestureToken = 0;
 
 @interface ApolloAutoHideWeakTabBarControllerBox : NSObject
 @property (nonatomic, weak) UITabBarController *controller;
@@ -123,44 +135,150 @@ static void ApolloApplyMinimizeBehavior(UITabBarController *tbc,
     ApolloApplyMinimizeBehaviorInternal(tbc, behavior, NO);
 }
 
-static ApolloTabBarMinimizeBehavior ApolloLastAppliedMinimizeBehavior(UITabBarController *tbc) {
-    NSNumber *lastApplied = objc_getAssociatedObject(tbc, &kApolloAppliedMinimizeBehaviorKey);
-    if ([lastApplied isKindOfClass:[NSNumber class]]) {
-        return (ApolloTabBarMinimizeBehavior)lastApplied.integerValue;
-    }
-    return ApolloTabBarMinimizeBehaviorNever;
+static BOOL ApolloCustomRevealIsActive(UITabBarController *tbc) {
+    return [objc_getAssociatedObject(tbc, &kApolloCustomRevealActiveKey) boolValue];
 }
 
-static CGFloat ApolloUpwardRevealDistance(UITabBarController *tbc) {
-    NSNumber *distance = objc_getAssociatedObject(tbc, &kApolloUpwardRevealDistanceKey);
-    if ([distance isKindOfClass:[NSNumber class]]) {
-        return (CGFloat)distance.doubleValue;
-    }
-    return 0.0;
-}
-
-static void ApolloSetUpwardRevealDistance(UITabBarController *tbc, CGFloat distance) {
+static void ApolloClearCustomRevealState(UITabBarController *tbc) {
     if (!tbc) return;
-    objc_setAssociatedObject(tbc,
+    objc_setAssociatedObject(tbc, &kApolloCustomRevealActiveKey, nil,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(tbc, &kApolloCustomRevealGestureTokenKey, nil,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(tbc, &kApolloCustomRevealStartedAtKey, nil,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static CGFloat ApolloUpwardRevealDistance(UIScrollView *scrollView) {
+    NSNumber *distance = objc_getAssociatedObject(scrollView, &kApolloUpwardRevealDistanceKey);
+    return [distance isKindOfClass:[NSNumber class]] ? (CGFloat)distance.doubleValue : 0.0;
+}
+
+static void ApolloSetUpwardRevealDistance(UIScrollView *scrollView, CGFloat distance) {
+    if (!scrollView) return;
+    objc_setAssociatedObject(scrollView,
                              &kApolloUpwardRevealDistanceKey,
                              distance > 0.0 ? @(distance) : nil,
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-static CGFloat ApolloDownwardCollapseDistance(UITabBarController *tbc) {
-    NSNumber *distance = objc_getAssociatedObject(tbc, &kApolloDownwardCollapseDistanceKey);
-    if ([distance isKindOfClass:[NSNumber class]]) {
-        return (CGFloat)distance.doubleValue;
-    }
-    return 0.0;
+static NSNumber *ApolloScrollGestureToken(UIScrollView *scrollView) {
+    NSNumber *token = objc_getAssociatedObject(scrollView, &kApolloScrollGestureTokenKey);
+    if ([token isKindOfClass:[NSNumber class]]) return token;
+
+    // The pan target normally stamps the token at .began. Keep this fallback
+    // for scroll-view subclasses which update contentOffset before forwarding
+    // the recognizer callback.
+    token = @(++sApolloScrollGestureToken);
+    objc_setAssociatedObject(scrollView, &kApolloScrollGestureTokenKey, token,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return token;
 }
 
-static void ApolloSetDownwardCollapseDistance(UITabBarController *tbc, CGFloat distance) {
-    if (!tbc) return;
-    objc_setAssociatedObject(tbc,
-                             &kApolloDownwardCollapseDistanceKey,
-                             distance > 0.0 ? @(distance) : nil,
+// Apollo's tab-driving content views are tables/collection views. Text views
+// and WKWebView internals also inherit UIScrollView, but observing every one
+// of those adds several targets per cell/web page and lets a nested editor
+// gesture alter the main tab bar's reveal state. The pan observer AND the
+// custom-reveal trigger must use the same filter: a reveal triggered from an
+// unobserved scroll view would never receive its gesture-end re-arm, leaving
+// .never stuck (no collapse) until the next list gesture's began-branch rescue.
+static BOOL ApolloAutoHideScrollViewParticipates(UIScrollView *scrollView) {
+    return [scrollView isKindOfClass:[UITableView class]] ||
+           [scrollView isKindOfClass:[UICollectionView class]];
+}
+
+static void ApolloEnsureAutoHidePanObserver(UIScrollView *scrollView) {
+    // The observer only powers Mode B's custom upward reveal. Avoid adding a
+    // gesture target to every scroll view for users who leave that mode off.
+    // If it is enabled later, setContentOffset: attaches to the live pan.
+    if (!scrollView || !sAutoHideTabBarShowOnIdle ||
+        !ApolloSupportsNativeTabBarMinimize()) return;
+    if (!ApolloAutoHideScrollViewParticipates(scrollView)) return;
+
+    UIPanGestureRecognizer *pan = scrollView.panGestureRecognizer;
+    if (!pan || objc_getAssociatedObject(pan, &kApolloAutoHidePanObserverAttachedKey)) return;
+
+    objc_setAssociatedObject(pan, &kApolloAutoHidePanObserverAttachedKey, @YES,
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [pan addTarget:scrollView action:@selector(_apolloAutoHideTabBarPanChanged:)];
+
+    // ASTableView can bypass UIScrollView's didMoveToWindow implementation or
+    // replace its recognizer after that callback. If first seen while already
+    // dragging, establish this gesture's token now; the newly attached target
+    // will still receive its eventual ended/cancelled transition.
+    if ((pan.state == UIGestureRecognizerStateBegan ||
+         pan.state == UIGestureRecognizerStateChanged) &&
+        (scrollView.tracking || scrollView.dragging)) {
+        NSNumber *token = @(++sApolloScrollGestureToken);
+        objc_setAssociatedObject(scrollView, &kApolloScrollGestureTokenKey, token,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloSetUpwardRevealDistance(scrollView, 0.0);
+        ApolloLog(@"[AutoHideTabBarFix] Attached live pan observer late scroll=%@ token=%@ state=%ld",
+                  NSStringFromClass(scrollView.class), token, (long)pan.state);
+    } else {
+        ApolloLog(@"[AutoHideTabBarFix] Attached pan observer scroll=%@ state=%ld",
+                  NSStringFromClass(scrollView.class), (long)pan.state);
+    }
+}
+
+// Re-arm .onScrollDown for the reveal owned by `token` once the bar's expand
+// morph has settled (stable target 0, not animating). A behavior write while
+// the morph is in flight restarts the glass transition — the visible stutter
+// this defers around. The token check on every hop hands ownership to the
+// began-branch re-arm if a new gesture starts first; the attempt deadline
+// guarantees the controller can never wedge on .never if the morph state stays
+// unsettled or unreadable.
+static const NSInteger ApolloRearmMaxAttempts = 12; // ~1s at 80ms steps
+// _currentMorphTarget flips to the DESTINATION at animation start, and on
+// iOS 27 the isAnimatingCollapsedState ivar is gone (device logs: animKnown=no)
+// — so "target 0" alone cannot prove the expand finished. The time floor below
+// (measured from when the reveal applied .never) is the reliable settle signal
+// across versions; the glass expand runs ~300ms. Waiting is free: applying
+// .onScrollDown to a settled expanded bar changes nothing visible.
+static const NSTimeInterval ApolloRevealExpandSettleSeconds = 0.45;
+static void ApolloRearmCustomRevealWhenExpanded(UITabBarController *tbc,
+                                                NSNumber *token,
+                                                NSInteger attempt) {
+    __weak UITabBarController *weakTBC = tbc;
+    int64_t delay = attempt == 0 ? 0 : (int64_t)(80 * NSEC_PER_MSEC);
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay), dispatch_get_main_queue(), ^{
+        UITabBarController *strongTBC = weakTBC;
+        if (!strongTBC) return;
+
+        // Like the idle timer, a settle poll can become overdue if the app is
+        // suspended during its 450ms floor. Never let that delayed behavior
+        // write land inside the next foreground transition. willEnterForeground
+        // invalidates its token below, and the paired activation reconcile
+        // restores the desired policy after UIKit resumes.
+        if (UIApplication.sharedApplication.applicationState != UIApplicationStateActive) return;
+
+        NSNumber *currentRevealToken = objc_getAssociatedObject(strongTBC,
+            &kApolloCustomRevealGestureTokenKey);
+        if (!ApolloCustomRevealIsActive(strongTBC) ||
+            ![token isEqual:currentRevealToken]) return;
+
+        NSNumber *startedAt = objc_getAssociatedObject(strongTBC, &kApolloCustomRevealStartedAtKey);
+        BOOL pastSettleFloor = ![startedAt isKindOfClass:[NSNumber class]] ||
+            CACurrentMediaTime() - startedAt.doubleValue >= ApolloRevealExpandSettleSeconds;
+
+        BOOL morphKnown = NO;
+        NSInteger morphTarget = ApolloTabBarVisualMorphTarget(strongTBC.tabBar, &morphKnown);
+        BOOL animKnown = NO;
+        BOOL animating = ApolloTabBarVisualProviderBoolIvar(strongTBC.tabBar,
+            "isAnimatingCollapsedState", &animKnown);
+        BOOL settledExpanded = pastSettleFloor &&
+            (!morphKnown || (morphTarget == 0 && !(animKnown && animating)));
+        if (!settledExpanded && attempt < ApolloRearmMaxAttempts) {
+            ApolloRearmCustomRevealWhenExpanded(strongTBC, token, attempt + 1);
+            return;
+        }
+        // Settled or deadline reached (morph unreadable counts as settled once
+        // past the time floor — fail open).
+        ApolloClearCustomRevealState(strongTBC);
+        ApolloApplyMinimizeBehavior(strongTBC, ApolloTabBarMinimizeBehaviorOnScrollDown);
+        ApolloLog(@"[AutoHideTabBarFix] Custom reveal re-armed after gesture token=%@ attempt=%ld morph=%ld",
+                  token, (long)attempt, (long)morphTarget);
+    });
 }
 
 // Walk only the parentViewController chain so modally-presented nav controllers
@@ -217,6 +335,7 @@ static void ApolloReapplyNativeMinimizeBehavior(UITabBarController *tbc, NSStrin
 
     BOOL anyWantsMinimize = ApolloTabBarControllerWantsNativeMinimize(tbc);
     ApolloCancelIdleRevealTimer(tbc);
+    ApolloClearCustomRevealState(tbc);
 
     ApolloTabBarMinimizeBehavior behavior = anyWantsMinimize
         ? ApolloTabBarMinimizeBehaviorOnScrollDown
@@ -231,6 +350,7 @@ static void ApolloReconcileNativeMinimizeBehaviorAfterActivation(UITabBarControl
     if (!tbc || !ApolloSupportsNativeTabBarMinimize()) return;
 
     BOOL anyWantsMinimize = ApolloTabBarControllerWantsNativeMinimize(tbc);
+    ApolloClearCustomRevealState(tbc);
     ApolloTabBarMinimizeBehavior behavior = anyWantsMinimize
         ? ApolloTabBarMinimizeBehaviorOnScrollDown
         : ApolloTabBarMinimizeBehaviorNever;
@@ -243,8 +363,11 @@ static void ApolloReconcileNativeMinimizeBehaviorAfterActivation(UITabBarControl
               anyWantsMinimize, reason ?: @"unknown");
 }
 
-static NSString *const ApolloTabBarSlideDownAnimationKey = @"apolloTabBarSlideDown";
-static NSString *const ApolloTabBarSlideUpAnimationKey = @"apolloTabBarSlideUp";
+// Non-static: ApolloListBottomInsetGuard reads these to stand down while a
+// slide is animating the bar with pristine model state (declared in
+// ApolloListLayoutSupport.h).
+NSString *const ApolloTabBarSlideDownAnimationKey = @"apolloTabBarSlideDown";
+NSString *const ApolloTabBarSlideUpAnimationKey = @"apolloTabBarSlideUp";
 // KVC key stamped on each slide-down animation with its owning generation.
 static NSString *const ApolloTabBarSlideGenerationKey = @"apolloTabBarSlideGeneration";
 
@@ -337,6 +460,16 @@ static void ApolloShowTabBar(UITabBarController *tbc, BOOL animated) {
         slideUp.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
         [tabBar.layer addAnimation:slideUp forKey:ApolloTabBarSlideUpAnimationKey];
     }
+
+    // iOS 27 may not re-deliver a safe-area signal for the just-grown safe
+    // area, leaving the list's bottom inset at its hidden-bar value — the
+    // last rows (and the next-page link) end up stranded behind the re-shown
+    // bar (issue #809's mechanism). Verify after the slide-up settles; the
+    // guard stands down while the slide animation is still running.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(350 * NSEC_PER_MSEC)),
+                   dispatch_get_main_queue(), ^{
+        ApolloListVerifyBottomInsetForVisibleLists(@"legacyTabBarShown");
+    });
 }
 
 static void ApolloHideTabBar(UITabBarController *tbc, BOOL animated) {
@@ -452,7 +585,8 @@ static void ApolloHideTabBar(UITabBarController *tbc, BOOL animated) {
 }
 
 static void ApolloScheduleIdleRevealTimer(UITabBarController *tbc) {
-    if (!tbc || !sAutoHideTabBarShowOnIdle || !ApolloTabBarControllerWantsNativeMinimize(tbc)) return;
+    if (!tbc || !sAutoHideTabBarShowOnIdle || ApolloCustomRevealIsActive(tbc) ||
+        !ApolloTabBarControllerWantsNativeMinimize(tbc)) return;
 
     NSTimeInterval now = CACurrentMediaTime();
     NSNumber *lastScheduled = objc_getAssociatedObject(tbc, &kApolloIdleRevealTimerScheduledAtKey);
@@ -484,13 +618,34 @@ static void ApolloScheduleIdleRevealTimer(UITabBarController *tbc) {
         if (!strongTBC) return;
         objc_setAssociatedObject(strongTBC, &kApolloIdleRevealTimerKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(strongTBC, &kApolloIdleRevealTimerScheduledAtKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        // A timer armed before backgrounding fires immediately (overdue) when
+        // the process resumes — its .never/.onScrollDown pulse would then land
+        // exactly as the user's first post-foreground gesture begins. The
+        // willEnterForeground cancel in %ctor covers the notification path;
+        // this covers the race where the overdue fire beats that observer.
+        if (UIApplication.sharedApplication.applicationState != UIApplicationStateActive) return;
         if (!sAutoHideTabBarShowOnIdle || !ApolloTabBarControllerWantsNativeMinimize(strongTBC)) return;
         ApolloApplyMinimizeBehavior(strongTBC, ApolloTabBarMinimizeBehaviorNever);
         __weak UITabBarController *rearmTBC = strongTBC;
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(180 * NSEC_PER_MSEC)), dispatch_get_main_queue(), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                     (int64_t)(ApolloIdleRevealRearmDelaySeconds * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
             UITabBarController *rearmStrongTBC = rearmTBC;
             if (!rearmStrongTBC || !sAutoHideTabBarShowOnIdle || !ApolloTabBarControllerWantsNativeMinimize(rearmStrongTBC)) return;
-            if (objc_getAssociatedObject(rearmStrongTBC, &kApolloIdleRevealTimerKey)) return;
+            // Same resume hazard as the timer handler above: if the app
+            // suspends inside this 0.5s window, the block fires overdue at
+            // resume and would write policy during UIKit's foreground
+            // restoration, ahead of the didBecomeActive reconcile.
+            if (UIApplication.sharedApplication.applicationState != UIApplicationStateActive) return;
+            // A custom upward reveal can arm inside the window too; its
+            // token-owned re-arm (settle-floor deferred) supersedes this
+            // un-tokened one — clobbering it here would collapse the bar the
+            // user just deliberately expanded.
+            if (ApolloCustomRevealIsActive(rearmStrongTBC)) return;
+            // Scrolling may already have scheduled the next idle pulse. That
+            // timer does not supersede restoring the stable interactive
+            // policy from this completed pulse; otherwise the controller can
+            // remain stuck on .never until the next 30-second idle fire.
             ApolloApplyMinimizeBehavior(rearmStrongTBC, ApolloTabBarMinimizeBehaviorOnScrollDown);
         });
     });
@@ -658,9 +813,15 @@ static BOOL sApolloInBarHideSwipeHandler = NO;
             ApolloTabBarMinimizeBehavior behavior = value
                 ? ApolloTabBarMinimizeBehaviorOnScrollDown
                 : ApolloTabBarMinimizeBehaviorNever;
-            ApolloApplyMinimizeBehavior(tbc, behavior);
+            // Apollo may repeat its YES configuration while the user-driven
+            // reveal intentionally holds .never. Do not let that unrelated
+            // setup call collapse the bar before the next downward gesture.
+            if (!value || !ApolloCustomRevealIsActive(tbc)) {
+                ApolloApplyMinimizeBehavior(tbc, behavior);
+            }
             if (!value) {
                 ApolloCancelIdleRevealTimer(tbc);
+                ApolloClearCustomRevealState(tbc);
             }
         }
         return;
@@ -702,6 +863,60 @@ static BOOL sApolloInBarHideSwipeHandler = NO;
     }
     if (self.window) {
         ApolloApplyScrollEdgeEffectStyle(self);
+        ApolloEnsureAutoHidePanObserver(self);
+    }
+}
+
+%new
+- (void)_apolloAutoHideTabBarPanChanged:(UIPanGestureRecognizer *)pan {
+    // The token/reveal bookkeeping below only serves Mode B's custom upward
+    // reveal. With the idle mode off this handler is pure overhead on every
+    // gesture; if the user turns it on mid-gesture, the setContentOffset
+    // fallback mints the missing token.
+    if (!sAutoHideTabBarShowOnIdle) return;
+
+    if (pan.state == UIGestureRecognizerStateBegan) {
+        NSNumber *token = @(++sApolloScrollGestureToken);
+        objc_setAssociatedObject(self, &kApolloScrollGestureTokenKey, token,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloSetUpwardRevealDistance(self, 0.0);
+
+        UITabBarController *tbc = ApolloTabBarControllerForScrollView(self);
+        NSNumber *revealToken = objc_getAssociatedObject(tbc, &kApolloCustomRevealGestureTokenKey);
+        if (ApolloCustomRevealIsActive(tbc) && ![token isEqual:revealToken]) {
+            // tabBarMinimizeBehavior must be in place when UIKit begins the
+            // pan. Changing .never -> .onScrollDown after contentOffset has
+            // already moved does not enroll that in-flight gesture in the
+            // collapse transition on iOS 27.
+            ApolloClearCustomRevealState(tbc);
+            ApolloApplyMinimizeBehavior(tbc, ApolloTabBarMinimizeBehaviorOnScrollDown);
+            ApolloLog(@"[AutoHideTabBarFix] Custom reveal re-armed before next gesture token=%@",
+                      token);
+        }
+    } else if (pan.state == UIGestureRecognizerStateEnded ||
+               pan.state == UIGestureRecognizerStateCancelled ||
+               pan.state == UIGestureRecognizerStateFailed) {
+        ApolloSetUpwardRevealDistance(self, 0.0);
+
+        // `token` can be nil for a pan that never delivered .began to our
+        // late-attached target — compare with nil-safe isEqual: on the token
+        // (nil receiver → NO), never isEqualToNumber: with a nil argument.
+        NSNumber *token = objc_getAssociatedObject(self, &kApolloScrollGestureTokenKey);
+        UITabBarController *tbc = ApolloTabBarControllerForScrollView(self);
+        NSNumber *revealToken = objc_getAssociatedObject(tbc, &kApolloCustomRevealGestureTokenKey);
+        if (ApolloCustomRevealIsActive(tbc) && [token isEqual:revealToken]) {
+            // Leave .never in place until UIKit has fully finished delivering
+            // the reveal gesture, AND until the expand morph has settled at
+            // target 0. When the finger lifts right as the reveal threshold
+            // crosses, an immediate re-arm lands mid-morph — and a behavior
+            // write during a morph restarts the glass transition (visible bar
+            // stutter; device logs showed re-arms 8ms after the reveal). Poll
+            // briefly for the stable expanded state; if a new gesture begins
+            // first, the began-branch re-arm above takes over via the token
+            // check, and the deadline fallback re-arms regardless so the
+            // controller can never wedge on .never.
+            ApolloRearmCustomRevealWhenExpanded(tbc, token, 0);
+        }
     }
 }
 
@@ -712,6 +927,11 @@ static BOOL sApolloInBarHideSwipeHandler = NO;
         return;
     }
 
+    // AsyncDisplayKit's ASTableView does not reliably reach our inherited
+    // didMoveToWindow hook with the recognizer it ultimately scrolls with.
+    // Attach against the live recognizer from the path every scroller uses.
+    ApolloEnsureAutoHidePanObserver(self);
+
     CGPoint oldOffset = self.contentOffset;
     CGFloat deltaY = contentOffset.y - oldOffset.y;
     UITabBarController *tbc = nil;
@@ -720,35 +940,53 @@ static BOOL sApolloInBarHideSwipeHandler = NO;
     if (fabs(deltaY) >= 0.5) {
         tbc = ApolloTabBarControllerForScrollView(self);
         if (ApolloTabBarControllerWantsNativeMinimize(tbc)) {
-            BOOL userDriven = self.tracking || self.dragging;
-            if (userDriven) {
-                // Re-arm before UIKit processes a deliberate downward drag. Use
-                // hysteresis so rubber-band/reversal noise doesn't thrash safe areas.
-                if (deltaY > 0.0) {
-                    ApolloSetUpwardRevealDistance(tbc, 0.0);
-                    CGFloat downwardDistance = ApolloDownwardCollapseDistance(tbc) + deltaY;
-                    if (ApolloLastAppliedMinimizeBehavior(tbc) != ApolloTabBarMinimizeBehaviorNever ||
-                        downwardDistance >= ApolloDownwardCollapseDistanceThreshold) {
-                        ApolloSetDownwardCollapseDistance(tbc, 0.0);
-                        if (ApolloLastAppliedMinimizeBehavior(tbc) == ApolloTabBarMinimizeBehaviorNever) {
-                            ApolloApplyMinimizeBehavior(tbc, ApolloTabBarMinimizeBehaviorOnScrollDown);
+            // Same filter as the pan observer (see above): non-list scrollers
+            // never trigger a reveal, never mint tokens, and stay fully
+            // neutral to the reveal state machine. UIKit's native
+            // .onScrollDown collapse still tracks them on its own.
+            BOOL participates = ApolloAutoHideScrollViewParticipates(self);
+            BOOL userDriven = participates && (self.tracking || self.dragging);
+            NSNumber *gestureToken = userDriven ? ApolloScrollGestureToken(self) : nil;
+            BOOL customRevealActive = ApolloCustomRevealIsActive(tbc);
+
+            if (userDriven && deltaY > 0.0) {
+                ApolloSetUpwardRevealDistance(self, 0.0);
+            } else if (userDriven && deltaY < 0.0) {
+                if (!customRevealActive) {
+                    // Shared cached reader (ApolloCommon): UITabBar's private
+                    // _isMinimized accessor is Apple-app-assertion-guarded, so
+                    // the provider's stored morph target is the only safe read.
+                    BOOL morphKnown = NO;
+                    NSInteger morphTarget = ApolloTabBarVisualMorphTarget(tbc.tabBar, &morphKnown);
+
+                    // If UIKit has already reached target 0, the full bar is
+                    // open and forcing .never would only create an unnecessary
+                    // layout.
+                    if (!morphKnown || morphTarget != 0) {
+                        CGFloat upwardDistance = ApolloUpwardRevealDistance(self) + fabs(deltaY);
+                        if (upwardDistance >= ApolloUpwardRevealDistanceThreshold) {
+                            ApolloSetUpwardRevealDistance(self, 0.0);
+                            ApolloCancelIdleRevealTimer(tbc);
+                            objc_setAssociatedObject(tbc, &kApolloCustomRevealActiveKey, @YES,
+                                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                            objc_setAssociatedObject(tbc, &kApolloCustomRevealGestureTokenKey,
+                                                     gestureToken,
+                                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                            objc_setAssociatedObject(tbc, &kApolloCustomRevealStartedAtKey,
+                                                     @(CACurrentMediaTime()),
+                                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                            ApolloApplyMinimizeBehavior(tbc, ApolloTabBarMinimizeBehaviorNever);
+                            ApolloLog(@"[AutoHideTabBarFix] Custom upward reveal token=%@ morph=%ld known=%d",
+                                      gestureToken, (long)morphTarget, morphKnown);
+                        } else {
+                            ApolloSetUpwardRevealDistance(self, upwardDistance);
                         }
                     } else {
-                        ApolloSetDownwardCollapseDistance(tbc, downwardDistance);
-                    }
-                } else {
-                    ApolloSetDownwardCollapseDistance(tbc, 0.0);
-                    CGFloat upwardDistance = ApolloUpwardRevealDistance(tbc) + fabs(deltaY);
-                    if (upwardDistance >= ApolloUpwardRevealDistanceThreshold) {
-                        ApolloSetUpwardRevealDistance(tbc, 0.0);
-                        ApolloApplyMinimizeBehavior(tbc, ApolloTabBarMinimizeBehaviorNever);
-                    } else {
-                        ApolloSetUpwardRevealDistance(tbc, upwardDistance);
+                        ApolloSetUpwardRevealDistance(self, 0.0);
                     }
                 }
             } else if (deltaY > 0.0) {
-                ApolloSetUpwardRevealDistance(tbc, 0.0);
-                ApolloSetDownwardCollapseDistance(tbc, 0.0);
+                ApolloSetUpwardRevealDistance(self, 0.0);
             }
             shouldScheduleIdleReveal = YES;
         }
@@ -799,10 +1037,30 @@ static BOOL sApolloInBarHideSwipeHandler = NO;
     // will-enter, did-become, and next-turn made the glass transition restart;
     // putting the live-property comparison in the general apply path was worse
     // because scroll callbacks then fought UIKit every frame.
+    //
+    // Keyed off a real background->foreground transition: bare didBecomeActive
+    // (Notification/Control Center dismissal) cannot restore stale policy, and
+    // reconciling there churned behavior state mid-interaction. The foreground
+    // observer also cancels armed idle timers so a fire that went overdue
+    // during suspension cannot pulse .never right as scrolling resumes (the
+    // handler's applicationState check covers the overdue-beats-observer race).
+    static BOOL sPendingForegroundReconcile = NO;
+    [center addObserverForName:UIApplicationWillEnterForegroundNotification
+                        object:nil
+                         queue:[NSOperationQueue mainQueue]
+                    usingBlock:^(__unused NSNotification *notification) {
+        sPendingForegroundReconcile = YES;
+        ApolloForEachVisibleTabBarController(^(UITabBarController *tbc) {
+            ApolloCancelIdleRevealTimer(tbc);
+            ApolloClearCustomRevealState(tbc);
+        });
+    }];
     [center addObserverForName:UIApplicationDidBecomeActiveNotification
                         object:nil
                          queue:[NSOperationQueue mainQueue]
                     usingBlock:^(__unused NSNotification *notification) {
+        if (!sPendingForegroundReconcile) return;
+        sPendingForegroundReconcile = NO;
         dispatch_async(dispatch_get_main_queue(), ^{
             ApolloForEachVisibleTabBarController(^(UITabBarController *tbc) {
                 ApolloReconcileNativeMinimizeBehaviorAfterActivation(

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -175,6 +175,24 @@ void ApolloAppendLoginDiag(NSString *line);
 // Never include post titles, account names, URLs, or other user content.
 void ApolloAppendListLayoutDiag(NSString *line);
 
+// iOS 26+ Liquid Glass: the tab bar's real expanded/collapsed state, read from
+// the visual provider's stored `_currentMorphTarget` (0 expanded, 1 mid-morph,
+// 2 minimized). UITabBar's own `_isMinimized` accessor is guarded by an
+// Apple-app assertion (UIKit literally checks for Photos), so calling it from a
+// sideloaded app crashes — the runtime ivar read is the only safe path.
+// Returns NSNotFound with *known = NO when the private layout is missing
+// (future iOS). Callers must treat unknown as "assume nothing" and fail OPEN
+// (accept UIKit's writes), never as "expanded" — fighting UIKit per frame on a
+// wrong guess is worse than missing one correction. Main-thread only.
+NSInteger ApolloTabBarVisualMorphTarget(UITabBar *tabBar, BOOL *known);
+
+// One-byte Swift Bool stored property on the tab bar's visual provider (e.g.
+// "isAnimatingCollapsedState"). Swift ivars carry no useful ObjC type encoding
+// (RuntimeBrowser shows `void`), so this mirrors UIKit's own one-byte
+// read/write of the exported ivar offset. *known = NO when the ivar is gone.
+// Main-thread only.
+BOOL ApolloTabBarVisualProviderBoolIvar(UITabBar *tabBar, const char *name, BOOL *known);
+
 // Dev-only login-persistence debug (see Tweak.xm): a report of where the account keychain item
 // lives (each copy's access group / size / protection class), and a FLEX-gated action that
 // poisons/restores the account item's protection class to reproduce the -25300 on demand. Both

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -169,6 +169,12 @@ NSArray<NSDictionary *> *ApolloKeychainMirrorItemsForBackup(void);
 // session that actually signed the user out. Safe to call from any thread; never logs secrets.
 void ApolloAppendLoginDiag(NSString *line);
 
+// Append an iOS 27 list/tab-bar geometry diagnostic to a bounded cross-launch
+// buffer. Export Debug Logs prepends this buffer so the foregrounding session
+// that produced a stale inset remains available even if Apollo is later killed.
+// Never include post titles, account names, URLs, or other user content.
+void ApolloAppendListLayoutDiag(NSString *line);
+
 // Dev-only login-persistence debug (see Tweak.xm): a report of where the account keychain item
 // lives (each copy's access group / size / protection class), and a FLEX-gated action that
 // poisons/restores the account item's protection class to reproduce the -25300 on demand. Both

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -45,47 +45,56 @@ static const NSUInteger kApolloPersistentDiagTrimTo = 192 * 1024;
 
 static void ApolloAppendPersistentDiag(NSString *line, NSString *path) {
     if (![line isKindOfClass:[NSString class]] || line.length == 0) return;
-    static os_unfair_lock lock = OS_UNFAIR_LOCK_INIT;
+    static dispatch_queue_t queue = nil;
     static NSDateFormatter *fmt = nil;
-    os_unfair_lock_lock(&lock);
-    if (!fmt) {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        // The list-layout diag can fire from inside setContentInset: during a
+        // scroll frame, so the file I/O must never run on the caller's thread.
+        // A serial utility queue keeps line order without blocking anyone; the
+        // only loss window is lines still queued at a hard crash (~ms), which
+        // the os_log copy of every line still covers.
+        queue = dispatch_queue_create("com.apollo.reborn.persistent-diag",
+            dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_UTILITY, 0));
         fmt = [[NSDateFormatter alloc] init];
         fmt.dateFormat = @"MM-dd HH:mm:ss.SSS";
         fmt.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-    }
+    });
+    // Stamp on the calling thread so the timestamp is the event time, not the
+    // (slightly later) write time. NSDateFormatter is thread-safe on iOS 7+.
     NSString *stamped = [NSString stringWithFormat:@"[%@] %@\n", [fmt stringFromDate:[NSDate date]], line];
-    NSFileManager *fm = [NSFileManager defaultManager];
-
-    @try {
-        NSFileHandle *fh = [NSFileHandle fileHandleForWritingAtPath:path];
-        if (!fh) {
-            [fm createFileAtPath:path contents:nil
-                      attributes:@{NSFileProtectionKey: NSFileProtectionCompleteUntilFirstUserAuthentication}];
-            fh = [NSFileHandle fileHandleForWritingAtPath:path];
-        }
-        if (fh) {
-            unsigned long long end = [fh seekToEndOfFile];
-            [fh writeData:[stamped dataUsingEncoding:NSUTF8StringEncoding]];
-            [fh closeFile];
-            // Trim to the tail when it grows past the cap: reload, keep the last N bytes from a
-            // line boundary, rewrite. Cheap because it only fires occasionally.
-            if (end + stamped.length > kApolloPersistentDiagMaxBytes) {
-                NSData *all = [NSData dataWithContentsOfFile:path];
-                if (all.length > kApolloPersistentDiagMaxBytes) {
-                    NSData *tail = [all subdataWithRange:NSMakeRange(all.length - kApolloPersistentDiagTrimTo, kApolloPersistentDiagTrimTo)];
-                    NSString *tailStr = [[NSString alloc] initWithData:tail encoding:NSUTF8StringEncoding];
-                    NSRange nl = [tailStr rangeOfString:@"\n"];
-                    if (nl.location != NSNotFound && nl.location + 1 < tailStr.length) {
-                        tailStr = [tailStr substringFromIndex:nl.location + 1];
+    dispatch_async(queue, ^{
+        NSFileManager *fm = [NSFileManager defaultManager];
+        @try {
+            NSFileHandle *fh = [NSFileHandle fileHandleForWritingAtPath:path];
+            if (!fh) {
+                [fm createFileAtPath:path contents:nil
+                          attributes:@{NSFileProtectionKey: NSFileProtectionCompleteUntilFirstUserAuthentication}];
+                fh = [NSFileHandle fileHandleForWritingAtPath:path];
+            }
+            if (fh) {
+                unsigned long long end = [fh seekToEndOfFile];
+                [fh writeData:[stamped dataUsingEncoding:NSUTF8StringEncoding]];
+                [fh closeFile];
+                // Trim to the tail when it grows past the cap: reload, keep the last N bytes from a
+                // line boundary, rewrite. Cheap because it only fires occasionally.
+                if (end + stamped.length > kApolloPersistentDiagMaxBytes) {
+                    NSData *all = [NSData dataWithContentsOfFile:path];
+                    if (all.length > kApolloPersistentDiagMaxBytes) {
+                        NSData *tail = [all subdataWithRange:NSMakeRange(all.length - kApolloPersistentDiagTrimTo, kApolloPersistentDiagTrimTo)];
+                        NSString *tailStr = [[NSString alloc] initWithData:tail encoding:NSUTF8StringEncoding];
+                        NSRange nl = [tailStr rangeOfString:@"\n"];
+                        if (nl.location != NSNotFound && nl.location + 1 < tailStr.length) {
+                            tailStr = [tailStr substringFromIndex:nl.location + 1];
+                        }
+                        [tailStr writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:nil];
                     }
-                    [tailStr writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:nil];
                 }
             }
+        } @catch (__unused NSException *e) {
+            // Diagnostics must never take the app down; a lost line is acceptable.
         }
-    } @catch (__unused NSException *e) {
-        // Diagnostics must never take the app down; a lost line is acceptable.
-    }
-    os_unfair_lock_unlock(&lock);
+    });
 }
 
 void ApolloAppendLoginDiag(NSString *line) {
@@ -99,6 +108,81 @@ static NSString *ApolloListLayoutDiagLogPath(void) {
 
 void ApolloAppendListLayoutDiag(NSString *line) {
     ApolloAppendPersistentDiag(line, ApolloListLayoutDiagLogPath());
+}
+
+#pragma mark - Liquid Glass tab bar morph state (private-ivar reads)
+
+// Single-slot Ivar caches: Apollo runs one tab bar class and one visual
+// provider class per process, and these reads sit on scroll-frame paths
+// (ApolloAutoHideTabBar's upward-reveal detection, the list bottom-inset
+// guard), where repeated class_getInstanceVariable lookups would pay a
+// runtime-lock toll per frame. Main-thread only, so plain statics suffice.
+static id ApolloTabBarVisualProvider(UITabBar *tabBar) {
+    if (!tabBar) return nil;
+    static Class barClass = Nil;
+    static Ivar providerIvar = NULL;
+    Class cls = object_getClass(tabBar);
+    if (cls != barClass) {
+        providerIvar = class_getInstanceVariable(cls, "_visualProvider");
+        barClass = cls;
+    }
+    return providerIvar ? object_getIvar(tabBar, providerIvar) : nil;
+}
+
+NSInteger ApolloTabBarVisualMorphTarget(UITabBar *tabBar, BOOL *known) {
+    if (known) *known = NO;
+    id provider = ApolloTabBarVisualProvider(tabBar);
+    if (!provider) return NSNotFound;
+
+    static Class providerClass = Nil;
+    static Ivar targetIvar = NULL;
+    static BOOL encodingIsInteger = NO;
+    Class cls = object_getClass(provider);
+    if (cls != providerClass) {
+        targetIvar = class_getInstanceVariable(cls, "_currentMorphTarget");
+        const char *encoding = targetIvar ? ivar_getTypeEncoding(targetIvar) : NULL;
+        encodingIsInteger = encoding && (encoding[0] == 'q' || encoding[0] == 'Q');
+        providerClass = cls;
+    }
+    if (!targetIvar || !encodingIsInteger) return NSNotFound;
+
+    NSInteger target = NSNotFound;
+    memcpy(&target,
+           (const uint8_t *)(__bridge const void *)provider + ivar_getOffset(targetIvar),
+           sizeof(target));
+    if (known) *known = YES;
+    return target;
+}
+
+BOOL ApolloTabBarVisualProviderBoolIvar(UITabBar *tabBar, const char *name, BOOL *known) {
+    if (known) *known = NO;
+    if (!name) return NO;
+    id provider = ApolloTabBarVisualProvider(tabBar);
+    if (!provider) return NO;
+
+    // Cache keyed on (class, name pointer): the name is a string literal at
+    // every call site, so pointer identity is stable; a rare miss on an equal
+    // but distinct literal just re-runs the lookup.
+    static Class providerClass = Nil;
+    static const char *cachedName = NULL;
+    static Ivar boolIvar = NULL;
+    Class cls = object_getClass(provider);
+    if (cls != providerClass || name != cachedName) {
+        boolIvar = class_getInstanceVariable(cls, name);
+        providerClass = cls;
+        cachedName = name;
+    }
+    if (!boolIvar) return NO;
+
+    // Swift stored Bools carry no useful ObjC type encoding (RuntimeBrowser
+    // shows `void`); UIKit's own code reads and writes exactly one byte at the
+    // exported ivar offset, so mirror that representation.
+    uint8_t value = 0;
+    memcpy(&value,
+           (const uint8_t *)(__bridge const void *)provider + ivar_getOffset(boolIvar),
+           sizeof(value));
+    if (known) *known = YES;
+    return (value & 1) != 0;
 }
 
 // The prior/persistent diagnostics tail, for the exporter to prepend. Empty string if none.

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -37,13 +37,13 @@ static NSString *ApolloLoginDiagLogPath(void) {
                 stringByAppendingPathComponent:@"ApolloLoginDiag.log"];
 }
 
-static const NSUInteger kApolloLoginDiagMaxBytes = 256 * 1024; // ~256KB tail is plenty of sessions
+static const NSUInteger kApolloPersistentDiagMaxBytes = 256 * 1024; // ~256KB tail is plenty of sessions
 // When trimming, drop back to this (not just under the cap) so the next ~64KB of lines don't each
 // re-trigger a full read+rewrite of the file. Without the headroom, once the buffer is at capacity
 // every single append would rewrite the whole file — expensive on the keychain hot path.
-static const NSUInteger kApolloLoginDiagTrimTo = 192 * 1024;
+static const NSUInteger kApolloPersistentDiagTrimTo = 192 * 1024;
 
-void ApolloAppendLoginDiag(NSString *line) {
+static void ApolloAppendPersistentDiag(NSString *line, NSString *path) {
     if (![line isKindOfClass:[NSString class]] || line.length == 0) return;
     static os_unfair_lock lock = OS_UNFAIR_LOCK_INIT;
     static NSDateFormatter *fmt = nil;
@@ -54,7 +54,6 @@ void ApolloAppendLoginDiag(NSString *line) {
         fmt.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
     }
     NSString *stamped = [NSString stringWithFormat:@"[%@] %@\n", [fmt stringFromDate:[NSDate date]], line];
-    NSString *path = ApolloLoginDiagLogPath();
     NSFileManager *fm = [NSFileManager defaultManager];
 
     @try {
@@ -70,10 +69,10 @@ void ApolloAppendLoginDiag(NSString *line) {
             [fh closeFile];
             // Trim to the tail when it grows past the cap: reload, keep the last N bytes from a
             // line boundary, rewrite. Cheap because it only fires occasionally.
-            if (end + stamped.length > kApolloLoginDiagMaxBytes) {
+            if (end + stamped.length > kApolloPersistentDiagMaxBytes) {
                 NSData *all = [NSData dataWithContentsOfFile:path];
-                if (all.length > kApolloLoginDiagMaxBytes) {
-                    NSData *tail = [all subdataWithRange:NSMakeRange(all.length - kApolloLoginDiagTrimTo, kApolloLoginDiagTrimTo)];
+                if (all.length > kApolloPersistentDiagMaxBytes) {
+                    NSData *tail = [all subdataWithRange:NSMakeRange(all.length - kApolloPersistentDiagTrimTo, kApolloPersistentDiagTrimTo)];
                     NSString *tailStr = [[NSString alloc] initWithData:tail encoding:NSUTF8StringEncoding];
                     NSRange nl = [tailStr rangeOfString:@"\n"];
                     if (nl.location != NSNotFound && nl.location + 1 < tailStr.length) {
@@ -89,9 +88,28 @@ void ApolloAppendLoginDiag(NSString *line) {
     os_unfair_lock_unlock(&lock);
 }
 
+void ApolloAppendLoginDiag(NSString *line) {
+    ApolloAppendPersistentDiag(line, ApolloLoginDiagLogPath());
+}
+
+static NSString *ApolloListLayoutDiagLogPath(void) {
+    return [[NSHomeDirectory() stringByAppendingPathComponent:@"Library"]
+                stringByAppendingPathComponent:@"ApolloListLayoutDiag.log"];
+}
+
+void ApolloAppendListLayoutDiag(NSString *line) {
+    ApolloAppendPersistentDiag(line, ApolloListLayoutDiagLogPath());
+}
+
 // The prior/persistent diagnostics tail, for the exporter to prepend. Empty string if none.
 static NSString *ApolloPersistentLoginDiagnostics(void) {
     NSString *contents = [NSString stringWithContentsOfFile:ApolloLoginDiagLogPath()
+                                                   encoding:NSUTF8StringEncoding error:nil];
+    return contents.length ? contents : @"";
+}
+
+static NSString *ApolloPersistentListLayoutDiagnostics(void) {
+    NSString *contents = [NSString stringWithContentsOfFile:ApolloListLayoutDiagLogPath()
                                                    encoding:NSUTF8StringEncoding error:nil];
     return contents.length ? contents : @"";
 }
@@ -132,19 +150,27 @@ static NSString *ApolloCollectLogsFiltered(BOOL aiOnly) {
 
         // The cross-launch login-diagnostics tail (prior sessions too) — prepended for the full
         // log so a force-quit sign-out is still diagnosable. Not included in the AI-only export.
-        NSString *persistent = aiOnly ? @"" : ApolloPersistentLoginDiagnostics();
+        NSString *persistentLogin = aiOnly ? @"" : ApolloPersistentLoginDiagnostics();
+        NSString *persistentListLayout = aiOnly ? @"" : ApolloPersistentListLayoutDiagnostics();
 
-        if (filteredEntries.count == 0 && persistent.length == 0) {
+        if (filteredEntries.count == 0 && persistentLogin.length == 0 && persistentListLayout.length == 0) {
             return aiOnly
                 ? @"No Apollo AI log entries found since app launch."
                 : @"No [ApolloFix] log entries found since app launch.";
         }
 
         NSMutableString *output = [NSMutableString new];
-        if (persistent.length) {
+        if (persistentListLayout.length) {
+            [output appendString:@"===== Persistent list/tab-bar diagnostics (spans previous sessions; survives force-quit) =====\n"];
+            [output appendString:persistentListLayout];
+            if (![persistentListLayout hasSuffix:@"\n"]) [output appendString:@"\n"];
+        }
+        if (persistentLogin.length) {
             [output appendString:@"===== Persistent login diagnostics (spans previous sessions; survives force-quit) =====\n"];
-            [output appendString:persistent];
-            if (![persistent hasSuffix:@"\n"]) [output appendString:@"\n"];
+            [output appendString:persistentLogin];
+            if (![persistentLogin hasSuffix:@"\n"]) [output appendString:@"\n"];
+        }
+        if (persistentListLayout.length || persistentLogin.length) {
             [output appendString:@"===== Current session ([ApolloFix] os_log) =====\n"];
         }
         [output appendFormat:@"%@ — %@ (%lu entries)\n\n",

--- a/src/ApolloDirectChatWeb.xm
+++ b/src/ApolloDirectChatWeb.xm
@@ -8,6 +8,7 @@
 #import "ApolloDirectChatWeb.h"
 #import "ApolloAccountCredentials.h"
 #import "ApolloCommon.h"
+#import "ApolloListLayoutSupport.h"
 #import "ApolloState.h"
 #import "ApolloThemeRuntime.h"
 #import "ApolloWebSessionLoginViewController.h"
@@ -1676,8 +1677,8 @@ static NSTimeInterval ApolloChatStaleRefreshThreshold(void) {
         // A room can be left through Reddit history, Apollo Back, a native
         // route, or a tab switch. Normalize every visual state that Apollo
         // hide-on-scroll may have left behind before handing the bar back.
-        [tabBar.layer removeAnimationForKey:@"apolloTabBarSlideDown"];
-        [tabBar.layer removeAnimationForKey:@"apolloTabBarSlideUp"];
+        [tabBar.layer removeAnimationForKey:ApolloTabBarSlideDownAnimationKey];
+        [tabBar.layer removeAnimationForKey:ApolloTabBarSlideUpAnimationKey];
         tabBar.transform = CGAffineTransformIdentity;
         tabBar.alpha = 1.0;
         tabBar.hidden = NO;
@@ -1685,6 +1686,17 @@ static NSTimeInterval ApolloChatStaleRefreshThreshold(void) {
 
     [tabBarController.view setNeedsLayout];
     [tabBarController.view layoutIfNeeded];
+
+    if (!hidesForConversation) {
+        // The bar's return just grew the bottom safe area, and iOS 27 may not
+        // re-deliver a layout signal for it — the underlying list's inset can
+        // stay at its hidden-bar value with the last rows stranded behind the
+        // bar (same no-write mechanism as the legacy mirror's re-show). Give
+        // Apollo one turn to react on its own, then verify.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            ApolloListVerifyBottomInsetForVisibleLists(@"chatTabBarRestored");
+        });
+    }
     ApolloLog(@"[DirectChatWeb] %@ Inbox tab bar for %@ %@",
               hidesForConversation ? @"Hid" : @"Restored",
               self.mailboxKind == ApolloModernMailboxKindModmail ? @"Modmail" : @"Chat",

--- a/src/ApolloListBottomInsetGuard.xm
+++ b/src/ApolloListBottomInsetGuard.xm
@@ -1,41 +1,28 @@
 // ApolloListBottomInsetGuard.xm
 //
-// iOS 26/27 list bottom-inset protection — the FUNCTIONAL fix. Covers BOTH
-// tab-bar paths: the Liquid Glass floating bar (glass IPA) and the legacy
-// translucent UITabBar (standard IPA, issue #809 — next-page link stranded
-// behind the bar). (Verbose geometry snapshots live in
-// ApolloListLayoutDiagnostics.xm, which is safe to drop for shipping; this
-// module must ship.)
+// iOS 26/27 list bottom-inset compatibility — the FUNCTIONAL fix. Covers BOTH
+// tab-bar paths: the Liquid Glass floating bar and the legacy translucent bar
+// (issue #809). Verbose geometry snapshots live separately in
+// ApolloListLayoutDiagnostics.xm.
 //
 // Apollo manages ASTableView.contentInset itself with adjustmentBehavior=.never.
-// iOS 26 introduced floating/minimizing tab bars and explicit content-scroll-
-// view observation. iOS 27 can restore an expanded tab bar across activation,
-// then write the observed table's bottom inset from its healthy value (153 for
-// comments: 83 chrome + Apollo's 70 extra) all the way to zero without changing
-// safeAreaInsets or contentLayoutGuide. Apollo receives no later layout signal,
-// so the zero sticks and the final rows remain under the tab bar.
+// The root cause recovered in Hopper and proved by the keyboard-origin trace is
+// Apollo's global keyboard notification handling: it consumes non-local frames
+// during app switching, treats screen coordinates as view coordinates, and
+// treats CGRect.zero as a real keyboard. Comments consequently animate
+// 153 -> 347 -> 0; downstream guards can only fight that sequence.
 //
-// This module does two things at the source:
-//   1. Explicitly registers Apollo's nested ASTableView as the bottom content
-//      scroll view, following the iOS 26 public UIKit contract.
-//   2. Guards setContentInset: while an expanded Liquid Glass tab bar overlaps
-//      the list. It combines the tab controller's unobscured content guide with
-//      a per-table healthy baseline, preserving Apollo's dynamic extras without
-//      hardcoding screen-specific values. The guard deliberately stands down
-//      while UIKit's visual provider is at its minimized morph target: iOS 27
-//      keeps the expanded tab frame/guide during that state, so geometry alone
-//      cannot distinguish a legitimate zero inset from the foreground bug. It
-//      also retains PR #744's protection for the older transient where
-//      safeAreaInsets.bottom itself under-reports the visible tab bar.
+// This module fixes the input once: explicit non-local frames are ignored;
+// local frames are converted through the notification screen into the view and
+// intersected with its bounds; no overlap is represented with the hidden-frame
+// sentinel Apollo's native calculator already understands. Apollo then writes
+// its correct screen-specific inset exactly once.
 //
-// Failure policy: the morph state comes from private UIKit ivars
-// (ApolloTabBarVisualMorphTarget in ApolloCommon). If a future iOS renames
-// them, the morph-gated corrections FAIL OPEN — they simply stop firing —
-// because geometry alone cannot tell minimized from expanded (see above), and
-// a guard armed on a wrong guess would fight UIKit's per-frame minimized-state
-// inset writes: exactly the scroll jank this branch exists to remove. Only the
-// geometry-provable safe-area-deficit case and the time-bounded foreground
-// window stay active without morph knowledge.
+// Redundant recovery is deliberately cold-path only. The ASTableView hook is a
+// pointer comparison unless a normalized keyboard-hide event is synchronously
+// executing. Settled verification runs only after explicit appearance,
+// foreground, or legacy tab-bar-show boundaries; it never participates in
+// scrolling or Liquid Glass morph frames.
 
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
@@ -54,15 +41,19 @@
 @end
 
 static NSHashTable<UIViewController *> *sApolloListGuardControllers;
-static CFTimeInterval sApolloListForegroundProtectionUntil = 0.0;
+static UIScrollView *sApolloListActiveKeyboardRecoveryTable;
+static UIViewController *sApolloListActiveKeyboardRecoveryController;
+static CGFloat sApolloListActiveKeyboardRecoveryFloor = 0.0;
 static char kApolloListHealthyBottomExtraKey;
 static char kApolloListHealthyBottomChromeKey;
-static char kApolloListOwningControllerBoxKey;
 
 // A real Apollo list extra is small (comments use 70pt). This cap prevents a
 // temporary keyboard-sized inset from becoming a persistent foreground floor.
 static const CGFloat kApolloListMaximumRememberedExtra = 200.0;
-static const NSTimeInterval kApolloListForegroundProtectionSeconds = 2.0;
+// UIKit can legitimately round an accessory inset by one point during an
+// interactive transition (observed as Inbox 84 -> 83). The recovery exists for
+// material losses such as Comments 153 -> 0, not harmless pixel rounding.
+static const CGFloat kApolloListKeyboardRecoveryTolerance = 1.0;
 
 BOOL ApolloListLayoutGuardEnabled(void) {
     // Not gated on IsLiquidGlass(): the iOS 27 inset regression also hits
@@ -101,36 +92,6 @@ UIScrollView *ApolloListTableForController(UIViewController *controller) {
     if (![tableNode respondsToSelector:@selector(view)]) return nil;
     UIView *tableView = [tableNode view];
     return [tableView isKindOfClass:[UIScrollView class]] ? (UIScrollView *)tableView : nil;
-}
-
-@interface ApolloListWeakControllerBox : NSObject
-@property (nonatomic, weak) UIViewController *controller;
-@end
-
-@implementation ApolloListWeakControllerBox
-@end
-
-// setContentInset: runs on scroll-adjacent paths, so cache the responder-chain
-// walk. An ASTableView never migrates to a different ASTableViewController in
-// Apollo; the weak box simply empties when the controller deallocates.
-static UIViewController *ApolloListOwningViewController(UIView *view) {
-    ApolloListWeakControllerBox *box =
-        objc_getAssociatedObject(view, &kApolloListOwningControllerBoxKey);
-    UIViewController *cached = box.controller;
-    if (cached) return cached;
-
-    UIResponder *responder = view;
-    Class listControllerClass = objc_getClass("_TtC6Apollo21ASTableViewController");
-    while ((responder = responder.nextResponder)) {
-        if (listControllerClass && [responder isKindOfClass:listControllerClass]) {
-            ApolloListWeakControllerBox *newBox = [ApolloListWeakControllerBox new];
-            newBox.controller = (UIViewController *)responder;
-            objc_setAssociatedObject(view, &kApolloListOwningControllerBoxKey, newBox,
-                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            return newBox.controller;
-        }
-    }
-    return nil;
 }
 
 ApolloListBottomGeometry ApolloListBottomGeometryForController(UIViewController *controller) {
@@ -204,33 +165,6 @@ ApolloListBottomGeometry ApolloListBottomGeometryForController(UIViewController 
     return geometry;
 }
 
-typedef NS_OPTIONS(NSUInteger, ApolloListInsetCorrectionReason) {
-    ApolloListInsetCorrectionReasonSafeAreaDeficit = 1 << 0,
-    ApolloListInsetCorrectionReasonExtrasBeforeChrome = 1 << 1,
-    ApolloListInsetCorrectionReasonBelowVisibleChrome = 1 << 2,
-    ApolloListInsetCorrectionReasonForegroundBaseline = 1 << 3,
-};
-
-static NSString *ApolloListInsetCorrectionReasonDescription(
-    ApolloListInsetCorrectionReason reasons) {
-    // This runs only for an actual correction. The old mutable array allocated
-    // on every setContentInset:, including accepted per-frame scroll writes.
-    NSMutableArray<NSString *> *names = [NSMutableArray arrayWithCapacity:4];
-    if (reasons & ApolloListInsetCorrectionReasonSafeAreaDeficit) {
-        [names addObject:@"safe-area-deficit"];
-    }
-    if (reasons & ApolloListInsetCorrectionReasonExtrasBeforeChrome) {
-        [names addObject:@"extras-before-chrome"];
-    }
-    if (reasons & ApolloListInsetCorrectionReasonBelowVisibleChrome) {
-        [names addObject:@"below-visible-chrome"];
-    }
-    if (reasons & ApolloListInsetCorrectionReasonForegroundBaseline) {
-        [names addObject:@"foreground-baseline"];
-    }
-    return [names componentsJoinedByString:@","];
-}
-
 CGFloat ApolloListRememberedHealthyBottom(UIScrollView *table,
                                           CGFloat requiredChromeBottom) {
     NSNumber *extra = objc_getAssociatedObject(table, &kApolloListHealthyBottomExtraKey);
@@ -278,133 +212,156 @@ static void ApolloListRememberCurrentBottom(UIScrollView *table,
     ApolloListRememberHealthyBottom(table, bottom, requiredChromeBottom);
 }
 
+// Only armed around Apollo's synchronous handling of a normalized no-keyboard
+// event. In every other code path — including scrolling and tab-bar morphs —
+// the hook below is one pointer comparison followed by the original method.
 %hook ASTableView
 
 - (void)setContentInset:(UIEdgeInsets)inset {
-    UIEdgeInsets proposed = inset;
-    if (!ApolloListLayoutGuardEnabled() || !self.window ||
-        self.contentInsetAdjustmentBehavior != UIScrollViewContentInsetAdjustmentNever) {
+    if ((UIScrollView *)self != sApolloListActiveKeyboardRecoveryTable ||
+        sApolloListActiveKeyboardRecoveryFloor <= 0.5) {
         %orig(inset);
         return;
     }
 
-    UIViewController *controller = ApolloListOwningViewController(self);
-    if (!controller || !controller.view.window || !controller.tabBarController) {
-        %orig(inset);
-        return;
-    }
-
-    ApolloListBottomGeometry geometry = ApolloListBottomGeometryForController(controller);
-    if (!geometry.tabBarVisible || geometry.requiredChromeBottom <= 0.5) {
-        // A genuinely hidden/removed tab bar is allowed to reduce the inset.
-        // Forget the old floor so it cannot leak across a different layout.
-        objc_setAssociatedObject(self, &kApolloListHealthyBottomExtraKey,
-                                 nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        objc_setAssociatedObject(self, &kApolloListHealthyBottomChromeKey,
-                                 nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        %orig(inset);
-        return;
-    }
-
-    if (geometry.tabBarInsetGuardShouldStandDown) {
-        // iOS 27 leaves tabBar.frame and contentLayoutGuide at their expanded
-        // 83pt geometry while the floating bar is minimized or morphing. Its
-        // changing inset writes are therefore valid and must not be fought on
-        // each scroll frame. Preserve the expanded healthy baseline for the
-        // next stable target 0, but accept this write unchanged.
-        %orig(inset);
-        return;
-    }
-
-    CGFloat currentBottom = self.contentInset.bottom;
-    ApolloListRememberCurrentBottom(self, currentBottom, geometry.requiredChromeBottom);
-    CGFloat healthyBottom = ApolloListRememberedHealthyBottom(
-        self, geometry.requiredChromeBottom);
-    ApolloListInsetCorrectionReason reasons = 0;
-
-    // PR #744 / iOS 26-compatible case: Apollo computes safe-area + extras
-    // while safeAreaInsets.bottom transiently excludes part of a visible tab
-    // bar. Add only that missing chrome; Apollo's extras remain untouched.
-    // Geometry alone proves this one, so it needs no morph knowledge.
-    CGFloat safeAreaDeficit = MAX(0.0, geometry.requiredChromeBottom - geometry.safeBottom);
-    if (safeAreaDeficit > 0.5) {
-        inset.bottom += safeAreaDeficit;
-        reasons |= ApolloListInsetCorrectionReasonSafeAreaDeficit;
-    }
-
-    // The next two corrections need a trusted bar state: on Liquid Glass a
-    // provably expanded bar (readable stable morph target 0 — without morph
-    // knowledge the same numbers also occur legitimately while minimized,
-    // since iOS 27 keeps the expanded frame/guide in that state), on the
-    // legacy bar simply visible-and-not-sliding. Untrusted fails OPEN (see
-    // header).
-    if (geometry.tabBarStateTrusted) {
-        // Apollo sometimes emits its list-specific extra first (comments: 70)
-        // before its next layout adds the stable tab-bar safe area. If UIKit's
-        // content guide already says the full chrome is present, combine those
-        // values immediately instead of allowing the first-scroll jump reported
-        // on PR #744.
-        BOOL safeAreaAlreadyCoversChrome =
-            geometry.safeBottom + 0.5 >= geometry.requiredChromeBottom;
-        if (safeAreaAlreadyCoversChrome && proposed.bottom > 0.5 &&
-            proposed.bottom + 0.5 < geometry.requiredChromeBottom) {
-            inset.bottom = geometry.requiredChromeBottom + proposed.bottom;
-            reasons |= ApolloListInsetCorrectionReasonExtrasBeforeChrome;
-        }
-
-        // iOS 27 case captured on-device: expanded-bar foreground restoration
-        // writes 153 -> 0 while safe area, tab frame, guide and registration
-        // all remain correct. Any value below visible chrome is invalid for
-        // Apollo's adjustmentBehavior=.never table. Preserve the last healthy
-        // value when available so comments keep their 70pt extra as well as
-        // the 83pt bar.
-        if (inset.bottom + 0.5 < geometry.requiredChromeBottom) {
-            inset.bottom = MAX(geometry.requiredChromeBottom, healthyBottom);
-            reasons |= ApolloListInsetCorrectionReasonBelowVisibleChrome;
-        }
-    }
-
-    // Also reject a partial baseline drop during the short activation window
-    // (for example 153 -> 83). Outside that window a value at or above chrome
-    // is trusted, allowing Apollo to legitimately add/remove dynamic extras.
-    // Time-bounded, so it stays active even without morph knowledge.
-    BOOL foregroundProtected = CACurrentMediaTime() < sApolloListForegroundProtectionUntil;
-    if (foregroundProtected && healthyBottom > 0.5 && inset.bottom + 0.5 < healthyBottom) {
-        inset.bottom = healthyBottom;
-        reasons |= ApolloListInsetCorrectionReasonForegroundBaseline;
-    }
-
-    BOOL corrected = fabs(inset.bottom - proposed.bottom) > 0.5;
+    BOOL corrected = sApolloListActiveKeyboardRecoveryFloor - inset.bottom >
+        kApolloListKeyboardRecoveryTolerance;
     if (corrected) {
-        NSInteger minimizeBehavior = -1;
-        if (@available(iOS 26.0, *)) {
-            minimizeBehavior = controller.tabBarController.tabBarMinimizeBehavior;
-        }
+        CGFloat proposedBottom = inset.bottom;
+        CGFloat priorBottom = self.contentInset.bottom;
+        inset.bottom = sApolloListActiveKeyboardRecoveryFloor;
         ApolloListLayoutLog(
-            @"guarded setContentInset vc=%@ reasons=%@ proposedB=%.1f correctedB=%.1f "
-             "currentB=%.1f healthyB=%.1f safeB=%.1f overlap=%.1f guide=%.1f "
-             "required=%.1f minimize=%ld morph=%ld morphKnown=%@ appState=%ld",
-            NSStringFromClass(controller.class),
-            ApolloListInsetCorrectionReasonDescription(reasons),
-            proposed.bottom, inset.bottom, currentBottom, healthyBottom,
-            geometry.safeBottom, geometry.tabBarOverlap, geometry.guideBottomClearance,
-            geometry.requiredChromeBottom, (long)minimizeBehavior,
-            (long)geometry.tabBarMorphTarget,
-            geometry.tabBarMorphTargetKnown ? @"yes" : @"no",
-            (long)UIApplication.sharedApplication.applicationState);
+            @"keyboard fallback corrected native inset vc=%@ proposedB=%.1f "
+             "correctedB=%.1f priorB=%.1f",
+            NSStringFromClass(sApolloListActiveKeyboardRecoveryController.class),
+            proposedBottom, inset.bottom, priorBottom);
     }
 
     %orig(inset);
-    // Only Apollo's own accepted values become the healthy baseline. Feeding a
-    // corrected value back in would let one wrong correction defend itself via
-    // foreground-baseline on the next pass; the uncorrected path re-remembers
-    // on every accepted write, so nothing is lost by skipping here.
-    if (!corrected) {
-        ApolloListRememberHealthyBottom(self, inset.bottom, geometry.requiredChromeBottom);
-    }
 }
 
 %end
+
+static BOOL ApolloListKeyboardRectIsFinite(CGRect rect) {
+    return isfinite(rect.origin.x) && isfinite(rect.origin.y) &&
+        isfinite(rect.size.width) && isfinite(rect.size.height);
+}
+
+static BOOL ApolloListKeyboardRectHasIntersection(CGRect rect, CGRect bounds,
+                                                  CGRect *intersectionOut) {
+    if (!ApolloListKeyboardRectIsFinite(rect) || CGRectIsNull(rect) ||
+        CGRectIsInfinite(rect) || CGRectIsEmpty(rect)) return NO;
+    CGRect intersection = CGRectIntersection(bounds, rect);
+    if (CGRectIsNull(intersection) || CGRectIsEmpty(intersection)) return NO;
+    if (intersectionOut) *intersectionOut = intersection;
+    return YES;
+}
+
+static NSNotification *ApolloListKeyboardNotificationWithEndFrame(
+    NSNotification *notification, CGRect endFrame) {
+    NSMutableDictionary *userInfo = [notification.userInfo mutableCopy]
+        ?: [NSMutableDictionary dictionary];
+    userInfo[UIKeyboardFrameEndUserInfoKey] = [NSValue valueWithCGRect:endFrame];
+    return [NSNotification notificationWithName:notification.name
+                                          object:notification.object
+                                        userInfo:userInfo];
+}
+
+// Normalize the notification at Apollo's input boundary. UIKit explicitly
+// marks app-switch keyboard frames as non-local; consuming them was the source
+// of the 153 -> 347 half of the visible jump. CGRect.zero / no intersection is
+// converted to Apollo's native hidden sentinel (origin.y == view height),
+// preventing the 347 -> 0 half without bypassing Apollo's own per-screen inset
+// calculator (comments retain their 70pt extra naturally).
+static NSNotification *ApolloListNormalizedKeyboardNotification(
+    UIViewController *controller,
+    NSNotification *notification,
+    BOOL *ignoreOut,
+    BOOL *armRecoveryOut,
+    NSString **decisionOut) {
+    if (ignoreOut) *ignoreOut = NO;
+    if (armRecoveryOut) *armRecoveryOut = NO;
+
+    NSDictionary *userInfo = [notification.userInfo isKindOfClass:NSDictionary.class]
+        ? notification.userInfo : nil;
+    NSNumber *local = [userInfo[UIKeyboardIsLocalUserInfoKey]
+        isKindOfClass:NSNumber.class] ? userInfo[UIKeyboardIsLocalUserInfoKey] : nil;
+    if (local && !local.boolValue) {
+        if (ignoreOut) *ignoreOut = YES;
+        if (decisionOut) *decisionOut = @"ignored:non-local";
+        return nil;
+    }
+
+    id endValue = userInfo[UIKeyboardFrameEndUserInfoKey];
+    if (![endValue respondsToSelector:@selector(CGRectValue)] ||
+        !controller.isViewLoaded) {
+        if (decisionOut) *decisionOut = @"passthrough:missing-frame-or-view";
+        return notification;
+    }
+
+    UIView *view = controller.view;
+    CGRect rawEnd = [endValue CGRectValue];
+    UIScreen *notificationScreen = [notification.object isKindOfClass:UIScreen.class]
+        ? (UIScreen *)notification.object : nil;
+    UIScreen *sourceScreen = notificationScreen ?: view.window.screen ?: UIScreen.mainScreen;
+
+    // Apollo observes globally, so live but off-hierarchy list controllers also
+    // receive every event. Ignore a visible keyboard for those controllers;
+    // still pass a hide/no-overlap event so a controller that previously owned
+    // the keyboard cannot retain stale Swift Optional<CGRect> state.
+    if (!view.window) {
+        CGRect screenIntersection = CGRectNull;
+        BOOL rawOverlapsScreen = sourceScreen &&
+            ApolloListKeyboardRectHasIntersection(rawEnd, sourceScreen.bounds,
+                                                  &screenIntersection);
+        if (rawOverlapsScreen) {
+            if (ignoreOut) *ignoreOut = YES;
+            if (decisionOut) *decisionOut = @"ignored:hidden-controller-visible-frame";
+            return nil;
+        }
+    }
+
+    CGRect convertedEnd = rawEnd;
+    if (sourceScreen && view.window) {
+        convertedEnd = [view convertRect:rawEnd
+                     fromCoordinateSpace:sourceScreen.coordinateSpace];
+    }
+
+    CGRect intersection = CGRectNull;
+    BOOL overlapsView = ApolloListKeyboardRectHasIntersection(
+        convertedEnd, view.bounds, &intersection);
+    CGRect deliveredEnd;
+    NSString *decision;
+    if (overlapsView) {
+        deliveredEnd = intersection;
+        decision = @"normalized:local-intersection";
+    } else {
+        deliveredEnd = CGRectMake(CGRectGetMinX(view.bounds),
+                                  CGRectGetMaxY(view.bounds),
+                                  CGRectGetWidth(view.bounds), 0.0);
+        decision = @"normalized:no-local-overlap";
+        // Hidden controllers still receive the sentinel so Apollo clears its
+        // cached Optional<CGRect>, but their offscreen insets need no defense.
+        // Arming only the visible list keeps this redundant clamp from doing
+        // work across every retained navigation stack on each keyboard hide.
+        if (armRecoveryOut) *armRecoveryOut = view.window != nil;
+    }
+    if (decisionOut) *decisionOut = decision;
+
+    if (view.window) {
+        ApolloListLayoutLog(
+            @"keyboard source decision=%@ vc=%@ local=%@ rawEnd=%@ "
+             "convertedEnd=%@ deliveredEnd=%@",
+            decision, NSStringFromClass(controller.class),
+            local ? (local.boolValue ? @"yes" : @"no") : @"missing",
+            NSStringFromCGRect(rawEnd), NSStringFromCGRect(convertedEnd),
+            NSStringFromCGRect(deliveredEnd));
+    }
+
+    return CGRectEqualToRect(rawEnd, deliveredEnd)
+        ? notification
+        : ApolloListKeyboardNotificationWithEndFrame(notification, deliveredEnd);
+}
 
 // The iOS 26 content-scroll-view contract: tell UIKit which scroll view drives
 // the bottom accessory (the minimizing tab bar). Apollo never registers its
@@ -439,10 +396,40 @@ static void ApolloListReRegisterTrackedControllers(NSString *reason) {
     });
 }
 
-// The setContentInset: hook can only fix writes that happen. iOS 27 can also
-// change the effective safe area WITHOUT Apollo ever writing again (legacy
-// mirror re-showing the bar, foreground restoration) — this walks the visible
-// tracked lists and raises any inset stranded below a steady visible bar.
+static void ApolloListCaptureHealthyBottomForController(
+    UIViewController *controller, NSString *reason) {
+    if (!controller.isViewLoaded || !controller.view.window) return;
+    UIScrollView *table = ApolloListTableForController(controller);
+    if (!table || !table.window ||
+        table.contentInsetAdjustmentBehavior != UIScrollViewContentInsetAdjustmentNever) return;
+
+    ApolloListBottomGeometry geometry = ApolloListBottomGeometryForController(controller);
+    if (!geometry.tabBarVisible || geometry.requiredChromeBottom <= 0.5 ||
+        geometry.tabBarInsetGuardShouldStandDown || !geometry.tabBarStateTrusted) return;
+
+    CGFloat before = ApolloListRememberedHealthyBottom(table,
+                                                        geometry.requiredChromeBottom);
+    ApolloListRememberCurrentBottom(table, table.contentInset.bottom,
+                                    geometry.requiredChromeBottom);
+    CGFloat after = ApolloListRememberedHealthyBottom(table,
+                                                       geometry.requiredChromeBottom);
+    if (after > 0.5 && fabs(after - before) > 0.5) {
+        ApolloListLayoutLog(@"captured healthy bottom reason=%@ vc=%@ bottom=%.1f chrome=%.1f",
+                            reason, NSStringFromClass(controller.class), after,
+                            geometry.requiredChromeBottom);
+    }
+}
+
+void ApolloListCaptureHealthyBottomForVisibleLists(NSString *reason) {
+    if (!ApolloListLayoutGuardEnabled()) return;
+    for (UIViewController *controller in sApolloListGuardControllers.allObjects) {
+        ApolloListCaptureHealthyBottomForController(controller, reason);
+    }
+}
+
+// Cold-path redundancy for a no-write safe-area failure. It runs only after an
+// explicit settled boundary; unlike the old setContentInset guard it cannot
+// intercept Apollo's expected 70 -> 153 setup or UIKit's per-frame morphs.
 void ApolloListVerifyBottomInsetForVisibleLists(NSString *reason) {
     if (!ApolloListLayoutGuardEnabled()) return;
     for (UIViewController *controller in sApolloListGuardControllers.allObjects) {
@@ -456,20 +443,81 @@ void ApolloListVerifyBottomInsetForVisibleLists(NSString *reason) {
             geometry.tabBarInsetGuardShouldStandDown || !geometry.tabBarStateTrusted) continue;
 
         UIEdgeInsets inset = table.contentInset;
-        if (inset.bottom + 0.5 >= geometry.requiredChromeBottom) continue;
+        if (inset.bottom + 0.5 >= geometry.requiredChromeBottom) {
+            ApolloListRememberCurrentBottom(table, inset.bottom,
+                                            geometry.requiredChromeBottom);
+            continue;
+        }
         CGFloat healthyBottom = ApolloListRememberedHealthyBottom(table, geometry.requiredChromeBottom);
         CGFloat raised = MAX(geometry.requiredChromeBottom, healthyBottom);
         ApolloListLayoutLog(@"verify raised stale bottom inset reason=%@ vc=%@ from=%.1f to=%.1f required=%.1f healthyB=%.1f",
                             reason, NSStringFromClass(controller.class),
                             inset.bottom, raised, geometry.requiredChromeBottom, healthyBottom);
         inset.bottom = raised;
-        // Routed through the setContentInset: hook; the raised value is at or
-        // above chrome, so it passes untouched and refreshes the baseline.
         table.contentInset = inset;
+        ApolloListRememberHealthyBottom(table, raised, geometry.requiredChromeBottom);
     }
 }
 
+static void ApolloListScheduleSettledVerification(NSString *reason,
+                                                  NSTimeInterval delay) {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                 (int64_t)(delay * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        ApolloListVerifyBottomInsetForVisibleLists(reason);
+    });
+}
+
 %hook _TtC6Apollo21ASTableViewController
+
+- (void)keyboardWillChangeFrameWithNotification:(NSNotification *)notification {
+    if (!ApolloListLayoutGuardEnabled()) {
+        %orig(notification);
+        return;
+    }
+
+    UIViewController *controller = (UIViewController *)self;
+    BOOL ignore = NO;
+    BOOL armRecovery = NO;
+    NSString *decision = nil;
+    NSNotification *deliveredNotification = ApolloListNormalizedKeyboardNotification(
+        controller, notification, &ignore, &armRecovery, &decision);
+    if (ignore || !deliveredNotification) {
+        if (controller.view.window) {
+            ApolloListLayoutLog(@"keyboard source decision=%@ vc=%@",
+                                decision, NSStringFromClass(controller.class));
+        }
+        return;
+    }
+
+    UIScrollView *table = ApolloListTableForController(controller);
+    UIScrollView *previousTable = sApolloListActiveKeyboardRecoveryTable;
+    UIViewController *previousController = sApolloListActiveKeyboardRecoveryController;
+    CGFloat previousFloor = sApolloListActiveKeyboardRecoveryFloor;
+    if (armRecovery && table) {
+        // Snapshot the healthy non-keyboard baseline before Apollo consumes the
+        // hide event. A real keyboard-sized current inset is rejected by the
+        // remembered-extra cap, preserving the baseline captured before show.
+        ApolloListCaptureHealthyBottomForController(controller,
+                                                     @"keyboard.no-overlap.before");
+        ApolloListBottomGeometry geometry =
+            ApolloListBottomGeometryForController(controller);
+        CGFloat healthyBottom = ApolloListRememberedHealthyBottom(
+            table, geometry.requiredChromeBottom);
+        sApolloListActiveKeyboardRecoveryTable = table;
+        sApolloListActiveKeyboardRecoveryController = controller;
+        sApolloListActiveKeyboardRecoveryFloor = healthyBottom > 0.5
+            ? healthyBottom : geometry.requiredChromeBottom;
+    }
+
+    @try {
+        %orig(deliveredNotification);
+    } @finally {
+        sApolloListActiveKeyboardRecoveryTable = previousTable;
+        sApolloListActiveKeyboardRecoveryController = previousController;
+        sApolloListActiveKeyboardRecoveryFloor = previousFloor;
+    }
+}
 
 - (void)viewDidLoad {
     %orig;
@@ -481,6 +529,16 @@ void ApolloListVerifyBottomInsetForVisibleLists(NSString *reason) {
     %orig(animated);
     [sApolloListGuardControllers addObject:(UIViewController *)self];
     ApolloListEnsureContentScrollViewRegistered((UIViewController *)self, @"viewDidAppear");
+    // Wait beyond Apollo's transition/layout sequence before deciding anything
+    // is stale. In particular, comments legitimately emit 70 before their
+    // native calculator follows with 153 in the same appearance pass.
+    ApolloListScheduleSettledVerification(@"viewDidAppear.settled", 0.35);
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    ApolloListCaptureHealthyBottomForController((UIViewController *)self,
+                                                @"viewWillDisappear");
+    %orig(animated);
 }
 
 %end
@@ -494,21 +552,22 @@ void ApolloListVerifyBottomInsetForVisibleLists(NSString *reason) {
 
         sApolloListGuardControllers = [NSHashTable weakObjectsHashTable];
 
-        // didBecomeActive also fires after Notification Center / Control
-        // Center dismissals (no backgrounding). The iOS 27 inset restoration
-        // only happens on a real background->foreground transition, so heavier
-        // work is keyed off willEnterForeground; a bare re-activation extends
-        // nothing and re-registers nothing (device logs showed 6 activations
-        // in 90s, each previously bursting main-thread work mid-interaction).
+        // didBecomeActive also fires after Notification Center / Control Center
+        // dismissals. Keep work keyed to a real foreground pair and capture the
+        // stable baseline before any app-switch keyboard notifications arrive.
         static BOOL sPendingForegroundActivation = NO;
         NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+        [center addObserverForName:UIApplicationWillResignActiveNotification
+                            object:nil
+                             queue:[NSOperationQueue mainQueue]
+                        usingBlock:^(__unused NSNotification *notification) {
+            ApolloListCaptureHealthyBottomForVisibleLists(@"willResignActive");
+        }];
         [center addObserverForName:UIApplicationWillEnterForegroundNotification
                             object:nil
                              queue:[NSOperationQueue mainQueue]
                         usingBlock:^(__unused NSNotification *notification) {
             sPendingForegroundActivation = YES;
-            sApolloListForegroundProtectionUntil =
-                CACurrentMediaTime() + kApolloListForegroundProtectionSeconds;
             ApolloListReRegisterTrackedControllers(@"willEnterForeground");
         }];
         [center addObserverForName:UIApplicationDidBecomeActiveNotification
@@ -517,16 +576,11 @@ void ApolloListVerifyBottomInsetForVisibleLists(NSString *reason) {
                         usingBlock:^(__unused NSNotification *notification) {
             if (!sPendingForegroundActivation) return;
             sPendingForegroundActivation = NO;
-            sApolloListForegroundProtectionUntil = MAX(
-                sApolloListForegroundProtectionUntil,
-                CACurrentMediaTime() + kApolloListForegroundProtectionSeconds);
             ApolloListReRegisterTrackedControllers(@"didBecomeActive");
-            // After the app settles, catch the no-write variant of the
-            // restoration bug: safe area changed but Apollo never re-emitted
-            // an inset for the hook to correct.
-            dispatch_async(dispatch_get_main_queue(), ^{
-                ApolloListVerifyBottomInsetForVisibleLists(@"didBecomeActive.nextTurn");
-            });
+            // A cold-path fallback only. The captured iOS 27 zero-frame event
+            // arrived ~300ms after activation, so wait well past it and the tab
+            // bar's own restoration animation before checking final geometry.
+            ApolloListScheduleSettledVerification(@"didBecomeActive.settled", 0.65);
         }];
     }
 }

--- a/src/ApolloListBottomInsetGuard.xm
+++ b/src/ApolloListBottomInsetGuard.xm
@@ -1,0 +1,532 @@
+// ApolloListBottomInsetGuard.xm
+//
+// iOS 26/27 list bottom-inset protection — the FUNCTIONAL fix. Covers BOTH
+// tab-bar paths: the Liquid Glass floating bar (glass IPA) and the legacy
+// translucent UITabBar (standard IPA, issue #809 — next-page link stranded
+// behind the bar). (Verbose geometry snapshots live in
+// ApolloListLayoutDiagnostics.xm, which is safe to drop for shipping; this
+// module must ship.)
+//
+// Apollo manages ASTableView.contentInset itself with adjustmentBehavior=.never.
+// iOS 26 introduced floating/minimizing tab bars and explicit content-scroll-
+// view observation. iOS 27 can restore an expanded tab bar across activation,
+// then write the observed table's bottom inset from its healthy value (153 for
+// comments: 83 chrome + Apollo's 70 extra) all the way to zero without changing
+// safeAreaInsets or contentLayoutGuide. Apollo receives no later layout signal,
+// so the zero sticks and the final rows remain under the tab bar.
+//
+// This module does two things at the source:
+//   1. Explicitly registers Apollo's nested ASTableView as the bottom content
+//      scroll view, following the iOS 26 public UIKit contract.
+//   2. Guards setContentInset: while an expanded Liquid Glass tab bar overlaps
+//      the list. It combines the tab controller's unobscured content guide with
+//      a per-table healthy baseline, preserving Apollo's dynamic extras without
+//      hardcoding screen-specific values. The guard deliberately stands down
+//      while UIKit's visual provider is at its minimized morph target: iOS 27
+//      keeps the expanded tab frame/guide during that state, so geometry alone
+//      cannot distinguish a legitimate zero inset from the foreground bug. It
+//      also retains PR #744's protection for the older transient where
+//      safeAreaInsets.bottom itself under-reports the visible tab bar.
+//
+// Failure policy: the morph state comes from private UIKit ivars
+// (ApolloTabBarVisualMorphTarget in ApolloCommon). If a future iOS renames
+// them, the morph-gated corrections FAIL OPEN — they simply stop firing —
+// because geometry alone cannot tell minimized from expanded (see above), and
+// a guard armed on a wrong guess would fight UIKit's per-frame minimized-state
+// inset writes: exactly the scroll jank this branch exists to remove. Only the
+// geometry-provable safe-area-deficit case and the time-bounded foreground
+// window stay active without morph knowledge.
+
+#import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
+#import <UIKit/UIKit.h>
+#import <math.h>
+#import <objc/runtime.h>
+#import <stdarg.h>
+
+#import "ApolloCommon.h"
+#import "ApolloListLayoutSupport.h"
+
+@interface ASTableView : UITableView
+@end
+
+@interface _TtC6Apollo21ASTableViewController : UIViewController
+@end
+
+static NSHashTable<UIViewController *> *sApolloListGuardControllers;
+static CFTimeInterval sApolloListForegroundProtectionUntil = 0.0;
+static char kApolloListHealthyBottomExtraKey;
+static char kApolloListHealthyBottomChromeKey;
+static char kApolloListOwningControllerBoxKey;
+
+// A real Apollo list extra is small (comments use 70pt). This cap prevents a
+// temporary keyboard-sized inset from becoming a persistent foreground floor.
+static const CGFloat kApolloListMaximumRememberedExtra = 200.0;
+static const NSTimeInterval kApolloListForegroundProtectionSeconds = 2.0;
+
+BOOL ApolloListLayoutGuardEnabled(void) {
+    // Not gated on IsLiquidGlass(): the iOS 27 inset regression also hits
+    // legacy-linked (standard IPA) builds, where the translucent UITabBar
+    // underlaps the list and a zero bottom inset strands the last rows and
+    // the next-page link behind it (issue #809).
+    if (@available(iOS 26.0, *)) return YES;
+    return NO;
+}
+
+void ApolloListLayoutLog(NSString *format, ...) {
+    va_list args;
+    va_start(args, format);
+    NSString *body = [[NSString alloc] initWithFormat:format arguments:args];
+    va_end(args);
+
+    NSString *line = [NSString stringWithFormat:@"[ListLayoutGuard] %@", body ?: @""];
+    ApolloLog(@"%@", line);
+    ApolloAppendListLayoutDiag(line);
+}
+
+// Swift's `tableNode` is an ObjC object ivar on ASTableViewController, but it
+// has no public getter. Static helpers cannot use MSHookIvar, so walk the
+// runtime ivars and ask the ASTableNode for its underlying ASTableView.
+UIScrollView *ApolloListTableForController(UIViewController *controller) {
+    if (!controller) return nil;
+    Ivar tableNodeIvar = NULL;
+    Class cls = object_getClass(controller);
+    while (cls && !tableNodeIvar) {
+        tableNodeIvar = class_getInstanceVariable(cls, "tableNode");
+        cls = class_getSuperclass(cls);
+    }
+    if (!tableNodeIvar) return nil;
+
+    id tableNode = object_getIvar(controller, tableNodeIvar);
+    if (![tableNode respondsToSelector:@selector(view)]) return nil;
+    UIView *tableView = [tableNode view];
+    return [tableView isKindOfClass:[UIScrollView class]] ? (UIScrollView *)tableView : nil;
+}
+
+@interface ApolloListWeakControllerBox : NSObject
+@property (nonatomic, weak) UIViewController *controller;
+@end
+
+@implementation ApolloListWeakControllerBox
+@end
+
+// setContentInset: runs on scroll-adjacent paths, so cache the responder-chain
+// walk. An ASTableView never migrates to a different ASTableViewController in
+// Apollo; the weak box simply empties when the controller deallocates.
+static UIViewController *ApolloListOwningViewController(UIView *view) {
+    ApolloListWeakControllerBox *box =
+        objc_getAssociatedObject(view, &kApolloListOwningControllerBoxKey);
+    UIViewController *cached = box.controller;
+    if (cached) return cached;
+
+    UIResponder *responder = view;
+    Class listControllerClass = objc_getClass("_TtC6Apollo21ASTableViewController");
+    while ((responder = responder.nextResponder)) {
+        if (listControllerClass && [responder isKindOfClass:listControllerClass]) {
+            ApolloListWeakControllerBox *newBox = [ApolloListWeakControllerBox new];
+            newBox.controller = (UIViewController *)responder;
+            objc_setAssociatedObject(view, &kApolloListOwningControllerBoxKey, newBox,
+                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            return newBox.controller;
+        }
+    }
+    return nil;
+}
+
+ApolloListBottomGeometry ApolloListBottomGeometryForController(UIViewController *controller) {
+    ApolloListBottomGeometry geometry = {0};
+    if (!controller.isViewLoaded) return geometry;
+
+    UIView *view = controller.view;
+    UITabBarController *tabs = controller.tabBarController;
+    UITabBar *tabBar = tabs.tabBar;
+    geometry.safeBottom = view.safeAreaInsets.bottom;
+    if (!tabs || !tabBar || tabBar.hidden || tabBar.alpha < 0.01 || !tabBar.superview) {
+        return geometry;
+    }
+
+    if (IsLiquidGlass()) {
+        geometry.tabBarMorphTarget = ApolloTabBarVisualMorphTarget(tabBar,
+            &geometry.tabBarMorphTargetKnown);
+        geometry.tabBarMinimized = geometry.tabBarMorphTargetKnown &&
+            geometry.tabBarMorphTarget == 2;
+        geometry.tabBarMorphAnimating = ApolloTabBarVisualProviderBoolIvar(tabBar,
+            "isAnimatingCollapsedState", &geometry.tabBarMorphAnimatingKnown);
+        // Target 0 is the fully expanded provider. Target 1 is an intermediate
+        // collapse presentation and target 2 is minimized. UIKit exposes a
+        // separate Swift Bool while animating back toward target 0; include it
+        // so the guard never snaps a legitimate animated inset to its final
+        // value.
+        geometry.tabBarInsetGuardShouldStandDown =
+            (geometry.tabBarMorphTargetKnown && geometry.tabBarMorphTarget != 0) ||
+            (geometry.tabBarMorphAnimatingKnown && geometry.tabBarMorphAnimating);
+        geometry.tabBarStateTrusted = geometry.tabBarMorphTargetKnown;
+    } else {
+        // Legacy (pre-26-linked) opaque/translucent bar: no minimize states to
+        // disambiguate — a visible bar simply must be covered by the inset.
+        // The only in-flux window is ApolloAutoHideTabBar's hide/show mirror,
+        // which slides the bar with explicit layer animations while the model
+        // still reads fully visible; stand down while one is running (or the
+        // bar is parked mid-transform) so those transitions aren't fought.
+        geometry.tabBarMorphTarget = NSNotFound;
+        BOOL slideAnimating =
+            [tabBar.layer animationForKey:ApolloTabBarSlideDownAnimationKey] != nil ||
+            [tabBar.layer animationForKey:ApolloTabBarSlideUpAnimationKey] != nil;
+        BOOL transformed = !CGAffineTransformIsIdentity(tabBar.transform);
+        geometry.tabBarInsetGuardShouldStandDown = slideAnimating || transformed;
+        geometry.tabBarStateTrusted = !slideAnimating && !transformed;
+    }
+
+    if (@available(iOS 26.0, *)) {
+        if (tabs.isTabBarHidden) return geometry;
+    }
+
+    CGRect tabFrame = [view convertRect:tabBar.bounds fromView:tabBar];
+    if (!CGRectIsNull(tabFrame) && !CGRectIsInfinite(tabFrame)) {
+        geometry.tabBarOverlap = MAX(0.0, CGRectGetMaxY(view.bounds) - CGRectGetMinY(tabFrame));
+    }
+
+    if (@available(iOS 26.0, *)) {
+        UILayoutGuide *guide = tabs.contentLayoutGuide;
+        UIView *owner = guide.owningView;
+        if (owner) {
+            CGRect guideFrame = [view convertRect:guide.layoutFrame fromView:owner];
+            if (!CGRectIsNull(guideFrame) && !CGRectIsInfinite(guideFrame)) {
+                geometry.guideBottomClearance =
+                    MAX(0.0, CGRectGetMaxY(view.bounds) - CGRectGetMaxY(guideFrame));
+            }
+        }
+    }
+
+    geometry.tabBarVisible = geometry.tabBarOverlap > 0.5 || geometry.guideBottomClearance > 0.5;
+    geometry.requiredChromeBottom = MIN(200.0,
+        MAX(geometry.tabBarOverlap, geometry.guideBottomClearance));
+    return geometry;
+}
+
+typedef NS_OPTIONS(NSUInteger, ApolloListInsetCorrectionReason) {
+    ApolloListInsetCorrectionReasonSafeAreaDeficit = 1 << 0,
+    ApolloListInsetCorrectionReasonExtrasBeforeChrome = 1 << 1,
+    ApolloListInsetCorrectionReasonBelowVisibleChrome = 1 << 2,
+    ApolloListInsetCorrectionReasonForegroundBaseline = 1 << 3,
+};
+
+static NSString *ApolloListInsetCorrectionReasonDescription(
+    ApolloListInsetCorrectionReason reasons) {
+    // This runs only for an actual correction. The old mutable array allocated
+    // on every setContentInset:, including accepted per-frame scroll writes.
+    NSMutableArray<NSString *> *names = [NSMutableArray arrayWithCapacity:4];
+    if (reasons & ApolloListInsetCorrectionReasonSafeAreaDeficit) {
+        [names addObject:@"safe-area-deficit"];
+    }
+    if (reasons & ApolloListInsetCorrectionReasonExtrasBeforeChrome) {
+        [names addObject:@"extras-before-chrome"];
+    }
+    if (reasons & ApolloListInsetCorrectionReasonBelowVisibleChrome) {
+        [names addObject:@"below-visible-chrome"];
+    }
+    if (reasons & ApolloListInsetCorrectionReasonForegroundBaseline) {
+        [names addObject:@"foreground-baseline"];
+    }
+    return [names componentsJoinedByString:@","];
+}
+
+CGFloat ApolloListRememberedHealthyBottom(UIScrollView *table,
+                                          CGFloat requiredChromeBottom) {
+    NSNumber *extra = objc_getAssociatedObject(table, &kApolloListHealthyBottomExtraKey);
+    if (![extra isKindOfClass:NSNumber.class]) return 0.0;
+    return requiredChromeBottom + extra.doubleValue;
+}
+
+static void ApolloListRememberHealthyBottom(UIScrollView *table,
+                                            CGFloat bottom,
+                                            CGFloat requiredChromeBottom) {
+    if (!table || requiredChromeBottom <= 0.5 || bottom + 0.5 < requiredChromeBottom) return;
+    CGFloat extra = bottom - requiredChromeBottom;
+    if (extra < -0.5 || extra > kApolloListMaximumRememberedExtra) return;
+    CGFloat clampedExtra = MAX(0.0, extra);
+
+    // Steady state re-remembers the same pair on every accepted write; two
+    // associated reads are cheaper than two NSNumber boxes + two writes.
+    NSNumber *storedExtra = objc_getAssociatedObject(table, &kApolloListHealthyBottomExtraKey);
+    NSNumber *storedChrome = objc_getAssociatedObject(table, &kApolloListHealthyBottomChromeKey);
+    if ([storedExtra isKindOfClass:NSNumber.class] &&
+        [storedChrome isKindOfClass:NSNumber.class] &&
+        fabs(storedExtra.doubleValue - clampedExtra) <= 0.5 &&
+        fabs(storedChrome.doubleValue - requiredChromeBottom) <= 0.5) {
+        return;
+    }
+
+    // Store Apollo's list-specific padding separately from the current glass
+    // bar height. The bar can legitimately expand/collapse between writes; a
+    // 70pt comments extra should become `new chrome + 70`, not preserve an
+    // absolute inset measured against the previous bar state.
+    objc_setAssociatedObject(table, &kApolloListHealthyBottomExtraKey,
+                             @(clampedExtra), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(table, &kApolloListHealthyBottomChromeKey,
+                             @(requiredChromeBottom), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static void ApolloListRememberCurrentBottom(UIScrollView *table,
+                                            CGFloat bottom,
+                                            CGFloat requiredChromeBottom) {
+    NSNumber *previousChrome = objc_getAssociatedObject(table, &kApolloListHealthyBottomChromeKey);
+    // If the bar geometry changed first, `bottom` still belongs to the old
+    // geometry. Keep the prior extra until the new inset has been accepted.
+    if ([previousChrome isKindOfClass:NSNumber.class] &&
+        fabs(previousChrome.doubleValue - requiredChromeBottom) > 0.5) return;
+    ApolloListRememberHealthyBottom(table, bottom, requiredChromeBottom);
+}
+
+%hook ASTableView
+
+- (void)setContentInset:(UIEdgeInsets)inset {
+    UIEdgeInsets proposed = inset;
+    if (!ApolloListLayoutGuardEnabled() || !self.window ||
+        self.contentInsetAdjustmentBehavior != UIScrollViewContentInsetAdjustmentNever) {
+        %orig(inset);
+        return;
+    }
+
+    UIViewController *controller = ApolloListOwningViewController(self);
+    if (!controller || !controller.view.window || !controller.tabBarController) {
+        %orig(inset);
+        return;
+    }
+
+    ApolloListBottomGeometry geometry = ApolloListBottomGeometryForController(controller);
+    if (!geometry.tabBarVisible || geometry.requiredChromeBottom <= 0.5) {
+        // A genuinely hidden/removed tab bar is allowed to reduce the inset.
+        // Forget the old floor so it cannot leak across a different layout.
+        objc_setAssociatedObject(self, &kApolloListHealthyBottomExtraKey,
+                                 nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(self, &kApolloListHealthyBottomChromeKey,
+                                 nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        %orig(inset);
+        return;
+    }
+
+    if (geometry.tabBarInsetGuardShouldStandDown) {
+        // iOS 27 leaves tabBar.frame and contentLayoutGuide at their expanded
+        // 83pt geometry while the floating bar is minimized or morphing. Its
+        // changing inset writes are therefore valid and must not be fought on
+        // each scroll frame. Preserve the expanded healthy baseline for the
+        // next stable target 0, but accept this write unchanged.
+        %orig(inset);
+        return;
+    }
+
+    CGFloat currentBottom = self.contentInset.bottom;
+    ApolloListRememberCurrentBottom(self, currentBottom, geometry.requiredChromeBottom);
+    CGFloat healthyBottom = ApolloListRememberedHealthyBottom(
+        self, geometry.requiredChromeBottom);
+    ApolloListInsetCorrectionReason reasons = 0;
+
+    // PR #744 / iOS 26-compatible case: Apollo computes safe-area + extras
+    // while safeAreaInsets.bottom transiently excludes part of a visible tab
+    // bar. Add only that missing chrome; Apollo's extras remain untouched.
+    // Geometry alone proves this one, so it needs no morph knowledge.
+    CGFloat safeAreaDeficit = MAX(0.0, geometry.requiredChromeBottom - geometry.safeBottom);
+    if (safeAreaDeficit > 0.5) {
+        inset.bottom += safeAreaDeficit;
+        reasons |= ApolloListInsetCorrectionReasonSafeAreaDeficit;
+    }
+
+    // The next two corrections need a trusted bar state: on Liquid Glass a
+    // provably expanded bar (readable stable morph target 0 — without morph
+    // knowledge the same numbers also occur legitimately while minimized,
+    // since iOS 27 keeps the expanded frame/guide in that state), on the
+    // legacy bar simply visible-and-not-sliding. Untrusted fails OPEN (see
+    // header).
+    if (geometry.tabBarStateTrusted) {
+        // Apollo sometimes emits its list-specific extra first (comments: 70)
+        // before its next layout adds the stable tab-bar safe area. If UIKit's
+        // content guide already says the full chrome is present, combine those
+        // values immediately instead of allowing the first-scroll jump reported
+        // on PR #744.
+        BOOL safeAreaAlreadyCoversChrome =
+            geometry.safeBottom + 0.5 >= geometry.requiredChromeBottom;
+        if (safeAreaAlreadyCoversChrome && proposed.bottom > 0.5 &&
+            proposed.bottom + 0.5 < geometry.requiredChromeBottom) {
+            inset.bottom = geometry.requiredChromeBottom + proposed.bottom;
+            reasons |= ApolloListInsetCorrectionReasonExtrasBeforeChrome;
+        }
+
+        // iOS 27 case captured on-device: expanded-bar foreground restoration
+        // writes 153 -> 0 while safe area, tab frame, guide and registration
+        // all remain correct. Any value below visible chrome is invalid for
+        // Apollo's adjustmentBehavior=.never table. Preserve the last healthy
+        // value when available so comments keep their 70pt extra as well as
+        // the 83pt bar.
+        if (inset.bottom + 0.5 < geometry.requiredChromeBottom) {
+            inset.bottom = MAX(geometry.requiredChromeBottom, healthyBottom);
+            reasons |= ApolloListInsetCorrectionReasonBelowVisibleChrome;
+        }
+    }
+
+    // Also reject a partial baseline drop during the short activation window
+    // (for example 153 -> 83). Outside that window a value at or above chrome
+    // is trusted, allowing Apollo to legitimately add/remove dynamic extras.
+    // Time-bounded, so it stays active even without morph knowledge.
+    BOOL foregroundProtected = CACurrentMediaTime() < sApolloListForegroundProtectionUntil;
+    if (foregroundProtected && healthyBottom > 0.5 && inset.bottom + 0.5 < healthyBottom) {
+        inset.bottom = healthyBottom;
+        reasons |= ApolloListInsetCorrectionReasonForegroundBaseline;
+    }
+
+    BOOL corrected = fabs(inset.bottom - proposed.bottom) > 0.5;
+    if (corrected) {
+        NSInteger minimizeBehavior = -1;
+        if (@available(iOS 26.0, *)) {
+            minimizeBehavior = controller.tabBarController.tabBarMinimizeBehavior;
+        }
+        ApolloListLayoutLog(
+            @"guarded setContentInset vc=%@ reasons=%@ proposedB=%.1f correctedB=%.1f "
+             "currentB=%.1f healthyB=%.1f safeB=%.1f overlap=%.1f guide=%.1f "
+             "required=%.1f minimize=%ld morph=%ld morphKnown=%@ appState=%ld",
+            NSStringFromClass(controller.class),
+            ApolloListInsetCorrectionReasonDescription(reasons),
+            proposed.bottom, inset.bottom, currentBottom, healthyBottom,
+            geometry.safeBottom, geometry.tabBarOverlap, geometry.guideBottomClearance,
+            geometry.requiredChromeBottom, (long)minimizeBehavior,
+            (long)geometry.tabBarMorphTarget,
+            geometry.tabBarMorphTargetKnown ? @"yes" : @"no",
+            (long)UIApplication.sharedApplication.applicationState);
+    }
+
+    %orig(inset);
+    // Only Apollo's own accepted values become the healthy baseline. Feeding a
+    // corrected value back in would let one wrong correction defend itself via
+    // foreground-baseline on the next pass; the uncorrected path re-remembers
+    // on every accepted write, so nothing is lost by skipping here.
+    if (!corrected) {
+        ApolloListRememberHealthyBottom(self, inset.bottom, geometry.requiredChromeBottom);
+    }
+}
+
+%end
+
+// The iOS 26 content-scroll-view contract: tell UIKit which scroll view drives
+// the bottom accessory (the minimizing tab bar). Apollo never registers its
+// nested ASTableView itself, which is half of why iOS 27's restoration writes
+// target the wrong geometry. Registration is idempotent; log only on change.
+static void ApolloListEnsureContentScrollViewRegistered(UIViewController *controller,
+                                                        NSString *reason) {
+    // Glass builds only: the registration exists for the iOS 26 minimizing
+    // bar's content-scroll-view observation. On legacy-linked builds it could
+    // instead flip the bar's standard/scroll-edge appearance selection, a
+    // visual change the standard IPA never had.
+    if (!IsLiquidGlass()) return;
+    if (!ApolloListLayoutGuardEnabled() || !controller.isViewLoaded) return;
+    UIScrollView *table = ApolloListTableForController(controller);
+    if (!table) return;
+    if (@available(iOS 26.0, *)) {
+        UIScrollView *before = [controller contentScrollViewForEdge:NSDirectionalRectEdgeBottom];
+        if (before == table) return;
+        [controller setContentScrollView:table forEdge:NSDirectionalRectEdgeBottom];
+        ApolloListLayoutLog(@"registered bottom content scroll view reason=%@ vc=%@ before=%@",
+                            reason, NSStringFromClass(controller.class),
+                            before ? NSStringFromClass(before.class) : @"nil");
+    }
+}
+
+static void ApolloListReRegisterTrackedControllers(NSString *reason) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        for (UIViewController *controller in sApolloListGuardControllers.allObjects) {
+            if (!controller.isViewLoaded || !controller.view.window) continue;
+            ApolloListEnsureContentScrollViewRegistered(controller, reason);
+        }
+    });
+}
+
+// The setContentInset: hook can only fix writes that happen. iOS 27 can also
+// change the effective safe area WITHOUT Apollo ever writing again (legacy
+// mirror re-showing the bar, foreground restoration) — this walks the visible
+// tracked lists and raises any inset stranded below a steady visible bar.
+void ApolloListVerifyBottomInsetForVisibleLists(NSString *reason) {
+    if (!ApolloListLayoutGuardEnabled()) return;
+    for (UIViewController *controller in sApolloListGuardControllers.allObjects) {
+        if (!controller.isViewLoaded || !controller.view.window) continue;
+        UIScrollView *table = ApolloListTableForController(controller);
+        if (!table || !table.window ||
+            table.contentInsetAdjustmentBehavior != UIScrollViewContentInsetAdjustmentNever) continue;
+
+        ApolloListBottomGeometry geometry = ApolloListBottomGeometryForController(controller);
+        if (!geometry.tabBarVisible || geometry.requiredChromeBottom <= 0.5 ||
+            geometry.tabBarInsetGuardShouldStandDown || !geometry.tabBarStateTrusted) continue;
+
+        UIEdgeInsets inset = table.contentInset;
+        if (inset.bottom + 0.5 >= geometry.requiredChromeBottom) continue;
+        CGFloat healthyBottom = ApolloListRememberedHealthyBottom(table, geometry.requiredChromeBottom);
+        CGFloat raised = MAX(geometry.requiredChromeBottom, healthyBottom);
+        ApolloListLayoutLog(@"verify raised stale bottom inset reason=%@ vc=%@ from=%.1f to=%.1f required=%.1f healthyB=%.1f",
+                            reason, NSStringFromClass(controller.class),
+                            inset.bottom, raised, geometry.requiredChromeBottom, healthyBottom);
+        inset.bottom = raised;
+        // Routed through the setContentInset: hook; the raised value is at or
+        // above chrome, so it passes untouched and refreshes the baseline.
+        table.contentInset = inset;
+    }
+}
+
+%hook _TtC6Apollo21ASTableViewController
+
+- (void)viewDidLoad {
+    %orig;
+    [sApolloListGuardControllers addObject:(UIViewController *)self];
+    ApolloListEnsureContentScrollViewRegistered((UIViewController *)self, @"viewDidLoad");
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig(animated);
+    [sApolloListGuardControllers addObject:(UIViewController *)self];
+    ApolloListEnsureContentScrollViewRegistered((UIViewController *)self, @"viewDidAppear");
+}
+
+%end
+
+%ctor {
+    @autoreleasepool {
+        // The %hook bodies self-gate, so skipping setup here only disables the
+        // foreground machinery — nothing on legacy/non-glass installs ever
+        // touches the persistent diag file or holds a controller table.
+        if (!ApolloListLayoutGuardEnabled()) return;
+
+        sApolloListGuardControllers = [NSHashTable weakObjectsHashTable];
+
+        // didBecomeActive also fires after Notification Center / Control
+        // Center dismissals (no backgrounding). The iOS 27 inset restoration
+        // only happens on a real background->foreground transition, so heavier
+        // work is keyed off willEnterForeground; a bare re-activation extends
+        // nothing and re-registers nothing (device logs showed 6 activations
+        // in 90s, each previously bursting main-thread work mid-interaction).
+        static BOOL sPendingForegroundActivation = NO;
+        NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+        [center addObserverForName:UIApplicationWillEnterForegroundNotification
+                            object:nil
+                             queue:[NSOperationQueue mainQueue]
+                        usingBlock:^(__unused NSNotification *notification) {
+            sPendingForegroundActivation = YES;
+            sApolloListForegroundProtectionUntil =
+                CACurrentMediaTime() + kApolloListForegroundProtectionSeconds;
+            ApolloListReRegisterTrackedControllers(@"willEnterForeground");
+        }];
+        [center addObserverForName:UIApplicationDidBecomeActiveNotification
+                            object:nil
+                             queue:[NSOperationQueue mainQueue]
+                        usingBlock:^(__unused NSNotification *notification) {
+            if (!sPendingForegroundActivation) return;
+            sPendingForegroundActivation = NO;
+            sApolloListForegroundProtectionUntil = MAX(
+                sApolloListForegroundProtectionUntil,
+                CACurrentMediaTime() + kApolloListForegroundProtectionSeconds);
+            ApolloListReRegisterTrackedControllers(@"didBecomeActive");
+            // After the app settles, catch the no-write variant of the
+            // restoration bug: safe area changed but Apollo never re-emitted
+            // an inset for the hook to correct.
+            dispatch_async(dispatch_get_main_queue(), ^{
+                ApolloListVerifyBottomInsetForVisibleLists(@"didBecomeActive.nextTurn");
+            });
+        }];
+    }
+}

--- a/src/ApolloListLayoutDiagnostics.xm
+++ b/src/ApolloListLayoutDiagnostics.xm
@@ -1,0 +1,453 @@
+// ApolloListLayoutDiagnostics.xm
+//
+// iOS 26/27 Liquid Glass list-bottom protection and diagnostics.
+//
+// Apollo manages ASTableView.contentInset itself with adjustmentBehavior=.never.
+// iOS 26 introduced floating/minimizing tab bars and explicit content-scroll-
+// view observation. iOS 27 can restore an expanded tab bar across activation,
+// then write the observed table's bottom inset from its healthy value (153 for
+// comments: 83 chrome + Apollo's 70 extra) all the way to zero without changing
+// safeAreaInsets or contentLayoutGuide. Apollo receives no later layout signal,
+// so the zero sticks and the final rows remain under the tab bar.
+//
+// This module does two things at the source:
+//   1. Explicitly registers Apollo's nested ASTableView as the bottom content
+//      scroll view, following the iOS 26 public UIKit contract.
+//   2. Guards setContentInset: while an on-screen Liquid Glass tab bar overlaps
+//      the list. It combines the tab controller's unobscured content guide with
+//      a per-table healthy baseline, preserving Apollo's dynamic extras without
+//      hardcoding screen-specific values. It also retains PR #744's protection
+//      for the older transient where safeAreaInsets.bottom itself under-reports
+//      the visible tab bar.
+//
+// Every line is written both to the apollofix OSLog stream and to a bounded
+// cross-launch file included by Settings > Apollo Reborn > Export Debug Logs.
+// That makes a force-quit/relaunch reproduction diagnosable without Console.app.
+
+#import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
+#import <UIKit/UIKit.h>
+#import <math.h>
+#import <objc/runtime.h>
+#import <stdarg.h>
+
+#import "ApolloCommon.h"
+
+@interface ASTableView : UITableView
+@end
+
+@interface _TtC6Apollo21ASTableViewController : UIViewController
+@end
+
+static NSHashTable<UIViewController *> *sApolloListDiagnosticControllers;
+static CFTimeInterval sApolloListForegroundProtectionUntil = 0.0;
+static char kApolloListHealthyBottomExtraKey;
+static char kApolloListHealthyBottomChromeKey;
+
+// A real Apollo list extra is small (comments use 70pt). This cap prevents a
+// temporary keyboard-sized inset from becoming a persistent foreground floor.
+static const CGFloat kApolloListMaximumRememberedExtra = 200.0;
+static const NSTimeInterval kApolloListForegroundProtectionSeconds = 2.0;
+
+static BOOL ApolloListDiagnosticsEnabled(void) {
+    if (!IsLiquidGlass()) return NO;
+    if (@available(iOS 26.0, *)) return YES;
+    return NO;
+}
+
+// Swift's `tableNode` is an ObjC object ivar on ASTableViewController, but it
+// has no public getter. Static helpers cannot use MSHookIvar, so walk the
+// runtime ivars and ask the ASTableNode for its underlying ASTableView.
+static UIScrollView *ApolloListDiagnosticTable(UIViewController *controller) {
+    if (!controller) return nil;
+    Ivar tableNodeIvar = NULL;
+    Class cls = object_getClass(controller);
+    while (cls && !tableNodeIvar) {
+        tableNodeIvar = class_getInstanceVariable(cls, "tableNode");
+        cls = class_getSuperclass(cls);
+    }
+    if (!tableNodeIvar) return nil;
+
+    id tableNode = object_getIvar(controller, tableNodeIvar);
+    if (![tableNode respondsToSelector:@selector(view)]) return nil;
+    UIView *tableView = [tableNode view];
+    return [tableView isKindOfClass:[UIScrollView class]] ? (UIScrollView *)tableView : nil;
+}
+
+static UIViewController *ApolloListOwningViewController(UIView *view) {
+    UIResponder *responder = view;
+    Class listControllerClass = objc_getClass("_TtC6Apollo21ASTableViewController");
+    while ((responder = responder.nextResponder)) {
+        if (listControllerClass && [responder isKindOfClass:listControllerClass]) {
+            return (UIViewController *)responder;
+        }
+    }
+    return nil;
+}
+
+typedef struct {
+    CGFloat safeBottom;
+    CGFloat tabBarOverlap;
+    CGFloat guideBottomClearance;
+    CGFloat requiredChromeBottom;
+    BOOL tabBarVisible;
+} ApolloListBottomGeometry;
+
+static ApolloListBottomGeometry ApolloListBottomGeometryForController(UIViewController *controller) {
+    ApolloListBottomGeometry geometry = {0};
+    if (!controller.isViewLoaded) return geometry;
+
+    UIView *view = controller.view;
+    UITabBarController *tabs = controller.tabBarController;
+    UITabBar *tabBar = tabs.tabBar;
+    geometry.safeBottom = view.safeAreaInsets.bottom;
+    if (!tabs || !tabBar || tabBar.hidden || tabBar.alpha < 0.01 || !tabBar.superview) {
+        return geometry;
+    }
+
+    if (@available(iOS 26.0, *)) {
+        if (tabs.isTabBarHidden) return geometry;
+    }
+
+    CGRect tabFrame = [view convertRect:tabBar.bounds fromView:tabBar];
+    if (!CGRectIsNull(tabFrame) && !CGRectIsInfinite(tabFrame)) {
+        geometry.tabBarOverlap = MAX(0.0, CGRectGetMaxY(view.bounds) - CGRectGetMinY(tabFrame));
+    }
+
+    if (@available(iOS 26.0, *)) {
+        UILayoutGuide *guide = tabs.contentLayoutGuide;
+        UIView *owner = guide.owningView;
+        if (owner) {
+            CGRect guideFrame = [view convertRect:guide.layoutFrame fromView:owner];
+            if (!CGRectIsNull(guideFrame) && !CGRectIsInfinite(guideFrame)) {
+                geometry.guideBottomClearance =
+                    MAX(0.0, CGRectGetMaxY(view.bounds) - CGRectGetMaxY(guideFrame));
+            }
+        }
+    }
+
+    geometry.tabBarVisible = geometry.tabBarOverlap > 0.5 || geometry.guideBottomClearance > 0.5;
+    geometry.requiredChromeBottom = MIN(200.0,
+        MAX(geometry.tabBarOverlap, geometry.guideBottomClearance));
+    return geometry;
+}
+
+static CGFloat ApolloListRememberedHealthyBottom(UIScrollView *table,
+                                                 CGFloat requiredChromeBottom) {
+    NSNumber *extra = objc_getAssociatedObject(table, &kApolloListHealthyBottomExtraKey);
+    if (![extra isKindOfClass:NSNumber.class]) return 0.0;
+    return requiredChromeBottom + extra.doubleValue;
+}
+
+static void ApolloListRememberHealthyBottom(UIScrollView *table,
+                                            CGFloat bottom,
+                                            CGFloat requiredChromeBottom) {
+    if (!table || requiredChromeBottom <= 0.5 || bottom + 0.5 < requiredChromeBottom) return;
+    CGFloat extra = bottom - requiredChromeBottom;
+    if (extra < -0.5 || extra > kApolloListMaximumRememberedExtra) return;
+    // Store Apollo's list-specific padding separately from the current glass
+    // bar height. The bar can legitimately expand/collapse between writes; a
+    // 70pt comments extra should become `new chrome + 70`, not preserve an
+    // absolute inset measured against the previous bar state.
+    objc_setAssociatedObject(table, &kApolloListHealthyBottomExtraKey,
+                             @(MAX(0.0, extra)), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(table, &kApolloListHealthyBottomChromeKey,
+                             @(requiredChromeBottom), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static void ApolloListRememberCurrentBottom(UIScrollView *table,
+                                            CGFloat bottom,
+                                            CGFloat requiredChromeBottom) {
+    NSNumber *previousChrome = objc_getAssociatedObject(table, &kApolloListHealthyBottomChromeKey);
+    // If the bar geometry changed first, `bottom` still belongs to the old
+    // geometry. Keep the prior extra until the new inset has been accepted.
+    if ([previousChrome isKindOfClass:NSNumber.class] &&
+        fabs(previousChrome.doubleValue - requiredChromeBottom) > 0.5) return;
+    ApolloListRememberHealthyBottom(table, bottom, requiredChromeBottom);
+}
+
+static void ApolloListDiagnosticLog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
+static void ApolloListDiagnosticLog(NSString *format, ...) {
+    va_list args;
+    va_start(args, format);
+    NSString *body = [[NSString alloc] initWithFormat:format arguments:args];
+    va_end(args);
+
+    NSString *line = [NSString stringWithFormat:@"[ListLayoutDiag] %@", body ?: @""];
+    ApolloLog(@"%@", line);
+    ApolloAppendListLayoutDiag(line);
+}
+
+%hook ASTableView
+
+- (void)setContentInset:(UIEdgeInsets)inset {
+    UIEdgeInsets proposed = inset;
+    if (!ApolloListDiagnosticsEnabled() || !self.window ||
+        self.contentInsetAdjustmentBehavior != UIScrollViewContentInsetAdjustmentNever) {
+        %orig(inset);
+        return;
+    }
+
+    UIViewController *controller = ApolloListOwningViewController(self);
+    if (!controller || !controller.view.window || !controller.tabBarController) {
+        %orig(inset);
+        return;
+    }
+
+    ApolloListBottomGeometry geometry = ApolloListBottomGeometryForController(controller);
+    if (!geometry.tabBarVisible || geometry.requiredChromeBottom <= 0.5) {
+        // A genuinely hidden/removed tab bar is allowed to reduce the inset.
+        // Forget the old floor so it cannot leak across a different layout.
+        objc_setAssociatedObject(self, &kApolloListHealthyBottomExtraKey,
+                                 nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(self, &kApolloListHealthyBottomChromeKey,
+                                 nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        %orig(inset);
+        return;
+    }
+
+    CGFloat currentBottom = self.contentInset.bottom;
+    ApolloListRememberCurrentBottom(self, currentBottom, geometry.requiredChromeBottom);
+    CGFloat healthyBottom = ApolloListRememberedHealthyBottom(
+        self, geometry.requiredChromeBottom);
+    NSMutableArray<NSString *> *reasons = [NSMutableArray array];
+
+    // PR #744 / iOS 26-compatible case: Apollo computes safe-area + extras
+    // while safeAreaInsets.bottom transiently excludes part of a visible tab
+    // bar. Add only that missing chrome; Apollo's extras remain untouched.
+    CGFloat safeAreaDeficit = MAX(0.0, geometry.requiredChromeBottom - geometry.safeBottom);
+    if (safeAreaDeficit > 0.5) {
+        inset.bottom += safeAreaDeficit;
+        [reasons addObject:@"safe-area-deficit"];
+    }
+
+    // Apollo sometimes emits its list-specific extra first (comments: 70)
+    // before its next layout adds the stable tab-bar safe area. If UIKit's
+    // content guide already says the full chrome is present, combine those
+    // values immediately instead of allowing the first-scroll jump reported
+    // on PR #744.
+    BOOL safeAreaAlreadyCoversChrome =
+        geometry.safeBottom + 0.5 >= geometry.requiredChromeBottom;
+    if (safeAreaAlreadyCoversChrome && proposed.bottom > 0.5 &&
+        proposed.bottom + 0.5 < geometry.requiredChromeBottom) {
+        inset.bottom = geometry.requiredChromeBottom + proposed.bottom;
+        [reasons addObject:@"extras-before-chrome"];
+    }
+
+    // iOS 27 case captured on-device: expanded-bar foreground restoration
+    // writes 153 -> 0 while safe area, tab frame, guide and registration all
+    // remain correct. Any value below visible chrome is invalid for Apollo's
+    // adjustmentBehavior=.never table. Preserve the last healthy value when
+    // available so comments keep their 70pt extra as well as the 83pt bar.
+    if (inset.bottom + 0.5 < geometry.requiredChromeBottom) {
+        inset.bottom = MAX(geometry.requiredChromeBottom, healthyBottom);
+        [reasons addObject:@"below-visible-chrome"];
+    }
+
+    // Also reject a partial baseline drop during the short activation window
+    // (for example 153 -> 83). Outside that window a value at or above chrome
+    // is trusted, allowing Apollo to legitimately add/remove dynamic extras.
+    BOOL foregroundProtected = CACurrentMediaTime() < sApolloListForegroundProtectionUntil;
+    if (foregroundProtected && healthyBottom > 0.5 && inset.bottom + 0.5 < healthyBottom) {
+        inset.bottom = healthyBottom;
+        [reasons addObject:@"foreground-baseline"];
+    }
+
+    BOOL corrected = fabs(inset.bottom - proposed.bottom) > 0.5;
+    if (corrected) {
+        NSInteger minimizeBehavior = -1;
+        if (@available(iOS 26.0, *)) {
+            minimizeBehavior = controller.tabBarController.tabBarMinimizeBehavior;
+        }
+        ApolloListDiagnosticLog(
+            @"guarded setContentInset vc=%@ reasons=%@ proposedB=%.1f correctedB=%.1f "
+             "currentB=%.1f healthyB=%.1f safeB=%.1f overlap=%.1f guide=%.1f "
+             "required=%.1f minimize=%ld appState=%ld",
+            NSStringFromClass(controller.class), [reasons componentsJoinedByString:@","],
+            proposed.bottom, inset.bottom, currentBottom, healthyBottom,
+            geometry.safeBottom, geometry.tabBarOverlap, geometry.guideBottomClearance,
+            geometry.requiredChromeBottom, (long)minimizeBehavior,
+            (long)UIApplication.sharedApplication.applicationState);
+    }
+
+    %orig(inset);
+    ApolloListRememberHealthyBottom(self, inset.bottom, geometry.requiredChromeBottom);
+}
+
+%end
+
+static CGRect ApolloListDiagnosticRectInView(UIView *source, UIView *destination) {
+    if (!source || !destination) return CGRectNull;
+    return [destination convertRect:source.bounds fromView:source];
+}
+
+static void ApolloListDiagnosticSnapshot(UIViewController *controller,
+                                         NSString *reason,
+                                         BOOL registerContentScrollView) {
+    if (!ApolloListDiagnosticsEnabled() || !controller.isViewLoaded) return;
+
+    UIView *view = controller.view;
+    UIScrollView *table = ApolloListDiagnosticTable(controller);
+    UITabBarController *tabs = controller.tabBarController;
+    if (!table) {
+        ApolloListDiagnosticLog(@"reason=%@ vc=%@ missing tableNode.view window=%@",
+                                reason, NSStringFromClass(controller.class),
+                                view.window ? @"yes" : @"no");
+        return;
+    }
+
+    UIScrollView *registeredBefore = nil;
+    UIScrollView *registeredAfter = nil;
+    if (@available(iOS 26.0, *)) {
+        registeredBefore = [controller contentScrollViewForEdge:NSDirectionalRectEdgeBottom];
+        if (registerContentScrollView) {
+            [controller setContentScrollView:table forEdge:NSDirectionalRectEdgeBottom];
+        }
+        registeredAfter = [controller contentScrollViewForEdge:NSDirectionalRectEdgeBottom];
+    }
+
+    UIEdgeInsets safe = view.safeAreaInsets;
+    UIEdgeInsets content = table.contentInset;
+    UIEdgeInsets adjusted = table.adjustedContentInset;
+    CGRect tabFrame = CGRectNull;
+    CGRect guideFrame = CGRectNull;
+    CGFloat tabOverlap = -1.0;
+    CGFloat guideBottomClearance = -1.0;
+    NSInteger minimizeBehavior = -1;
+    ApolloListBottomGeometry geometry = ApolloListBottomGeometryForController(controller);
+    CGFloat healthyBottom = ApolloListRememberedHealthyBottom(
+        table, geometry.requiredChromeBottom);
+
+    if (tabs) {
+        UITabBar *tabBar = tabs.tabBar;
+        if (tabBar) {
+            tabFrame = ApolloListDiagnosticRectInView(tabBar, view);
+            if (!CGRectIsNull(tabFrame)) {
+                tabOverlap = MAX(0.0, CGRectGetMaxY(view.bounds) - CGRectGetMinY(tabFrame));
+            }
+        }
+
+        if (@available(iOS 26.0, *)) {
+            UILayoutGuide *guide = tabs.contentLayoutGuide;
+            UIView *owner = guide.owningView;
+            if (owner) {
+                guideFrame = [view convertRect:guide.layoutFrame fromView:owner];
+                guideBottomClearance = MAX(0.0, CGRectGetMaxY(view.bounds) - CGRectGetMaxY(guideFrame));
+            }
+            minimizeBehavior = tabs.tabBarMinimizeBehavior;
+        }
+    }
+
+    ApolloListDiagnosticLog(
+        @"reason=%@ register=%@ vc=%@ vcWindow=%@ tableWindow=%@ "
+         "registeredBefore=%@ registeredAfter=%@ matches=%@ minimize=%ld "
+         "adjustment=%ld healthyB=%.1f requiredB=%.1f "
+         "safe={%.1f,%.1f,%.1f,%.1f} content={%.1f,%.1f,%.1f,%.1f} "
+         "adjusted={%.1f,%.1f,%.1f,%.1f} offset={%.1f,%.1f} size={%.1f,%.1f} "
+         "bounds={%.1f,%.1f,%.1f,%.1f} tabFrame={%.1f,%.1f,%.1f,%.1f} "
+         "tabOverlap=%.1f guideFrame={%.1f,%.1f,%.1f,%.1f} guideBottomClearance=%.1f",
+        reason, registerContentScrollView ? @"yes" : @"no",
+        NSStringFromClass(controller.class), view.window ? @"yes" : @"no",
+        table.window ? @"yes" : @"no",
+        registeredBefore ? NSStringFromClass(registeredBefore.class) : @"nil",
+        registeredAfter ? NSStringFromClass(registeredAfter.class) : @"nil",
+        registeredAfter == table ? @"yes" : @"no", (long)minimizeBehavior,
+        (long)table.contentInsetAdjustmentBehavior, healthyBottom, geometry.requiredChromeBottom,
+        safe.top, safe.left, safe.bottom, safe.right,
+        content.top, content.left, content.bottom, content.right,
+        adjusted.top, adjusted.left, adjusted.bottom, adjusted.right,
+        table.contentOffset.x, table.contentOffset.y,
+        table.contentSize.width, table.contentSize.height,
+        table.bounds.origin.x, table.bounds.origin.y,
+        table.bounds.size.width, table.bounds.size.height,
+        tabFrame.origin.x, tabFrame.origin.y, tabFrame.size.width, tabFrame.size.height,
+        tabOverlap,
+        guideFrame.origin.x, guideFrame.origin.y, guideFrame.size.width, guideFrame.size.height,
+        guideBottomClearance);
+}
+
+static void ApolloListDiagnosticScheduleNextTurn(UIViewController *controller,
+                                                 NSString *reason,
+                                                 BOOL registerContentScrollView) {
+    __weak UIViewController *weakController = controller;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *strongController = weakController;
+        if (!strongController) return;
+        ApolloListDiagnosticSnapshot(strongController,
+                                     [reason stringByAppendingString:@".nextTurn"],
+                                     registerContentScrollView);
+    });
+}
+
+static void ApolloListDiagnosticRunTracked(NSString *reason) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        for (UIViewController *controller in sApolloListDiagnosticControllers.allObjects) {
+            if (!controller.isViewLoaded || !controller.view.window) continue;
+            ApolloListDiagnosticSnapshot(controller, reason, YES);
+            ApolloListDiagnosticScheduleNextTurn(controller, reason, YES);
+        }
+    });
+}
+
+%hook _TtC6Apollo21ASTableViewController
+
+- (void)viewDidLoad {
+    %orig;
+    [sApolloListDiagnosticControllers addObject:(UIViewController *)self];
+    ApolloListDiagnosticSnapshot((UIViewController *)self, @"viewDidLoad", YES);
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig(animated);
+    [sApolloListDiagnosticControllers addObject:(UIViewController *)self];
+    ApolloListDiagnosticSnapshot((UIViewController *)self, @"viewDidAppear", YES);
+    ApolloListDiagnosticScheduleNextTurn((UIViewController *)self, @"viewDidAppear", YES);
+}
+
+- (void)viewSafeAreaInsetsDidChange {
+    %orig;
+    ApolloListDiagnosticSnapshot((UIViewController *)self, @"safeAreaChanged", NO);
+    ApolloListDiagnosticScheduleNextTurn((UIViewController *)self, @"safeAreaChanged", NO);
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    ApolloListDiagnosticSnapshot((UIViewController *)self, @"viewWillDisappear", NO);
+    %orig(animated);
+}
+
+%end
+
+%ctor {
+    @autoreleasepool {
+        sApolloListDiagnosticControllers = [NSHashTable weakObjectsHashTable];
+        ApolloListDiagnosticLog(@"bottom-inset guard loaded; persistent diagnostics are included by Export Debug Logs");
+
+        NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+        [center addObserverForName:UIApplicationWillEnterForegroundNotification
+                           object:nil
+                            queue:[NSOperationQueue mainQueue]
+                       usingBlock:^(__unused NSNotification *notification) {
+            sApolloListForegroundProtectionUntil =
+                CACurrentMediaTime() + kApolloListForegroundProtectionSeconds;
+            ApolloListDiagnosticLog(@"applicationWillEnterForeground");
+            ApolloListDiagnosticRunTracked(@"willEnterForeground");
+        }];
+        [center addObserverForName:UIApplicationDidBecomeActiveNotification
+                           object:nil
+                            queue:[NSOperationQueue mainQueue]
+                       usingBlock:^(__unused NSNotification *notification) {
+            sApolloListForegroundProtectionUntil = MAX(
+                sApolloListForegroundProtectionUntil,
+                CACurrentMediaTime() + kApolloListForegroundProtectionSeconds);
+            ApolloListDiagnosticLog(@"applicationDidBecomeActive");
+            ApolloListDiagnosticRunTracked(@"didBecomeActive");
+        }];
+        [center addObserverForName:UIApplicationDidEnterBackgroundNotification
+                           object:nil
+                            queue:[NSOperationQueue mainQueue]
+                       usingBlock:^(__unused NSNotification *notification) {
+            ApolloListDiagnosticLog(@"applicationDidEnterBackground");
+            ApolloListDiagnosticRunTracked(@"didEnterBackground");
+        }];
+    }
+}

--- a/src/ApolloListLayoutDiagnostics.xm
+++ b/src/ApolloListLayoutDiagnostics.xm
@@ -1,309 +1,49 @@
 // ApolloListLayoutDiagnostics.xm
 //
-// iOS 26/27 Liquid Glass list-bottom protection and diagnostics.
+// VERBOSE geometry snapshots for the iOS 26/27 Liquid Glass list-layout work.
+// Diagnostics ONLY: the functional fix (content-scroll-view registration +
+// setContentInset guard + foreground protection) lives in
+// ApolloListBottomInsetGuard.xm. Removing this file from the Makefile for a
+// shipping build loses nothing but log detail.
 //
-// Apollo manages ASTableView.contentInset itself with adjustmentBehavior=.never.
-// iOS 26 introduced floating/minimizing tab bars and explicit content-scroll-
-// view observation. iOS 27 can restore an expanded tab bar across activation,
-// then write the observed table's bottom inset from its healthy value (153 for
-// comments: 83 chrome + Apollo's 70 extra) all the way to zero without changing
-// safeAreaInsets or contentLayoutGuide. Apollo receives no later layout signal,
-// so the zero sticks and the final rows remain under the tab bar.
-//
-// This module does two things at the source:
-//   1. Explicitly registers Apollo's nested ASTableView as the bottom content
-//      scroll view, following the iOS 26 public UIKit contract.
-//   2. Guards setContentInset: while an on-screen Liquid Glass tab bar overlaps
-//      the list. It combines the tab controller's unobscured content guide with
-//      a per-table healthy baseline, preserving Apollo's dynamic extras without
-//      hardcoding screen-specific values. It also retains PR #744's protection
-//      for the older transient where safeAreaInsets.bottom itself under-reports
-//      the visible tab bar.
-//
-// Every line is written both to the apollofix OSLog stream and to a bounded
-// cross-launch file included by Settings > Apollo Reborn > Export Debug Logs.
-// That makes a force-quit/relaunch reproduction diagnosable without Console.app.
+// Every line is written both to the apollofix OSLog stream and to the bounded
+// cross-launch file included by Settings > Apollo Reborn > Export Debug Logs,
+// so a force-quit/relaunch reproduction is diagnosable without Console.app.
+// Never log post titles, account names, URLs, or other user content here.
 
 #import <Foundation/Foundation.h>
-#import <QuartzCore/QuartzCore.h>
 #import <UIKit/UIKit.h>
-#import <math.h>
 #import <objc/runtime.h>
-#import <stdarg.h>
 
 #import "ApolloCommon.h"
-
-@interface ASTableView : UITableView
-@end
+#import "ApolloListLayoutSupport.h"
 
 @interface _TtC6Apollo21ASTableViewController : UIViewController
 @end
 
 static NSHashTable<UIViewController *> *sApolloListDiagnosticControllers;
-static CFTimeInterval sApolloListForegroundProtectionUntil = 0.0;
-static char kApolloListHealthyBottomExtraKey;
-static char kApolloListHealthyBottomChromeKey;
-
-// A real Apollo list extra is small (comments use 70pt). This cap prevents a
-// temporary keyboard-sized inset from becoming a persistent foreground floor.
-static const CGFloat kApolloListMaximumRememberedExtra = 200.0;
-static const NSTimeInterval kApolloListForegroundProtectionSeconds = 2.0;
-
-static BOOL ApolloListDiagnosticsEnabled(void) {
-    if (!IsLiquidGlass()) return NO;
-    if (@available(iOS 26.0, *)) return YES;
-    return NO;
-}
-
-// Swift's `tableNode` is an ObjC object ivar on ASTableViewController, but it
-// has no public getter. Static helpers cannot use MSHookIvar, so walk the
-// runtime ivars and ask the ASTableNode for its underlying ASTableView.
-static UIScrollView *ApolloListDiagnosticTable(UIViewController *controller) {
-    if (!controller) return nil;
-    Ivar tableNodeIvar = NULL;
-    Class cls = object_getClass(controller);
-    while (cls && !tableNodeIvar) {
-        tableNodeIvar = class_getInstanceVariable(cls, "tableNode");
-        cls = class_getSuperclass(cls);
-    }
-    if (!tableNodeIvar) return nil;
-
-    id tableNode = object_getIvar(controller, tableNodeIvar);
-    if (![tableNode respondsToSelector:@selector(view)]) return nil;
-    UIView *tableView = [tableNode view];
-    return [tableView isKindOfClass:[UIScrollView class]] ? (UIScrollView *)tableView : nil;
-}
-
-static UIViewController *ApolloListOwningViewController(UIView *view) {
-    UIResponder *responder = view;
-    Class listControllerClass = objc_getClass("_TtC6Apollo21ASTableViewController");
-    while ((responder = responder.nextResponder)) {
-        if (listControllerClass && [responder isKindOfClass:listControllerClass]) {
-            return (UIViewController *)responder;
-        }
-    }
-    return nil;
-}
-
-typedef struct {
-    CGFloat safeBottom;
-    CGFloat tabBarOverlap;
-    CGFloat guideBottomClearance;
-    CGFloat requiredChromeBottom;
-    BOOL tabBarVisible;
-} ApolloListBottomGeometry;
-
-static ApolloListBottomGeometry ApolloListBottomGeometryForController(UIViewController *controller) {
-    ApolloListBottomGeometry geometry = {0};
-    if (!controller.isViewLoaded) return geometry;
-
-    UIView *view = controller.view;
-    UITabBarController *tabs = controller.tabBarController;
-    UITabBar *tabBar = tabs.tabBar;
-    geometry.safeBottom = view.safeAreaInsets.bottom;
-    if (!tabs || !tabBar || tabBar.hidden || tabBar.alpha < 0.01 || !tabBar.superview) {
-        return geometry;
-    }
-
-    if (@available(iOS 26.0, *)) {
-        if (tabs.isTabBarHidden) return geometry;
-    }
-
-    CGRect tabFrame = [view convertRect:tabBar.bounds fromView:tabBar];
-    if (!CGRectIsNull(tabFrame) && !CGRectIsInfinite(tabFrame)) {
-        geometry.tabBarOverlap = MAX(0.0, CGRectGetMaxY(view.bounds) - CGRectGetMinY(tabFrame));
-    }
-
-    if (@available(iOS 26.0, *)) {
-        UILayoutGuide *guide = tabs.contentLayoutGuide;
-        UIView *owner = guide.owningView;
-        if (owner) {
-            CGRect guideFrame = [view convertRect:guide.layoutFrame fromView:owner];
-            if (!CGRectIsNull(guideFrame) && !CGRectIsInfinite(guideFrame)) {
-                geometry.guideBottomClearance =
-                    MAX(0.0, CGRectGetMaxY(view.bounds) - CGRectGetMaxY(guideFrame));
-            }
-        }
-    }
-
-    geometry.tabBarVisible = geometry.tabBarOverlap > 0.5 || geometry.guideBottomClearance > 0.5;
-    geometry.requiredChromeBottom = MIN(200.0,
-        MAX(geometry.tabBarOverlap, geometry.guideBottomClearance));
-    return geometry;
-}
-
-static CGFloat ApolloListRememberedHealthyBottom(UIScrollView *table,
-                                                 CGFloat requiredChromeBottom) {
-    NSNumber *extra = objc_getAssociatedObject(table, &kApolloListHealthyBottomExtraKey);
-    if (![extra isKindOfClass:NSNumber.class]) return 0.0;
-    return requiredChromeBottom + extra.doubleValue;
-}
-
-static void ApolloListRememberHealthyBottom(UIScrollView *table,
-                                            CGFloat bottom,
-                                            CGFloat requiredChromeBottom) {
-    if (!table || requiredChromeBottom <= 0.5 || bottom + 0.5 < requiredChromeBottom) return;
-    CGFloat extra = bottom - requiredChromeBottom;
-    if (extra < -0.5 || extra > kApolloListMaximumRememberedExtra) return;
-    // Store Apollo's list-specific padding separately from the current glass
-    // bar height. The bar can legitimately expand/collapse between writes; a
-    // 70pt comments extra should become `new chrome + 70`, not preserve an
-    // absolute inset measured against the previous bar state.
-    objc_setAssociatedObject(table, &kApolloListHealthyBottomExtraKey,
-                             @(MAX(0.0, extra)), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    objc_setAssociatedObject(table, &kApolloListHealthyBottomChromeKey,
-                             @(requiredChromeBottom), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-static void ApolloListRememberCurrentBottom(UIScrollView *table,
-                                            CGFloat bottom,
-                                            CGFloat requiredChromeBottom) {
-    NSNumber *previousChrome = objc_getAssociatedObject(table, &kApolloListHealthyBottomChromeKey);
-    // If the bar geometry changed first, `bottom` still belongs to the old
-    // geometry. Keep the prior extra until the new inset has been accepted.
-    if ([previousChrome isKindOfClass:NSNumber.class] &&
-        fabs(previousChrome.doubleValue - requiredChromeBottom) > 0.5) return;
-    ApolloListRememberHealthyBottom(table, bottom, requiredChromeBottom);
-}
-
-static void ApolloListDiagnosticLog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
-static void ApolloListDiagnosticLog(NSString *format, ...) {
-    va_list args;
-    va_start(args, format);
-    NSString *body = [[NSString alloc] initWithFormat:format arguments:args];
-    va_end(args);
-
-    NSString *line = [NSString stringWithFormat:@"[ListLayoutDiag] %@", body ?: @""];
-    ApolloLog(@"%@", line);
-    ApolloAppendListLayoutDiag(line);
-}
-
-%hook ASTableView
-
-- (void)setContentInset:(UIEdgeInsets)inset {
-    UIEdgeInsets proposed = inset;
-    if (!ApolloListDiagnosticsEnabled() || !self.window ||
-        self.contentInsetAdjustmentBehavior != UIScrollViewContentInsetAdjustmentNever) {
-        %orig(inset);
-        return;
-    }
-
-    UIViewController *controller = ApolloListOwningViewController(self);
-    if (!controller || !controller.view.window || !controller.tabBarController) {
-        %orig(inset);
-        return;
-    }
-
-    ApolloListBottomGeometry geometry = ApolloListBottomGeometryForController(controller);
-    if (!geometry.tabBarVisible || geometry.requiredChromeBottom <= 0.5) {
-        // A genuinely hidden/removed tab bar is allowed to reduce the inset.
-        // Forget the old floor so it cannot leak across a different layout.
-        objc_setAssociatedObject(self, &kApolloListHealthyBottomExtraKey,
-                                 nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        objc_setAssociatedObject(self, &kApolloListHealthyBottomChromeKey,
-                                 nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        %orig(inset);
-        return;
-    }
-
-    CGFloat currentBottom = self.contentInset.bottom;
-    ApolloListRememberCurrentBottom(self, currentBottom, geometry.requiredChromeBottom);
-    CGFloat healthyBottom = ApolloListRememberedHealthyBottom(
-        self, geometry.requiredChromeBottom);
-    NSMutableArray<NSString *> *reasons = [NSMutableArray array];
-
-    // PR #744 / iOS 26-compatible case: Apollo computes safe-area + extras
-    // while safeAreaInsets.bottom transiently excludes part of a visible tab
-    // bar. Add only that missing chrome; Apollo's extras remain untouched.
-    CGFloat safeAreaDeficit = MAX(0.0, geometry.requiredChromeBottom - geometry.safeBottom);
-    if (safeAreaDeficit > 0.5) {
-        inset.bottom += safeAreaDeficit;
-        [reasons addObject:@"safe-area-deficit"];
-    }
-
-    // Apollo sometimes emits its list-specific extra first (comments: 70)
-    // before its next layout adds the stable tab-bar safe area. If UIKit's
-    // content guide already says the full chrome is present, combine those
-    // values immediately instead of allowing the first-scroll jump reported
-    // on PR #744.
-    BOOL safeAreaAlreadyCoversChrome =
-        geometry.safeBottom + 0.5 >= geometry.requiredChromeBottom;
-    if (safeAreaAlreadyCoversChrome && proposed.bottom > 0.5 &&
-        proposed.bottom + 0.5 < geometry.requiredChromeBottom) {
-        inset.bottom = geometry.requiredChromeBottom + proposed.bottom;
-        [reasons addObject:@"extras-before-chrome"];
-    }
-
-    // iOS 27 case captured on-device: expanded-bar foreground restoration
-    // writes 153 -> 0 while safe area, tab frame, guide and registration all
-    // remain correct. Any value below visible chrome is invalid for Apollo's
-    // adjustmentBehavior=.never table. Preserve the last healthy value when
-    // available so comments keep their 70pt extra as well as the 83pt bar.
-    if (inset.bottom + 0.5 < geometry.requiredChromeBottom) {
-        inset.bottom = MAX(geometry.requiredChromeBottom, healthyBottom);
-        [reasons addObject:@"below-visible-chrome"];
-    }
-
-    // Also reject a partial baseline drop during the short activation window
-    // (for example 153 -> 83). Outside that window a value at or above chrome
-    // is trusted, allowing Apollo to legitimately add/remove dynamic extras.
-    BOOL foregroundProtected = CACurrentMediaTime() < sApolloListForegroundProtectionUntil;
-    if (foregroundProtected && healthyBottom > 0.5 && inset.bottom + 0.5 < healthyBottom) {
-        inset.bottom = healthyBottom;
-        [reasons addObject:@"foreground-baseline"];
-    }
-
-    BOOL corrected = fabs(inset.bottom - proposed.bottom) > 0.5;
-    if (corrected) {
-        NSInteger minimizeBehavior = -1;
-        if (@available(iOS 26.0, *)) {
-            minimizeBehavior = controller.tabBarController.tabBarMinimizeBehavior;
-        }
-        ApolloListDiagnosticLog(
-            @"guarded setContentInset vc=%@ reasons=%@ proposedB=%.1f correctedB=%.1f "
-             "currentB=%.1f healthyB=%.1f safeB=%.1f overlap=%.1f guide=%.1f "
-             "required=%.1f minimize=%ld appState=%ld",
-            NSStringFromClass(controller.class), [reasons componentsJoinedByString:@","],
-            proposed.bottom, inset.bottom, currentBottom, healthyBottom,
-            geometry.safeBottom, geometry.tabBarOverlap, geometry.guideBottomClearance,
-            geometry.requiredChromeBottom, (long)minimizeBehavior,
-            (long)UIApplication.sharedApplication.applicationState);
-    }
-
-    %orig(inset);
-    ApolloListRememberHealthyBottom(self, inset.bottom, geometry.requiredChromeBottom);
-}
-
-%end
 
 static CGRect ApolloListDiagnosticRectInView(UIView *source, UIView *destination) {
     if (!source || !destination) return CGRectNull;
     return [destination convertRect:source.bounds fromView:source];
 }
 
-static void ApolloListDiagnosticSnapshot(UIViewController *controller,
-                                         NSString *reason,
-                                         BOOL registerContentScrollView) {
-    if (!ApolloListDiagnosticsEnabled() || !controller.isViewLoaded) return;
+static void ApolloListDiagnosticSnapshot(UIViewController *controller, NSString *reason) {
+    if (!ApolloListLayoutGuardEnabled() || !controller.isViewLoaded) return;
 
     UIView *view = controller.view;
-    UIScrollView *table = ApolloListDiagnosticTable(controller);
+    UIScrollView *table = ApolloListTableForController(controller);
     UITabBarController *tabs = controller.tabBarController;
     if (!table) {
-        ApolloListDiagnosticLog(@"reason=%@ vc=%@ missing tableNode.view window=%@",
-                                reason, NSStringFromClass(controller.class),
-                                view.window ? @"yes" : @"no");
+        ApolloListLayoutLog(@"reason=%@ vc=%@ missing tableNode.view window=%@",
+                            reason, NSStringFromClass(controller.class),
+                            view.window ? @"yes" : @"no");
         return;
     }
 
-    UIScrollView *registeredBefore = nil;
-    UIScrollView *registeredAfter = nil;
+    UIScrollView *registered = nil;
     if (@available(iOS 26.0, *)) {
-        registeredBefore = [controller contentScrollViewForEdge:NSDirectionalRectEdgeBottom];
-        if (registerContentScrollView) {
-            [controller setContentScrollView:table forEdge:NSDirectionalRectEdgeBottom];
-        }
-        registeredAfter = [controller contentScrollViewForEdge:NSDirectionalRectEdgeBottom];
+        registered = [controller contentScrollViewForEdge:NSDirectionalRectEdgeBottom];
     }
 
     UIEdgeInsets safe = view.safeAreaInsets;
@@ -338,20 +78,24 @@ static void ApolloListDiagnosticSnapshot(UIViewController *controller,
         }
     }
 
-    ApolloListDiagnosticLog(
-        @"reason=%@ register=%@ vc=%@ vcWindow=%@ tableWindow=%@ "
-         "registeredBefore=%@ registeredAfter=%@ matches=%@ minimize=%ld "
+    ApolloListLayoutLog(
+        @"reason=%@ vc=%@ vcWindow=%@ tableWindow=%@ "
+         "registered=%@ matches=%@ minimize=%ld "
+         "morph=%ld morphKnown=%@ minimized=%@ morphAnimating=%@ animKnown=%@ "
          "adjustment=%ld healthyB=%.1f requiredB=%.1f "
          "safe={%.1f,%.1f,%.1f,%.1f} content={%.1f,%.1f,%.1f,%.1f} "
          "adjusted={%.1f,%.1f,%.1f,%.1f} offset={%.1f,%.1f} size={%.1f,%.1f} "
          "bounds={%.1f,%.1f,%.1f,%.1f} tabFrame={%.1f,%.1f,%.1f,%.1f} "
          "tabOverlap=%.1f guideFrame={%.1f,%.1f,%.1f,%.1f} guideBottomClearance=%.1f",
-        reason, registerContentScrollView ? @"yes" : @"no",
-        NSStringFromClass(controller.class), view.window ? @"yes" : @"no",
+        reason, NSStringFromClass(controller.class), view.window ? @"yes" : @"no",
         table.window ? @"yes" : @"no",
-        registeredBefore ? NSStringFromClass(registeredBefore.class) : @"nil",
-        registeredAfter ? NSStringFromClass(registeredAfter.class) : @"nil",
-        registeredAfter == table ? @"yes" : @"no", (long)minimizeBehavior,
+        registered ? NSStringFromClass(registered.class) : @"nil",
+        registered == table ? @"yes" : @"no", (long)minimizeBehavior,
+        (long)geometry.tabBarMorphTarget,
+        geometry.tabBarMorphTargetKnown ? @"yes" : @"no",
+        geometry.tabBarMinimized ? @"yes" : @"no",
+        geometry.tabBarMorphAnimating ? @"yes" : @"no",
+        geometry.tabBarMorphAnimatingKnown ? @"yes" : @"no",
         (long)table.contentInsetAdjustmentBehavior, healthyBottom, geometry.requiredChromeBottom,
         safe.top, safe.left, safe.bottom, safe.right,
         content.top, content.left, content.bottom, content.right,
@@ -366,16 +110,13 @@ static void ApolloListDiagnosticSnapshot(UIViewController *controller,
         guideBottomClearance);
 }
 
-static void ApolloListDiagnosticScheduleNextTurn(UIViewController *controller,
-                                                 NSString *reason,
-                                                 BOOL registerContentScrollView) {
+static void ApolloListDiagnosticScheduleNextTurn(UIViewController *controller, NSString *reason) {
     __weak UIViewController *weakController = controller;
     dispatch_async(dispatch_get_main_queue(), ^{
         UIViewController *strongController = weakController;
         if (!strongController) return;
         ApolloListDiagnosticSnapshot(strongController,
-                                     [reason stringByAppendingString:@".nextTurn"],
-                                     registerContentScrollView);
+                                     [reason stringByAppendingString:@".nextTurn"]);
     });
 }
 
@@ -383,8 +124,8 @@ static void ApolloListDiagnosticRunTracked(NSString *reason) {
     dispatch_async(dispatch_get_main_queue(), ^{
         for (UIViewController *controller in sApolloListDiagnosticControllers.allObjects) {
             if (!controller.isViewLoaded || !controller.view.window) continue;
-            ApolloListDiagnosticSnapshot(controller, reason, YES);
-            ApolloListDiagnosticScheduleNextTurn(controller, reason, YES);
+            ApolloListDiagnosticSnapshot(controller, reason);
+            ApolloListDiagnosticScheduleNextTurn(controller, reason);
         }
     });
 }
@@ -394,24 +135,24 @@ static void ApolloListDiagnosticRunTracked(NSString *reason) {
 - (void)viewDidLoad {
     %orig;
     [sApolloListDiagnosticControllers addObject:(UIViewController *)self];
-    ApolloListDiagnosticSnapshot((UIViewController *)self, @"viewDidLoad", YES);
+    ApolloListDiagnosticSnapshot((UIViewController *)self, @"viewDidLoad");
 }
 
 - (void)viewDidAppear:(BOOL)animated {
     %orig(animated);
     [sApolloListDiagnosticControllers addObject:(UIViewController *)self];
-    ApolloListDiagnosticSnapshot((UIViewController *)self, @"viewDidAppear", YES);
-    ApolloListDiagnosticScheduleNextTurn((UIViewController *)self, @"viewDidAppear", YES);
+    ApolloListDiagnosticSnapshot((UIViewController *)self, @"viewDidAppear");
+    ApolloListDiagnosticScheduleNextTurn((UIViewController *)self, @"viewDidAppear");
 }
 
 - (void)viewSafeAreaInsetsDidChange {
     %orig;
-    ApolloListDiagnosticSnapshot((UIViewController *)self, @"safeAreaChanged", NO);
-    ApolloListDiagnosticScheduleNextTurn((UIViewController *)self, @"safeAreaChanged", NO);
+    ApolloListDiagnosticSnapshot((UIViewController *)self, @"safeAreaChanged");
+    ApolloListDiagnosticScheduleNextTurn((UIViewController *)self, @"safeAreaChanged");
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
-    ApolloListDiagnosticSnapshot((UIViewController *)self, @"viewWillDisappear", NO);
+    ApolloListDiagnosticSnapshot((UIViewController *)self, @"viewWillDisappear");
     %orig(animated);
 }
 
@@ -419,34 +160,41 @@ static void ApolloListDiagnosticRunTracked(NSString *reason) {
 
 %ctor {
     @autoreleasepool {
-        sApolloListDiagnosticControllers = [NSHashTable weakObjectsHashTable];
-        ApolloListDiagnosticLog(@"bottom-inset guard loaded; persistent diagnostics are included by Export Debug Logs");
+        // Legacy/non-glass installs never write a diagnostics line or grow the
+        // persistent file: the %hook bodies self-gate via the snapshot's
+        // enabled check, and everything else is registered behind this gate.
+        if (!ApolloListLayoutGuardEnabled()) return;
 
+        sApolloListDiagnosticControllers = [NSHashTable weakObjectsHashTable];
+        ApolloListLayoutLog(@"list-layout diagnostics loaded (guard: ApolloListBottomInsetGuard)");
+
+        // Snapshot sweeps only on real background->foreground transitions —
+        // bare didBecomeActive (Notification/Control Center dismissal) fired
+        // full sweeps mid-interaction on device. Mirrors the guard's gating.
+        static BOOL sPendingForegroundActivation = NO;
         NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
         [center addObserverForName:UIApplicationWillEnterForegroundNotification
                            object:nil
                             queue:[NSOperationQueue mainQueue]
                        usingBlock:^(__unused NSNotification *notification) {
-            sApolloListForegroundProtectionUntil =
-                CACurrentMediaTime() + kApolloListForegroundProtectionSeconds;
-            ApolloListDiagnosticLog(@"applicationWillEnterForeground");
+            sPendingForegroundActivation = YES;
+            ApolloListLayoutLog(@"applicationWillEnterForeground");
             ApolloListDiagnosticRunTracked(@"willEnterForeground");
         }];
         [center addObserverForName:UIApplicationDidBecomeActiveNotification
                            object:nil
                             queue:[NSOperationQueue mainQueue]
                        usingBlock:^(__unused NSNotification *notification) {
-            sApolloListForegroundProtectionUntil = MAX(
-                sApolloListForegroundProtectionUntil,
-                CACurrentMediaTime() + kApolloListForegroundProtectionSeconds);
-            ApolloListDiagnosticLog(@"applicationDidBecomeActive");
+            if (!sPendingForegroundActivation) return;
+            sPendingForegroundActivation = NO;
+            ApolloListLayoutLog(@"applicationDidBecomeActive");
             ApolloListDiagnosticRunTracked(@"didBecomeActive");
         }];
         [center addObserverForName:UIApplicationDidEnterBackgroundNotification
                            object:nil
                             queue:[NSOperationQueue mainQueue]
                        usingBlock:^(__unused NSNotification *notification) {
-            ApolloListDiagnosticLog(@"applicationDidEnterBackground");
+            ApolloListLayoutLog(@"applicationDidEnterBackground");
             ApolloListDiagnosticRunTracked(@"didEnterBackground");
         }];
     }

--- a/src/ApolloListLayoutSupport.h
+++ b/src/ApolloListLayoutSupport.h
@@ -2,13 +2,12 @@
 //
 // Shared surface between the two iOS 26/27 Liquid Glass list-layout modules:
 //
-//   ApolloListBottomInsetGuard.xm   — the FUNCTIONAL fix (content-scroll-view
-//                                     registration + setContentInset guard +
-//                                     foreground protection window). Ships.
-//   ApolloListLayoutDiagnostics.xm  — verbose geometry snapshots for Export
-//                                     Debug Logs. Safe to drop from the
-//                                     Makefile for shipping builds with zero
-//                                     functional loss.
+//   ApolloListBottomInsetGuard.xm   — the FUNCTIONAL fix (keyboard-frame
+//                                     normalization, content-scroll-view
+//                                     registration, and settled recovery).
+//   ApolloListLayoutDiagnostics.xm  — optional investigation-only geometry
+//                                     snapshots, deliberately excluded from
+//                                     shipping builds.
 //
 // Everything declared here is implemented in ApolloListBottomInsetGuard.xm so
 // removing the diagnostics module never takes the fix with it.
@@ -52,9 +51,9 @@ UIScrollView *ApolloListTableForController(UIViewController *controller);
 
 ApolloListBottomGeometry ApolloListBottomGeometryForController(UIViewController *controller);
 
-// The last accepted healthy bottom inset for this table under the current
+// The last captured healthy bottom inset for this table under the current
 // chrome height (chrome + the table's remembered Apollo-specific extra), or 0
-// when nothing has been remembered yet.
+// when nothing has been captured yet.
 CGFloat ApolloListRememberedHealthyBottom(UIScrollView *table, CGFloat requiredChromeBottom);
 
 // Logs to the apollofix os_log stream AND the bounded cross-launch buffer that
@@ -67,11 +66,15 @@ void ApolloListLayoutLog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
 extern NSString *const ApolloTabBarSlideDownAnimationKey;
 extern NSString *const ApolloTabBarSlideUpAnimationKey;
 
-// Actively re-assert the bottom inset of every visible tracked list whose
-// inset no longer covers a steady visible tab bar. Needed when iOS 27 changes
-// the safe area without Apollo ever writing a new inset (nothing for the
-// setContentInset: hook to intercept) — e.g. after the legacy mirror re-shows
-// the bar, or after foreground restoration.
+// Capture the currently healthy inset of visible lists at explicit lifecycle /
+// chrome boundaries. This avoids doing responder/geometry work on every
+// scroll-adjacent setContentInset: call.
+void ApolloListCaptureHealthyBottomForVisibleLists(NSString *reason);
+
+// Settled recovery fallback: re-assert the bottom inset only when a visible
+// tracked list remains below a stable visible tab bar after normal UIKit/Apollo
+// layout has had time to finish. Used by the legacy tab-bar show path (#809)
+// and once after a real foreground transition.
 void ApolloListVerifyBottomInsetForVisibleLists(NSString *reason);
 
 __END_DECLS

--- a/src/ApolloListLayoutSupport.h
+++ b/src/ApolloListLayoutSupport.h
@@ -1,0 +1,77 @@
+// ApolloListLayoutSupport.h
+//
+// Shared surface between the two iOS 26/27 Liquid Glass list-layout modules:
+//
+//   ApolloListBottomInsetGuard.xm   — the FUNCTIONAL fix (content-scroll-view
+//                                     registration + setContentInset guard +
+//                                     foreground protection window). Ships.
+//   ApolloListLayoutDiagnostics.xm  — verbose geometry snapshots for Export
+//                                     Debug Logs. Safe to drop from the
+//                                     Makefile for shipping builds with zero
+//                                     functional loss.
+//
+// Everything declared here is implemented in ApolloListBottomInsetGuard.xm so
+// removing the diagnostics module never takes the fix with it.
+
+#import <UIKit/UIKit.h>
+
+// Bottom-edge geometry for an Apollo list controller, as seen by the guard.
+// On iOS 27 the tab bar's frame and the tab controller's contentLayoutGuide
+// KEEP their expanded (83pt) values while the floating bar is minimized or
+// morphing, so the morph fields — not the frame math — are what distinguish a
+// legitimate small inset from the expanded-bar foreground bug.
+typedef struct {
+    CGFloat safeBottom;
+    CGFloat tabBarOverlap;
+    CGFloat guideBottomClearance;
+    CGFloat requiredChromeBottom;
+    BOOL tabBarVisible;
+    BOOL tabBarMorphTargetKnown;
+    BOOL tabBarMinimized;
+    BOOL tabBarMorphAnimatingKnown;
+    BOOL tabBarMorphAnimating;
+    BOOL tabBarInsetGuardShouldStandDown;
+    // YES when the bar's visual state is known well enough to trust the
+    // below-chrome corrections: Liquid Glass needs a readable morph target
+    // (an expanded frame is ambiguous while minimized); the legacy opaque bar
+    // needs no morph — visible and not mid-slide is proof (issue #809).
+    BOOL tabBarStateTrusted;
+    NSInteger tabBarMorphTarget;
+} ApolloListBottomGeometry;
+
+__BEGIN_DECLS
+
+// YES only on Liquid Glass builds running iOS 26+ — the sole environment where
+// the guard and its diagnostics operate.
+BOOL ApolloListLayoutGuardEnabled(void);
+
+// Apollo's ASTableViewController keeps its list in a Swift `tableNode` ivar
+// with no ObjC getter; this resolves the underlying ASTableView (nil if the
+// layout ever changes).
+UIScrollView *ApolloListTableForController(UIViewController *controller);
+
+ApolloListBottomGeometry ApolloListBottomGeometryForController(UIViewController *controller);
+
+// The last accepted healthy bottom inset for this table under the current
+// chrome height (chrome + the table's remembered Apollo-specific extra), or 0
+// when nothing has been remembered yet.
+CGFloat ApolloListRememberedHealthyBottom(UIScrollView *table, CGFloat requiredChromeBottom);
+
+// Logs to the apollofix os_log stream AND the bounded cross-launch buffer that
+// Export Debug Logs prepends. File I/O is async (see ApolloAppendListLayoutDiag).
+void ApolloListLayoutLog(NSString *format, ...) NS_FORMAT_FUNCTION(1, 2);
+
+// ApolloAutoHideTabBar's legacy hide/show mirror animates the tab bar with
+// explicit layer animations under these keys while the MODEL state still says
+// fully visible — the guard treats their presence as "bar state in flux".
+extern NSString *const ApolloTabBarSlideDownAnimationKey;
+extern NSString *const ApolloTabBarSlideUpAnimationKey;
+
+// Actively re-assert the bottom inset of every visible tracked list whose
+// inset no longer covers a steady visible tab bar. Needed when iOS 27 changes
+// the safe area without Apollo ever writing a new inset (nothing for the
+// setContentInset: hook to intercept) — e.g. after the legacy mirror re-shows
+// the bar, or after foreground restoration.
+void ApolloListVerifyBottomInsetForVisibleLists(NSString *reason);
+
+__END_DECLS

--- a/src/ApolloSimDebugTap.xm
+++ b/src/ApolloSimDebugTap.xm
@@ -166,7 +166,7 @@ static void ApolloSimDebugTypeText(NSString *text) {
 // "insetbottom N" command: ask every visible Apollo ASTableView to accept a
 // specific bottom inset. This reproduces the iOS 27 foreground write (153 -> 0)
 // without depending on the simulator exhibiting the upstream lifecycle bug.
-// ApolloListLayoutDiagnostics should guard the zero and log the correction.
+// ApolloListBottomInsetGuard should guard the zero and log the correction.
 static void ApolloSimDebugForceBottomInsetInView(UIView *view, CGFloat bottom) {
     if ([view isKindOfClass:objc_getClass("ASTableView")] && view.window) {
         UIScrollView *scrollView = (UIScrollView *)view;

--- a/src/ApolloSimDebugTap.xm
+++ b/src/ApolloSimDebugTap.xm
@@ -163,11 +163,41 @@ static void ApolloSimDebugTypeText(NSString *text) {
               (unsigned long)text.length, NSStringFromClass(responder.class));
 }
 
+// "insetbottom N" command: ask every visible Apollo ASTableView to accept a
+// specific bottom inset. This reproduces the iOS 27 foreground write (153 -> 0)
+// without depending on the simulator exhibiting the upstream lifecycle bug.
+// ApolloListLayoutDiagnostics should guard the zero and log the correction.
+static void ApolloSimDebugForceBottomInsetInView(UIView *view, CGFloat bottom) {
+    if ([view isKindOfClass:objc_getClass("ASTableView")] && view.window) {
+        UIScrollView *scrollView = (UIScrollView *)view;
+        UIEdgeInsets inset = scrollView.contentInset;
+        CGFloat before = inset.bottom;
+        inset.bottom = bottom;
+        scrollView.contentInset = inset;
+        ApolloLog(@"[SimDebugTap] insetbottom requested=%.1f before=%.1f after=%.1f table=%@",
+                  bottom, before, scrollView.contentInset.bottom,
+                  NSStringFromClass(scrollView.class));
+    }
+    for (UIView *subview in view.subviews) {
+        ApolloSimDebugForceBottomInsetInView(subview, bottom);
+    }
+}
+
+static void ApolloSimDebugForceBottomInset(CGFloat bottom) {
+    for (UIWindow *window in ApolloAllWindows()) {
+        if (!window.hidden) ApolloSimDebugForceBottomInsetInView(window, bottom);
+    }
+}
+
 static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *observer,
                                           CFStringRef name, const void *object, CFDictionaryRef userInfo) {
     dispatch_async(dispatch_get_main_queue(), ^{
         NSString *contents = [NSString stringWithContentsOfFile:kApolloSimTapFile
                                                        encoding:NSUTF8StringEncoding error:nil];
+        if ([contents hasPrefix:@"insetbottom "]) {
+            ApolloSimDebugForceBottomInset([[contents substringFromIndex:12] doubleValue]);
+            return;
+        }
         if ([contents hasPrefix:@"text "]) {
             NSString *payload = [[contents substringFromIndex:5] stringByTrimmingCharactersInSet:
                 NSCharacterSet.newlineCharacterSet];


### PR DESCRIPTION
Fixes #732 (duplicate: #619). Fixes #809. Supersedes #744.

## Symptom

On iOS 27, returning to Apollo can leave a comments list below the tab bar. Earlier revisions corrected the resulting inset after it had already changed, which could visibly jump or stutter. The standard/non-Glass build can also strand the load-next-page row behind its legacy tab bar (#809).

## Root cause

On-device instrumentation of the bottom-edge app-switch gesture found the actual producer:

1. While Apollo is inactive, iOS posts a non-local `UIKeyboardWillChangeFrameNotification` with a 347pt frame belonging to the app being switched to.
2. Apollo observes keyboard notifications globally and sends that screen-space frame through every live `ASTableViewController`, including visible Comments, changing its inset from `153 → 347`.
3. On activation, a local `CGRect.zero` event is treated as a real frame and Apollo changes the inset from `347 → 0`.

The tab bar is correlated with the failure because its expanded 83pt safe area is what Apollo loses, but the bar itself is not the source of the bad write.

## Fix

### Correct Apollo's keyboard input

`ApolloListBottomInsetGuard.xm` now hooks Apollo's keyboard handler at the source:

- Explicitly non-local keyboard frames are ignored.
- Local frames are converted from the notification screen's coordinate space into the controller view and intersected with its bounds.
- A zero or non-overlapping frame becomes Apollo's proper hidden-keyboard sentinel at the bottom of the view.
- Offscreen controllers ignore visible keyboard frames, but still receive the hidden sentinel so their cached Swift `Optional<CGRect>` is cleared.

Apollo therefore never receives the foreign 347pt frame and keeps its own list-specific inset calculation, including Comments' 70pt extra.

### Keep recovery cold

- The `ASTableView setContentInset:` hook is now only a pointer comparison during ordinary scrolling. It can clamp a material loss only while the visible controller is synchronously processing a normalized keyboard-hide event; it ignores harmless one-point UIKit rounding.
- Healthy baselines are captured only at explicit lifecycle/chrome boundaries.
- The no-write verifier runs after settled appearance, a real background→foreground transition, or the legacy tab bar finishing its show animation. It stands down while Liquid Glass is minimized, morphing, or otherwise untrusted.
- Glass builds still register Apollo's nested `ASTableView` as the iOS 26 bottom content scroll view.

### Preserve #809 and hide-bars behavior

- The legacy hide-bars path captures the visible list baseline immediately before hiding and verifies it only after the bar has fully returned, retaining #809 protection without a permanent inset policy.
- The existing Mode B reveal/re-arm timing remains gesture-owned and morph-aware, so custom upward reveal still works without restarting a Liquid Glass transition.

### Remove diagnostic overhead

The high-volume lifecycle, stack, and geometry instrumentation used to find the cause is excluded from shipping builds. Rare source/fallback decisions still use the existing bounded Export Debug Logs path.

## Validation

- iPhone 16 Pro, iOS 27: repeated bottom-edge app switching reproduced the exact foreign 347pt event. The final build ignored it before Apollo's handler, Comments stayed at 153, and neither the inset clamp nor settled verifier fired during the target reproduction.
- The only unrelated clamp observed during diagnostics was an Inbox `84 → 83` interactive-keyboard rounding event; shipping tolerance now accepts it.
- Standard/legacy fallback remains scoped to stable visible-bar boundaries for #809.
- Device build (`make package`, `-Werror`) passes.
- Liquid Glass simulator build passes, launches injected, and confirms bottom content-scroll registration.
