### PR TITLE
Stop the theme crash kill-switch tripping on force-quits and prewarms (#916)

### DIFF
--- a/src/ApolloThemeRuntime.xm
+++ b/src/ApolloThemeRuntime.xm
@@ -2102,10 +2102,31 @@ static void ApolloThemeRestoreOverlayPillText(id node) {
         if (store.runtimeDisabledDueToCrash)
             ApolloLog(@"ThemeRuntime: ctor — runtime DISABLED by crash kill-switch");
         ApolloThemeRuntimeReload();
-        // Mark launch stable once the UI has had time to come up (the feed
-        // renders within ~1-3s; 5s clears the kill-switch marker for a healthy
-        // launch while still catching a theme that crashes during startup).
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)),
-                       dispatch_get_main_queue(), ^{ [store markLaunchStable]; });
+        // Stability bookkeeping is anchored to the first main-queue drain, not
+        // ctor time: during an iOS prewarm this ctor runs but the run loop does
+        // not, so both marks must wait for the app to REALLY launch (a timer
+        // from ctor would have long expired by the time a prewarmed process is
+        // foregrounded, shrinking the crash-detection window to zero).
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [store markRunLoopStarted];
+            // Mark launch stable once the UI has had time to come up (the feed
+            // renders within ~1-3s; 5s clears the kill-switch marker for a
+            // healthy launch while still catching a theme crashing at startup).
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)),
+                           dispatch_get_main_queue(), ^{ [store markLaunchStable]; });
+        });
+        // Reaching the background is also proof the launch didn't brick: the
+        // user got in and left before the 5s timer. Without this, backgrounding
+        // quickly and later being jetsammed while suspended (timer never fired)
+        // would count a strike against the theme. One-shot — the timer owns
+        // every later stable mark.
+        __block id bgObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:UIApplicationDidEnterBackgroundNotification
+                        object:nil
+                         queue:[NSOperationQueue mainQueue]
+                    usingBlock:^(NSNotification *note) {
+            [store markLaunchStable];
+            if (bgObserver) { [[NSNotificationCenter defaultCenter] removeObserver:bgObserver]; bgObserver = nil; }
+        }];
     }
 }

--- a/src/ApolloThemeStore.h
+++ b/src/ApolloThemeStore.h
@@ -151,6 +151,7 @@ typedef NSDictionary *_Nullable (^ApolloThemeGalleryResolver)(NSString *slug);
 #pragma mark - Crash kill-switch (spec §18)
 
 - (void)beginLaunchAttempt;     // call early, before runtime activation
+- (void)markRunLoopStarted;     // call on the first main-queue drain (real launch, not prewarm)
 - (void)markLaunchStable;       // call once the app reaches a stable point
 - (BOOL)runtimeDisabledDueToCrash;
 - (void)clearCrashDisable;      // user re-enables from Theme Manager

--- a/src/ApolloThemeStore.m
+++ b/src/ApolloThemeStore.m
@@ -866,7 +866,17 @@ static const NSInteger kUnexplainedDeathTripCount = 3;
         // the stable point. That alone is NOT proof of a theme crash: a user
         // force-quit, a prewarmed process iOS discarded, and jetsam all look
         // identical from here (#916). Corroborate before tripping.
-        BOOL crashed = [ApolloCrashManager sharedManager].crashedLastLaunch;
+        //
+        // ORDERING DEPENDENCY: crashedLastLaunch is only meaningful if the
+        // crash recorder is already installed, which happens in Tweak.xm's
+        // %ctor — and that runs before this one ONLY because Tweak.xm precedes
+        // ApolloThemeRuntime.xm in the Makefile's ApolloReborn_FILES (dyld
+        // fires constructors in link order). Reordering that list would
+        // silently degrade real theme crashes from first-strike to 3-strike
+        // detection; the recorder-down log below is the tripwire for that.
+        ApolloCrashManager *recorder = [ApolloCrashManager sharedManager];
+        BOOL recorderUp = recorder.installed;
+        BOOL crashed = recorder.crashedLastLaunch;
         BOOL prevRanRunLoop = [g boolForKey:kLaunchRunLoopKey];
         BOOL prevPrewarmed = [g boolForKey:kLaunchPrewarmKey];
         if (crashed) {
@@ -887,13 +897,19 @@ static const NSInteger kUnexplainedDeathTripCount = 3;
             // few, but a streak with no stable launch in between still trips.
             NSInteger count = [g integerForKey:kCrashCountKey] + 1;
             [g setInteger:count forKey:kCrashCountKey];
+            // Say WHY there was no crash on record: "recorder not installed"
+            // here means capture is user-disabled — or the ctor ordering above
+            // broke, which this line is the only visible symptom of.
+            const char *why = recorderUp ? "no crash was recorded"
+                                         : "crash recorder not installed (capture disabled, or theme ctor ran first)";
             if (count >= kUnexplainedDeathTripCount) {
-                ApolloLog(@"ThemeStore: %ld consecutive theme launches died before the stable point — tripping kill switch", (long)count);
+                ApolloLog(@"ThemeStore: %ld consecutive theme launches died before the stable point (%s) — tripping kill switch",
+                          (long)count, why);
                 [g setBool:YES forKey:kApolloRebornThemeRuntimeDisabledKey];
                 themeActive = NO;
             } else {
-                ApolloLog(@"ThemeStore: previous theme launch did not complete but no crash was recorded (strike %ld/%ld) — keeping theme enabled",
-                          (long)count, (long)kUnexplainedDeathTripCount);
+                ApolloLog(@"ThemeStore: previous theme launch did not complete but %s (strike %ld/%ld) — keeping theme enabled",
+                          why, (long)count, (long)kUnexplainedDeathTripCount);
             }
         }
         // On trip, leave the selection pointer intact. The crash flag alone
