### PR TITLE
Fix pixel pal sinking behind the Dynamic Island on newer devices (#826)

### DIFF
--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -1419,10 +1419,24 @@ static int uname_replacement(struct utsname *buf) {
     });
 
     NSString *machine = @(buf->machine);
+#if APOLLO_SIM_BUILD
+    // The simulator's uname reports the host arch ("arm64"), so Apollo's
+    // device mapper sees "unknown" and hides Pixel Pals. Substitute the
+    // simulated device's identifier so the same remap table below applies.
+    if (![machine hasPrefix:@"iPhone"]) {
+        const char *simModel = getenv("SIMULATOR_MODEL_IDENTIFIER");
+        if (simModel) machine = @(simModel);
+    }
+#endif
     NSString *remap = modelRemap[machine];
     if (remap) {
         strlcpy(buf->machine, remap.UTF8String, sizeof(buf->machine));
     }
+#if APOLLO_SIM_BUILD
+    else if (![@(buf->machine) isEqualToString:machine]) {
+        strlcpy(buf->machine, machine.UTF8String, sizeof(buf->machine));
+    }
+#endif
     return ret;
 }
 
@@ -2826,9 +2840,16 @@ static void ApolloImgurRetryAlbumViaTextProxy(NSString *albumID,
 //   sub_10030afa0: FauxCutOutView y=11.5, w=125, h=37
 //   sub_10030c880: PixelPalView y=-2.0
 //   sub_10030d6c4: tap overlay y=11.0, w=125, h=37, cornerRadius=18.5
-// On devices with different safe area insets, compute the correct DI Y position.
-// The gap between DI bottom and safe area scales proportionally with safeTop.
-// Y is floored to the nearest half-pixel to match the baseline's sub-pixel alignment.
+// The island's real position varies per device AND per iOS release, and the
+// safe-area top is not a reliable proxy for it (issue #826: iPhone Air on
+// iOS 27 reports a taller safe area while the physical island stayed put, so
+// the old proportional model over-shifted the whole pal cluster down behind
+// the island pill). Instead, read the physical cutout rect the same way
+// UIKit's own status bar does when laying out around the island
+// (-[_UIStatusBarVisualProvider_DynamicSplit sensorAreaRect], iOS 16+):
+// -[UIScreen _exclusionArea].rect, converted into the current coordinate
+// space with nativeScale/scale. The old proportional model stays as the
+// fallback if the private API ever disappears.
 //
 // --- Pixel Pals freeze guard (issue #305) ---
 // Tapping the Dynamic Island Pixel Pals area (pixelPalTappedWithTapGestureRecognizer:)
@@ -2848,6 +2869,77 @@ static void ApolloImgurRetryAlbumViaTextProxy(NSString *albumID,
 // ("preventing the pixel pal menu from opening with any media or website open
 // should fix everything") and is a strict superset of Apollo's intended
 // behaviour (the menu is already meant to be unreachable while media is open).
+// Reads the physical Dynamic Island cutout rect in the app's logical
+// coordinate space via -[UIScreen _exclusionArea] (private, island devices
+// only — nil on notch/older hardware). This is the exact source and
+// conversion UIKit's status bar uses, so it tracks new devices and iOS
+// releases without a per-device table, and is correct under Display Zoom
+// (nativeScale != scale), which the proportional fallback has to bail on.
+static BOOL ApolloDynamicIslandRect(CGRect *outRect) {
+    UIScreen *screen = [UIScreen mainScreen];
+    SEL exclusionSel = NSSelectorFromString(@"_exclusionArea");
+    if (![screen respondsToSelector:exclusionSel]) return NO;
+    id area = ((id (*)(id, SEL))objc_msgSend)(screen, exclusionSel);
+    SEL rectSel = NSSelectorFromString(@"rect");
+    if (!area || ![area respondsToSelector:rectSel]) return NO;
+    CGRect rect = ((CGRect (*)(id, SEL))objc_msgSend)(area, rectSel);
+    // Mirror -[_UIStatusBarVisualProvider_DynamicSplit sensorAreaRect]'s
+    // conversion into the current (Display Zoom) coordinate space.
+    CGFloat nativeScale = screen.nativeScale;
+    CGFloat scale = screen.scale;
+    if (nativeScale > 0 && scale > 0 && nativeScale != scale) {
+        CGFloat zoom = nativeScale / scale;
+        rect.origin.x *= zoom;
+        rect.origin.y *= zoom;
+        rect.size.width *= zoom;
+        rect.size.height *= zoom;
+    }
+    // Sanity: a small pill near the top of the screen, or the API changed.
+    if (CGRectIsEmpty(rect) ||
+        rect.origin.y < 0.0 || rect.origin.y > 40.0 ||
+        rect.size.height < 20.0 || rect.size.height > 60.0 ||
+        rect.size.width < 60.0 || rect.size.width > CGRectGetWidth(screen.bounds) * 0.6) {
+        return NO;
+    }
+    *outRect = rect;
+    return YES;
+}
+
+// Vertical shift to add to Apollo's hardcoded 14 Pro DI element positions so
+// they line up with this device's actual island. 0 when no correction applies.
+static CGFloat ApolloPixelPalShift(UIWindow *window) {
+    CGFloat nativeScale = [UIScreen mainScreen].nativeScale;
+    CGFloat halfPx = 0.5 / (nativeScale > 0 ? nativeScale : 3.0);
+
+    CGRect island;
+    if (ApolloDynamicIslandRect(&island)) {
+        // Center Apollo's 37pt faux pill on the real cutout; floor to the
+        // nearest half-pixel to match the baseline's sub-pixel alignment.
+        CGFloat correctY = floor((CGRectGetMidY(island) - 37.0 / 2.0) / halfPx) * halfPx;
+        CGFloat shift = correctY - 11.5;
+        static dispatch_once_t logOnce;
+        dispatch_once(&logOnce, ^{
+            ApolloLog(@"[PixelPals] island cutout {%.2f, %.2f, %.2f, %.2f} safeTop=%.1f → shift %.3f",
+                      island.origin.x, island.origin.y, island.size.width, island.size.height,
+                      window.safeAreaInsets.top, shift);
+        });
+        // Baseline devices land within a half-point of Apollo's own 11.5;
+        // leave them untouched.
+        return fabs(shift) < 0.75 ? 0.0 : shift;
+    }
+
+    // Fallback (pre-iOS-16 UIKit internals changed): proportional model —
+    // gap between DI bottom and safe area scales with safeTop. Wrong on
+    // devices where the safe area moved independently of the island (#826),
+    // but better than nothing.
+    if (nativeScale != [UIScreen mainScreen].scale) return 0.0;
+    CGFloat safeTop = window.safeAreaInsets.top;
+    if (safeTop < 50.0 || fabs(safeTop - 59.0) < 0.5) return 0.0;
+    CGFloat scaledGap = 10.5 * safeTop / 59.0;
+    CGFloat correctY = floor((safeTop - 37.0 - scaledGap) / halfPx) * halfPx;
+    return correctY - 11.5;
+}
+
 static BOOL ApolloPixelPalsBlockedByModal(UIWindow *window) {
     Class overlayCls = objc_getClass("_TtC6Apollo29PixelPalOverlayViewController");
     UIViewController *vc = window.rootViewController;
@@ -2880,18 +2972,9 @@ static BOOL ApolloPixelPalsBlockedByModal(UIWindow *window) {
     %orig;
 
     UIWindow *window = (UIWindow *)self;
-    CGFloat nativeScale = [UIScreen mainScreen].nativeScale;
-    if (nativeScale != [UIScreen mainScreen].scale) return;
-
-    CGFloat safeTop = window.safeAreaInsets.top;
-    if (safeTop < 50.0 || fabs(safeTop - 59.0) < 0.5) return;
-
-    // Compute correct Y: gap scales proportionally, floor to half-pixel.
-    // Baseline (14 Pro): safeTop=59, y=11.5, gap=10.5, y at half-pixel (34.5px@3x).
-    CGFloat scaledGap = 10.5 * safeTop / 59.0;
-    CGFloat halfPx = 0.5 / nativeScale;
-    CGFloat correctY = floor((safeTop - 37.0 - scaledGap) / halfPx) * halfPx;
-    CGFloat shift = correctY - 11.5;
+    CGFloat shift = ApolloPixelPalShift(window);
+    if (shift == 0.0) return;
+    CGFloat correctY = 11.5 + shift;
 
     // Shift FauxCutOutView — %orig sets y=11.5 via sub_10030afa0
     Ivar fauxIvar = class_getInstanceVariable(object_getClass(self), "fauxCutOutView");
@@ -2909,8 +2992,8 @@ static BOOL ApolloPixelPalsBlockedByModal(UIWindow *window) {
         fauxView.layer.cornerRadius = CGRectGetHeight(fauxView.bounds) * 0.5;
         fauxView.layer.cornerCurve = kCACornerCurveContinuous;
 
-        ApolloLog(@"[PixelPals] FauxCutOutView y: 11.5 → %.3f (safeTop=%.1f, gap=%.3f, shift=%.3f)",
-                  correctY, safeTop, scaledGap, shift);
+        ApolloLog(@"[PixelPals] FauxCutOutView y: 11.5 → %.3f (safeTop=%.1f, shift=%.3f)",
+                  correctY, window.safeAreaInsets.top, shift);
     }
 
     // Shift PixelPalView — %orig sets y=-2.0 via sub_10030c880
@@ -2932,20 +3015,13 @@ static BOOL ApolloPixelPalsBlockedByModal(UIWindow *window) {
     %orig;
 
     UIWindow *window = (UIWindow *)self;
-    CGFloat safeTop = window.safeAreaInsets.top;
-    if (safeTop < 50.0 || fabs(safeTop - 59.0) < 0.5) return;
-    CGFloat nativeScale = [UIScreen mainScreen].nativeScale;
-    if (nativeScale != [UIScreen mainScreen].scale) return;
+    CGFloat shift = ApolloPixelPalShift(window);
+    if (shift == 0.0) return;
 
     if (![view isMemberOfClass:[UIView class]]) return;
     CGRect f = view.frame;
     if (fabs(f.size.width - 125.0) > 0.5 || fabs(f.size.height - 37.0) > 0.5) return;
     if (!view.clipsToBounds || view.layer.cornerRadius < 18.0) return;
-
-    CGFloat scaledGap = 10.5 * safeTop / 59.0;
-    CGFloat halfPx = 0.5 / nativeScale;
-    CGFloat correctY = floor((safeTop - 37.0 - scaledGap) / halfPx) * halfPx;
-    CGFloat shift = correctY - 11.5;
 
     ApolloLog(@"[PixelPals] Tap overlay y: %.1f → %.3f", f.origin.y, f.origin.y + shift);
     f.origin.y += shift;


### PR DESCRIPTION
Fixes #826

## Problem

Apollo hardcodes the Dynamic Island element positions for the iPhone 14 Pro (faux pill `y=11.5` under `safeAreaInsets.top=59`), and our existing correction rescaled those positions proportionally from the safe-area top. But the safe-area top moves independently of the physical island: the cutout sits at `y≈11.33` on every island device measured so far, while safeTop keeps growing (59 on 14 Pro, 61 on 16 Pro, 64 on iPhone Air — and taller again on iOS 27). The proportional model therefore over-shifts the whole pal cluster downward: ~4pt on the iPhone Air under iOS 26 (barely noticeable), and far enough under iOS 27's taller safe area to bury the pal behind the pill, which is what the reporter photographed.

## Fix

Position off the island's real cutout rect instead of guessing from the safe area: `-[UIScreen _exclusionArea].rect`, the same source UIKit's own status bar lays out around (`-[_UIStatusBarVisualProvider_DynamicSplit sensorAreaRect]`), including its `nativeScale/scale` Display Zoom conversion (which the old model had to bail on entirely). The proportional model is kept only as a fallback if the private API disappears or returns a nonsense rect, and a one-time `[PixelPals] island cutout {…} → shift …` log line records which path ran.

Also bridges `SIMULATOR_MODEL_IDENTIFIER` into the uname device remap under `APOLLO_SIM_BUILD`, so the simulator (whose `uname` reports the host arch) is recognized as an island device — Pixel Pals are now fully testable in the sim.

## Verification

- iPhone 16 Pro + iPhone Air simulators (iOS 26.5): the Air reports safeTop 64 with the island still at y=11.33; the new code computes shift ≈ 0 and the pal sits correctly on the pill on both devices, while the old model would have shifted it 4.1pt down.
- iOS 27 hardware verification pending (no iOS 27 runtime locally); if `_exclusionArea` misbehaves there the fallback keeps today's behavior and the log line will show what was reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)