### PR TITLE
Fix the stack-overflow crash wave: table geometry queries nested inside row-height measurement

### DIFF
--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -12,6 +12,24 @@
 __BEGIN_DECLS
 os_log_t ApolloFixLog(void);
 NSString *ApolloCollectLogs(void);
+
+// --- Row-measure re-entrancy guard (issues #831/#833/#838/#839/#841) ---
+// Main-thread depth of UITableView row-height passes currently on the stack
+// (maintained by the ASTableView tableView:heightForRowAtIndexPath: hook in
+// ApolloInlineLinkPreviews.xm). While a pass is in progress, UIKit is inside
+// its row-data (re)validation (-[UISectionRowData refreshWithSection:...] /
+// endUpdates); calling ANY UITableView geometry query (indexPathForCell:,
+// rectForRowAtIndexPath:, indexPathsForVisibleRows, ...) from tweak code at
+// that moment makes UIKit start a NESTED full-section validation — one extra
+// ~48-frame nesting level per row — until the main thread's 1MB stack
+// overflows (EXC_BAD_ACCESS on a stack-guard address, crashing whatever
+// innocent code runs at the boundary). Any tweak code that can run inside a
+// row measure (layoutSpecThatFits:, text-setter hooks, ...) must check
+// ApolloRowMeasureInProgress() before touching table geometry and decline or
+// defer instead.
+BOOL ApolloRowMeasureInProgress(void);
+void ApolloRowMeasureWillBegin(void);
+void ApolloRowMeasureDidEnd(void);
 NSString *ApolloCollectAILogs(void);
 BOOL IsLiquidGlass(void);
 NSURL *ApolloURLByConvertingResolvedURLToApolloScheme(NSURL *url);

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -23,6 +23,37 @@ os_log_t ApolloFixLog(void) {
     return log;
 }
 
+#pragma mark - Row-measure re-entrancy guard
+
+// See ApolloCommon.h. Main-thread only: row-height queries are delivered on
+// the main thread, and the recursion this guards against exists only there
+// (background Texture measures never sit inside UIKit row-data validation).
+// Off-main callers get NO / no-op so they behave exactly as before.
+static NSInteger sApolloRowMeasureDepth = 0;
+
+BOOL ApolloRowMeasureInProgress(void) {
+    return [NSThread isMainThread] && sApolloRowMeasureDepth > 0;
+}
+
+void ApolloRowMeasureWillBegin(void) {
+    if (![NSThread isMainThread]) return;
+    sApolloRowMeasureDepth++;
+    // A depth beyond 1 means a geometry query escaped into a measure pass and
+    // UIKit re-entered row validation — the #831/#833 stack-overflow geometry.
+    // The guards should make this unreachable; log loudly (but bounded) if a
+    // new edge ever appears so field reports pinpoint it.
+    static NSInteger sLoggedNestedMeasures = 0;
+    if (sApolloRowMeasureDepth > 1 && sLoggedNestedMeasures < 8) {
+        sLoggedNestedMeasures++;
+        ApolloLog(@"[RowMeasure] NESTED row-height pass (depth %ld) - a table geometry call leaked into a measure pass", (long)sApolloRowMeasureDepth);
+    }
+}
+
+void ApolloRowMeasureDidEnd(void) {
+    if (![NSThread isMainThread]) return;
+    if (sApolloRowMeasureDepth > 0) sApolloRowMeasureDepth--;
+}
+
 #pragma mark - Persistent login diagnostics (cross-launch)
 
 // The os_log export (ApolloCollectLogs) only sees the current process, so a force-quit

--- a/src/ApolloInlineLinkPreviews.xm
+++ b/src/ApolloInlineLinkPreviews.xm
@@ -3540,6 +3540,11 @@ static void ApolloLPScheduleCollectionItemReloadWhenIdle(UICollectionView *colle
 }
 
 static BOOL ApolloLPInvokeRowReloadIfPossible(ASDisplayNode *startNode, ASDisplayNode *originNode, NSString *host) {
+    // No table geometry (indexPathForCell: below) while a row-height pass is on
+    // the stack — that nests a full row-data re-validation per row and
+    // overflows the main stack (#831/#833 geometry). Report "not handled":
+    // callers renote and the healers retry once the pass has unwound.
+    if (ApolloRowMeasureInProgress()) return NO;
     // Hard convergence budget, keyed on the preview URL (falls back to host): every
     // reload path (V12 shrink heal, V18 overflow, V20 pending mark, V23 poll) funnels
     // through here, and a row whose height never converges used to reload FOREVER —
@@ -4393,16 +4398,24 @@ static void ApolloLPStackGuardReport(const char *where, size_t used, size_t size
     ApolloAppendLoginDiag(line);
 }
 
-// Row-measure entry: purely observational (a height must be returned either
-// way), but this is the earliest point the exhaustion is visible when the hog
-// sits below the ASDK layout recursion.
+// Row-measure entry. Besides the observational exhaustion report, this is the
+// chokepoint that marks "a row-height pass is on the stack" for
+// ApolloRowMeasureInProgress() (ApolloCommon.h): geometry-querying tweak code
+// reachable from a measure (the translation preempt, the link-preview row
+// healer) declines while the flag is up, which is what breaks the
+// query→re-validate→re-measure recursion behind the #831/#833 crashes.
 %hook ASTableView
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
     size_t diagUsed = 0, diagSize = 0;
     if (ApolloLPMainStackNearlyExhausted(&diagUsed, &diagSize)) {
         ApolloLPStackGuardReport("heightForRow", diagUsed, diagSize);
     }
-    return %orig;
+    ApolloRowMeasureWillBegin();
+    @try {
+        return %orig;
+    } @finally {
+        ApolloRowMeasureDidEnd();
+    }
 }
 %end
 