@@ -920,6 +936,9 @@ static const NSInteger kUnexplainedDeathTripCount = 3;
     // launching. A prewarmed process iOS discards never gets here, which is
     // what lets beginLaunchAttempt tell those deaths apart.
     NSUserDefaults *g = GroupDefaults();
+    // Only pay the synchronous flush when this launch actually armed the
+    // marker — on theme-off launches the key is never read.
+    if ([g objectForKey:kLaunchStartedKey] == nil || [g boolForKey:kLaunchDoneKey]) return;
     [g setBool:YES forKey:kLaunchRunLoopKey];
     [g synchronize];
 }

--- a/src/ApolloThemeStore.m
+++ b/src/ApolloThemeStore.m
@@ -1,6 +1,10 @@
 #import "ApolloThemeStore.h"
 #import "ApolloThemeCompiler.h"
 #import "ApolloCommon.h"
+#import "crash/ApolloCrashManager.h"
+
+#include <stdlib.h>
+#include <string.h>
 
 // ---------------------------------------------------------------------------
 // Defaults access
@@ -840,36 +844,84 @@ static ApolloThemeGalleryResolver sGalleryResolver = nil;
 static NSString * const kLaunchStartedKey = @"ApolloReborn.themeLaunchAttemptStartedAt";
 static NSString * const kLaunchDoneKey    = @"ApolloReborn.themeLaunchAttemptCompleted";
 static NSString * const kCrashCountKey    = @"ApolloReborn.themeRecentCrashCount";
