### PR TITLE
Fix Community Highlights stuck at 2 when Reddit serves its bot challenge

### DIFF
--- a/src/ApolloBadgeBookScraper.m
+++ b/src/ApolloBadgeBookScraper.m
@@ -704,6 +704,13 @@ typedef NS_ENUM(NSInteger, ApolloBBPhase) {
 @end
 
 @implementation ApolloBBWebFetch
+// Last-resort insurance: Create attaches the web view, so the window (not this
+// object) holds the strong reference — dropping the fetch without Destroy would
+// orphan an attached web view behind the app. Every normal path already goes
+// through Destroy; this makes "no orphaned attached web view" structural.
+- (void)dealloc {
+    ApolloScrapeWebViewDestroy(_web);
+}
 
 // Give a hydrating/challenged page plenty of room: 3s initial + 2s per poll.
 // Reddit's JS bot-challenge typically clears in ~5-10s and then auto-redirects to

--- a/src/ApolloBadgeBookScraper.m
+++ b/src/ApolloBadgeBookScraper.m
@@ -1025,7 +1025,7 @@ static NSTimeInterval const kApolloBBWebFetchWatchdog = 90.0;
 - (void)finish {
     if (self.finished) return;
     self.finished = YES;
-    if (self.web) { self.web.navigationDelegate = nil; [self.web stopLoading]; self.web = nil; }
+    if (self.web) { ApolloScrapeWebViewDestroy(self.web); self.web = nil; }
     // Release the slot BEFORE the completion so a waiting scrape starts straight
     // away rather than a callback-chain later.
     NSMutableArray<ApolloBBWebFetch *> *queue = ApolloBBWebFetchQueue();

--- a/src/ApolloProfileSocialLinks.m
+++ b/src/ApolloProfileSocialLinks.m
@@ -600,6 +600,13 @@ static NSString *ApolloSLScrapeCookieHeader(void) {
 @end
 
 @implementation ApolloSLWebFetch
+// Last-resort insurance: Create attaches the web view, so the window (not this
+// object) holds the strong reference — dropping the fetch without Destroy would
+// orphan an attached web view behind the app. Every normal path already goes
+// through Destroy; this makes "no orphaned attached web view" structural.
+- (void)dealloc {
+    ApolloScrapeWebViewDestroy(_web);
+}
 
 // A single non-persistent (in-memory) WKWebsiteDataStore, reused for every
 // social-links scrape this app session.

--- a/src/ApolloProfileSocialLinks.m
+++ b/src/ApolloProfileSocialLinks.m
@@ -623,7 +623,7 @@ static NSString *ApolloSLScrapeCookieHeader(void) {
 + (WKWebsiteDataStore *)apollo_scrapeDataStore {
     static WKWebsiteDataStore *store;
     static dispatch_once_t once;
-    dispatch_once(&once, ^{ store = [WKWebsiteDataStore nonPersistentDataStore]; });
+    dispatch_once(&once, ^{ store = ApolloScrapeWebViewSharedDataStore(); });
     return store;
 }
 
@@ -878,7 +878,7 @@ static NSTimeInterval const kApolloSLWebMinTimeForNone  = 4.0;
 - (void)finish:(NSArray<ApolloSocialLink *> *)links {
     if (self.finished) return;   // watchdog / poll / queue-drop can race
     self.finished = YES;
-    if (self.web) { self.web.navigationDelegate = nil; [self.web stopLoading]; self.web = nil; }
+    if (self.web) { ApolloScrapeWebViewDestroy(self.web); self.web = nil; }
     // Release the slot BEFORE the completion so a waiting scrape starts straight
     // away rather than a callback-chain later.
     NSMutableArray<ApolloSLWebFetch *> *queue = ApolloSLWebFetchQueue();

--- a/src/ApolloScrapeWebView.h
+++ b/src/ApolloScrapeWebView.h
@@ -55,7 +55,11 @@ CGRect ApolloScrapeWebViewFrame(void);
 /// mobile Safari user agent, inserts it at the BACK of the key window (index 0,
 /// alpha 0.011, no interaction — invisible and untouchable, but "visible" to the
 /// page, which Reddit's bot challenge requires), and hands it back on the main
-/// queue. Tear it down with ApolloScrapeWebViewDestroy when done.
+/// queue. The attach is gated on the blocker actually being present: if the rule
+/// list failed to compile, the view stays DETACHED — an attached unblocked web
+/// view on reddit is the #902 configuration, so the unblocked path degrades to
+/// challenge-vulnerable rather than ad-vulnerable. Tear the view down with
+/// ApolloScrapeWebViewDestroy when done.
 ///
 /// `ready` is always called, always on the main queue, always with a non-nil web
 /// view: if the blocker cannot be compiled we log and continue unblocked, since a
@@ -64,13 +68,18 @@ void ApolloScrapeWebViewCreate(WKWebViewConfiguration *config, void (^ready)(WKW
 
 /// Stops any in-flight load and removes the view from the window. Call from every
 /// finish/cancel path — Create attaches the view, so dropping the reference alone
-/// would leak an attached web view behind the app.
+/// would leak an attached web view behind the app. Safe from any thread (UIKit
+/// work hops to main), so the fetch classes also call it from dealloc as
+/// last-resort insurance.
 void ApolloScrapeWebViewDestroy(WKWebView *web);
 
 /// The shared logged-out scrape cookie jar: persistent on iOS 17+ (challenge
 /// cookies survive relaunch), process-cached non-persistent below. Never used for
 /// logged-in scrapes, never the app's default store (so a logged-in "use old
-/// reddit" account can't poison what www.reddit.com serves — see #499).
+/// reddit" account can't poison what www.reddit.com serves — see #499). Bounded:
+/// on first use each launch, origins other than reddit/google/recaptcha are
+/// pruned, so the jar holds only the session-trust and challenge-reputation
+/// cookies the scrape actually needs.
 WKWebsiteDataStore *ApolloScrapeWebViewSharedDataStore(void);
 
 /// Compile/lookup the blocker ahead of time so the first scrape after launch is

--- a/src/ApolloScrapeWebView.h
+++ b/src/ApolloScrapeWebView.h
@@ -5,30 +5,41 @@
 // load a real reddit.com page purely to read its DOM (Community Highlights, Badge
 // Book, Social Links, User Flair, Subreddit Sidebar).
 //
-// These used to be inserted into the key window at alpha 0.011. That is unsafe:
-// WebKit presents fullscreen video in its own window ABOVE the app, so the host
-// view's alpha and userInteractionEnabled do not apply to it. A promoted video
-// ad on the loaded page could therefore take over the whole screen while the
-// user was reading something else (issue #902).
+// #902 history: these views used to be inserted into the key window at alpha
+// 0.011 with nothing blocking page media. WebKit presents fullscreen video in
+// its own window ABOVE the app, so the host view's alpha/userInteractionEnabled
+// do not apply to it — a promoted video ad on the loaded page could take over
+// the whole screen. The fix that actually stops that is the content rule list
+// below: it blocks every media load outright, so nothing can start playing and
+// WebKit's fullscreen promotion has nothing to promote.
 //
-// Two independent defences, both verified in the simulator:
-//   1. The web view is NEVER added to a window. Video fullscreen is presented on
-//      the view's window, so with no window there is nothing to present on. This
-//      is why ApolloChatUnreadPoller (CGRectZero, unattached) was never affected.
-//   2. A content rule list blocks media (and known ad/tracking hosts) outright,
-//      so the ad never loads in the first place — independent of whatever any
-//      given iOS version's autoplay policy happens to be.
+// Attachment history: #908 additionally stopped attaching the views to any
+// window (belt and braces against #902). That turned out to break every scrape
+// that Reddit chooses to challenge: www.reddit.com now serves a Google reCAPTCHA
+// "Prove your humanity" interstitial on a per-request risk score, and a web view
+// that is not in any window reports document.visibilityState == "hidden" — a
+// hard bot signal the challenge never clears, so the scrape sits on the
+// interstitial until timeout (Community Highlights stuck at the 2 REST stickies,
+// flair/sidebar/badge scrapes intermittently empty). The views are therefore
+// attached again (key window, index 0, alpha 0.011, no interaction) exactly as
+// before #908, with the rule-list blocker carrying the #902 protection.
 //
-// Do NOT "fix" this by setting allowsInlineMediaPlayback = YES. Testing showed
-// that is the one configuration in which the ad video actually plays: it relaxes
-// WebKit's gate, and the video then runs (invisibly) behind the user's UI,
-// holding an audio session. See docs in the issue thread.
+// Because a challenged request may still not clear in a view the user can't
+// actually see, the real goal is not being challenged in the first place:
+//   1. Create() defaults customUserAgent to real mobile Safari. WKWebView's
+//      default UA has no "Version/x ... Safari" token — an instant embedded-
+//      webview tell that raises the challenge rate. Callers can override it
+//      after Create returns (the sidebar stats scrape sets a desktop UA).
+//   2. ApolloScrapeWebViewSharedDataStore() is a persistent, dedicated,
+//      logged-out cookie jar on iOS 17+. Session cookies that have already
+//      passed Reddit's checks keep future loads unchallenged across launches,
+//      instead of every launch starting cookie-less at maximum suspicion.
+//      Logged-in scrape variants must keep their isolated per-fetch stores.
 //
-// Detachment is safe for every current caller: none of them snapshot the web
-// view or read rendered geometry, and no extraction JS uses layout APIs
-// (getBoundingClientRect / offset* / client* / innerHeight / getComputedStyle /
-// IntersectionObserver). Verified per module against live reddit routes —
-// detached extraction matched attached, including page-initiated fetch().
+// Do NOT "fix" any of this by setting allowsInlineMediaPlayback = YES. Testing
+// showed that is the one configuration in which an ad video actually plays: it
+// relaxes WebKit's gate, and the video then runs (invisibly) behind the user's
+// UI, holding an audio session. See the #902 issue thread.
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,15 +50,28 @@ extern "C" {
 /// picks its breakpoint from the viewport, and a zero-sized one hydrates oddly.
 CGRect ApolloScrapeWebViewFrame(void);
 
-/// Builds an off-screen scrape web view from `config` (callers keep owning the
-/// data store / user scripts / user agent they need) with the shared ad+media
-/// blocker attached, and hands it back on the main queue. The web view is not in
-/// any view hierarchy — retain it, load into it, and drop it when done.
+/// Builds a scrape web view from `config` (callers keep owning the data store /
+/// user scripts they need) with the shared ad+media blocker attached and a real
+/// mobile Safari user agent, inserts it at the BACK of the key window (index 0,
+/// alpha 0.011, no interaction — invisible and untouchable, but "visible" to the
+/// page, which Reddit's bot challenge requires), and hands it back on the main
+/// queue. Tear it down with ApolloScrapeWebViewDestroy when done.
 ///
 /// `ready` is always called, always on the main queue, always with a non-nil web
 /// view: if the blocker cannot be compiled we log and continue unblocked, since a
 /// scrape without the blocker still beats no scrape at all.
 void ApolloScrapeWebViewCreate(WKWebViewConfiguration *config, void (^ready)(WKWebView *web));
+
+/// Stops any in-flight load and removes the view from the window. Call from every
+/// finish/cancel path — Create attaches the view, so dropping the reference alone
+/// would leak an attached web view behind the app.
+void ApolloScrapeWebViewDestroy(WKWebView *web);
+
+/// The shared logged-out scrape cookie jar: persistent on iOS 17+ (challenge
+/// cookies survive relaunch), process-cached non-persistent below. Never used for
+/// logged-in scrapes, never the app's default store (so a logged-in "use old
+/// reddit" account can't poison what www.reddit.com serves — see #499).
+WKWebsiteDataStore *ApolloScrapeWebViewSharedDataStore(void);
 
 /// Compile/lookup the blocker ahead of time so the first scrape after launch is
 /// already covered. Called from %ctor; safe to call repeatedly.

--- a/src/ApolloScrapeWebView.m
+++ b/src/ApolloScrapeWebView.m
@@ -62,15 +62,31 @@ static BOOL sBlockerFailed;                     // don't retry forever
 static BOOL sCompileInFlight;
 static NSMutableArray<void (^)(void)> *sWaiters;
 
-CGRect ApolloScrapeWebViewFrame(void) {
-    CGRect frame = CGRectZero;
+static UIWindow *ApolloScrapeKeyWindow(void) {
     for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
         if (![scene isKindOfClass:[UIWindowScene class]]) continue;
         for (UIWindow *w in ((UIWindowScene *)scene).windows) {
-            if (w.isKeyWindow) { frame = w.bounds; break; }
+            if (w.isKeyWindow) return w;
         }
-        if (!CGRectIsEmpty(frame)) break;
     }
+    return nil;
+}
+
+// Real mobile Safari UA for this OS version. WKWebView's default UA is missing
+// the trailing "Version/x ... Safari" token, which marks the request as an
+// embedded web view and measurably raises Reddit's challenge rate.
+static NSString *ApolloScrapeSafariUserAgent(void) {
+    NSArray<NSString *> *parts = [UIDevice.currentDevice.systemVersion componentsSeparatedByString:@"."];
+    NSString *major = parts.count > 0 ? parts[0] : @"18";
+    NSString *minor = parts.count > 1 ? parts[1] : @"0";
+    BOOL pad = UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad;
+    NSString *os = pad ? [NSString stringWithFormat:@"iPad; CPU OS %@_%@ like Mac OS X", major, minor]
+                       : [NSString stringWithFormat:@"iPhone; CPU iPhone OS %@_%@ like Mac OS X", major, minor];
+    return [NSString stringWithFormat:@"Mozilla/5.0 (%@) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/%@.%@ Mobile/15E148 Safari/604.1", os, major, minor];
+}
+
+CGRect ApolloScrapeWebViewFrame(void) {
+    CGRect frame = ApolloScrapeKeyWindow().bounds;
     if (CGRectIsEmpty(frame)) frame = UIScreen.mainScreen.bounds;
     // Last resort: a plausible phone viewport, so shreddit still picks its mobile
     // breakpoint rather than hydrating against a zero-sized layout.
@@ -150,10 +166,38 @@ void ApolloScrapeWebViewCreate(WKWebViewConfiguration *config, void (^ready)(WKW
             [cfg.userContentController addContentRuleList:sBlocker];
         }
         WKWebView *web = [[WKWebView alloc] initWithFrame:ApolloScrapeWebViewFrame() configuration:cfg];
-        // Belt and braces only — with no window these have nothing to act on. They
-        // matter if someone ever re-attaches one of these views by accident.
+        // Invisible and untouchable to the user, but attached — an unparented web
+        // view reports document.visibilityState == "hidden", which Reddit's
+        // reCAPTCHA interstitial treats as a bot and never clears. The rule-list
+        // blocker (no media can load) is what keeps #902 fixed with the view in
+        // the window.
         web.alpha = 0.011;
         web.userInteractionEnabled = NO;
+        web.customUserAgent = ApolloScrapeSafariUserAgent();
+        UIWindow *win = ApolloScrapeKeyWindow();
+        if (win) [win insertSubview:web atIndex:0];
         ready(web);
     });
+}
+
+void ApolloScrapeWebViewDestroy(WKWebView *web) {
+    if (!web) return;
+    web.navigationDelegate = nil;
+    [web stopLoading];
+    [web removeFromSuperview];
+}
+
+WKWebsiteDataStore *ApolloScrapeWebViewSharedDataStore(void) {
+    static WKWebsiteDataStore *store; static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        if (@available(iOS 17.0, *)) {
+            // Fixed identifier → the same on-disk store every launch. Cookies that
+            // already passed Reddit's checks keep future scrapes unchallenged,
+            // instead of every launch starting cookie-less at maximum suspicion.
+            NSUUID *ident = [[NSUUID alloc] initWithUUIDString:@"C4A9B7D2-3E61-4F0A-9B5C-8D2F7E1A6035"];
+            if (ident) store = [WKWebsiteDataStore dataStoreForIdentifier:ident];
+        }
+        if (!store) store = [WKWebsiteDataStore nonPersistentDataStore];
+    });
+    return store;
 }

--- a/src/ApolloScrapeWebView.m
+++ b/src/ApolloScrapeWebView.m
@@ -174,14 +174,26 @@ void ApolloScrapeWebViewCreate(WKWebViewConfiguration *config, void (^ready)(WKW
         web.alpha = 0.011;
         web.userInteractionEnabled = NO;
         web.customUserAgent = ApolloScrapeSafariUserAgent();
+        // Attach ONLY when the blocker made it into the configuration. If the rule
+        // list failed to compile, an attached unblocked web view loading reddit is
+        // exactly the #902 configuration (fullscreen video promotion over the app)
+        // — so on that path the scrape stays detached instead: it still runs, it
+        // just can't clear a bot challenge, which is the safer way to degrade.
         UIWindow *win = ApolloScrapeKeyWindow();
-        if (win) [win insertSubview:web atIndex:0];
+        if (win && sBlocker) [win insertSubview:web atIndex:0];
         ready(web);
     });
 }
 
 void ApolloScrapeWebViewDestroy(WKWebView *web) {
     if (!web) return;
+    // Callable from any thread: the fetch classes also call this from dealloc as
+    // last-resort insurance, and dealloc offers no thread guarantee. UIKit work
+    // hops to main; the block keeps the web view alive until it runs.
+    if (!NSThread.isMainThread) {
+        dispatch_async(dispatch_get_main_queue(), ^{ ApolloScrapeWebViewDestroy(web); });
+        return;
+    }
     web.navigationDelegate = nil;
     [web stopLoading];
     [web removeFromSuperview];
@@ -198,6 +210,25 @@ WKWebsiteDataStore *ApolloScrapeWebViewSharedDataStore(void) {
             if (ident) store = [WKWebsiteDataStore dataStoreForIdentifier:ident];
         }
         if (!store) store = [WKWebsiteDataStore nonPersistentDataStore];
+        // Keep the persistent jar bounded: prune any origin the scrape doesn't
+        // need. Reddit's own cookies carry the session trust, and Google's carry
+        // reCAPTCHA reputation; everything else (link-shim redirects and whatever
+        // page JS stores) accumulates forever with no user-facing reset, so drop
+        // it once per launch. Async and best-effort — a miss just waits a launch.
+        WKWebsiteDataStore *prune = store;
+        [prune fetchDataRecordsOfTypes:[WKWebsiteDataStore allWebsiteDataTypes]
+                     completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+            NSMutableArray<WKWebsiteDataRecord *> *evict = [NSMutableArray array];
+            for (WKWebsiteDataRecord *r in records) {
+                NSString *name = r.displayName.lowercaseString ?: @"";
+                BOOL keep = [name containsString:@"reddit"] || [name containsString:@"redd.it"] ||
+                            [name containsString:@"google"] || [name containsString:@"gstatic"] ||
+                            [name containsString:@"recaptcha"];
+                if (!keep) [evict addObject:r];
+            }
+            if (evict.count) [prune removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes]
+                                       forDataRecords:evict completionHandler:^{}];
+        }];
     });
     return store;
 }

