### PR TITLE
Fix image previews getting cropped in multi-image feed carousels

### DIFF
--- a/src/ApolloFeedGalleryCarousel.xm
+++ b/src/ApolloFeedGalleryCarousel.xm
@@ -77,12 +77,17 @@ struct ApolloFeedGallerySizeRange { CGSize min; CGSize max; };
 // Apollo's native album mosaic is 16:9 (confirmed in Hopper's
 // AlbumThumbnailsNode.layoutSpecThatFits helper: height = width * 0.5625).
 // The carousel sizes each card to the gallery's median image aspect instead,
-// clamped between that 16:9 floor and a 5:4 portrait ceiling: a full-bleed
+// clamped between that 16:9 floor and a 4:3 portrait ceiling: a full-bleed
 // pager reads as "the image", so center-cropping a portrait photo into a hard
 // 16:9 box looked like a bug, while an unclamped 1:3 comic would swallow the
-// feed. AspectFill within the clamp keeps residual crops modest.
+// feed. Pages render aspect-fit within the card (#899): aspect-fill cropped
+// every page whose aspect differs from the card's — a wide sketch in a
+// portrait-median gallery lost both edges — so off-aspect pages letterbox on
+// the page background instead. The 4:3 ceiling keeps the most common gallery
+// (3:4 iPhone photos) full-bleed now that residual crops are no longer an
+// option.
 static const CGFloat kApolloFeedGalleryRatio = 9.0 / 16.0;
