### PR TITLE
Fix avatar & subreddit-header glitches: identity checks, banner lifecycle, fetch scheduling

### DIFF
--- a/src/ApolloSubredditHeaders.xm
+++ b/src/ApolloSubredditHeaders.xm
@@ -109,6 +109,17 @@ typedef NS_ENUM(NSInteger, ApolloSubredditHeaderAssetKind) {
 @property(nonatomic, copy) NSString *subredditName;
 @property(nonatomic) BOOL usesCustomBanner;
 @property(nonatomic) BOOL usesCustomIcon;
+// Provenance of the banner image currently displayed (custom asset, fetched
+// URL, or the shared default), stamped at the moment the image is applied.
+// The ambient blur cache key must describe the image actually on screen —
+// deriving it from info.bannerURL let a failed fetch stamp the shared
+// default-banner singleton with a real subreddit's URL, poisoning the blur
+// cache for every header showing the default.
+@property(nonatomic, copy) NSString *bannerProvenanceKey;
+// The banner URL this header most recently started fetching. Completions
+// compare against it so an older in-flight fetch can't paint over a newer
+// banner (same guard as the profile header's currentBannerURL).
+@property(nonatomic, strong) NSURL *pendingBannerURL;
 @property(nonatomic) BOOL subscriptionStateKnown;
 @property(nonatomic) BOOL subscribed;
 @property(nonatomic) BOOL subscriptionRequestInFlight;
@@ -664,7 +675,7 @@ static NSInteger const ApolloSubredditAboutCollapsedLines = 3;
     void (^completion)(NSError *error) = ^(NSError *error) {
         dispatch_async(dispatch_get_main_queue(), ^{
             ApolloSubredditHeaderView *strongSelf = weakSelf;
-            if (!strongSelf || ![strongSelf.subredditName isEqualToString:subredditName]) return;
+            if (!strongSelf || !ApolloSubredditNamesEqual(strongSelf.subredditName, subredditName)) return;
             strongSelf.subscriptionRequestInFlight = NO;
             BOOL succeeded = ![error isKindOfClass:[NSError class]];
             BOOL finalState = succeeded ? desiredState : oldState;
@@ -908,6 +919,12 @@ static BOOL ApolloSubredditNamesEqual(NSString *left, NSString *right) {
     NSString *normalizedRight = ApolloNormalizedSubredditName(right);
     if (normalizedLeft.length == 0 || normalizedRight.length == 0) return NO;
     return [normalizedLeft caseInsensitiveCompare:normalizedRight] == NSOrderedSame;
+}
+
+static BOOL ApolloSubredditURLsMatch(NSURL *left, NSURL *right) {
+    if (left == right) return YES;
+    if (!left || !right) return NO;
+    return [left.absoluteString isEqualToString:right.absoluteString];
 }
 
 static BOOL ApolloSubredditIsLikelyObjectPointer(id value) {
@@ -1265,13 +1282,21 @@ static UIColor *ApolloSubredditBannerBackgroundColor(void) {
 static void ApolloSubredditApplyLoadingBanner(ApolloSubredditHeaderView *header) {
     if (!header) return;
     header.bannerImageView.image = nil;
+    header.bannerProvenanceKey = nil;
+    header.pendingBannerURL = nil;
     header.bannerImageView.backgroundColor = ApolloSubredditBannerBackgroundColor();
     ApolloSubredditSyncAmbient(header);
 }
 
 static void ApolloSubredditApplyDefaultBanner(ApolloSubredditHeaderView *header) {
     if (!header) return;
-    header.bannerImageView.image = ApolloSubredditDefaultBanner();
+    UIImage *defaultBanner = ApolloSubredditDefaultBanner();
+    header.bannerImageView.image = defaultBanner;
+    // The default banner is a shared singleton: a constant provenance key means
+    // every header showing it shares one blur cache entry, and no header can
+    // stamp it with a real subreddit's URL.
+    header.bannerProvenanceKey = [NSString stringWithFormat:@"subreddit-default:%@",
+                                  ApolloImmersiveBannerInstanceIdentity(defaultBanner)];
     header.bannerImageView.backgroundColor = [UIColor clearColor];
     ApolloSubredditSyncAmbient(header);
 }
@@ -1300,6 +1325,12 @@ static void ApolloSubredditApplyBannerForHeader(ApolloSubredditHeaderView *heade
     UIImage *customBanner = [customCache cachedBannerForSubreddit:subredditName];
     if (customBanner) {
         header.bannerImageView.image = customBanner;
+        // Instance identity, NOT the raw pointer — a recycled heap address
+        // would alias a newly-selected custom image to the dead one's blur.
+        header.bannerProvenanceKey = [NSString stringWithFormat:@"subreddit-custom:%@:%@",
+                                      ApolloNormalizedSubredditName(subredditName).lowercaseString ?: @"unknown",
+                                      ApolloImmersiveBannerInstanceIdentity(customBanner)];
+        header.pendingBannerURL = nil;
         header.bannerImageView.backgroundColor = [UIColor clearColor];
         header.usesCustomBanner = YES;
         ApolloSubredditSyncAmbient(header);
@@ -1309,45 +1340,70 @@ static void ApolloSubredditApplyBannerForHeader(ApolloSubredditHeaderView *heade
     header.usesCustomBanner = NO;
     if (info.bannerURL) {
         ApolloUserProfileCache *imageCache = [ApolloUserProfileCache sharedCache];
-        UIImage *banner = [imageCache cachedImageForURL:info.bannerURL];
+        UIImage *banner = [imageCache cachedBannerImageForURL:info.bannerURL];
         if (banner) {
             header.bannerImageView.image = banner;
+            header.bannerProvenanceKey = info.bannerURL.absoluteString;
+            header.pendingBannerURL = nil;
             header.bannerImageView.backgroundColor = [UIColor clearColor];
             ApolloSubredditSyncAmbient(header);
             return;
         }
 
-        ApolloSubredditApplyLoadingBanner(header);
+        // Keep whatever banner is already on screen while the refetch runs
+        // (the icon path has always done this) — blanking here made the whole
+        // immersive backdrop blink off and back on every info notification
+        // whose image had been evicted from the cache. A stale-subreddit image
+        // can't linger: the subreddit-changed path blanks explicitly before
+        // reloading.
+        if (!header.bannerImageView.image) {
+            ApolloSubredditApplyLoadingBanner(header);
+        }
 
         __weak ApolloSubredditHeaderView *weakHeader = header;
         NSURL *bannerURL = info.bannerURL;
-        [imageCache requestImageForURL:bannerURL completion:^(UIImage *image) {
+        header.pendingBannerURL = bannerURL;
+        [imageCache requestBannerImageForURL:bannerURL completion:^(UIImage *image) {
             ApolloSubredditHeaderView *strongHeader = weakHeader;
             // The header can be repointed to a different subreddit while this
             // fetch is in flight (fast back-and-forth navigation reuses the
             // same header instance) — without this check a slow fetch for the
             // previous subreddit would silently paint over the new one.
             if (!strongHeader || !ApolloSubredditNamesEqual(strongHeader.subredditName, subredditName)) return;
+            // Same idea for the URL: the subreddit can change its banner while
+            // an older fetch is still in flight — only the most recently
+            // requested URL may land (profile-header guard, ported).
+            if (!ApolloSubredditURLsMatch(strongHeader.pendingBannerURL, bannerURL)) return;
             if (strongHeader.usesCustomBanner) return;
             if ([[ApolloSubredditCustomBannerCache sharedCache] hasCustomBannerForSubreddit:subredditName]) return;
             if (image) {
                 strongHeader.bannerImageView.image = image;
+                strongHeader.bannerProvenanceKey = bannerURL.absoluteString;
+                strongHeader.pendingBannerURL = nil;
                 strongHeader.bannerImageView.backgroundColor = [UIColor clearColor];
                 ApolloSubredditSyncAmbient(strongHeader);
-            } else {
+            } else if (!strongHeader.bannerImageView.image) {
+                // Fetch failed and nothing usable is on screen. If we kept an
+                // older banner above, keep showing it instead of downgrading
+                // to the default.
                 ApolloSubredditApplyDefaultBanner(strongHeader);
             }
         }];
         return;
     }
 
-    if (info || infoFetchFailed) {
-        // A successful fetch with no banner configured, or a definitively
-        // failed info fetch (private/quarantined/banned/deleted subreddit,
-        // network error) — either way, stop showing the loading placeholder
-        // forever and fall back to the default banner.
+    if (info) {
+        // A successful fetch with no banner configured — swap to the default
+        // (also covers a subreddit that removed its banner).
         ApolloSubredditApplyDefaultBanner(header);
-    } else {
+    } else if (infoFetchFailed) {
+        // Definitively failed info fetch (private/quarantined/banned/deleted
+        // subreddit, network error): stop showing the loading placeholder, but
+        // never downgrade a banner that's already on screen for this subreddit.
+        if (!header.bannerImageView.image) ApolloSubredditApplyDefaultBanner(header);
+    } else if (!header.bannerImageView.image) {
+        // First load only — never blank an already-visible banner just because
+        // a refresh pass came through with no cached info yet.
         ApolloSubredditApplyLoadingBanner(header);
     }
 }
@@ -1547,25 +1603,18 @@ static void ApolloSubredditSyncAmbient(ApolloSubredditHeaderView *header) {
     }
     UIImage *banner = header.bannerImageView.image;
     if (banner) {
-        NSString *workKey = nil;
-        if (header.usesCustomBanner) {
-            // A newly-selected custom image must not reuse the previous custom
-            // image's backdrop merely because the subreddit name is unchanged.
-            // Instance identity, NOT the raw pointer — a recycled heap address
-            // would alias the new image to the dead one's cached blur.
-            workKey = [NSString stringWithFormat:@"subreddit-custom:%@:%@",
-                       header.subredditName.lowercaseString ?: @"unknown",
+        // The provenance key is stamped at the moment each banner image is
+        // applied (custom asset / fetched URL / shared default), so it always
+        // describes the image actually on screen. Re-deriving it here from
+        // info.bannerURL used to stamp the shared default-banner singleton
+        // with a real subreddit's URL whenever a banner fetch failed,
+        // poisoning the immersive blur cache for that URL globally.
+        NSString *workKey = header.bannerProvenanceKey;
+        if (workKey.length == 0) {
+            // Unknown provenance (shouldn't happen, but stay safe): instance
+            // identity never aliases two different images.
+            workKey = [NSString stringWithFormat:@"subreddit-fallback:%@",
                        ApolloImmersiveBannerInstanceIdentity(banner)];
-        } else {
-            ApolloSubredditInfo *info = [[ApolloSubredditInfoCache sharedCache]
-                cachedInfoForSubreddit:header.subredditName];
-            workKey = info.bannerURL.absoluteString;
-            if (workKey.length == 0) {
-                // Default/placeholder assets can vary with appearance. Instance
-                // identity is safer than sharing a stale blur between variants.
-                workKey = [NSString stringWithFormat:@"subreddit-fallback:%@",
-                           ApolloImmersiveBannerInstanceIdentity(banner)];
-            }
         }
         ApolloImmersiveSetBannerCacheKey(banner, workKey);
     }
@@ -1858,7 +1907,10 @@ static BOOL ApolloSubredditNeedsInstall(UIViewController *viewController) {
     if (header.hidden || wrappedHeader.hidden || header.alpha < 0.99 || wrappedHeader.alpha < 0.99) return YES;
 
     NSString *installedName = objc_getAssociatedObject(viewController, kApolloSubredditNameKey);
-    if (![installedName isEqualToString:subredditName]) return YES;
+    // Case-insensitive: the name arrives from the nav title first ("denver")
+    // and from currentSubreddit ("Denver") a beat later — a case-only
+    // difference is the same subreddit and must not read as "needs install".
+    if (!ApolloSubredditNamesEqual(installedName, subredditName)) return YES;
 
     CGFloat width = tableView.bounds.size.width;
     if (width > 0 && fabs(CGRectGetWidth(wrappedHeader.frame) - width) > 0.5) return YES;
@@ -2080,7 +2132,10 @@ static void ApolloSubredditInstallOrUpdateHeader(UIViewController *viewControlle
     ApolloSubredditSyncAssociations(tableView, viewController, header, wrappedHeader, originalHeader);
 
     NSString *storedSubredditName = objc_getAssociatedObject(viewController, kApolloSubredditNameKey);
-    BOOL subredditChanged = ![storedSubredditName isEqualToString:subredditName];
+    // Case-insensitive (see ApolloSubredditNeedsInstall): a nav-title/ivar
+    // case-only mismatch used to read as a subreddit change and wipe the
+    // freshly-loaded icon/banner/info mid-load on most subreddit opens.
+    BOOL subredditChanged = !ApolloSubredditNamesEqual(storedSubredditName, subredditName);
     if (subredditChanged) {
         // The subreddit name (and thus ApolloSubredditTitleShouldTruncate's
         // eligibility) only becomes known here, asynchronously, well after the
@@ -2140,7 +2195,10 @@ static void ApolloSubredditRefreshBannerInTree(UIViewController *viewController,
     if (!viewController || subredditName.length == 0 || [visited containsObject:viewController]) return;
     [visited addObject:viewController];
 
-    if ([ApolloSubredditNameFromViewController(viewController) isEqualToString:subredditName]) {
+    // Case-insensitive: the caches post lowercased names, this VC's name may
+    // be display-cased — a mismatch left second visible instances (iPad split
+    // view, another tab) showing the stale custom asset.
+    if (ApolloSubredditNamesEqual(ApolloSubredditNameFromViewController(viewController), subredditName)) {
         ApolloSubredditHeaderView *header = objc_getAssociatedObject(viewController, kApolloSubredditHeaderViewKey);
         if (header) {
             ApolloSubredditInfo *info = [[ApolloSubredditInfoCache sharedCache] cachedInfoForSubreddit:subredditName];
@@ -2172,7 +2230,8 @@ static void ApolloSubredditRefreshIconInTree(UIViewController *viewController,
     if (!viewController || subredditName.length == 0 || [visited containsObject:viewController]) return;
     [visited addObject:viewController];
 
-    if ([ApolloSubredditNameFromViewController(viewController) isEqualToString:subredditName]) {
+    // Case-insensitive for the same reason as the banner walker above.
+    if (ApolloSubredditNamesEqual(ApolloSubredditNameFromViewController(viewController), subredditName)) {
         ApolloSubredditHeaderView *header = objc_getAssociatedObject(viewController, kApolloSubredditHeaderViewKey);
         if (header) {
             ApolloSubredditInfo *info = [[ApolloSubredditInfoCache sharedCache] cachedInfoForSubreddit:subredditName];

--- a/src/ApolloSubredditHeaders.xm
+++ b/src/ApolloSubredditHeaders.xm
@@ -1395,6 +1395,10 @@ static void ApolloSubredditApplyBannerForHeader(ApolloSubredditHeaderView *heade
     if (info) {
         // A successful fetch with no banner configured — swap to the default
         // (also covers a subreddit that removed its banner).
+        // Invalidate any older fetch before installing the default: otherwise
+        // its completion still matches pendingBannerURL and can paint the
+        // removed banner back over this authoritative no-banner state.
+        header.pendingBannerURL = nil;
         ApolloSubredditApplyDefaultBanner(header);
     } else if (infoFetchFailed) {
         // Definitively failed info fetch (private/quarantined/banned/deleted

--- a/src/ApolloSubredditInfoCache.m
+++ b/src/ApolloSubredditInfoCache.m
@@ -1,6 +1,7 @@
 #import "ApolloSubredditInfoCache.h"
 
 #import "ApolloAccountCredentials.h"   // ApolloActiveAccountUsername() — userIsSubscriber stamping
+#import "ApolloCommon.h"               // ApolloLog
 #import "ApolloState.h"
 
 NSString * const ApolloSubredditInfoUpdatedNotification = @"ApolloSubredditInfoUpdatedNotification";
@@ -57,12 +58,47 @@ NSString *ApolloSubredditFormattedMemberCount(NSInteger subscriberCount) {
 
 @end
 
+// Retry budget + backoff for transient failures (network blips, 429, 5xx) —
+// ported from ApolloUserProfileCache's fetch discipline.
+static NSInteger const ApolloSubredditInfoMaxFetchAttempts = 3;
+static NSTimeInterval ApolloSubredditInfoRetryBackoffForAttempt(NSInteger attempt) {
+    return attempt == 0 ? 1.0 : 3.0;
+}
+
+// How long a permanently-failed subreddit (private/banned/deleted → 403/404,
+// unparseable body) is negative-cached before another fetch may run.
+// Memory-only: a transient upstream failure must not persist across launches.
+static NSTimeInterval const ApolloSubredditInfoNotFoundTTL = 10.0 * 60.0;
+
+static BOOL ApolloSubredditInfoErrorIsTransient(NSError *error) {
+    if (![error.domain isEqualToString:NSURLErrorDomain]) return NO;
+    switch (error.code) {
+        case NSURLErrorTimedOut:
+        case NSURLErrorCannotFindHost:
+        case NSURLErrorCannotConnectToHost:
+        case NSURLErrorNetworkConnectionLost:
+        case NSURLErrorDNSLookupFailed:
+        case NSURLErrorNotConnectedToInternet:
+        case NSURLErrorSecureConnectionFailed:
+            return YES;
+        default:
+            return NO;
+    }
+}
+
 @interface ApolloSubredditInfoCache ()
 @property(nonatomic, strong) NSCache<NSString *, ApolloSubredditInfo *> *infoCache;
 @property(nonatomic, strong) NSMutableDictionary<NSString *, ApolloSubredditInfo *> *diskInfo;
 @property(nonatomic, strong) NSMutableDictionary<NSString *, NSMutableArray<void (^)(ApolloSubredditInfo *)> *> *infoCompletions;
+// Negative cache for permanent misses (touched only on `queue`).
+@property(nonatomic, strong) NSMutableDictionary<NSString *, NSDate *> *notFoundDates;
+// Keys with a non-forced request in flight when a forced one arrived: the
+// in-flight response may be HTTP-cache-stale, so one forced fetch reruns after
+// it finishes instead of being silently swallowed by the coalescer.
+@property(nonatomic, strong) NSMutableSet<NSString *> *pendingForcedKeys;
 @property(nonatomic, strong) NSURLSession *session;
 @property(nonatomic) dispatch_queue_t queue;
+- (void)startFetchForKey:(NSString *)key cached:(ApolloSubredditInfo *)cached forced:(BOOL)forced attempt:(NSInteger)attempt;
 @end
 
 @implementation ApolloSubredditInfoCache
@@ -84,6 +120,8 @@ NSString *ApolloSubredditFormattedMemberCount(NSInteger subscriberCount) {
         _infoCache.countLimit = ApolloSubredditInfoDiskCacheMaxEntries;
         _diskInfo = [NSMutableDictionary dictionary];
         _infoCompletions = [NSMutableDictionary dictionary];
+        _notFoundDates = [NSMutableDictionary dictionary];
+        _pendingForcedKeys = [NSMutableSet set];
 
         NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
         configuration.requestCachePolicy = NSURLRequestReturnCacheDataElseLoad;
@@ -307,6 +345,10 @@ NSString *ApolloSubredditFormattedMemberCount(NSInteger subscriberCount) {
 - (ApolloSubredditInfo *)infoFromResponseData:(NSData *)data fallbackSubredditName:(NSString *)fallbackSubredditName {
     if (!data.length) return nil;
     id json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    // Root must be a dictionary before keyed subscripting — an array root
+    // (error payloads do this) would raise unrecognized-selector. Same guard
+    // the profile cache carries.
+    if (![json isKindOfClass:[NSDictionary class]]) return nil;
     NSDictionary *dataDict = [json[@"data"] isKindOfClass:[NSDictionary class]] ? json[@"data"] : nil;
     if (!dataDict) return nil;
 
@@ -374,17 +416,33 @@ NSString *ApolloSubredditFormattedMemberCount(NSInteger subscriberCount) {
 
 - (void)finishRequestForKey:(NSString *)key info:(ApolloSubredditInfo *)info {
     dispatch_async(self.queue, ^{
+        // `info == diskInfo[key]` means the fetch failed and fell back to the
+        // entry we already had — re-persisting and re-broadcasting it would
+        // fire a disk write + full controller-tree reinstall per failed
+        // refetch (a storm on flaky networks) for data nothing changed.
+        BOOL unchanged = (info != nil && info == self.diskInfo[key]);
         if (info) {
-            self.diskInfo[key] = info;
             [self.infoCache setObject:info forKey:key];
-            [self saveDiskCacheLocked];
+            if (!unchanged) {
+                self.diskInfo[key] = info;
+                [self saveDiskCacheLocked];
+            }
         }
 
         NSArray<void (^)(ApolloSubredditInfo *)> *callbacks = [self.infoCompletions[key] copy];
         [self.infoCompletions removeObjectForKey:key];
 
+        // A forced request that arrived while a non-forced fetch was already
+        // in flight reruns now with the HTTP cache bypassed.
+        BOOL rerunForced = [self.pendingForcedKeys containsObject:key];
+        [self.pendingForcedKeys removeObject:key];
+        if (rerunForced) {
+            self.infoCompletions[key] = [NSMutableArray array];
+            [self startFetchForKey:key cached:(info ?: self.diskInfo[key]) forced:YES attempt:0];
+        }
+
         dispatch_async(dispatch_get_main_queue(), ^{
-            if (info) {
+            if (info && !unchanged) {
                 [[NSNotificationCenter defaultCenter] postNotificationName:ApolloSubredditInfoUpdatedNotification
                                                                     object:self
                                                                   userInfo:@{ApolloSubredditNameKey: key}];
@@ -394,6 +452,70 @@ NSString *ApolloSubredditFormattedMemberCount(NSInteger subscriberCount) {
             }
         });
     });
+}
+
+// Runs on `queue`. Owns status-code inspection, transient-failure backoff and
+// the permanent-miss negative cache (all ported from ApolloUserProfileCache).
+- (void)startFetchForKey:(NSString *)key cached:(ApolloSubredditInfo *)cached forced:(BOOL)forced attempt:(NSInteger)attempt {
+    NSMutableURLRequest *request = [[self requestForSubreddit:key] mutableCopy];
+    if (forced) {
+        // The session policy is ReturnCacheDataElseLoad; without this a
+        // "refetch" (post-Join subscriber sync, pull-to-refresh) happily
+        // serves days-old HTTP-cached about.json.
+        request.cachePolicy = NSURLRequestReloadIgnoringLocalAndRemoteCacheData;
+    }
+
+    __weak typeof(self) weakSelf = self;
+    void (^retryOrGiveUp)(NSString *) = ^(NSString *reason) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        if (attempt + 1 < ApolloSubredditInfoMaxFetchAttempts) {
+            NSTimeInterval backoff = ApolloSubredditInfoRetryBackoffForAttempt(attempt);
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(backoff * NSEC_PER_SEC)), strongSelf.queue, ^{
+                [strongSelf startFetchForKey:key cached:cached forced:forced attempt:attempt + 1];
+            });
+        } else {
+            ApolloLog(@"[SubredditHeaders] Info fetch r/%@ %@ — gave up after %ld attempts",
+                      key, reason, (long)ApolloSubredditInfoMaxFetchAttempts);
+            [strongSelf finishRequestForKey:key info:cached];
+        }
+    };
+
+    NSURLSessionDataTask *task = [self.session dataTaskWithRequest:request
+                                                 completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        if (error) {
+            if (ApolloSubredditInfoErrorIsTransient(error)) {
+                retryOrGiveUp([NSString stringWithFormat:@"network error (%@)", error.localizedDescription]);
+                return;
+            }
+            [strongSelf finishRequestForKey:key info:cached];
+            return;
+        }
+
+        NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
+        NSInteger statusCode = http ? http.statusCode : 200;
+        if (statusCode == 429 || statusCode >= 500) {
+            retryOrGiveUp([NSString stringWithFormat:@"HTTP %ld", (long)statusCode]);
+            return;
+        }
+        if (statusCode < 200 || statusCode >= 300) {
+            // Permanent (403 private/quarantined, 404 banned/deleted): stop
+            // refetching on every visit for a while.
+            ApolloLog(@"[SubredditHeaders] Info fetch r/%@ returned HTTP %ld", key, (long)statusCode);
+            dispatch_async(strongSelf.queue, ^{ strongSelf.notFoundDates[key] = [NSDate date]; });
+            [strongSelf finishRequestForKey:key info:cached];
+            return;
+        }
+
+        ApolloSubredditInfo *info = [strongSelf infoFromResponseData:data fallbackSubredditName:key];
+        if (!info) {
+            dispatch_async(strongSelf.queue, ^{ strongSelf.notFoundDates[key] = [NSDate date]; });
+        }
+        [strongSelf finishRequestForKey:key info:(info ?: cached)];
+    }];
+    [task resume];
 }
 
 - (void)enqueueRequestForSubreddit:(NSString *)subredditName forceRefresh:(BOOL)forceRefresh completion:(void (^)(ApolloSubredditInfo *info))completion {
@@ -410,21 +532,29 @@ NSString *ApolloSubredditFormattedMemberCount(NSInteger subscriberCount) {
     }
 
     dispatch_async(self.queue, ^{
+        // Negative cache: a recently-confirmed private/banned/deleted
+        // subreddit doesn't get refetched on every visit. A forced refresh
+        // punches through (and clears the entry so the retry is honest).
+        NSDate *notFoundAt = self.notFoundDates[key];
+        if (notFoundAt) {
+            if (!forceRefresh && -[notFoundAt timeIntervalSinceNow] < ApolloSubredditInfoNotFoundTTL) {
+                if (completion) dispatch_async(dispatch_get_main_queue(), ^{ completion(cached); });
+                return;
+            }
+            [self.notFoundDates removeObjectForKey:key];
+        }
+
         BOOL hadRequest = (self.infoCompletions[key] != nil);
         if (!self.infoCompletions[key]) self.infoCompletions[key] = [NSMutableArray array];
         if (completion) [self.infoCompletions[key] addObject:[completion copy]];
-        if (hadRequest) return;
+        if (hadRequest) {
+            // Don't silently swallow a forced refresh in the coalescer — the
+            // in-flight non-forced request may serve HTTP-cache-stale data.
+            if (forceRefresh) [self.pendingForcedKeys addObject:key];
+            return;
+        }
 
-        NSURLSessionDataTask *task = [self.session dataTaskWithRequest:[self requestForSubreddit:key]
-                                                     completionHandler:^(NSData *data, __unused NSURLResponse *response, NSError *error) {
-            ApolloSubredditInfo *info = nil;
-            if (!error) info = [self infoFromResponseData:data fallbackSubredditName:key];
-            if (!info && cached) {
-                info = cached;
-            }
-            [self finishRequestForKey:key info:info];
-        }];
-        [task resume];
+        [self startFetchForKey:key cached:cached forced:forceRefresh attempt:0];
     });
 }
 
@@ -452,6 +582,7 @@ NSString *ApolloSubredditFormattedMemberCount(NSInteger subscriberCount) {
     dispatch_async(self.queue, ^{
         [self.infoCache removeAllObjects];
         [self.diskInfo removeAllObjects];
+        [self.notFoundDates removeAllObjects];
         [[NSFileManager defaultManager] removeItemAtPath:[self cachePath] error:nil];
     });
 }

--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -1628,8 +1628,12 @@ static volatile BOOL sApolloAvatarInterfaceIsDark = NO;
 
 static void ApolloAvatarRefreshInterfaceStyle(void) {
     if (![NSThread isMainThread]) return;
-    sApolloAvatarInterfaceIsDark =
-        UIScreen.mainScreen.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark;
+    // Apollo themes can override each window independently of the system
+    // appearance, so UIScreen alone picks the wrong placeholder fill when a
+    // dark Apollo theme is active on a light system (or vice versa).
+    UITraitCollection *traits = ApolloAllWindows().firstObject.traitCollection
+        ?: UIScreen.mainScreen.traitCollection;
+    sApolloAvatarInterfaceIsDark = traits.userInterfaceStyle == UIUserInterfaceStyleDark;
 }
 
 static CGFloat ApolloAvatarScreenScale(void) {
@@ -4477,6 +4481,10 @@ static void ApolloInlineAvatarReapplyAfterModelUpdate(NSString *fullName) {
     ApolloAvatarRefreshInterfaceStyle();
     (void)ApolloAvatarScreenScale();
     (void)ApolloAvatarPlaceholderFillColor();
+    // -init warms ApolloBannerMaxPixelDimension's UIScreen access. Pin the
+    // singleton's first construction to main before Texture background layout
+    // can reach sharedCache through a setAttributedText: hook.
+    (void)[ApolloUserProfileCache sharedCache];
     [[NSNotificationCenter defaultCenter] addObserverForName:@"com.christianselig.ModelObjectUpdated"
                                                       object:nil
                                                        queue:nil

--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -1619,6 +1619,41 @@ static UIBezierPath *ApolloHexagonPath(CGRect rect) {
     return path;
 }
 
+// The avatar renderers below run on Texture layout/background queues (reached
+// from the setAttributedText: hooks), where UIScreen access and ambient
+// dynamic-color resolution are off-limits. Scale is read once; the placeholder
+// fill is pre-resolved for both styles and picked by a flag the main-thread
+// entry points keep fresh. Both are warmed from %ctor on the main thread.
+static volatile BOOL sApolloAvatarInterfaceIsDark = NO;
+
+static void ApolloAvatarRefreshInterfaceStyle(void) {
+    if (![NSThread isMainThread]) return;
+    sApolloAvatarInterfaceIsDark =
+        UIScreen.mainScreen.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark;
+}
+
+static CGFloat ApolloAvatarScreenScale(void) {
+    static CGFloat scale = 0.0;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        scale = UIScreen.mainScreen.scale;
+    });
+    return scale > 0.0 ? scale : 2.0;
+}
+
+static UIColor *ApolloAvatarPlaceholderFillColor(void) {
+    static UIColor *lightFill = nil;
+    static UIColor *darkFill = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        lightFill = [UIColor.secondarySystemFillColor resolvedColorWithTraitCollection:
+                     [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight]];
+        darkFill = [UIColor.secondarySystemFillColor resolvedColorWithTraitCollection:
+                    [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark]];
+    });
+    return sApolloAvatarInterfaceIsDark ? darkFill : lightFill;
+}
+
 static void ApolloDrawAvatarSourceImage(UIImage *sourceImage, CGRect rect) {
     if (sourceImage) {
         CGFloat imageAspect = sourceImage.size.width > 0 ? sourceImage.size.height / sourceImage.size.width : 1.0;
@@ -1634,7 +1669,7 @@ static void ApolloDrawAvatarSourceImage(UIImage *sourceImage, CGRect rect) {
         CGRect drawRect = CGRectMake(CGRectGetMidX(rect) - drawWidth / 2.0, CGRectGetMidY(rect) - drawHeight / 2.0, drawWidth, drawHeight);
         [sourceImage drawInRect:drawRect];
     } else {
-        [[UIColor secondarySystemFillColor] setFill];
+        [ApolloAvatarPlaceholderFillColor() setFill];
         UIRectFill(rect);
     }
 }
@@ -1646,7 +1681,7 @@ static BOOL ApolloAvatarHasFrame(ApolloUserProfileInfo *info) {
 static UIImage *ApolloClippedAvatarImage(UIImage *sourceImage, CGFloat diameter, BOOL hexagon) {
     CGSize size = CGSizeMake(diameter, diameter);
     UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
-    format.scale = [UIScreen mainScreen].scale;
+    format.scale = ApolloAvatarScreenScale();
     UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size format:format];
     return [renderer imageWithActions:^(UIGraphicsImageRendererContext *context) {
         CGRect rect = CGRectMake(0.0, 0.0, diameter, diameter);
@@ -1667,7 +1702,7 @@ static UIImage *ApolloClippedAvatarImage(UIImage *sourceImage, CGFloat diameter,
             CGRect drawRect = CGRectMake((diameter - drawWidth) / 2.0, (diameter - drawHeight) / 2.0, drawWidth, drawHeight);
             [sourceImage drawInRect:drawRect];
         } else {
-            [[UIColor secondarySystemFillColor] setFill];
+            [ApolloAvatarPlaceholderFillColor() setFill];
             UIRectFill(rect);
         }
     }];
@@ -1686,7 +1721,7 @@ static UIImage *ApolloAvatarImageForInfo(ApolloUserProfileInfo *info, UIImage *s
 
     CGSize size = CGSizeMake(diameter, diameter);
     UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
-    format.scale = [UIScreen mainScreen].scale;
+    format.scale = ApolloAvatarScreenScale();
     UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size format:format];
     return [renderer imageWithActions:^(UIGraphicsImageRendererContext *context) {
         CGRect rect = CGRectMake(0.0, 0.0, diameter, diameter);
@@ -1702,18 +1737,47 @@ static UIImage *ApolloAvatarImageForInfo(ApolloUserProfileInfo *info, UIImage *s
     }];
 }
 
+// Word-boundary username search: "bob" must not match inside "bobby". A
+// candidate hit only counts when the characters on both sides are outside the
+// legal Reddit username alphabet (letters/digits/underscore/hyphen) — bare
+// rangeOfString matching is how a substring-named author used to steal a
+// longer-named author's byline (wrong avatar, stacked avatars).
+static NSRange ApolloUsernameWordRangeInString(NSString *string, NSString *needle) {
+    NSRange notFound = NSMakeRange(NSNotFound, 0);
+    if (string.length == 0 || needle.length == 0) return notFound;
+    static NSCharacterSet *usernameChars = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        usernameChars = [NSCharacterSet characterSetWithCharactersInString:
+            @"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"];
+    });
+    NSRange searchRange = NSMakeRange(0, string.length);
+    while (searchRange.length >= needle.length) {
+        NSRange found = [string rangeOfString:needle options:NSCaseInsensitiveSearch range:searchRange];
+        if (found.location == NSNotFound) return notFound;
+        BOOL leftBoundary = found.location == 0 ||
+            ![usernameChars characterIsMember:[string characterAtIndex:found.location - 1]];
+        NSUInteger end = NSMaxRange(found);
+        BOOL rightBoundary = end >= string.length ||
+            ![usernameChars characterIsMember:[string characterAtIndex:end]];
+        if (leftBoundary && rightBoundary) return found;
+        NSUInteger next = found.location + 1;
+        searchRange = NSMakeRange(next, string.length - next);
+    }
+    return notFound;
+}
+
 static NSRange ApolloUsernameRangeInString(NSString *string, NSString *username) {
     NSRange notFound = NSMakeRange(NSNotFound, 0);
     NSString *normalized = ApolloAvatarNormalizedUsername(username);
     if (string.length == 0 || normalized.length == 0) return notFound;
 
     NSString *prefixed = [@"u/" stringByAppendingString:normalized];
-    NSRange withPrefix = [string rangeOfString:prefixed options:NSCaseInsensitiveSearch];
+    NSRange withPrefix = ApolloUsernameWordRangeInString(string, prefixed);
     if (withPrefix.location != NSNotFound) {
         return NSMakeRange(withPrefix.location + 2, withPrefix.length - 2);
     }
-    NSRange direct = [string rangeOfString:normalized options:NSCaseInsensitiveSearch];
-    return direct;
+    return ApolloUsernameWordRangeInString(string, normalized);
 }
 
 static NSAttributedString *ApolloAttributedTextByPrependingAvatar(NSAttributedString *baseText, NSString *username, UIImage *avatarImage, UIImage *decoratorImage, ApolloUserProfileInfo *info, CGFloat diameter) {
@@ -1774,7 +1838,7 @@ static BOOL ApolloTextLooksAvatarPrepended(NSAttributedString *text) {
 static BOOL ApolloAttributedTextContainsUsername(NSAttributedString *text, NSString *username) {
     username = ApolloAvatarNormalizedUsername(username);
     if (text.string.length == 0 || username.length == 0) return NO;
-    return [text.string rangeOfString:username options:NSCaseInsensitiveSearch].location != NSNotFound;
+    return ApolloUsernameWordRangeInString(text.string, username).location != NSNotFound;
 }
 
 static CGFloat ApolloInlineAvatarDiameterForObject(id object) {
@@ -1840,10 +1904,12 @@ static BOOL ApolloSetAvatarImageOnTextNode(id textNode, NSString *username, UIIm
     NSAttributedString *baseText = objc_getAssociatedObject(textNode, kApolloAvatarOriginalAttributedTextKey);
 
     if (![storedUsername isEqualToString:username]) {
+        // The node still shows a previous author's avatar-prepended text (its
+        // clean rebind hasn't landed yet). Prepending onto it would stack a
+        // second avatar with no upper bound — bail and let the rebind hook /
+        // retry ladder apply once fresh text arrives.
+        if (ApolloTextLooksAvatarPrepended(current)) return NO;
         baseText = current;
-        if (ApolloTextLooksAvatarPrepended(baseText)) {
-            baseText = nil;
-        }
     }
     if (!baseText) baseText = current;
     if (!ApolloAttributedTextContainsUsername(baseText, username)) return NO;
@@ -1875,7 +1941,7 @@ static BOOL ApolloTextNodeContainsUsername(id textNode, NSString *username) {
     if (!textNode || username.length == 0) return NO;
     NSAttributedString *text = ApolloAttributedTextForNode(textNode);
     if (text.string.length == 0) return NO;
-    return [text.string.lowercaseString containsString:username.lowercaseString];
+    return ApolloUsernameWordRangeInString(text.string, username).location != NSNotFound;
 }
 
 static id ApolloCurrentAuthorTextNodeForCell(id cell, NSString *username) {
@@ -1899,10 +1965,40 @@ static void ApolloRequestDecoratorRefreshIfNeeded(ApolloUserProfileCache *cache,
     [cache requestImageForURL:info.decoratorURL completion:nil];
 }
 
-static NSMutableArray<void (^)(void)> *ApolloInlineAvatarInfoRequestQueue(void) {
-    static NSMutableArray<void (^)(void)> *queue = nil;
+// Backlog cap for queued inline-avatar info requests. Entries past the cap
+// are the ones farthest off-screen; they get dropped (and their cells'
+// pending-fetch flag cleared) rather than kept forever.
+static const NSUInteger ApolloInlineAvatarMaxQueuedInfoRequests = 48;
+
+static void ApolloDrainInlineAvatarInfoRequestQueue(void);
+static void ApolloClearPendingInlineAvatarFetch(id cell, NSString *username);
+static BOOL ApolloInlineAvatarCellUsernameMatches(id cell, NSString *username);
+static BOOL ApolloBindInlineAvatarTextNodeForCell(id cell, NSString *username);
+static void ApolloApplyInlineAvatarInfoToCell(id cell, NSString *username, ApolloUserProfileInfo *info);
+
+// One queued inline-avatar info request. Entries carry the cell weakly plus
+// the username so the drain can skip dead cells and dedupe in-flight
+// usernames without executing anything.
+@interface ApolloInlineAvatarQueueEntry : NSObject
+@property(nonatomic, weak) id cell;
+@property(nonatomic, copy) NSString *username;
+@end
+@implementation ApolloInlineAvatarQueueEntry
+@end
+
+static NSMutableArray<ApolloInlineAvatarQueueEntry *> *ApolloInlineAvatarInfoRequestQueue(void) {
+    static NSMutableArray<ApolloInlineAvatarQueueEntry *> *queue = nil;
     if (!queue) queue = [NSMutableArray array];
     return queue;
+}
+
+// Usernames whose info fetch currently occupies a request slot. A second cell
+// for the same author piggybacks on the cache-level coalescing instead of
+// consuming another slot (twenty comments by one author used to fill all ten).
+static NSMutableSet<NSString *> *ApolloInlineAvatarInFlightUsernames(void) {
+    static NSMutableSet<NSString *> *usernames = nil;
+    if (!usernames) usernames = [NSMutableSet set];
+    return usernames;
 }
 
 static NSUInteger sApolloInlineAvatarActiveInfoRequests = 0;
@@ -1936,8 +2032,12 @@ static BOOL ApolloPrepareAvatarRewriteForTextNode(id textNode, NSAttributedStrin
     }
 
     if (!ApolloAttributedTextContainsUsername(incomingAttributedText, username)) {
-        NSString *trimmed = [incomingAttributedText.string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-        if (trimmed.length > 0) ApolloClearAvatarTextNodeAssociations(textNode);
+        // Clear on ANY non-matching text, including whitespace-only: Texture's
+        // standard clear-then-rebind used to keep the old author's association
+        // alive through the whitespace pass, so the next author was compared
+        // against the previous name — a "bob" association could then claim
+        // "bobby"'s byline and paint the wrong avatar.
+        ApolloClearAvatarTextNodeAssociations(textNode);
         return NO;
     }
 
@@ -1981,24 +2081,82 @@ static NSTimeInterval ApolloInlineAvatarBindDelayForAttempt(NSUInteger attempt) 
     }
 }
 
-static void ApolloDrainInlineAvatarInfoRequestQueue(void) {
-    NSMutableArray<void (^)(void)> *queue = ApolloInlineAvatarInfoRequestQueue();
-    while (sApolloInlineAvatarActiveInfoRequests < ApolloInlineAvatarMaxActiveInfoRequests && queue.count > 0) {
-        void (^requestBlock)(void) = [queue.firstObject copy];
-        [queue removeObjectAtIndex:0];
-        sApolloInlineAvatarActiveInfoRequests++;
-        requestBlock();
-    }
-}
-
-static void ApolloEnqueueInlineAvatarInfoRequest(void (^requestBlock)(void)) {
-    if (!requestBlock) return;
-    [ApolloInlineAvatarInfoRequestQueue() addObject:[requestBlock copy]];
+static void ApolloInlineAvatarInfoRequestDidFinish(void) {
+    if (sApolloInlineAvatarActiveInfoRequests > 0) sApolloInlineAvatarActiveInfoRequests--;
     ApolloDrainInlineAvatarInfoRequestQueue();
 }
 
-static void ApolloInlineAvatarInfoRequestDidFinish(void) {
-    if (sApolloInlineAvatarActiveInfoRequests > 0) sApolloInlineAvatarActiveInfoRequests--;
+// Validate the cell/username pairing and start (or piggyback on) the cache
+// fetch. Slot accounting lives here: a request only occupies a slot when it
+// actually starts a fresh fetch for a username with no fetch in flight.
+static void ApolloInlineAvatarStartInfoRequest(id cell, NSString *username, BOOL piggyback) {
+    if (!cell) return;
+    if (!sShowUserAvatars || !ApolloInlineAvatarCellUsernameMatches(cell, username) ||
+        !ApolloBindInlineAvatarTextNodeForCell(cell, username)) {
+        ApolloClearPendingInlineAvatarFetch(cell, username);
+        return;
+    }
+
+    NSMutableSet<NSString *> *inFlight = ApolloInlineAvatarInFlightUsernames();
+    if (!piggyback) {
+        sApolloInlineAvatarActiveInfoRequests++;
+        [inFlight addObject:username];
+    }
+    __block BOOL releasedSlot = piggyback;
+    void (^releaseSlot)(void) = ^{
+        if (releasedSlot) return;
+        releasedSlot = YES;
+        [inFlight removeObject:username];
+        ApolloInlineAvatarInfoRequestDidFinish();
+    };
+
+    __weak id weakCell = cell;
+    ApolloUserProfileCache *cache = [ApolloUserProfileCache sharedCache];
+    [cache requestInfoForUsername:username completion:^(ApolloUserProfileInfo *info) {
+        releaseSlot();
+        id cellNow = weakCell;
+        if (!cellNow) return;
+        ApolloClearPendingInlineAvatarFetch(cellNow, username);
+        if (!sShowUserAvatars || !info.iconURL) return;
+        ApolloApplyInlineAvatarInfoToCell(cellNow, username, info);
+    }];
+}
+
+static void ApolloDrainInlineAvatarInfoRequestQueue(void) {
+    NSMutableArray<ApolloInlineAvatarQueueEntry *> *queue = ApolloInlineAvatarInfoRequestQueue();
+    NSMutableSet<NSString *> *inFlight = ApolloInlineAvatarInFlightUsernames();
+    while (sApolloInlineAvatarActiveInfoRequests < ApolloInlineAvatarMaxActiveInfoRequests && queue.count > 0) {
+        // LIFO: during a fling the newest entries belong to the cells that are
+        // actually on screen — FIFO served the oldest (long since scrolled
+        // away) first and starved the visible ones.
+        ApolloInlineAvatarQueueEntry *entry = queue.lastObject;
+        [queue removeLastObject];
+        id cell = entry.cell;
+        if (!cell) continue; // dead cell: drop without consuming a slot
+        BOOL piggyback = [inFlight containsObject:entry.username];
+        ApolloInlineAvatarStartInfoRequest(cell, entry.username, piggyback);
+    }
+}
+
+static void ApolloEnqueueInlineAvatarInfoRequest(id cell, NSString *username) {
+    if (!cell || username.length == 0) return;
+    NSMutableArray<ApolloInlineAvatarQueueEntry *> *queue = ApolloInlineAvatarInfoRequestQueue();
+    // Prune dead-weak-cell entries eagerly so they never occupy queue space.
+    for (NSInteger index = (NSInteger)queue.count - 1; index >= 0; index--) {
+        if (!queue[(NSUInteger)index].cell) [queue removeObjectAtIndex:(NSUInteger)index];
+    }
+    ApolloInlineAvatarQueueEntry *entry = [[ApolloInlineAvatarQueueEntry alloc] init];
+    entry.cell = cell;
+    entry.username = username;
+    [queue addObject:entry];
+    // Bounded backlog: drop the oldest (farthest off-screen) entries, clearing
+    // their pending-fetch flag so scrolling back re-requests them.
+    while (queue.count > ApolloInlineAvatarMaxQueuedInfoRequests) {
+        ApolloInlineAvatarQueueEntry *dropped = queue.firstObject;
+        [queue removeObjectAtIndex:0];
+        id droppedCell = dropped.cell;
+        if (droppedCell) ApolloClearPendingInlineAvatarFetch(droppedCell, dropped.username);
+    }
     ApolloDrainInlineAvatarInfoRequestQueue();
 }
 
@@ -2074,7 +2232,13 @@ static void ApolloScheduleInlineAvatarLateReapplyForCell(id cell, NSString *user
             if (cachedInfo.iconURL && cachedImage) {
                 id previousTextNode = objc_getAssociatedObject(strongCell, kApolloAvatarTextNodeKey);
                 BOOL hadAvatar = ApolloTextLooksAvatarPrepended(ApolloAttributedTextForNode(previousTextNode));
-                objc_setAssociatedObject(strongCell, kApolloAvatarTextNodeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                // Keep the existing binding: nil-ing it here forced a fresh
+                // fuzzy re-scan on a byline that now contains the avatar
+                // attachment (+2 chars), which worsens the real byline's score
+                // enough that body text / flair containing the username could
+                // win — migrating or duplicating the avatar. The bind helper
+                // already re-validates the stored node and only rescans when
+                // it's genuinely gone from the cell's tree.
                 ApolloApplyInlineAvatarInfoToCell(strongCell, username, cachedInfo);
                 id currentTextNode = objc_getAssociatedObject(strongCell, kApolloAvatarTextNodeKey);
                 BOOL hasAvatar = ApolloTextLooksAvatarPrepended(ApolloAttributedTextForNode(currentTextNode));
@@ -2169,39 +2333,7 @@ static void ApolloScheduleInlineAvatarInfoFetchAttempt(id cell, NSString *userna
         if (ApolloInlineAvatarShouldLog(&sApolloInlineAvatarQueuedLogCount)) {
             ApolloLog(@"[UserAvatars] Inline avatar queued metadata fetch u/%@ cell=%p", username, strongCell);
         }
-        ApolloEnqueueInlineAvatarInfoRequest(^{
-            id requestCell = weakCell;
-            if (!requestCell) {
-                ApolloInlineAvatarInfoRequestDidFinish();
-                return;
-            }
-            if (!sShowUserAvatars) {
-                ApolloClearPendingInlineAvatarFetch(requestCell, username);
-                ApolloInlineAvatarInfoRequestDidFinish();
-                return;
-            }
-            if (!ApolloInlineAvatarCellUsernameMatches(requestCell, username) || !ApolloBindInlineAvatarTextNodeForCell(requestCell, username)) {
-                ApolloClearPendingInlineAvatarFetch(requestCell, username);
-                ApolloInlineAvatarInfoRequestDidFinish();
-                return;
-            }
-
-            __block BOOL releasedSlot = NO;
-            void (^releaseSlot)(void) = ^{
-                if (releasedSlot) return;
-                releasedSlot = YES;
-                ApolloInlineAvatarInfoRequestDidFinish();
-            };
-
-            [cache requestInfoForUsername:username completion:^(ApolloUserProfileInfo *info) {
-                releaseSlot();
-                id cellNow = weakCell;
-                if (!cellNow) return;
-                ApolloClearPendingInlineAvatarFetch(cellNow, username);
-                if (!sShowUserAvatars || !info.iconURL) return;
-                ApolloApplyInlineAvatarInfoToCell(cellNow, username, info);
-            }];
-        });
+        ApolloEnqueueInlineAvatarInfoRequest(strongCell, username);
     });
 }
 
@@ -2216,6 +2348,9 @@ static void ApolloScheduleInlineAvatarInfoFetchForCell(id cell, NSString *userna
 }
 
 static void ApolloApplyAvatarToCellWithDiameter(id cell, NSString *username, CGFloat diameter) {
+    // Cheap main-thread hook to keep the pre-resolved placeholder fill's
+    // light/dark pick current for the off-main renderers.
+    ApolloAvatarRefreshInterfaceStyle();
     username = ApolloAvatarNormalizedUsername(username);
     if (!cell || username.length == 0) {
         ApolloRestoreAvatarForCell(cell);
@@ -2500,14 +2635,16 @@ static void ApolloProfileLoadImages(ApolloProfileHeaderView *header, NSString *u
             header.bannerImageView.image = nil;
             ApolloProfileSyncAmbient(header);
         } else if (info.bannerURL) {
-            UIImage *banner = [cache cachedImageForURL:info.bannerURL];
+            // Banner-sized path: decoded at display scale into its own small
+            // cache so profile banners can't evict the avatar cache.
+            UIImage *banner = [cache cachedBannerImageForURL:info.bannerURL];
             if (banner) {
                 ApolloImmersiveSetBannerCacheKey(banner, info.bannerURL.absoluteString);
                 header.bannerImageView.image = banner;
                 ApolloProfileSyncAmbient(header);
             } else {
                 NSURL *bannerURL = info.bannerURL;
-                [cache requestImageForURL:bannerURL completion:^(UIImage *loadedImage) {
+                [cache requestBannerImageForURL:bannerURL completion:^(UIImage *loadedImage) {
                     if (!loadedImage) return;
                     if (!ApolloAvatarUsernameMatches(header.username, targetUsername)) return;
                     if (!ApolloProfileURLsMatch(header.currentBannerURL, bannerURL)) return;
@@ -4335,6 +4472,11 @@ static void ApolloInlineAvatarReapplyAfterModelUpdate(NSString *fullName) {
 
 %ctor {
     %init;
+    // Warm the off-main-safe render statics while we're guaranteed to be on
+    // the main thread (see ApolloAvatarScreenScale / PlaceholderFillColor).
+    ApolloAvatarRefreshInterfaceStyle();
+    (void)ApolloAvatarScreenScale();
+    (void)ApolloAvatarPlaceholderFillColor();
     [[NSNotificationCenter defaultCenter] addObserverForName:@"com.christianselig.ModelObjectUpdated"
                                                       object:nil
                                                        queue:nil

--- a/src/ApolloUserProfileCache.h
+++ b/src/ApolloUserProfileCache.h
@@ -65,6 +65,14 @@ extern NSString * const ApolloUserProfileUsernameKey;
 - (UIImage *)cachedImageForURL:(NSURL *)url;
 - (void)requestImageForURL:(NSURL *)url completion:(void (^)(UIImage *image))completion;
 
+// Banner-sized artwork (profile/subreddit banners). Decoded at ~display
+// resolution into a separate small cache: a native-size banner decode can run
+// ~19MB for a 4000px source, and two of those used to evict essentially every
+// avatar from the shared image cache. Disk-cached as the downscaled re-encode,
+// so >2MB sources still persist (the avatar path skips anything that large).
+- (UIImage *)cachedBannerImageForURL:(NSURL *)url;
+- (void)requestBannerImageForURL:(NSURL *)url completion:(void (^)(UIImage *image))completion;
+
 - (void)clearAllCaches;
 
 - (BOOL)cachedIsSuspendedForUsername:(NSString *)username;

--- a/src/ApolloUserProfileCache.m
+++ b/src/ApolloUserProfileCache.m
@@ -1095,6 +1095,25 @@ static UIImage *ApolloDownscaledBannerImage(UIImage *image) {
     return result ?: image;
 }
 
+static BOOL ApolloImageHasAlphaChannel(UIImage *image) {
+    CGImageRef imageRef = image.CGImage;
+    if (!imageRef) return NO;
+
+    switch (CGImageGetAlphaInfo(imageRef)) {
+        case kCGImageAlphaPremultipliedLast:
+        case kCGImageAlphaPremultipliedFirst:
+        case kCGImageAlphaLast:
+        case kCGImageAlphaFirst:
+        case kCGImageAlphaOnly:
+            return YES;
+        case kCGImageAlphaNone:
+        case kCGImageAlphaNoneSkipLast:
+        case kCGImageAlphaNoneSkipFirst:
+            return NO;
+    }
+    return NO;
+}
+
 - (NSString *)bannerKeyForURL:(NSURL *)url {
     return [@"banner:" stringByAppendingString:url.absoluteString ?: @""];
 }
@@ -1175,9 +1194,12 @@ static UIImage *ApolloDownscaledBannerImage(UIImage *image) {
 
             NSURLSessionDataTask *task = [self.imageSession dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                 UIImage *image = nil;
+                BOOL sourceHasAlpha = NO;
                 if (!error && data.length > 0) {
                     @autoreleasepool {
-                        image = ApolloDownscaledBannerImage([UIImage imageWithData:data]);
+                        UIImage *sourceImage = [UIImage imageWithData:data];
+                        sourceHasAlpha = ApolloImageHasAlphaChannel(sourceImage);
+                        image = ApolloDownscaledBannerImage(sourceImage);
                     }
                 }
                 if (!image && error) {
@@ -1192,7 +1214,12 @@ static UIImage *ApolloDownscaledBannerImage(UIImage *image) {
                         dispatch_async(self.queue, ^{ self.imageNotFoundDates[key] = [NSDate date]; });
                     }
                 } else {
-                    NSData *persistData = UIImageJPEGRepresentation(image, 0.85);
+                    // JPEG flattens transparency. Preserve alpha-bearing banner
+                    // sources as PNG so their cold-cache rendering matches the
+                    // in-memory result from the download that created the file.
+                    NSData *persistData = sourceHasAlpha
+                        ? UIImagePNGRepresentation(image)
+                        : UIImageJPEGRepresentation(image, 0.85);
                     if (persistData) {
                         dispatch_barrier_async(self.imageIOQueue, ^{ [self persistImageData:persistData forKey:key]; });
                     }

--- a/src/ApolloUserProfileCache.m
+++ b/src/ApolloUserProfileCache.m
@@ -14,6 +14,21 @@ static NSTimeInterval const ApolloUserProfileCacheTTL = 7.0 * 24.0 * 60.0 * 60.0
 static NSUInteger const ApolloUserProfileDiskCacheMaxEntries = 2000;
 static NSInteger const ApolloUserProfileCacheSchemaVersion = 2;
 
+// Longest pixel dimension worth keeping for banner art: the device's longest
+// screen side in pixels (covers rotation and the immersive backdrop's needs).
+// Warmed from -init on the main thread so off-queue callers never touch
+// UIScreen themselves.
+static CGFloat ApolloBannerMaxPixelDimension(void) {
+    static CGFloat dimension = 0.0;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        CGSize bounds = UIScreen.mainScreen.bounds.size;
+        CGFloat scale = UIScreen.mainScreen.scale > 0.0 ? UIScreen.mainScreen.scale : 2.0;
+        dimension = MAX(bounds.width, bounds.height) * scale;
+    });
+    return dimension;
+}
+
 static UIImage *ApolloDecodedAvatarImage(UIImage *image) {
     if (!image || image.images.count > 0 || image.size.width <= 0.0 || image.size.height <= 0.0) return image;
 
@@ -51,9 +66,21 @@ static UIImage *ApolloDecodedAvatarImage(UIImage *image) {
 
 @end
 
+// How long a permanently-failed image URL (404/403/undecodable body) is
+// negative-cached before another fetch may be attempted. Memory-only.
+static NSTimeInterval const ApolloUserProfileImageNotFoundTTL = 15.0 * 60.0;
+
 @interface ApolloUserProfileCache ()
 @property(nonatomic, strong) NSCache<NSString *, ApolloUserProfileInfo *> *infoCache;
 @property(nonatomic, strong) NSCache<NSString *, UIImage *> *imageCache;
+// Banner art lives in its own small cache (see the header note) so its bulk
+// can never evict avatars. Keys are "banner:"-prefixed URL strings, which also
+// keeps its in-flight coalescing distinct inside the shared imageCompletions.
+@property(nonatomic, strong) NSCache<NSString *, UIImage *> *bannerCache;
+// Image-URL negative cache (touched only on `queue`): info fetches have had a
+// not-found sentinel for a while, but failed image URLs used to refetch once
+// per cell per reapply, forever.
+@property(nonatomic, strong) NSMutableDictionary<NSString *, NSDate *> *imageNotFoundDates;
 @property(nonatomic, strong) NSMutableDictionary<NSString *, ApolloUserProfileInfo *> *diskInfo;
 // Immutable point-in-time view of diskInfo. Render/preload callers read this
 // without synchronously entering the serial persistence/network queue.
@@ -107,10 +134,16 @@ static UIImage *ApolloDecodedAvatarImage(UIImage *image) {
         _imageCache.countLimit = 800;
         _imageCache.totalCostLimit = 40 * 1024 * 1024;
 
+        _bannerCache = [[NSCache alloc] init];
+        _bannerCache.countLimit = 8;
+        _bannerCache.totalCostLimit = 32 * 1024 * 1024;
+        (void)ApolloBannerMaxPixelDimension(); // warm the UIScreen read on main
+
         _diskInfo = [NSMutableDictionary dictionary];
         _infoSnapshot = @{};
         _infoCompletions = [NSMutableDictionary dictionary];
         _imageCompletions = [NSMutableDictionary dictionary];
+        _imageNotFoundDates = [NSMutableDictionary dictionary];
         _batchRequestedFullNames = [NSMutableSet set];
 
         NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
@@ -613,6 +646,11 @@ static NSTimeInterval ApolloUserProfileRetryBackoffForAttempt(NSInteger attempt)
     ApolloUserProfileInfo *sentinel = [ApolloUserProfileInfo new];
     sentinel.fetchedAt = [NSDate date];
     sentinel.suspensionChecked = YES;
+    // [ApolloUserProfileInfo new] bypasses the designated init's -1 "unknown"
+    // karma defaults — without these, deleted users' stat cards render
+    // "0 Post Karma" instead of staying hidden.
+    sentinel.linkKarma = -1;
+    sentinel.commentKarma = -1;
     [self.infoCache setObject:sentinel forKey:key];
 }
 
@@ -959,6 +997,18 @@ static NSTimeInterval ApolloUserProfileRetryBackoffForAttempt(NSInteger attempt)
     }
 
     dispatch_async(self.queue, ^{
+        // Negative cache: a URL that recently failed permanently (deleted CDN
+        // asset, undecodable bytes) short-circuits instead of refiring a
+        // network fetch from every cell on every reapply.
+        NSDate *notFoundAt = self.imageNotFoundDates[key];
+        if (notFoundAt) {
+            if (-[notFoundAt timeIntervalSinceNow] < ApolloUserProfileImageNotFoundTTL) {
+                if (completion) dispatch_async(dispatch_get_main_queue(), ^{ completion(nil); });
+                return;
+            }
+            [self.imageNotFoundDates removeObjectForKey:key];
+        }
+
         NSMutableArray<void (^)(UIImage *)> *callbacks = self.imageCompletions[key];
         if (callbacks) {
             if (completion) [callbacks addObject:[completion copy]];
@@ -999,10 +1049,155 @@ static NSTimeInterval ApolloUserProfileRetryBackoffForAttempt(NSInteger attempt)
                 if (!image && error) {
                     ApolloLog(@"[UserAvatars] Failed to load image %@: %@", key, error.localizedDescription);
                 }
+                if (!image) {
+                    // Negative-cache only permanent failures — transient
+                    // network errors and 429/5xx must stay retryable.
+                    NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
+                    NSInteger statusCode = http ? http.statusCode : 0;
+                    BOOL transient = (error && ApolloUserProfileErrorIsTransient(error)) ||
+                        statusCode == 429 || statusCode >= 500;
+                    if (!transient) {
+                        dispatch_async(self.queue, ^{ self.imageNotFoundDates[key] = [NSDate date]; });
+                    }
+                }
                 if (persistData) {
                     dispatch_barrier_async(self.imageIOQueue, ^{ [self persistImageData:persistData forKey:key]; });
                 }
                 [self finishImageRequestForKey:key image:image];
+            }];
+            [task resume];
+        });
+    });
+}
+
+#pragma mark - Banner images
+
+// Downscale banner art to at most the device's longest screen side (in
+// pixels) while force-decoding it. Sources at or below that size just get the
+// normal decode.
+static UIImage *ApolloDownscaledBannerImage(UIImage *image) {
+    if (!image || image.size.width <= 0.0 || image.size.height <= 0.0) return image;
+    CGFloat maxDimension = ApolloBannerMaxPixelDimension();
+    CGFloat pixelWidth = image.size.width * image.scale;
+    CGFloat pixelHeight = image.size.height * image.scale;
+    CGFloat longest = MAX(pixelWidth, pixelHeight);
+    if (maxDimension <= 0.0 || longest <= maxDimension) return ApolloDecodedAvatarImage(image);
+
+    CGFloat ratio = maxDimension / longest;
+    CGSize target = CGSizeMake(MAX(1.0, floor(pixelWidth * ratio)), MAX(1.0, floor(pixelHeight * ratio)));
+    UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
+    format.scale = 1.0;
+    format.opaque = NO;
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:target format:format];
+    UIImage *result = [renderer imageWithActions:^(__unused UIGraphicsImageRendererContext *context) {
+        [image drawInRect:CGRectMake(0.0, 0.0, target.width, target.height)];
+    }];
+    return result ?: image;
+}
+
+- (NSString *)bannerKeyForURL:(NSURL *)url {
+    return [@"banner:" stringByAppendingString:url.absoluteString ?: @""];
+}
+
+- (UIImage *)cachedBannerImageForURL:(NSURL *)url {
+    if (![url isKindOfClass:[NSURL class]]) return nil;
+    return [self.bannerCache objectForKey:[self bannerKeyForURL:url]];
+}
+
+- (void)finishBannerImageRequestForKey:(NSString *)key image:(UIImage *)image {
+    dispatch_async(self.queue, ^{
+        if (image) {
+            NSUInteger cost = (NSUInteger)MAX(1.0, image.size.width * image.size.height * image.scale * image.scale * 4.0);
+            [self.bannerCache setObject:image forKey:key cost:cost];
+        }
+
+        NSArray<void (^)(UIImage *)> *callbacks = [self.imageCompletions[key] copy];
+        [self.imageCompletions removeObjectForKey:key];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            for (void (^callback)(UIImage *) in callbacks) {
+                callback(image);
+            }
+        });
+    });
+}
+
+// Same shape as requestImageForURL, but decodes at display scale into
+// bannerCache and disk-persists the downscaled re-encode (so >2MB originals
+// still survive cold starts instead of re-downloading every launch).
+- (void)requestBannerImageForURL:(NSURL *)url completion:(void (^)(UIImage *image))completion {
+    if (![url isKindOfClass:[NSURL class]]) {
+        if (completion) dispatch_async(dispatch_get_main_queue(), ^{ completion(nil); });
+        return;
+    }
+    NSString *key = [self bannerKeyForURL:url];
+    UIImage *cached = [self.bannerCache objectForKey:key];
+    if (cached) {
+        if (completion) dispatch_async(dispatch_get_main_queue(), ^{ completion(cached); });
+        return;
+    }
+
+    dispatch_async(self.queue, ^{
+        NSDate *notFoundAt = self.imageNotFoundDates[key];
+        if (notFoundAt) {
+            if (-[notFoundAt timeIntervalSinceNow] < ApolloUserProfileImageNotFoundTTL) {
+                if (completion) dispatch_async(dispatch_get_main_queue(), ^{ completion(nil); });
+                return;
+            }
+            [self.imageNotFoundDates removeObjectForKey:key];
+        }
+
+        NSMutableArray<void (^)(UIImage *)> *callbacks = self.imageCompletions[key];
+        if (callbacks) {
+            if (completion) [callbacks addObject:[completion copy]];
+            return;
+        }
+
+        callbacks = [NSMutableArray array];
+        if (completion) [callbacks addObject:[completion copy]];
+        self.imageCompletions[key] = callbacks;
+
+        NSString *diskPath = [self imageDiskPathForKey:key];
+        dispatch_async(self.imageIOQueue, ^{
+            NSData *diskData = [NSData dataWithContentsOfFile:diskPath];
+            if (diskData.length > 0) {
+                UIImage *diskImage = nil;
+                @autoreleasepool {
+                    // Disk entries were already downscaled before persisting;
+                    // the call is a plain decode for them.
+                    diskImage = ApolloDownscaledBannerImage([UIImage imageWithData:diskData]);
+                }
+                if (diskImage) {
+                    [[NSFileManager defaultManager] setAttributes:@{NSFileModificationDate: [NSDate date]} ofItemAtPath:diskPath error:nil];
+                    [self finishBannerImageRequestForKey:key image:diskImage];
+                    return;
+                }
+            }
+
+            NSURLSessionDataTask *task = [self.imageSession dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                UIImage *image = nil;
+                if (!error && data.length > 0) {
+                    @autoreleasepool {
+                        image = ApolloDownscaledBannerImage([UIImage imageWithData:data]);
+                    }
+                }
+                if (!image && error) {
+                    ApolloLog(@"[UserAvatars] Failed to load banner %@: %@", key, error.localizedDescription);
+                }
+                if (!image) {
+                    NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
+                    NSInteger statusCode = http ? http.statusCode : 0;
+                    BOOL transient = (error && ApolloUserProfileErrorIsTransient(error)) ||
+                        statusCode == 429 || statusCode >= 500;
+                    if (!transient) {
+                        dispatch_async(self.queue, ^{ self.imageNotFoundDates[key] = [NSDate date]; });
+                    }
+                } else {
+                    NSData *persistData = UIImageJPEGRepresentation(image, 0.85);
+                    if (persistData) {
+                        dispatch_barrier_async(self.imageIOQueue, ^{ [self persistImageData:persistData forKey:key]; });
+                    }
+                }
+                [self finishBannerImageRequestForKey:key image:image];
             }];
             [task resume];
         });
@@ -1018,6 +1213,8 @@ static NSTimeInterval ApolloUserProfileRetryBackoffForAttempt(NSInteger attempt)
         self.diskSaveScheduled = NO;
         [self.infoCache removeAllObjects];
         [self.imageCache removeAllObjects];
+        [self.bannerCache removeAllObjects];
+        [self.imageNotFoundDates removeAllObjects];
         // Reset the batch-prefetch dedupe set so already-seen users get re-warmed
         // through the fast user_data_by_account_ids path after a clear.
         [self.batchRequestedFullNames removeAllObjects];


### PR DESCRIPTION
Implements the high-impact fixes (implementation-order items 1–6) from [`docs/avatar-header-deepdive.md`](https://github.com/Apollo-Reborn/Apollo-Reborn/blob/main/docs/avatar-header-deepdive.md), the Aug 2026 audit of why avatars/headers feel "glitchy and not great" (#252, #197, #338 class of complaints).

## Subreddit header stops resetting itself (SA1/SA2)

The top finding: the header's identity compares were case-sensitive while the subreddit name arrives from two sources that disagree on case — the nav title (`denver`) first, then the `currentSubreddit` ivar (`Denver`) ~300ms later. That read as a "subreddit change" on most subreddit opens and wiped the freshly-loaded icon/banner/info mid-load (height collapse + refetch). All identity compares now go through the existing case-insensitive `ApolloSubredditNamesEqual`, including the custom banner/icon notification walkers (which post lowercased names, so iPad split-view / second-tab instances used to miss refreshes).

## Banner lifecycle (SA3/SA4/SA5)

- **Keep the old banner while refetching** (parity with the icon path, which always did this). Blanking on every reload made the whole immersive backdrop blink off/on whenever an info notification arrived with the image evicted.
- **URL guard on the fetch completion** (`pendingBannerURL`, ported from the profile header): an older in-flight fetch can no longer paint over a newer banner.
- **Blur-cache key stamped at point of application** (`bannerProvenanceKey`): SyncAmbient used to re-derive the key from `info.bannerURL`, so a failed fetch stamped the *shared default-banner singleton* with a real subreddit's URL — poisoning that URL's immersive blur globally, last-failure-wins.

## Inline comment avatars (A1/A2/A3)

- Double-prepend guard returned the very text it rejected → **stacked avatars**. Now bails.
- Late reapply nil'ed the node binding and re-ran the fuzzy byline scorer against text that now contains the avatar attachment (+2 chars, worsening the real byline's score) → **avatar migrating into body text/flair**. Now re-validates the existing bound node.
- Associations survived whitespace-only rebinds and username matching was bare-substring (`bob` matched `bobby`) → **literal wrong avatar**. Now clears on any non-matching rebind and matches on word boundaries everywhere.

## Fetch scheduling & caching (B1–B4, SB2/SB3/SB9/SB10, SB4)

- Request gate queue: **LIFO** (visible cells first during a fling — FIFO served long-scrolled-away cells first), 48-entry cap, eager dead-cell pruning, and **per-username slots** (20 comments by one author used to occupy all 10 slots; they now piggyback on the cache-level coalescing).
- **Negative caching**: permanently-failed image URLs (15 min) and private/banned/deleted subreddits (10 min) stop refetching per cell per reapply / per visit, forever.
- Subreddit info fetches gain the profile cache's discipline: status-code inspection, transient-failure backoff (429/5xx/network), and the 404 sentinel keeps karma at −1 "unknown" (deleted users no longer show "0 Post Karma" cards).
- `refetchInfoForSubreddit:` now actually bypasses the HTTP cache and survives the in-flight coalescer (post-Join subscriber counts stop going stale — the #197 "never updates" class); failed refetches no longer re-persist + re-broadcast identical data (disk-write + controller-tree-reinstall storm on flaky networks).
- JSON root type guard in the info parser (array root → unrecognized selector; same crash class as #785).
- **SB4**: banners (subreddit *and* profile) now decode at display scale into a dedicated 8-entry/32MB cache instead of native size into the shared 40MB avatar NSCache — a 4000px banner decoded ~19MB and two of them evicted essentially every avatar (comment-scroll re-decode stutter). Downscaled re-encodes also disk-persist, so >2MB originals stop re-downloading every cold start.

## Threading hygiene (C1)

The avatar renderers run on Texture background queues via the `setAttributedText:` hooks; they no longer touch `UIScreen` or resolve dynamic colors ambiently there (hoisted scale, pre-resolved light/dark placeholder fill, warmed from `%ctor`).

## Deferred (with reasons)

- **D1/SB5 purge handlers** — `ApolloMemoryDiagnostics.h` arrives with #823, still open. Should be a small follow-up once that merges.
- **SC2 custom banner/icon cache dedup** — #845 (open) touches both caches; deduping now would guarantee conflicts.
- **SA7/C3 layout-hook hygiene, SB1 off-queue disk saves, SC1 dead-code deletion, items 7–8** — mechanical but broader; better as a follow-up PR.

## Validation

- Device build (`iphone:clang:26.0:14.0`) and simulator build both compile clean.
- Simulator smoke test: tweak loads, `r/Denver` (the doc's literal SA1 repro) installs its header with banner/icon/immersive backdrop intact across repeated install passes — no reset, no backdrop blink:

| r/Denver header after this PR |
|---|
| banner + icon + backdrop render on first load, repeated `install vc=… subreddit=Denver` passes leave them untouched |

Manual test suggestions: open several subreddits with mixed-case names (Denver, AskReddit), background/foreground, pull-to-refresh; scroll fast through a comment thread with many same-author replies and users with substring-related names; toggle a custom banner on a subreddit open in two tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)