### PR TITLE
Fix custom theme and profile UI issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,11 @@ screens. See `docs/settings-form-refactor-plan.md`.
 
 **Working on settings? Read `src/settings/README.md` first** — it has the 5-step add-a-setting recipe, the form-layer rules, and the Eureka facts. The hard rules: tweak-owned screens declare rows in `-buildForm` (never hand-rolled index math); Apollo's native General screen is modified ONLY through `ApolloSettingsGeneralTable`'s registry (never `%hook` its table methods — one remapper per screen); new settings do NOT get added to `ApolloBackupRestore`'s statics re-sync (restore force-exits; `%ctor` re-reads on relaunch).
 
+**Settings cell primary text is opt-in.** Standard form rows are marked
+automatically; normal enabled `customRow` and hand-rolled cells must call
+`apollo_applyPrimaryTextColorToCell:` before returning. Do not mark accent,
+destructive, disabled/placeholder, or intentionally secondary/tertiary rows.
+
 ### Crash Reporting (`src/crash/`)
 
 Local-only crash recording built on KSCrash 2.5.1's **recording layer only** (`modules/KSCrash` submodule, pinned; only Core/RecordingCore/Recording compile — no sinks/filters/installations, so no transmission path exists in the binary). Every public KSCrash symbol AND ObjC class is namespaced via `-DKSCRASH_NAMESPACE=_ApolloReborn` (global CFLAG — required in every TU that imports KSCrash headers). Reports live under `Library/Caches/ApolloReborn/LocalCrashReports` (max 3, cleanup policy Never) and leave the device only through the user-reviewed report-form flow.

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -127,6 +127,9 @@ NSArray<UIWindow *> *ApolloAllWindows(void);
 // Re-centers every live nav bar title after the LG title-centering mode toggle
 // changes (defined in ApolloLiquidGlass.xm; no-op off Liquid Glass).
 void ApolloLGTitleCenteringModeChanged(void);
+// Keeps the Liquid Glass title capsule in sync with a custom title view's
+// independently-faded content (defined in ApolloLiquidGlass.xm; no-op off LG).
+void ApolloNavigationTitleGlassSetContentAlpha(UIView *contentView, CGFloat alpha);
 
 // Apollo's main ApolloTabBarController, found via the scene/app delegate's
 // tabBarController ivar or by walking window root VCs. Returns nil while the

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -730,12 +730,28 @@ BOOL ApolloThemeSourceTableIsStale(UITableView *sourceTable) {
     return sourceTable == nil || sourceTable.window == nil;
 }
 
+static UIColor *ApolloVisibleBackgroundColorForTable(UITableView *tableView,
+                                                      UITraitCollection *traits) {
+    // Immersive profile/subreddit screens deliberately make their table clear
+    // and render the backdrop behind it. A pushed tweak-owned screen still
+    // needs an opaque transition surface, so inherit the first visible
+    // ancestor color instead of propagating clearColor into the destination.
+    for (UIView *view = tableView; view; view = view.superview) {
+        UIColor *color = view.backgroundColor;
+        if (!color) continue;
+        UIColor *resolved = [color resolvedColorWithTraitCollection:traits ?: view.traitCollection];
+        if (resolved && CGColorGetAlpha(resolved.CGColor) >= 0.99) return color;
+    }
+    return nil;
+}
+
 void ApolloApplyInheritedSettingsTableTheme(UITableViewController *controller) {
     if (!controller) return;
 
     UITableView *source = ApolloInheritedSettingsThemeSourceTableView(controller);
     BOOL stale = ApolloThemeSourceTableIsStale(source);
-    UIColor *backgroundColor = (stale ? nil : source.backgroundColor)
+    UIColor *backgroundColor = (stale ? nil
+        : ApolloVisibleBackgroundColorForTable(source, controller.traitCollection))
         ?: ApolloThemePageBackgroundColor() ?: controller.tableView.backgroundColor;
     controller.view.backgroundColor = backgroundColor;
     controller.tableView.backgroundColor = backgroundColor;

--- a/src/ApolloLiquidGlass.xm
+++ b/src/ApolloLiquidGlass.xm
@@ -835,19 +835,40 @@ static BOOL ApolloJumpBarIsSearching(UIView *jumpBar) {
     return !field.hidden && field.alpha > 0.01;
 }
 
+static BOOL ApolloViewIsProfileNavTitleView(UIView *view) {
+    return [NSStringFromClass(view.class) isEqualToString:@"ApolloProfileNavTitleView"];
+}
+
 static void ApolloCollectNavigationTitleContent(UIView *root,
                                                 UIView *excluded,
-                                                NSMutableArray<UIView *> *content) {
+                                                NSMutableArray<UIView *> *content,
+                                                BOOL includeTransparent) {
     for (UIView *subview in root.subviews) {
-        if (subview == excluded || subview.hidden || subview.alpha < 0.01) continue;
+        BOOL childIncludesTransparent = includeTransparent || ApolloViewIsProfileNavTitleView(subview);
+        if (subview == excluded || subview.hidden ||
+            (!childIncludesTransparent && subview.alpha < 0.01)) continue;
 
         if ([subview isKindOfClass:UILabel.class] ||
             [subview isKindOfClass:UIImageView.class] ||
             [subview isKindOfClass:UITextField.class]) {
             [content addObject:subview];
         }
-        ApolloCollectNavigationTitleContent(subview, excluded, content);
+        ApolloCollectNavigationTitleContent(subview, excluded, content,
+                                            childIncludesTransparent);
     }
+}
+
+static UILabel *ApolloProfileNavigationTitleLabel(UIView *root) {
+    if (ApolloViewIsProfileNavTitleView(root)) {
+        for (UIView *subview in root.subviews) {
+            if ([subview isKindOfClass:UILabel.class]) return (UILabel *)subview;
+        }
+    }
+    for (UIView *subview in root.subviews) {
+        UILabel *label = ApolloProfileNavigationTitleLabel(subview);
+        if (label) return label;
+    }
+    return nil;
 }
 
 static BOOL ApolloRecenterTitleControl(UIView *titleControl);
@@ -952,8 +973,10 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl);
         if (CGRectIsEmpty(frame)) return CGRectNull;
     } else {
         CGRect contentFrame = CGRectNull;
+        UILabel *profileTitleLabel = ApolloProfileNavigationTitleLabel(self.titleControl);
         for (UIView *view in candidateViews) {
-            if (![view isKindOfClass:UIView.class] || view.hidden || view.alpha < 0.01 ||
+            if (![view isKindOfClass:UIView.class] || view.hidden ||
+                (view != profileTitleLabel && view.alpha < 0.01) ||
                 CGRectIsEmpty(view.bounds)) continue;
             CGRect viewFrame = [view convertRect:view.bounds toView:hostView];
             contentFrame = CGRectIsNull(contentFrame) ? viewFrame : CGRectUnion(contentFrame, viewFrame);
@@ -1005,6 +1028,8 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl);
         self.glassView = [self newRegularGlassView];
         if (!self.glassView) return;
         self.glassView.frame = targetFrame;
+        UILabel *profileTitleLabel = ApolloProfileNavigationTitleLabel(self.titleControl);
+        self.glassView.alpha = profileTitleLabel ? profileTitleLabel.alpha : 1.0;
         [hostView insertSubview:self.glassView atIndex:0];
         ApolloLog(@"[NavigationTitleGlass] installed %@ capsule frame=%@",
                   NSStringFromClass(hostView.class), NSStringFromCGRect(self.glassView.frame));
@@ -1014,6 +1039,8 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl);
     if (hostView.subviews.firstObject != self.glassView) {
         [hostView sendSubviewToBack:self.glassView];
     }
+    UILabel *profileTitleLabel = ApolloProfileNavigationTitleLabel(self.titleControl);
+    self.glassView.alpha = profileTitleLabel ? profileTitleLabel.alpha : 1.0;
     if (CGRectEqualToRect(self.glassView.frame, targetFrame)) return;
     // UIKit already animates the containing navigation transition. A second,
     // independently timed frame animation made the capsule visibly trail the
@@ -1095,7 +1122,8 @@ static NSUInteger ApolloJumpBarContentMetric(UIView *jumpBar) {
     } else {
         // Plain titles, profile titles, and Apollo's dual-label title buttons
         // all ultimately expose their visible label/image content here.
-        ApolloCollectNavigationTitleContent(self.titleControl, self.glassView, glassCandidates);
+        ApolloCollectNavigationTitleContent(self.titleControl, self.glassView,
+                                            glassCandidates, NO);
     }
 
     [self updateGlassForHostView:hostView candidateViews:glassCandidates];
@@ -1155,6 +1183,27 @@ static void ApolloUpdateNavigationTitleGlass(UIView *titleControl) {
                                  controller, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
     [controller scheduleTargetRefresh];
+}
+
+void ApolloNavigationTitleGlassSetContentAlpha(UIView *contentView, CGFloat alpha) {
+    if (!IsLiquidGlass() || !contentView) return;
+    UIView *titleControl = contentView;
+    while (titleControl &&
+           ![NSStringFromClass(titleControl.class) isEqualToString:@"_UINavigationBarTitleControl"]) {
+        titleControl = titleControl.superview;
+    }
+    if (!titleControl) return;
+
+    ApolloNavigationTitleGlassController *controller =
+        objc_getAssociatedObject(titleControl, &kApolloNavigationTitleGlassControllerKey);
+    if (!controller) {
+        ApolloUpdateNavigationTitleGlass(titleControl);
+    } else if (!controller.glassView) {
+        [controller scheduleTargetRefresh];
+    } else {
+        controller.glassView.alpha = alpha;
+        [controller scheduleTargetRefreshIfNeeded];
+    }
 }
 
 // Returns whether the recenter actually ran to a decision. NO means it bailed
@@ -1366,8 +1415,10 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl) {
         objc_setAssociatedObject(self, &kApolloNavigationTitleGlassControllerKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         return;
     }
+    __weak UIView *weakTitleControl = (UIView *)self;
     dispatch_async(dispatch_get_main_queue(), ^{
-        ApolloUpdateNavigationTitleGlass(self);
+        UIView *titleControl = weakTitleControl;
+        if (titleControl) ApolloUpdateNavigationTitleGlass(titleControl);
     });
 }
 
