### PR TITLE
Fix the OOM crash wave: bound inline-video poster memory, add memory instrumentation, fix Go-to-user crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ ApolloReborn_FILES = \
     $(WHATS_NEW_GEN_M) \
     $(SRC_DIR)/Tweak.xm \
     $(SRC_DIR)/ApolloCommon.m \
+    $(SRC_DIR)/ApolloMemoryDiagnostics.m \
     $(SRC_DIR)/settings/ApolloSettingsTableViewController.m \
     $(SRC_DIR)/settings/ApolloSettingsForm.m \
     $(SRC_DIR)/settings/ApolloContributors.m \

--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -11,6 +11,7 @@
 #import "ApolloCommon.h"
 #import "ApolloImageChestResolver.h"
 #import "ApolloMediaAutoplay.h"
+#import "ApolloMemoryDiagnostics.h"
 #import "ApolloState.h"
 #import "Tweak.h"
 #import "UserDefaultConstants.h"
@@ -784,16 +785,57 @@ static NSURL *ApolloDashURLFromMediaMetadata(NSDictionary *mediaMetadata, NSURL 
 
 // Cache: assetID → UIImage (success) | NSNull (failed, don't retry)
 // Pending callbacks coalesce concurrent fetches for the same asset.
-static NSMutableDictionary *sApolloDashPosterCache;
+//
+// Memory (issues #806/#814/#820, the 8/2026 OOM wave): this cache used to be a
+// plain NSMutableDictionary of decoded full-resolution posters held for the
+// whole session — JetsamEvent reports showed Apollo at 550-750MB. It is now an
+// NSCache costed in decoded bytes (auto-evicts under system pressure), posters
+// are downscaled before caching (they render at comment width, never full
+// video resolution), and at most kApolloDashPosterMaxConcurrentFetches
+// MPD-download + AVAssetImageGenerator pipelines run at once — fast-scrolling
+// a video-heavy thread used to spawn one 5-frame decoder per video node with
+// no cap, which is exactly the allocation-failure spike in the crash reports.
+static NSCache<NSString *, id> *sApolloDashPosterCache;
 static NSMutableDictionary<NSString *, NSMutableArray *> *sApolloDashPosterPending;
+// FIFO of @[assetID, dashURL] waiting for a fetch slot; guarded by the queue.
+static NSMutableArray<NSArray *> *sApolloDashPosterWaiting;
+static NSUInteger sApolloDashPosterInFlight;
 static dispatch_queue_t sApolloDashPosterQueue;
+static const NSUInteger kApolloDashPosterMaxConcurrentFetches = 2;
 static void ApolloDashPosterInit(void) {
     static dispatch_once_t once;
     dispatch_once(&once, ^{
-        sApolloDashPosterCache = [NSMutableDictionary dictionary];
+        sApolloDashPosterCache = [NSCache new];
+        sApolloDashPosterCache.name = @"ApolloDashPosterCache";
+        sApolloDashPosterCache.countLimit = 48;
+        sApolloDashPosterCache.totalCostLimit = 48 * 1024 * 1024; // decoded bytes
         sApolloDashPosterPending = [NSMutableDictionary dictionary];
+        sApolloDashPosterWaiting = [NSMutableArray array];
         sApolloDashPosterQueue = dispatch_queue_create("ca.jeffrey.apollo.dashposter", DISPATCH_QUEUE_SERIAL);
+        ApolloMemoryRegisterPurgeHandler(@"dash-posters", ^{
+            [sApolloDashPosterCache removeAllObjects];
+        });
     });
+}
+
+// Posters display at comment width; cap the longest side so a 1080p-only DASH
+// rep doesn't pin ~8MB of decoded RGBA per video for the cache's lifetime.
+static UIImage *ApolloDashPosterDownscaled(UIImage *img) {
+    static const CGFloat kMaxSide = 720.0;
+    CGFloat w = img.size.width, h = img.size.height;
+    if (w <= 0 || h <= 0 || (w <= kMaxSide && h <= kMaxSide)) return img;
+    CGFloat scale = kMaxSide / MAX(w, h);
+    CGSize target = CGSizeMake(round(w * scale), round(h * scale));
+    UIGraphicsImageRendererFormat *fmt = [UIGraphicsImageRendererFormat preferredFormat];
+    fmt.scale = 1.0; // pixel-exact target; the node scales for display
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:target format:fmt];
+    return [renderer imageWithActions:^(__unused UIGraphicsImageRendererContext *ctx) {
+        [img drawInRect:CGRectMake(0, 0, target.width, target.height)];
+    }];
+}
+
+static NSUInteger ApolloDashPosterCost(UIImage *img) {
+    return (NSUInteger)(img.size.width * img.scale * img.size.height * img.scale * 4);
 }
 
 // Find the lowest-bitrate video MP4 Representation in a DASH MPD. Reddit
