### PR TITLE
Multireddit editing: rename, descriptions, and custom icons from the Subreddits list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloSubredditIndexPolish.xm \
     $(SRC_DIR)/ApolloQuickActions.xm \
     $(SRC_DIR)/ApolloHideModSubreddits.xm \
+    $(SRC_DIR)/ApolloMultiredditEdit.xm \
     $(SRC_DIR)/ApolloSubredditSidebar.xm \
     $(SRC_DIR)/ApolloTagFilters.xm \
     $(SRC_DIR)/ApolloThemeTokens.m \

--- a/src/ApolloMultiredditEdit.xm
+++ b/src/ApolloMultiredditEdit.xm
@@ -1,0 +1,593 @@
+#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+#import <PhotosUI/PhotosUI.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+#import "ApolloCommon.h"
+#import "ApolloState.h"
+#import "UserDefaultConstants.h"
+#import "ApolloAccountCredentials.h"
+#import "ApolloSubredditCustomIconCache.h"
+
+// MARK: - Multireddit Rename & Descriptions
+//
+// Reddit's website lets you rename a multireddit and give it a description
+// (the "edit details" dialog), but Apollo only asks for a name at creation
+// time — an existing multireddit can never be renamed or described in-app.
+//
+// This module adds both, plus display rules for the Subreddits list:
+//
+// 1. EDITING — in the list's Edit mode, tapping a MULTIREDDITS row opens an
+//    editor prefilled with the multireddit's name and description. Saving
+//    PUTs the website's own model shape ({"display_name", "description_md"})
+//    to api/multi/<path>, so the multireddit's URL slug is untouched, exactly
+//    like the website's edit-details dialog. Taps reach us because our
+//    setEditing: hook turns on allowsSelectionDuringEditing; Apollo's own
+//    didSelect was unreachable in Edit mode (and it navigates), so the
+//    didSelect hook swallows every edit-mode tap instead of forwarding it.
+// 2. DISPLAY — a multireddit row's subtitle normally lists the subreddits it
+//    contains. When the multireddit has a description, the description
+//    replaces that list (clear it in the editor and the list comes back).
+//    The "Hide Multireddit Descriptions" toggle blanks the subtitle line
+//    entirely, mirroring what Hide Feed Descriptions does for the built-in
+//    feed rows.
+// 3. CUSTOM ICONS — the editor also offers "Choose Custom Icon…" (and
+//    "Remove Custom Icon"): a photo picked from the library is stored in the
+//    existing subreddit custom-icon cache under a slash-free key derived from
+//    the multireddit's path (rename-stable) and drawn over the row's icon.
+//    Local-only: Reddit's API has no custom image upload for multireddits.
+//
+// Mechanics worth noting:
+// - Writes go through ApolloActiveAccountClient(): RDKClient.sharedClient is
+//   Apollo's application-only bootstrap client whose currentUser is nil while
+//   a real account is signed in (see ApolloAccountCredentials.m), and every
+//   api/multi path is built from currentUser.username.
+// - putPath:parameters:completion:'s completion takes THREE arguments
+//   (response, responseObject, error) — verified in the binary from the
+//   wrapper block setDescription:forMultiredditWithName: hands it (0x10001f7e8),
+//   which forwards to the public two-argument (object, error) completions.
+// - After a successful save the local RDKMultireddit is updated via KVC for
+//   instant UI, then com.christianselig.MultiredditsUpdatedForAccount is
+//   posted (object nil, matching Apollo's own add/remove-subreddit flows),
+//   which makes RedditListViewController refetch the authoritative list.
+// - Rows are resolved by NAME, never by index. The list re-sorts its model
+//   arrays for display, so a visible row index means nothing against the
+//   stored array (the exact lesson of the MODERATOR-section fix in
+//   ApolloHideModSubreddits.xm). The tapped cell's title label is matched
+//   against RDKMultireddit.displayName case-insensitively.
+// - The model array is captured from -[RDKUser setMultireddits:] (fired by
+//   the list's own fetch) with the active client's user as fallback, so no
+//   Swift ivar of the view controller is ever read (its `multireddits` field
+//   is a Swift Array — a bridge object, not a safe NSArray pointer).
+
+// Minimal surface of Apollo's bundled RedditKit model. Entries of the captured
+// multireddits array; all methods are ObjC-visible (verified via Hopper).
+@interface RDKMultireddit : NSObject
+- (NSString *)name;
+- (NSString *)displayName;
+- (NSString *)path;
+- (NSString *)descriptionMarkdown;
+- (BOOL)isEditable;
+@end
+
+@interface RedditListViewController : UIViewController <UITableViewDataSource, UITableViewDelegate>
+// The %new methods this module adds, declared so in-module calls type-check.
+- (void)apolloMultiEditPresentEditorFor:(RDKMultireddit *)multireddit;
+- (void)apolloMultiEditSave:(RDKMultireddit *)multireddit name:(NSString *)newName descriptionText:(NSString *)newDescription;
+- (void)apolloMultiEditShowError:(NSString *)message;
+- (void)apolloMultiEditPickIconFor:(RDKMultireddit *)multireddit;
+@end
+
+// Posted by Apollo after multireddit mutations; RedditListViewController
+// listens and refetches. Recovered from the binary (posted with object:nil).
+static NSString *const kApolloMultiredditsUpdatedNotification = @"com.christianselig.MultiredditsUpdatedForAccount";
+
+// Multireddit arrays captured from -[RDKClient multiredditsWithCompletion:],
+// keyed by the client instance that fetched them (weak keys — a released
+// account client drops its entry). Apollo runs that fetch for every signed-in
+// account around launch, so a single "latest array" global would be clobbered
+// by whichever account answered last; keying by client keeps the signed-in
+// account's list resolvable via ApolloActiveAccountClient().
+static NSMapTable<id, NSArray *> *sMultiredditsByClient = nil;
+
+// The Subreddits list table most recently configured through our cellForRow
+// hook — reloaded when the hide-descriptions toggle changes.
+static __weak UITableView *sMultiEditListTable = nil;
+
+// Associated flag: we (not Apollo) enabled allowsSelectionDuringEditing on
+// this table, so we also turn it back off when Edit mode ends.
+static char kApolloMultiEditSelectionEnabledKey;
+
+// Associates the multireddit being re-iconed with its PHPicker instance.
+static char kApolloMultiEditPickerTargetKey;
+
+// MARK: - Helpers
+
+static NSString *ApolloMultiEditTrim(NSString *text) {
+    return [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
+// Leftmost non-empty UILabel in a view tree — section headers contain just
+// their title label. (Same approach as ApolloHideModSubreddits.)
+static NSString *ApolloMultiEditLeftmostLabelText(UIView *root) {
+    if (!root) return nil;
+
+    UILabel *best = nil;
+    CGFloat bestX = CGFLOAT_MAX;
+    NSMutableArray<UIView *> *stack = [NSMutableArray arrayWithObject:root];
+    while (stack.count > 0) {
+        UIView *candidate = stack.lastObject;
+        [stack removeLastObject];
+        if ([candidate isKindOfClass:[UILabel class]]) {
+            UILabel *label = (UILabel *)candidate;
+            NSString *text = ApolloMultiEditTrim(label.text);
+            if (text.length > 0) {
+                CGFloat minX = CGRectGetMinX([label convertRect:label.bounds toView:root]);
+                if (minX < bestX) {
+                    best = label;
+                    bestX = minX;
+                }
+            }
+        }
+        [stack addObjectsFromArray:candidate.subviews];
+    }
+    return ApolloMultiEditTrim(best.text);
+}
+
+// Resolves a section's header title (uppercased) by checking the visible
+// header first, then asking the delegate to build one.
+static NSString *ApolloMultiEditSectionTitle(id delegate, UITableView *tableView, NSInteger section) {
+    if (!tableView || section < 0 || section >= tableView.numberOfSections) return nil;
+
+    UIView *header = [tableView headerViewForSection:section];
+    if (!header && [delegate respondsToSelector:@selector(tableView:viewForHeaderInSection:)]) {
+        header = [delegate tableView:tableView viewForHeaderInSection:section];
+    }
+    NSString *text = ApolloMultiEditLeftmostLabelText(header);
+    return text.length > 0 ? text.uppercaseString : nil;
+}
+
+static id ApolloMultiEditObjectIvar(id object, const char *name) {
+    if (!object || !name) return nil;
+    Ivar ivar = class_getInstanceVariable(object_getClass(object), name);
+    return ivar ? object_getIvar(object, ivar) : nil;
+}
+
+static UITableView *ApolloMultiEditTableView(UIViewController *viewController) {
+    UITableView *tableView = (UITableView *)ApolloMultiEditObjectIvar(viewController, "tableView");
+    return [tableView isKindOfClass:[UITableView class]] ? tableView : nil;
+}
+
+// A UILabel stored property on Apollo's Swift RedditListTableViewCell.
+// ObjC-class-typed Swift stored properties are real runtime ivars under their
+// Swift names, so plain ivar access is safe (unlike Swift struct fields).
+static UILabel *ApolloMultiEditCellLabel(UITableViewCell *cell, const char *name) {
+    UILabel *label = (UILabel *)ApolloMultiEditObjectIvar(cell, name);
+    return [label isKindOfClass:[UILabel class]] ? label : nil;
+}
+
+static Class ApolloMultiEditListCellClass(void) {
+    static Class cls = Nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        cls = objc_getClass("_TtC6Apollo23RedditListTableViewCell");
+    });
+    return cls;
+}
+
+// MARK: - Custom icons
+
+// Custom multireddit icons ride the existing subreddit custom-icon cache. Its
+// keys map straight to <key>.png filenames, so the multireddit's path (stable
+// across display-name renames — the URL slug never changes) is made slash-free
+// and namespaced away from every possible subreddit name.
+static NSString *ApolloMultiEditIconKey(RDKMultireddit *multireddit) {
+    NSString *path = [multireddit path];
+    if (path.length == 0) return nil;
+    return [@"multi" stringByAppendingString:[path stringByReplacingOccurrencesOfString:@"/" withString:@"~"]];
+}
+
+static UIImage *ApolloMultiEditCustomIcon(RDKMultireddit *multireddit) {
+    NSString *key = ApolloMultiEditIconKey(multireddit);
+    return key ? [[ApolloSubredditCustomIconCache sharedCache] cachedIconForSubreddit:key] : nil;
+}
+
+// The cell's icon image view has no fixed size constraint — it takes the
+// image's intrinsic size, and Apollo hands it display-sized images. So the
+// stored 256px icon must be redrawn at the stock icon's point size before
+// going into the view (a raw 256pt image blows the row up). Resized copies are
+// cached per size; the cache is dumped whenever an icon is saved or removed.
+static NSCache<NSString *, UIImage *> *sMultiEditDisplayIconCache = nil;
+
+static UIImage *ApolloMultiEditDisplayIcon(RDKMultireddit *multireddit, CGSize targetSize) {
+    NSString *key = ApolloMultiEditIconKey(multireddit);
+    if (!key || targetSize.width < 1.0 || targetSize.height < 1.0) return nil;
+
+    NSString *cacheKey = [NSString stringWithFormat:@"%@|%.0fx%.0f", key, targetSize.width, targetSize.height];
+    UIImage *cached = [sMultiEditDisplayIconCache objectForKey:cacheKey];
+    if (cached) return cached;
+
+    UIImage *stored = [[ApolloSubredditCustomIconCache sharedCache] cachedIconForSubreddit:key];
+    if (!stored) return nil;
+
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:targetSize];
+    UIImage *resized = [renderer imageWithActions:^(UIGraphicsImageRendererContext *context) {
+        [stored drawInRect:CGRectMake(0, 0, targetSize.width, targetSize.height)];
+    }];
+    if (!sMultiEditDisplayIconCache) sMultiEditDisplayIconCache = [[NSCache alloc] init];
+    [sMultiEditDisplayIconCache setObject:resized forKey:cacheKey];
+    return resized;
+}
+
+// Renders the picked photo as a 256px circular icon: center-cropped square,
+// aspect-filled, clipped to a circle — the shape of Apollo's own list icons —
+// so it looks native regardless of the source photo's aspect ratio or the
+// image view's configuration. List icons render ~40pt, so 256px is generous
+// while keeping the PNG (and the load-time NSCache entry) small.
+static UIImage *ApolloMultiEditScaledIcon(UIImage *image) {
+    CGFloat side = 256.0;
+    CGSize size = image.size;
+    if (size.width < 1.0 || size.height < 1.0) return image;
+
+    UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat preferredFormat];
+    format.scale = 1.0;
+    format.opaque = NO;
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:CGSizeMake(side, side) format:format];
+    return [renderer imageWithActions:^(UIGraphicsImageRendererContext *context) {
+        [[UIBezierPath bezierPathWithOvalInRect:CGRectMake(0, 0, side, side)] addClip];
+        CGFloat fillScale = MAX(side / size.width, side / size.height);
+        CGSize scaled = CGSizeMake(size.width * fillScale, size.height * fillScale);
+        [image drawInRect:CGRectMake((side - scaled.width) / 2.0, (side - scaled.height) / 2.0,
+                                     scaled.width, scaled.height)];
+    }];
+}
+
+// MARK: - Model lookup
+
+// The lists to search for a tapped/rendered row's model: the active account
+// client's fetch result first (authoritative for the Subreddits list), then
+// every other captured fetch as a fallback.
+static NSArray<NSArray *> *ApolloMultiEditCandidateLists(void) {
+    if (!sMultiredditsByClient) return @[];
+
+    NSMutableArray<NSArray *> *lists = [NSMutableArray array];
+    id activeClient = ApolloActiveAccountClient();
+    NSArray *activeList = activeClient ? [sMultiredditsByClient objectForKey:activeClient] : nil;
+    if (activeList.count > 0) [lists addObject:activeList];
+
+    for (id client in sMultiredditsByClient) {
+        NSArray *list = [sMultiredditsByClient objectForKey:client];
+        if (list.count > 0 && list != activeList) [lists addObject:list];
+    }
+    return lists;
+}
+
+static RDKMultireddit *ApolloMultiEditFindByTitle(NSString *title) {
+    if (title.length == 0) return nil;
+    for (NSArray *list in ApolloMultiEditCandidateLists()) {
+        for (RDKMultireddit *candidate in list) {
+            NSString *display = nil;
+            if ([candidate respondsToSelector:@selector(displayName)]) display = [candidate displayName];
+            if (display.length == 0 && [candidate respondsToSelector:@selector(name)]) display = [candidate name];
+            if (display.length > 0 && [display caseInsensitiveCompare:title] == NSOrderedSame) return candidate;
+        }
+    }
+    return nil;
+}
+
+// MARK: - Capture Apollo's multireddit fetches
+
+// The Subreddits list populates its MULTIREDDITS section from this fetch, so
+// wrapping the completion hands us the exact model objects behind the rows.
+// Apollo issues the same fetch for every signed-in account's client around
+// launch — hence the per-client keying above. Completion arity is
+// (NSArray *collection, NSError *error) (RedditKit's RDKArrayCompletionBlock).
+%hook RDKClient
+
+- (id)multiredditsWithCompletion:(void (^)(NSArray *collection, NSError *error))completion {
+    if (!completion) return %orig;
+    __weak typeof(self) weakClient = self;
+    void (^wrapped)(NSArray *, NSError *) = ^(NSArray *collection, NSError *error) {
+        id client = weakClient;
+        if (client && [collection isKindOfClass:[NSArray class]] && collection.count > 0) {
+            // The map is read from the main thread (didSelect / cellForRow),
+            // so mutate it there too; completions aren't guaranteed on main.
+            void (^store)(void) = ^{
+                if (!sMultiredditsByClient) {
+                    sMultiredditsByClient = [NSMapTable weakToStrongObjectsMapTable];
+                }
+                [sMultiredditsByClient setObject:collection forKey:client];
+                ApolloLog(@"[MultiEdit] captured %lu multireddits for client %p%@",
+                          (unsigned long)collection.count, client,
+                          client == ApolloActiveAccountClient() ? @" (active)" : @"");
+            };
+            if ([NSThread isMainThread]) store();
+            else dispatch_async(dispatch_get_main_queue(), store);
+        }
+        completion(collection, error);
+    };
+    return %orig(wrapped);
+}
+
+%end
+
+// MARK: - Subreddits list hooks
+
+%group ApolloMultiEditList
+
+%hook RedditListViewController
+
+// Apollo leaves allowsSelectionDuringEditing off, so multireddit rows can't be
+// tapped in Edit mode. Turn it on while editing (and back off afterwards, but
+// only if we were the ones who enabled it).
+- (void)setEditing:(BOOL)editing animated:(BOOL)animated {
+    %orig;
+
+    UITableView *tableView = ApolloMultiEditTableView((UIViewController *)self);
+    if (!tableView) return;
+
+    if (editing) {
+        if (!tableView.allowsSelectionDuringEditing) {
+            tableView.allowsSelectionDuringEditing = YES;
+            objc_setAssociatedObject(tableView, &kApolloMultiEditSelectionEnabledKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+    } else if ([objc_getAssociatedObject(tableView, &kApolloMultiEditSelectionEnabledKey) boolValue]) {
+        tableView.allowsSelectionDuringEditing = NO;
+        objc_setAssociatedObject(tableView, &kApolloMultiEditSelectionEnabledKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+}
+
+// Edit-mode taps exist only because our setEditing: hook enabled selection.
+// Never forward them to Apollo (its didSelect navigates and was written for
+// browsing); a tap on a MULTIREDDITS row opens the rename/description editor,
+// anything else just deselects.
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (![(UIViewController *)self isEditing]) {
+        %orig;
+        return;
+    }
+
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+
+    if (![ApolloMultiEditSectionTitle(self, tableView, indexPath.section) isEqualToString:@"MULTIREDDITS"]) return;
+
+    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+    NSString *title = ApolloMultiEditTrim(ApolloMultiEditCellLabel(cell, "redditTitleLabel").text);
+    RDKMultireddit *multireddit = ApolloMultiEditFindByTitle(title);
+    if (!multireddit) {
+        ApolloLog(@"[MultiEdit] no multireddit model matches tapped row '%@' (%lu candidate lists)",
+                  title, (unsigned long)ApolloMultiEditCandidateLists().count);
+        return;
+    }
+    if ([multireddit respondsToSelector:@selector(isEditable)] && ![multireddit isEditable]) {
+        ApolloLog(@"[MultiEdit] '%@' is not editable (copied/unowned); ignoring tap", title);
+        return;
+    }
+    [(RedditListViewController *)self apolloMultiEditPresentEditorFor:multireddit];
+}
+
+// A multireddit row's subtitle is the joined list of its subreddits. Swap in
+// the user's description when one is set, or blank the line when the hide
+// toggle is on; also apply any custom icon. Only rows Apollo gave a subtitle
+// are touched (cheap first gate, hot path during scrolls): that skips the
+// expanded-multireddit child rows (plain subreddit rows in the same section,
+// no subtitle) and every other RedditListTableViewCell use.
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = %orig;
+    sMultiEditListTable = tableView;
+
+    Class cellClass = ApolloMultiEditListCellClass();
+    if (!cellClass || ![cell isKindOfClass:cellClass]) return cell;
+
+    UILabel *subtitleLabel = ApolloMultiEditCellLabel(cell, "subtitleLabel");
+    if (subtitleLabel.text.length == 0) return cell;
+
+    if (![ApolloMultiEditSectionTitle(self, tableView, indexPath.section) isEqualToString:@"MULTIREDDITS"]) return cell;
+
+    NSString *title = ApolloMultiEditTrim(ApolloMultiEditCellLabel(cell, "redditTitleLabel").text);
+    RDKMultireddit *multireddit = ApolloMultiEditFindByTitle(title);
+
+    if (multireddit) {
+        UIImageView *iconView = (UIImageView *)ApolloMultiEditObjectIvar(cell, "subredditIconImageView");
+        if ([iconView isKindOfClass:[UIImageView class]]) {
+            // Match the stock icon's point size (Apollo just set it in %orig)
+            // so the intrinsic-size-driven layout doesn't change.
+            CGSize targetSize = iconView.image.size;
+            if (targetSize.width < 1.0) targetSize = iconView.bounds.size;
+            UIImage *customIcon = ApolloMultiEditDisplayIcon(multireddit, targetSize);
+            if (customIcon) iconView.image = customIcon;
+        }
+    }
+
+    if (sHideMultiredditDescriptions) {
+        subtitleLabel.text = nil;
+        return cell;
+    }
+
+    NSString *description = [multireddit respondsToSelector:@selector(descriptionMarkdown)]
+        ? ApolloMultiEditTrim([multireddit descriptionMarkdown]) : nil;
+    if (description.length > 0) {
+        subtitleLabel.text = description;
+    }
+    return cell;
+}
+
+// MARK: Editor
+
+%new
+- (void)apolloMultiEditPresentEditorFor:(RDKMultireddit *)multireddit {
+    NSString *currentName = [multireddit displayName].length > 0 ? [multireddit displayName] : [multireddit name];
+    NSString *currentDescription = [multireddit respondsToSelector:@selector(descriptionMarkdown)]
+        ? ([multireddit descriptionMarkdown] ?: @"") : @"";
+
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Edit Multireddit"
+                                                                   message:@"Renaming keeps the multireddit's URL. With no description, the list of subreddits is shown instead."
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField *textField) {
+        textField.text = currentName;
+        textField.placeholder = @"Name";
+        textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    }];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField *textField) {
+        textField.text = currentDescription;
+        textField.placeholder = @"Description (optional)";
+    }];
+
+    __weak typeof(self) weakSelf = self;
+    [alert addAction:[UIAlertAction actionWithTitle:@"Save" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        NSString *newName = ApolloMultiEditTrim(alert.textFields.firstObject.text);
+        if (newName.length == 0) newName = currentName; // a multireddit can't be nameless
+        NSString *newDescription = ApolloMultiEditTrim(alert.textFields.lastObject.text) ?: @"";
+        if ([newName isEqualToString:currentName] && [newDescription isEqualToString:currentDescription]) return;
+        [weakSelf apolloMultiEditSave:multireddit name:newName descriptionText:newDescription];
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Choose Custom Icon…" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        [weakSelf apolloMultiEditPickIconFor:multireddit];
+    }]];
+    if (ApolloMultiEditCustomIcon(multireddit)) {
+        [alert addAction:[UIAlertAction actionWithTitle:@"Remove Custom Icon" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+            NSString *key = ApolloMultiEditIconKey(multireddit);
+            if (key) [[ApolloSubredditCustomIconCache sharedCache] removeIconForSubreddit:key];
+            [sMultiEditDisplayIconCache removeAllObjects];
+            ApolloLog(@"[MultiEdit] removed custom icon for %@", [multireddit path]);
+            // Apollo re-applies its own icon inside every cellForRow pass, so a
+            // plain reload restores the stock icon.
+            [(ApolloMultiEditTableView((UIViewController *)weakSelf) ?: sMultiEditListTable) reloadData];
+        }]];
+    }
+    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    [(UIViewController *)self presentViewController:alert animated:YES completion:nil];
+}
+
+%new
+- (void)apolloMultiEditPickIconFor:(RDKMultireddit *)multireddit {
+    PHPickerConfiguration *configuration = [[PHPickerConfiguration alloc] init];
+    configuration.filter = [PHPickerFilter imagesFilter];
+    configuration.selectionLimit = 1;
+    PHPickerViewController *picker = [[PHPickerViewController alloc] initWithConfiguration:configuration];
+    picker.delegate = (id<PHPickerViewControllerDelegate>)self;
+    objc_setAssociatedObject(picker, &kApolloMultiEditPickerTargetKey, multireddit, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [(UIViewController *)self presentViewController:picker animated:YES completion:nil];
+}
+
+// PHPickerViewControllerDelegate — added to the list controller via %new; the
+// picker dispatches by respondsToSelector:, so no compile-time conformance is
+// needed beyond the cast at the assignment.
+%new
+- (void)picker:(PHPickerViewController *)picker didFinishPicking:(NSArray<PHPickerResult *> *)results {
+    RDKMultireddit *multireddit = objc_getAssociatedObject(picker, &kApolloMultiEditPickerTargetKey);
+    [picker dismissViewControllerAnimated:YES completion:nil];
+
+    NSItemProvider *provider = results.firstObject.itemProvider;
+    if (!multireddit || ![provider canLoadObjectOfClass:[UIImage class]]) return;
+
+    __weak typeof(self) weakSelf = self;
+    [provider loadObjectOfClass:[UIImage class] completionHandler:^(id<NSItemProviderReading> object, NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (![object isKindOfClass:[UIImage class]]) {
+                ApolloLog(@"[MultiEdit] icon load failed: %@", error);
+                return;
+            }
+            NSString *key = ApolloMultiEditIconKey(multireddit);
+            NSError *saveError = nil;
+            UIImage *scaled = ApolloMultiEditScaledIcon((UIImage *)object);
+            if (key && [[ApolloSubredditCustomIconCache sharedCache] saveIcon:scaled forSubreddit:key error:&saveError]) {
+                [sMultiEditDisplayIconCache removeAllObjects];
+                ApolloLog(@"[MultiEdit] saved custom icon for %@ (%.0fx%.0f)", [multireddit path], scaled.size.width, scaled.size.height);
+                [(ApolloMultiEditTableView((UIViewController *)weakSelf) ?: sMultiEditListTable) reloadData];
+                // Land the user back in the editor they came from.
+                [weakSelf apolloMultiEditPresentEditorFor:multireddit];
+            } else {
+                ApolloLog(@"[MultiEdit] icon save failed for %@: %@", [multireddit path], saveError);
+            }
+        });
+    }];
+}
+
+%new
+- (void)apolloMultiEditSave:(RDKMultireddit *)multireddit name:(NSString *)newName descriptionText:(NSString *)newDescription {
+    NSString *path = [multireddit path];
+    id client = ApolloActiveAccountClient();
+    if (path.length == 0 || ![client respondsToSelector:@selector(putPath:parameters:completion:)]) {
+        ApolloLog(@"[MultiEdit] cannot save '%@': path=%@ client=%@", newName, path, client ? @"unsupported" : @"nil");
+        [(RedditListViewController *)self apolloMultiEditShowError:@"Couldn't reach your account session. Please try again."];
+        return;
+    }
+
+    // The website's edit-details request: PUT api/multi/<path> with a model
+    // containing only the fields being edited — everything omitted (subreddits,
+    // visibility, ...) is left untouched by Reddit.
+    NSDictionary *model = @{ @"display_name": newName, @"description_md": newDescription ?: @"" };
+    NSData *modelData = [NSJSONSerialization dataWithJSONObject:model options:0 error:nil];
+    NSString *modelJSON = [[NSString alloc] initWithData:modelData encoding:NSUTF8StringEncoding];
+    if (modelJSON.length == 0) return;
+
+    NSString *requestPath = [@"api/multi" stringByAppendingString:path];
+    NSDictionary *parameters = @{ @"model": modelJSON, @"multipath": path };
+    ApolloLog(@"[MultiEdit] PUT %@ (rename to '%@', description %lu chars)",
+              requestPath, newName, (unsigned long)newDescription.length);
+
+    __weak typeof(self) weakSelf = self;
+    // Arity verified in the binary: putPath's completion takes (response,
+    // responseObject, error) — see the module header.
+    void (^completion)(NSHTTPURLResponse *, id, NSError *) = ^(NSHTTPURLResponse *response, id responseObject, NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (error) {
+                ApolloLog(@"[MultiEdit] save failed for %@: %@", path, error);
+                [(RedditListViewController *)weakSelf apolloMultiEditShowError:@"Reddit rejected the change. Please try again."];
+                return;
+            }
+            ApolloLog(@"[MultiEdit] save succeeded for %@ (HTTP %ld)", path, (long)response.statusCode);
+
+            // Instant UI: update the local model and redraw, then let Apollo
+            // refetch the authoritative list (same notification its own
+            // add/remove-subreddit flows post).
+            @try {
+                [multireddit setValue:newName forKey:@"displayName"];
+                [multireddit setValue:(newDescription ?: @"") forKey:@"descriptionMarkdown"];
+            } @catch (NSException *exception) {
+                ApolloLog(@"[MultiEdit] local model update skipped: %@", exception);
+            }
+            UITableView *tableView = ApolloMultiEditTableView((UIViewController *)weakSelf) ?: sMultiEditListTable;
+            [tableView reloadData];
+            [[NSNotificationCenter defaultCenter] postNotificationName:kApolloMultiredditsUpdatedNotification object:nil];
+        });
+    };
+    ((id (*)(id, SEL, id, id, id))objc_msgSend)(client, @selector(putPath:parameters:completion:),
+                                                requestPath, parameters, (id)completion);
+}
+
+%new
+- (void)apolloMultiEditShowError:(NSString *)message {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Couldn't Save Multireddit"
+                                                                   message:message
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+    [(UIViewController *)self presentViewController:alert animated:YES completion:nil];
+}
+
+%end
+
+%end // ApolloMultiEditList
+
+%ctor {
+    %init;
+
+    Class listClass = objc_getClass("Apollo.RedditListViewController");
+    if (!listClass) listClass = NSClassFromString(@"Apollo.RedditListViewController");
+    if (listClass) {
+        %init(ApolloMultiEditList, RedditListViewController = listClass);
+        ApolloLog(@"[MultiEdit] list hooks installed on %@", NSStringFromClass(listClass));
+    } else {
+        ApolloLog(@"[MultiEdit] RedditListViewController class missing; multireddit editing unavailable");
+    }
+
+    // Re-render the list when Hide Multireddit Descriptions changes.
+    [[NSNotificationCenter defaultCenter] addObserverForName:ApolloHideMultiredditDescriptionsChangedNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(NSNotification *note) {
+        [sMultiEditListTable reloadData];
+    }];
+}