--- a/src/ApolloTranslation.xm
+++ b/src/ApolloTranslation.xm
@@ -5188,6 +5188,15 @@ static id ApolloCommentCellNodeForTextNode(id textNode) {
 // height makes the preview overflow and appear to jump up the screen.
 static BOOL ApolloCommentCellNodeIsBackedByActiveCommentsTable(id commentCellNode, UIViewController *commentsVC) {
     if (!commentCellNode || !commentsVC || ![NSThread isMainThread]) return NO;
+    // NEVER query table geometry while UIKit is inside a row-height pass. The
+    // indexPathForCell: below re-validates the table's row data; issued from
+    // inside a measure (deleted-comments sets its replacement body/chip text
+    // in layoutSpecThatFits: → the global setAttributedText: hook → the
+    // comment preempt → here) it nests a full re-validation per row until the
+    // main stack overflows — the #831/#833 crash cycle. Declining is safe:
+    // the sync preempt falls through to the deferred retry, which runs
+    // between runloop turns where this returns real answers again.
+    if (ApolloRowMeasureInProgress()) return NO;
     @try {
         UITableView *commentsTable = GetCommentsTableView(commentsVC);
         if (!commentsTable) return NO;


### PR DESCRIPTION
This one took some digging because the crash reports all look like they die in random places. They don't — they all die the same way.

## What's actually happening

#833 came with a real Apple .ips: EXC_BAD_ACCESS / KERN_PROTECTION_FAILURE at a **stack guard address** — the main thread's 1MB stack is completely gone, and whoever happens to be running at that moment eats the SIGSEGV (in that report it's the deleted comments reason chip building a cache key with `stringWithFormat:`, which is why the top of the stack looks innocent). I symbolicated it against the 3.5.0 dSYMs and measured every frame on the stack from the shipped binaries — the visible frames only account for ~30KB, so something was eating the stack invisibly.

#831 (from a build running the new crash reporting layer) is the smoking gun: its 256-frame capture shows a repeating ~48 frame cycle:

```
ASTableView heightForRowAtIndexPath
→ cell node layout → MarkdownNode layoutSpecThatFits:
   (deleted comments sets its replacement body/chip text during the measure)
→ global ASTextNode setAttributedText: hook (translation)
→ comment preempt → ApolloCommentCellNodeIsBackedByActiveCommentsTable
→ [table indexPathForCell:]   ← the villain
→ UIKit re-validates the section's row data NESTED inside the pass already running
→ heightForRowAtIndexPath for the next row → repeat
```

Calling any UITableView geometry query (`indexPathForCell:`, `rectForRowAtIndexPath:`, `indexPathsForVisibleRows`…) while UIKit is inside its own row-height pass makes it start a **nested** full re-validation — one extra ~48-frame nesting level per row — until the stack overflows. Big thread + deleted comments + translated mode = dead. Matches the reports perfectly: #833 was reading Arctic Shift restored comments, #838/#839/#841 are "scrolling and it crashed" on the same build.

## The fix (small on purpose)

- `ApolloCommon`: a main-thread row-measure depth counter (`ApolloRowMeasureInProgress()`), maintained by the ASTableView `heightForRowAtIndexPath:` hook we already have in ApolloInlineLinkPreviews.xm.
- The two tweak paths that could issue table geometry queries from inside a measure now just decline while a pass is on the stack:
  - the translation preempt's table-backing check — safe, its deferred retry runs between runloop turns and still adopts the node (that path already existed for detached nodes)
  - the link-preview row-reload healer — safe, callers renote and retry after the pass unwinds
- Plus a bounded diagnostic that logs `[RowMeasure] NESTED` if any future edge slips through, so field logs will name it instead of us staring at another stack-guard mystery.

No behavior changes otherwise — chips, reveal, translations all render exactly as before.

## How I verified it

Got the exact #831 scenario running in the sim (the actual r/wholesomememes reproducer thread, auto-translate on, deleted comments recovering via Arctic). Then did an A/B: compiled the guards out but kept the detector — **the nested re-validation fires instantly at thread load (depth 3–4 logged), exactly the diagnosed mechanism**. Guards back in: zero nested passes, app stable through hard scrolling, collapse/expand, reveal.

Ran the full matrix: Liquid Glass + non-glass (SDK-downgraded shell), API-key + keyless (WebJSON sessions), plus a default-settings pass — all clean, 0 guard trips, no rendering changes.

Closes #833, closes #838, closes #839, closes #841, closes #831

#816, #820 and #814 are comment-scroll crashes with no attached .ips — same symptom on the same build, so decent odds this covers them too, but I can't prove it from the reports. The backgrounding/reload reports (#827, #811, the crash zip in #806) are the separate OOM family that jordanearle's #823/#824 are about — different mechanism, no overlap with this change (verified his PRs touch different code, nothing conflicts).
