### PR TITLE
Stop hidden scrape web views leaking Reddit video ads over the app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/ApolloImmersiveHeaderBackground.m \
     $(SRC_DIR)/ApolloIdentityHeaderLayout.m \
     $(SRC_DIR)/ApolloUserAvatars.xm \
+    $(SRC_DIR)/ApolloScrapeWebView.m \
     $(SRC_DIR)/ApolloProfileSocialLinks.m \
     $(SRC_DIR)/ApolloBadgeBookCatalog.m \
     $(SRC_DIR)/ApolloBadgeBookScraper.m \

--- a/src/ApolloBadgeBookScraper.m
+++ b/src/ApolloBadgeBookScraper.m
@@ -1,5 +1,6 @@
 #import "ApolloBadgeBookScraper.h"
 #import "ApolloCommon.h"
+#import "ApolloScrapeWebView.h"   // off-screen scrape web view + ad/media blocker
 #import "ApolloState.h"                // sLatestRedditBearerToken, sUserAgent
 #import "ApolloProfileSocialLinks.h"   // ApolloSharedScrapeDataStore()
 #import "ApolloWebSessionStore.h"      // ApolloActiveWebSession() — logged-in scrape cookies
@@ -782,13 +783,8 @@ static NSTimeInterval const kApolloBBWebFetchWatchdog = 90.0;
         });
     }
 
-    UIWindow *win = nil;
-    for (UIScene *s in UIApplication.sharedApplication.connectedScenes) {
-        if (![s isKindOfClass:[UIWindowScene class]]) continue;
-        for (UIWindow *w in ((UIWindowScene *)s).windows) { if (w.isKeyWindow) win = w; }
-    }
-    if (!win) win = ApolloAllWindows().firstObject;
-    if (!win) { [self finish]; return; }
+    // No window lookup: the scrape web view is deliberately never added to one
+    // (ApolloScrapeWebView.h explains why), and it sizes its own viewport.
 
     // Reddit HARD-BLOCKS logged-out page loads from flagged networks — the
     // interstitial literally says "log in to your Reddit account to continue"
@@ -808,13 +804,15 @@ static NSTimeInterval const kApolloBBWebFetchWatchdog = 90.0;
         if (self.finished) return;
         WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
         config.websiteDataStore = store;
-        self.web = [[WKWebView alloc] initWithFrame:win.bounds configuration:config];
-        self.web.navigationDelegate = self;
-        self.web.alpha = 0.011;
-        self.web.userInteractionEnabled = NO;
-        self.web.customUserAgent = kApolloBBDesktopUA;
-        [win insertSubview:self.web atIndex:0];
-        [self loadPhase:self.startPhase];
+        ApolloScrapeWebViewCreate(config, ^(WKWebView *web) {
+            // Blocker resolution adds another async hop before the web view
+            // exists, so re-check finished for the same reason as above.
+            if (self.finished) return;
+            self.web = web;
+            web.navigationDelegate = self;
+            web.customUserAgent = kApolloBBDesktopUA;
+            [self loadPhase:self.startPhase];
+        });
     };
 
     if (session.cookieHeader.length == 0) {
@@ -1027,7 +1025,7 @@ static NSTimeInterval const kApolloBBWebFetchWatchdog = 90.0;
 - (void)finish {
     if (self.finished) return;
     self.finished = YES;
-    if (self.web) { self.web.navigationDelegate = nil; [self.web stopLoading]; [self.web removeFromSuperview]; self.web = nil; }
+    if (self.web) { self.web.navigationDelegate = nil; [self.web stopLoading]; self.web = nil; }
     // Release the slot BEFORE the completion so a waiting scrape starts straight
     // away rather than a callback-chain later.
     NSMutableArray<ApolloBBWebFetch *> *queue = ApolloBBWebFetchQueue();

--- a/src/ApolloProfileSocialLinks.m
+++ b/src/ApolloProfileSocialLinks.m
@@ -2,6 +2,7 @@
 
 #import "ApolloProfileSocialLinks.h"
 #import "ApolloCommon.h"
+#import "ApolloScrapeWebView.h"   // off-screen scrape web view + ad/media blocker
 #import "ApolloState.h"
 #import "ApolloWebSessionStore.h"   // ApolloActiveWebSession() — logged-in scrape cookies
 #import "ApolloWebJSON.h"           // ApolloWebJSONProbeURL() — opt-out of the Web JSON rewrite
@@ -688,13 +689,8 @@ static NSMutableArray<ApolloSLWebFetch *> *ApolloSLWebFetchQueue(void) {
         });
     }
 