--- a/src/ApolloMultiredditEdit.xm
+++ b/src/ApolloMultiredditEdit.xm
@@ -51,11 +51,19 @@
 //   instant UI, then com.christianselig.MultiredditsUpdatedForAccount is
 //   posted (object nil, matching Apollo's own add/remove-subreddit flows),
 //   which makes RedditListViewController refetch the authoritative list.
-// - Rows are resolved by NAME, never by index. The list re-sorts its model
-//   arrays for display, so a visible row index means nothing against the
-//   stored array (the exact lesson of the MODERATOR-section fix in
-//   ApolloHideModSubreddits.xm). The tapped cell's title label is matched
-//   against RDKMultireddit.displayName case-insensitively.
+// - Rows are resolved by MODEL, never by index and never by title. The list
+//   re-sorts its model arrays for display, so a visible row index means
+//   nothing against the stored array (the exact lesson of the
+//   MODERATOR-section fix in ApolloHideModSubreddits.xm) — and display_name
+//   is editable independently of the path, so two multireddits can share a
+//   title and a title match alone would resolve both rows to the first of
+//   them. Apollo's cellForRowAt never messages the model (verified in the
+//   binary — it renders from cached Swift storage), so a row is identified by
+//   title AND, when a title is shared, by matching each candidate's own
+//   subreddits against the subtitle Apollo rendered. The resolved model is
+//   bound to the cell and the edit-mode tap reads it back from there, so the
+//   tap never re-derives a multireddit from a title. A row that still can't
+//   be pinned to one model is left alone rather than guessed at.
 // - The model array is captured from -[RDKUser setMultireddits:] (fired by
 //   the list's own fetch) with the active client's user as fallback, so no
 //   Swift ivar of the view controller is ever read (its `multireddits` field