--- a/src/ApolloSubredditHighlights.xm
+++ b/src/ApolloSubredditHighlights.xm
@@ -552,6 +552,13 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
 @property (nonatomic) BOOL sawChallenge;
 @end
 @implementation ApolloHLWebFetch
+// Last-resort insurance: Create attaches the web view, so the window (not this
+// object) holds the strong reference — dropping the fetch without Destroy would
+// orphan an attached web view behind the app. Every normal path already goes
+// through Destroy; this makes "no orphaned attached web view" structural.
+- (void)dealloc {
+    ApolloScrapeWebViewDestroy(_web);
+}
 
 // A single non-persistent (in-memory) WKWebsiteDataStore, reused for every
 // highlights scrape this app session.

--- a/src/ApolloSubredditHighlights.xm
+++ b/src/ApolloSubredditHighlights.xm
@@ -546,6 +546,10 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
 // more than the REST-sized two cards, take one confirming probe before finishing
 // so bestItems can grow to the complete set without restoring the old 3s delay.
 @property (nonatomic) BOOL awaitingLargeSetConfirmation;
+// The poll saw Reddit's "Prove your humanity" interstitial at least once this
+// fetch. A challenged load that still times out is retryable (the challenge is
+// served per-request), unlike a clean page that genuinely has no highlights.
+@property (nonatomic) BOOL sawChallenge;
 @end
 @implementation ApolloHLWebFetch
 