+// Sub-markers distinguishing real crashes from benign process deaths (#916:
+// a force-quit or discarded iOS prewarm inside the 5s stable window used to
+// read as a theme crash and silently disable the active theme).
+static NSString * const kLaunchRunLoopKey = @"ApolloReborn.themeLaunchRunLoopStarted";
+static NSString * const kLaunchPrewarmKey = @"ApolloReborn.themeLaunchPrewarmed";
+
+// Consecutive armed launches that may die with no crash on record before the
+// switch trips anyway. Covers kills KSCrash cannot see (jetsam, watchdog) and
+// capture-disabled users, so an undetectable crash loop still cannot brick the
+// app — while a stray force-quit no longer costs the user their theme.
+static const NSInteger kUnexplainedDeathTripCount = 3;
 
 - (void)beginLaunchAttempt {
     NSUserDefaults *g = GroupDefaults();
     BOOL themeActive = self.customThemeEnabled;
-    // If the previous launch armed the marker (theme was active) but never
-    // reached the stable point, it almost certainly crashed during/after theme
-    // activation. Trip the kill switch on the FIRST such launch — a bad theme
-    // must never be able to brick the app.
     BOOL prevCompleted = [g boolForKey:kLaunchDoneKey];
     BOOL hadStart = [g objectForKey:kLaunchStartedKey] != nil;
     if (hadStart && !prevCompleted) {
-        NSInteger count = [g integerForKey:kCrashCountKey] + 1;
-        [g setInteger:count forKey:kCrashCountKey];
-        ApolloLog(@"ThemeStore: previous theme launch did NOT complete (crashCount=%ld) — tripping kill switch", (long)count);
-        [g setBool:YES forKey:kApolloRebornThemeRuntimeDisabledKey];
-        // Leave the selection pointer intact. The crash flag alone gates the
-        // runtime so recovery UI can show and re-enable the last active theme.
-        themeActive = NO;
+        // The previous launch armed the marker (theme active) but never reached
+        // the stable point. That alone is NOT proof of a theme crash: a user
+        // force-quit, a prewarmed process iOS discarded, and jetsam all look
+        // identical from here (#916). Corroborate before tripping.
+        BOOL crashed = [ApolloCrashManager sharedManager].crashedLastLaunch;
+        BOOL prevRanRunLoop = [g boolForKey:kLaunchRunLoopKey];
+        BOOL prevPrewarmed = [g boolForKey:kLaunchPrewarmKey];
+        if (crashed) {
+            // KSCrash recorded a genuine crash, and that session died inside
+            // the theme launch window — the case this switch exists for. Trip
+            // on the first strike: a bad theme must never brick the app.
+            ApolloLog(@"ThemeStore: previous theme launch CRASHED before the stable point — tripping kill switch");
+            [g setBool:YES forKey:kApolloRebornThemeRuntimeDisabledKey];
+            themeActive = NO;
+        } else if (!prevRanRunLoop && prevPrewarmed) {
+            // iOS prewarmed the app (ctor ran, marker armed) and killed the
+            // process before the main run loop ever turned. The user never saw
+            // the app; nothing can be inferred about the theme.
+            ApolloLog(@"ThemeStore: previous theme launch was a discarded prewarm — ignoring");
+        } else {
+            // Died inside the stable window with no crash recorded: most
+            // likely a force-quit, else a kill KSCrash cannot see. Tolerate a
+            // few, but a streak with no stable launch in between still trips.
+            NSInteger count = [g integerForKey:kCrashCountKey] + 1;
+            [g setInteger:count forKey:kCrashCountKey];
+            if (count >= kUnexplainedDeathTripCount) {
+                ApolloLog(@"ThemeStore: %ld consecutive theme launches died before the stable point — tripping kill switch", (long)count);
+                [g setBool:YES forKey:kApolloRebornThemeRuntimeDisabledKey];
+                themeActive = NO;
+            } else {
+                ApolloLog(@"ThemeStore: previous theme launch did not complete but no crash was recorded (strike %ld/%ld) — keeping theme enabled",
+                          (long)count, (long)kUnexplainedDeathTripCount);
+            }
+        }
+        // On trip, leave the selection pointer intact. The crash flag alone
+        // gates the runtime so recovery UI can re-enable the last active theme.
     }
     // Only arm the marker when a theme is actually active this launch, so normal
     // (theme-off) launches can never trip it, and a clean disabled state resets.
     if (themeActive) {
+        const char *prewarm = getenv("ActivePrewarm");
         [g setObject:@(NowTS()) forKey:kLaunchStartedKey];
         [g setBool:NO forKey:kLaunchDoneKey];
+        [g setBool:NO forKey:kLaunchRunLoopKey];
+        [g setBool:(prewarm != NULL && strcmp(prewarm, "1") == 0) forKey:kLaunchPrewarmKey];
     } else {
         [g removeObjectForKey:kLaunchStartedKey];
         [g setBool:YES forKey:kLaunchDoneKey];
     }
     [g synchronize]; // CRITICAL: flush now so a crash in ms still leaves the marker on disk
     ApolloLog(@"ThemeStore: beginLaunchAttempt themeActive=%d (marker armed=%d)", themeActive, themeActive);
+}
+
+- (void)markRunLoopStarted {
+    // First main-queue drain: the process is past dyld/ctor and genuinely
+    // launching. A prewarmed process iOS discards never gets here, which is
+    // what lets beginLaunchAttempt tell those deaths apart.
+    NSUserDefaults *g = GroupDefaults();
+    [g setBool:YES forKey:kLaunchRunLoopKey];
+    [g synchronize];
 }
 
 - (void)markLaunchStable {


### PR DESCRIPTION
Fixes #916. Closes #921. Closes #924. Closes #930.

## What the log actually showed (#916)

The reporter's `apollo-reborn.log` has **no crash in it at all**. The night before the report there's a run of quick manual relaunches, and on the morning of the report three launches inside 12 seconds — each process dying before the 5-second `markLaunchStable` timer. The old kill switch treats any armed-but-incomplete launch as a theme crash and trips on the FIRST one, so Monokai Pro got disabled; the log then shows the user finding Theme Manager and re-enabling it ten minutes before the issue was filed. "Theme crashes after a few days" = the kill switch false-positiving on a force-quit (or a discarded iOS prewarm — those run our %ctor and arm the marker too, then get SIGKILLed without ever reaching the run loop).

## The fix

`beginLaunchAttempt` now corroborates before blaming the theme:

- **Real crash on record** (KSCrash `crashedLastLaunch` — an in-process handler actually fired and saved state; SIGKILL can never set it) → trip immediately, same first-strike protection as before.
- **Prewarm discard** (previous launch was `ActivePrewarm` and died before its first main-queue drain) → ignored entirely; the user never saw the app.
- **Anything else** (force-quit, jetsam, watchdog, capture toggled off) → tolerated up to 2 consecutive early deaths; a 3rd consecutive one still trips, so an undetectable crash loop can never brick the app. Any stable launch resets the streak.

Also two windowing corrections: the run-loop-started/5s-stable marks are now anchored to the **first main-queue drain** instead of ctor time (a prewarm runs ctor hours before the real launch, which used to shrink the crash-detection window to zero), and reaching the background now marks the launch stable (one-shot observer), so backgrounding quickly and being jetsammed while suspended no longer counts a strike.

## Issues #918, #924, #930 (crashes on 3.5.0 while expanding/scrolling comments) — already fixed, no code needed

Checked as part of the same triage: that reporter is on **3.5.0**, and their log is saturated with `[StackGuard] heightForRow: main stack 848–857/1008KB, 1024 frames` lines, twice followed by a relaunch 2–8 seconds later (the crash). That's exactly the row-measure geometry recursion #844 fixed (heightForRow → deleted-comments replacement text during measure → geometry query → nested revalidation), which shipped in **3.5.1** — their build predates it. #924 ("random crash" scrolling a thread, also 3.5.0) is the same wave: identical StackGuard readings (848–853/1008KB, 1024-frame cap, heightForRow + LinkButtonNode.layoutSpecThatFits) throughout its log, then a silent mid-foreground death — no lifecycle callbacks — with a relaunch right before the report was filed. No memory warnings or other anomalies in the log. #930 ("tap removed-by-mod comment with a hyperlink, shows briefly, then crashes", also 3.5.0) is the same again — its log has two heightForRow 857/1008KB warnings each followed by a relaunch 2-3 seconds later, and the trigger combines the exact two ingredients of the #831 recursion cycle (deleted-comment replacement text set during measure + LinkButtonNode). Verified on current main in the sim with the #844 reproducer (r/wholesomememes 1vg40xy, ShowDeletedComments + auto-translate, expanding the deleted replies): zero `[RowMeasure] NESTED`, zero StackGuard, no crash, across all four build/auth combos. The reporter just needs 3.5.1+. Not auto-closing #918 so we can point them at the update first.

## Testing (simulator, all on this branch)

| Scenario | Result |
|---|---|
| Clean launch, theme active, wait >5s, relaunch | marker armed → stable, no strike |
| Kill at ~2s, relaunch | **strike 1/3, theme stays enabled** (old code: theme disabled) |
| 3 consecutive kills inside the window | 3rd trips the switch, selection kept, Re-enable recovery works |
| Real NSException crash at ~2s (debug bridge), relaunch | trips immediately via `crashedLastLaunch`, crash prompt flow intact |
| Faked prewarm death (marker keys via launch args) | "discarded prewarm — ignoring", no strike |
| Background at ~2s | marks stable (observer + timer, idempotent) |

Matrix: Liquid Glass + API-key (full suite), Glass + keyless (WebJSON confirmed), non-glass + API-key, non-glass + keyless (vtool-downgraded shell, verified by pixels) — deleted-comments reproducer run in each, 0 NESTED/StackGuard everywhere. `make package` (device target) also builds clean.


## Issue #921 (crash on Filters & Blocks → Edit) — already fixed by #897, closing it out here

No code in this PR: that crash was fixed in main by #897 (merged Aug 12), which landed *after* 3.5.1 was tagged, so every 3.5.1 build still has it. Linking it here so it closes out with this release rather than sitting open against a bug main no longer has.

The reporter attached a sanitized KSCrash JSON; symbolicated against the 3.5.1 release dSYM (UUID-matched) it lands on `SettingsFiltersViewController setEditing:animated:` in `ApolloFiltersBlocksInject.xm`, sending `-tableView` to a plain `UIViewController` that has no such accessor → `NSInvalidArgumentException` through CF forwarding. Same signature as #876/#870. A second `.ips` from a local device build shows the identical throw from the identical function.

The bug only exists in a five-day window: #728 (merged Aug 7) replaced a remembered table reference with `[(UITableViewController *)(id)self tableView]`, and #897 (merged Aug 12) replaced it with the zeroing-weak `ApolloPFTableBox` capture. 3.5.1 falls inside that window; current main does not.

Verified on this branch with a populated list (the reporter's case — an empty list never hits it): a native filtered subreddit plus a name filter present, tap Edit → edit mode opens, Blocked Users auto-expands, both row types show delete controls, and deleting the native filtered subreddit and the name-filter row both work. No exception, process stays alive.

Also audited the remaining `(UITableViewController *)` casts in the tree — the four in `ApolloLiquidGlassIconPicker.xm` / `ApolloLinkCompanionViewController.m` all route through `ApolloInheritedSettingsThemeSourceTableView`, which guards with `respondsToSelector:@selector(tableView)` before sending and otherwise falls back to a view-tree search. No instances of this crash class remain.