@@ -1382,8 +1433,10 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl) {
     if (controller) {
         [controller scheduleTargetRefreshIfNeeded];
     } else {
+        __weak UIView *weakTitleControl = (UIView *)self;
         dispatch_async(dispatch_get_main_queue(), ^{
-            ApolloUpdateNavigationTitleGlass(self);
+            UIView *titleControl = weakTitleControl;
+            if (titleControl) ApolloUpdateNavigationTitleGlass(titleControl);
         });
     }
 }

--- a/src/ApolloSubredditFilterDetailViewController.m
+++ b/src/ApolloSubredditFilterDetailViewController.m
@@ -104,6 +104,7 @@ typedef NS_ENUM(NSInteger, ApolloPFDetailSection) {
         UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
         cell.textLabel.text = items[indexPath.row];
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
+        [self apollo_applyPrimaryTextColorToCell:cell];
         return cell;
     }
 

--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -276,6 +276,9 @@ static ApolloThemeFont CurrentFontChoice(void) {
 
 static BOOL ClassNameLooksApolloOwned(const char *name);
 static BOOL TextSinkMayUseTheme(id object, uintptr_t caller);
+static NSAttributedString *ThemedAttributedText(NSAttributedString *text,
+                                                id owner,
+                                                uintptr_t caller);
 
 // Pinned views carry a font the tweak chose deliberately in a SPECIFIC design
 // (the editor's font-picker tiles and preview rows must each render their own
@@ -283,6 +286,9 @@ static BOOL TextSinkMayUseTheme(id object, uintptr_t caller);
 // skip them.
 static const void *kApolloThemeFontPinnedKey = &kApolloThemeFontPinnedKey;
 static const void *kApolloThemeBackgroundColorPassthroughKey = &kApolloThemeBackgroundColorPassthroughKey;
+static const void *kApolloThemeOriginalAttributedTextKey =
+    &kApolloThemeOriginalAttributedTextKey;
+static __thread NSInteger sAttributedTextAssignmentBypass;
 
 void ApolloThemeRuntimeSetFontPinned(id view, BOOL pinned) {
     if (!view) return;
@@ -596,22 +602,82 @@ static UINavigationBar *NavigationBarForDescendant(UIView *view) {
     return nil;
 }
 
+static UIViewController *ChromeBarOwningViewController(UIView *bar) {
+    for (UIResponder *responder = bar; responder; responder = responder.nextResponder) {
+        if ([responder isKindOfClass:[UINavigationController class]]) {
+            UINavigationController *navigationController = (UINavigationController *)responder;
+            return navigationController.visibleViewController ?: navigationController.topViewController;
+        }
+        if ([responder isKindOfClass:[UIViewController class]]) {
+            return (UIViewController *)responder;
+        }
+    }
+    return nil;
+}
+
 // Nav/tab bars host their labels outside Apollo's view/responder chain, so
 // ownership is vetted at the bar: either the chain reaches an Apollo class,
-// or the bar's delegate is one (Apollo's own controllers).
+// the bar's delegate is one, or the owning navigation controller is currently
+// displaying one. UINavigationBar.delegate is normally the UINavigationController
+// itself, so checking only the delegate misses Apollo's Swift child controllers.
 static BOOL ChromeBarLooksApolloOwned(UIView *bar) {
     if (!([bar isKindOfClass:[UINavigationBar class]] || [bar isKindOfClass:[UITabBar class]])) return NO;
     if (ObjectChainLooksApolloOwned(bar)) return YES;
     id delegate = ((id (*)(id, SEL))objc_msgSend)(bar, @selector(delegate));
     if (delegate && ClassNameLooksApolloOwned(class_getName(object_getClass(delegate)))) return YES;
+    UIViewController *owner = ChromeBarOwningViewController(bar);
+    if (owner && ClassNameLooksApolloOwned(class_getName(object_getClass(owner)))) return YES;
     return NO;
 }
 
 // Re-derive one live text control's font into `target`'s design. Only touches
 // fonts that are Apple system designs (explicit app fonts like markdown code
 // faces survive) and skips pinned views (the editor's picker tiles).
+static BOOL AttributedTextSuppliesAllTextFonts(NSAttributedString *text) {
+    if (![text isKindOfClass:[NSAttributedString class]] || text.length == 0) return NO;
+    __block BOOL foundFont = NO;
+    __block BOOL foundUnstyledText = NO;
+    [text enumerateAttributesInRange:NSMakeRange(0, text.length)
+                             options:0
+                          usingBlock:^(NSDictionary<NSAttributedStringKey, id> *attributes,
+                                       NSRange range,
+                                       BOOL *stop) {
+        if ([attributes[NSFontAttributeName] isKindOfClass:[UIFont class]]) {
+            foundFont = YES;
+            return;
+        }
+        // Attachments use their own bounds and intentionally have no font.
+        if ([attributes[NSAttachmentAttributeName] isKindOfClass:[NSTextAttachment class]]) return;
+        foundUnstyledText = YES;
+        *stop = YES;
+    }];
+    return foundFont && !foundUnstyledText;
+}
+
+static void SetLabelAttributedTextWithoutRecapture(UILabel *label,
+                                                   NSAttributedString *text) {
+    sAttributedTextAssignmentBypass++;
+    label.attributedText = text;
+    sAttributedTextAssignmentBypass--;
+}
+
 static void RefreshFontOnTextControl(UIView *view, ApolloThemeFont target) {
     if (FontPinned(view)) return;
+    if ([view isKindOfClass:[UILabel class]] &&
+        AttributedTextSuppliesAllTextFonts(((UILabel *)view).attributedText)) {
+        UILabel *label = (UILabel *)view;
+        NSAttributedString *original = objc_getAssociatedObject(
+            label, kApolloThemeOriginalAttributedTextKey);
+        NSAttributedString *source = original ?: label.attributedText;
+        NSAttributedString *themed = sEnabled
+            ? ThemedAttributedText(source, label,
+                                   (uintptr_t)&RefreshFontOnTextControl)
+            : source;
+        if (![themed isEqualToAttributedString:label.attributedText]) {
+            SetLabelAttributedTextWithoutRecapture(label, themed);
+        }
+        return;
+    }
     UIFont *font = ((UILabel *)view).font; // UILabel/UITextField/UITextView all expose `font`
     if (![font isKindOfClass:[UIFont class]] || !FontIsThemeable(font)) return;
     sFontBypass++;
@@ -668,20 +734,73 @@ static void RethemeFontOnAttach(UIView *view) {
     if (!sEnabled || sFontBypass) return;
     if (!view.window) return;
     if (FontPinned(view)) return;
+    // An attributed label's visible font and color come from its string, while
+    // UILabel.font remains the backing line-box font. Theme the attributed
+    // runs in place, but leave that backing font untouched: replacing it can
+    // both enlarge the rendered text and collapse spacing that intentionally
+    // relies on a larger line box (Recently Read's 12pt stats inside a default
+    // 17pt label).
+    if ([view isKindOfClass:[UILabel class]] &&
+        AttributedTextSuppliesAllTextFonts(((UILabel *)view).attributedText)) {
+        if (!ObjectChainLooksApolloOwned(view)) return;
+        UILabel *label = (UILabel *)view;
+        NSAttributedString *original = objc_getAssociatedObject(
+            label, kApolloThemeOriginalAttributedTextKey);
+        NSAttributedString *source = original ?: label.attributedText;
+        NSAttributedString *themed = ThemedAttributedText(
+            source, label, (uintptr_t)&RethemeFontOnAttach);
+        if (![themed isEqualToAttributedString:label.attributedText]) {
+            SetLabelAttributedTextWithoutRecapture(label, themed);
+        }
+        return;
+    }
     UIFont *font = ((UILabel *)view).font; // UILabel/UITextField/UITextView all expose `font`
     if (![font isKindOfClass:[UIFont class]] || !FontIsThemeable(font)) return;
     sFontBypass++;
     UIFont *themed = ApolloThemeFontApply(CurrentFontChoice(), font);
-    if (themed && ![themed.fontName isEqualToString:font.fontName] && ObjectChainLooksApolloOwned(view)) {
+    if (themed && ![themed.fontName isEqualToString:font.fontName] &&
+        ObjectChainLooksApolloOwned(view)) {
         ((void (*)(id, SEL, id))objc_msgSend)(view, @selector(setFont:), themed);
     }
     sFontBypass--;
 }
 
-static void ApplyThemeFontToNavigationTitleControl(UIView *titleControl) {
-    if (!sEnabled || ![titleControl isKindOfClass:[UIView class]]) return;
+static void ApplyThemeColorToNavigationTitleLabels(UIView *view, UIColor *primaryColor) {
+    if ([view isKindOfClass:[UILabel class]]) {
+        UILabel *label = (UILabel *)view;
+        NSAttributedString *original =
+            objc_getAssociatedObject(label, kApolloThemeOriginalAttributedTextKey);
+        NSAttributedString *source = original ?: label.attributedText;
+        if (source.length > 0) {
+            NSAttributedString *base = sEnabled
+                ? ThemedAttributedText(source, label,
+                                       (uintptr_t)&ApplyThemeColorToNavigationTitleLabels)
+                : source;
+            NSMutableAttributedString *colored = [base mutableCopy];
+            [colored addAttribute:NSForegroundColorAttributeName
+                            value:primaryColor
+                            range:NSMakeRange(0, colored.length)];
+            if (![colored isEqualToAttributedString:label.attributedText]) {
+                SetLabelAttributedTextWithoutRecapture(label, colored);
+            }
+        } else if (![label.textColor isEqual:primaryColor]) {
+            label.textColor = primaryColor;
+        }
+    }
+    for (UIView *subview in view.subviews) {
+        ApplyThemeColorToNavigationTitleLabels(subview, primaryColor);
+    }
+}
+
+static void ApplyThemeToNavigationTitleControl(UIView *titleControl) {
+    if (![titleControl isKindOfClass:[UIView class]]) return;
     if (!ChromeBarLooksApolloOwned(NavigationBarForDescendant(titleControl))) return;
-    RefreshFontsInViewTree(titleControl, CurrentFontChoice(), YES);
+    ApolloThemeFont target = sEnabled ? CurrentFontChoice() : ApolloThemeFontSystem;
+    RefreshFontsInViewTree(titleControl, target, YES);
+    UIColor *primary = sEnabled
+        ? ApolloThemeRuntimeColor(ApolloThemeTokenLabel)
+        : [UIColor labelColor];
+    if (primary) ApplyThemeColorToNavigationTitleLabels(titleControl, primary);
 }
 
 // Per-thread text-sink bypass (ASDK builds nodes off the main thread, so a
@@ -1634,6 +1753,12 @@ void ApolloThemeRuntimeInvalidate(void) {
 }
 
 - (void)setAttributedText:(NSAttributedString *)attributedText {
+    if (sAttributedTextAssignmentBypass) {
+        %orig(attributedText);
+        return;
+    }
+    objc_setAssociatedObject(self, kApolloThemeOriginalAttributedTextKey,
+                             [attributedText copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     uintptr_t caller = (uintptr_t)__builtin_return_address(0);
     %orig(ThemedAttributedText(attributedText, (id)self, caller));
 }
@@ -1724,9 +1849,14 @@ static ASImageNodeTintColorModificationBlockFn ASImageNodeTintColorModificationB
 
 %hook _UINavigationBarTitleControl
 
+- (void)didMoveToWindow {
+    %orig;
+    if (self.window) ApplyThemeToNavigationTitleControl((UIView *)self);
+}
+
 - (void)layoutSubviews {
     %orig;
-    ApplyThemeFontToNavigationTitleControl((UIView *)self);
+    ApplyThemeToNavigationTitleControl((UIView *)self);
 }
 
 %end

--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -67,12 +67,59 @@ static const void *kApolloProfileTabOriginalImageKey = &kApolloProfileTabOrigina
 static const void *kApolloProfileTabOriginalSelectedImageKey = &kApolloProfileTabOriginalSelectedImageKey;
 static const void *kApolloProfileTabAppliedUsernameKey = &kApolloProfileTabAppliedUsernameKey;
 static const void *kApolloProfileTabAppliedImageKey = &kApolloProfileTabAppliedImageKey;
+static const void *kApolloProfileNavTitleViewKey = &kApolloProfileNavTitleViewKey;
 // Marker stamped on every rendered profile-tab avatar UIImage so the UIImageView
 // monochromatic-treatment clamp can recognise our avatar regardless of which tab
 // view class hosts it.
 static const void *kApolloProfileTabAvatarImageMarkerKey = &kApolloProfileTabAvatarImageMarkerKey;
 
 @class ApolloProfileStatCard;
+
+@interface ApolloProfileNavTitleView : UIView
+@property(nonatomic, strong) UILabel *titleLabel;
+- (void)apollo_setTitle:(NSString *)title;
+@end
+
+@implementation ApolloProfileNavTitleView
+
+- (instancetype)initWithTitle:(NSString *)title {
+    self = [super initWithFrame:CGRectZero];
+    if (self) {
+        _titleLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+        _titleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
+        _titleLabel.adjustsFontForContentSizeCategory = YES;
+        _titleLabel.textColor = [UIColor labelColor];
+        _titleLabel.textAlignment = NSTextAlignmentCenter;
+        _titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
+        _titleLabel.alpha = 1.0;
+        _titleLabel.accessibilityElementsHidden = NO;
+        [self addSubview:_titleLabel];
+        [self apollo_setTitle:title];
+    }
+    return self;
+}
+
+- (void)apollo_setTitle:(NSString *)title {
+    self.titleLabel.text = title;
+    CGSize size = self.titleLabel.intrinsicContentSize;
+    size.width = MIN(size.width, 240.0);
+    self.bounds = (CGRect){ CGPointZero, size };
+    self.titleLabel.frame = self.bounds;
+    [self invalidateIntrinsicContentSize];
+    [self setNeedsLayout];
+}
+
+- (CGSize)intrinsicContentSize {
+    CGSize size = self.titleLabel.intrinsicContentSize;
+    return CGSizeMake(MIN(size.width, 240.0), size.height);
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    self.titleLabel.frame = self.bounds;
+}
+
+@end
 
 @interface ApolloProfileHeaderView : UIView
 @property(nonatomic, strong) UIImageView *bannerImageView;
@@ -2881,6 +2928,9 @@ static UIView *ApolloProfileUsernameCopyFindLabelInView(UIView *rootView, NSStri
 
 static UIView *ApolloProfileUsernameCopyTargetForController(UIViewController *viewController, NSString *username) {
     UIView *titleView = viewController.navigationItem.titleView;
+    if ([titleView isKindOfClass:[ApolloProfileNavTitleView class]]) {
+        return ((ApolloProfileNavTitleView *)titleView).titleLabel;
+    }
     UIView *target = ApolloProfileUsernameCopyFindLabelInView(titleView, username);
     if (target) return target;
     if ([titleView isKindOfClass:[UILabel class]] && ApolloAvatarUsernameMatches(((UILabel *)titleView).text, username)) return titleView;
@@ -3000,76 +3050,24 @@ static void ApolloProfileRemoveAmbient(UIViewController *viewController, UITable
     header.bannerImageView.alpha = 1.0;
 }
 
-// Like the username-copy finder, but without the alpha guard — once we have faded
-// the title to 0 we still need to find it again to fade it back in.
-static UIView *ApolloProfileNavTitleLabelInView(UIView *rootView, NSString *username) {
-    if (!rootView || username.length == 0 || rootView.hidden) return nil;
-    if ([rootView isKindOfClass:[UILabel class]] &&
-        ApolloAvatarUsernameMatches(((UILabel *)rootView).text, username)) {
-        return rootView;
+static ApolloProfileNavTitleView *ApolloProfileInstallNavTitleView(UIViewController *viewController) {
+    if (!viewController) return nil;
+    UINavigationItem *item = viewController.navigationItem;
+    ApolloProfileNavTitleView *titleView = objc_getAssociatedObject(item, kApolloProfileNavTitleViewKey);
+    if (!titleView) {
+        NSString *title = item.title ?: viewController.title
+            ?: ApolloUsernameFromProfileViewController(viewController);
+        titleView = [[ApolloProfileNavTitleView alloc] initWithTitle:title];
+        BOOL willInstallHeader =
+            sShowDetailedProfiles &&
+            ApolloUsernameFromProfileViewController(viewController).length > 0;
+        titleView.titleLabel.alpha = willInstallHeader ? 0.0 : 1.0;
+        titleView.titleLabel.accessibilityElementsHidden = willInstallHeader;
+        objc_setAssociatedObject(item, kApolloProfileNavTitleViewKey,
+                                 titleView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
-    for (UIView *subview in rootView.subviews) {
-        UIView *match = ApolloProfileNavTitleLabelInView(subview, username);
-        if (match) return match;
-    }
-    return nil;
-}
-
-static const void *kApolloProfileNavTitleFadeTargetKey = &kApolloProfileNavTitleFadeTargetKey;
-static const void *kApolloProfileNavTitleFadeMissAtKey = &kApolloProfileNavTitleFadeMissAtKey;
-// After a miss, don't re-walk the whole nav bar on every scroll frame — but the
-// target CAN appear late (the title control builds during a fling), so the miss
-// is only cached for a short window before we retry. Bounds a sustained miss to
-// a few walks/sec instead of 60-120, while still finding a late target quickly.
-static const NSTimeInterval kApolloProfileNavTitleFadeMissWindow = 0.3;
-
-// The view whose alpha the cross-fade drives: the _UINavigationBarTitleControl
-// hosting the title label when there is one (so the Liquid Glass title capsule
-// fades with the text), else the label itself.
-//
-// This runs on every scrollViewDidScroll: (60-120/sec during a fling), and the
-// lookup is an unbounded recursive subview walk of the whole nav bar plus a
-// string match per candidate label — expensive to repeat every frame. Cache
-// the resolved view on the controller and only re-walk when it's no longer
-// parented under this nav bar (Apollo occasionally rebuilds the title view,
-// e.g. on a nav-bar style change).
-static UIView *ApolloProfileNavTitleFadeTargetForController(UIViewController *viewController) {
-    ApolloProfileHeaderView *header = objc_getAssociatedObject(viewController, kApolloProfileHeaderViewKey);
-    if (!header || header.username.length == 0) return nil;
-    UINavigationBar *navigationBar = viewController.navigationController.navigationBar;
-    if (!navigationBar) return nil;
-
-    UIView *cached = objc_getAssociatedObject(viewController, kApolloProfileNavTitleFadeTargetKey);
-    if (cached) {
-        UIView *walk = cached.superview;
-        while (walk && walk != navigationBar) walk = walk.superview;
-        if (walk == navigationBar) return cached;
-    }
-
-    // Recent miss still within its window → skip the walk this frame.
-    NSNumber *missAt = objc_getAssociatedObject(viewController, kApolloProfileNavTitleFadeMissAtKey);
-    if (missAt && (CACurrentMediaTime() - missAt.doubleValue) < kApolloProfileNavTitleFadeMissWindow) {
-        return nil;
-    }
-
-    UIView *label = ApolloProfileNavTitleLabelInView(navigationBar, header.username);
-    if (!label) {
-        objc_setAssociatedObject(viewController, kApolloProfileNavTitleFadeTargetKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        objc_setAssociatedObject(viewController, kApolloProfileNavTitleFadeMissAtKey, @(CACurrentMediaTime()), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        return nil;
-    }
-    objc_setAssociatedObject(viewController, kApolloProfileNavTitleFadeMissAtKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    UIView *target = label;
-    UIView *candidate = label.superview;
-    while (candidate && candidate != navigationBar) {
-        if ([NSStringFromClass(candidate.class) containsString:@"TitleControl"]) {
-            target = candidate;
-            break;
-        }
-        candidate = candidate.superview;
-    }
-    objc_setAssociatedObject(viewController, kApolloProfileNavTitleFadeTargetKey, target, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    return target;
+    if (item.titleView != titleView) item.titleView = titleView;
+    return titleView;
 }
 
 // Large-title choreography: while the header's big display name is on screen the
@@ -3078,36 +3076,29 @@ static UIView *ApolloProfileNavTitleFadeTargetForController(UIViewController *vi
 // header is torn down (toggle off) or the name row is not part of the header.
 static void ApolloProfileApplyNavTitleFade(UIViewController *viewController, UIScrollView *scrollView) {
     if (!ApolloProfileViewControllerIsVisibleTopController(viewController)) return;
-    UIView *target = ApolloProfileNavTitleFadeTargetForController(viewController);
+    ApolloProfileNavTitleView *titleView = ApolloProfileInstallNavTitleView(viewController);
+    UILabel *target = titleView.titleLabel;
     if (!target) return;
 
     ApolloProfileHeaderView *header = objc_getAssociatedObject(viewController, kApolloProfileHeaderViewKey);
-    CGFloat alpha = 1.0;
+    CGFloat alpha = target.alpha;
     if (header.window && !header.displayNameLabel.hidden && [scrollView isKindOfClass:[UIScrollView class]]) {
         CGRect nameRect = [header convertRect:header.displayNameLabel.frame toView:scrollView];
         CGFloat visibleTop = scrollView.contentOffset.y + scrollView.adjustedContentInset.top;
         CGFloat fadeStart = CGRectGetMinY(nameRect);
         CGFloat fadeSpan = MAX(CGRectGetHeight(nameRect), 1.0);
         alpha = MIN(1.0, MAX(0.0, (visibleTop - fadeStart) / fadeSpan));
+    } else if (header.displayNameLabel.hidden) {
+        alpha = 1.0;
     }
-    if (fabs(target.alpha - alpha) > 0.001) target.alpha = alpha;
+    if (fabs(target.alpha - alpha) > 0.001) {
+        target.alpha = alpha;
+        ApolloNavigationTitleGlassSetContentAlpha(titleView, alpha);
+    }
     // An alpha-0 title is still hit-testable/VoiceOver-visible by default,
     // which would expose a duplicate (invisible) title alongside the header's
     // own name — hide it from the accessibility tree while faded out.
     target.accessibilityElementsHidden = alpha <= 0.01;
-}
-
-// Restore the faded title control to alpha 1 (and un-hide it from
-// accessibility). Called when the profile disappears: the fade drives the
-// SHARED _UINavigationBarTitleControl to alpha 0, and only scroll events
-// un-fade it — none fire after a pop, so a profile popped while scrolled to the
-// top would leave the title control at alpha 0. If UIKit then reuses that
-// control for the destination screen's title, it would render invisible.
-static void ApolloProfileResetNavTitleFade(UIViewController *viewController) {
-    UIView *target = objc_getAssociatedObject(viewController, kApolloProfileNavTitleFadeTargetKey);
-    if (!target) return;
-    if (fabs(target.alpha - 1.0) > 0.001) target.alpha = 1.0;
-    target.accessibilityElementsHidden = NO;
 }
 
 // Re-derive the fade from the table's current offset (appear/layout paths, where
@@ -3139,13 +3130,16 @@ static void ApolloProfileUpdateAmbientScroll(id viewControllerObject, UIScrollVi
 static void ApolloProfileRemoveHeader(id viewControllerObject, UITableView *tableView) {
     if (!viewControllerObject) return;
 
-    // The cross-fade may have the nav title at alpha 0; with the header gone the
-    // title is the only identity on the page, so bring it back before clearing
-    // the header association (the fade-target lookup needs it).
+    // With the custom header gone, the navigation title is the only identity.
     if ([viewControllerObject isKindOfClass:[UIViewController class]]) {
-        UIView *fadeTarget = ApolloProfileNavTitleFadeTargetForController((UIViewController *)viewControllerObject);
-        if (fadeTarget) fadeTarget.alpha = 1.0;
-        objc_setAssociatedObject(viewControllerObject, kApolloProfileNavTitleFadeTargetKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        UIViewController *viewController = (UIViewController *)viewControllerObject;
+        ApolloProfileNavTitleView *titleView =
+            objc_getAssociatedObject(viewController.navigationItem,
+                                     kApolloProfileNavTitleViewKey);
+        if (titleView.titleLabel) {
+            titleView.titleLabel.alpha = 1.0;
+            titleView.titleLabel.accessibilityElementsHidden = NO;
+        }
     }
 
     UIView *wrappedHeader = objc_getAssociatedObject(viewControllerObject, kApolloProfileWrappedHeaderKey);
@@ -3190,6 +3184,9 @@ static void ApolloProfileInstallOrUpdateHeader(id viewControllerObject) {
         if (ApolloViewControllerLooksProfileRelated(viewController)) {
             ApolloLogDebug(@"[UserAvatars] Profile header skipped class=%@ vc=%p reason=no-table", className, viewControllerObject);
         }
+        ApolloProfileNavTitleView *titleView = ApolloProfileInstallNavTitleView(viewController);
+        titleView.titleLabel.alpha = 1.0;
+        titleView.titleLabel.accessibilityElementsHidden = NO;
         return;
     }
 
@@ -3218,6 +3215,9 @@ static void ApolloProfileInstallOrUpdateHeader(id viewControllerObject) {
         if (ApolloViewControllerLooksProfileRelated(viewController)) {
             ApolloLogDebug(@"[UserAvatars] Profile header skipped class=%@ vc=%p table=%p reason=no-username title=%@", className, viewControllerObject, tableView, viewController.navigationItem.title ?: viewController.title ?: @"nil");
         }
+        ApolloProfileNavTitleView *titleView = ApolloProfileInstallNavTitleView(viewController);
+        titleView.titleLabel.alpha = 1.0;
+        titleView.titleLabel.accessibilityElementsHidden = NO;
         return;
     }
 
@@ -4186,6 +4186,7 @@ static void ApolloAvatarApplySubredditIconToSharePreview(id postInfo, NSString *
 
 - (void)viewDidLoad {
     %orig;
+    ApolloProfileInstallNavTitleView((UIViewController *)self);
     ApolloProfileScheduleInstallOrUpdateHeader(self);
     ApolloProfileInstallUsernameCopyInteraction((UIViewController *)self, @"viewDidLoad");
     ApolloProfileApplyTabAvatarForController(((UIViewController *)self).tabBarController);
@@ -4198,20 +4199,15 @@ static void ApolloAvatarApplySubredditIconToSharePreview(id postInfo, NSString *
 
 - (void)viewWillAppear:(BOOL)animated {
     %orig;
+    ApolloProfileInstallNavTitleView((UIViewController *)self);
     ApolloProfileScheduleInstallOrUpdateHeader(self);
     ApolloProfileInstallUsernameCopyInteraction((UIViewController *)self, @"viewWillAppear");
     ApolloProfileApplyTabAvatarForController(((UIViewController *)self).tabBarController);
 }
 
-- (void)viewWillDisappear:(BOOL)animated {
-    %orig;
-    // Un-fade the shared nav title control we may have driven to alpha 0, so the
-    // next screen doesn't inherit an invisible title if UIKit reuses the control.
-    ApolloProfileResetNavTitleFade((UIViewController *)self);
-}
-
 - (void)viewDidAppear:(BOOL)animated {
     %orig;
+    ApolloProfileInstallNavTitleView((UIViewController *)self);
     ApolloProfileScheduleInstallOrUpdateHeader(self);
     ApolloProfileInstallUsernameCopyInteraction((UIViewController *)self, @"viewDidAppear");
     ApolloProfileApplyTabAvatarForController(((UIViewController *)self).tabBarController);
@@ -4219,6 +4215,7 @@ static void ApolloAvatarApplySubredditIconToSharePreview(id postInfo, NSString *
 
 - (void)viewDidLayoutSubviews {
     %orig;
+    ApolloProfileInstallNavTitleView((UIViewController *)self);
     ApolloProfileScheduleInstallOrUpdateHeader(self);
     ApolloProfileInstallUsernameCopyInteraction((UIViewController *)self, @"viewDidLayoutSubviews");
 }
@@ -4246,6 +4243,17 @@ static void ApolloAvatarApplySubredditIconToSharePreview(id postInfo, NSString *
     %orig(notification);
     ApolloProfileRefreshControllersForUsername(nil);
     ApolloProfileScheduleAccountChangeTabAvatarRefresh(@"ProfileViewController account notification");
+}
+
+%end
+
+%hook UINavigationItem
+
+- (void)setTitle:(NSString *)title {
+    %orig(title);
+    ApolloProfileNavTitleView *titleView =
+        objc_getAssociatedObject(self, kApolloProfileNavTitleViewKey);
+    [titleView apollo_setTitle:title];
 }
 
 %end

--- a/src/PictureInPictureViewController.m
+++ b/src/PictureInPictureViewController.m
@@ -78,6 +78,7 @@ typedef NS_ENUM(NSInteger, PictureInPictureSharedRow) {
     sw.enabled = enabled;
     [sw addTarget:self action:action forControlEvents:UIControlEventValueChanged];
     cell.accessoryView = sw;
+    if (enabled) [self apollo_applyPrimaryTextColorToCell:cell];
     return cell;
 }
 
@@ -96,6 +97,7 @@ typedef NS_ENUM(NSInteger, PictureInPictureSharedRow) {
     cell.textLabel.enabled = enabled;
     cell.detailTextLabel.text = detail;
     cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+    if (enabled) [self apollo_applyPrimaryTextColorToCell:cell];
     return cell;
 }
 

--- a/src/TagFiltersViewController.m
+++ b/src/TagFiltersViewController.m
@@ -90,6 +90,7 @@ typedef NS_ENUM(NSInteger, TagFiltersSection) {
     sw.on = on;
     [sw addTarget:self action:action forControlEvents:UIControlEventValueChanged];
     cell.accessoryView = sw;
+    [self apollo_applyPrimaryTextColorToCell:cell];
     return cell;
 }
 
@@ -221,6 +222,7 @@ typedef NS_ENUM(NSInteger, TagFiltersSection) {
     sw.enabled = enabled;
     [sw addTarget:self action:action forControlEvents:UIControlEventValueChanged];
     cell.accessoryView = sw;
+    if (enabled) [self apollo_applyPrimaryTextColorToCell:cell];
     return cell;
 }
 
@@ -244,6 +246,7 @@ typedef NS_ENUM(NSInteger, TagFiltersSection) {
             cell.detailTextLabel.text = [self summaryForOverride:sub];
             cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+            [self apollo_applyPrimaryTextColorToCell:cell];
             return cell;
         }
         UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];

--- a/src/settings/ApolloAISettingsViewController.m
+++ b/src/settings/ApolloAISettingsViewController.m
@@ -429,6 +429,7 @@ static UIView *ApolloAIModelAccessory(NSString *badge, BOOL selected, UIColor *f
     cell.accessoryType = UITableViewCellAccessoryNone;
     cell.accessoryView = ApolloAIModelAccessory(badge,
         [modelID isEqualToString:self.currentModel], tableView.tintColor);
+    [self apollo_applyPrimaryTextColorToCell:cell];
     return cell;
 }
 

--- a/src/settings/ApolloBuyUsACoffeeViewController.m
+++ b/src/settings/ApolloBuyUsACoffeeViewController.m
@@ -103,6 +103,7 @@ static NSString *const kBuyCoffeeCellId = @"Cell_BuyCoffee";
     cell.textLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     cell.imageView.image = ApolloBuyMeACoffeeSettingsIcon(32.0);
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    [self apollo_applyPrimaryTextColorToCell:cell];
     return cell;
 }
 

--- a/src/settings/ApolloLinkPreviewSettingsViewController.m
+++ b/src/settings/ApolloLinkPreviewSettingsViewController.m
@@ -451,6 +451,7 @@ static NSArray<NSString *> *ApolloLPQuickSwatchHexes(void) {
         ? [NSString stringWithFormat:@"#%@", [sLinkPreviewCardColorHex uppercaseString]]
         : @"Default";
     cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+    [self apollo_applyPrimaryTextColorToCell:cell];
     return cell;
 }
 

--- a/src/settings/ApolloPollSettingsViewController.m
+++ b/src/settings/ApolloPollSettingsViewController.m
@@ -116,6 +116,7 @@ typedef NS_ENUM(NSInteger, ApolloPollSettingsSection) {
     cell.textLabel.text = @"Option Text Alignment";
     cell.detailTextLabel.text = [self alignmentText];
     cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+    [self apollo_applyPrimaryTextColorToCell:cell];
     return cell;
 }
 
@@ -127,6 +128,7 @@ typedef NS_ENUM(NSInteger, ApolloPollSettingsSection) {
     toggle.on = [self pollsEnabled];
     [toggle addTarget:self action:@selector(pollsSwitchToggled:) forControlEvents:UIControlEventValueChanged];
     cell.accessoryView = toggle;
+    [self apollo_applyPrimaryTextColorToCell:cell];
     return cell;
 }
 
@@ -157,6 +159,7 @@ typedef NS_ENUM(NSInteger, ApolloPollSettingsSection) {
         check.tintColor = [UIColor systemGreenColor];
         [check sizeToFit];
         cell.accessoryView = check;
+        [self apollo_applyPrimaryTextColorToCell:cell];
         return cell;
     }
 

--- a/src/settings/ApolloSettings.xm
+++ b/src/settings/ApolloSettings.xm
@@ -11,6 +11,7 @@
 #import "PictureInPictureViewController.h"
 #import "ApolloSettingsSearch.h"
 #import "ApolloReportViewController.h"
+#import "ApolloThemeRuntime.h"
 
 // MARK: - Settings View Controller (Custom API row injection)
 
@@ -211,6 +212,8 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
             cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:reuseID];
         }
         cell.textLabel.text = indexPath.row == 0 ? @"Apollo Reborn" : @"Buy Us a Coffee";
+        UIColor *primaryText = ApolloThemeRuntimeColor(ApolloThemeTokenLabel);
+        if (primaryText) cell.textLabel.textColor = primaryText;
         cell.imageView.image = indexPath.row == 0
             ? (ApolloRebornOptionsSettingsIcon(29.0) ?: createSettingsIcon(@"key.fill", [UIColor systemTealColor]))
             : ApolloBuyMeACoffeeSettingsIcon(29.0);

--- a/src/settings/ApolloSettingsForm.m
+++ b/src/settings/ApolloSettingsForm.m
@@ -431,6 +431,9 @@ static void ApolloSFAddPath(NSMutableDictionary<NSNumber *, NSMutableArray<NSInd
     } else if (row.kind != ApolloSFRowKindCustom) {
         cell.imageView.image = nil;
     }
+    if (row.kind != ApolloSFRowKindButton && row.kind != ApolloSFRowKindCustom) {
+        [self apollo_applyPrimaryTextColorToCell:cell];
+    }
     if (row.configure) row.configure(cell);
     return cell;
 }

--- a/src/settings/ApolloSettingsSearch.m
+++ b/src/settings/ApolloSettingsSearch.m
@@ -567,6 +567,7 @@ static void ApolloSettingsSearchOpenEntry(UIViewController *settingsVC, ApolloSe
     cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
     cell.imageView.image = entry.iconImage;
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    [self apollo_applyPrimaryTextColorToCell:cell];
     return cell;
 }
 

--- a/src/settings/ApolloSettingsTableViewController.h
+++ b/src/settings/ApolloSettingsTableViewController.h
@@ -4,6 +4,7 @@
 - (UITableView *)apollo_sourceThemeTableView;
 - (UIColor *)apollo_themeCellBackgroundColor;
 - (UIColor *)apollo_themeAccentColor;
+- (void)apollo_applyPrimaryTextColorToCell:(UITableViewCell *)cell;
 - (void)apollo_applyAccentActionTextColorToCell:(UITableViewCell *)cell;
 - (void)apollo_applyThemeToCell:(UITableViewCell *)cell;
 - (void)apollo_applyTheme;

--- a/src/settings/ApolloSettingsTableViewController.m
+++ b/src/settings/ApolloSettingsTableViewController.m
@@ -5,6 +5,7 @@
 #import <objc/runtime.h>
 
 static char kApolloAccentActionCellKey;
+static char kApolloPrimaryTextCellKey;
 
 @implementation ApolloSettingsTableViewController
 
@@ -42,6 +43,11 @@ static char kApolloAccentActionCellKey;
     return ApolloThemeAccentColor() ?: self.view.tintColor ?: [UIColor systemBlueColor];
 }
 
+- (void)apollo_applyPrimaryTextColorToCell:(UITableViewCell *)cell {
+    if (!cell) return;
+    objc_setAssociatedObject(cell, &kApolloPrimaryTextCellKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 - (void)apollo_applyAccentActionTextColorToCell:(UITableViewCell *)cell {
     if (!cell) return;
     objc_setAssociatedObject(cell, &kApolloAccentActionCellKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -63,6 +69,10 @@ static char kApolloAccentActionCellKey;
 
     if ([objc_getAssociatedObject(cell, &kApolloAccentActionCellKey) boolValue]) {
         cell.textLabel.textColor = accentColor;
+    } else if (cell.textLabel.enabled &&
+               [objc_getAssociatedObject(cell, &kApolloPrimaryTextCellKey) boolValue]) {
+        UIColor *primary = ApolloThemeRuntimeColor(ApolloThemeTokenLabel);
+        if (primary) cell.textLabel.textColor = primary;
     }
 }
 

--- a/src/settings/ApolloThanksToViewController.m
+++ b/src/settings/ApolloThanksToViewController.m
@@ -129,6 +129,7 @@ static BOOL ApolloThanksToContributorIsPinned(NSDictionary *contributor) {
         : [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.imageView.image = nil;
+    [self apollo_applyPrimaryTextColorToCell:cell];
     return cell;
 }
 

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -640,6 +640,7 @@ typedef NS_ENUM(NSInteger, Tag) {
         cell.textLabel.text = title;
         cell.textLabel.numberOfLines = 0;
         cell.detailTextLabel.text = subtitle ? subtitle() : nil;
+        [weakSelf apollo_applyPrimaryTextColorToCell:cell];
         return cell;
     }
                                      onSelect:^{
@@ -981,6 +982,7 @@ typedef NS_ENUM(NSInteger, Tag) {
                 [check sizeToFit];
                 cell.accessoryView = check;
                 cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+                [weakSelf apollo_applyPrimaryTextColorToCell:cell];
                 return cell;
             }
             cell.textLabel.text = @"Set Up reddit.com Web Sign-In";
@@ -1002,6 +1004,7 @@ typedef NS_ENUM(NSInteger, Tag) {
                 cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             }
             cell.textLabel.text = @"Can't sign in?";
+            [weakSelf apollo_applyPrimaryTextColorToCell:cell];
             return cell;
         }
                                   onSelect:^{ [weakSelf pushTroubleshootingViewController]; }];
@@ -1016,6 +1019,7 @@ typedef NS_ENUM(NSInteger, Tag) {
                 cell.textLabel.numberOfLines = 0;
             }
             cell.textLabel.text = @"Giphy & Image Chest API Key Setup";
+            [weakSelf apollo_applyPrimaryTextColorToCell:cell];
             return cell;
         }
                                   onSelect:^{ [weakSelf pushInstructionsViewController]; }];
@@ -1117,6 +1121,7 @@ typedef NS_ENUM(NSInteger, Tag) {
                 cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
                 cell.detailTextLabel.text = @"Not signed in — tap to add a web-session account";
             }
+            [weakSelf apollo_applyPrimaryTextColorToCell:cell];
             return cell;
         }
                                   onSelect:^{
@@ -1210,6 +1215,7 @@ typedef NS_ENUM(NSInteger, Tag) {
                 cell.selectionStyle = UITableViewCellSelectionStyleDefault;
             }
             cell.textLabel.text = @"Deleted Comments";
+            [weakSelf apollo_applyPrimaryTextColorToCell:cell];
             return cell;
         }
                                   onSelect:^{ [weakSelf openDeletedCommentsSettings]; }];
@@ -1482,6 +1488,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
             cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
             cell.detailTextLabel.numberOfLines = 0;
             cell.detailTextLabel.lineBreakMode = NSLineBreakByWordWrapping;
+            [weakSelf apollo_applyPrimaryTextColorToCell:cell];
             return cell;
         }
                                   onSelect:^{ [weakSelf openApolloAISettings]; }];
@@ -1523,6 +1530,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
             cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
             cell.detailTextLabel.numberOfLines = 0;
             cell.detailTextLabel.lineBreakMode = NSLineBreakByWordWrapping;
+            [weakSelf apollo_applyPrimaryTextColorToCell:cell];
             return cell;
         }
                                   onSelect:^{ [weakSelf openInlineMediaSettings]; }];
@@ -1565,6 +1573,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
             cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
             cell.detailTextLabel.numberOfLines = 0;
             cell.detailTextLabel.lineBreakMode = NSLineBreakByWordWrapping;
+            [weakSelf apollo_applyPrimaryTextColorToCell:cell];
             return cell;
         }
                                   onSelect:^{ [weakSelf openLinkPreviewSettings]; }];
@@ -1589,6 +1598,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
             cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
             cell.detailTextLabel.numberOfLines = 0;
             cell.detailTextLabel.lineBreakMode = NSLineBreakByWordWrapping;
+            [weakSelf apollo_applyPrimaryTextColorToCell:cell];
             return cell;
         }
                                   onSelect:^{ [weakSelf openPollSettings]; }];
@@ -2149,6 +2159,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
             cell.imageView.image = ApolloEmojiSettingsIcon(@"🙏", [UIColor systemIndigoColor], 29.0);
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+            [weakSelf apollo_applyPrimaryTextColorToCell:cell];
             return cell;
         }
                                   onSelect:^{ [weakSelf pushThanksToViewController]; }];
@@ -2170,6 +2181,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
             cell.imageView.image = ApolloEmojiSettingsIcon(@"\U0001F4A1", [UIColor systemYellowColor], 29.0);
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+            [weakSelf apollo_applyPrimaryTextColorToCell:cell];
             return cell;
         }
                                   onSelect:^{
@@ -2190,6 +2202,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
             cell.imageView.image = ApolloEmojiSettingsIcon(@"\U0001F41B", [UIColor systemRedColor], 29.0);
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+            [weakSelf apollo_applyPrimaryTextColorToCell:cell];
             return cell;
         }
                                   onSelect:^{
@@ -2208,6 +2221,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
             cell.imageView.image = ApolloEmojiSettingsIcon(@"\U0001F512", [UIColor systemGreenColor], 29.0);
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+            [weakSelf apollo_applyPrimaryTextColorToCell:cell];
             return cell;
         }
                                   onSelect:^{
@@ -2274,6 +2288,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
     textField.text = text;
     textField.accessibilityLabel = label;   // VoiceOver: tie the field to its caption
     cell.textLabel.text = label;
+    [self apollo_applyPrimaryTextColorToCell:cell];
 
     return cell;
 }
@@ -2542,6 +2557,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
     cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+    [self apollo_applyPrimaryTextColorToCell:cell];
     if (b64Image.length > 0) {
         cell.imageView.image = [self roundedImage:[self decodeBase64ToImage:b64Image] size:29 cornerRadius:6.5];
     } else if (!cell.imageView.image) {

--- a/src/settings/InlineMediaSettingsViewController.m
+++ b/src/settings/InlineMediaSettingsViewController.m
@@ -624,6 +624,7 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
     sw.enabled = enabled;
     [sw addTarget:self action:action forControlEvents:UIControlEventValueChanged];
     cell.accessoryView = sw;
+    if (enabled) [self apollo_applyPrimaryTextColorToCell:cell];
     return cell;
 }
 
@@ -635,6 +636,7 @@ typedef NS_ENUM(NSInteger, ApolloIMOptionsRow) {
     cell.textLabel.enabled = enabled;
     cell.detailTextLabel.text = detail;
     cell.detailTextLabel.textColor = [UIColor secondaryLabelColor];
+    if (enabled) [self apollo_applyPrimaryTextColorToCell:cell];
     return cell;
 }
 

--- a/src/settings/SavedCategoriesViewController.m
+++ b/src/settings/SavedCategoriesViewController.m
@@ -59,7 +59,7 @@ static NSString *const kGroupSuiteName = @"group.com.christianselig.apollo";
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
     }
     cell.textLabel.text = _categoryNames[indexPath.row];
-    cell.textLabel.textColor = [UIColor labelColor];
+    [self apollo_applyPrimaryTextColorToCell:cell];
     return cell;
 }
 

--- a/src/settings/TranslationSettingsViewController.m
+++ b/src/settings/TranslationSettingsViewController.m
@@ -188,6 +188,7 @@ static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguag
                 cell.selectionStyle = UITableViewCellSelectionStyleDefault;
                 cell.textLabel.text = [weakSelf displayNameForLanguageCode:code];
                 cell.detailTextLabel.text = code.uppercaseString;
+                [weakSelf apollo_applyPrimaryTextColorToCell:cell];
                 UIButton *trash = [UIButton buttonWithType:UIButtonTypeSystem];
                 if (@available(iOS 13.0, *)) {
                     [trash setImage:[UIImage systemImageNamed:@"trash"] forState:UIControlStateNormal];
@@ -436,6 +437,7 @@ static NSArray<NSDictionary<NSString *, NSString *> *> *ApolloTranslationLanguag
     textField.placeholder = placeholder;
     textField.text = text;
     textField.secureTextEntry = secureEntry;
+    [self apollo_applyPrimaryTextColorToCell:cell];
 
     return cell;
 }


### PR DESCRIPTION
This PR fixes Recently Read transition/rendering regressions and closes several custom-theme gaps in tweak-owned settings UI.

| Without fix | With fix |
|---|---|
| <img width="500" alt="IMG_3916" src="https://github.com/user-attachments/assets/3a26f775-452f-4158-9cf1-39e67b8cda3a" /> | <img width="500" alt="IMG_3915" src="https://github.com/user-attachments/assets/2b2071f6-94ed-4f8c-8c67-7c108933ce77" /> |
| <img width="500" alt="IMG_3913" src="https://github.com/user-attachments/assets/975ad6ac-7924-4bf7-b034-e5fc1a53c462" /> | <img width="500" alt="IMG_3914" src="https://github.com/user-attachments/assets/1f5eee43-88fc-4e71-b32d-d73d9bc3c601" /> |


### Recently Read

Opening Recently Read from Profile could show a partially completed push, an incorrect black background, and oversized vote/comment/time metadata whose spacing changed after navigating away and back.

Two shared behaviors caused this:

- Settings screens inherited the previous table's background directly. Immersive profile/subreddit tables are intentionally transparent, so Recently Read inherited transparency instead of the opaque page behind it.
- Attach-time font repair replaced `UILabel.font` even when the visible text supplied explicit attributed fonts. Recently Read's 12pt stats use the label's default 17pt backing line box for spacing, so rewriting that backing font changed both rendering and geometry.

Theme inheritance now selects the first opaque ancestor background. Fully font-attributed labels retain a per-label source string that is re-themed in place while their backing label font is preserved; the source is restored when custom theming is disabled. Partially attributed labels continue through the normal repair path.

### Settings theme coverage

Normal tweak-owned settings titles now explicitly opt into the custom theme's primary text token through `apollo_applyPrimaryTextColorToCell:`. Coverage includes:

- Standard form switch, value, and disclosure rows.
- Apollo Reborn hub and bespoke feature/About rows.
- Root Apollo Reborn and Buy Us a Coffee entries.
- Contributors, support links, settings search, saved categories, polls, inline media, translation, PiP, filters, AI models, and link-preview settings.

Accent actions, destructive rows, disabled/placeholder states, and intentionally secondary/tertiary labels retain their existing semantic colors. `AGENTS.md` documents the marker rule for future settings work.

Native Apollo navigation titles now resolve ownership through the navigation controller's visible child, so titles such as Subreddits, Inbox, Settings, and General also use the custom theme font.

### Profile title transitions

The profile username could flash during first tab entry, tab switches, and navigation transitions such as returning from Recently Read.

UIKit owns and animates the outer `_UINavigationBarTitleControl` alpha during push/pop transitions, so repeatedly writing that control's alpha could not reliably suppress the flash. Profile now uses a tweak-owned `navigationItem.titleView` with an inner label:

- Apollo's original `navigationItem.title` remains intact for back-button and internal title semantics.
- Apollo title changes are mirrored into the custom label.
- The profile scroll cross-fade controls only the inner label, which UIKit's transition code does not modify.
- The Liquid Glass title capsule is measured even while the label is transparent and follows the same alpha, so text and glass appear/disappear together.

The Liquid Glass title updater's deferred blocks now use weak title-control captures, preventing a use-after-free when navigation transitions replace a title control before the queued refresh runs.

### Testing

- Device-checked Recently Read's transition, background, metadata size/spacing, custom-theme fonts/colors, profile-title transitions, and the relocated Interface setting throughout development.