### PR TITLE
Prepare 3.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,34 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v3.5.1] - 2026-08-??
+
 ### Features
 
+- Add **Swipe Through Feed Galleries** for paging through every image directly in a feed card, with smarter sizing and seamless fullscreen transitions, plus **Swipe Up for Comments** to open the real comments screen over fullscreen media (#805: @jordanearle)
+- Expand **multireddits** with Gallery View, in-app renaming and descriptions, custom icons, and an option to hide their descriptions in the Subreddits list (#799, #837: @icpryde)
+- Add approximate **vote breakdowns** for posts and author-only insights for your own comments (#802: @jordanearle)
+- Replace **Scroll Edge Effect** with a clearer **Header Style** picker and add a progressive Blur option alongside the iOS 26 Soft and iOS 27 Hard styles (#843: @jordanearle)
+- Add private, local-only **Crash Reports** that stay on your device unless you review and explicitly attach a sanitized report to the bug form (#824: @jordanearle)
+- Add an opt-in **Apple Translate** sheet for Apollo's post and comment Translate action on supported iOS versions (#812: @DeltAndy123)
+- Add full-screen **View Banner** and **View Icon** actions to subreddit headers, with tap-and-hold access to customization options (#845: @icpryde)
+- Improve the **Search** tab with pull-to-refresh for subreddit discovery, reliable trending limits, and a separate Random NSFW Subreddit row (#788: @JeffreyCA)
+- Improve cloud **AI Summaries** with searchable Gemini and OpenRouter model browsers, working defaults, provider attribution, and clearer service errors (#778: @jordanearle)
+- Improve **Settings** discoverability with a reddit.com Web Sign-In row under Accounts & API Keys and a Theme Manager shortcut on the Apollo Reborn hub (#855: @jordanearle)
 - Add gaze and pointer hover effects plus multiwindow support when Apollo runs on **Apple Vision Pro** (#759: @rebelancap)
+- Add Original Apollo, Halo, Aloppo, and Pixels **Liquid Glass app icons**, while refreshing the Apollo Classic, Helios, and Jryng artwork for iOS 27 (#784, #800, #804, #819, #842: @IllIIllIllIllII)
+- Make **Open Reddit Links in Apollo** more reliable by moving recommended automatic Safari routing into Link Companion and retaining manual and legacy fallback extensions (#786: @jordanearle)
 
 ### Fixes
 
-- Fix lists becoming stuck beneath the floating tab bar on **iOS 27**, including comments opened from deep links and feeds loading another page (#744: @jordanearle)
-- Improve networking and media reliability by removing avoidable stalls, bounding caches and concurrent downloads, and preserving original animated album media when saving or sharing (#728: @ryannair05)
+- Improve networking and media reliability by removing avoidable stalls, bounding caches and concurrent downloads, preserving animated album media when saving or sharing, and making uploads and share-link resolution more resilient (#728: @ryannair05)
+- Fix newly posted or edited **comments** appearing blank or incomplete until the thread is reopened, including missing usernames, flair, scores, and timestamps (#808: @icpryde)
+- Fix major **crash and memory** regressions affecting video-heavy threads, translated or recovered comments, native video comments, and profile-tab long presses (#796, #823, #829, #844: @icpryde, @jordanearle)
+- Fix **Gallery and media** issues including silent hosted videos, ignored NSFW blur preferences, iOS 27 menu crashes, frozen search-result videos, and blank or permanently compact link previews (#767, #769, #781, #789, #807: @jordanearle, @JeffreyCA, @icpryde)
+- Fix **profiles, subreddit headers, and themes** flickering or laying out incorrectly, including unreadable context menus and duration pills, indistinct read posts, uneven row highlights, misaligned profile cards, stuck refresh offsets, and Pixel Pals drifting behind the Dynamic Island (#846, #848, #849, #853: @icpryde, @jordanearle)
+- Fix **posting, translation, and moderation** regressions including long composer titles, an unsafe Text editor Post button, untranslated media-post bodies, poll flair, search state, long translated titles, and incorrect moderator-row routing (#780, #793, #795, #835: @jordanearle, @icpryde)
+- Fix lists becoming stuck beneath the tab bar on **iOS 27** or hiding their final rows on standard builds, while smoothing legacy hide-bars transitions (#821: @jordanearle)
+- Prevent account recovery and Settings Backup from triggering repeated **keychain passcode prompts** (#777: @jordanearle)
 
 ## [v3.5.0] - 2026-07-??
 
@@ -732,6 +752,7 @@ There are currently a few limitations:
 ## [v1.0.0] - 2023-10-13
 - Initial release
 
+[v3.5.1]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v1.15.11_3.5.0...v1.15.11_3.5.1
 [v3.5.0]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v1.15.11_3.4.2...v1.15.11_3.5.0
 [v3.4.2]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v1.15.11_3.4.1...v1.15.11_3.4.2
 [v3.4.1]: https://github.com/Apollo-Reborn/Apollo-Reborn/compare/v1.15.11_3.4.0...v1.15.11_3.4.1

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: com.apollo.reborn
 Name: Apollo-Reborn
-Version: 3.5.0
+Version: 3.5.1
 Architecture: iphoneos-arm
 Description: Apollo for Reddit tweak with in-app configurable API keys
 Maintainer: Apollo Reborn team

--- a/distribution/config.json
+++ b/distribution/config.json
@@ -12,7 +12,7 @@
   },
   "app": {
     "bundleIdentifier": "com.christianselig.Apollo",
-    "buildVersion": "294",
+    "buildVersion": "295",
     "developerName": "Christian Selig (& Apollo-Reborn contributors)",
     "iconURL": "https://apolloreborn.app/assets/icon.png",
     "tintColor": "#F0542D",

--- a/whats-new/generated/ApolloWhatsNewCatalog.gen.m
+++ b/whats-new/generated/ApolloWhatsNewCatalog.gen.m
@@ -15,6 +15,7 @@ typedef struct {
 
 static const ApolloWhatsNewReleaseEntry kWhatsNewReleases[] = {
     { "3.5.0", "What's New in Apollo Reborn" },
+    { "3.5.1", "What's New in Apollo Reborn" },
 };
 
 static const ApolloWhatsNewItemEntry kWhatsNewItems[] = {
@@ -26,6 +27,11 @@ static const ApolloWhatsNewItemEntry kWhatsNewItems[] = {
     { "3.5.0", "chart.bar.fill", "Native Polls", "Vote on and create polls without leaving the app." },
     { "3.5.0", "bubble.left.and.bubble.right.fill", "Modern Chat & Modmail", "Use Reddit's current conversations without leaving Apollo." },
     { "3.5.0", "link.circle.fill", "Open Reddit Links", "Send Safari links straight to any sideloaded Apollo build with Link Companion." },
+    { "3.5.1", "rectangle.stack.fill", "Swipe Through Galleries", "Swipe through every image right from the feed, with smarter sizing and seamless fullscreen transitions." },
+    { "3.5.1", "bubble.left.and.bubble.right.fill", "Comments Over Media", "Swipe up in the media viewer to read and reply while the photo or video stays on screen." },
+    { "3.5.1", "square.grid.2x2.fill", "Better Multireddits", "Browse multireddits in Gallery View, then rename them and add descriptions or custom icons." },
+    { "3.5.1", "checkmark.circle.fill", "Posting & Media Fixes", "New comments appear correctly right away, while videos, previews, uploads, saves, and shares work more reliably." },
+    { "3.5.1", "shield.fill", "Smoother, More Stable Apollo", "Major memory and crash fixes make Apollo more reliable, with smoother headers, profiles, themes, navigation, and iOS 27 layouts." },
 };
 
 static NSString *S(const char *value) { return [NSString stringWithUTF8String:value]; }

--- a/whats-new/releases/3.5.1.json
+++ b/whats-new/releases/3.5.1.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 1,
+  "version": "3.5.1",
+  "headline": "What's New in Apollo Reborn",
+  "items": [
+    { "icon": "rectangle.stack.fill", "title": "Swipe Through Galleries", "subtitle": "Swipe through every image right from the feed, with smarter sizing and seamless fullscreen transitions." },
+    { "icon": "bubble.left.and.bubble.right.fill", "title": "Comments Over Media", "subtitle": "Swipe up in the media viewer to read and reply while the photo or video stays on screen." },
+    { "icon": "square.grid.2x2.fill", "title": "Better Multireddits", "subtitle": "Browse multireddits in Gallery View, then rename them and add descriptions or custom icons." },
+    { "icon": "checkmark.circle.fill", "title": "Posting & Media Fixes", "subtitle": "New comments appear correctly right away, while videos, previews, uploads, saves, and shares work more reliably." },
+    { "icon": "shield.fill", "title": "Smoother, More Stable Apollo", "subtitle": "Major memory and crash fixes make Apollo more reliable, with smoother headers, profiles, themes, navigation, and iOS 27 layouts." }
+  ]
+}


### PR DESCRIPTION
## Summary

Prepares the Apollo-Reborn 3.5.1 release metadata and user-facing release content.

- bumps the tweak version from 3.5.0 to 3.5.1
- increments the IPA build number from 294 to 295
- moves included work into a new 3.5.1 changelog section
- adds a curated five-highlight What's New sheet and regenerates its catalog
- verifies the generated README contributor credits remain current

## Assumed release scope

This draft treats every PR currently open against `main` as included in 3.5.1:

- #728 — networking and media reliability
- #808 — just-posted comments rendering correctly
- #853 — theming and profile fixes
- #855 — reddit.com web sign-in and Theme Manager settings shortcuts

None of those PRs was marked draft at the final scope audit. If another PR opens before release, the changelog should be audited again rather than assuming this list remains complete.

## What's New highlights

The update sheet stays intentionally curated rather than mirroring every changelog item. Its five highlights are:

- Swipe Through Galleries
- Comments Over Media
- Better Multireddits
- Posting & Media Fixes
- Smoother, More Stable Apollo

The sheet was built and visually checked in the iOS 26.5 Liquid Glass simulator. All five SF Symbols rendered without fallback warnings.

## Contributors

The GitHub contributors API was compared case-insensitively with `contributors.json`; no contributors are missing. Every credited 3.5.1 author is represented with the existing role assignments, and regenerating the README contributor block produced no diff.

Current maintainers remain JeffreyCA, icpryde, jordanearle, nickclyde, and DeltAndy123.

## Validation

- `python3 whats-new/scripts/generate_catalog.py whats-new/releases whats-new/generated/ApolloWhatsNewCatalog.gen.h whats-new/generated/ApolloWhatsNewCatalog.gen.m`
- `APOLLO_VERSION=1.15.11 TWEAK_VERSION=3.5.1 python3 scripts/generate_release_notes.py`
- JSON validation for the release catalog and distribution config
- `git diff --check`
- simulator build and Liquid Glass launch on iOS 26.5
- `[WhatsNew] Presented What's New for 3.5.1` confirmed in `apollofix` logs
- contributor coverage audit and README contributor regeneration

## Before release

- replace the changelog date placeholder `2026-08-??` with the intended release date
- merge or otherwise include #728, #808, #853, and #855 before publishing the release
- re-audit open PRs immediately before release in case the assumed scope changes
