### PR TITLE
Fix five 3.5.1 crashes: Filters & Blocks, account switch, token refresh, nav title glass

### DIFF
--- a/src/ApolloChatsFilter.xm
+++ b/src/ApolloChatsFilter.xm
@@ -260,6 +260,27 @@ static UITableView *ApolloBoxesTableView(id controller) {
     return [value isKindOfClass:[UITableView class]] ? value : nil;
 }
 
+// Our tableView:numberOfRowsInSection: adds +1 to the Messages section while the
+// row state names a messagesSection (ApolloBoxesUsesInsertedDirectChat). A fresh
+// state has messagesSection == -1, so simply swapping the state object out drops
+// that row from the count with no delete to match — and if a table update was
+// already in flight, UIKit's row-count assertion fires inside
+// -[ASTableView rangeController:updateWithChangeSet:updates:]. That is issue #865:
+// switching accounts with the inbox on screen.
+//
+// Reset and reload as one main-queue step instead, so the count only ever changes
+// at a moment the table is being told to re-read it from scratch.
+static void ApolloBoxesResetRowStateAndReload(id controller, NSString *reason) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (!controller) return;
+        UITableView *tableView = ApolloBoxesTableView(controller);
+        objc_setAssociatedObject(controller, &kApolloBoxesRowStateKey,
+                                 [ApolloBoxesRowState new], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        [tableView reloadData];
+        ChatsFilterLog(@"reset Boxes row state + reloaded (%@)", reason ?: @"unknown");
+    });
+}
+
 static void ApolloRefreshBoxesForModeratorState(NSString *reason) {
     dispatch_async(dispatch_get_main_queue(), ^{
         id controller = sLatestBoxesController;
@@ -1329,9 +1350,9 @@ static void ApolloWarnIfUnhandledRowDelegates(id vc) {
     ApolloCaptureInboxTabBarItem((UIViewController *)self);
     ApolloApplyCombinedInboxBadge();
     // Section membership changes with moderator status. Force a fresh probe so
-    // stale coordinates from the previous account cannot route the wrong row.
-    objc_setAssociatedObject(self, &kApolloBoxesRowStateKey,
-                             [ApolloBoxesRowState new], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    // stale coordinates from the previous account cannot route the wrong row —
+    // paired with a reload, never on its own (#865).
+    ApolloBoxesResetRowStateAndReload(self, @"account switch");
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.75 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (sLatestBoxesController == self) ApolloRefreshBoxesForModeratorState(@"account switch +0.75s");
     });

--- a/src/ApolloFiltersBlocksInject.xm
+++ b/src/ApolloFiltersBlocksInject.xm
@@ -70,6 +70,31 @@ enum {
 // we only add a trailing row).
 static const void *kApolloPFBlockedExpandedKey   = &kApolloPFBlockedExpandedKey;   // NSNumber BOOL on the VC
 static const void *kApolloPFBlockedNativeCountKey = &kApolloPFBlockedNativeCountKey; // NSNumber on the VC (rows incl. Add)
+static const void *kApolloPFTableBoxKey           = &kApolloPFTableBoxKey;           // ApolloPFTableBox on the VC
+
+// Zeroing-weak box for the controller's table view. The VC is not a
+// UITableViewController and exposes no -tableView, so the only way to reach the
+// table outside a data-source callback is to remember the one UIKit hands us.
+// Weak (not ASSIGN) so a torn-down table can never be messaged.
+@interface ApolloPFTableBox : NSObject
+@property (nonatomic, weak) UITableView *table;
+@end
+@implementation ApolloPFTableBox
+@end
+
+static void ApolloPFRememberTable(id vc, UITableView *tableView) {
+    if (![tableView isKindOfClass:[UITableView class]]) return;
+    ApolloPFTableBox *box = objc_getAssociatedObject(vc, kApolloPFTableBoxKey);
+    if (!box) {
+        box = [ApolloPFTableBox new];
+        objc_setAssociatedObject(vc, kApolloPFTableBoxKey, box, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    box.table = tableView;
+}
+
+static UITableView *ApolloPFTableView(id vc) {
+    return ((ApolloPFTableBox *)objc_getAssociatedObject(vc, kApolloPFTableBoxKey)).table;
+}
 
 // Our "Blocked Users (N)" toggle is row 0 of the blocked section and Apollo's own
 // rows follow at display index 1..nativeCount (so it all reads as ONE rounded group).
@@ -135,6 +160,13 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    // Capture the table here (the first data-source callback, and one that fires on
+    // every reload) so the switch handler and setEditing: below have something to
+    // reload. SettingsFiltersViewController is a plain UIViewController that owns a
+    // table — it has NO -tableView accessor, so asking for one raises
+    // NSInvalidArgumentException (#870 "Enable Tag Filters" toggle, #876 Block list
+    // Edit; both regressions from #728, which dropped this capture).
+    ApolloPFRememberTable(self, tableView);
     return %orig + kApolloPFExtraSections;
 }
 
@@ -463,7 +495,7 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
     [[NSUserDefaults standardUserDefaults] setBool:sw.on forKey:UDKeyTagFilterEnabled];
     [[NSNotificationCenter defaultCenter] postNotificationName:ApolloTagFiltersChangedNotification object:nil];
     // Re-gate the NSFW/Spoiler/Overrides rows' enabled look.
-    UITableView *t = [(UITableViewController *)(id)self tableView];
+    UITableView *t = ApolloPFTableView(self);
     if ([t isKindOfClass:[UITableView class]]) {
         NSInteger section = [self apollo_pfNativeSectionCount:t] + 2;
         @try { [t reloadSections:[NSIndexSet indexSetWithIndex:section] withRowAnimation:UITableViewRowAnimationNone]; } @catch (__unused id e) {}
@@ -586,7 +618,7 @@ static UIView *ApolloPFSectionFooterView(NSString *text) {
 - (void)setEditing:(BOOL)editing animated:(BOOL)animated {
     %orig;
     if (editing && ![objc_getAssociatedObject(self, kApolloPFBlockedExpandedKey) boolValue]) {
-        UITableView *t = [(UITableViewController *)(id)self tableView];
+        UITableView *t = ApolloPFTableView(self);
         if ([t isKindOfClass:[UITableView class]]) [self apollo_pfSetBlockedExpanded:YES table:t];
     }
 }

--- a/src/ApolloLiquidGlass.xm
+++ b/src/ApolloLiquidGlass.xm
@@ -818,10 +818,37 @@ static UIView *ApolloFindJumpBar(UIView *root) {
     return nil;
 }
 
+// JumpBar is a Swift class (_TtC6Apollo7JumpBar), so its ivars are NOT all plain
+// strong ObjC object pointers: a `weak var` stores a side-table pointer and a
+// non-class-typed property stores inline value bits. `object_getIvar` is declared
+// to return `id`, so ARC retains whatever it finds — retaining those bits is an
+// immediate EXC_BAD_ACCESS at a nonsense address (issue #893: iPad launch,
+// fault address 0x103ba258720, straight out of objc_retain).
+//
+// Read the slot as raw memory instead, and only hand it back as an object once
+// it looks like one: strong-object type encoding, pointer-aligned, and a class
+// pointer the runtime actually recognizes. Anything else reads as "absent",
+// which is exactly how the callers already treat a nil ivar.
 static id ApolloJumpBarObjectIvar(UIView *jumpBar, const char *name) {
     if (!jumpBar || !name) return nil;
     Ivar ivar = class_getInstanceVariable(jumpBar.class, name);
-    return ivar ? object_getIvar(jumpBar, ivar) : nil;
+    if (!ivar) return nil;
+
+    // Swift weak/unowned and value-typed ivars do not carry a plain '@' encoding.
+    const char *encoding = ivar_getTypeEncoding(ivar);
+    if (!encoding || encoding[0] != '@' || encoding[1] == '?') return nil;
+
+    ptrdiff_t offset = ivar_getOffset(ivar);
+    if (offset <= 0) return nil;
+    void *slot = (__bridge void *)jumpBar;
+    uintptr_t raw = *(uintptr_t *)((uint8_t *)slot + offset);
+    if (raw == 0 || (raw & (sizeof(void *) - 1)) != 0) return nil;
+
+    // Past the encoding gate the slot is a plain strong object pointer, so it is
+    // either nil (handled above) or a live object — no further probing needed.
+    // Deliberately no isa validation here: dereferencing a candidate to check it
+    // is the very thing that would fault if we were wrong.
+    return (__bridge __unsafe_unretained id)(void *)raw;
 }
 
 // Whether the JumpBar is in "type a subreddit name" mode. Apollo swaps the name
@@ -1415,10 +1442,17 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl) {
         objc_setAssociatedObject(self, &kApolloNavigationTitleGlassControllerKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         return;
     }
-    __weak UIView *weakTitleControl = (UIView *)self;
+    // Strong capture, deliberately. This used to capture __weak and reload inside
+    // the block, and issue #893 crashed in objc_retain on the reloaded pointer at
+    // ApolloUpdateNavigationTitleGlass's entry — i.e. the weak slot handed back a
+    // dangling _UINavigationBarTitleControl instead of nil on iOS 27. Owning the
+    // view for the one main-queue turn the block takes removes that path entirely
+    // and costs nothing: a nav-bar title control outliving its removal by a single
+    // runloop hop has no observable effect, and the function already no-ops on a
+    // view with no window.
+    UIView *titleControl = (UIView *)self;
     dispatch_async(dispatch_get_main_queue(), ^{
-        UIView *titleControl = weakTitleControl;
-        if (titleControl) ApolloUpdateNavigationTitleGlass(titleControl);
+        ApolloUpdateNavigationTitleGlass(titleControl);
     });
 }
 
@@ -1433,10 +1467,9 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl) {
     if (controller) {
         [controller scheduleTargetRefreshIfNeeded];
     } else {
-        __weak UIView *weakTitleControl = (UIView *)self;
+        UIView *titleControl = (UIView *)self;   // strong — see didMoveToWindow (#893)
         dispatch_async(dispatch_get_main_queue(), ^{
-            UIView *titleControl = weakTitleControl;
-            if (titleControl) ApolloUpdateNavigationTitleGlass(titleControl);
+            ApolloUpdateNavigationTitleGlass(titleControl);
         });
     }
 }

--- a/src/ApolloWebJSONIdentity.xm
+++ b/src/ApolloWebJSONIdentity.xm
@@ -280,6 +280,36 @@ static void ApolloWebJSONFulfillTokenCompletion(id completion) {
     dispatch_async(dispatch_get_main_queue(), ^{ block(nil, nil); });
 }
 
+// Same signature, failure side: error != nil is what every caller checks before
+// touching self.authorizationCredential.
+static void ApolloWebJSONFailTokenCompletion(id completion, NSString *reason) {
+    if (!completion) return;
+    NSError *error = [NSError errorWithDomain:@"ApolloReborn.WebJSON.Identity"
+                                         code:881
+                                     userInfo:@{ NSLocalizedDescriptionKey: reason ?: @"Token refresh unavailable." }];
+    void (^block)(id, NSError *) = [completion copy];
+    dispatch_async(dispatch_get_main_queue(), ^{ block(nil, error); });
+}
+
+// -[RDKClient refreshAccessTokenWithCompletion:] reads
+// authorizationCredential.accessToken.refreshToken and hands it straight to
+// -refreshAccessTokenWithCompletion:completion:, which stuffs it into
+// +[NSDictionary dictionaryWithObjects:forKeys:count:] with no nil check. A
+// credential whose refresh token is missing therefore raises
+// NSInvalidArgumentException from inside RedditKit — issue #881, seen mid-scroll
+// when a token refresh fires on a credential we (or a restore) installed without
+// one. Detect the nil BEFORE %orig; there is nothing to refresh with, so failing
+// the completion is strictly better than the throw.
+static BOOL ApolloWebJSONCredentialHasRefreshToken(RDKClient *client) {
+    if (![client respondsToSelector:@selector(authorizationCredential)]) return YES;
+    id credential = [client authorizationCredential];
+    if (!credential || ![credential respondsToSelector:@selector(accessToken)]) return NO;
+    id accessToken = ((id (*)(id, SEL))objc_msgSend)(credential, @selector(accessToken));
+    if (!accessToken || ![accessToken respondsToSelector:@selector(refreshToken)]) return NO;
+    id refreshToken = ((id (*)(id, SEL))objc_msgSend)(accessToken, @selector(refreshToken));
+    return [refreshToken isKindOfClass:[NSString class]] && ((NSString *)refreshToken).length > 0;
+}
+
 #pragma mark - Signed-in account synthesis (cold-start identity)
 
 // Apollo's account model is two parallel blobs merged by index (verified in
@@ -780,6 +810,14 @@ static id ApolloWebJSONThingProperty(id thing, SEL selector) {
         ApolloLogDebug(@"[WebJSON][identity] Short-circuited token refresh (cookie session) for u/%@",
                        ApolloWebJSONClientUsername(self) ?: @"(anonymous)");
         ApolloWebJSONFulfillTokenCompletion(completion);
+        return nil;
+    }
+    // Runs in EVERY auth mode, not just Web JSON: RedditKit throws on a nil
+    // refresh token regardless of how the credential got there (#881).
+    if (!ApolloWebJSONCredentialHasRefreshToken((RDKClient *)self)) {
+        ApolloLog(@"[WebJSON][identity] Refusing token refresh for u/%@ — credential has no refresh token (would raise in RedditKit)",
+                  ApolloWebJSONClientUsername(self) ?: @"(anonymous)");
+        ApolloWebJSONFailTokenCompletion(completion, @"This account has no refresh token. Sign out and back in to restore it.");
         return nil;
     }
     return %orig;


### PR DESCRIPTION
## Summary

Fixes five crashes reported against 3.5.1, each traced by symbolicating the attached crash reports against the release dSYMs (the `-summary.txt` symbol names in those reports are nearest-exported-symbol guesses from the stripped dylib and point at the wrong functions — every root cause below comes from re-symbolication, not from those names).

Fixes #870. Fixes #876. Fixes #865. Fixes #881. Fixes #893.

## Filters & Blocks: crash on Edit and on the Tag Filters toggle (#876, #870)

`_TtC6Apollo29SettingsFiltersViewController` is a plain `UIViewController` that owns a table — it is declared that way at the top of `ApolloFiltersBlocksInject.xm` and has no `-tableView` accessor. #728 replaced the remembered table reference with `[(UITableViewController *)(id)self tableView]` at two call sites, so both raise `NSInvalidArgumentException` through CF forwarding:

- Settings → Block list → Edit (`setEditing:animated:`)
- Settings → Filters & Blocks → Enable Tag Filters (`apollo_tfEnableChanged:`)

This is why the same toggle works from Apollo Reborn Settings → Tag Filters but crashes from Filters & Blocks: only the latter path goes through this controller.

Remember the table UIKit hands the data source in `numberOfSectionsInTableView:` instead, held in a zeroing-weak box so a torn-down table can never be messaged.

## Inbox: crash when switching accounts (#865)

`redditAccountChangedWithNotification:` swapped in a fresh `ApolloBoxesRowState`, whose `messagesSection` is `-1`. That instantly drops the inserted Direct Chat row from `tableView:numberOfRowsInSection:` with no matching delete, so a table update already in flight fails UIKit's row-count assertion inside `-[ASTableView rangeController:updateWithChangeSet:updates:]` (`NSInternalInconsistencyException`).

Reset the state and reload the table as one main-queue step, so the row count only ever changes at a moment the table is being told to re-read it.

## Token refresh with no refresh token (#881)

`-[RDKClient refreshAccessTokenWithCompletion:completion:]` passes the credential's refresh token straight into `+[NSDictionary dictionaryWithObjects:forKeys:count:]` with no nil check (confirmed by decompiling the method), so a credential without one raises `NSInvalidArgumentException` from inside RedditKit.

Check the credential before `%orig` and fail the completion with an error instead. Deliberately not gated on Web JSON mode: RedditKit throws regardless of how the credential got into that state.

## Navigation title glass: crash on launch (#893)

`EXC_BAD_ACCESS` at `0x103ba258720` — garbage, not a heap address. Disassembling the shipped 3.5.1 dylib pins it exactly: the faulting PC is the instruction immediately after `bl _objc_retain` in `ApolloUpdateNavigationTitleGlass`'s prologue, so it crashed retaining its own `titleControl` argument on entry. The callers are the two `dispatch_async` blocks in `_UINavigationBarTitleControl`'s `didMoveToWindow` / `layoutSubviews`, which loaded the view from a `__weak` slot — that slot handed back a dangling view rather than nil.

Capture the view strongly for the single main-queue turn the block takes. A nav-bar title control outliving its removal by one runloop hop has no observable effect, the function already no-ops on a windowless view, and it removes the dangling read entirely.

Also hardens `ApolloJumpBarObjectIvar` in passing (not the #893 fix): `object_getIvar`'s result is retained by ARC, so a Swift `weak` or value-typed ivar would retain raw bits. It now gates on the strong-object type encoding and reads the slot without ARC ownership. The class dump cannot tell us whether those `JumpBar` properties are weak, so the gate is worth having either way.

## Also triaged, no code change

- **#858 / #885** are the same crash and are already fixed by #864 — `-[RDKClient multiredditsWithCompletion:]` → `getPath:@"api/multi/mine.json"` → `taskWithMethod:path:parameters:completion:`, which is exactly the chokepoint that PR guards. Not duplicated here.
- **#895** was a third-party `ApolloAPI.dylib` in the reporter's IPA hooking the same networking method; closed as external.
- **#883** needs more information; the attached log has no hang window in it.

## Validation

- `make package` clean.
- #870 / #876: root cause is a selector that does not exist on the class, confirmed against the class's own declaration in the same file, and reproduced in the crash reports from two independent reporters on different iOS versions (27.0 and 17.6.1).
- #865, #881: root causes confirmed by decompiling the Apollo-side frames.
- #893: root cause confirmed against the shipped release dylib as described above. The fix is reasoned rather than reproduced — I do not have an iPad on iOS 27 — but it is safe regardless of what makes the weak slot go stale.

