### PR TITLE
Inbox: stop the title shifting between Notifications/Chat + swipe between the tabs

### DIFF
--- a/src/ApolloChatsFilter.xm
+++ b/src/ApolloChatsFilter.xm
@@ -723,12 +723,28 @@ static void ApolloSetInboxChatHubVisible(UIViewController *host, BOOL visible, B
 static void ApolloDismantleInboxChatHub(UIViewController *host, NSString *reason);
 static void ApolloInboxWireModePanPrecedence(UIViewController *controller, UIPanGestureRecognizer *modePan);
 
-// The inbox mode-pan (both tab-switch directions): the association carries the
-// host controller and doubles as the marker the shared gesture delegate uses
-// to recognize its own pan.
-static char kInboxModePanHostKey;
-// Recognizers already wired to require the mode-pan's failure (weak set).
-static char kInboxModePanWiredKey;
+// The inbox mode-pan (both tab-switch directions) is a PROCESS SINGLETON,
+// not a per-host recognizer. Apollo's full-width back/forward pans and the
+// interactive pop live on the navigation controller's UILayoutContainerView
+// and are shared by every screen in that stack, and
+// requireGestureRecognizerToFail: is permanent — UIKit has no API to remove
+// a requirement. Minting a fresh pan per install would re-wire those shared
+// recognizers against each new pan, accumulating stale requirements (each
+// pointing at a since-dead pan) for the life of the session. One immortal
+// pan keeps every shared recognizer wired at most once, ever: the pan
+// migrates to whichever Inbox host is installing (addGestureRecognizer:
+// moves it between views), and while it is detached — feature off, host
+// gone — it can never begin, so its requirements are vacuously satisfied
+// and every other screen's gestures behave stock.
+static UIPanGestureRecognizer *sInboxModePan;
+// Zeroing-weak host back-pointer, read from gesture-delegate callbacks. An
+// ASSIGN association here would dangle if the host deallocs while UIKit
+// still holds the pan across a touch (the #921/#876/#870 crash shape).
+static __weak UIViewController *sInboxModePanHost;
+// Recognizers already wired to require the mode-pan's failure. Weak members
+// (dead recognizers fall out on their own); static so the dedupe spans
+// switcher reinstalls and host controller lifetimes.
+static NSHashTable *sInboxModePanWired;
 
 @implementation ApolloInboxChatHubViewController
 
@@ -910,13 +926,13 @@ static ApolloInboxChatHubViewController *ApolloEnsureInboxChatHub(UIViewControll
     return hub;
 }
 
-static UIPanGestureRecognizer *ApolloInboxFindModePan(UIViewController *host) {
-    for (UIGestureRecognizer *recognizer in host.viewIfLoaded.gestureRecognizers) {
-        if (objc_getAssociatedObject(recognizer, &kInboxModePanHostKey)) {
-            return (UIPanGestureRecognizer *)recognizer;
-        }
-    }
-    return nil;
+// The singleton mode-pan, but only while `host` is the controller it is
+// currently attached to and targeting — nil for any other (stale) host.
+static UIPanGestureRecognizer *ApolloInboxModePanForHost(UIViewController *host) {
+    if (!sInboxModePan || !host) return nil;
+    if (sInboxModePanHost != host) return nil;
+    if (sInboxModePan.view != host.viewIfLoaded) return nil;
+    return sInboxModePan;
 }
 
 static void ApolloSetInboxChatHubVisible(UIViewController *host, BOOL visible, BOOL animated) {
@@ -983,7 +999,7 @@ static void ApolloSetInboxChatHubVisible(UIViewController *host, BOOL visible, B
         // navigation container, so Apollo's full-width back/forward pans
         // (they live on the nav controller's UILayoutContainerView) are only
         // reachable now — re-wire so they yield to the mode-pan.
-        ApolloInboxWireModePanPrecedence(host, ApolloInboxFindModePan(host));
+        ApolloInboxWireModePanPrecedence(host, ApolloInboxModePanForHost(host));
         // Align the persistent Chat overlay to the live sticky Notifications
         // switcher before making it visible.
         [hub apollo_alignModeSwitcherWithHostSwitcher:notificationsSwitcher];
@@ -1047,6 +1063,16 @@ static void ApolloSetInboxChatHubVisible(UIViewController *host, BOOL visible, B
 // client, injected scripts, and private data store all go with it.
 static void ApolloDismantleInboxChatHub(UIViewController *host, NSString *reason) {
     if (!host) return;
+    // Same main-thread deferral as ApolloSetInboxChatHubVisible. Without it,
+    // an off-main caller (Apollo posts the account-change notification from
+    // wherever) would tear the hub down off-main while the hide it just
+    // requested is still queued for main — the deferred hide then finds the
+    // association already cleared, no-ops, and the stripped right bar items
+    // (and the reservation hold) are never restored.
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{ ApolloDismantleInboxChatHub(host, reason); });
+        return;
+    }
     ApolloInboxChatHubViewController *hub = objc_getAssociatedObject(host, &kInboxAllChatHubKey);
     if (!hub) return;
     // Hiding first restores the host's saved right bar items, hands the
@@ -1061,6 +1087,10 @@ static void ApolloDismantleInboxChatHub(UIViewController *host, NSString *reason
     // The restored right bar items are live on the navigation item again;
     // clear the stash so a later re-enable captures a fresh copy.
     objc_setAssociatedObject(host, &kInboxAllOriginalRightItemsKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    // The hide above already released the trailing reservation hold, but keep
+    // dismantle self-sufficient: the hold must never outlive the hub on this
+    // navigation item, whatever path led here.
+    ApolloNavItemSetTrailingReservationHold(host.navigationItem, NO);
     ChatsFilterLog(@"dismantled Inbox chat hub (%@)", reason ?: @"unknown");
 }
 
@@ -1129,12 +1159,11 @@ static UIRefreshControl *ApolloInboxRefreshControl(UITableView *tableView) {
 // the touch history accumulated so far, which lets a pan begin late but
 // leaves a discrete swipe dead (verified with real HID swipes over the hub).
 static void ApolloInboxWireModePanPrecedence(UIViewController *controller, UIPanGestureRecognizer *modePan) {
-    if (!modePan) return;
-    NSHashTable *wired = objc_getAssociatedObject(modePan, &kInboxModePanWiredKey);
-    if (!wired) {
-        wired = [NSHashTable weakObjectsHashTable];
-        objc_setAssociatedObject(modePan, &kInboxModePanWiredKey, wired, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    }
+    // Only wire while the pan actually belongs to this controller — never
+    // point shared recognizers at the pan on a stale host's behalf.
+    if (!modePan || modePan != ApolloInboxModePanForHost(controller)) return;
+    if (!sInboxModePanWired) sInboxModePanWired = [NSHashTable weakObjectsHashTable];
+    NSHashTable *wired = sInboxModePanWired;
     UIGestureRecognizer *pop = controller.navigationController.interactivePopGestureRecognizer;
     if (pop && ![wired containsObject:pop]) {
         [pop requireGestureRecognizerToFail:modePan];
@@ -1154,6 +1183,12 @@ static void ApolloInboxWireModePanPrecedence(UIViewController *controller, UIPan
     // WebKit re-creates content views (and their edge recognizers) across
     // navigations; this wiring re-runs on every install pass and every
     // Chat reveal, which keeps new ones covered.
+    // NOTE: ApolloFeedGalleryCarousel's wiring walk deliberately SKIPS
+    // UIScreenEdgePanGestureRecognizers (a permanent requirement there would
+    // block navigation for every carousel on screen). The trade-off flips
+    // here because the required pan is the process singleton: detached or
+    // instantly-failed, it satisfies the requirement immediately. Read both
+    // rationales before "harmonizing" either walk.
     ApolloInboxChatHubViewController *hub = objc_getAssociatedObject(controller, &kInboxAllChatHubKey);
     UIView *hubView = hub.viewIfLoaded;
     if (hubView) {
@@ -1252,15 +1287,15 @@ static void ApolloInboxEnsureRefreshHaptic(UITableView *tableView) {
     objc_setAssociatedObject(refreshControl, &kInboxRefreshHapticKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-// Delegate for the inbox mode-swipe recognizers. Both live on the host view
-// above two scroll surfaces (the notifications ASTableView and the Chat hub's
+// Delegate for the singleton inbox mode-pan. It lives on the host view above
+// two scroll surfaces (the notifications ASTableView and the Chat hub's
 // WKWebView scroll view), whose pan recognizers begin on ANY drag — and once a
-// pan has begun, UIKit's default exclusivity blocks a still-tracking swipe
+// pan has begun, UIKit's default exclusivity blocks a still-tracking sibling
 // from ever reaching Recognized (verified: synthesized began/moved/ended
 // swipes through -[UIApplication sendEvent:] never fired the handler without
-// this). Allowing simultaneous recognition lets the swipe complete alongside
-// the pan; the pop-gesture failure requirement set at install time still
-// takes precedence over simultaneity, so edge-pops stay exclusive.
+// this). Allowing simultaneous recognition lets the mode-pan complete
+// alongside the scroll pans; the pop-gesture failure requirement set at wire
+// time still takes precedence over simultaneity, so edge-pops stay exclusive.
 @interface ApolloInboxSwipeGestureDelegate : NSObject <UIGestureRecognizerDelegate>
 @end
 
@@ -1290,23 +1325,34 @@ static void ApolloInboxEnsureRefreshHaptic(UITableView *tableView) {
 // gestureRecognizerShouldBegin: — only the velocity direction is usable
 // (learned on #805).
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
-    UIViewController *host = objc_getAssociatedObject(gestureRecognizer, &kInboxModePanHostKey);
-    if (!host || ![gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) return YES;
-    if (!ApolloModernChatShouldOpen()) return NO;
+    if (gestureRecognizer != sInboxModePan) return YES;
+    // Zeroing-weak read: once the host controller deallocs this is nil and
+    // the pan simply never begins (it cannot serve a dead host).
+    UIViewController *host = sInboxModePanHost;
+    if (!host || !ApolloModernChatShouldOpen()) return NO;
     UIPanGestureRecognizer *pan = (UIPanGestureRecognizer *)gestureRecognizer;
     CGPoint velocity = [pan velocityInView:pan.view];
     if (fabs(velocity.x) <= fabs(velocity.y)) return NO;   // decisively horizontal only
+    // Mirror the whole quadrant under RTL: the segmented switcher mirrors
+    // (Chat sits at the physical LEFT), so "toward Chat" is a rightward drag
+    // there and the back/pop directions flip with it. In the mirrored
+    // coordinate `horizontal`, negative always means "toward Chat" and
+    // positive "toward Notifications / back", exactly as velocity.x does LTR.
+    CGFloat rtlSign = (pan.view.effectiveUserInterfaceLayoutDirection ==
+                       UIUserInterfaceLayoutDirectionRightToLeft) ? -1.0 : 1.0;
+    CGFloat horizontal = velocity.x * rtlSign;
     if ([objc_getAssociatedObject(host, &kInboxAllChatHubVisibleKey) boolValue]) {
-        if (velocity.x <= 0.0) return NO;   // leftward on Chat = Apollo's forward pan
-        // Inside a conversation a rightward drag must never yank the user out
-        // to Notifications (rooms keep their own back affordances — the web
-        // view's edge history-back — and the GIF picker's grid scrolls
-        // horizontally). Failing here also un-gates those wired gestures.
+        if (horizontal <= 0.0) return NO;   // further toward-Chat on Chat = Apollo's forward pan
+        // Inside a conversation a toward-Notifications drag must never yank
+        // the user out to Notifications (rooms keep their own back
+        // affordances — the web view's edge history-back — and the GIF
+        // picker's grid scrolls horizontally). Failing here also un-gates
+        // those wired gestures.
         ApolloInboxChatHubViewController *hub = objc_getAssociatedObject(host, &kInboxAllChatHubKey);
         if (!hub || ApolloModernChatControllerIsOnConversationRoute(hub.chatController)) return NO;
         return YES;
     }
-    return velocity.x < 0.0;   // rightward on Notifications = back-swipe / pop
+    return horizontal < 0.0;   // toward-Notifications/back on Notifications stays with back-swipe / pop
 }
 
 @end
@@ -1336,12 +1382,15 @@ static void ApolloInstallInboxModeSwitcher(id controller) {
                                  OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(tableView, &kInboxAllSwitcherTableKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(tableView, &kInboxAllSwitcherRefKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        // The mode-pan exists only alongside the switcher.
+        // The mode-pan attaches only alongside the switcher. Detach it (and
+        // drop its target on us) but keep the singleton itself alive: the
+        // failure requirements wired on shared recognizers are permanent, and
+        // a detached pan never begins, so they stay vacuously satisfied.
         UIView *staleHostView = ((UIViewController *)controller).viewIfLoaded;
-        for (UIGestureRecognizer *recognizer in [staleHostView.gestureRecognizers copy]) {
-            if (objc_getAssociatedObject(recognizer, &kInboxModePanHostKey)) {
-                [staleHostView removeGestureRecognizer:recognizer];
-            }
+        if (staleHostView && sInboxModePan && sInboxModePan.view == staleHostView) {
+            [staleHostView removeGestureRecognizer:sInboxModePan];
+            [sInboxModePan removeTarget:nil action:NULL];
+            if (sInboxModePanHost == (UIViewController *)controller) sInboxModePanHost = nil;
         }
         return;
     }
@@ -1415,19 +1464,48 @@ static void ApolloInstallInboxModeSwitcher(id controller) {
     // over the hub, and the shared delegate's gestureRecognizerShouldBegin:
     // for the quadrant rule that keeps back/pop on Notifications and Apollo's
     // forward pan on Chat working untouched).
-    UIPanGestureRecognizer *modePan = ApolloInboxFindModePan((UIViewController *)controller);
-    if (!modePan) {
-        modePan = [[UIPanGestureRecognizer alloc]
-            initWithTarget:controller action:NSSelectorFromString(@"apollo_inboxModePanned:")];
-        modePan.maximumNumberOfTouches = 1;
-        modePan.delegate = [ApolloInboxSwipeGestureDelegate shared];
-        objc_setAssociatedObject(modePan, &kInboxModePanHostKey, controller, OBJC_ASSOCIATION_ASSIGN);
-        [hostView addGestureRecognizer:modePan];
+    if (!sInboxModePan) {
+        sInboxModePan = [UIPanGestureRecognizer new];
+        sInboxModePan.maximumNumberOfTouches = 1;
+        sInboxModePan.delegate = [ApolloInboxSwipeGestureDelegate shared];
     }
-    // Re-wire every install pass: cheap, idempotent, and it catches pop/pan
+    // Migrate the singleton to this host (addGestureRecognizer: detaches it
+    // from any previous owner's view), guarded two ways:
+    //   * never while the pan is actively tracking a touch — install passes
+    //     arrive via async notifications (chat-status ticks, account
+    //     changes), and yanking a Began/Changed recognizer off its view or
+    //     swapping its target mid-drag kills the gesture, or delivers the
+    //     end action to the wrong host;
+    //   * an OFF-window instance may not steal the pan from an on-window
+    //     owner — the status notification is broadcast to every live Inbox
+    //     instance, and letting whichever install pass ran last win would
+    //     silently strip the visible Inbox of its swipes until its next
+    //     appearance. The frontmost host always reclaims the pan in
+    //     viewDidAppear (a full install pass), by which point the outgoing
+    //     owner has left the window.
+    UIGestureRecognizerState panState = sInboxModePan.state;
+    BOOL panTracking = (panState == UIGestureRecognizerStateBegan ||
+                        panState == UIGestureRecognizerStateChanged);
+    UIView *panOwnerView = sInboxModePan.view;
+    BOOL mayClaim = !panTracking &&
+        (hostView.window != nil || !panOwnerView || panOwnerView.window == nil);
+    if (panOwnerView != hostView && mayClaim) {
+        [hostView addGestureRecognizer:sInboxModePan];
+    }
+    if (sInboxModePan.view == hostView && !panTracking) {
+        // Swap the (unretained) target in the same pass that sets the host
+        // pointer so the two can never drift; recognizer targets are
+        // unretained, so the pan must never keep a previous (possibly
+        // deallocated) controller as its action target.
+        [sInboxModePan removeTarget:nil action:NULL];
+        [sInboxModePan addTarget:controller action:NSSelectorFromString(@"apollo_inboxModePanned:")];
+        sInboxModePanHost = (UIViewController *)controller;
+    }
+    // Re-wire every install pass: cheap, idempotent (the static weak set
+    // dedupes across reinstalls AND host lifetimes), and it catches pop/pan
     // recognizers that attach to the navigation container after first install
     // (plus WebKit's re-created edge recognizers).
-    ApolloInboxWireModePanPrecedence((UIViewController *)controller, modePan);
+    ApolloInboxWireModePanPrecedence((UIViewController *)controller, sInboxModePan);
     BOOL chatVisible = [objc_getAssociatedObject(controller, &kInboxAllChatHubVisibleKey) boolValue];
     ApolloInboxChatHubViewController *hub = objc_getAssociatedObject(controller, &kInboxAllChatHubKey);
     // The host switcher is the single live mode control in BOTH modes; it and
@@ -1785,11 +1863,13 @@ static NSArray *ApolloChatFilterOutChats(NSArray *messages) {
     %orig;
     // Only now is the host view attached under the navigation controller's
     // UILayoutContainerView, where Apollo's full-width pop pans live — the
-    // install-time wiring pass cannot reach them (see
-    // ApolloInboxWireModePanPrecedence). Idempotent per recognizer.
+    // earlier wiring passes cannot reach them — and only now can this host
+    // reclaim the singleton mode-pan from a previous owner (the migration
+    // refuses to steal from an on-window view, and during the push/pop
+    // transition the outgoing owner was still on-window). Run the full
+    // install pass: idempotent, and it ends with the wiring pass.
     if (ApolloInboxControllerIsAll(self) && ApolloModernChatShouldOpen()) {
-        ApolloInboxWireModePanPrecedence((UIViewController *)self,
-                                         ApolloInboxFindModePan((UIViewController *)self));
+        ApolloInstallInboxModeSwitcher(self);
     }
 }
 
@@ -1811,6 +1891,12 @@ static NSArray *ApolloChatFilterOutChats(NSArray *messages) {
 }
 
 - (void)dealloc {
+    // The singleton mode-pan holds its action targets unretained, and a host
+    // that dies with the feature still on never runs the disable path's
+    // target cleanup — strip this controller's pair so the immortal pan can
+    // never message a deallocated host. (removeTarget: matches by pointer;
+    // no-op for every other host and for a nil pan.)
+    [sInboxModePan removeTarget:self action:NULL];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     %orig;
 }
@@ -1846,12 +1932,21 @@ static NSArray *ApolloChatFilterOutChats(NSArray *messages) {
     // conversation route at begin time; here only judge whether the finished
     // drag reads as a deliberate tab switch.
     BOOL chatVisible = [objc_getAssociatedObject(self, &kInboxAllChatHubVisibleKey) boolValue];
-    CGFloat direction = chatVisible ? 1.0 : -1.0;   // toward Notifications : toward Chat
+    // Same RTL mirror as the delegate's quadrant rule.
+    CGFloat rtlSign = (pan.view.effectiveUserInterfaceLayoutDirection ==
+                       UIUserInterfaceLayoutDirectionRightToLeft) ? -1.0 : 1.0;
+    CGFloat direction = (chatVisible ? 1.0 : -1.0) * rtlSign;   // toward Notifications : toward Chat
     CGPoint translation = [pan translationInView:pan.view];
     CGPoint velocity = [pan velocityInView:pan.view];
     CGFloat progress = translation.x * direction;
     BOOL far = progress > 60.0 && fabs(translation.x) > 2.0 * fabs(translation.y);
-    BOOL flick = velocity.x * direction > 300.0 && progress > 20.0;
+    // The flick arm needs its own axis-dominance check: the begin gate only
+    // samples the FIRST velocity, so a drag that starts horizontal and turns
+    // into a vertical list scroll can still end with residual horizontal
+    // velocity — without the dominance test that diagonal release flipped
+    // tabs mid-scroll.
+    BOOL flick = velocity.x * direction > 300.0 && progress > 20.0 &&
+                 fabs(translation.x) > fabs(translation.y);
     if (!far && !flick) return;
     ChatsFilterLog(@"Inbox (All) swipe: %@", chatVisible ? @"Chat hub -> Notifications"
                                                         : @"Notifications -> Chat hub");

--- a/src/ApolloChatsFilter.xm
+++ b/src/ApolloChatsFilter.xm
@@ -81,6 +81,7 @@ static char kInboxAllStatusObserverKey;
 static char kInboxAllChatHubKey;
 static char kInboxAllChatHubVisibleKey;
 static char kInboxAllOriginalRightItemsKey;
+static char kInboxAllSwipeLeftKey;
 
 // Apollo owns the Inbox badge for notification/message counts. Keep that raw
 // value separately and render Chat as an additive overlay so either producer
@@ -721,6 +722,14 @@ typedef NS_ENUM(NSInteger, ApolloInboxMode) {
 static ApolloInboxChatHubViewController *ApolloEnsureInboxChatHub(UIViewController *host);
 static void ApolloSetInboxChatHubVisible(UIViewController *host, BOOL visible, BOOL animated);
 static void ApolloDismantleInboxChatHub(UIViewController *host, NSString *reason);
+static void ApolloInboxWireBackPanPrecedence(UIViewController *controller, UIPanGestureRecognizer *backPan);
+
+// Chat -> Notifications back-pan: the association carries the host controller
+// and doubles as the marker the shared gesture delegate uses to tell this pan
+// apart from the plain Notifications -> Chat swipe.
+static char kInboxChatBackPanHostKey;
+// Recognizers already wired to require the back-pan's failure (weak set).
+static char kInboxChatBackPanWiredKey;
 
 @implementation ApolloInboxChatHubViewController
 
@@ -902,6 +911,15 @@ static ApolloInboxChatHubViewController *ApolloEnsureInboxChatHub(UIViewControll
     return hub;
 }
 
+static UIPanGestureRecognizer *ApolloInboxFindBackPan(UIViewController *host) {
+    for (UIGestureRecognizer *recognizer in host.viewIfLoaded.gestureRecognizers) {
+        if (objc_getAssociatedObject(recognizer, &kInboxChatBackPanHostKey)) {
+            return (UIPanGestureRecognizer *)recognizer;
+        }
+    }
+    return nil;
+}
+
 static void ApolloSetInboxChatHubVisible(UIViewController *host, BOOL visible, BOOL animated) {
     if (!host) return;
     if (![NSThread isMainThread]) {
@@ -949,10 +967,24 @@ static void ApolloSetInboxChatHubVisible(UIViewController *host, BOOL visible, B
         objc_setAssociatedObject(host, &kInboxAllOriginalRightItemsKey,
                                  [savedRightItems copy], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
+    // Stripping the right buttons must not let the Liquid Glass recenter
+    // re-balance the "Inbox" title against an empty trailing side — the title
+    // visibly slid toward screen center on every Notifications -> Chat switch
+    // and back again on the return. Hold the trailing reservation BEFORE the
+    // strip (so a recenter pass mid-removal already holds the old edge) and
+    // release it only AFTER the restore (so no pass between the two sees a
+    // bare bar). No-op off-glass and under the pre-26 nav bar.
+    if (visible) ApolloNavItemSetTrailingReservationHold(host.navigationItem, YES);
     [host.navigationItem setRightBarButtonItems:visible ? nil : (savedRightItems.count ? savedRightItems : nil)
                                        animated:animated];
+    if (!visible) ApolloNavItemSetTrailingReservationHold(host.navigationItem, NO);
 
     if (visible) {
+        // The install-time wiring runs before the host view joins the
+        // navigation container, so Apollo's full-width pop pans (they live on
+        // the nav controller's UILayoutContainerView) are only reachable now
+        // — re-wire so they yield to the back-pan while Chat is up.
+        ApolloInboxWireBackPanPrecedence(host, ApolloInboxFindBackPan(host));
         // Align the persistent Chat overlay to the live sticky Notifications
         // switcher before making it visible.
         [hub apollo_alignModeSwitcherWithHostSwitcher:notificationsSwitcher];
@@ -1074,6 +1106,47 @@ static UIRefreshControl *ApolloInboxRefreshControl(UITableView *tableView) {
 // normal spot; the switcher fades back in when the list returns to rest.
 // The table carries a flag plus a reference to its switcher so this scroll
 // hook can drive the fade with one associated-object read per frame.
+// MARK: - Chat -> Notifications back-pan precedence
+//
+// Apollo pops screens with full-width swipe-back PANS on the navigation
+// container (plus the system interactive pop) — which is why a left-to-right
+// drag on the Notifications list already means "back". While the Chat hub is
+// visible the same drag must mean "back to Notifications" instead, so the
+// hub's back-pan (installed in ApolloInstallInboxModeSwitcher) is wired here
+// as a failure requirement into every pan on the host's ancestor chain: when
+// the back-pan begins (chat visible, mid-screen, decisively rightward — see
+// the shared delegate's gestureRecognizerShouldBegin:), Apollo's pop pans sit
+// it out; in every other situation the back-pan fails on the spot and they
+// behave exactly as stock. Scroll views' own pans are spared (the delegate
+// already recognizes simultaneously with them). A pan — not a discrete swipe
+// recognizer — because WebKit's deferring gates release held recognizers with
+// the touch history accumulated so far, which lets a pan begin late but
+// leaves a discrete swipe dead (verified with real HID swipes over the hub).
+static void ApolloInboxWireBackPanPrecedence(UIViewController *controller, UIPanGestureRecognizer *backPan) {
+    if (!backPan) return;
+    NSHashTable *wired = objc_getAssociatedObject(backPan, &kInboxChatBackPanWiredKey);
+    if (!wired) {
+        wired = [NSHashTable weakObjectsHashTable];
+        objc_setAssociatedObject(backPan, &kInboxChatBackPanWiredKey, wired, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    UIGestureRecognizer *pop = controller.navigationController.interactivePopGestureRecognizer;
+    if (pop && ![wired containsObject:pop]) {
+        [pop requireGestureRecognizerToFail:backPan];
+        [wired addObject:pop];
+    }
+    for (UIView *view = controller.viewIfLoaded; view; view = view.superview) {
+        UIGestureRecognizer *scrollPan =
+            [view isKindOfClass:[UIScrollView class]] ? ((UIScrollView *)view).panGestureRecognizer : nil;
+        for (UIGestureRecognizer *recognizer in view.gestureRecognizers) {
+            if (recognizer == backPan || recognizer == scrollPan || recognizer == pop) continue;
+            if ([wired containsObject:recognizer]) continue;
+            if (![recognizer isKindOfClass:[UIPanGestureRecognizer class]]) continue;
+            [recognizer requireGestureRecognizerToFail:backPan];
+            [wired addObject:recognizer];
+        }
+    }
+}
+
 %hook ASTableView
 - (void)setContentOffset:(CGPoint)contentOffset {
     %orig(contentOffset);
@@ -1155,6 +1228,59 @@ static void ApolloInboxEnsureRefreshHaptic(UITableView *tableView) {
     objc_setAssociatedObject(refreshControl, &kInboxRefreshHapticKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+// Delegate for the inbox mode-swipe recognizers. Both live on the host view
+// above two scroll surfaces (the notifications ASTableView and the Chat hub's
+// WKWebView scroll view), whose pan recognizers begin on ANY drag — and once a
+// pan has begun, UIKit's default exclusivity blocks a still-tracking swipe
+// from ever reaching Recognized (verified: synthesized began/moved/ended
+// swipes through -[UIApplication sendEvent:] never fired the handler without
+// this). Allowing simultaneous recognition lets the swipe complete alongside
+// the pan; the pop-gesture failure requirement set at install time still
+// takes precedence over simultaneity, so edge-pops stay exclusive.
+@interface ApolloInboxSwipeGestureDelegate : NSObject <UIGestureRecognizerDelegate>
+@end
+
+@implementation ApolloInboxSwipeGestureDelegate
+
++ (instancetype)shared {
+    static ApolloInboxSwipeGestureDelegate *shared;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ shared = [ApolloInboxSwipeGestureDelegate new]; });
+    return shared;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+    shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return YES;
+}
+
+// The Chat -> Notifications back-pan must fail INSTANTLY whenever it doesn't
+// apply — every pan on the host's ancestor chain (Apollo's full-width
+// swipe-back, the interactive pop) waits on its failure, so a lingering
+// Possible state here would add drag to ordinary back-swipes. NOTE:
+// translationInView: is still zero inside gestureRecognizerShouldBegin: —
+// only the velocity direction is usable (learned on #805).
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
+    UIViewController *host = objc_getAssociatedObject(gestureRecognizer, &kInboxChatBackPanHostKey);
+    if (!host) return YES;   // the Notifications -> Chat swipe: no begin gating
+    if (![gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) return YES;
+    if (![objc_getAssociatedObject(host, &kInboxAllChatHubVisibleKey) boolValue]) return NO;
+    UIPanGestureRecognizer *pan = (UIPanGestureRecognizer *)gestureRecognizer;
+    // Leave the left edge band to the system back gestures (interactive pop,
+    // the chat web view's own history-back), exactly like stock.
+    if ([pan locationInView:pan.view].x < 44.0) return NO;
+    CGPoint velocity = [pan velocityInView:pan.view];
+    if (velocity.x <= 0.0 || fabs(velocity.x) <= fabs(velocity.y)) return NO;
+    // Inside a conversation a rightward flick must never yank the user out to
+    // Notifications (rooms keep their own back affordances, and the GIF
+    // picker's grid scrolls horizontally).
+    ApolloInboxChatHubViewController *hub = objc_getAssociatedObject(host, &kInboxAllChatHubKey);
+    if (!hub || ApolloModernChatControllerIsOnConversationRoute(hub.chatController)) return NO;
+    return YES;
+}
+
+@end
+
 static void ApolloInstallInboxModeSwitcher(id controller) {
     if (!ApolloInboxControllerIsAll(controller)) return;
     UITableView *tableView = ApolloInboxControllerTableView(controller);
@@ -1180,6 +1306,16 @@ static void ApolloInstallInboxModeSwitcher(id controller) {
                                  OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(tableView, &kInboxAllSwitcherTableKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(tableView, &kInboxAllSwitcherRefKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        // The mode-swipe recognizers exist only alongside the switcher.
+        UISwipeGestureRecognizer *staleLeft = objc_getAssociatedObject(controller, &kInboxAllSwipeLeftKey);
+        [staleLeft.view removeGestureRecognizer:staleLeft];
+        objc_setAssociatedObject(controller, &kInboxAllSwipeLeftKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        UIView *staleHostView = ((UIViewController *)controller).viewIfLoaded;
+        for (UIGestureRecognizer *recognizer in [staleHostView.gestureRecognizers copy]) {
+            if (objc_getAssociatedObject(recognizer, &kInboxChatBackPanHostKey)) {
+                [staleHostView removeGestureRecognizer:recognizer];
+            }
+        }
         return;
     }
 
@@ -1244,6 +1380,49 @@ static void ApolloInstallInboxModeSwitcher(id controller) {
         objc_setAssociatedObject(tableView, &kInboxAllSwitcherRefKey, switcher, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         ChatsFilterLog(@"installed sticky Notifications / Chat switcher in Inbox (All)");
     }
+    // Swipe between the two modes like adjacent pages: right-to-left on
+    // Notifications reveals Chat. A discrete directional swipe on the HOST
+    // view covers the notifications list without touching its own pan/scroll
+    // handling (a vertical scroll never reads as a directional swipe); the
+    // simultaneous-recognition delegate is what lets it complete alongside
+    // the table's pan. The reverse (Chat -> Notifications) swipe is NOT a
+    // recognizer: over the Chat hub's WKWebView, WebKit's deferring gesture
+    // gates starve ancestor recognizers (verified with both synthesized and
+    // real HID swipes), so that direction is detected by the sendEvent
+    // tracker below instead. Left-to-right on Notifications intentionally
+    // stays unhandled so the navigation controller's edge-pop keeps meaning
+    // "back".
+    UISwipeGestureRecognizer *swipeLeft = objc_getAssociatedObject(controller, &kInboxAllSwipeLeftKey);
+    if (!swipeLeft) {
+        swipeLeft = [[UISwipeGestureRecognizer alloc]
+            initWithTarget:controller action:NSSelectorFromString(@"apollo_inboxModeSwiped:")];
+        swipeLeft.direction = UISwipeGestureRecognizerDirectionLeft;
+        swipeLeft.delegate = [ApolloInboxSwipeGestureDelegate shared];
+        [hostView addGestureRecognizer:swipeLeft];
+        objc_setAssociatedObject(controller, &kInboxAllSwipeLeftKey, swipeLeft, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    // Chat -> Notifications is a PAN (see ApolloInboxWireBackPanPrecedence for
+    // why a discrete swipe cannot work over the hub's web view). The shared
+    // delegate's gestureRecognizerShouldBegin: keeps it failing everywhere it
+    // doesn't apply, so the precedence wiring below never slows stock pops.
+    UIPanGestureRecognizer *backPan = nil;
+    for (UIGestureRecognizer *recognizer in hostView.gestureRecognizers) {
+        if (objc_getAssociatedObject(recognizer, &kInboxChatBackPanHostKey)) {
+            backPan = (UIPanGestureRecognizer *)recognizer;
+            break;
+        }
+    }
+    if (!backPan) {
+        backPan = [[UIPanGestureRecognizer alloc]
+            initWithTarget:controller action:NSSelectorFromString(@"apollo_inboxChatBackPanned:")];
+        backPan.maximumNumberOfTouches = 1;
+        backPan.delegate = [ApolloInboxSwipeGestureDelegate shared];
+        objc_setAssociatedObject(backPan, &kInboxChatBackPanHostKey, controller, OBJC_ASSOCIATION_ASSIGN);
+        [hostView addGestureRecognizer:backPan];
+    }
+    // Re-wire every install pass: cheap, idempotent, and it catches pop/pan
+    // recognizers that attach to the navigation container after first install.
+    ApolloInboxWireBackPanPrecedence((UIViewController *)controller, backPan);
     BOOL chatVisible = [objc_getAssociatedObject(controller, &kInboxAllChatHubVisibleKey) boolValue];
     ApolloInboxChatHubViewController *hub = objc_getAssociatedObject(controller, &kInboxAllChatHubKey);
     // The host switcher is the single live mode control in BOTH modes; it and
@@ -1597,6 +1776,18 @@ static NSArray *ApolloChatFilterOutChats(NSArray *messages) {
     if ([objc_getAssociatedObject(self, &kChatFilterKey) boolValue]) sChatFilterActive = NO;
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    // Only now is the host view attached under the navigation controller's
+    // UILayoutContainerView, where Apollo's full-width pop pans live — the
+    // install-time wiring pass cannot reach them (see
+    // ApolloInboxWireBackPanPrecedence). Idempotent per recognizer.
+    if (ApolloInboxControllerIsAll(self) && ApolloModernChatShouldOpen()) {
+        ApolloInboxWireBackPanPrecedence((UIViewController *)self,
+                                         ApolloInboxFindBackPan((UIViewController *)self));
+    }
+}
+
 // Apollo notifies every inbox surface on account switches. The persistent
 // Chat hub is seeded with one account's cookies, so it must be destroyed at
 // this exact moment — keeping it would show (and compose as) the previous
@@ -1639,6 +1830,32 @@ static NSArray *ApolloChatFilterOutChats(NSArray *messages) {
     }
     if (sender.selectedMode != ApolloInboxModeChat || !ApolloModernChatShouldOpen()) return;
     ChatsFilterLog(@"Inbox (All) switching in place from Notifications to Chat hub");
+    ApolloSetInboxChatHubVisible((UIViewController *)self, YES, YES);
+}
+
+%new
+- (void)apollo_inboxChatBackPanned:(UIPanGestureRecognizer *)pan {
+    if (pan.state != UIGestureRecognizerStateEnded) return;
+    // The delegate already vetted chat visibility, the edge band, direction,
+    // and the conversation route at begin time; here only judge whether the
+    // finished drag reads as a deliberate back-swipe.
+    CGPoint translation = [pan translationInView:pan.view];
+    CGPoint velocity = [pan velocityInView:pan.view];
+    BOOL far = translation.x > 60.0 && fabs(translation.x) > 2.0 * fabs(translation.y);
+    BOOL flick = velocity.x > 300.0 && translation.x > 20.0;
+    if (!far && !flick) return;
+    if (![objc_getAssociatedObject(self, &kInboxAllChatHubVisibleKey) boolValue]) return;
+    ChatsFilterLog(@"Inbox (All) swipe: Chat hub -> Notifications");
+    ApolloSetInboxChatHubVisible((UIViewController *)self, NO, YES);
+}
+
+%new
+- (void)apollo_inboxModeSwiped:(UISwipeGestureRecognizer *)recognizer {
+    if (recognizer.state != UIGestureRecognizerStateEnded) return;
+    if (!ApolloInboxControllerIsAll(self) || !ApolloModernChatShouldOpen()) return;
+    BOOL chatVisible = [objc_getAssociatedObject(self, &kInboxAllChatHubVisibleKey) boolValue];
+    if (chatVisible) return;   // already on Chat
+    ChatsFilterLog(@"Inbox (All) swipe: Notifications -> Chat hub");
     ApolloSetInboxChatHubVisible((UIViewController *)self, YES, YES);
 }
 

--- a/src/ApolloChatsFilter.xm
+++ b/src/ApolloChatsFilter.xm
@@ -81,7 +81,6 @@ static char kInboxAllStatusObserverKey;
 static char kInboxAllChatHubKey;
 static char kInboxAllChatHubVisibleKey;
 static char kInboxAllOriginalRightItemsKey;
-static char kInboxAllSwipeLeftKey;
 
 // Apollo owns the Inbox badge for notification/message counts. Keep that raw
 // value separately and render Chat as an additive overlay so either producer
@@ -722,14 +721,14 @@ typedef NS_ENUM(NSInteger, ApolloInboxMode) {
 static ApolloInboxChatHubViewController *ApolloEnsureInboxChatHub(UIViewController *host);
 static void ApolloSetInboxChatHubVisible(UIViewController *host, BOOL visible, BOOL animated);
 static void ApolloDismantleInboxChatHub(UIViewController *host, NSString *reason);
-static void ApolloInboxWireBackPanPrecedence(UIViewController *controller, UIPanGestureRecognizer *backPan);
+static void ApolloInboxWireModePanPrecedence(UIViewController *controller, UIPanGestureRecognizer *modePan);
 
-// Chat -> Notifications back-pan: the association carries the host controller
-// and doubles as the marker the shared gesture delegate uses to tell this pan
-// apart from the plain Notifications -> Chat swipe.
-static char kInboxChatBackPanHostKey;
-// Recognizers already wired to require the back-pan's failure (weak set).
-static char kInboxChatBackPanWiredKey;
+// The inbox mode-pan (both tab-switch directions): the association carries the
+// host controller and doubles as the marker the shared gesture delegate uses
+// to recognize its own pan.
+static char kInboxModePanHostKey;
+// Recognizers already wired to require the mode-pan's failure (weak set).
+static char kInboxModePanWiredKey;
 
 @implementation ApolloInboxChatHubViewController
 
@@ -911,9 +910,9 @@ static ApolloInboxChatHubViewController *ApolloEnsureInboxChatHub(UIViewControll
     return hub;
 }
 
-static UIPanGestureRecognizer *ApolloInboxFindBackPan(UIViewController *host) {
+static UIPanGestureRecognizer *ApolloInboxFindModePan(UIViewController *host) {
     for (UIGestureRecognizer *recognizer in host.viewIfLoaded.gestureRecognizers) {
-        if (objc_getAssociatedObject(recognizer, &kInboxChatBackPanHostKey)) {
+        if (objc_getAssociatedObject(recognizer, &kInboxModePanHostKey)) {
             return (UIPanGestureRecognizer *)recognizer;
         }
     }
@@ -981,10 +980,10 @@ static void ApolloSetInboxChatHubVisible(UIViewController *host, BOOL visible, B
 
     if (visible) {
         // The install-time wiring runs before the host view joins the
-        // navigation container, so Apollo's full-width pop pans (they live on
-        // the nav controller's UILayoutContainerView) are only reachable now
-        // — re-wire so they yield to the back-pan while Chat is up.
-        ApolloInboxWireBackPanPrecedence(host, ApolloInboxFindBackPan(host));
+        // navigation container, so Apollo's full-width back/forward pans
+        // (they live on the nav controller's UILayoutContainerView) are only
+        // reachable now — re-wire so they yield to the mode-pan.
+        ApolloInboxWireModePanPrecedence(host, ApolloInboxFindModePan(host));
         // Align the persistent Chat overlay to the live sticky Notifications
         // switcher before making it visible.
         [hub apollo_alignModeSwitcherWithHostSwitcher:notificationsSwitcher];
@@ -1106,43 +1105,68 @@ static UIRefreshControl *ApolloInboxRefreshControl(UITableView *tableView) {
 // normal spot; the switcher fades back in when the list returns to rest.
 // The table carries a flag plus a reference to its switcher so this scroll
 // hook can drive the fade with one associated-object read per frame.
-// MARK: - Chat -> Notifications back-pan precedence
+// MARK: - Inbox mode-pan precedence
 //
 // Apollo pops screens with full-width swipe-back PANS on the navigation
-// container (plus the system interactive pop) — which is why a left-to-right
-// drag on the Notifications list already means "back". While the Chat hub is
-// visible the same drag must mean "back to Notifications" instead, so the
-// hub's back-pan (installed in ApolloInstallInboxModeSwitcher) is wired here
-// as a failure requirement into every pan on the host's ancestor chain: when
-// the back-pan begins (chat visible, mid-screen, decisively rightward — see
-// the shared delegate's gestureRecognizerShouldBegin:), Apollo's pop pans sit
-// it out; in every other situation the back-pan fails on the spot and they
-// behave exactly as stock. Scroll views' own pans are spared (the delegate
-// already recognizes simultaneously with them). A pan — not a discrete swipe
+// container (plus the system interactive pop), and offers the mirrored
+// full-width FORWARD pan to re-enter the screen you swiped back from. Inside
+// the Inbox those whole-screen gestures belong only to their "end" tabs:
+// back means "previous screen" only from Notifications (the first tab) and
+// forward only from Chat (the last tab). Everything in between is the
+// tab-switch pan installed in ApolloInstallInboxModeSwitcher, so every pan on
+// the host's ancestor chain is wired here to REQUIRE the mode-pan's failure:
+// when the mode-pan begins (a horizontal drag toward the other tab — see the
+// shared delegate's gestureRecognizerShouldBegin:), Apollo's back/forward
+// pans and the interactive pop sit the touch out; in every other situation
+// the mode-pan fails on the spot and they behave exactly as stock. Scroll
+// views' own pans are spared (the delegate already recognizes simultaneously
+// with them). The chat hub's WKWebView edge gestures (history back/forward)
+// are wired too, so an edge grab on the chat LIST cleanly returns to
+// Notifications instead of also walking web history — inside a conversation
+// the mode-pan fails (route guard), which hands the edge back to the web
+// view's own history gesture untouched. A pan — not a discrete swipe
 // recognizer — because WebKit's deferring gates release held recognizers with
 // the touch history accumulated so far, which lets a pan begin late but
 // leaves a discrete swipe dead (verified with real HID swipes over the hub).
-static void ApolloInboxWireBackPanPrecedence(UIViewController *controller, UIPanGestureRecognizer *backPan) {
-    if (!backPan) return;
-    NSHashTable *wired = objc_getAssociatedObject(backPan, &kInboxChatBackPanWiredKey);
+static void ApolloInboxWireModePanPrecedence(UIViewController *controller, UIPanGestureRecognizer *modePan) {
+    if (!modePan) return;
+    NSHashTable *wired = objc_getAssociatedObject(modePan, &kInboxModePanWiredKey);
     if (!wired) {
         wired = [NSHashTable weakObjectsHashTable];
-        objc_setAssociatedObject(backPan, &kInboxChatBackPanWiredKey, wired, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(modePan, &kInboxModePanWiredKey, wired, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
     UIGestureRecognizer *pop = controller.navigationController.interactivePopGestureRecognizer;
     if (pop && ![wired containsObject:pop]) {
-        [pop requireGestureRecognizerToFail:backPan];
+        [pop requireGestureRecognizerToFail:modePan];
         [wired addObject:pop];
     }
     for (UIView *view = controller.viewIfLoaded; view; view = view.superview) {
         UIGestureRecognizer *scrollPan =
             [view isKindOfClass:[UIScrollView class]] ? ((UIScrollView *)view).panGestureRecognizer : nil;
         for (UIGestureRecognizer *recognizer in view.gestureRecognizers) {
-            if (recognizer == backPan || recognizer == scrollPan || recognizer == pop) continue;
+            if (recognizer == modePan || recognizer == scrollPan || recognizer == pop) continue;
             if ([wired containsObject:recognizer]) continue;
             if (![recognizer isKindOfClass:[UIPanGestureRecognizer class]]) continue;
-            [recognizer requireGestureRecognizerToFail:backPan];
+            [recognizer requireGestureRecognizerToFail:modePan];
             [wired addObject:recognizer];
+        }
+    }
+    // WebKit re-creates content views (and their edge recognizers) across
+    // navigations; this wiring re-runs on every install pass and every
+    // Chat reveal, which keeps new ones covered.
+    ApolloInboxChatHubViewController *hub = objc_getAssociatedObject(controller, &kInboxAllChatHubKey);
+    UIView *hubView = hub.viewIfLoaded;
+    if (hubView) {
+        NSMutableArray<UIView *> *queue = [NSMutableArray arrayWithObject:hubView];
+        for (NSUInteger index = 0; index < queue.count; index++) {
+            UIView *view = queue[index];
+            for (UIView *subview in view.subviews) [queue addObject:subview];
+            for (UIGestureRecognizer *recognizer in view.gestureRecognizers) {
+                if (![recognizer isKindOfClass:[UIScreenEdgePanGestureRecognizer class]]) continue;
+                if ([wired containsObject:recognizer]) continue;
+                [recognizer requireGestureRecognizerToFail:modePan];
+                [wired addObject:recognizer];
+            }
         }
     }
 }
@@ -1254,29 +1278,35 @@ static void ApolloInboxEnsureRefreshHaptic(UITableView *tableView) {
     return YES;
 }
 
-// The Chat -> Notifications back-pan must fail INSTANTLY whenever it doesn't
-// apply — every pan on the host's ancestor chain (Apollo's full-width
-// swipe-back, the interactive pop) waits on its failure, so a lingering
-// Possible state here would add drag to ordinary back-swipes. NOTE:
-// translationInView: is still zero inside gestureRecognizerShouldBegin: —
-// only the velocity direction is usable (learned on #805).
+// The mode-pan must fail INSTANTLY whenever it doesn't apply — every pan on
+// the host's ancestor chain (Apollo's full-width back AND forward swipes, the
+// interactive pop) plus the chat web view's edge gestures wait on its
+// failure, so a lingering Possible state here would add drag to the stock
+// gestures. The quadrant rule: on Notifications only a leftward drag (toward
+// Chat) begins, leaving rightward for back/pop; on Chat only a rightward drag
+// (toward Notifications) begins, leaving leftward for Apollo's forward pan.
+// That is exactly "back only on the first tab, forward only on the last".
+// NOTE: translationInView: is still zero inside
+// gestureRecognizerShouldBegin: — only the velocity direction is usable
+// (learned on #805).
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
-    UIViewController *host = objc_getAssociatedObject(gestureRecognizer, &kInboxChatBackPanHostKey);
-    if (!host) return YES;   // the Notifications -> Chat swipe: no begin gating
-    if (![gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) return YES;
-    if (![objc_getAssociatedObject(host, &kInboxAllChatHubVisibleKey) boolValue]) return NO;
+    UIViewController *host = objc_getAssociatedObject(gestureRecognizer, &kInboxModePanHostKey);
+    if (!host || ![gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) return YES;
+    if (!ApolloModernChatShouldOpen()) return NO;
     UIPanGestureRecognizer *pan = (UIPanGestureRecognizer *)gestureRecognizer;
-    // Leave the left edge band to the system back gestures (interactive pop,
-    // the chat web view's own history-back), exactly like stock.
-    if ([pan locationInView:pan.view].x < 44.0) return NO;
     CGPoint velocity = [pan velocityInView:pan.view];
-    if (velocity.x <= 0.0 || fabs(velocity.x) <= fabs(velocity.y)) return NO;
-    // Inside a conversation a rightward flick must never yank the user out to
-    // Notifications (rooms keep their own back affordances, and the GIF
-    // picker's grid scrolls horizontally).
-    ApolloInboxChatHubViewController *hub = objc_getAssociatedObject(host, &kInboxAllChatHubKey);
-    if (!hub || ApolloModernChatControllerIsOnConversationRoute(hub.chatController)) return NO;
-    return YES;
+    if (fabs(velocity.x) <= fabs(velocity.y)) return NO;   // decisively horizontal only
+    if ([objc_getAssociatedObject(host, &kInboxAllChatHubVisibleKey) boolValue]) {
+        if (velocity.x <= 0.0) return NO;   // leftward on Chat = Apollo's forward pan
+        // Inside a conversation a rightward drag must never yank the user out
+        // to Notifications (rooms keep their own back affordances — the web
+        // view's edge history-back — and the GIF picker's grid scrolls
+        // horizontally). Failing here also un-gates those wired gestures.
+        ApolloInboxChatHubViewController *hub = objc_getAssociatedObject(host, &kInboxAllChatHubKey);
+        if (!hub || ApolloModernChatControllerIsOnConversationRoute(hub.chatController)) return NO;
+        return YES;
+    }
+    return velocity.x < 0.0;   // rightward on Notifications = back-swipe / pop
 }
 
 @end
@@ -1306,13 +1336,10 @@ static void ApolloInstallInboxModeSwitcher(id controller) {
                                  OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(tableView, &kInboxAllSwitcherTableKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         objc_setAssociatedObject(tableView, &kInboxAllSwitcherRefKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        // The mode-swipe recognizers exist only alongside the switcher.
-        UISwipeGestureRecognizer *staleLeft = objc_getAssociatedObject(controller, &kInboxAllSwipeLeftKey);
-        [staleLeft.view removeGestureRecognizer:staleLeft];
-        objc_setAssociatedObject(controller, &kInboxAllSwipeLeftKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        // The mode-pan exists only alongside the switcher.
         UIView *staleHostView = ((UIViewController *)controller).viewIfLoaded;
         for (UIGestureRecognizer *recognizer in [staleHostView.gestureRecognizers copy]) {
-            if (objc_getAssociatedObject(recognizer, &kInboxChatBackPanHostKey)) {
+            if (objc_getAssociatedObject(recognizer, &kInboxModePanHostKey)) {
                 [staleHostView removeGestureRecognizer:recognizer];
             }
         }
@@ -1380,49 +1407,27 @@ static void ApolloInstallInboxModeSwitcher(id controller) {
         objc_setAssociatedObject(tableView, &kInboxAllSwitcherRefKey, switcher, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         ChatsFilterLog(@"installed sticky Notifications / Chat switcher in Inbox (All)");
     }
-    // Swipe between the two modes like adjacent pages: right-to-left on
-    // Notifications reveals Chat. A discrete directional swipe on the HOST
-    // view covers the notifications list without touching its own pan/scroll
-    // handling (a vertical scroll never reads as a directional swipe); the
-    // simultaneous-recognition delegate is what lets it complete alongside
-    // the table's pan. The reverse (Chat -> Notifications) swipe is NOT a
-    // recognizer: over the Chat hub's WKWebView, WebKit's deferring gesture
-    // gates starve ancestor recognizers (verified with both synthesized and
-    // real HID swipes), so that direction is detected by the sendEvent
-    // tracker below instead. Left-to-right on Notifications intentionally
-    // stays unhandled so the navigation controller's edge-pop keeps meaning
-    // "back".
-    UISwipeGestureRecognizer *swipeLeft = objc_getAssociatedObject(controller, &kInboxAllSwipeLeftKey);
-    if (!swipeLeft) {
-        swipeLeft = [[UISwipeGestureRecognizer alloc]
-            initWithTarget:controller action:NSSelectorFromString(@"apollo_inboxModeSwiped:")];
-        swipeLeft.direction = UISwipeGestureRecognizerDirectionLeft;
-        swipeLeft.delegate = [ApolloInboxSwipeGestureDelegate shared];
-        [hostView addGestureRecognizer:swipeLeft];
-        objc_setAssociatedObject(controller, &kInboxAllSwipeLeftKey, swipeLeft, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    }
-    // Chat -> Notifications is a PAN (see ApolloInboxWireBackPanPrecedence for
-    // why a discrete swipe cannot work over the hub's web view). The shared
-    // delegate's gestureRecognizerShouldBegin: keeps it failing everywhere it
-    // doesn't apply, so the precedence wiring below never slows stock pops.
-    UIPanGestureRecognizer *backPan = nil;
-    for (UIGestureRecognizer *recognizer in hostView.gestureRecognizers) {
-        if (objc_getAssociatedObject(recognizer, &kInboxChatBackPanHostKey)) {
-            backPan = (UIPanGestureRecognizer *)recognizer;
-            break;
-        }
-    }
-    if (!backPan) {
-        backPan = [[UIPanGestureRecognizer alloc]
-            initWithTarget:controller action:NSSelectorFromString(@"apollo_inboxChatBackPanned:")];
-        backPan.maximumNumberOfTouches = 1;
-        backPan.delegate = [ApolloInboxSwipeGestureDelegate shared];
-        objc_setAssociatedObject(backPan, &kInboxChatBackPanHostKey, controller, OBJC_ASSOCIATION_ASSIGN);
-        [hostView addGestureRecognizer:backPan];
+    // Swipe between the two modes like adjacent pages: a leftward drag on
+    // Notifications reveals Chat, a rightward drag on Chat returns to
+    // Notifications — one direction-aware PAN on the host view covering the
+    // notifications list and the Chat hub's web view alike (see
+    // ApolloInboxWireModePanPrecedence for why a discrete swipe cannot work
+    // over the hub, and the shared delegate's gestureRecognizerShouldBegin:
+    // for the quadrant rule that keeps back/pop on Notifications and Apollo's
+    // forward pan on Chat working untouched).
+    UIPanGestureRecognizer *modePan = ApolloInboxFindModePan((UIViewController *)controller);
+    if (!modePan) {
+        modePan = [[UIPanGestureRecognizer alloc]
+            initWithTarget:controller action:NSSelectorFromString(@"apollo_inboxModePanned:")];
+        modePan.maximumNumberOfTouches = 1;
+        modePan.delegate = [ApolloInboxSwipeGestureDelegate shared];
+        objc_setAssociatedObject(modePan, &kInboxModePanHostKey, controller, OBJC_ASSOCIATION_ASSIGN);
+        [hostView addGestureRecognizer:modePan];
     }
     // Re-wire every install pass: cheap, idempotent, and it catches pop/pan
-    // recognizers that attach to the navigation container after first install.
-    ApolloInboxWireBackPanPrecedence((UIViewController *)controller, backPan);
+    // recognizers that attach to the navigation container after first install
+    // (plus WebKit's re-created edge recognizers).
+    ApolloInboxWireModePanPrecedence((UIViewController *)controller, modePan);
     BOOL chatVisible = [objc_getAssociatedObject(controller, &kInboxAllChatHubVisibleKey) boolValue];
     ApolloInboxChatHubViewController *hub = objc_getAssociatedObject(controller, &kInboxAllChatHubKey);
     // The host switcher is the single live mode control in BOTH modes; it and
@@ -1781,10 +1786,10 @@ static NSArray *ApolloChatFilterOutChats(NSArray *messages) {
     // Only now is the host view attached under the navigation controller's
     // UILayoutContainerView, where Apollo's full-width pop pans live — the
     // install-time wiring pass cannot reach them (see
-    // ApolloInboxWireBackPanPrecedence). Idempotent per recognizer.
+    // ApolloInboxWireModePanPrecedence). Idempotent per recognizer.
     if (ApolloInboxControllerIsAll(self) && ApolloModernChatShouldOpen()) {
-        ApolloInboxWireBackPanPrecedence((UIViewController *)self,
-                                         ApolloInboxFindBackPan((UIViewController *)self));
+        ApolloInboxWireModePanPrecedence((UIViewController *)self,
+                                         ApolloInboxFindModePan((UIViewController *)self));
     }
 }
 
@@ -1834,29 +1839,23 @@ static NSArray *ApolloChatFilterOutChats(NSArray *messages) {
 }
 
 %new
-- (void)apollo_inboxChatBackPanned:(UIPanGestureRecognizer *)pan {
+- (void)apollo_inboxModePanned:(UIPanGestureRecognizer *)pan {
     if (pan.state != UIGestureRecognizerStateEnded) return;
-    // The delegate already vetted chat visibility, the edge band, direction,
-    // and the conversation route at begin time; here only judge whether the
-    // finished drag reads as a deliberate back-swipe.
+    if (!ApolloInboxControllerIsAll(self) || !ApolloModernChatShouldOpen()) return;
+    // The delegate already vetted chat state, drag direction, and the
+    // conversation route at begin time; here only judge whether the finished
+    // drag reads as a deliberate tab switch.
+    BOOL chatVisible = [objc_getAssociatedObject(self, &kInboxAllChatHubVisibleKey) boolValue];
+    CGFloat direction = chatVisible ? 1.0 : -1.0;   // toward Notifications : toward Chat
     CGPoint translation = [pan translationInView:pan.view];
     CGPoint velocity = [pan velocityInView:pan.view];
-    BOOL far = translation.x > 60.0 && fabs(translation.x) > 2.0 * fabs(translation.y);
-    BOOL flick = velocity.x > 300.0 && translation.x > 20.0;
+    CGFloat progress = translation.x * direction;
+    BOOL far = progress > 60.0 && fabs(translation.x) > 2.0 * fabs(translation.y);
+    BOOL flick = velocity.x * direction > 300.0 && progress > 20.0;
     if (!far && !flick) return;
-    if (![objc_getAssociatedObject(self, &kInboxAllChatHubVisibleKey) boolValue]) return;
-    ChatsFilterLog(@"Inbox (All) swipe: Chat hub -> Notifications");
-    ApolloSetInboxChatHubVisible((UIViewController *)self, NO, YES);
-}
-
-%new
-- (void)apollo_inboxModeSwiped:(UISwipeGestureRecognizer *)recognizer {
-    if (recognizer.state != UIGestureRecognizerStateEnded) return;
-    if (!ApolloInboxControllerIsAll(self) || !ApolloModernChatShouldOpen()) return;
-    BOOL chatVisible = [objc_getAssociatedObject(self, &kInboxAllChatHubVisibleKey) boolValue];
-    if (chatVisible) return;   // already on Chat
-    ChatsFilterLog(@"Inbox (All) swipe: Notifications -> Chat hub");
-    ApolloSetInboxChatHubVisible((UIViewController *)self, YES, YES);
+    ChatsFilterLog(@"Inbox (All) swipe: %@", chatVisible ? @"Chat hub -> Notifications"
+                                                        : @"Notifications -> Chat hub");
+    ApolloSetInboxChatHubVisible((UIViewController *)self, !chatVisible, YES);
 }
 
 %new

--- a/src/ApolloCommon.h
+++ b/src/ApolloCommon.h
@@ -63,6 +63,26 @@ NSURLSessionDataTask *ApolloStartBoundedDataRequest(
     ApolloBoundedDataCompletion completion);
 
 BOOL IsLiquidGlass(void);
+
+// --- Liquid Glass trailing-cluster reservation ---
+// Some screens temporarily strip their right bar buttons while staying on the
+// SAME navigation item (the Inbox strips them whenever its in-place Chat hub
+// covers Notifications). The Liquid Glass title recenter in
+// ApolloLiquidGlass.xm would then re-balance the title against an empty
+// trailing side, visibly sliding it — in gap-centering mode because the gap
+// midpoint moves, and in screen-centering mode because the overlap clamp
+// relaxes. While a "hold" is set on the navigation item, the recenter keeps
+// using the trailing content edge it last measured for that item (stored as an
+// inset from the bar's trailing edge, so rotation keeps working), making the
+// title position identical whether the buttons are up or stripped. The
+// recenter itself records the live inset via
+// ApolloNavItemNoteTrailingContentInset on every pass that sees real trailing
+// content; holders only toggle the hold. All four are no-ops off-glass (the
+// recenter never runs there and nothing else reads the values).
+void ApolloNavItemSetTrailingReservationHold(UINavigationItem *item, BOOL hold);
+BOOL ApolloNavItemTrailingReservationHold(UINavigationItem *item);
+void ApolloNavItemNoteTrailingContentInset(UINavigationItem *item, CGFloat inset);
+CGFloat ApolloNavItemTrailingContentInset(UINavigationItem *item);   // 0 = never captured
 NSURL *ApolloURLByConvertingResolvedURLToApolloScheme(NSURL *url);
 BOOL ApolloRouteResolvedURLViaApolloScheme(NSURL *resolvedURL);
 void ApolloFlushReadPostIDsToDefaults(void);

--- a/src/ApolloCommon.m
+++ b/src/ApolloCommon.m
@@ -583,6 +583,32 @@ BOOL IsLiquidGlass(void) {
     return available;
 }
 
+// --- Liquid Glass trailing-cluster reservation (see ApolloCommon.h) ---
+// Plain associated storage on the navigation item; the recenter in
+// ApolloLiquidGlass.xm is the only reader and sole inset writer.
+static char kApolloNavItemTrailingHoldKey;
+static char kApolloNavItemTrailingInsetKey;
+
+void ApolloNavItemSetTrailingReservationHold(UINavigationItem *item, BOOL hold) {
+    if (!item) return;
+    objc_setAssociatedObject(item, &kApolloNavItemTrailingHoldKey,
+                             hold ? @YES : nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+BOOL ApolloNavItemTrailingReservationHold(UINavigationItem *item) {
+    return [objc_getAssociatedObject(item, &kApolloNavItemTrailingHoldKey) boolValue];
+}
+
+void ApolloNavItemNoteTrailingContentInset(UINavigationItem *item, CGFloat inset) {
+    if (!item || inset <= 0) return;
+    objc_setAssociatedObject(item, &kApolloNavItemTrailingInsetKey,
+                             @(inset), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+CGFloat ApolloNavItemTrailingContentInset(UINavigationItem *item) {
+    return [objc_getAssociatedObject(item, &kApolloNavItemTrailingInsetKey) doubleValue];
+}
+
 // Route a URL through Apollo's own URL handler, bypassing iOS URL dispatch.
 //
 // On iOS 13+ with scenes, the SceneDelegate owns the tabBarController while

--- a/src/ApolloDirectChatWeb.h
+++ b/src/ApolloDirectChatWeb.h
@@ -62,6 +62,13 @@ void ApolloModernChatControllerShowInboxSection(UIViewController *controller,
 // Notifications returns.
 void ApolloModernChatControllerSetInboxVisible(UIViewController *controller, BOOL visible);
 void ApolloModernChatControllerRefreshEmbeddedLayout(UIViewController *controller);
+// YES while `controller` (a modern Chat controller) is inside a conversation
+// (/chat/room/… or a /chat/threads/<id> reply thread) rather than one of the
+// list surfaces. The Inbox hub's Chat -> Notifications swipe tracker checks
+// this so a horizontal flick inside a room (message bubbles, the GIF picker's
+// horizontally scrolling grid, …) can never yank the user out to
+// Notifications; rooms keep their own back affordances.
+BOOL ApolloModernChatControllerIsOnConversationRoute(UIViewController * _Nullable controller);
 // API-key-free accounts cannot use Apollo's OAuth-only native new-Modmail
 // endpoints. This presents Reddit's current cookie-authenticated Modmail inbox
 // in the same isolated, Apollo-themed mailbox shell as modern Chat.

--- a/src/ApolloDirectChatWeb.xm
+++ b/src/ApolloDirectChatWeb.xm
@@ -3193,6 +3193,16 @@ void ApolloModernChatControllerSetInboxVisible(UIViewController *controller, BOO
     }
 }
 
+BOOL ApolloModernChatControllerIsOnConversationRoute(UIViewController *controller) {
+    if (![controller isKindOfClass:[ApolloDirectChatWebViewController class]]) return NO;
+    ApolloDirectChatWebViewController *chatController =
+        (ApolloDirectChatWebViewController *)controller;
+    // lastObservedWebPath tracks the URL KVO (covers same-document SPA
+    // transitions); fall back to the live URL before the first observation.
+    NSString *path = chatController.lastObservedWebPath ?: (chatController.webView.URL.path ?: @"");
+    return [chatController apollo_isChatConversationPath:path];
+}
+
 void ApolloModernChatControllerRefreshEmbeddedLayout(UIViewController *controller) {
     if (![controller isMemberOfClass:[ApolloDirectChatWebViewController class]]) return;
     ApolloDirectChatWebViewController *chatController =

--- a/src/ApolloLiquidGlass.xm
+++ b/src/ApolloLiquidGlass.xm
@@ -1307,6 +1307,32 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl) {
 
     const CGFloat kEdgePadding = 8.0;
 
+    UIViewController *topVC = ApolloOwningTopViewController(titleControl);
+
+    // Trailing-cluster reservation (ApolloCommon.h): screens that strip their
+    // right bar buttons in place (Inbox while its Chat hub is up) hold a
+    // reservation on their navigation item so the title doesn't re-balance
+    // against the suddenly-empty trailing side and slide. Record the trailing
+    // content edge whenever one is really there (as an inset from the bar's
+    // trailing edge, so a rotation mid-hold still resolves correctly), and
+    // while the hold is set with no real trailing content, treat the recorded
+    // edge as still present. Both centering arms below then compute the exact
+    // geometry they computed with the buttons up — gap midpoint and overlap
+    // clamp alike — which is what keeps the title still in either
+    // Balance-Title mode.
+    UINavigationItem *navItem = topVC.navigationItem;
+    if (navItem) {
+        if (foundRight) {
+            ApolloNavItemNoteTrailingContentInset(navItem, CGRectGetWidth(bar.bounds) - rightLimit);
+        } else if (ApolloNavItemTrailingReservationHold(navItem)) {
+            CGFloat reservedInset = ApolloNavItemTrailingContentInset(navItem);
+            if (reservedInset > 0) {
+                rightLimit = CGRectGetWidth(bar.bounds) - reservedInset;
+                foundRight = YES;
+            }
+        }
+    }
+
     // Subreddit headers only (see the MARK above): size the JumpBar to its
     // actual content before centering, instead of leaving it at whatever
     // fixed width Apollo's own layout handed it (measured: exactly 156pt when
@@ -1314,7 +1340,6 @@ static BOOL ApolloRecenterTitleControl(UIView *titleControl) {
     // never content-dependent on its own). Measured fresh via -sizeThatFits:
     // every pass — never cached, never read from a possibly-mid-transition
     // frame — because that's the one thing here that's immune to timing.
-    UIViewController *topVC = ApolloOwningTopViewController(titleControl);
     if (topVC && ApolloSubredditTitleShouldTruncate(topVC)) {
         UIView *jumpBar = ApolloFindJumpBar(titleControl);
         CGFloat availableWidth = (rightLimit - kEdgePadding) - (leftLimit + kEdgePadding);


### PR DESCRIPTION
two things for the inbox screen:

**1. the Inbox title was sliding around when you switch tabs**

when you go from Notifications to Chat the right buttons (mark all read + compose) get hidden, and on liquid glass the title recenter would re-balance against the now empty right side so "Inbox" visibly slid over toward screen center, then slid back when you return. this respects the Balance Title Between Buttons setting in both modes now:

- balance ON: the recenter remembers where the trailing button cluster was (as an inset from the bar edge so rotation still works) and while the chat hub has the buttons stripped it keeps balancing against that remembered edge → title doesn't move at all
- balance OFF: same reservation feeds the overlap clamp so the screen-centered position is identical on both tabs too

the reservation is a tiny shared helper in ApolloCommon, the chat hub holds it around its strip/restore of the nav items. no-op off glass (classic bar centers the title itself, verified it doesn't shift there either).

**2. swipe between Notifications and Chat**

- swipe right-to-left on Notifications → Chat
- swipe left-to-right on Chat → back to Notifications
- left-to-right on Notifications is untouched → still Apollo's normal swipe-back to the previous screen, edge pop also untouched

the notifications side is a plain swipe recognizer (needed a simultaneous-recognition delegate or the table's pan starves it). the chat side could NOT be a swipe recognizer — webkit's deferring gestures hold ancestor recognizers hostage until the web process acks the touch, and when they finally release, a pan can begin from the accumulated history but a discrete swipe is just dead (verified with real HID swipes, not just synthesized ones). so chat → notifications is a pan that fails instantly whenever it doesn't apply, and the nav container's pop pans get failure requirements against it so apollo's full-width back swipe doesn't ALSO pop you out of the inbox mid-gesture. extra guards:

- left edge band (44pt) is left alone so the system edge-pop and the chat webview's own history-back keep working
- inside a chat room (or its GIF picker which scrolls horizontally) a rightward flick does nothing — conversation routes are excluded via the web controller's route tracking, so you can't get yanked out of a conversation. rooms behave exactly like before

## Screenshots
<img width="2436" height="610" alt="image-1786422229756" src="https://github.com/user-attachments/assets/15bcb926-42e4-4619-ba7c-524d7d3eaca4" />
<img width="2436" height="610" alt="image-1786422236772" src="https://github.com/user-attachments/assets/4ef27628-d2e6-4408-98d8-ec1e4748c769" />


**tested in the sim** (glass + non-glass, api-key + api-key-free):

- glass + keyless: title pinned in both balance modes, both swipe directions, back-swipe on notifications still pops
- glass + api key (with and without a chat web session): same
- non-glass (vtool-downgraded shell): classic title doesn't shift, both swipes work, hand-drawn switcher variant fine
- room guard: swiping right inside a conversation doesn't switch tabs

not device tested yet, will do that before merging ideally