### PR TITLE
Use max_completion_tokens instead of deprecated max_tokens

### DIFF
--- a/src/ApolloAICloudBridge.m
+++ b/src/ApolloAICloudBridge.m
@@ -225,7 +225,7 @@ maximumResponseTokens:(NSInteger)maximumResponseTokens
     NSMutableDictionary *payload = [NSMutableDictionary dictionaryWithDictionary:@{
         @"model": model,
         @"messages": messages,
-        @"max_tokens": @(tokenBudget),
+        @"max_completion_tokens": @(tokenBudget),
         @"stream": @YES,
     }];
     if ([sAISummaryProvider isEqualToString:@"openrouter"]) {


### PR DESCRIPTION
Beginning with the `o1` model series released in late 2024, OpenAI switched from the `max_tokens` parameter and moved to the `max_completion_tokens` parameter. By hard-coding `max_tokens`, Apollo Reborn is currently unable to use models newer than GPT 4.1 when connecting through OpenAI directly. This change will allow using newer models with an OpenAI API key, but does not affect the other supported Gemini and OpenRouter endpoints as they support either parameter.

This fixes #801.