-static const CGFloat kApolloFeedGalleryMaxRatio = 5.0 / 4.0;
+static const CGFloat kApolloFeedGalleryMaxRatio = 4.0 / 3.0;
 
 static CGFloat ApolloFeedGalleryRatioForItems(NSArray<NSDictionary *> *items) {
     NSMutableArray<NSNumber *> *aspects = [NSMutableArray arrayWithCapacity:items.count];
@@ -447,7 +452,7 @@ static NSArray<NSDictionary *> *ApolloFeedGalleryItems(id albumNode) {
         for (NSUInteger index = 0; index < items.count; index++) {
             UIImageView *imageView = [[UIImageView alloc] initWithFrame:CGRectZero];
             imageView.backgroundColor = [UIColor colorWithWhite:0.10 alpha:1.0];
-            imageView.contentMode = UIViewContentModeScaleAspectFill;
+            imageView.contentMode = UIViewContentModeScaleAspectFit;
             imageView.clipsToBounds = YES;
             imageView.isAccessibilityElement = YES;
             imageView.accessibilityLabel = [NSString stringWithFormat:@"Gallery image %lu of %lu",
@@ -544,6 +549,22 @@ static NSArray<NSDictionary *> *ApolloFeedGalleryItems(id albumNode) {
     ApolloLog(@"[FeedGallery] obscured gallery revealed by user");
 }
 
+// Where the page's image actually renders under aspect-fit. The zoom
+// transition and viewer placeholder use the sender view's frame as their
+// origin; handing them the full page bounds would zoom out of the letterbox
+// bars on off-aspect pages.
+- (CGRect)apollo_fittedImageRectForPage:(UIImageView *)pageView {
+    CGRect bounds = pageView.bounds;
+    CGSize imageSize = pageView.image.size;
+    if (imageSize.width <= 0.0 || imageSize.height <= 0.0 || CGRectIsEmpty(bounds)) return bounds;
+    CGFloat scale = MIN(CGRectGetWidth(bounds) / imageSize.width,
+                        CGRectGetHeight(bounds) / imageSize.height);
+    CGSize fitted = CGSizeMake(imageSize.width * scale, imageSize.height * scale);
+    return CGRectMake(CGRectGetMidX(bounds) - fitted.width / 2.0,
+                      CGRectGetMidY(bounds) - fitted.height / 2.0,
+                      fitted.width, fitted.height);
+}
+
 - (void)apollo_pageTapped:(UITapGestureRecognizer *)recognizer {
     if (recognizer.state != UIGestureRecognizerStateEnded || self.contentIsObscured) return;
     NSInteger index = self.currentIndex;
@@ -578,7 +599,8 @@ static NSArray<NSDictionary *> *ApolloFeedGalleryItems(id albumNode) {
     UIView *senderView = [senderNode respondsToSelector:@selector(view)]
         ? ((UIView *(*)(id, SEL))objc_msgSend)(senderNode, @selector(view)) : nil;
     if (senderView.superview && pageView.window) {
-        senderView.frame = [senderView.superview convertRect:pageView.bounds fromView:pageView];
+        senderView.frame = [senderView.superview convertRect:[self apollo_fittedImageRectForPage:pageView]
+                                                    fromView:pageView];
     }
 
     // Pages >= 3 have no matching native sender; seed the pager's index ivar

--- a/src/ApolloFeedGalleryCarousel.xm
+++ b/src/ApolloFeedGalleryCarousel.xm
@@ -78,17 +78,18 @@ struct ApolloFeedGallerySizeRange { CGSize min; CGSize max; };
 // Apollo's native album mosaic is 16:9 (confirmed in Hopper's
 // AlbumThumbnailsNode.layoutSpecThatFits helper: height = width * 0.5625).
 // The carousel sizes each card to the gallery's median image aspect instead,
-// clamped between that 16:9 floor and a 4:3 portrait ceiling: a full-bleed
+// clamped between that 16:9 floor and a 5:4 portrait ceiling: a full-bleed
 // pager reads as "the image", so center-cropping a portrait photo into a hard
 // 16:9 box looked like a bug, while an unclamped 1:3 comic would swallow the
 // feed. Pages render aspect-fit within the card (#899): aspect-fill cropped
 // every page whose aspect differs from the card's — a wide sketch in a
 // portrait-median gallery lost both edges — so off-aspect pages letterbox on
-// the theme's card surface instead. The 4:3 ceiling keeps the most common
-// gallery (3:4 iPhone photos) full-bleed now that residual crops are no
-// longer an option.
+// the theme's card surface instead. A 4:3 ceiling (full-bleed 3:4 iPhone
+// photos) was tried and deliberately reverted: the tighter 5:4 card reads
+// better in the feed, and the thin side bars it costs on portrait galleries
+// don't hide anything — the fullscreen viewer always shows the full image.
 static const CGFloat kApolloFeedGalleryRatio = 9.0 / 16.0;
-static const CGFloat kApolloFeedGalleryMaxRatio = 4.0 / 3.0;
+static const CGFloat kApolloFeedGalleryMaxRatio = 5.0 / 4.0;
 
 // Letterbox/placeholder surface behind carousel pages. Under aspect-fill this
 // was a debug backstop that only flashed during loads; with aspect-fit it is

--- a/src/ApolloFeedGalleryCarousel.xm
+++ b/src/ApolloFeedGalleryCarousel.xm
@@ -24,6 +24,7 @@
 
 #import "ApolloCommon.h"
 #import "ApolloState.h"
+#import "ApolloThemeRuntime.h"
 #import "Tweak.h"
 #import "UserDefaultConstants.h"
 
@@ -83,11 +84,34 @@ struct ApolloFeedGallerySizeRange { CGSize min; CGSize max; };
 // feed. Pages render aspect-fit within the card (#899): aspect-fill cropped
 // every page whose aspect differs from the card's — a wide sketch in a
 // portrait-median gallery lost both edges — so off-aspect pages letterbox on
-// the page background instead. The 4:3 ceiling keeps the most common gallery
-// (3:4 iPhone photos) full-bleed now that residual crops are no longer an
-// option.
+// the theme's card surface instead. The 4:3 ceiling keeps the most common
+// gallery (3:4 iPhone photos) full-bleed now that residual crops are no
+// longer an option.
 static const CGFloat kApolloFeedGalleryRatio = 9.0 / 16.0;
 static const CGFloat kApolloFeedGalleryMaxRatio = 4.0 / 3.0;
+
+// Letterbox/placeholder surface behind carousel pages. Under aspect-fill this
+// was a debug backstop that only flashed during loads; with aspect-fit it is
+// permanently on screen beside every off-aspect page, so it follows the
+// theme's card background (Pure Black Dark Mode aware, custom themes
+// included) instead of a fixed near-black that read as a slab on light
+// themes. Fallback per the ApolloThemeRuntime contract.
+static UIColor *ApolloFeedGalleryPageSurfaceColor(void) {
+    return ApolloThemeCardBackgroundColor() ?: UIColor.secondarySystemGroupedBackgroundColor;
+}
+
+// The page dots were UIPageControl's default white, which disappears into a
+// light letterbox surface. Resolve the surface per trait collection and pick
+// contrasting dots; a dynamic provider so light/dark flips and theme reloads
+// re-resolve without reconfiguring the card.
+static UIColor *ApolloFeedGalleryPageIndicatorColor(BOOL current) {
+    return [UIColor colorWithDynamicProvider:^UIColor *(UITraitCollection *traits) {
+        UIColor *surface = [ApolloFeedGalleryPageSurfaceColor() resolvedColorWithTraitCollection:traits];
+        CGFloat alpha = current ? 1.0 : 0.35;
+        return ApolloColorIsLight(surface) ? [UIColor colorWithWhite:0.0 alpha:alpha]
+                                           : [UIColor colorWithWhite:1.0 alpha:alpha];
+    }];
+}
 
 static CGFloat ApolloFeedGalleryRatioForItems(NSArray<NSDictionary *> *items) {
     NSMutableArray<NSNumber *> *aspects = [NSMutableArray arrayWithCapacity:items.count];
@@ -347,7 +371,9 @@ static NSArray<NSDictionary *> *ApolloFeedGalleryItems(id albumNode) {
     if (!self) return nil;
 
     self.clipsToBounds = YES;
-    self.backgroundColor = UIColor.blackColor;
+    // Same surface as the pages so horizontal bounce past the first/last page
+    // stays seamless.
+    self.backgroundColor = ApolloFeedGalleryPageSurfaceColor();
     self.accessibilityIdentifier = @"ApolloFeedGalleryCarousel";
     self.shouldGroupAccessibilityChildren = YES;
 
@@ -373,6 +399,8 @@ static NSArray<NSDictionary *> *ApolloFeedGalleryItems(id albumNode) {
 
     _pageControl = [[UIPageControl alloc] initWithFrame:CGRectZero];
     if (@available(iOS 14.0, *)) _pageControl.backgroundStyle = UIPageControlBackgroundStyleMinimal;
+    _pageControl.currentPageIndicatorTintColor = ApolloFeedGalleryPageIndicatorColor(YES);
+    _pageControl.pageIndicatorTintColor = ApolloFeedGalleryPageIndicatorColor(NO);
     [_pageControl addTarget:self action:@selector(apollo_pageControlChanged:)
            forControlEvents:UIControlEventValueChanged];
     [self addSubview:_pageControl];
@@ -451,7 +479,7 @@ static NSArray<NSDictionary *> *ApolloFeedGalleryItems(id albumNode) {
 
         for (NSUInteger index = 0; index < items.count; index++) {
             UIImageView *imageView = [[UIImageView alloc] initWithFrame:CGRectZero];
-            imageView.backgroundColor = [UIColor colorWithWhite:0.10 alpha:1.0];
+            imageView.backgroundColor = ApolloFeedGalleryPageSurfaceColor();
             imageView.contentMode = UIViewContentModeScaleAspectFit;
             imageView.clipsToBounds = YES;
             imageView.isAccessibilityElement = YES;


### PR DESCRIPTION
Fixes #899

The feed gallery carousel sized each card to the gallery's median image aspect and then aspect-filled every page into it, so any page whose aspect didn't match the card got center-cropped — in the report's example a wide concept sketch in a portrait-median gallery lost both edges in the feed while fullscreen showed the whole thing.

Changes:
- Pages now render **aspect-fit** inside the card, so the feed preview always shows the complete image (letterboxed on the page background when the aspect doesn't match), matching what you get when you tap into the fullscreen viewer.
- The card ratio clamp is unchanged (16:9 floor, 5:4 portrait ceiling). A 4:3 ceiling was tried so 3:4 iPhone photos would render full-bleed, but reverted to keep feed density — with fit, the clamp only costs thin side bars on portrait pages, and the fullscreen viewer shows the full image either way.
- The tap-to-fullscreen zoom transition now originates from the fitted image rect instead of the whole page, so it doesn't zoom out of the letterbox bars.
- The letterbox/placeholder surface follows the theme's card background (`ApolloThemeCardBackgroundColor()`, Pure Black Dark Mode and custom themes included) instead of a fixed near-black, and the page dots resolve their contrast against that surface so they stay visible on light themes.

## Screenshots

| In feed | In preview |
| :---: | :---: |
| <img width="300" alt="in feed" src="https://github.com/user-attachments/assets/b22a93c4-c852-4897-8809-10c3cc351b2e" /> | <img width="300" alt="in preview" src="https://github.com/user-attachments/assets/d12c8754-44d7-4fba-b522-bd8fdaa8244c" /> |

Tested in the sim on glass and non-glass shells, with both API-key and API-key-free accounts, using the exact gallery from the report (r/WorldBuilding, wide page 1 + tall pages 2-3) plus a 5-image gallery:
- toggle ON: every page shows the full image; tapping opens the viewer at the right index via both the native-sender path (pages 1-3) and the seeded-index path (pages 4+), and the feed preview now matches the fullscreen composition
- toggle OFF: native mosaic renders and tile taps open the viewer as before
