### PR TITLE
Fix custom-theme text colors in pure black mode and media pills

### DIFF
--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -448,14 +448,24 @@ typedef struct { uint32_t rgb; ApolloThemeToken token; } TextPaletteEntry;
 // which ends in UIColor initWithRed:green:blue:alpha:. We intentionally use the
 // constants only at text render sinks, never as global constructor remaps.
 static const TextPaletteEntry kTextPaletteEntries[] = {
-    // role 0: primary. Read-state primary (0x303030 light / 0xD0D1D6 dark —
-    // the dimmed title Apollo renders once a post is read) routes to secondary
-    // so custom themes keep a visible read/unread distinction (issue #716);
-    // mapping it to Label made read posts identical to unread ones.
+    // role 0: primary. sub_100689abc(role, isRead, isDark) emits three
+    // unread/read pairs, the third gated on "UsePureBlackDarkMode" in the
+    // group.com.christianselig.apollo suite (branch at 0x100689d78):
+    //
+    //     light             #000000 / #999999
+    //     dark              #EEEFF5 / #939499
+    //     dark, pure black  #D0D1D6 / #86868A
+    //
+    // Only the read halves route to SecondaryLabel; that is what keeps a
+    // read/unread distinction under custom themes (issue #716). #D0D1D6 is a
+    // PRIMARY despite being the dimmest of the three — routing it to
+    // SecondaryLabel greys out nearly all text for Pure Black Dark Mode users.
+    // #303030 is emitted nowhere in the binary and is kept only as a defensive
+    // alias of the light primary.
     { 0x000000, ApolloThemeTokenLabel },
-    { 0x303030, ApolloThemeTokenSecondaryLabel },
+    { 0x303030, ApolloThemeTokenLabel },
     { 0xEEEFF5, ApolloThemeTokenLabel },
-    { 0xD0D1D6, ApolloThemeTokenSecondaryLabel },
+    { 0xD0D1D6, ApolloThemeTokenLabel },
     { 0x999999, ApolloThemeTokenSecondaryLabel },
     { 0x939499, ApolloThemeTokenSecondaryLabel },
     { 0x86868A, ApolloThemeTokenSecondaryLabel },
@@ -686,12 +696,8 @@ static void ApplyThemeFontToNavigationTitleControl(UIView *titleControl) {
 
 // Per-thread text-sink bypass (ASDK builds nodes off the main thread, so a
 // plain global would leak the bypass across concurrently-initializing nodes).
-// Incremented around code whose text must keep its original colors — currently
-// SmallInfoOverlayNode, the GIF/gallery duration pill (issue #710): its text
-// sits on an always-dark blurred pill that never follows the theme, but its
-// near-white color collides with the dark-mode text palette constants, so the
-// remap sank it to the theme's Label token — dark, and therefore unreadable on
-// the pill, whenever a light custom theme was active.
+// Raised around the duration-pill restore below (issue #710) so our own
+// corrective setAttributedText: is not re-themed by the ASTextNode sink.
 static __thread NSInteger sTextSinkBypass;
 
 static BOOL TextSinkMayUseTheme(id object, uintptr_t caller) {
@@ -1802,23 +1808,59 @@ static ASImageNodeTintColorModificationBlockFn ASImageNodeTintColorModificationB
 
 %end
 
-// The GIF/gallery duration pill (issue #710 — see sTextSinkBypass). Its text
-// is set from init and (re)referenced while building the layout spec; bypass
-// the text remap inside both so the pill keeps Apollo's original near-white
-// text on its always-dark backdrop instead of the theme's Label color.
-%hook _TtC6Apollo20SmallInfoOverlayNode
+// The GIF/gallery duration pill (issue #710). Apollo's Swift init
+// (sub_1002d78a4) builds a translucent WHITE capsule with BLACK text in both
+// appearances. #000000 is the light primary in kTextPaletteEntries, so without
+// this the ASTextNode sink swaps it for the theme's dynamic Label colour —
+// near-black in light mode, near-white in dark, i.e. white-on-white. The
+// capsule is never themed, so only the text moves.
+//
+// There is nowhere to raise the bypass around that assignment: -init is a Swift
+// unimplemented-initializer stub that is never called, the designated init
+// reaches ASDisplayNode via objc_msgSendSuper2, -layoutSpecThatFits: runs long
+// after the text is set, and -didLoad never fires — the pill loads no view or
+// layer of its own. So schedule the restore from the layout pass and write on
+// the main thread once it has ended; mutating node state mid-layout is
+// unsupported in ASDK. The flag is set at schedule time so repeated passes
+// queue the work once.
+static const void *kApolloThemePillRestoredKey = &kApolloThemePillRestoredKey;
 
-- (id)init {
+static void ApolloThemeRestoreOverlayPillText(id node) {
+    if (!node || !sEnabled) return;
+    Ivar ivar = class_getInstanceVariable(object_getClass(node), "textNode");
+    id textNode = ivar ? object_getIvar(node, ivar) : nil;
+    if (![textNode respondsToSelector:@selector(attributedText)]) return;
+
+    NSAttributedString *text = [textNode attributedText];
+    if (![text isKindOfClass:[NSAttributedString class]] || text.length == 0) return;
+
+    if (sDebugLogging) {
+        UIColor *was = [text attribute:NSForegroundColorAttributeName atIndex:0 effectiveRange:NULL];
+        ApolloLog(@"ThemeRuntime: pill '%@' restore #%06X -> #000000",
+                  text.string, ApolloThemeRGBFromUIColor(was));
+    }
+    NSMutableAttributedString *stock = [text mutableCopy];
+    [stock addAttribute:NSForegroundColorAttributeName
+                  value:[UIColor blackColor]
+                  range:NSMakeRange(0, stock.length)];
     sTextSinkBypass++;
-    id result = %orig;
+    [textNode setAttributedText:stock];
     sTextSinkBypass--;
-    return result;
 }
 
+%hook _TtC6Apollo20SmallInfoOverlayNode
+
 - (id)layoutSpecThatFits:(struct ApolloThemeSizeRange)fits {
-    sTextSinkBypass++;
     id result = %orig;
-    sTextSinkBypass--;
+    // ASDK lays out off the main thread; schedule, never write, from in here.
+    if (sEnabled && !objc_getAssociatedObject(self, kApolloThemePillRestoredKey)) {
+        objc_setAssociatedObject(self, kApolloThemePillRestoredKey, @YES,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        __weak id weakNode = self;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            ApolloThemeRestoreOverlayPillText(weakNode);
+        });
+    }
     return result;
 }
 


### PR DESCRIPTION
## Summary

Fixes two text-color bugs in the custom theme runtime, both of which only appear when a custom theme is active. The first greys out nearly all primary text for anyone using Pure Black Dark Mode; the second leaves the GIF/gallery count pill on compact posts rendering white-on-white under dark themes.

## Impact

- Pure Black Dark Mode + a custom theme: primary text (post titles, comment bodies, usernames) rendered at the theme's secondary/grey level instead of its full-contrast label color. It now renders correctly. Users on Pure Black Dark Mode without a custom theme, and custom-theme users without Pure Black Dark Mode, were never affected.
- The "GIF" / image-count pill on compact post thumbnails took the theme's label color instead of Apollo's stock black, so under a dark theme it became near-white text on the pill's white capsule. It is now always black, matching stock.

## Changes

- `kTextPaletteEntries`: route `#D0D1D6` back to `Label`. Also routes `#303030` back to `Label` — it is emitted nowhere in the binary, so this is inert either way, but it was moved on the same incorrect premise.
- `SmallInfoOverlayNode`: replace the `-init` / `-layoutSpecThatFits:` bypass hooks, neither of which ran at a point where they could affect the pill, with a restore that re-stamps the stock black after construction.
- Rewrite the comments on the palette table, `sTextSinkBypass`, and the pill hook to match what the binary actually does.

## Reasoning

`#D0D1D6` is not a read-state color. `sub_100689abc(role, isRead, isDark)` emits three unread/read pairs for role 0 — `#000000`/`#999999` (light), `#EEEFF5`/`#939499` (dark), and `#D0D1D6`/`#86868A` (dark with `UsePureBlackDarkMode` set). `#D0D1D6` is the *unread* half of the third pair, i.e. the pure-black primary, which is why routing it to `SecondaryLabel` affected essentially all text rather than just read posts. All three read halves were already on `SecondaryLabel`, so read/unread distinction is unchanged by this PR.

The pill restore is scheduled rather than bypassed because there is no hookable window around the assignment: `-init` is a Swift unimplemented-initializer stub that is never called, the designated initializer reaches `ASDisplayNode` via `objc_msgSendSuper2`, `-layoutSpecThatFits:` runs long after the text is set, and `-didLoad` never fires at all since the pill loads no view or layer of its own. `-layoutSpecThatFits:` is therefore used only to schedule; the write lands on the main thread after the layout pass, since mutating node state mid-layout is unsupported in ASDK.

## Testing

Verified in the iOS simulator with a custom theme active in dark mode, using the theme runtime's debug logging.

- With `UsePureBlackDarkMode` set, the sink now logs `text #D0D1D6 -> label` (325 occurrences over a scrolled feed) where it previously logged `secondaryLabel`; post titles render at full contrast against the pure-black background.
- On compact-mode feeds, the pill restore logs `pill '2' restore #F2F2F2 -> #000000` per node — `#F2F2F2` being the test theme's dark label color — and the badge renders legibly dark instead of washing out.
- Device build (`iphone:clang:26.0:14.0`) compiles clean, and works when tested on device.