@@ -844,6 +886,32 @@ static BOOL ApolloImageIsMostlyBlack(UIImage *img) {
 // fade in from a logo/black intro, so frame at t=0 is usually black.
 // Calls back on main queue with the UIImage (or nil on failure).
 // Coalesces concurrent calls for the same assetID.
+static void ApolloDashPosterStartFetch(NSString *assetID, NSURL *dashURL);
+
+// Serial-queue only. Finishes one fetch: caches the result, flushes callbacks,
+// frees the slot and starts the next waiting fetch (FIFO).
+static void ApolloDashPosterFinishFetch(NSString *assetID, UIImage *result) {
+    if (result) {
+        [sApolloDashPosterCache setObject:result forKey:assetID cost:ApolloDashPosterCost(result)];
+    } else {
+        [sApolloDashPosterCache setObject:[NSNull null] forKey:assetID cost:1];
+    }
+    NSArray *cbs = [sApolloDashPosterPending[assetID] copy];
+    [sApolloDashPosterPending removeObjectForKey:assetID];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        for (void (^c)(UIImage *) in cbs) c(result);
+    });
+
+    if (sApolloDashPosterInFlight > 0) sApolloDashPosterInFlight--;
+    while (sApolloDashPosterInFlight < kApolloDashPosterMaxConcurrentFetches &&
+           sApolloDashPosterWaiting.count > 0) {
+        NSArray *next = sApolloDashPosterWaiting.firstObject;
+        [sApolloDashPosterWaiting removeObjectAtIndex:0];
+        sApolloDashPosterInFlight++;
+        ApolloDashPosterStartFetch(next[0], next[1]);
+    }
+}
+
 static void ApolloFetchDashPoster(NSString *assetID, NSURL *dashURL,
                                    void (^completion)(UIImage *poster)) {
     if (!assetID.length || !dashURL || !completion) {
@@ -854,7 +922,7 @@ static void ApolloFetchDashPoster(NSString *assetID, NSURL *dashURL,
     void (^cb)(UIImage *) = [completion copy];
 
     dispatch_async(sApolloDashPosterQueue, ^{
-        id cached = sApolloDashPosterCache[assetID];
+        id cached = [sApolloDashPosterCache objectForKey:assetID];
         if (cached) {
             UIImage *out = (cached == [NSNull null]) ? nil : (UIImage *)cached;
             dispatch_async(dispatch_get_main_queue(), ^{ cb(out); });
@@ -864,93 +932,99 @@ static void ApolloFetchDashPoster(NSString *assetID, NSURL *dashURL,
         if (pending) { [pending addObject:cb]; return; }
         sApolloDashPosterPending[assetID] = [NSMutableArray arrayWithObject:cb];
 
-        void (^deliver)(UIImage *) = ^(UIImage *result) {
-            dispatch_async(sApolloDashPosterQueue, ^{
-                sApolloDashPosterCache[assetID] = result ?: (id)[NSNull null];
-                NSArray *cbs = [sApolloDashPosterPending[assetID] copy];
-                [sApolloDashPosterPending removeObjectForKey:assetID];
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    for (void (^c)(UIImage *) in cbs) c(result);
-                });
-            });
-        };
+        if (sApolloDashPosterInFlight >= kApolloDashPosterMaxConcurrentFetches) {
+            [sApolloDashPosterWaiting addObject:@[assetID, dashURL]];
+            return;
+        }
+        sApolloDashPosterInFlight++;
+        ApolloDashPosterStartFetch(assetID, dashURL);
+    });
+}
 
-        NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:dashURL
+// One MPD download + frame-extraction pipeline. Callers hold a fetch slot;
+// every exit path must go through deliver() exactly once to release it.
+static void ApolloDashPosterStartFetch(NSString *assetID, NSURL *dashURL) {
+    void (^deliver)(UIImage *) = ^(UIImage *result) {
+        dispatch_async(sApolloDashPosterQueue, ^{
+            ApolloDashPosterFinishFetch(assetID, result);
+        });
+    };
+
+    NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:dashURL
                                                            cachePolicy:NSURLRequestUseProtocolCachePolicy
                                                        timeoutInterval:8.0];
-        NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:req
-            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-            NSInteger status = [response isKindOfClass:[NSHTTPURLResponse class]]
-                ? ((NSHTTPURLResponse *)response).statusCode : 0;
-            if (error || status < 200 || status >= 300 || data.length == 0) {
-                ApolloLog(@"[InlineImages] DASH MPD fetch FAIL asset=%@ status=%ld err=%@",
-                          assetID, (long)status, error.localizedDescription ?: @"nil");
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:req
+        completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        NSInteger status = [response isKindOfClass:[NSHTTPURLResponse class]]
+            ? ((NSHTTPURLResponse *)response).statusCode : 0;
+        if (error || status < 200 || status >= 300 || data.length == 0) {
+            ApolloLog(@"[InlineImages] DASH MPD fetch FAIL asset=%@ status=%ld err=%@",
+                      assetID, (long)status, error.localizedDescription ?: @"nil");
+            deliver(nil);
+            return;
+        }
+        NSURL *mp4URL = ApolloLowestDashMP4URL(data, dashURL);
+        if (!mp4URL) {
+            ApolloLog(@"[InlineImages] DASH parse FAIL asset=%@", assetID);
+            deliver(nil);
+            return;
+        }
+        AVURLAsset *asset = [AVURLAsset URLAssetWithURL:mp4URL options:nil];
+        [asset loadValuesAsynchronouslyForKeys:@[@"tracks", @"duration"] completionHandler:^{
+            if ([asset statusOfValueForKey:@"tracks" error:nil] != AVKeyValueStatusLoaded) {
+                ApolloLog(@"[InlineImages] DASH asset load FAIL asset=%@", assetID);
                 deliver(nil);
                 return;
             }
-            NSURL *mp4URL = ApolloLowestDashMP4URL(data, dashURL);
-            if (!mp4URL) {
-                ApolloLog(@"[InlineImages] DASH parse FAIL asset=%@", assetID);
-                deliver(nil);
-                return;
+            AVAssetImageGenerator *gen = [[AVAssetImageGenerator alloc] initWithAsset:asset];
+            gen.appliesPreferredTrackTransform = YES;
+            gen.requestedTimeToleranceBefore = CMTimeMakeWithSeconds(0.5, 600);
+            gen.requestedTimeToleranceAfter = CMTimeMakeWithSeconds(0.5, 600);
+
+            Float64 durSec = CMTIME_IS_NUMERIC(asset.duration)
+                ? CMTimeGetSeconds(asset.duration) : 0;
+            NSMutableArray<NSValue *> *times = [NSMutableArray array];
+            for (NSNumber *t in @[@3.0, @5.0, @1.5, @0.5, @0.0]) {
+                Float64 v = t.doubleValue;
+                if (durSec <= 0 || v < durSec) {
+                    [times addObject:[NSValue valueWithCMTime:CMTimeMakeWithSeconds(v, 600)]];
+                }
             }
-            AVURLAsset *asset = [AVURLAsset URLAssetWithURL:mp4URL options:nil];
-            [asset loadValuesAsynchronouslyForKeys:@[@"tracks", @"duration"] completionHandler:^{
-                if ([asset statusOfValueForKey:@"tracks" error:nil] != AVKeyValueStatusLoaded) {
-                    ApolloLog(@"[InlineImages] DASH asset load FAIL asset=%@", assetID);
-                    deliver(nil);
-                    return;
-                }
-                AVAssetImageGenerator *gen = [[AVAssetImageGenerator alloc] initWithAsset:asset];
-                gen.appliesPreferredTrackTransform = YES;
-                gen.requestedTimeToleranceBefore = CMTimeMakeWithSeconds(0.5, 600);
-                gen.requestedTimeToleranceAfter = CMTimeMakeWithSeconds(0.5, 600);
+            if (times.count == 0) [times addObject:[NSValue valueWithCMTime:kCMTimeZero]];
 
-                Float64 durSec = CMTIME_IS_NUMERIC(asset.duration)
-                    ? CMTimeGetSeconds(asset.duration) : 0;
-                NSMutableArray<NSValue *> *times = [NSMutableArray array];
-                for (NSNumber *t in @[@3.0, @5.0, @1.5, @0.5, @0.0]) {
-                    Float64 v = t.doubleValue;
-                    if (durSec <= 0 || v < durSec) {
-                        [times addObject:[NSValue valueWithCMTime:CMTimeMakeWithSeconds(v, 600)]];
-                    }
-                }
-                if (times.count == 0) [times addObject:[NSValue valueWithCMTime:kCMTimeZero]];
+            __block BOOL delivered = NO;
+            __block UIImage *darkFallback = nil;
+            __block NSInteger remaining = (NSInteger)times.count;
+            __block AVAssetImageGenerator *retainedGen = gen;
 
-                __block BOOL delivered = NO;
-                __block UIImage *darkFallback = nil;
-                __block NSInteger remaining = (NSInteger)times.count;
-                __block AVAssetImageGenerator *retainedGen = gen;
-
-                [gen generateCGImagesAsynchronouslyForTimes:times
-                    completionHandler:^(CMTime requested, CGImageRef cgImage,
-                                        CMTime actualT, AVAssetImageGeneratorResult res,
-                                        NSError *genError) {
-                    @synchronized (retainedGen ?: (id)@"x") {
-                        if (delivered) return;
-                        remaining--;
-                        if (res == AVAssetImageGeneratorSucceeded && cgImage) {
-                            UIImage *ui = [UIImage imageWithCGImage:cgImage];
-                            BOOL dark = ApolloImageIsMostlyBlack(ui);
-                            if (!dark) {
-                                delivered = YES;
-                                retainedGen = nil;
-                                deliver(ui);
-                                return;
-                            }
-                            if (!darkFallback) darkFallback = ui;
-                        }
-                        if (remaining <= 0 && !delivered) {
+            [gen generateCGImagesAsynchronouslyForTimes:times
+                completionHandler:^(CMTime requested, CGImageRef cgImage,
+                                    CMTime actualT, AVAssetImageGeneratorResult res,
+                                    NSError *genError) {
+                @synchronized (retainedGen ?: (id)@"x") {
+                    if (delivered) return;
+                    remaining--;
+                    if (res == AVAssetImageGeneratorSucceeded && cgImage) {
+                        UIImage *ui = [UIImage imageWithCGImage:cgImage];
+                        BOOL dark = ApolloImageIsMostlyBlack(ui);
+                        if (!dark) {
                             delivered = YES;
                             retainedGen = nil;
-                            deliver(darkFallback);
+                            deliver(ApolloDashPosterDownscaled(ui));
+                            return;
                         }
+                        if (!darkFallback) darkFallback = ui;
                     }
-                }];
+                    if (remaining <= 0 && !delivered) {
+                        delivered = YES;
+                        retainedGen = nil;
+                        deliver(ApolloDashPosterDownscaled(darkFallback));
+                    }
+                }
             }];
         }];
-        [task resume];
-    });
+    }];
+    [task resume];
 }
 
 static NSURL *ApolloNormalizeInlineImageURL(NSURL *url) {

--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -1009,6 +1009,12 @@ static void ApolloDashPosterStartFetch(NSString *assetID, NSURL *dashURL) {
                         BOOL dark = ApolloImageIsMostlyBlack(ui);
                         if (!dark) {
                             delivered = YES;
+                            // The first usable frame completes this pipeline.
+                            // Stop the remaining candidate-time decodes before
+                            // releasing our FIFO slot, otherwise the next
+                            // queued generator overlaps work with this one and
+                            // defeats the two-decoder memory cap.
+                            [retainedGen cancelAllCGImageGeneration];
                             retainedGen = nil;
                             deliver(ApolloDashPosterDownscaled(ui));
                             return;

--- a/src/ApolloMemoryDiagnostics.h
+++ b/src/ApolloMemoryDiagnostics.h
@@ -1,0 +1,31 @@
+// Memory diagnostics + coordinated cache purging.
+//
+// Motivation: the 8/2026 crash-report wave (issues #806/#811/#814/#816/#820)
+// showed Apollo reaching 550-750MB phys footprint and dying in every way an
+// OOM can present (jetsam, allocation-failure aborts, couldNotInstantiate
+// recursion) — while apollo-reborn.log carried zero memory signal. This module
+// makes footprint visible in the log and gives cache-owning modules a single
+// place to register purge handlers that run on UIKit memory warnings.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+__BEGIN_DECLS
+
+// Current phys_footprint in MB (the number jetsam judges), or -1 if the
+// task_info query fails.
+double ApolloMemoryFootprintMB(void);
+
+// Register a named handler run on the main queue whenever UIKit posts
+// UIApplicationDidReceiveMemoryWarningNotification. Handlers should drop
+// re-derivable caches (decoded images, poster frames, players). The name is
+// used in the log line reporting per-handler effect. Safe to call from any
+// thread, including before the app finishes launching.
+void ApolloMemoryRegisterPurgeHandler(NSString *name, void (^handler)(void));
+
+// Log the current footprint with a context tag (e.g. after a purge, at a
+// suspected growth point). Rate-limited only by the caller.
+void ApolloMemoryLogFootprint(NSString *context);
+
+__END_DECLS
+NS_ASSUME_NONNULL_END

--- a/src/ApolloMemoryDiagnostics.m
+++ b/src/ApolloMemoryDiagnostics.m
@@ -1,0 +1,109 @@
+#import "ApolloMemoryDiagnostics.h"
+#import "ApolloCommon.h"
+
+#import <UIKit/UIKit.h>
+#import <mach/mach.h>
+
+// MARK: - Footprint query
+
+double ApolloMemoryFootprintMB(void) {
+    task_vm_info_data_t info;
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    kern_return_t kr = task_info(mach_task_self(), TASK_VM_INFO,
+                                 (task_info_t)&info, &count);
+    if (kr != KERN_SUCCESS) return -1;
+    return (double)info.phys_footprint / (1024.0 * 1024.0);
+}
+
+// MARK: - Purge handler registry
+
+static NSMutableArray<NSDictionary *> *sPurgeHandlers;
+static NSObject *sPurgeLock;
+
+static void ApolloMemoryDiagnosticsEnsureState(void) {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        sPurgeHandlers = [NSMutableArray array];
+        sPurgeLock = [NSObject new];
+    });
+}
+
+void ApolloMemoryRegisterPurgeHandler(NSString *name, void (^handler)(void)) {
+    if (!handler) return;
+    ApolloMemoryDiagnosticsEnsureState();
+    @synchronized (sPurgeLock) {
+        [sPurgeHandlers addObject:@{ @"name": name ?: @"?", @"handler": [handler copy] }];
+    }
+}
+
+void ApolloMemoryLogFootprint(NSString *context) {
+    ApolloLog(@"[MemoryDiag] %@ | footprint=%.0fMB", context ?: @"-", ApolloMemoryFootprintMB());
+}
+
+// MARK: - Warning + lifecycle observers, periodic sampler
+
+static double sPeakFootprintMB;
+static double sLastLoggedFootprintMB;
+
+static void ApolloMemoryRunPurgeHandlers(void) {
+    NSArray<NSDictionary *> *handlers;
+    @synchronized (sPurgeLock) { handlers = [sPurgeHandlers copy]; }
+    for (NSDictionary *entry in handlers) {
+        double before = ApolloMemoryFootprintMB();
+        void (^handler)(void) = entry[@"handler"];
+        handler();
+        double after = ApolloMemoryFootprintMB();
+        ApolloLog(@"[MemoryDiag] purge '%@' | footprint %.0fMB -> %.0fMB",
+                  entry[@"name"], before, after);
+    }
+}
+
+__attribute__((constructor))
+static void ApolloMemoryDiagnosticsInstall(void) {
+    ApolloMemoryDiagnosticsEnsureState();
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+
+    // Memory warning: log, then purge everything registered. This is the last
+    // signal before jetsam considers the app; footprint here is the number
+    // that matters in JetsamEvent reports.
+    [nc addObserverForName:UIApplicationDidReceiveMemoryWarningNotification
+                    object:nil
+                     queue:[NSOperationQueue mainQueue]
+                usingBlock:^(__unused NSNotification *note) {
+        ApolloLog(@"[MemoryDiag] MEMORY WARNING | footprint=%.0fMB peak=%.0fMB",
+                  ApolloMemoryFootprintMB(), sPeakFootprintMB);
+        ApolloMemoryRunPurgeHandlers();
+    }];
+
+    // Backgrounding: suspended footprint decides eviction order while the user
+    // is away (issue #811: "Apollo reloads when I come back"). Log it and purge
+    // proactively — a suspended app never gets another chance to shrink.
+    [nc addObserverForName:UIApplicationDidEnterBackgroundNotification
+                    object:nil
+                     queue:[NSOperationQueue mainQueue]
+                usingBlock:^(__unused NSNotification *note) {
+        ApolloLog(@"[MemoryDiag] didEnterBackground | footprint=%.0fMB peak=%.0fMB",
+                  ApolloMemoryFootprintMB(), sPeakFootprintMB);
+        ApolloMemoryRunPurgeHandlers();
+    }];
+
+    // Periodic sampler on a utility queue: tracks peak and logs only on
+    // meaningful movement (>=50MB since the last logged value) so a healthy
+    // session adds a handful of lines, a leaking one draws its own growth curve.
+    dispatch_queue_t q = dispatch_get_global_queue(QOS_CLASS_UTILITY, 0);
+    dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, q);
+    dispatch_source_set_timer(timer, dispatch_time(DISPATCH_TIME_NOW, 15 * NSEC_PER_SEC),
+                              30 * NSEC_PER_SEC, 5 * NSEC_PER_SEC);
+    dispatch_source_set_event_handler(timer, ^{
+        double mb = ApolloMemoryFootprintMB();
+        if (mb < 0) return;
+        if (mb > sPeakFootprintMB) sPeakFootprintMB = mb;
+        if (fabs(mb - sLastLoggedFootprintMB) >= 50.0) {
+            sLastLoggedFootprintMB = mb;
+            ApolloLog(@"[MemoryDiag] footprint=%.0fMB peak=%.0fMB", mb, sPeakFootprintMB);
+        }
+    });
+    dispatch_resume(timer);
+    // Keep the source alive for the process lifetime.
+    CFRetain((__bridge CFTypeRef)timer);
+}

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -167,21 +167,48 @@ static NSMutableSet<NSString *> *sLoggedSkippedStructuredPostFullNames;
 // persistence on backgrounding. All writes go through helper macros below.
 static NSMutableDictionary<NSString *, NSString *> *sCommentTranslationMirror = nil;
 static NSMutableDictionary<NSString *, NSString *> *sLinkTranslationMirror = nil;
+// The NSCaches these mirror are capped (2048/256) but the mirrors themselves
+// were unbounded — an all-day session accumulated every translated body ever
+// shown. Cap them the same insertion-order way as sRawTranslationMirror below.
+static NSMutableArray<NSString *> *sCommentTranslationMirrorOrder = nil;
+static NSMutableArray<NSString *> *sLinkTranslationMirrorOrder = nil;
+static const NSUInteger kApolloTranslationMirrorCap = 4096;
+static void ApolloMirrorSetCapped(NSMutableDictionary<NSString *, NSString *> *mirror,
+                                  NSMutableArray<NSString *> *order,
+                                  NSString *key, NSString *value) {
+    @synchronized (mirror) {
+        if (!mirror[key]) [order addObject:key];
+        mirror[key] = value;
+        if (order.count > kApolloTranslationMirrorCap) {
+            NSRange oldest = NSMakeRange(0, order.count / 4);
+            for (NSString *evicted in [order subarrayWithRange:oldest]) {
+                [mirror removeObjectForKey:evicted];
+            }
+            [order removeObjectsInRange:oldest];
+        }
+    }
+}
 static inline void ApolloMirrorSetComment(NSString *key, NSString *value) {
     if (!key || !value) return;
-    @synchronized (sCommentTranslationMirror) { sCommentTranslationMirror[key] = value; }
+    ApolloMirrorSetCapped(sCommentTranslationMirror, sCommentTranslationMirrorOrder, key, value);
 }
 static inline void ApolloMirrorRemoveComment(NSString *key) {
     if (!key) return;
-    @synchronized (sCommentTranslationMirror) { [sCommentTranslationMirror removeObjectForKey:key]; }
+    @synchronized (sCommentTranslationMirror) {
+        [sCommentTranslationMirror removeObjectForKey:key];
+        [sCommentTranslationMirrorOrder removeObject:key];
+    }
 }
 static inline void ApolloMirrorSetLink(NSString *key, NSString *value) {
     if (!key || !value) return;
-    @synchronized (sLinkTranslationMirror) { sLinkTranslationMirror[key] = value; }
+    ApolloMirrorSetCapped(sLinkTranslationMirror, sLinkTranslationMirrorOrder, key, value);
 }
 static inline void ApolloMirrorRemoveLink(NSString *key) {
     if (!key) return;
-    @synchronized (sLinkTranslationMirror) { [sLinkTranslationMirror removeObjectForKey:key]; }
+    @synchronized (sLinkTranslationMirror) {
+        [sLinkTranslationMirror removeObjectForKey:key];
+        [sLinkTranslationMirrorOrder removeObject:key];
+    }
 }
 // Mirror of the raw text-keyed cache (sTranslationCache). Titles, rich link
 // previews, and post bodies key by source text rather than fullName, so they
@@ -253,8 +280,14 @@ static void ApolloClearAllTranslationCaches(void) {
         [sRawTranslationMirror removeAllObjects];
         [sRawTranslationMirrorOrder removeAllObjects];
     }
-    @synchronized (sCommentTranslationMirror) { [sCommentTranslationMirror removeAllObjects]; }
-    @synchronized (sLinkTranslationMirror) { [sLinkTranslationMirror removeAllObjects]; }
+    @synchronized (sCommentTranslationMirror) {
+        [sCommentTranslationMirror removeAllObjects];
+        [sCommentTranslationMirrorOrder removeAllObjects];
+    }
+    @synchronized (sLinkTranslationMirror) {
+        [sLinkTranslationMirror removeAllObjects];
+        [sLinkTranslationMirrorOrder removeAllObjects];
+    }
 }
 static NSMutableDictionary<NSString *, NSMutableArray *> *sPendingTranslationCallbacks;
 static __weak UIViewController *sVisibleCommentsViewController = nil;
@@ -9436,7 +9469,9 @@ static void ApolloDbgPurgeNSCaches(CFNotificationCenterRef c, void *o, CFStringR
     sLoggedSkippedCommentFullNames = [NSMutableSet set];
     sLoggedSkippedStructuredPostFullNames = [NSMutableSet set];
     sCommentTranslationMirror = [NSMutableDictionary dictionary];
+    sCommentTranslationMirrorOrder = [NSMutableArray array];
     sLinkTranslationMirror = [NSMutableDictionary dictionary];
+    sLinkTranslationMirrorOrder = [NSMutableArray array];
     sRawTranslationMirror = [NSMutableDictionary dictionary];
     sRawTranslationMirrorOrder = [NSMutableArray array];
     sPendingTranslationCallbacks = [NSMutableDictionary dictionary];

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1910,6 +1910,24 @@ static const char kARCompletion = '\0';
     return customUA;
 }
 
+// #785: "Go to user" with a trailing space after the username crashes. Apollo
+// interpolates the raw search text into "user/<name>/about.json", and the
+// malformed request's response reaches +[RDKObjectBuilder objectFromJSON:] as a
+// plain NSString, which traps on `json[@"kind"]` (unrecognized selector). Trim
+// whitespace/newlines so the request targets the user the person actually typed.
+- (id)userWithUsername:(NSString *)username completion:(id)completion {
+    if ([username isKindOfClass:[NSString class]]) {
+        NSString *trimmed = [username stringByTrimmingCharactersInSet:
+                             [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        if (trimmed.length > 0 && ![trimmed isEqualToString:username]) {
+            ApolloLog(@"[GoToUser] Trimmed username (len %lu -> %lu) before user lookup",
+                      (unsigned long)username.length, (unsigned long)trimmed.length);
+            return %orig(trimmed, completion);
+        }
+    }
+    return %orig;
+}
+
 // Defensive guard: bail out if the response isn't a dictionary. Apollo otherwise
 // crashes with "unrecognized selector" when it does `response[@"kind"]` on a string.
 - (NSArray *)objectsFromListingResponse:(id)response {


### PR DESCRIPTION
## Root cause

The late-July/early-August crash wave (#806, #811, #814, #815, #816, #820 — spanning 3.4.2 **and** 3.5.0) is one bug: **memory exhaustion**. The JetsamEvents in #806's report zip show Apollo at **679MB / 548MB / 743MB phys footprint while frontmost**. The 11 `.ips` crash reports in that zip are the same OOM presenting different ways:

- 4× `couldNotInstantiate` → `+[NSException exceptionWithName:...]` infinite recursion (CF can't allocate the exception about the allocation that failed)
- 1× `swift_abortAllocationFailure` (malloc failed outright)
- 2× SIGSEGV on nil allocator returns mid-`UIImageView init` / `__NSSetM_new`
- 1× `_UIGraphicsBeginImageContextWithOptions` assert on the ASDK display queue
- 1× `0x8BADF00D` watchdog: main thread blocked in Apollo's **own** sync `AVAsset tracks` XPC during a MediaViewer transition (mediaserverd presumably wedged by the same memory storm; our `animateTransition` hook is on the stack but only calls `%orig`)

Symbolicated with the release dSYMs, the tweak frames concentrate in **ApolloInlineImages.xm's inline video thumbnail path** — matching #814 (video hyperlink in comments) and #820 (comments crash, "possibly video related"). #811 ("Apollo reloads when leaving the app") is the same footprint problem from the suspended side: a 500MB+ app is jetsam's first eviction.

An audit of every static collection in the tweak found the drivers:

1. `sApolloDashPosterCache`: unbounded dictionary of session-lifetime, **full-resolution decoded poster UIImages** (a 1080p-only DASH rep pins ~8MB per video, forever, across threads).
2. Uncapped `AVAssetImageGenerator` fan-out: every video node spawned its own MPD download + 5-candidate-frame decoder concurrently — fast-scrolling a video-heavy thread is the allocation-failure spike.
3. Secondary: translation comment/link mirrors were unbounded (the raw mirror was already capped).

## Changes

- **ApolloInlineImages.xm**: DASH poster cache → cost-limited `NSCache` (48MB, auto-evicts under pressure, purged on memory warning); posters downscaled to ≤720px before caching (they render at comment width); poster fetch pipeline capped at **2 concurrent** with a FIFO waiting queue (slot released exactly once on every exit path).
- **ApolloMemoryDiagnostics.{h,m} (new)**: `phys_footprint` sampler (logs on ≥50MB movement + peak), memory-warning and backgrounding logging, and a purge-handler registry (`ApolloMemoryRegisterPurgeHandler`) so cache owners drop re-derivable data under pressure. The reporter logs on these issues carried **zero** memory signal; future `apollo-reborn.log` uploads will draw the growth curve themselves.
- **ApolloTranslation.xm**: cap `sCommentTranslationMirror`/`sLinkTranslationMirror` (insertion-order, 4096) using the same pattern as `sRawTranslationMirror`.
- **Tweak.xm**: fix #785 — "Go to user" with a trailing space builds `user/<name> /about.json`, whose response reaches `+[RDKObjectBuilder objectFromJSON:]` as a bare `NSString` and traps on `json[@"kind"]` (unrecognized selector; confirmed in Hopper — Apollo even leaves a Bugsnag breadcrumb about the type mismatch before crashing). Trim whitespace in the `RDKClient userWithUsername:completion:` hook. (A nil-guard in the builder hook would NOT be safe: the array-enumeration caller does `addObject:` unguarded.)

## Testing

- Simulator build + launch verified: all hooks install, `[MemoryDiag] footprint=84MB peak=84MB` sampling live.
- Device build (`make package`, iOS 26 SDK / iOS 14 floor) compiles and packages clean.
- DASH refactor invariant-reviewed (every path releases its fetch slot exactly once; serial-queue-only slot accounting; no deadlock). Could not end-to-end test against #820's exact r/denver thread — anonymous Reddit JSON is blocked from this network.

## Known follow-ups (deliberately not in this PR)

- Paused inline GIFs retain cover + full animated image + Texture backing simultaneously (worst case: Tap-to-Play in a GIF-heavy thread). Dropping the stored animation breaks tap-to-play resume — that pipeline usually has no `node.URL` for a re-fetch round trip — so it needs its own careful change.
- `sApolloDeletedCommentsArchivedByFullName` is unbounded (~1-4KB/entry, slow burn).
- #771 (iOS 16.2 TrollStore, crash-on-any-tap after fresh install) does not fit the OOM pattern and has no log; needs an `.ips` from the reporter.

Closes #785. Should resolve #806, #811, #814, #815, #816, #820 pending confirmation from reporters on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)