-    UIWindow *win = nil;
-    for (UIScene *s in UIApplication.sharedApplication.connectedScenes) {
-        if (![s isKindOfClass:[UIWindowScene class]]) continue;
-        for (UIWindow *w in ((UIWindowScene *)s).windows) { if (w.isKeyWindow) win = w; }
-    }
-    if (!win) win = ApolloAllWindows().firstObject;
-    if (!win) { [self finish:nil]; return; }
+    // No window lookup: the scrape web view is deliberately never added to one
+    // (ApolloScrapeWebView.h explains why), and it sizes its own viewport.
 
     // Reddit HARD-BLOCKS logged-out page loads from flagged networks (the
     // interstitial says "log in to your Reddit account to continue" and never
@@ -712,16 +708,19 @@ static NSMutableArray<ApolloSLWebFetch *> *ApolloSLWebFetchQueue(void) {
         if (self.finished) return;
         WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
         config.websiteDataStore = store;
-        self.web = [[WKWebView alloc] initWithFrame:win.bounds configuration:config];
-        self.web.navigationDelegate = self;
-        self.web.alpha = 0.011; self.web.userInteractionEnabled = NO;
-        self.web.customUserAgent = kApolloSLDesktopUA;
-        [win insertSubview:self.web atIndex:0];
-        NSString *urlString = [NSString stringWithFormat:@"https://www.reddit.com/user/%@/", ApolloSLEscapedUsername(self.username)];
-        [self.web loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:urlString]]];
-        ApolloLog(@"[SocialLinks][web] loading u/%@", self.username);
-        self.startedAt = CFAbsoluteTimeGetCurrent();
-        [self pollAfter:0.75];
+        ApolloScrapeWebViewCreate(config, ^(WKWebView *web) {
+            // Blocker resolution adds another async hop before the web view
+            // exists, so re-check finished for the same reason as above.
+            if (self.finished) return;
+            self.web = web;
+            web.navigationDelegate = self;
+            web.customUserAgent = kApolloSLDesktopUA;
+            NSString *urlString = [NSString stringWithFormat:@"https://www.reddit.com/user/%@/", ApolloSLEscapedUsername(self.username)];
+            [web loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:urlString]]];
+            ApolloLog(@"[SocialLinks][web] loading u/%@", self.username);
+            self.startedAt = CFAbsoluteTimeGetCurrent();
+            [self pollAfter:0.75];
+        });
     };
 
     if (sessionCookieHeader.length == 0) {
@@ -879,7 +878,7 @@ static NSTimeInterval const kApolloSLWebMinTimeForNone  = 4.0;
 - (void)finish:(NSArray<ApolloSocialLink *> *)links {
     if (self.finished) return;   // watchdog / poll / queue-drop can race
     self.finished = YES;
-    if (self.web) { self.web.navigationDelegate = nil; [self.web stopLoading]; [self.web removeFromSuperview]; self.web = nil; }
+    if (self.web) { self.web.navigationDelegate = nil; [self.web stopLoading]; self.web = nil; }
     // Release the slot BEFORE the completion so a waiting scrape starts straight
     // away rather than a callback-chain later.
     NSMutableArray<ApolloSLWebFetch *> *queue = ApolloSLWebFetchQueue();

--- a/src/ApolloScrapeWebView.h
+++ b/src/ApolloScrapeWebView.h
@@ -1,0 +1,58 @@
+#import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
+
+// Shared construction for the tweak's hidden "scrape" web views — the ones that
+// load a real reddit.com page purely to read its DOM (Community Highlights, Badge
+// Book, Social Links, User Flair, Subreddit Sidebar).
+//
+// These used to be inserted into the key window at alpha 0.011. That is unsafe:
+// WebKit presents fullscreen video in its own window ABOVE the app, so the host
+// view's alpha and userInteractionEnabled do not apply to it. A promoted video
+// ad on the loaded page could therefore take over the whole screen while the
+// user was reading something else (issue #902).
+//
+// Two independent defences, both verified in the simulator:
+//   1. The web view is NEVER added to a window. Video fullscreen is presented on
+//      the view's window, so with no window there is nothing to present on. This
+//      is why ApolloChatUnreadPoller (CGRectZero, unattached) was never affected.
+//   2. A content rule list blocks media (and known ad/tracking hosts) outright,
+//      so the ad never loads in the first place — independent of whatever any
+//      given iOS version's autoplay policy happens to be.
+//
+// Do NOT "fix" this by setting allowsInlineMediaPlayback = YES. Testing showed
+// that is the one configuration in which the ad video actually plays: it relaxes
+// WebKit's gate, and the video then runs (invisibly) behind the user's UI,
+// holding an audio session. See docs in the issue thread.
+//
+// Detachment is safe for every current caller: none of them snapshot the web
+// view or read rendered geometry, and no extraction JS uses layout APIs
+// (getBoundingClientRect / offset* / client* / innerHeight / getComputedStyle /
+// IntersectionObserver). Verified per module against live reddit routes —
+// detached extraction matched attached, including page-initiated fetch().
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// The layout viewport a scrape web view should use. Key window bounds when there
+/// is one, else the screen, else a phone-sized fallback. Never CGRectZero: shreddit
+/// picks its breakpoint from the viewport, and a zero-sized one hydrates oddly.
+CGRect ApolloScrapeWebViewFrame(void);
+
+/// Builds an off-screen scrape web view from `config` (callers keep owning the
+/// data store / user scripts / user agent they need) with the shared ad+media
+/// blocker attached, and hands it back on the main queue. The web view is not in
+/// any view hierarchy — retain it, load into it, and drop it when done.
+///
+/// `ready` is always called, always on the main queue, always with a non-nil web
+/// view: if the blocker cannot be compiled we log and continue unblocked, since a
+/// scrape without the blocker still beats no scrape at all.
+void ApolloScrapeWebViewCreate(WKWebViewConfiguration *config, void (^ready)(WKWebView *web));
+
+/// Compile/lookup the blocker ahead of time so the first scrape after launch is
+/// already covered. Called from %ctor; safe to call repeatedly.
+void ApolloScrapeWebViewPrewarmBlocker(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ApolloScrapeWebView.m
+++ b/src/ApolloScrapeWebView.m
@@ -1,0 +1,159 @@
+#import "ApolloScrapeWebView.h"
+#import "ApolloCommon.h"
+
+// Bump the version suffix whenever kApolloScrapeBlockerRules changes — the
+// compiled list is cached on disk by WKContentRuleListStore under this
+// identifier, so a stale cache would otherwise keep serving the old rules.
+static NSString *const kApolloScrapeBlockerID = @"ApolloScrapeBlocker-v1";
+
+// Rules are deliberately conservative about what they DON'T touch: shreddit needs
+// its own scripts, styles and XHR/fetch to hydrate before there is any DOM worth
+// reading, and ApolloUserFlair's whole mechanism is a page-initiated fetch() to
+// /svc/shreddit/…. So this blocks media, fonts, and known ad/measurement hosts —
+// never reddit's own app JS/CSS, images, or service endpoints.
+//
+// Only "media" and "font" resource-types are used: both have been valid for many
+// WebKit releases. An unknown resource-type fails the WHOLE list to compile,
+// which would silently leave every scrape unblocked — not worth the extra saving.
+//
+// url-filter takes a RESTRICTED regex grammar, and a single unsupported pattern
+// fails the entire list (not just its own rule), silently disabling all blocking.
+// If "[ScrapeWeb] blocker compile FAILED" ever appears, find the culprit by
+// compiling each rule on its own rather than guessing. Verified as supported
+// here: `^`, `https?`, `([^/]+\.)?`, `[^.]*`, escaped dots. NOT supported:
+// alternation inside a group, e.g. `criteo\.(com|net)`.
+static NSString *const kApolloScrapeBlockerRules = @"["
+    // The actual issue-#902 fix: a video that starts playing in a hidden web view
+    // gets promoted into WebKit's fullscreen player, presented above the app.
+    "{\"trigger\":{\"url-filter\":\".*\",\"resource-type\":[\"media\"]},\"action\":{\"type\":\"block\"}},"
+    // Pure bandwidth in a view nobody looks at; nothing here reads layout.
+    "{\"trigger\":{\"url-filter\":\".*\",\"resource-type\":[\"font\"]},\"action\":{\"type\":\"block\"}},"
+    // Reddit's own ad + telemetry endpoints.
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?ads\\\\.reddit\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?alb\\\\.reddit\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?events\\\\.reddit\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://w3-reporting[^.]*\\\\.reddit\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://pixel\\\\.redditmedia\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    // Third-party ad networks / measurement vendors.
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?adzerk\\\\.net\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?doubleclick\\\\.net\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?googlesyndication\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?googleadservices\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?googletagmanager\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?google-analytics\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?amazon-adsystem\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?scorecardresearch\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?quantserve\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?moatads\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?adsafeprotected\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?doubleverify\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    // Two rules rather than criteo\.(com|net): WebKit's url-filter grammar rejects
+    // alternation inside a group, and ONE bad regex fails the WHOLE list to
+    // compile (verified — see the compile-failure log line below).
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?criteo\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?criteo\\\\.net\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?taboola\\\\.com\"},\"action\":{\"type\":\"block\"}},"
+    "{\"trigger\":{\"url-filter\":\"^https?://([^/]+\\\\.)?outbrain\\\\.com\"},\"action\":{\"type\":\"block\"}}"
+    "]";
+
+// Main-thread only.
+static WKContentRuleList *sBlocker;             // nil until compiled
+static BOOL sBlockerFailed;                     // don't retry forever
+static BOOL sCompileInFlight;
+static NSMutableArray<void (^)(void)> *sWaiters;
+
+CGRect ApolloScrapeWebViewFrame(void) {
+    CGRect frame = CGRectZero;
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if (![scene isKindOfClass:[UIWindowScene class]]) continue;
+        for (UIWindow *w in ((UIWindowScene *)scene).windows) {
+            if (w.isKeyWindow) { frame = w.bounds; break; }
+        }
+        if (!CGRectIsEmpty(frame)) break;
+    }
+    if (CGRectIsEmpty(frame)) frame = UIScreen.mainScreen.bounds;
+    // Last resort: a plausible phone viewport, so shreddit still picks its mobile
+    // breakpoint rather than hydrating against a zero-sized layout.
+    if (CGRectIsEmpty(frame)) frame = CGRectMake(0, 0, 390, 844);
+    return frame;
+}
+
+// Resolves the shared blocker, then runs `next` on the main queue. Concurrent
+// callers during a compile all queue up behind the one in-flight compile.
+static void ApolloScrapeBlockerResolve(void (^next)(void)) {
+    if (!NSThread.isMainThread) {
+        dispatch_async(dispatch_get_main_queue(), ^{ ApolloScrapeBlockerResolve(next); });
+        return;
+    }
+    if (sBlocker || sBlockerFailed) { if (next) next(); return; }
+
+    if (!sWaiters) sWaiters = [NSMutableArray array];
+    if (next) [sWaiters addObject:[next copy]];
+    if (sCompileInFlight) return;
+    sCompileInFlight = YES;
+
+    void (^drain)(void) = ^{
+        sCompileInFlight = NO;
+        NSArray *waiters = [sWaiters copy];
+        [sWaiters removeAllObjects];
+        for (void (^w)(void) in waiters) w();
+    };
+
+    WKContentRuleListStore *store = [WKContentRuleListStore defaultStore];
+    if (!store) {
+        ApolloLog(@"[ScrapeWeb] no WKContentRuleListStore — scrapes run unblocked");
+        sBlockerFailed = YES;
+        drain();
+        return;
+    }
+
+    // Disk-cached from a previous launch in the common case; compiling is only
+    // the first-run cost.
+    [store lookUpContentRuleListForIdentifier:kApolloScrapeBlockerID
+                            completionHandler:^(WKContentRuleList *found, NSError *lookupError) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (found) {
+                sBlocker = found;
+                ApolloLog(@"[ScrapeWeb] ad/media blocker loaded from cache");
+                drain();
+                return;
+            }
+            [store compileContentRuleListForIdentifier:kApolloScrapeBlockerID
+                                encodedContentRuleList:kApolloScrapeBlockerRules
+                                     completionHandler:^(WKContentRuleList *list, NSError *compileError) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (list) {
+                        sBlocker = list;
+                        ApolloLog(@"[ScrapeWeb] ad/media blocker compiled");
+                    } else {
+                        sBlockerFailed = YES;
+                        ApolloLog(@"[ScrapeWeb] blocker compile FAILED (%@) — scrapes run unblocked",
+                                  compileError.localizedDescription ?: @"unknown");
+                    }
+                    drain();
+                });
+            }];
+        });
+    }];
+}
+
+void ApolloScrapeWebViewPrewarmBlocker(void) {
+    ApolloScrapeBlockerResolve(nil);
+}
+
+void ApolloScrapeWebViewCreate(WKWebViewConfiguration *config, void (^ready)(WKWebView *web)) {
+    if (!ready) return;
+    WKWebViewConfiguration *cfg = config ?: [[WKWebViewConfiguration alloc] init];
+    ApolloScrapeBlockerResolve(^{
+        if (sBlocker) {
+            if (!cfg.userContentController) cfg.userContentController = [[WKUserContentController alloc] init];
+            [cfg.userContentController addContentRuleList:sBlocker];
+        }
+        WKWebView *web = [[WKWebView alloc] initWithFrame:ApolloScrapeWebViewFrame() configuration:cfg];
+        // Belt and braces only — with no window these have nothing to act on. They
+        // matter if someone ever re-attaches one of these views by accident.
+        web.alpha = 0.011;
+        web.userInteractionEnabled = NO;
+        ready(web);
+    });
+}

