### PR TITLE
Fix theme deletion, stat-card popups, highlight strength, and Search-tab field theming (#797 #742 #743 #748)

### DIFF
--- a/src/ApolloSimDebugTap.xm
+++ b/src/ApolloSimDebugTap.xm
@@ -61,12 +61,20 @@ static void ApolloSimDebugSendTouch(UITouch *touch) {
 }
 
 static void ApolloSimDebugPerformTap(CGPoint point) {
+    // Hit-test every visible window from topmost down, not just the key
+    // window: alert/overlay windows sit above it, and key-window-only taps
+    // sailed straight through their chrome into the app underneath.
+    UIView *hitView = nil;
     UIWindow *window = nil;
-    for (UIWindow *candidate in ApolloAllWindows()) {
-        if (candidate.isKeyWindow) { window = candidate; break; }
+    NSArray<UIWindow *> *ordered = [ApolloAllWindows() sortedArrayUsingComparator:^NSComparisonResult(UIWindow *a, UIWindow *b) {
+        if (a.windowLevel == b.windowLevel) return NSOrderedSame;
+        return a.windowLevel > b.windowLevel ? NSOrderedAscending : NSOrderedDescending;
+    }];
+    for (UIWindow *candidate in ordered) {
+        if (candidate.hidden) continue;
+        UIView *hit = [candidate hitTest:point withEvent:nil];
+        if (hit) { window = candidate; hitView = hit; break; }
     }
-    if (!window) window = ApolloAllWindows().firstObject;
-    UIView *hitView = [window hitTest:point withEvent:nil];
     if (!window || !hitView) {
         ApolloLog(@"[SimDebugTap] no window/hit view for (%.0f, %.0f)", point.x, point.y);
         return;

--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -1317,8 +1317,21 @@ static UIView *ApolloSubredditIndexModernPressOverlay(UITableView *tableView, UI
         [container insertSubview:overlay atIndex:0];
     }
 
-    UIColor *accentColor = ApolloSubredditIndexThemeAccentColor(tableView, cell);
-    UIColor *overlayColor = [accentColor colorWithAlphaComponent:0.16];
+    // Highlight tint (issue #743): stock Apollo themes get the muted iOS-grey
+    // tap feedback they always had — the accent-derived tint only ever
+    // belonged to custom themes, and even there 0.16 read stronger than
+    // Apollo's original feedback, so it's dialled down to 0.10.
+    UIColor *overlayColor;
+    if (ApolloThemeRuntimeIsActive()) {
+        UIColor *accentColor = ApolloSubredditIndexThemeAccentColor(tableView, cell);
+        overlayColor = [accentColor colorWithAlphaComponent:0.10];
+    } else {
+        overlayColor = [UIColor systemGray4Color]; // what UIKit's default selection paints
+    }
+    // Resolve against the cell's own traits before the .CGColor write —
+    // systemGray4 is dynamic and ambient resolution can pick the wrong
+    // light/dark variant when Apollo overrides the window style.
+    overlayColor = [overlayColor resolvedColorWithTraitCollection:container.traitCollection];
     overlay.frame = container.bounds;
     overlay.backgroundColor = overlayColor;
     overlay.layer.backgroundColor = overlayColor.CGColor;

--- a/src/ApolloThemeManagerViewController.m
+++ b/src/ApolloThemeManagerViewController.m
@@ -1634,34 +1634,41 @@ static NSString *SpacedThemeName(NSString *raw) {
     [self.navigationController pushViewController:editor animated:YES];
 }
 
-// Deleting can reassign activeThemeID (if the deleted theme was active) or empty
-// the theme list entirely — reload+invalidate unconditionally so the running
-// theme (or its absence) is never left showing a just-deleted theme's stale
-// colours until some unrelated trigger happens to reload it.
+// Deleting can reassign the active pointer (if the deleted theme was active)
+// or hand control back to Apollo themes entirely. The enabled->disabled
+// transition MUST go through ApolloThemeRuntimeDisable(): it restores the
+// hijacked donor AppColorTheme slot and repaints live. Just skipping the
+// reload (the old behaviour) left the deleted theme's colours on screen until
+// a force-quit, after which the app came back showing the DONOR Apollo theme
+// — issue #742's "switched to an unexpected theme (e.g. Outrun)".
 - (void)deleteThemeAndRefresh:(NSString *)themeID {
+    BOOL wasEnabled = [self store].customThemeEnabled;
     [[self store] deleteTheme:themeID];
     if ([self store].customThemeEnabled) {
         ApolloThemeRuntimeReload();
         ApolloThemeRuntimeInvalidate();
+    } else if (wasEnabled) {
+        ApolloThemeRuntimeDisable();
     }
     [self.tableView reloadData];
 }
 
+// Destructive deletion always confirms (issue #742) — inactive themes used to
+// vanish on a bare swipe. The active-theme message states the actual outcome.
 - (void)confirmDeleteThemeIDIfNeeded:(NSString *)themeID {
     ApolloThemeStore *store = [self store];
     BOOL active = store.customThemeEnabled &&
         ([store isCustomThemeID:themeID selectedForMode:ApolloThemeModeLight] ||
          [store isCustomThemeID:themeID selectedForMode:ApolloThemeModeDark]);
-    if (!active) {
-        [self deleteThemeAndRefresh:themeID];
-        return;
-    }
 
     NSDictionary *theme = [store themeWithID:themeID];
     NSString *name = [theme[@"name"] isKindOfClass:NSString.class] ? theme[@"name"] : @"this theme";
+    NSString *message = active
+        ? [NSString stringWithFormat:@"“%@” is currently active. Deleting it will switch back to Apollo themes.", name]
+        : [NSString stringWithFormat:@"Delete “%@”? This can’t be undone.", name];
     UIAlertController *alert =
-        [UIAlertController alertControllerWithTitle:@"Delete active theme?"
-                                            message:[NSString stringWithFormat:@"Delete “%@”? Apollo will switch to another theme or back to Apollo Themes.", name]
+        [UIAlertController alertControllerWithTitle:(active ? @"Delete active theme?" : @"Delete Theme")
+                                            message:message
                                      preferredStyle:UIAlertControllerStyleAlert];
     [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
     [alert addAction:[UIAlertAction actionWithTitle:@"Delete" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *a) {

--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -104,12 +104,48 @@ static void ApplyThemeTableSeparator(UITableView *tableView) {
     }
 }
 
+static const void *kApolloThemeSearchPillKey = &kApolloThemeSearchPillKey;
+
 static void ApplyThemeSearchFieldBackground(UISearchBar *searchBar) {
     if (!sEnabled || !searchBar) return;
-    UIColor *raised = ApolloThemeRuntimeColor(ApolloThemeTokenTertiaryBackground);
+    // Elevated (== card), NOT Tertiary/raised: Apollo natively paints the
+    // Search tab's whole header band with the theme's raised surface, so a
+    // raised pill would vanish into its own band. The card color keeps the
+    // pill distinct on that band (and reads like an inset control on the
+    // bars-colored toolbars other search bars sit in).
+    UIColor *pillColor = ApolloThemeRuntimeColor(ApolloThemeTokenElevatedBackground);
     UITextField *field = searchBar.searchTextField;
-    if (raised && field && ![field.backgroundColor isEqual:raised]) {
-        field.backgroundColor = raised;
+    if (!pillColor || !field) return;
+    // Writing searchTextField.backgroundColor does nothing visible: the stock
+    // UISearchBar draws its pill via _UISearchBarSearchFieldBackgroundView and
+    // UISearchBarTextField never renders its own backgroundColor — so on the
+    // Search tab the themed fill silently missed (issue #748). (A themed
+    // setSearchFieldBackgroundImage: was tried first; UIKit swaps in an image
+    // background host but never renders the image.) Instead paint the capsule
+    // ourselves: an inert themed overlay stacked directly above UIKit's pill
+    // view and below the field's text/icons — same overlay pattern the rest of
+    // the tweak uses. Dynamic color, so light/dark resolves via the trait
+    // cascade; didMoveToWindow/traitCollectionDidChange keep it applied.
+    UIView *pill = objc_getAssociatedObject(field, kApolloThemeSearchPillKey);
+    if (!pill) {
+        pill = [[UIView alloc] initWithFrame:field.bounds];
+        pill.userInteractionEnabled = NO;
+        pill.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        pill.layer.cornerRadius = IsLiquidGlass() ? 18.0 : 10.0;
+        pill.layer.cornerCurve = kCACornerCurveContinuous;
+        objc_setAssociatedObject(field, kApolloThemeSearchPillKey, pill, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    pill.backgroundColor = pillColor;
+    pill.frame = field.bounds;
+    if (pill.superview != field) {
+        // Directly above UIKit's own background view when it exists (covering
+        // its grey material), else at the very back.
+        UIView *systemPill = nil;
+        for (UIView *sub in field.subviews) {
+            if ([NSStringFromClass(sub.class) containsString:@"Background"]) { systemPill = sub; break; }
+        }
+        if (systemPill) [field insertSubview:pill aboveSubview:systemPill];
+        else [field insertSubview:pill atIndex:0];
     }
 }
 

--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -107,14 +107,24 @@ static void ApplyThemeTableSeparator(UITableView *tableView) {
 static const void *kApolloThemeSearchPillKey = &kApolloThemeSearchPillKey;
 
 static void ApplyThemeSearchFieldBackground(UISearchBar *searchBar) {
-    if (!sEnabled || !searchBar) return;
+    if (!searchBar) return;
+    UITextField *field = searchBar.searchTextField;
+    UIView *pill = field ? objc_getAssociatedObject(field, kApolloThemeSearchPillKey) : nil;
+    // The pill is tweak-owned, so UIKit has no native state transition that
+    // removes it when the custom runtime turns off. The disable invalidation
+    // re-enters here through the trait cascade; use that pass to tear down the
+    // stale themed fill immediately. Keep the association so a later re-enable
+    // can cheaply reinsert the same view.
+    if (!sEnabled) {
+        [pill removeFromSuperview];
+        return;
+    }
     // Elevated (== card), NOT Tertiary/raised: Apollo natively paints the
     // Search tab's whole header band with the theme's raised surface, so a
     // raised pill would vanish into its own band. The card color keeps the
     // pill distinct on that band (and reads like an inset control on the
     // bars-colored toolbars other search bars sit in).
     UIColor *pillColor = ApolloThemeRuntimeColor(ApolloThemeTokenElevatedBackground);
-    UITextField *field = searchBar.searchTextField;
     if (!pillColor || !field) return;
     // Writing searchTextField.backgroundColor does nothing visible: the stock
     // UISearchBar draws its pill via _UISearchBarSearchFieldBackgroundView and
@@ -126,7 +136,6 @@ static void ApplyThemeSearchFieldBackground(UISearchBar *searchBar) {
     // view and below the field's text/icons — same overlay pattern the rest of
     // the tweak uses. Dynamic color, so light/dark resolves via the trait
     // cascade; didMoveToWindow/traitCollectionDidChange keep it applied.
-    UIView *pill = objc_getAssociatedObject(field, kApolloThemeSearchPillKey);
     if (!pill) {
         pill = [[UIView alloc] initWithFrame:field.bounds];
         pill.userInteractionEnabled = NO;

--- a/src/ApolloThemeStore.m
+++ b/src/ApolloThemeStore.m
@@ -535,11 +535,12 @@ static ApolloThemeGalleryResolver sGalleryResolver = nil;
     NSDictionary *p = [self activePointer];
     if ([p[kPointerIDKey] isEqual:themeID]) {
         if ([self storedSelectionKind] == ApolloThemeSelectionCustom) {
-            // Deleted the active theme: fall to the next stored theme, or all
-            // the way back to Apollo when the list is now empty.
-            NSString *nextID = themes.firstObject[@"id"];
-            if (nextID) [self selectCustomTheme:nextID];
-            else [self setActivePointer:@{ kPointerKindKey: kPointerApollo }];
+            // Deleted the ACTIVE theme: switch back to Apollo themes. Falling
+            // to the next stored theme (themes.firstObject) landed on whatever
+            // happened to sort first — reported as "switched to an unexpected
+            // theme" in issue #742. Apollo themes are the predictable fallback
+            // (and what the delete confirmation promises).
+            [self setActivePointer:@{ kPointerKindKey: kPointerApollo }];
         } else {
             // Only the remembered last-selection payload named it: forget it.
             NSMutableDictionary *m = [p mutableCopy];

--- a/src/ApolloThemeStore.m
+++ b/src/ApolloThemeStore.m
@@ -517,18 +517,15 @@ static ApolloThemeGalleryResolver sGalleryResolver = nil;
     ApolloLog(@"ThemeStore: deleteTheme %@ (now %lu themes)", themeID, (unsigned long)themes.count);
     [self setAllThemes:themes];
     if (self.separateThemesEnabled) {
-        NSString *nextID = themes.firstObject[@"id"];
         for (ApolloThemeMode mode = ApolloThemeModeLight; mode < ApolloThemeModeCount; mode++) {
             if (![self isCustomThemeID:themeID selectedForMode:mode]) continue;
             ApolloThemeApplyTarget target = mode == ApolloThemeModeDark
                 ? ApolloThemeApplyTargetDark : ApolloThemeApplyTargetLight;
-            if (nextID) {
-                [self selectCustomTheme:nextID forTarget:target];
-            } else {
-                ApolloThemeMode otherMode = mode == ApolloThemeModeDark
-                    ? ApolloThemeModeLight : ApolloThemeModeDark;
-                [self setPointer:[self pointerForMode:otherMode] forTarget:target];
-            }
+            // Match the single-theme deletion contract and the confirmation
+            // copy: every affected appearance returns to Apollo themes. Picking
+            // themes.firstObject here reproduced issue #742 whenever another
+            // stored theme happened to sort first.
+            [self setPointer:@{ kPointerKindKey: kPointerApollo } forTarget:target];
         }
         return YES;
     }

--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -115,6 +115,11 @@ static const void *kApolloProfileTabAvatarImageMarkerKey = &kApolloProfileTabAva
 // the visible subset in display order; cards with no data stay hidden and out of
 // the row, so the layout centres however many actually have values.
 @property(nonatomic, strong) NSArray<ApolloProfileStatCard *> *statCards;
+// Raw values behind the cards' compact text, kept for the tap-detail popup
+// (issue #797): the cards show "13.1k", the popup shows "13,102".
+@property(nonatomic) NSInteger statLinkKarma;
+@property(nonatomic) NSInteger statCommentKarma;
+@property(nonatomic) NSTimeInterval statCreatedUTC;
 @property(nonatomic, strong) ApolloProfileStatCard *postKarmaCard;
 @property(nonatomic, strong) ApolloProfileStatCard *commentKarmaCard;
 @property(nonatomic, strong) ApolloProfileStatCard *ageCard;
@@ -326,6 +331,8 @@ static UIImage *ApolloProfileTintedSymbol(NSString *name, CGFloat pointSize, UIC
 - (void)setValue:(NSString *)value caption:(NSString *)caption {
     self.valueLabel.text = value;
     self.captionLabel.text = caption;
+    self.accessibilityLabel = [NSString stringWithFormat:@"%@: %@", caption, value];
+    self.accessibilityHint = @"Double tap for details";
 }
 
 - (void)layoutSubviews {
@@ -507,11 +514,18 @@ static const void *kApolloProfileGlassAccentKey = &kApolloProfileGlassAccentKey;
         [self addSubview:_badgeBookView];
 
         // Glass stat cards. Created up front (hidden) and populated in applyProfileInfo.
+        // Tappable (issue #797): stock Apollo's karma/age text opened a detail
+        // popup with the exact counts; the cards replaced that text, so they
+        // take over the tap too.
         _postKarmaCard = [[ApolloProfileStatCard alloc] init];
         _commentKarmaCard = [[ApolloProfileStatCard alloc] init];
         _ageCard = [[ApolloProfileStatCard alloc] init];
         for (ApolloProfileStatCard *card in @[_postKarmaCard, _commentKarmaCard, _ageCard]) {
             card.hidden = YES;
+            [card addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self
+                                                                               action:@selector(apollo_statCardTapped:)]];
+            card.isAccessibilityElement = YES;
+            card.accessibilityTraits = UIAccessibilityTraitButton;
             [self addSubview:card];
         }
         _statCards = @[];
@@ -1182,9 +1196,15 @@ static UIFont *ApolloProfileClassicNameFont(void) {
         // a "0 karma" row); !sProfileShowStatCards is the viewer turning cards off.
         for (ApolloProfileStatCard *card in @[self.postKarmaCard, self.commentKarmaCard, self.ageCard]) card.hidden = YES;
         self.statCards = @[];
+        self.statLinkKarma = -1;
+        self.statCommentKarma = -1;
+        self.statCreatedUTC = 0.0;
         return;
     }
 
+    self.statLinkKarma = info.linkKarma;
+    self.statCommentKarma = info.commentKarma;
+    self.statCreatedUTC = info.createdUTC;
     if (info.linkKarma >= 0) {
         [self.postKarmaCard setValue:ApolloProfileFormatCount(info.linkKarma) caption:@"Post Karma"];
         [visible addObject:self.postKarmaCard];
@@ -1202,6 +1222,55 @@ static UIFont *ApolloProfileClassicNameFont(void) {
         card.hidden = ![visible containsObject:card];
     }
     self.statCards = visible;
+}
+
+// Stat-card tap (issue #797): show the detail popup stock Apollo offered on
+// its karma/age text — exact grouped counts, and for the age card the actual
+// join date (the card itself can only say "New" for young accounts, which
+// reporters called out as unhelpful).
+- (void)apollo_statCardTapped:(UITapGestureRecognizer *)gesture {
+    UIView *card = gesture.view;
+    NSString *title = nil, *message = nil;
+
+    NSNumberFormatter *grouped = [[NSNumberFormatter alloc] init];
+    grouped.numberStyle = NSNumberFormatterDecimalStyle;
+
+    if (card == self.postKarmaCard && self.statLinkKarma >= 0) {
+        title = @"Post Karma";
+        message = [grouped stringFromNumber:@(self.statLinkKarma)];
+    } else if (card == self.commentKarmaCard && self.statCommentKarma >= 0) {
+        title = @"Comment Karma";
+        message = [grouped stringFromNumber:@(self.statCommentKarma)];
+    } else if (card == self.ageCard && self.statCreatedUTC > 0.0) {
+        NSDate *created = [NSDate dateWithTimeIntervalSince1970:self.statCreatedUTC];
+        NSDateFormatter *joined = [[NSDateFormatter alloc] init];
+        joined.dateStyle = NSDateFormatterLongStyle;
+        joined.timeStyle = NSDateFormatterNoStyle;
+        NSDateComponentsFormatter *age = [[NSDateComponentsFormatter alloc] init];
+        age.unitsStyle = NSDateComponentsFormatterUnitsStyleFull;
+        age.allowedUnits = NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay;
+        age.maximumUnitCount = 2;
+        NSString *ago = [age stringFromDate:created toDate:[NSDate date]];
+        title = @"Reddit Age";
+        message = ago.length
+            ? [NSString stringWithFormat:@"Joined %@\n(%@ ago)", [joined stringFromDate:created], ago]
+            : [NSString stringWithFormat:@"Joined %@", [joined stringFromDate:created]];
+    }
+    if (!title) return;
+
+    // Nearest owning view controller via the responder chain — the header is
+    // a plain table header view with no controller reference of its own.
+    UIViewController *presenter = nil;
+    for (UIResponder *r = self.nextResponder; r; r = r.nextResponder) {
+        if ([r isKindOfClass:[UIViewController class]]) { presenter = (UIViewController *)r; break; }
+    }
+    if (!presenter) return;
+
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title
+                                                                   message:message
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+    [presenter presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)applyProfileInfo:(ApolloUserProfileInfo *)info fallbackUsername:(NSString *)username {


### PR DESCRIPTION
Second 3.5.1 batch, stacked on #853 (GitHub will retarget to main when that merges). All verified in the simulator except where noted; device target builds clean.

## #797 — Karma/age popup (closes the rest of the issue; the LG-look half shipped in #853)
The stat cards replaced Apollo's tappable karma/age text without taking over the tap. Cards are now buttons: Post/Comment Karma show the exact grouped count (e.g. "13,081"), and Reddit Age shows the actual join date + precise age — which also answers the "accounts newer than a month just say New" complaint in the issue thread. Verified in-sim on both karma cards.

## #742 — Theme deletion (closes)
Root cause of the weird behavior: when deleting the active (or last) theme flipped the pointer back to Apollo, the manager **skipped** the runtime teardown (`if customThemeEnabled` was now false), leaving the deleted theme's colors live until a force-quit — after which the app came back showing the hijacked **donor** slot theme, i.e. the reporter's "switched to an unexpected theme (e.g. Outrun)". Fixes:
- every deletion now confirms (inactive themes used to vanish on a bare swipe), with copy that states the actual outcome;
- the enabled→disabled transition goes through `ApolloThemeRuntimeDisable()` — donor slot restored, repaint live;
- the store's active-theme fallback is Apollo themes, not `themes.firstObject`.

Verified end-to-end in-sim: swipe → Delete → new confirmation alert → entire UI switches to Apollo default instantly (`ThemeRuntime: disabled (restored=default)` in the log), Theme Manager shows "Apollo Theme / No custom themes yet".

## #743 — Row highlight strength (partial per triage)
Stock Apollo themes get their muted iOS-gray tap feedback back (systemGray4, trait-resolved); custom themes keep the accent-derived highlight at 0.10 instead of 0.16. The "editable highlight color" part of the issue is a feature request and intentionally not included.

## #748 — Search tab field ignores custom theme (closes)
Reproduced with an injected loud-green Raised color: the themed fill never appeared because `searchTextField.backgroundColor` paints *behind* UIKit's `_UISearchBarSearchFieldBackgroundView` pill (and `setSearchFieldBackgroundImage:` installs an image host that never renders). Fix: an inert themed capsule overlay directly above UIKit's pill view, below the field's content. Token choice is **Elevated (card)**, not raised — Apollo natively paints the Search tab's whole header band with the raised surface, so a raised pill would vanish into its own band. Verified: pill renders themed immediately, persists across tab switches, correct with the default palette too.

## #787 — investigated, deferred
The green-injection test revealed the anatomy: Apollo natively paints the entire feed/search header band with the theme's **raised** surface while the nav chrome uses **bars** — the donor remap reproduces that faithfully, so the "bleed" is the gap between a custom theme's raised and bars values being larger than the stock themes'. Making the band read as part of the toolbar needs the feed top-chrome work (same subsystem as the #830 investigation), not a remap tweak — deferring to 3.5.2 with these findings noted on the issue.

Also: the sim debug bridge's taps now hit-test all windows topmost-first so alert buttons can be driven (needed for the #742 verification).

Closes #797, closes #742, closes #748. Refs #743, refs #787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)