@@ -68,6 +76,9 @@
 - (NSString *)displayName;
 - (NSString *)path;
 - (NSString *)descriptionMarkdown;
+// The multireddit's member subreddits; Mantle's subredditsJSONTransformer
+// decides the element type, so callers must handle both objects and strings.
+- (NSArray *)subreddits;
 - (BOOL)isEditable;
 @end
 
@@ -114,6 +125,11 @@ static char kApolloMultiEditPickerTargetKey;
 // moment later; the UIImageView setImage: hook below re-asserts the custom
 // icon on every attempt to replace it while the tag is present.
 static char kApolloMultiEditIconEnforceKey;
+
+// The RDKMultireddit a MULTIREDDITS row was built from, bound to the cell in
+// cellForRow. display_name is user-editable and not unique, so it can never be
+// the row's identity; this is.
+static char kApolloMultiEditRowModelKey;
 
 // Fast path for that hook: stays NO (one static read per setImage:) until any
 // custom multireddit icon exists this session.
@@ -279,17 +295,118 @@ static NSArray<NSArray *> *ApolloMultiEditCandidateLists(void) {
     return lists;
 }
 
-static RDKMultireddit *ApolloMultiEditFindByTitle(NSString *title) {
-    if (title.length == 0) return nil;
+static NSString *ApolloMultiEditDisplayTitle(RDKMultireddit *candidate) {
+    NSString *display = nil;
+    if ([candidate respondsToSelector:@selector(displayName)]) display = [candidate displayName];
+    if (display.length == 0 && [candidate respondsToSelector:@selector(name)]) display = [candidate name];
+    return display;
+}
+
+// Every model whose rendered title matches, deduplicated by path.
+//
+// display_name is user-editable and independent of the path, so it is NOT an
+// identity: two multireddits can legitimately share one title while living at
+// different paths. Callers must treat a >1 result as unresolved rather than
+// taking the first — editing, describing or icon-tagging the wrong
+// multireddit is worse than not acting.
+static NSArray<RDKMultireddit *> *ApolloMultiEditFindAllByTitle(NSString *title) {
+    if (title.length == 0) return @[];
+    NSMutableArray<RDKMultireddit *> *matches = [NSMutableArray array];
+    NSMutableSet<NSString *> *seenPaths = [NSMutableSet set];
     for (NSArray *list in ApolloMultiEditCandidateLists()) {
         for (RDKMultireddit *candidate in list) {
-            NSString *display = nil;
-            if ([candidate respondsToSelector:@selector(displayName)]) display = [candidate displayName];
-            if (display.length == 0 && [candidate respondsToSelector:@selector(name)]) display = [candidate name];
-            if (display.length > 0 && [display caseInsensitiveCompare:title] == NSOrderedSame) return candidate;
+            NSString *display = ApolloMultiEditDisplayTitle(candidate);
+            if (display.length == 0 || [display caseInsensitiveCompare:title] != NSOrderedSame) continue;
+            // The same multireddit reached through two accounts' captured
+            // lists is one multireddit, not an ambiguity.
+            NSString *path = [candidate respondsToSelector:@selector(path)] ? [candidate path] : nil;
+            if (path.length > 0) {
+                if ([seenPaths containsObject:path]) continue;
+                [seenPaths addObject:path];
+            }
+            [matches addObject:candidate];
         }
     }
-    return nil;
+    return matches;
+}
+
+// MARK: - Row identity
+//
+// Apollo's cell carries only strings (redditTitle/subtitle — see
+// Headers/Swift/RedditListTableViewCell.swift), and its
+// tableView(_:cellForRowAt:) never messages the model: disassembling it
+// (0x10063dbb4, reached from -[… tableView:cellForRowAtIndexPath:] at
+// 0x1006401f4) shows no objc_msgSend to displayName/name/path/subreddits
+// anywhere in the function — it renders from cached Swift storage. So there is
+// no configure-time model read to piggyback on; the row's identity has to be
+// recovered from what Apollo rendered.
+//
+// The title alone cannot do it (that is the bug). The stock subtitle can: it
+// is the row's subreddit list, and two multireddits sharing a display_name
+// still differ in what they contain. So a same-titled group is disambiguated
+// by matching each candidate's own subreddits against the rendered subtitle,
+// and a group that still can't be told apart is left alone rather than
+// resolved to whichever came first.
+
+// A multireddit's subreddit names, whatever the transformed array holds
+// (RDKSubreddit objects or plain strings).
+static NSArray<NSString *> *ApolloMultiEditSubredditNames(RDKMultireddit *multireddit) {
+    if (![multireddit respondsToSelector:@selector(subreddits)]) return @[];
+    NSArray *subreddits = [multireddit subreddits];
+    if (![subreddits isKindOfClass:[NSArray class]]) return @[];
+
+    NSMutableArray<NSString *> *names = [NSMutableArray array];
+    for (id entry in subreddits) {
+        NSString *name = nil;
+        if ([entry isKindOfClass:[NSString class]]) name = entry;
+        else if ([entry respondsToSelector:@selector(name)]) name = [entry name];
+        if (name.length == 0 && [entry respondsToSelector:@selector(displayName)]) name = [entry displayName];
+        if (name.length > 0) [names addObject:name];
+    }
+    return names;
+}
+
+// How many of the multireddit's subreddits appear in the rendered subtitle.
+static NSUInteger ApolloMultiEditSubtitleOverlap(RDKMultireddit *multireddit, NSString *subtitle) {
+    if (subtitle.length == 0) return 0;
+    NSUInteger matched = 0;
+    for (NSString *name in ApolloMultiEditSubredditNames(multireddit)) {
+        NSRange found = [subtitle rangeOfString:name options:NSCaseInsensitiveSearch];
+        if (found.location != NSNotFound) matched++;
+    }
+    return matched;
+}
+
+// The multireddit a row was rendered from, or nil when it can't be pinned down.
+//
+// `subtitle` must be the subtitle APOLLO rendered (read before this module
+// swaps in a description), since that is what identifies a row among
+// same-titled multireddits.
+static RDKMultireddit *ApolloMultiEditResolveRowModel(NSString *title, NSString *subtitle) {
+    NSArray<RDKMultireddit *> *matches = ApolloMultiEditFindAllByTitle(title);
+    if (matches.count <= 1) return matches.firstObject;
+
+    // Same title, different multireddits: let their contents decide.
+    RDKMultireddit *best = nil;
+    NSUInteger bestOverlap = 0;
+    BOOL tied = NO;
+    for (RDKMultireddit *candidate in matches) {
+        NSUInteger overlap = ApolloMultiEditSubtitleOverlap(candidate, subtitle);
+        if (overlap > bestOverlap) { best = candidate; bestOverlap = overlap; tied = NO; }
+        else if (overlap == bestOverlap && overlap > 0) tied = YES;
+    }
+    if (!best || tied) {
+        // Indistinguishable from the rendered row. Editing, describing or
+        // icon-tagging the wrong multireddit is worse than doing nothing.
+        ApolloLog(@"[MultiEdit] '%@' matches %lu multireddits and the row's subreddits don't "
+                  @"single one out — leaving this row alone",
+                  title, (unsigned long)matches.count);
+        return nil;
+    }
+    ApolloLog(@"[MultiEdit] '%@' is shared by %lu multireddits; row resolved to %@ by its subreddits",
+              title, (unsigned long)matches.count,
+              [best respondsToSelector:@selector(path)] ? [best path] : @"?");
+    return best;
 }
 
 // MARK: - Capture Apollo's multireddit fetches
@@ -399,9 +516,12 @@ static RDKMultireddit *ApolloMultiEditFindByTitle(NSString *title) {
 
     UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
     NSString *title = ApolloMultiEditTrim(ApolloMultiEditCellLabel(cell, "redditTitleLabel").text);
-    RDKMultireddit *multireddit = ApolloMultiEditFindByTitle(title);
+    // The model this exact row was built from — never a fresh title match,
+    // which would resolve two same-titled rows to the same multireddit and
+    // edit the wrong one.
+    RDKMultireddit *multireddit = objc_getAssociatedObject(cell, &kApolloMultiEditRowModelKey);
     if (!multireddit) {
-        ApolloLog(@"[MultiEdit] no multireddit model matches tapped row '%@' (%lu candidate lists)",
+        ApolloLog(@"[MultiEdit] tapped row '%@' has no bound multireddit model (%lu candidate lists)",
                   title, (unsigned long)ApolloMultiEditCandidateLists().count);
         return;
     }
@@ -431,7 +551,13 @@ static RDKMultireddit *ApolloMultiEditFindByTitle(NSString *title) {
     if (![ApolloMultiEditSectionTitle(self, tableView, indexPath.section) isEqualToString:@"MULTIREDDITS"]) return cell;
 
     NSString *title = ApolloMultiEditTrim(ApolloMultiEditCellLabel(cell, "redditTitleLabel").text);
-    RDKMultireddit *multireddit = ApolloMultiEditFindByTitle(title);
+    // Apollo's own subtitle (its subreddit list), read before the description
+    // swap below replaces it — it is what tells same-titled multireddits apart.
+    RDKMultireddit *multireddit = ApolloMultiEditResolveRowModel(title, subtitleLabel.text);
+    // Bind the model to the cell so the edit-mode tap acts on this row's
+    // multireddit rather than re-deriving one from the (non-unique) title.
+    // Cells are reused, so an unresolved row must clear the old binding.
+    objc_setAssociatedObject(cell, &kApolloMultiEditRowModelKey, multireddit, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
     UIImageView *iconView = (UIImageView *)ApolloMultiEditObjectIvar(cell, "subredditIconImageView");
     if ([iconView isKindOfClass:[UIImageView class]]) {
@@ -670,6 +796,9 @@ static RDKMultireddit *ApolloMultiEditFindByTitle(NSString *title) {
     if ([iconView isKindOfClass:[UIImageView class]]) {
         objc_setAssociatedObject(iconView, &kApolloMultiEditIconEnforceKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
     }
+    // A recycled cell must not carry the previous row's multireddit — an
+    // edit-mode tap landing before cellForRow rebinds would act on it.
+    objc_setAssociatedObject(self, &kApolloMultiEditRowModelKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 %end

--- a/src/ApolloMultiredditEdit.xm
+++ b/src/ApolloMultiredditEdit.xm
@@ -32,8 +32,8 @@
 //    The "Hide Multireddit Descriptions" toggle blanks the subtitle line
 //    entirely, mirroring what Hide Feed Descriptions does for the built-in
 //    feed rows.
-// 3. CUSTOM ICONS — the editor also offers "Choose Custom Icon…" (and
-//    "Remove Custom Icon"): a photo picked from the library is stored in the
+// 3. CUSTOM ICONS — the editor also offers "Choose Icon" (and "Remove
+//    Icon"): a photo picked from the library is stored in the
 //    existing subreddit custom-icon cache under a slash-free key derived from
 //    the multireddit's path (rename-stable) and drawn over the row's icon.
 //    Local-only: Reddit's API has no custom image upload for multireddits.
@@ -502,7 +502,7 @@ static RDKMultireddit *ApolloMultiEditFindByTitle(NSString *title) {
         if ([newName isEqualToString:currentName] && [newDescription isEqualToString:currentDescription]) return;
         [weakSelf apolloMultiEditSave:multireddit name:newName descriptionText:newDescription];
     }]];
-    [alert addAction:[UIAlertAction actionWithTitle:@"Choose Custom Icon…" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+    [alert addAction:[UIAlertAction actionWithTitle:@"Choose Icon" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
         // Alert actions dismiss the alert, so hand the unsaved field contents
         // to the picker flow — the editor reopens with them afterwards.
         [weakSelf apolloMultiEditPickIconFor:multireddit
@@ -510,7 +510,7 @@ static RDKMultireddit *ApolloMultiEditFindByTitle(NSString *title) {
                           pendingDescription:alert.textFields.lastObject.text];
     }]];
     if (ApolloMultiEditCustomIcon(multireddit)) {
-        [alert addAction:[UIAlertAction actionWithTitle:@"Remove Custom Icon" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+        [alert addAction:[UIAlertAction actionWithTitle:@"Remove Icon" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
             NSString *pendingName = alert.textFields.firstObject.text;
             NSString *pendingDescription = alert.textFields.lastObject.text;
             NSString *key = ApolloMultiEditIconKey(multireddit);

--- a/src/ApolloMultiredditEdit.xm
+++ b/src/ApolloMultiredditEdit.xm
@@ -71,12 +71,16 @@
 - (BOOL)isEditable;
 @end
 
+@interface RedditListTableViewCell : UITableViewCell
+@end
+
 @interface RedditListViewController : UIViewController <UITableViewDataSource, UITableViewDelegate>
 // The %new methods this module adds, declared so in-module calls type-check.
 - (void)apolloMultiEditPresentEditorFor:(RDKMultireddit *)multireddit;
+- (void)apolloMultiEditPresentEditorFor:(RDKMultireddit *)multireddit prefillName:(NSString *)prefillName prefillDescription:(NSString *)prefillDescription;
 - (void)apolloMultiEditSave:(RDKMultireddit *)multireddit name:(NSString *)newName descriptionText:(NSString *)newDescription;
 - (void)apolloMultiEditShowError:(NSString *)message;
-- (void)apolloMultiEditPickIconFor:(RDKMultireddit *)multireddit;
+- (void)apolloMultiEditPickIconFor:(RDKMultireddit *)multireddit pendingName:(NSString *)pendingName pendingDescription:(NSString *)pendingDescription;
 @end
 
 // Posted by Apollo after multireddit mutations; RedditListViewController
@@ -99,8 +103,21 @@ static __weak UITableView *sMultiEditListTable = nil;
 // this table, so we also turn it back off when Edit mode ends.
 static char kApolloMultiEditSelectionEnabledKey;
 
-// Associates the multireddit being re-iconed with its PHPicker instance.
+// Associates the picker context (multireddit + the editor's unsaved field
+// values) with its PHPicker instance, so the editor can reopen exactly as the
+// user left it after picking or cancelling.
 static char kApolloMultiEditPickerTargetKey;
+
+// Associates a custom-icon cache key with a row's icon image view. Apollo's
+// icon pipeline applies the multireddit's icon (the first subreddit's avatar)
+// asynchronously, so a one-shot write from cellForRow gets overwritten a
+// moment later; the UIImageView setImage: hook below re-asserts the custom
+// icon on every attempt to replace it while the tag is present.
+static char kApolloMultiEditIconEnforceKey;
+
+// Fast path for that hook: stays NO (one static read per setImage:) until any
+// custom multireddit icon exists this session.
+static BOOL sMultiEditIconEnforcementNeeded = NO;
 
 // MARK: - Helpers
 
@@ -200,9 +217,8 @@ static UIImage *ApolloMultiEditCustomIcon(RDKMultireddit *multireddit) {
 // cached per size; the cache is dumped whenever an icon is saved or removed.
 static NSCache<NSString *, UIImage *> *sMultiEditDisplayIconCache = nil;
 
-static UIImage *ApolloMultiEditDisplayIcon(RDKMultireddit *multireddit, CGSize targetSize) {
-    NSString *key = ApolloMultiEditIconKey(multireddit);
-    if (!key || targetSize.width < 1.0 || targetSize.height < 1.0) return nil;
+static UIImage *ApolloMultiEditDisplayIconForKey(NSString *key, CGSize targetSize) {
+    if (key.length == 0 || targetSize.width < 1.0 || targetSize.height < 1.0) return nil;
 
     NSString *cacheKey = [NSString stringWithFormat:@"%@|%.0fx%.0f", key, targetSize.width, targetSize.height];
     UIImage *cached = [sMultiEditDisplayIconCache objectForKey:cacheKey];
@@ -312,6 +328,35 @@ static RDKMultireddit *ApolloMultiEditFindByTitle(NSString *title) {
 
 %end
 
+// MARK: - Custom icon enforcement
+
+// Apollo applies a multireddit row's icon (its first subreddit's avatar)
+// through an asynchronous pipeline, so writing the custom icon once from
+// cellForRow loses the race whenever the real avatar lands afterwards: the
+// row flashes back to Apollo's icon (reported with the ApolloReborn robot).
+// cellForRow instead TAGS the icon view with the custom-icon key, and this
+// hook swaps every competing image assignment for the custom icon while the
+// tag is present. Untagged image views (the entire rest of the app, and any
+// multireddit row without a custom icon) pay one static BOOL read.
+%hook UIImageView
+
+- (void)setImage:(UIImage *)image {
+    if (sMultiEditIconEnforcementNeeded) {
+        NSString *iconKey = objc_getAssociatedObject(self, &kApolloMultiEditIconEnforceKey);
+        if (iconKey.length > 0) {
+            CGSize targetSize = (image && image.size.width >= 1.0) ? image.size : self.bounds.size;
+            UIImage *display = ApolloMultiEditDisplayIconForKey(iconKey, targetSize);
+            if (display && image != display) {
+                %orig(display);
+                return;
+            }
+        }
+    }
+    %orig;
+}
+
+%end
+
 // MARK: - Subreddits list hooks
 
 %group ApolloMultiEditList
@@ -388,14 +433,21 @@ static RDKMultireddit *ApolloMultiEditFindByTitle(NSString *title) {
     NSString *title = ApolloMultiEditTrim(ApolloMultiEditCellLabel(cell, "redditTitleLabel").text);
     RDKMultireddit *multireddit = ApolloMultiEditFindByTitle(title);
 
-    if (multireddit) {
-        UIImageView *iconView = (UIImageView *)ApolloMultiEditObjectIvar(cell, "subredditIconImageView");
-        if ([iconView isKindOfClass:[UIImageView class]]) {
-            // Match the stock icon's point size (Apollo just set it in %orig)
-            // so the intrinsic-size-driven layout doesn't change.
+    UIImageView *iconView = (UIImageView *)ApolloMultiEditObjectIvar(cell, "subredditIconImageView");
+    if ([iconView isKindOfClass:[UIImageView class]]) {
+        NSString *iconKey = multireddit ? ApolloMultiEditIconKey(multireddit) : nil;
+        UIImage *stored = iconKey ? [[ApolloSubredditCustomIconCache sharedCache] cachedIconForSubreddit:iconKey] : nil;
+        // Tag (or untag — cells are reused) the icon view for the enforcement
+        // hook, then apply the icon at the stock icon's point size so the
+        // intrinsic-size-driven layout doesn't change. Apollo's own async
+        // avatar assignment for this row is swapped by the hook from here on.
+        objc_setAssociatedObject(iconView, &kApolloMultiEditIconEnforceKey,
+                                 stored ? iconKey : nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+        if (stored) {
+            sMultiEditIconEnforcementNeeded = YES;
             CGSize targetSize = iconView.image.size;
             if (targetSize.width < 1.0) targetSize = iconView.bounds.size;
-            UIImage *customIcon = ApolloMultiEditDisplayIcon(multireddit, targetSize);
+            UIImage *customIcon = ApolloMultiEditDisplayIconForKey(iconKey, targetSize);
             if (customIcon) iconView.image = customIcon;
         }
     }
@@ -417,6 +469,14 @@ static RDKMultireddit *ApolloMultiEditFindByTitle(NSString *title) {
 
 %new
 - (void)apolloMultiEditPresentEditorFor:(RDKMultireddit *)multireddit {
+    [self apolloMultiEditPresentEditorFor:multireddit prefillName:nil prefillDescription:nil];
+}
+
+// prefillName/prefillDescription carry the editor's UNSAVED field contents
+// across a round trip through the icon picker (or an icon removal), so
+// typed-but-not-saved text is never lost; nil means "show the model's values".
+%new
+- (void)apolloMultiEditPresentEditorFor:(RDKMultireddit *)multireddit prefillName:(NSString *)prefillName prefillDescription:(NSString *)prefillDescription {
     NSString *currentName = [multireddit displayName].length > 0 ? [multireddit displayName] : [multireddit name];
     NSString *currentDescription = [multireddit respondsToSelector:@selector(descriptionMarkdown)]
         ? ([multireddit descriptionMarkdown] ?: @"") : @"";
@@ -425,12 +485,12 @@ static RDKMultireddit *ApolloMultiEditFindByTitle(NSString *title) {
                                                                    message:@"Renaming keeps the multireddit's URL. With no description, the list of subreddits is shown instead."
                                                             preferredStyle:UIAlertControllerStyleAlert];
     [alert addTextFieldWithConfigurationHandler:^(UITextField *textField) {
-        textField.text = currentName;
+        textField.text = prefillName ?: currentName;
         textField.placeholder = @"Name";
         textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
     }];
     [alert addTextFieldWithConfigurationHandler:^(UITextField *textField) {
-        textField.text = currentDescription;
+        textField.text = prefillDescription ?: currentDescription;
         textField.placeholder = @"Description (optional)";
     }];
 
@@ -443,17 +503,24 @@ static RDKMultireddit *ApolloMultiEditFindByTitle(NSString *title) {
         [weakSelf apolloMultiEditSave:multireddit name:newName descriptionText:newDescription];
     }]];
     [alert addAction:[UIAlertAction actionWithTitle:@"Choose Custom Icon…" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-        [weakSelf apolloMultiEditPickIconFor:multireddit];
+        // Alert actions dismiss the alert, so hand the unsaved field contents
+        // to the picker flow — the editor reopens with them afterwards.
+        [weakSelf apolloMultiEditPickIconFor:multireddit
+                                 pendingName:alert.textFields.firstObject.text
+                          pendingDescription:alert.textFields.lastObject.text];
     }]];
     if (ApolloMultiEditCustomIcon(multireddit)) {
         [alert addAction:[UIAlertAction actionWithTitle:@"Remove Custom Icon" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+            NSString *pendingName = alert.textFields.firstObject.text;
+            NSString *pendingDescription = alert.textFields.lastObject.text;
             NSString *key = ApolloMultiEditIconKey(multireddit);
             if (key) [[ApolloSubredditCustomIconCache sharedCache] removeIconForSubreddit:key];
             [sMultiEditDisplayIconCache removeAllObjects];
             ApolloLog(@"[MultiEdit] removed custom icon for %@", [multireddit path]);
-            // Apollo re-applies its own icon inside every cellForRow pass, so a
-            // plain reload restores the stock icon.
+            // The reload unTAGs the icon views (no stored icon anymore), so
+            // Apollo's own icon returns on the next configure pass.
             [(ApolloMultiEditTableView((UIViewController *)weakSelf) ?: sMultiEditListTable) reloadData];
+            [weakSelf apolloMultiEditPresentEditorFor:multireddit prefillName:pendingName prefillDescription:pendingDescription];
         }]];
     }
     [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
@@ -461,47 +528,64 @@ static RDKMultireddit *ApolloMultiEditFindByTitle(NSString *title) {
 }
 
 %new
-- (void)apolloMultiEditPickIconFor:(RDKMultireddit *)multireddit {
+- (void)apolloMultiEditPickIconFor:(RDKMultireddit *)multireddit pendingName:(NSString *)pendingName pendingDescription:(NSString *)pendingDescription {
     PHPickerConfiguration *configuration = [[PHPickerConfiguration alloc] init];
     configuration.filter = [PHPickerFilter imagesFilter];
     configuration.selectionLimit = 1;
     PHPickerViewController *picker = [[PHPickerViewController alloc] initWithConfiguration:configuration];
     picker.delegate = (id<PHPickerViewControllerDelegate>)self;
-    objc_setAssociatedObject(picker, &kApolloMultiEditPickerTargetKey, multireddit, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    NSMutableDictionary *context = [NSMutableDictionary dictionaryWithObject:multireddit forKey:@"multireddit"];
+    if (pendingName) context[@"name"] = [pendingName copy];
+    if (pendingDescription) context[@"description"] = [pendingDescription copy];
+    objc_setAssociatedObject(picker, &kApolloMultiEditPickerTargetKey, context, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     [(UIViewController *)self presentViewController:picker animated:YES completion:nil];
 }
 
 // PHPickerViewControllerDelegate — added to the list controller via %new; the
 // picker dispatches by respondsToSelector:, so no compile-time conformance is
-// needed beyond the cast at the assignment.
+// needed beyond the cast at the assignment. Whatever happens (picked,
+// cancelled, or a failed load), the editor reopens with the unsaved field
+// contents it was carrying.
 %new
 - (void)picker:(PHPickerViewController *)picker didFinishPicking:(NSArray<PHPickerResult *> *)results {
-    RDKMultireddit *multireddit = objc_getAssociatedObject(picker, &kApolloMultiEditPickerTargetKey);
-    [picker dismissViewControllerAnimated:YES completion:nil];
-
+    NSDictionary *context = objc_getAssociatedObject(picker, &kApolloMultiEditPickerTargetKey);
+    RDKMultireddit *multireddit = context[@"multireddit"];
+    NSString *pendingName = context[@"name"];
+    NSString *pendingDescription = context[@"description"];
     NSItemProvider *provider = results.firstObject.itemProvider;
-    if (!multireddit || ![provider canLoadObjectOfClass:[UIImage class]]) return;
 
     __weak typeof(self) weakSelf = self;
-    [provider loadObjectOfClass:[UIImage class] completionHandler:^(id<NSItemProviderReading> object, NSError *error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if (![object isKindOfClass:[UIImage class]]) {
-                ApolloLog(@"[MultiEdit] icon load failed: %@", error);
-                return;
-            }
-            NSString *key = ApolloMultiEditIconKey(multireddit);
-            NSError *saveError = nil;
-            UIImage *scaled = ApolloMultiEditScaledIcon((UIImage *)object);
-            if (key && [[ApolloSubredditCustomIconCache sharedCache] saveIcon:scaled forSubreddit:key error:&saveError]) {
-                [sMultiEditDisplayIconCache removeAllObjects];
-                ApolloLog(@"[MultiEdit] saved custom icon for %@ (%.0fx%.0f)", [multireddit path], scaled.size.width, scaled.size.height);
-                [(ApolloMultiEditTableView((UIViewController *)weakSelf) ?: sMultiEditListTable) reloadData];
-                // Land the user back in the editor they came from.
-                [weakSelf apolloMultiEditPresentEditorFor:multireddit];
-            } else {
-                ApolloLog(@"[MultiEdit] icon save failed for %@: %@", [multireddit path], saveError);
-            }
-        });
+    void (^reopenEditor)(void) = ^{
+        if (multireddit) {
+            [weakSelf apolloMultiEditPresentEditorFor:multireddit prefillName:pendingName prefillDescription:pendingDescription];
+        }
+    };
+
+    [picker dismissViewControllerAnimated:YES completion:^{
+        if (!multireddit || ![provider canLoadObjectOfClass:[UIImage class]]) {
+            reopenEditor(); // cancelled (or unloadable) — just restore the editor
+            return;
+        }
+        [provider loadObjectOfClass:[UIImage class] completionHandler:^(id<NSItemProviderReading> object, NSError *error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if ([object isKindOfClass:[UIImage class]]) {
+                    NSString *key = ApolloMultiEditIconKey(multireddit);
+                    NSError *saveError = nil;
+                    UIImage *scaled = ApolloMultiEditScaledIcon((UIImage *)object);
+                    if (key && [[ApolloSubredditCustomIconCache sharedCache] saveIcon:scaled forSubreddit:key error:&saveError]) {
+                        [sMultiEditDisplayIconCache removeAllObjects];
+                        sMultiEditIconEnforcementNeeded = YES;
+                        ApolloLog(@"[MultiEdit] saved custom icon for %@ (%.0fx%.0f)", [multireddit path], scaled.size.width, scaled.size.height);
+                        [(ApolloMultiEditTableView((UIViewController *)weakSelf) ?: sMultiEditListTable) reloadData];
+                    } else {
+                        ApolloLog(@"[MultiEdit] icon save failed for %@: %@", [multireddit path], saveError);
+                    }
+                } else {
+                    ApolloLog(@"[MultiEdit] icon load failed: %@", error);
+                }
+                reopenEditor();
+            });
+        }];
     }];
 }
 
@@ -571,6 +655,27 @@ static RDKMultireddit *ApolloMultiEditFindByTitle(NSString *title) {
 
 %end // ApolloMultiEditList
 
+// The enforcement tag rides the cell's icon image view, and cells are reused
+// across sections — a stale tag would swap a custom icon onto whatever row
+// inherits the cell (seen: a moderator row wearing a multireddit's icon).
+// Clearing on reuse is the one reliable reset point; cellForRow then re-tags
+// only the rows that actually have a custom icon.
+%group ApolloMultiEditCell
+
+%hook RedditListTableViewCell
+
+- (void)prepareForReuse {
+    %orig;
+    UIImageView *iconView = (UIImageView *)ApolloMultiEditObjectIvar(self, "subredditIconImageView");
+    if ([iconView isKindOfClass:[UIImageView class]]) {
+        objc_setAssociatedObject(iconView, &kApolloMultiEditIconEnforceKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    }
+}
+
+%end
+
+%end // ApolloMultiEditCell
+
 %ctor {
     %init;
 
@@ -581,6 +686,13 @@ static RDKMultireddit *ApolloMultiEditFindByTitle(NSString *title) {
         ApolloLog(@"[MultiEdit] list hooks installed on %@", NSStringFromClass(listClass));
     } else {
         ApolloLog(@"[MultiEdit] RedditListViewController class missing; multireddit editing unavailable");
+    }
+
+    Class cellClass = ApolloMultiEditListCellClass();
+    if (cellClass) {
+        %init(ApolloMultiEditCell, RedditListTableViewCell = cellClass);
+    } else {
+        ApolloLog(@"[MultiEdit] RedditListTableViewCell class missing; icon reuse guard unavailable");
     }
 
     // Re-render the list when Hide Multireddit Descriptions changes.

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -193,6 +193,9 @@ extern BOOL sSubredditListEnhancements;
 // Hide the description subtitles under the subreddit list's built-in feed rows
 // (see UDKeyHideSubredditListDescriptions). Independent of the enhancements master.
 extern BOOL sHideSubredditListDescriptions;
+// Blank the subtitle line under multireddit rows (see
+// UDKeyHideMultiredditDescriptions). Independent of the enhancements master.
+extern BOOL sHideMultiredditDescriptions;
 
 // Color post (link) flairs and user/author flairs using Reddit's assigned
 // colors (filled pill + matching text color). When NO, Apollo's default grey

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -63,6 +63,7 @@ NSInteger sScrollEdgeEffectStyle = ApolloScrollEdgeEffectStyleAutomatic;
 BOOL sModernSubredditDividers = YES;
 BOOL sSubredditListEnhancements = YES;
 BOOL sHideSubredditListDescriptions = NO;
+BOOL sHideMultiredditDescriptions = NO;
 BOOL sEnableFlairColors = NO;
 BOOL sEnableInlineImages = NO;
 BOOL sEnableChatMedia = NO;   // effective default YES via registerDefaults (UDKeyEnableChatMedia)

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -3547,6 +3547,7 @@ static void initializeRandomSources() {
     sModernSubredditDividers = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyModernSubredditDividers];
     sSubredditListEnhancements = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeySubredditListEnhancements];
     sHideSubredditListDescriptions = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyHideSubredditListDescriptions];
+    sHideMultiredditDescriptions = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyHideMultiredditDescriptions];
     sEnableFlairColors = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableFlairColors];
     sEnableBulkTranslation = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyEnableBulkTranslation];
     sAutoTranslateOnAppear = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyAutoTranslateOnAppear];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -42,6 +42,11 @@ static NSString *const ApolloModernSubredditDividersChangedNotification = @"Apol
 // Default NO. See ApolloSubredditIndexPolish.xm.
 static NSString *const UDKeyHideSubredditListDescriptions = @"HideSubredditListDescriptions";
 static NSString *const ApolloHideSubredditListDescriptionsChangedNotification = @"ApolloHideSubredditListDescriptionsChangedNotification";
+// Blank the subtitle line under multireddit rows in the subreddit list (which
+// otherwise shows the multireddit's description, or the subreddits it
+// contains). Default NO. See ApolloMultiredditEdit.xm.
+static NSString *const UDKeyHideMultiredditDescriptions = @"HideMultiredditDescriptions";
+static NSString *const ApolloHideMultiredditDescriptionsChangedNotification = @"ApolloHideMultiredditDescriptionsChangedNotification";
 // Color post (link) and user/author flairs with Reddit's assigned colors. Default NO.
 static NSString *const UDKeyEnableFlairColors = @"EnableFlairColors";
 static NSString *const ApolloFlairColorsChangedNotification = @"ApolloFlairColorsChangedNotification";

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -1700,6 +1700,15 @@ typedef NS_ENUM(NSInteger, Tag) {
                                       isOn:^BOOL { return sHideSubredditListDescriptions; }
                                   onToggle:^(UISwitch *sender) { [weakSelf hideSubredditListDescriptionsSwitchToggled:sender]; }];
 
+    // Sibling of Hide Feed Descriptions for the MULTIREDDITS section's rows
+    // (which otherwise show a custom description, or the joined subreddit
+    // list). Also independent of the enhancements master.
+    ApolloSettingsRow *hideMultiredditDescriptions =
+        [ApolloSettingsRow switchRowWithID:@"sub.hideMultiredditDescriptions"
+                                     title:@"Hide Multireddit Descriptions"
+                                      isOn:^BOOL { return sHideMultiredditDescriptions; }
+                                  onToggle:^(UISwitch *sender) { [weakSelf hideMultiredditDescriptionsSwitchToggled:sender]; }];
+
     // Pushes the dedicated Subreddit Layout screen — the single customize
     // screen for everything subreddit-page-related: Density (New, Classic, or
     // Apollo's native header), the Apollo Reborn header show switches, and
@@ -1714,8 +1723,8 @@ typedef NS_ENUM(NSInteger, Tag) {
         }];
 
     return [ApolloSettingsSection sectionWithTitle:nil
-                                            footer:@"Enhance the subreddit list with dividers, and customize subreddit pages. Hide Feed Descriptions removes the subtitles under Home, Popular, All and Moderator Posts."
-                                              rows:@[ enhancements, modernDividers, hideDescriptions, subredditLayout ]];
+                                            footer:@"Enhance the subreddit list with dividers, and customize subreddit pages. Hide Feed Descriptions removes the subtitles under Home, Popular, All and Moderator Posts. Multireddits show the subreddits they contain, or a custom description — tap a multireddit while editing the list to rename it or change its description. Hide Multireddit Descriptions blanks that line entirely."
+                                              rows:@[ enhancements, modernDividers, hideDescriptions, hideMultiredditDescriptions, subredditLayout ]];
 }
 
 - (NSString *)subredditLayoutSummaryText {
@@ -3168,6 +3177,12 @@ typedef NS_ENUM(NSInteger, Tag) {
     sHideSubredditListDescriptions = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sHideSubredditListDescriptions forKey:UDKeyHideSubredditListDescriptions];
     [[NSNotificationCenter defaultCenter] postNotificationName:ApolloHideSubredditListDescriptionsChangedNotification object:nil];
+}
+
+- (void)hideMultiredditDescriptionsSwitchToggled:(UISwitch *)sender {
+    sHideMultiredditDescriptions = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sHideMultiredditDescriptions forKey:UDKeyHideMultiredditDescriptions];
+    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloHideMultiredditDescriptionsChangedNotification object:nil];
 }
 
 - (void)showRecentlyReadThumbnailsSwitchToggled:(UISwitch *)sender {


### PR DESCRIPTION
Multireddits get first-class editing in the Subreddits list, and their rows learn to show something more useful than a comma-joined subreddit list.

Reddit's website lets you rename a multireddit and give it a description ("edit details"), but Apollo only ever asks for a name at creation time — an existing multireddit can't be renamed or described in-app at all, and one created on the website can't be touched. This adds that, plus custom icons and a display toggle to match the existing Hide Feed Descriptions.

## What's new

**Edit a multireddit from the list.** Tap Edit, then tap any multireddit: an editor opens with its name and description prefilled. Saving PUTs the website's own model shape (`display_name` + `description_md`) to `api/multi/<path>`, so the multireddit's **URL slug is preserved** — renaming doesn't break links or break other clients, exactly like the website's dialog.

**Descriptions replace the subreddit list.** A multireddit row's subtitle still lists the subreddits it contains by default. Set a description and it takes that line instead. Clear the description and the subreddit list comes back — nothing is lost either way.

**Custom icons.** The same editor offers "Choose Icon" and "Remove Icon". Pick any photo; it's center-cropped into a circle and drawn at the stock icon size, so it sits in the row like a native subreddit avatar. Local-only — Reddit's API has no image upload for multireddits — and keyed to the multireddit's path, so it survives renames.

**New "Hide Multireddit Descriptions" toggle** (Settings → Subreddits, next to Hide Feed Descriptions): blanks the subtitle line on multireddit rows entirely, whatever it would have shown.

| Editor (Edit mode → tap a multireddit) | Custom icons + descriptions in the list |
|---|---|
| ![editor](https://github.com/user-attachments/assets/dc02cb45-d81f-446d-95b1-b57e544d1d6b) | ![list](https://github.com/user-attachments/assets/368ffc88-e55d-47f1-9a28-be6d4cf5078d) |

| The new toggle in Settings → Subreddits | Hide Multireddit Descriptions ON |
|---|---|
| ![settings](https://github.com/user-attachments/assets/9d58f311-ae1e-4a97-a04d-f3aebcec5a65) | ![hidden](https://github.com/user-attachments/assets/2de322af-366c-4db4-8d92-e11dbf523b1b) |

## Implementation notes worth reviewing

- **Reaching the tap at all.** Apollo leaves `allowsSelectionDuringEditing` off, so multireddit rows were untappable in Edit mode. `setEditing:` turns it on (and restores it after); the `didSelect` hook swallows every edit-mode tap rather than forwarding — Apollo's own `didSelect` navigates and was written for browsing. Non-edit taps pass straight through untouched.
- **Which client does the write.** `RDKClient.sharedClient`'s `currentUser` is nil while a real account is signed in (already documented in `ApolloAccountCredentials.m`), and every `api/multi` path is built from `currentUser.username` — so writes go through `ApolloActiveAccountClient()`. `putPath:parameters:completion:`'s three-argument completion arity was verified in the binary rather than assumed (the wrapper block `setDescription:forMultiredditWithName:` passes it).
- **Rows are resolved by name, never by index.** The list re-sorts its model arrays for display, so a visible row index is meaningless against the stored array — the same trap behind the moderator-section bug in #835.
- **Model arrays are captured per-client.** Apollo runs `multiredditsWithCompletion:` for *every* signed-in account around launch, so a single "latest array" global gets clobbered by whichever account answers last. Captures are keyed by client in a weak-to-strong map and resolved active-client-first.
- **Custom icons have to win a race.** Apollo applies a multireddit row's icon (its first subreddit's avatar) asynchronously, so a one-shot write from `cellForRow` gets overwritten a moment later and the row flashes back. Instead `cellForRow` tags the icon view with its custom-icon key and a `UIImageView setImage:` hook re-asserts the custom icon over any competing assignment while the tag is present; untagged views (the entire rest of the app) pay a single static BOOL read. `prepareForReuse` clears the tag so a recycled cell can't carry a custom icon onto an unrelated row.
- **Unsaved text survives the picker.** Alert actions dismiss the alert, so choosing/removing an icon — or cancelling the photo picker — used to discard whatever you'd typed. The field contents now ride along through the picker and the editor reopens with them intact on every outcome.
- Expanded-multireddit child rows (plain subreddit rows in the same section) are skipped by a cheap subtitle-presence gate, which also keeps the scroll path light.

## Testing

Simulator, iPhone 17 Pro / iOS 26.5, signed-in account with 4 multireddits plus a second signed-in account.

- Rename → HTTP 200, title updates in place, URL slug unchanged; renaming back works.
- Description set → HTTP 200, subtitle swaps to the description and survives a relaunch (round-trips through Reddit's own refetch, not just local state); cleared → subtitle reverts to the subreddit list.
- Custom icon: pick → circular icon at stock size, survives Apollo's async avatar, scroll-away-and-back cell reuse, and relaunch; Remove restores Apollo's icon; no bleed onto other rows.
- Editor text preserved across "Choose Icon", "Remove Icon", and a cancelled picker.
- Hide Multireddit Descriptions ON → subtitle line blank on all multireddit rows; OFF restores. Feed rows unaffected either way.
- Matrix: Liquid Glass **and** non-glass builds; keyless (web session) **and** API-key modes (PUTs return HTTP 200 in both); Subreddit List Enhancements ON and OFF; Hide Feed Descriptions ON and OFF.
- Second account's fetch no longer clobbers the active account's multireddit list.

Not device-tested yet.



