### PR TITLE
Fix account switcher long-press crash (garbage Swift ivar read in the profile walk)

### DIFF
--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -3,6 +3,7 @@
 #import <CoreImage/CoreImage.h>
 #import <objc/runtime.h>
 #import <objc/message.h>
+#import <malloc/malloc.h>
 
 #import "ApolloCommon.h"
 #import "ApolloState.h"
@@ -1323,16 +1324,78 @@ static BOOL ApolloProfileUsernameIsLoggedInAccount(NSString *username) {
     return NO;
 }
 
+// One-shot registered-class set for validating candidate isa pointers by
+// identity only (no dereference). Classes never unregister, so a single
+// snapshot is safe; classes registered later (KVO subclasses etc.) miss and
+// the probe returns nil for them — a skipped read, never a crash.
+static BOOL ApolloRuntimeKnowsClass(Class candidate) {
+    static CFSetRef sKnownClasses;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        unsigned int count = 0;
+        Class *list = objc_copyClassList(&count);
+        CFMutableSetRef set = CFSetCreateMutable(NULL, count, NULL);
+        for (unsigned int i = 0; i < count; i++) {
+            CFSetAddValue(set, (__bridge const void *)list[i]);
+        }
+        free(list);
+        sKnownClasses = set;
+    });
+    return CFSetContainsValue(sKnownClasses, (__bridge const void *)candidate);
+}
+
+// Swift-class ivars carry no ObjC type encoding, so an ivar slot named e.g.
+// "username" may be an INLINE Swift struct, not an object reference — Apollo's
+// UserCommentsViewController.username is a 16-byte Swift.String whose first
+// word is the count-and-flags word (0xC00000000000000F for a bridged 15-char
+// ASCII username), which crashed objc_opt_isKindOfClass when returned as id
+// (profile-tab long-press .ips, 2026-08-05). Before treating such a word as an
+// object: it must be untagged, 8-byte aligned, plausibly heap-ranged, a live
+// malloc block, and its isa must resolve to a class the runtime knows.
+// Tagged pointers are rejected outright — an inline struct's flag word can
+// look tagged, and a genuinely tagged value in a Swift slot is rare enough
+// that skipping it (nil) is the right trade against misreading a struct.
+static BOOL ApolloWordLooksLikeObjCObject(uintptr_t raw) {
+    if (raw == 0) return NO;
+    if (raw & 0x8000000000000000ULL) return NO;
+    if (raw & 0x7) return NO;
+    if (raw < 0x100000000ULL) return NO;
+    if (malloc_size((const void *)raw) == 0) return NO;
+    Class cls = object_getClass((__bridge id)(void *)raw);
+    if (!cls) return NO;
+    return ApolloRuntimeKnowsClass(cls);
+}
+
 static id ApolloObjectIvarValue(id object, NSString *name) {
     if (!object || name.length == 0) return nil;
-    for (Class cls = [object class]; cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
+    for (Class cls = object_getClass(object); cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
         Ivar ivar = class_getInstanceVariable(cls, name.UTF8String);
         if (!ivar) continue;
-        @try {
+        const char *encoding = ivar_getTypeEncoding(ivar);
+        if (encoding && encoding[0] == '@') {
+            // ObjC-typed object ivar — the runtime vouches for it.
             return object_getIvar(object, ivar);
-        } @catch (__unused NSException *exception) {
+        }
+        if (encoding && encoding[0] != '\0') {
+            // Declared non-object ObjC type (int/BOOL/struct/...): never an id.
             return nil;
         }
+        // No encoding: Swift storage. Read the word manually and validate it
+        // before letting anyone message it.
+        ptrdiff_t offset = ivar_getOffset(ivar);
+        if (offset < 0) return nil;
+        if ((size_t)offset + sizeof(uintptr_t) > class_getInstanceSize(object_getClass(object))) return nil;
+        uintptr_t raw = 0;
+        memcpy(&raw, (const uint8_t *)(__bridge const void *)object + offset, sizeof(raw));
+        if (!ApolloWordLooksLikeObjCObject(raw)) {
+            // Non-zero garbage here is exactly the word that used to be
+            // messaged and crash — log it so field reports stay diagnosable.
+            if (raw != 0) {
+                ApolloLog(@"[UserAvatars] Skipping non-object ivar word %p (%@.%@)", (void *)raw, NSStringFromClass(cls), name);
+            }
+            return nil;
+        }
+        return (__bridge id)(void *)raw;
     }
     return nil;
 }


### PR DESCRIPTION
Got a crash report from my device this morning — long pressed the profile tab icon to open the account switcher and the app died instantly. Couldn't repro it after relaunch which was the tell that something timing/launch dependent was going on. Dug into the .ips and it's ours:

**What happened:** `EXC_BAD_ACCESS` in `objc_opt_isKindOfClass` called from `ApolloUsernameFromProfileViewController`, on the main queue from the coalesced VC-tree walk in ApolloUserAvatars.xm. The register holding the "object" was `0xC00000000000000F` — that's not a pointer, it's the count-and-flags word of a large Swift String (count 0xF = 15 chars = the length of the signed-in account name, bridged NSString so it's always large-form).

**Root cause:** `ApolloObjectIvarValue` did a raw `object_getIvar` for every probed ivar name (`username` / `user` / `account` / `profile` / `viewModel`). That's fine on ObjC classes, but on Swift classes those slots can be *inline structs*, not object refs. Apollo has five VCs like that (`UserCommentsViewController.username`, `TrophiesViewController.user`, `BanUserViewController.user`, `MultiredditViewController.username`, `UserMultiredditsViewController.username`) — all 16-byte inline Swift Strings. Have one of those resident in any nav stack (eg you opened someone's profile → Comments earlier), then open the account switcher: the sheet hook schedules the full-tree refresh walk, the walk probes the resident VC, and isKindOfClass gets fed the raw String word.

**Why it only crashed once:** whether that word kills you depends on the per-process tagged-pointer obfuscator — the top bit is set so objc decodes it as a tagged pointer into a random slot. Land on a registered tagged class and isKindOfClass just returns NO; land on an empty/ext slot and you get the SIGSEGV at ~0x1e. New launch, new dice roll — that's why it "worked fine after". The bad read happens *every* time though, I confirmed it in the sim (fix build logs the exact word, `0xC00000000000000E` = 14 chars = the u/messerschmitt1 comments screen I had open).

**Fix:** `ApolloObjectIvarValue` now trusts `@`-encoded (ObjC) ivars like before, bails on declared non-object encodings, and for encoding-less Swift storage reads the word manually and only returns it if it actually looks like an object: untagged, 8-byte aligned, plausible heap address, live malloc block, and the isa resolves to a class the runtime knows (one-shot `objc_copyClassList` set, pointer-identity check only). Anything else returns nil and logs a `[UserAvatars] Skipping non-object ivar word` line so future reports are diagnosable. Nothing that worked before is lost — none of those five Swift ivars were readable before, they were just crashes waiting on a dice roll (username detection on those screens comes from the nav-title fallback and still works).

**Testing (sim, iOS 26):** repro choreography = open any user's profile → Comments, long-press the profile tab. Pre-fix build survives or dies by obfuscator luck; fix build logs the skipped word and the switcher works every time. Verified sheet opens + accounts list + switching UI intact, keyless mode (both accounts web-session). Also ran it on the all-PRs integration tree. Device test pending — will update once I've run it on my phone.