### PR TITLE
Fix subreddit page stuck below top after pull-to-refresh

### DIFF
--- a/src/ApolloSubredditHeaders.xm
+++ b/src/ApolloSubredditHeaders.xm
@@ -2307,11 +2307,29 @@ static BOOL ApolloSubredditShouldBlockOffset(UITableView *tableView, CGPoint new
     return fabs(targetDelta - headerHeight) < 5.0;
 }
 
+// Apollo's "skip my header" scroll doubles as the resting-offset restore
+// after pull-to-refresh: the refresh spinner's inset unwind leaves the table
+// parked above its natural top, and the ONLY programmatic scroll Apollo then
+// issues is the skip-header one we block. Swallowing it whole left the table
+// stuck at the spinner gap until the next touch made UIKit re-clamp (visible
+// as the subreddit page resting ~60pt low after a refresh). When the blocked
+// call arrives with the table above natural top, complete the restore to
+// natural top ourselves — keeping the header visible, which is the point of
+// the block, without eating the settle.
+static void ApolloSubredditSettleBlockedTableToTop(UITableView *tableView) {
+    CGFloat topY = -tableView.adjustedContentInset.top;
+    if (tableView.contentOffset.y >= topY - 0.5) return;
+    ApolloLog(@"[SubredditHeaders] blocked skip-header scroll while parked at %.1f; settling to top %.1f",
+              tableView.contentOffset.y, topY);
+    [tableView setContentOffset:CGPointMake(tableView.contentOffset.x, topY) animated:YES];
+}
+
 %hook UIScrollView
 
 - (void)setContentOffset:(CGPoint)contentOffset {
     if (sShowSubredditHeaders && [self isKindOfClass:[UITableView class]] &&
         ApolloSubredditShouldBlockOffset((UITableView *)self, contentOffset)) {
+        ApolloSubredditSettleBlockedTableToTop((UITableView *)self);
         return;
     }
     %orig;
@@ -2323,6 +2341,7 @@ static BOOL ApolloSubredditShouldBlockOffset(UITableView *tableView, CGPoint new
 - (void)setContentOffset:(CGPoint)contentOffset animated:(BOOL)animated {
     if (sShowSubredditHeaders && [self isKindOfClass:[UITableView class]] &&
         ApolloSubredditShouldBlockOffset((UITableView *)self, contentOffset)) {
+        ApolloSubredditSettleBlockedTableToTop((UITableView *)self);
         return;
     }
     %orig;


### PR DESCRIPTION
fixes a bug we noticed while testing #845 (but it's not related to that PR — this is on main, it's been there since the subreddit header shipped)

**the bug:** on a subreddit page (with the Reborn header on), pull to refresh and after the refresh finishes the whole page just stays parked ~60pt below where it should be — stuck at the spinner gap. it doesn't fix itself until you tap or touch the screen, then it snaps back up.

**why:** after a refresh Apollo re-issues its "scroll past my tableHeaderView" call (the same one it does on load to hide its native header). the subreddit header feature blocks that call on purpose so our header stays visible — but that call was also doing double duty as the offset restore after the refresh spinner's inset unwinds. blocking it whole ate the restore too, so nothing ever put the table back until the next touch made UIKit re-clamp.

**the fix:** when the blocked call arrives and the table is resting above its natural top, settle it to natural top ourselves (animated) instead of just dropping the scroll. the header still stays visible (the point of the block), and initial load is unchanged — the table is already at top there so the settle is a no-op.

verified in the sim on glass and non glass: reproduced the stuck state first (log trace shows the blocked call arriving parked at the spinner gap), then with the fix the page settles back on its own after every refresh. left a log line on the settle path since it's a rare event and useful if anything else ever parks a table up there.

device test pending
