### PR TITLE
Add View Banner / View Icon to the subreddit header (#324)

### DIFF
--- a/src/ApolloInlineImages.xm
+++ b/src/ApolloInlineImages.xm
@@ -1573,19 +1573,25 @@ static CGFloat ApolloAspectRatioFromURL(NSURL *url) {
 
 - (void)apollo_dismissPanned:(UIPanGestureRecognizer *)recognizer {
     CGPoint translation = [recognizer translationInView:self.view.superview ?: self.view];
-    CGFloat dy = MAX(0.0, translation.y);
+    // Signed: the viewer follows the finger and dismisses in either vertical
+    // direction, matching Apollo's native media viewer (issue #324 asked for
+    // swipe-up dismiss specifically).
+    CGFloat dy = translation.y;
     switch (recognizer.state) {
         case UIGestureRecognizerStateBegan:
             [self apollo_setControlsVisible:NO animated:YES reschedule:NO];
             break;
         case UIGestureRecognizerStateChanged:
             self.view.transform = CGAffineTransformMakeTranslation(0.0, dy);
-            self.view.alpha = 1.0 - MIN(dy / 600.0, 0.4);
+            self.view.alpha = 1.0 - MIN(fabs(dy) / 600.0, 0.4);
             break;
         case UIGestureRecognizerStateEnded:
         case UIGestureRecognizerStateCancelled: {
             CGFloat velocity = [recognizer velocityInView:self.view].y;
-            if (recognizer.state == UIGestureRecognizerStateEnded && (dy > 140.0 || velocity > 900.0)) {
+            // Dismiss when the drag distance OR flick velocity clears the
+            // threshold in the same vertical direction (up or down).
+            if (recognizer.state == UIGestureRecognizerStateEnded &&
+                (fabs(dy) > 140.0 || fabs(velocity) > 900.0)) {
                 [self dismissViewControllerAnimated:YES completion:nil];
             } else {
                 [UIView animateWithDuration:0.25
@@ -1701,12 +1707,13 @@ static CGFloat ApolloAspectRatioFromURL(NSURL *url) {
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
     if (gestureRecognizer != self.dismissPan) return YES;
-    // Swipe-down dismiss only engages on a clearly downward drag while the
-    // current image isn't zoomed — horizontal drags page, zoomed drags pan.
+    // Swipe dismiss engages on a clearly vertical drag (either direction,
+    // like Apollo's native media viewer) while the current image isn't
+    // zoomed — horizontal drags page, zoomed drags pan.
     UIScrollView *zoom = (UIScrollView *)[self.scrollView viewWithTag:4000 + [self apollo_currentPageIndex]];
     if ([zoom isKindOfClass:[UIScrollView class]] && zoom.zoomScale > zoom.minimumZoomScale + 0.01) return NO;
     CGPoint velocity = [self.dismissPan velocityInView:self.view];
-    return velocity.y > 0.0 && fabs(velocity.y) > fabs(velocity.x) * 1.5;
+    return fabs(velocity.y) > fabs(velocity.x) * 1.5;
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer

--- a/src/ApolloSubredditCustomBannerCache.h
+++ b/src/ApolloSubredditCustomBannerCache.h
@@ -11,6 +11,10 @@ FOUNDATION_EXPORT NSString *const ApolloSubredditCustomBannerSubredditNameKey;
 
 - (nullable UIImage *)cachedBannerForSubreddit:(NSString *)subredditName;
 - (BOOL)hasCustomBannerForSubreddit:(NSString *)subredditName;
+// file:// URL of the stored custom banner, or nil when none is set. Lets the
+// fullscreen image viewer load the exact on-disk JPEG instead of re-encoding
+// the in-memory UIImage.
+- (nullable NSURL *)cachedBannerFileURLForSubreddit:(NSString *)subredditName;
 - (BOOL)saveBanner:(UIImage *)image forSubreddit:(NSString *)subredditName error:(NSError * _Nullable * _Nullable)error;
 - (BOOL)removeBannerForSubreddit:(NSString *)subredditName;
 - (void)clearAllCustomBanners;

--- a/src/ApolloSubredditCustomBannerCache.m
+++ b/src/ApolloSubredditCustomBannerCache.m
@@ -153,6 +153,16 @@ static NSUInteger const ApolloSubredditCustomBannerMaxBytes = 1572864; // 1.5 MB
     return exists;
 }
 
+- (NSURL *)cachedBannerFileURLForSubreddit:(NSString *)subredditName {
+    NSString *path = [self filePathForSubreddit:subredditName];
+    if (path.length == 0) return nil;
+    __block BOOL exists = NO;
+    dispatch_sync(self.queue, ^{
+        exists = [[NSFileManager defaultManager] fileExistsAtPath:path];
+    });
+    return exists ? [NSURL fileURLWithPath:path] : nil;
+}
+
 - (BOOL)saveBanner:(UIImage *)image forSubreddit:(NSString *)subredditName error:(NSError **)error {
     NSString *key = [self normalizedSubredditName:subredditName];
     NSString *path = [self filePathForSubreddit:subredditName];

--- a/src/ApolloSubredditCustomIconCache.h
+++ b/src/ApolloSubredditCustomIconCache.h
@@ -11,6 +11,10 @@ FOUNDATION_EXPORT NSString *const ApolloSubredditCustomIconSubredditNameKey;
 
 - (nullable UIImage *)cachedIconForSubreddit:(NSString *)subredditName;
 - (BOOL)hasCustomIconForSubreddit:(NSString *)subredditName;
+// file:// URL of the stored custom icon, or nil when none is set. Lets the
+// fullscreen image viewer load the exact on-disk PNG instead of re-encoding
+// the in-memory UIImage.
+- (nullable NSURL *)cachedIconFileURLForSubreddit:(NSString *)subredditName;
 - (BOOL)saveIcon:(UIImage *)image forSubreddit:(NSString *)subredditName error:(NSError * _Nullable * _Nullable)error;
 - (BOOL)removeIconForSubreddit:(NSString *)subredditName;
 - (void)clearAllCustomIcons;

--- a/src/ApolloSubredditCustomIconCache.m
+++ b/src/ApolloSubredditCustomIconCache.m
@@ -142,6 +142,16 @@ static NSUInteger const ApolloSubredditCustomIconMaxBytes = 512000; // 500 KB
     return exists;
 }
 
+- (NSURL *)cachedIconFileURLForSubreddit:(NSString *)subredditName {
+    NSString *path = [self filePathForSubreddit:subredditName];
+    if (path.length == 0) return nil;
+    __block BOOL exists = NO;
+    dispatch_sync(self.queue, ^{
+        exists = [[NSFileManager defaultManager] fileExistsAtPath:path];
+    });
+    return exists ? [NSURL fileURLWithPath:path] : nil;
+}
+
 - (BOOL)saveIcon:(UIImage *)image forSubreddit:(NSString *)subredditName error:(NSError **)error {
     NSString *key = [self normalizedSubredditName:subredditName];
     NSString *path = [self filePathForSubreddit:subredditName];

--- a/src/ApolloSubredditHeaders.xm
+++ b/src/ApolloSubredditHeaders.xm
@@ -124,6 +124,11 @@ typedef NS_ENUM(NSInteger, ApolloSubredditHeaderAssetKind) {
 - (void)applyInfo:(ApolloSubredditInfo *)info fallbackSubredditName:(NSString *)subredditName;
 - (void)apollo_bannerTapped;
 - (void)apollo_iconTapped;
+- (void)apollo_bannerLongPressed:(UILongPressGestureRecognizer *)recognizer;
+- (void)apollo_iconLongPressed:(UILongPressGestureRecognizer *)recognizer;
+- (void)apollo_showOptionsForAssetKind:(ApolloSubredditHeaderAssetKind)assetKind;
+- (void)apollo_viewImageForAssetKind:(ApolloSubredditHeaderAssetKind)assetKind;
+- (NSURL *)apollo_viewableImageURLForAssetKind:(ApolloSubredditHeaderAssetKind)assetKind;
 - (void)apollo_subscribeTapped;
 - (void)apollo_applySubscriptionState:(BOOL)subscribed known:(BOOL)known;
 - (void)apollo_applySubscriptionGlassWithAccent:(UIColor *)accent;
@@ -219,9 +224,11 @@ static NSInteger const ApolloSubredditAboutCollapsedLines = 3;
         _bannerImageView.isAccessibilityElement = YES;
         _bannerImageView.accessibilityTraits = UIAccessibilityTraitButton;
         _bannerImageView.accessibilityLabel = @"Subreddit banner";
-        _bannerImageView.accessibilityHint = @"Double tap to change banner photo";
+        _bannerImageView.accessibilityHint = @"Double tap to view the banner, or double tap and hold for options";
         UITapGestureRecognizer *bannerTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(apollo_bannerTapped)];
         [_bannerImageView addGestureRecognizer:bannerTap];
+        UILongPressGestureRecognizer *bannerHold = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(apollo_bannerLongPressed:)];
+        [_bannerImageView addGestureRecognizer:bannerHold];
         [self addSubview:_bannerImageView];
 
         _iconImageView = [[UIImageView alloc] init];
@@ -232,9 +239,11 @@ static NSInteger const ApolloSubredditAboutCollapsedLines = 3;
         _iconImageView.isAccessibilityElement = YES;
         _iconImageView.accessibilityTraits = UIAccessibilityTraitButton;
         _iconImageView.accessibilityLabel = @"Subreddit icon";
-        _iconImageView.accessibilityHint = @"Double tap to change subreddit icon";
+        _iconImageView.accessibilityHint = @"Double tap to view the icon, or double tap and hold for options";
         UITapGestureRecognizer *iconTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(apollo_iconTapped)];
         [_iconImageView addGestureRecognizer:iconTap];
+        UILongPressGestureRecognizer *iconHold = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(apollo_iconLongPressed:)];
+        [_iconImageView addGestureRecognizer:iconHold];
         [self addSubview:_iconImageView];
 
         _displayNameLabel = [[UILabel alloc] init];
@@ -718,70 +727,115 @@ static NSInteger const ApolloSubredditAboutCollapsedLines = 3;
     }
 }
 
-- (void)apollo_bannerTapped {
+// The image the header is actually showing, as a URL the fullscreen viewer can
+// load: the custom override's on-disk file when one is set, else the
+// subreddit's real banner/icon URL from the info cache. Nil when only the
+// bundled default banner / placeholder icon is showing — nothing to view then.
+- (NSURL *)apollo_viewableImageURLForAssetKind:(ApolloSubredditHeaderAssetKind)assetKind {
+    NSString *subredditName = self.subredditName;
+    if (subredditName.length == 0) return nil;
+    if (assetKind == ApolloSubredditHeaderAssetKindIcon) {
+        NSURL *customURL = [[ApolloSubredditCustomIconCache sharedCache] cachedIconFileURLForSubreddit:subredditName];
+        if (customURL) return customURL;
+        return [[ApolloSubredditInfoCache sharedCache] cachedInfoForSubreddit:subredditName].iconURL;
+    }
+    NSURL *customURL = [[ApolloSubredditCustomBannerCache sharedCache] cachedBannerFileURLForSubreddit:subredditName];
+    if (customURL) return customURL;
+    return [[ApolloSubredditInfoCache sharedCache] cachedInfoForSubreddit:subredditName].bannerURL;
+}
+
+// Issue #324: open the banner/icon fullscreen in the tweak's generic zoomable
+// viewer (share/save button, long-press Save/Share menu, swipe to dismiss).
+// NSURLSession loads file:// URLs too, so custom overrides view identically.
+- (void)apollo_viewImageForAssetKind:(ApolloSubredditHeaderAssetKind)assetKind {
+    NSURL *url = [self apollo_viewableImageURLForAssetKind:assetKind];
+    if (!url) return;
+    UIView *sourceView = assetKind == ApolloSubredditHeaderAssetKindIcon ? self.iconImageView : self.bannerImageView;
+    if (!ApolloPresentImageChestItems(@[@{ @"url": url }], sourceView, 0)) {
+        ApolloLog(@"[SubredditHeaders] view image: no presenter for %@", url);
+    }
+}
+
+- (void)apollo_showOptionsForAssetKind:(ApolloSubredditHeaderAssetKind)assetKind {
     UIViewController *host = self.hostViewController;
     NSString *subredditName = self.subredditName;
     if (!host || subredditName.length == 0 || !sShowSubredditHeaders) return;
 
-    ApolloSubredditCustomBannerCache *customCache = [ApolloSubredditCustomBannerCache sharedCache];
-    BOOL hasCustom = [customCache hasCustomBannerForSubreddit:subredditName];
+    BOOL isIcon = assetKind == ApolloSubredditHeaderAssetKindIcon;
+    BOOL hasCustom = isIcon
+        ? [[ApolloSubredditCustomIconCache sharedCache] hasCustomIconForSubreddit:subredditName]
+        : [[ApolloSubredditCustomBannerCache sharedCache] hasCustomBannerForSubreddit:subredditName];
+    NSURL *viewableURL = [self apollo_viewableImageURLForAssetKind:assetKind];
 
     UIAlertController *sheet = [UIAlertController alertControllerWithTitle:nil
                                                                    message:nil
                                                             preferredStyle:UIAlertControllerStyleActionSheet];
     __weak typeof(self) weakSelf = self;
+    if (viewableURL) {
+        [sheet addAction:[UIAlertAction actionWithTitle:isIcon ? @"View Icon" : @"View Banner"
+                                                  style:UIAlertActionStyleDefault
+                                                handler:^(__unused UIAlertAction *action) {
+            [weakSelf apollo_viewImageForAssetKind:assetKind];
+        }]];
+    }
     [sheet addAction:[UIAlertAction actionWithTitle:@"Choose Photo"
                                               style:UIAlertActionStyleDefault
                                             handler:^(__unused UIAlertAction *action) {
-        [weakSelf apollo_presentPhotoPickerForAssetKind:ApolloSubredditHeaderAssetKindBanner];
+        [weakSelf apollo_presentPhotoPickerForAssetKind:assetKind];
     }]];
     if (hasCustom) {
-        [sheet addAction:[UIAlertAction actionWithTitle:@"Remove Custom Banner"
+        [sheet addAction:[UIAlertAction actionWithTitle:isIcon ? @"Remove Custom Icon" : @"Remove Custom Banner"
                                                   style:UIAlertActionStyleDestructive
                                                 handler:^(__unused UIAlertAction *action) {
-            [customCache removeBannerForSubreddit:subredditName];
+            if (isIcon) {
+                [[ApolloSubredditCustomIconCache sharedCache] removeIconForSubreddit:subredditName];
+            } else {
+                [[ApolloSubredditCustomBannerCache sharedCache] removeBannerForSubreddit:subredditName];
+            }
         }]];
     }
     [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
 
+    UIView *sourceView = isIcon ? self.iconImageView : self.bannerImageView;
     if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
-        sheet.popoverPresentationController.sourceView = self.bannerImageView;
-        sheet.popoverPresentationController.sourceRect = self.bannerImageView.bounds;
+        sheet.popoverPresentationController.sourceView = sourceView;
+        sheet.popoverPresentationController.sourceRect = sourceView.bounds;
     }
     [host presentViewController:sheet animated:YES completion:nil];
 }
 
+// Tap views the artwork when there is any (matching how media behaves
+// elsewhere in Apollo); a sub still on the bundled default banner/placeholder
+// icon falls through to the options sheet so the photo picker stays one tap
+// away. Long-press always opens the options sheet.
+- (void)apollo_bannerTapped {
+    UIViewController *host = self.hostViewController;
+    if (!host || self.subredditName.length == 0 || !sShowSubredditHeaders) return;
+    if ([self apollo_viewableImageURLForAssetKind:ApolloSubredditHeaderAssetKindBanner]) {
+        [self apollo_viewImageForAssetKind:ApolloSubredditHeaderAssetKindBanner];
+        return;
+    }
+    [self apollo_showOptionsForAssetKind:ApolloSubredditHeaderAssetKindBanner];
+}
+
 - (void)apollo_iconTapped {
     UIViewController *host = self.hostViewController;
-    NSString *subredditName = self.subredditName;
-    if (!host || subredditName.length == 0 || !sShowSubredditHeaders) return;
-
-    ApolloSubredditCustomIconCache *customCache = [ApolloSubredditCustomIconCache sharedCache];
-    BOOL hasCustom = [customCache hasCustomIconForSubreddit:subredditName];
-
-    UIAlertController *sheet = [UIAlertController alertControllerWithTitle:nil
-                                                                   message:nil
-                                                            preferredStyle:UIAlertControllerStyleActionSheet];
-    __weak typeof(self) weakSelf = self;
-    [sheet addAction:[UIAlertAction actionWithTitle:@"Choose Photo"
-                                              style:UIAlertActionStyleDefault
-                                            handler:^(__unused UIAlertAction *action) {
-        [weakSelf apollo_presentPhotoPickerForAssetKind:ApolloSubredditHeaderAssetKindIcon];
-    }]];
-    if (hasCustom) {
-        [sheet addAction:[UIAlertAction actionWithTitle:@"Remove Custom Icon"
-                                                  style:UIAlertActionStyleDestructive
-                                                handler:^(__unused UIAlertAction *action) {
-            [customCache removeIconForSubreddit:subredditName];
-        }]];
+    if (!host || self.subredditName.length == 0 || !sShowSubredditHeaders) return;
+    if ([self apollo_viewableImageURLForAssetKind:ApolloSubredditHeaderAssetKindIcon]) {
+        [self apollo_viewImageForAssetKind:ApolloSubredditHeaderAssetKindIcon];
+        return;
     }
-    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    [self apollo_showOptionsForAssetKind:ApolloSubredditHeaderAssetKindIcon];
+}
 
-    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
-        sheet.popoverPresentationController.sourceView = self.iconImageView;
-        sheet.popoverPresentationController.sourceRect = self.iconImageView.bounds;
-    }
-    [host presentViewController:sheet animated:YES completion:nil];
+- (void)apollo_bannerLongPressed:(UILongPressGestureRecognizer *)recognizer {
+    if (recognizer.state != UIGestureRecognizerStateBegan) return;
+    [self apollo_showOptionsForAssetKind:ApolloSubredditHeaderAssetKindBanner];
+}
+
+- (void)apollo_iconLongPressed:(UILongPressGestureRecognizer *)recognizer {
+    if (recognizer.state != UIGestureRecognizerStateBegan) return;
+    [self apollo_showOptionsForAssetKind:ApolloSubredditHeaderAssetKindIcon];
 }
 
 @end


### PR DESCRIPTION
closes #324

right now tapping the banner or icon on a subreddit goes straight to the choose photo sheet. this adds the view option that was asked for and reworks the gestures a bit:

- **tap** on the banner or icon now just views it fullscreen in the image viewer — share button, press and hold to save, pinch to zoom, swipe up or down to dismiss (the viewer only did swipe-down before, added swipe-up to match the native media viewer)
- **tap and hold** brings up the options sheet, which now has **View Banner** / **View Icon** at the top along with Choose Photo / Remove Custom Banner (or Icon) / Cancel
- if the sub only has the default banner or the placeholder icon there's nothing to view, so a plain tap falls through to the options sheet like before (so you can still set a photo with one tap on subs that have nothing)

custom banners/icons open from the exact file on disk, so viewing/saving/sharing gives you the same image you picked, and remote ones use the same url the header loaded.

## Screenshots
| tap & hold → options | tap → view banner | viewer controls (share / done) |
|---|---|---|
| <img src="https://github.com/user-attachments/assets/facc2e94-d72a-4b83-afdd-0711ef349c97" alt="options sheet" /> | <img src="https://github.com/user-attachments/assets/d0e108e5-33c6-427b-bcee-48f542fb100f" alt="fullscreen viewer" /> | <img src="https://github.com/user-attachments/assets/efce2981-cb43-4932-acaa-c1a283e263b3" alt="viewer with share and done controls" /> |

tested in the sim:
- glass and non glass builds
- api key mode and api key free mode
- New (Immersive) and Classic (Compact) layouts
- subs with real banners (r/space, r/pics), a sub with no icon (r/test → sheet with no view option), custom banner set → view → remove

device test still pending, will update here after