@@ -574,7 +578,7 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
 + (WKWebsiteDataStore *)apollo_scrapeDataStore {
     static WKWebsiteDataStore *store;
     static dispatch_once_t once;
-    dispatch_once(&once, ^{ store = [WKWebsiteDataStore nonPersistentDataStore]; });
+    dispatch_once(&once, ^{ store = ApolloScrapeWebViewSharedDataStore(); });
     return store;
 }
 
@@ -582,6 +586,7 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
     self.sub = sub; self.done = done; self.polls = 0;
     self.startedAt = [NSDate date]; self.bestItems = nil; self.pollScheduled = NO; self.evaluationInFlight = NO;
     self.awaitingLargeSetConfirmation = NO;
+    self.sawChallenge = NO;
     WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
     config.websiteDataStore = [ApolloHLWebFetch apollo_scrapeDataStore];
     __weak typeof(self) ws = self;
@@ -613,7 +618,10 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
     if (!self.web || self.evaluationInFlight) return;
     NSTimeInterval elapsed = self.startedAt ? -self.startedAt.timeIntervalSinceNow : 0.0;
     if (elapsed >= kApolloHLWebTimeout) {
-        ApolloLog(@"[Highlights][web] r/%@ timed out after %.1fs (%d probes)", self.sub, elapsed, self.polls);
+        if (self.sawChallenge && self.bestItems.count == 0)
+            ApolloLog(@"[Highlights][web] r/%@ blocked by Reddit's bot challenge after %.1fs — will retry later", self.sub, elapsed);
+        else
+            ApolloLog(@"[Highlights][web] r/%@ timed out after %.1fs (%d probes)", self.sub, elapsed, self.polls);
         [self finish:self.bestItems ?: @[]];
         return;
     }