--- a/src/ApolloSubredditHighlights.xm
+++ b/src/ApolloSubredditHighlights.xm
@@ -31,6 +31,7 @@
 #import <objc/message.h>
 #import "ApolloState.h"
 #import "ApolloCommon.h"
+#import "ApolloScrapeWebView.h"
 #import "ApolloSubredditHighlights.h"
 
 #pragma mark - Minimal runtime interfaces
@@ -581,22 +582,20 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
     self.sub = sub; self.done = done; self.polls = 0;
     self.startedAt = [NSDate date]; self.bestItems = nil; self.pollScheduled = NO; self.evaluationInFlight = NO;
     self.awaitingLargeSetConfirmation = NO;
-    UIWindow *win = nil;
-    for (UIScene *s in UIApplication.sharedApplication.connectedScenes) {
-        if (![s isKindOfClass:[UIWindowScene class]]) continue;
-        for (UIWindow *w in ((UIWindowScene *)s).windows) { if (w.isKeyWindow) win = w; }
-    }
-    if (!win) win = UIApplication.sharedApplication.windows.firstObject;
-    if (!win) { [self finish:nil]; return; }
     WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
     config.websiteDataStore = [ApolloHLWebFetch apollo_scrapeDataStore];
-    self.web = [[WKWebView alloc] initWithFrame:win.bounds configuration:config];
-    self.web.navigationDelegate = self;
-    self.web.alpha = 0.011; self.web.userInteractionEnabled = NO;
-    [win insertSubview:self.web atIndex:0];
-    [self.web loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://www.reddit.com/r/%@/", sub]]]];
-    ApolloLog(@"[Highlights][web] loading r/%@ for full highlights", sub);
-    [self pollAfter:kApolloHLWebInitialPollDelay];
+    __weak typeof(self) ws = self;
+    ApolloScrapeWebViewCreate(config, ^(WKWebView *web) {
+        ApolloHLWebFetch *ss = ws;
+        // The blocker resolve is async, so the fetch may already have been
+        // cancelled (done cleared) by the time we get here.
+        if (!ss || !ss.done) return;
+        ss.web = web;
+        web.navigationDelegate = ss;
+        [web loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://www.reddit.com/r/%@/", sub]]]];
+        ApolloLog(@"[Highlights][web] loading r/%@ for full highlights", sub);
+        [ss pollAfter:kApolloHLWebInitialPollDelay];
+    });
 }
 - (void)pollAfter:(double)delay {
     // didFinishNavigation and the fallback timer can both ask for a probe. Keep
@@ -679,7 +678,7 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
     return out;
 }
 - (void)finish:(NSArray<ApolloHLItem *> *)items {
-    if (self.web) { self.web.navigationDelegate = nil; [self.web removeFromSuperview]; self.web = nil; }
+    if (self.web) { self.web.navigationDelegate = nil; self.web = nil; }
     self.pollScheduled = NO; self.evaluationInFlight = NO; self.awaitingLargeSetConfirmation = NO;
     self.startedAt = nil; self.bestItems = nil;
     void (^d)(NSArray *) = self.done; self.done = nil;
@@ -690,7 +689,6 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
     if (self.web) {
         self.web.navigationDelegate = nil;
         [self.web stopLoading];
-        [self.web removeFromSuperview];
         self.web = nil;
     }
     self.pollScheduled = NO; self.evaluationInFlight = NO; self.awaitingLargeSetConfirmation = NO;
@@ -2300,6 +2298,11 @@ static void ApolloHLCollapseOrphanSeparators(UIViewController *vc) {
 #pragma mark - Constructor
 
 %ctor {
+    // Compile the scrape ad/media blocker now so the first Full-highlights scrape
+    // of a launch — which can start within a couple of seconds — is already
+    // covered rather than racing the compile.
+    ApolloScrapeWebViewPrewarmBlocker();
+
     [[NSNotificationCenter defaultCenter] addObserverForName:@"ApolloCommunityHighlightsToggleChangedNotification"
                                                       object:nil
                                                        queue:[NSOperationQueue mainQueue]

--- a/src/ApolloSubredditSidebar.xm
+++ b/src/ApolloSubredditSidebar.xm
@@ -25,6 +25,7 @@
 #import <objc/message.h>
 #import <dlfcn.h>
 #import "ApolloCommon.h"
+#import "ApolloScrapeWebView.h"
 #import "ApolloState.h"
 
 // Section builders / keys here are wired up incrementally; tolerate not-yet-used
@@ -55,21 +56,18 @@ static NSCache<NSString *, NSArray<NSNumber *> *> *ApolloSBWebStatsCache(void) {
 @implementation ApolloSBStatsWebFetch
 - (void)startForSub:(NSString *)sub completion:(void (^)(NSNumber *, NSNumber *))done {
     self.sub = sub; self.done = done; self.polls = 0;
-    UIWindow *win = nil;
-    for (UIScene *s in UIApplication.sharedApplication.connectedScenes) {
-        if (![s isKindOfClass:[UIWindowScene class]]) continue;
-        for (UIWindow *w in ((UIWindowScene *)s).windows) { if (w.isKeyWindow) win = w; }
-    }
-    if (!win) win = UIApplication.sharedApplication.windows.firstObject;
-    if (!win) { [self finishV:nil c:nil]; return; }
-    self.web = [[WKWebView alloc] initWithFrame:win.bounds configuration:[[WKWebViewConfiguration alloc] init]];
-    self.web.navigationDelegate = self;
-    self.web.alpha = 0.011; self.web.userInteractionEnabled = NO;
-    self.web.customUserAgent = @"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
-    [win insertSubview:self.web atIndex:0];
-    [self.web loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://www.reddit.com/r/%@/", sub]]]];
-    ApolloLog(@"[Sidebar][webstats] loading r/%@", sub);
-    [self pollAfter:3.0];
+    __weak typeof(self) ws = self;
+    ApolloScrapeWebViewCreate([[WKWebViewConfiguration alloc] init], ^(WKWebView *web) {
+        ApolloSBStatsWebFetch *ss = ws;
+        // Blocker resolution is async — this fetch may already have finished.
+        if (!ss || !ss.done) return;
+        ss.web = web;
+        web.navigationDelegate = ss;
+        web.customUserAgent = @"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+        [web loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://www.reddit.com/r/%@/", sub]]]];
+        ApolloLog(@"[Sidebar][webstats] loading r/%@", sub);
+        [ss pollAfter:3.0];
+    });
 }
 - (void)pollAfter:(double)d {
     __weak typeof(self) ws = self;
@@ -92,7 +90,7 @@ static NSCache<NSString *, NSArray<NSNumber *> *> *ApolloSBWebStatsCache(void) {
     }];
 }
 - (void)finishV:(NSNumber *)v c:(NSNumber *)c {
-    if (self.web) { self.web.navigationDelegate = nil; [self.web removeFromSuperview]; self.web = nil; }
+    if (self.web) { self.web.navigationDelegate = nil; self.web = nil; }
     void (^d)(NSNumber *, NSNumber *) = self.done; self.done = nil;
     if (d) d(v, c);
 }

--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -1,4 +1,5 @@
 #import "ApolloCommon.h"
+#import "ApolloScrapeWebView.h"
 #import "ApolloOwnCommentFlair.h"
 #import "ApolloState.h"
 #import "ApolloUserFlair.h"
@@ -802,15 +803,8 @@ static NSArray<NSHTTPCookie *> *ApolloUserFlairCookiesFromHeader(NSString *heade
 
 - (void)start {
     self.polls = 0;
-    UIWindow *window = nil;
-    for (UIWindow *candidate in ApolloAllWindows()) {
-        if (candidate.isKeyWindow) { window = candidate; break; }
-    }
-    if (!window) window = ApolloAllWindows().firstObject;
-    if (!window) {
-        [self finishWithItems:nil status:0 responseLength:0 reason:@"no app window"];
-        return;
-    }
+    // No window lookup: the scrape web view is deliberately never added to one
+    // (ApolloScrapeWebView.h explains why), and it sizes its own viewport.
     WKWebViewConfiguration *config = [WKWebViewConfiguration new];
     // Keep this account's cookies isolated from other API-free accounts and
     // from any unrelated Reddit login left in WebKit's shared browser store.
@@ -818,12 +812,6 @@ static NSArray<NSHTTPCookie *> *ApolloUserFlairCookiesFromHeader(NSString *heade
     NSString *hook = @"(function(){var f=window.fetch;if(!f)return;window.fetch=function(){var a=arguments,u=String(a[0]&&a[0].url||a[0]),match=/\\/svc\\/shreddit\\/[^/]+\\/emojis\\/USER_FLAIR/i.test(u);var p=f.apply(this,a);if(match){p.then(function(r){r.clone().text().then(function(t){try{var d=new DOMParser().parseFromString(t,'text/html'),items=Array.from(d.querySelectorAll('li[data-token][data-url]')).map(function(n){var name=n.getAttribute('data-token')||'',url=n.getAttribute('data-url')||'';if(name.charAt(0)===':')name=name.slice(1);if(name.charAt(name.length-1)===':')name=name.slice(0,-1);return{name:name,url:url};}).filter(function(x){return x.name&&x.url;});window.__apolloEmojiCatalog={state:'done',status:r.status,length:t.length,items:items};}catch(e){window.__apolloEmojiCatalog={state:'error',error:String(e)};}}).catch(function(e){window.__apolloEmojiCatalog={state:'error',error:String(e)};});}).catch(function(e){window.__apolloEmojiCatalog={state:'error',error:String(e)};});}return p;};})();";
     WKUserScript *script = [[WKUserScript alloc] initWithSource:hook injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO];
     [config.userContentController addUserScript:script];
-    self.web = [[WKWebView alloc] initWithFrame:window.bounds configuration:config];
-    self.web.navigationDelegate = self;
-    self.web.alpha = 0.011;
-    self.web.userInteractionEnabled = NO;
-    self.web.customUserAgent = @"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
-    [window insertSubview:self.web atIndex:0];
     ApolloWebSessionEntry *session = ApolloActiveWebSession();
     NSArray<NSHTTPCookie *> *cookies = ApolloUserFlairCookiesFromHeader(session.cookieHeader);
     if (cookies.count == 0) {
@@ -844,8 +832,16 @@ static NSArray<NSHTTPCookie *> *ApolloUserFlairCookiesFromHeader(NSString *heade
     dispatch_group_notify(cookieGroup, dispatch_get_main_queue(), ^{
         typeof(self) self = weakSelf;
         if (!self || self.finished) return;
-        [self.web loadRequest:request];
-        [self pollAfter:2.5];
+        ApolloScrapeWebViewCreate(config, ^(WKWebView *web) {
+            // Blocker resolution is one more async hop — re-check liveness.
+            typeof(self) ss = weakSelf;
+            if (!ss || ss.finished) return;
+            ss.web = web;
+            web.navigationDelegate = ss;
+            web.customUserAgent = @"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+            [web loadRequest:request];
+            [ss pollAfter:2.5];
+        });
     });
 }
 
@@ -926,7 +922,6 @@ static NSArray<NSHTTPCookie *> *ApolloUserFlairCookiesFromHeader(NSString *heade
 
     self.web.navigationDelegate = nil;
     [self.web stopLoading];
-    [self.web removeFromSuperview];
     self.web = nil;
     NSMutableDictionary *fetches = ApolloUserFlairWebEmojiFetches();
     @synchronized (fetches) {


### PR DESCRIPTION
Fixes #902.

## What was happening

The reporter saw a fullscreen Charles Schwab video ad take over Apollo. It was our own code.

Five scrapers — Community Highlights, Badge Book, Social Links, User Flair, Subreddit Sidebar — each load a live `www.reddit.com` page into a full-window `WKWebView` inserted into the key window at `alpha 0.011`, for up to 18s (Badge Book: ~60s). Reddit's logged-out subreddit page serves promoted video posts. When one starts playing, WebKit promotes it into its fullscreen player, which is presented **in its own window above the app** — so the host view's `alpha` and `userInteractionEnabled` never applied to it.

The reporter's log lines up exactly:

```
15:40:36.192 [Highlights][web] loading r/startpagesearch for full highlights
15:40:38.1   (taps into a post; ad appears mid-transition)
15:40:54.274 [Highlights][web] r/startpagesearch timed out after 18.1s (36 probes)
```

Their attached screen recording confirms it: Apollo's whole UI dims while the ad animates from its inline rect out to fullscreen, with WebKit's fullscreen video chrome (X / PiP / mute).

This also explains the reporter's other observations — intermittent (only when Reddit happens to serve a video ad in that window), not tied to a subreddit, and unaffected by downgrading to 3.5.0, since this code predates both.

## The fix

New `src/ApolloScrapeWebView.{h,m}`, one factory the five scrapers share. Two independent defences:

1. **The web view is never added to a window.** Video fullscreen is presented on the view's window, so with no window there is nothing to present on. This is why `ApolloChatUnreadPoller` (`CGRectZero`, unattached) was never affected.
2. **A content rule list** blocks media, fonts and known ad/telemetry hosts, so the ad never loads — independent of whatever a given iOS version's autoplay policy is. Compiled from `%ctor` so the first scrape of a launch is covered rather than racing the compile.

Blocked: all media + fonts; Reddit's `ads.` / `alb.` / `events.reddit.com`, `w3-reporting*`, `pixel.redditmedia.com`; and adzerk, doubleclick, googlesyndication/adservices/tagmanager/analytics, amazon-adsystem, scorecardresearch, quantserve, moatads, adsafeprotected, doubleverify, criteo, taboola, outbrain. Never Reddit's own app JS/CSS, images, or `/svc/` endpoints.

Each scraper loses its window-lookup boilerplate, so the five call sites are a net **−6 lines**.

## Note: `allowsInlineMediaPlayback` is a trap

It looks like the fix and is the opposite. In simulator testing it was **the only configuration in which the ad video actually plays** — it relaxes WebKit's gate, and the video then runs invisibly behind the UI holding an audio session. The header comment records this so it doesn't get "fixed" that way later.

| Config | Video played? | Scrape works? |
|---|---|---|
| stock (as shipped) | no (`NotAllowedError`) | n=4 |
| `allowsInlineMediaPlayback = YES` | **yes — autoplayed and looped** | — |
| `mediaTypes…= All` explicit | no | — |
| content-rule-list block | no — `error`, never loaded | n=4 |
| detached from window | no | n=4 |

## Verification

Detachment is safe for every caller: none snapshot the web view or read rendered geometry, and no extraction JS uses layout APIs (`getBoundingClientRect` / `offset*` / `client*` / `innerHeight` / `getComputedStyle` / `IntersectionObserver`). User Flair's sprite regions come from the OAuth stylesheet API parsed as CSS text, not from the web view.

Tested per module against live reddit routes, attached vs detached:

| Module | Page | Attached | Detached |
|---|---|---|---|
| Sidebar (verbatim JS) | `/r/gaming/` | `{}` | `v=4088972 c=70082` |
| Social Links | `/user/spez/` | html 676298, social 15 | html 671678, social 15 |
| User Flair (page `fetch()`) | `sh.reddit.com/r/gaming/` | `status 200 ok` | `status 200 ok` |
| Highlights | `/r/gaming/` | n=4 | n=4 (×3 runs) |

Equal or better everywhere, with no latency cost (first full result at 3.2s/5.7s/4.3s detached vs 14.3s attached). Badge Book's achievements route needs a logged-in session so both runs hit Reddit's logged-out shell — that one is "no worse detached" rather than fully verified.

Also: the production rule set compiles and blocks media, r/gaming still yields the same 4 highlights with blocking + detached, both simulator and device builds are clean, and the tweak logs `[ScrapeWeb] ad/media blocker compiled` then `loaded from cache` on relaunch.

## Two caveats

**Not reproduced on iOS 27.** The stock config refuses playback outright there, so the bug may already be absent on iOS 26+. The reporter is on 18.7.8, and only iOS 27 runtimes were available locally. The fix is therefore verified against the mechanism rather than against the exact iOS 18 failure — the detachment defence doesn't depend on WebKit policy, so this shouldn't matter, but flagging it.

**A pre-existing bug found while testing, not touched here.** End-to-end in the app, the Full Highlights scrape on r/gaming times out at 18s finding nothing, while a standalone harness gets 4 items in ~3s from the same URL with the same probe JS. Confirmed pre-existing by stashing this change and rebuilding: baseline times out identically. Full mode may be silently degrading to the 2 REST stickies for some users. Worth its own issue.