@@ -622,7 +630,7 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
     NSString *js = @"(function(){"
         "var all=document.querySelectorAll('*'),heading=null;"
         "for(var i=0;i<all.length;i++){var e=all[i];if(e.children.length===0&&(e.textContent||'').trim().toLowerCase()==='community highlights'){heading=e;break;}}"
-        "if(!heading)return JSON.stringify({n:0});"
+        "if(!heading)return JSON.stringify({n:0,t:document.title});"
         "var c=heading;for(var d=0;d<7&&c.parentElement;d++){c=c.parentElement;if(c.querySelectorAll('a[href*=\"/comments/\"]').length>=1)break;}"
         "var links=c.querySelectorAll('a[href*=\"/comments/\"]');var seen={},out=[];"
         "for(var j=0;j<links.length;j++){var l=links[j];var h=(l.getAttribute('href')||'').split('?')[0];if(!h||seen[h])continue;var t=(l.textContent||'').trim().split('\\n')[0].trim();if(!t)continue;seen[h]=1;"
@@ -637,6 +645,11 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
         if (!ss.web) return;
         NSArray<ApolloHLItem *> *items = [ApolloHLWebFetch parseItems:res];
         if (items.count > ss.bestItems.count) ss.bestItems = items;
+        // "Reddit - Prove your humanity" = the bot-challenge interstitial. Keep
+        // polling — it can clear itself mid-fetch — but remember we saw it so a
+        // timeout is classified as blocked-not-empty.
+        if ([res isKindOfClass:[NSString class]] && [(NSString *)res containsString:@"Prove your humanity"])
+            ss.sawChallenge = YES;
         NSTimeInterval now = ss.startedAt ? -ss.startedAt.timeIntervalSinceNow : 0.0;
         if (ss.bestItems.count > 2 && !ss.awaitingLargeSetConfirmation && now < kApolloHLWebTimeout) {
             ss.awaitingLargeSetConfirmation = YES;
@@ -647,7 +660,10 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
             ApolloLog(@"[Highlights][web] r/%@ extracted %lu highlights in %.2fs (probe#%d)", ss.sub, (unsigned long)ss.bestItems.count, now, ss.polls);
             [ss finish:ss.bestItems];
         } else if (now >= kApolloHLWebTimeout) {
-            ApolloLog(@"[Highlights][web] r/%@ timed out after %.1fs (%d probes, last error=%@)", ss.sub, now, ss.polls, e.localizedDescription ?: @"nil");
+            if (ss.sawChallenge && ss.bestItems.count == 0)
+                ApolloLog(@"[Highlights][web] r/%@ blocked by Reddit's bot challenge after %.1fs — will retry later", ss.sub, now);
+            else
+                ApolloLog(@"[Highlights][web] r/%@ timed out after %.1fs (%d probes, last error=%@)", ss.sub, now, ss.polls, e.localizedDescription ?: @"nil");
             [ss finish:ss.bestItems ?: @[]];
         } else {
             [ss pollAfter:kApolloHLWebPollInterval];
@@ -678,7 +694,7 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
     return out;
 }
 - (void)finish:(NSArray<ApolloHLItem *> *)items {
-    if (self.web) { self.web.navigationDelegate = nil; self.web = nil; }
+    if (self.web) { ApolloScrapeWebViewDestroy(self.web); self.web = nil; }
     self.pollScheduled = NO; self.evaluationInFlight = NO; self.awaitingLargeSetConfirmation = NO;
     self.startedAt = nil; self.bestItems = nil;
     void (^d)(NSArray *) = self.done; self.done = nil;
@@ -687,8 +703,7 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
 - (void)cancel {
     self.done = nil;
     if (self.web) {
-        self.web.navigationDelegate = nil;
-        [self.web stopLoading];
+        ApolloScrapeWebViewDestroy(self.web);
         self.web = nil;
     }
     self.pollScheduled = NO; self.evaluationInFlight = NO; self.awaitingLargeSetConfirmation = NO;
@@ -1548,6 +1563,27 @@ static NSMutableDictionary<NSString *, ApolloHLWebFetch *> *ApolloHLWebFetchers(
     static NSMutableDictionary *d; static dispatch_once_t o; dispatch_once(&o, ^{ d = [NSMutableDictionary dictionary]; }); return d;
 }
 
+// Challenge-blocked subs are NOT marked web-done: the interstitial is served
+// per-request, so a later attempt often sails through. Bounded so a sub the
+// challenge keeps blocking doesn't re-run an 18s WebView on every layout pass:
+// at most kApolloHLWebChallengeMaxStrikes attempts per session, spaced at least
+// kApolloHLWebChallengeRetrySpacing apart. Any successful extraction clears all
+// strikes (the cookie jar has demonstrably passed Reddit's checks), and a
+// pull-to-refresh resets the blocked sub explicitly.
+static int const kApolloHLWebChallengeMaxStrikes = 3;
+static NSTimeInterval const kApolloHLWebChallengeRetrySpacing = 90.0;
+static NSMutableDictionary<NSString *, NSNumber *> *ApolloHLWebChallengeStrikes(void) {
+    static NSMutableDictionary *d; static dispatch_once_t o; dispatch_once(&o, ^{ d = [NSMutableDictionary dictionary]; }); return d;
+}
+static NSMutableDictionary<NSString *, NSDate *> *ApolloHLWebChallengeLastTry(void) {
+    static NSMutableDictionary *d; static dispatch_once_t o; dispatch_once(&o, ^{ d = [NSMutableDictionary dictionary]; }); return d;
+}
+static void ApolloHLWebChallengeReset(NSString *sub) {
+    if (sub.length == 0) return;
+    [ApolloHLWebChallengeStrikes() removeObjectForKey:sub];
+    [ApolloHLWebChallengeLastTry() removeObjectForKey:sub];
+}
+
 // Rebuild the carousel(s) for `sub` with a new (fuller) item set — used when the
 // WebView upgrade lands. Handles both placement modes.
 static void ApolloHLApplyItems(NSString *sub, NSArray<ApolloHLItem *> *items) {
@@ -1657,6 +1693,9 @@ static void ApolloHLMaybeWebUpgrade(NSString *subreddit) {
     if (!sCommunityHighlights || !sCommunityHighlightsWeb) return;
     NSString *sub = subreddit.lowercaseString;
     if (sub.length == 0 || [ApolloHLWebDone() containsObject:sub] || ApolloHLWebFetchers()[sub]) return;
+    if ([ApolloHLWebChallengeStrikes()[sub] intValue] >= kApolloHLWebChallengeMaxStrikes) return;
+    NSDate *lastTry = ApolloHLWebChallengeLastTry()[sub];
+    if (lastTry && -lastTry.timeIntervalSinceNow < kApolloHLWebChallengeRetrySpacing) return;
     ApolloHLWebFetch *fetch = [[ApolloHLWebFetch alloc] init];
     ApolloHLWebFetchers()[sub] = fetch;
     [fetch startForSub:sub completion:^(NSArray<ApolloHLItem *> *items) {
@@ -1664,9 +1703,20 @@ static void ApolloHLMaybeWebUpgrade(NSString *subreddit) {
         // The user may have changed Full to Partial/Off while WebKit was still
         // rendering. Never let that stale completion restore the full set.
         if (!sCommunityHighlights || !sCommunityHighlightsWeb) return;
+        if (items.count == 0 && fetch.sawChallenge) {
+            // Blocked, not empty — leave the sub eligible for a bounded retry.
+            int strikes = [ApolloHLWebChallengeStrikes()[sub] intValue] + 1;
+            ApolloHLWebChallengeStrikes()[sub] = @(strikes);
+            ApolloHLWebChallengeLastTry()[sub] = [NSDate date];
+            return;
+        }
         [ApolloHLWebDone() addObject:sub];
         NSArray<ApolloHLItem *> *apiItems = ApolloHLRestCache()[sub] ?: ApolloHLCache()[sub];
         if (items.count == 0) return; // web found nothing
+        // A successful extraction proves this cookie jar passes Reddit's checks —
+        // let every challenge-blocked sub retry on its next layout pass.
+        [ApolloHLWebChallengeStrikes() removeAllObjects];
+        [ApolloHLWebChallengeLastTry() removeAllObjects];
 
         // The DOM already has the authoritative order, titles, and links. Merge
         // whatever metadata the fast REST result already knows, then show the full
@@ -1746,6 +1796,7 @@ static void ApolloHLRefreshSub(NSString *subreddit, BOOL alwaysWeb) {
             // Re-harvest the full web set; it re-applies if it differs from what's shown.
             [ApolloHLWebDone() removeObject:key];
             [ApolloHLWebFetchers() removeObjectForKey:key];
+            ApolloHLWebChallengeReset(key); // explicit refresh overrides the challenge backoff
             ApolloHLMaybeWebUpgrade(subreddit);
         }
     });
@@ -2321,10 +2372,12 @@ static void ApolloHLCollapseOrphanSeparators(UIViewController *vc) {
             [ApolloHLWebFetchers() removeAllObjects];
             for (ApolloHLWebFetch *fetch in fetches) [fetch cancel];
             [ApolloHLWebDone() removeAllObjects];
+            [ApolloHLWebChallengeStrikes() removeAllObjects];
+            [ApolloHLWebChallengeLastTry() removeAllObjects];
         } else {
             // Full selected after Partial: allow each visible subreddit to run a
             // fresh web upgrade even if it completed earlier in this app session.
-            for (NSString *sub in visibleSubs) [ApolloHLWebDone() removeObject:sub];
+            for (NSString *sub in visibleSubs) { [ApolloHLWebDone() removeObject:sub]; ApolloHLWebChallengeReset(sub); }
         }
 
         if (sCommunityHighlights && !sCommunityHighlightsWeb) {

--- a/src/ApolloSubredditSidebar.xm
+++ b/src/ApolloSubredditSidebar.xm
@@ -54,6 +54,13 @@ static NSCache<NSString *, NSArray<NSNumber *> *> *ApolloSBWebStatsCache(void) {
 @property (nonatomic) int polls;
 @end
 @implementation ApolloSBStatsWebFetch
+// Last-resort insurance: Create attaches the web view, so the window (not this
+// object) holds the strong reference — dropping the fetch without Destroy would
+// orphan an attached web view behind the app. Every normal path already goes
+// through Destroy; this makes "no orphaned attached web view" structural.
+- (void)dealloc {
+    ApolloScrapeWebViewDestroy(_web);
+}
 - (void)startForSub:(NSString *)sub completion:(void (^)(NSNumber *, NSNumber *))done {
     self.sub = sub; self.done = done; self.polls = 0;
     __weak typeof(self) ws = self;

--- a/src/ApolloSubredditSidebar.xm
+++ b/src/ApolloSubredditSidebar.xm
@@ -90,7 +90,7 @@ static NSCache<NSString *, NSArray<NSNumber *> *> *ApolloSBWebStatsCache(void) {
     }];
 }
 - (void)finishV:(NSNumber *)v c:(NSNumber *)c {
-    if (self.web) { self.web.navigationDelegate = nil; self.web = nil; }
+    if (self.web) { ApolloScrapeWebViewDestroy(self.web); self.web = nil; }
     void (^d)(NSNumber *, NSNumber *) = self.done; self.done = nil;
     if (d) d(v, c);
 }

--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -787,6 +787,13 @@ static NSArray<NSHTTPCookie *> *ApolloUserFlairCookiesFromHeader(NSString *heade
 @end
 
 @implementation ApolloUserFlairWebEmojiFetch
+// Last-resort insurance: Create attaches the web view, so the window (not this
+// object) holds the strong reference — dropping the fetch without Destroy would
+// orphan an attached web view behind the app. Every normal path already goes
+// through Destroy; this makes "no orphaned attached web view" structural.
+- (void)dealloc {
+    ApolloScrapeWebViewDestroy(_web);
+}
 - (instancetype)initWithSubreddit:(NSString *)subreddit fallback:(NSArray *)fallback {
     if ((self = [super init])) {
         _subreddit = [subreddit copy];

--- a/src/ApolloUserFlair.xm
+++ b/src/ApolloUserFlair.xm
@@ -920,8 +920,7 @@ static NSArray<NSHTTPCookie *> *ApolloUserFlairCookiesFromHeader(NSString *heade
               self.subreddit, (long)status, (unsigned long)responseLength,
               (unsigned long)result.count, validResponse ? @"no" : @"yes", reason ?: @"none");
 
-    self.web.navigationDelegate = nil;
-    [self.web stopLoading];
+    ApolloScrapeWebViewDestroy(self.web);
     self.web = nil;
     NSMutableDictionary *fetches = ApolloUserFlairWebEmojiFetches();
     @synchronized (fetches) {


### PR DESCRIPTION
## What was happening

With "Load All Highlights (Web)" on, some subreddits stay stuck at the 2 REST stickies while others upgrade to the full set fine. Device log for a stuck sub:

```
21:39:44.365 [Highlights][web] loading r/apolloreborn for full highlights
21:40:02.385 [Highlights][web] r/apolloreborn timed out after 18.0s (36 probes)
```

Same session, other subs worked (`r/nintendo` 2 → 6 in 1.3s, `r/benfica` 2 → 3). So the scrape JS runs fine — on the failing subs the Community Highlights DOM just never appears.

## Root cause

A DOM dump at the timeout shows what the page actually is on the failing loads:

```
{"title":"Reddit - Prove your humanity", ..., "iframes":["https://www.google.com", ...],
 "scripts":["https://www.gstatic.com","https://www.google.com"], "vis":"hidden", ...}
```

**Reddit now serves a Google reCAPTCHA interstitial on a per-request risk score.** Unchallenged requests work in any configuration — that's why the failures are per-sub/per-request and look random. Challenged requests currently can never recover, for three stacking reasons:

1. **#908 detached the scrape web view from the window.** An unparented WKWebView reports `document.visibilityState == "hidden"` — a hard bot signal the challenge never clears. (Verified: re-attaching and making the view genuinely renderable lets the interstitial auto-resolve with zero interaction, after which the same sub extracts its full set — `r/apolloreborn` 2 → 4.)
2. **WKWebView's default user agent has no `Version/x … Safari` token** — an instant embedded-webview tell that raises the challenge rate. (The sidebar stats scrape already spoofs a Safari UA; Community Highlights never did.)
3. **The scrape cookie jar was non-persistent**, so every launch starts cookie-less at maximum suspicion. Cookies that have passed Reddit's checks make later loads sail through unchallenged (observed repeatedly: after one cleared session, the same subs extract in ~2s).

## The fix

- **Re-attach the scrape views** (key window, index 0, alpha 0.011, no interaction — exactly the pre-#908 placement). This does NOT reopen #902: the rule-list blocker from #908 blocks every media load outright, so no video can begin playing and WebKit's fullscreen promotion has nothing to promote. The header keeps the full history, including the `allowsInlineMediaPlayback` trap note.
- **Default the factory's `customUserAgent` to real mobile Safari** (derived from the OS version, iPad-aware). The other scrapers already override with their own desktop UAs, so in practice this only changes Community Highlights — the one consumer that still had the webview-tell UA.
- **`ApolloScrapeWebViewSharedDataStore()`** — a persistent (iOS 17+, `dataStoreForIdentifier:`), dedicated, logged-out jar shared by the logged-out scrapers; process-cached non-persistent below 17. Never the app's default store, so the #499 old-reddit poisoning stays impossible; logged-in scrape variants keep their isolated per-fetch stores.
- **Challenge detection + bounded retry** in Community Highlights: the poll now returns `document.title`, so a timeout on the interstitial logs `blocked by Reddit's bot challenge — will retry later` and does NOT mark the sub web-done. Retries are capped (3 per session, ≥90s apart), any successful extraction clears all strikes (the jar has demonstrably passed Reddit's checks), and pull-to-refresh/toggle changes reset the backoff explicitly.
- All five consumers now tear down through `ApolloScrapeWebViewDestroy` (stop + detach), since Create attaches again.

## Verified in the simulator

- Stuck sub heals: launch 1 → challenge served, new log line fires, sub left retryable; launch 2 → scrape runs again, `r/apolloreborn` extracts 4 in 2.5s and the carousel rebuilds 2 → 4.
- Fresh scrapes work attached: `r/nintendo` 2 → 6, `r/benfica` 2 → 3, `r/applemusic` 2 → 3.
- iPhone 13 + iPhone 17 Pro device types, Liquid Glass and non-glass (vtool-downgraded) shells, signed-in keyless account. (API-key mode isn't exercised by this change — the fix only touches the always-logged-out web scrape; the REST sticky path that differs by auth mode is untouched.)
- Works nicely with #925's disk snapshot when both are installed: the last-known-good full set installs instantly from disk while a blocked scrape waits for its retry.

Note: a challenged request in a view the user can't see still may not auto-resolve (Google's scoring decides) — but with the UA + persistent jar the challenge rate drops sharply, and the retry/backoff plus cookie persistence means one cleared session heals everything, instead of today's permanent stuck-at-2.
