### PR TITLE
Swipe past feed gallery edges to go back/forward

### DIFF
--- a/src/ApolloFeedGalleryCarousel.xm
+++ b/src/ApolloFeedGalleryCarousel.xm
@@ -260,6 +260,36 @@ static NSArray<NSDictionary *> *ApolloFeedGalleryItems(id albumNode) {
 
 #pragma mark - Gesture-cooperative paging scroll view
 
+static UINavigationController *ApolloFeedGalleryAncestorNavigationController(UIView *view) {
+    for (UIResponder *responder = view.nextResponder; responder; responder = responder.nextResponder) {
+        if ([responder isKindOfClass:[UIViewController class]]) {
+            UIViewController *viewController = (UIViewController *)responder;
+            if (viewController.navigationController) return viewController.navigationController;
+            return [viewController isKindOfClass:[UINavigationController class]]
+                ? (UINavigationController *)viewController : nil;
+        }
+    }
+    return nil;
+}
+
+// ApolloNavigationController keeps the pages popped by swipe-back in a Swift
+// [UIViewController] ivar named poppedViewControllers; its goForward command
+// and right-side navigation pan re-push from it (RE: the class's ivar list and
+// method list). A Swift array ivar is a single word holding the storage
+// object, which on Darwin is an NSArray subclass, so counting it through the
+// runtime is legitimate. Every failure path (different nav class, missing
+// ivar on a future Apollo, nil/empty array) returns NO, which keeps the
+// carousel's native rubber-band.
+static BOOL ApolloFeedGalleryCanGoForward(UINavigationController *navigationController) {
+    id popped = ApolloFeedGalleryObjectIvar(navigationController, "poppedViewControllers");
+    if (![popped respondsToSelector:@selector(count)]) return NO;
+    @try {
+        return ((NSUInteger (*)(id, SEL))objc_msgSend)(popped, @selector(count)) > 0;
+    } @catch (__unused NSException *exception) {
+        return NO;
+    }
+}
+
 @interface ApolloFeedGalleryScrollView : UIScrollView
 @end
 
@@ -270,6 +300,50 @@ static NSArray<NSDictionary *> *ApolloFeedGalleryItems(id albumNode) {
     // carousel drag. There is no reorder interaction to preserve here.
     (void)view;
     return YES;
+}
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
+    if (gestureRecognizer == self.panGestureRecognizer && sFeedGalleryEdgeSwipeNav) {
+        // The carousel owns a horizontal drag only while it still has a page
+        // to show in that direction. At the first/last page the drag could
+        // only rubber-band, so decline it: the failure requirements wired in
+        // didMoveToWindow then release Apollo's own back/forward navigation
+        // pans (ApolloNavigationController's left/right pan recognizers) to
+        // take over the same touch. Only decline when that navigation can
+        // actually act; otherwise keep the native bounce.
+        //
+        // Direction comes from the velocity SIGN alone: translationInView: is
+        // still zero at pan-hysteresis time, and any magnitude or axis-ratio
+        // gate here rejects slow or arced swipes (both measured during the
+        // PR #805 review).
+        UIPanGestureRecognizer *pan = (UIPanGestureRecognizer *)gestureRecognizer;
+        CGFloat velocityX = [pan velocityInView:self].x;
+        BOOL rightToLeft = self.effectiveUserInterfaceLayoutDirection ==
+            UIUserInterfaceLayoutDirectionRightToLeft;
+        CGFloat towardPrevious = rightToLeft ? -velocityX : velocityX;
+        CGFloat maximumOffset = self.contentSize.width - CGRectGetWidth(self.bounds);
+        if (maximumOffset > 0.5 && velocityX != 0.0) {
+            BOOL atFirstPage = rightToLeft ? (self.contentOffset.x >= maximumOffset - 0.5)
+                                           : (self.contentOffset.x <= 0.5);
+            BOOL atLastPage = rightToLeft ? (self.contentOffset.x <= 0.5)
+                                          : (self.contentOffset.x >= maximumOffset - 0.5);
+            BOOL wantsBack = atFirstPage && towardPrevious > 0.0;
+            BOOL wantsForward = atLastPage && towardPrevious < 0.0;
+            if (wantsBack || wantsForward) {
+                UINavigationController *navigationController =
+                    ApolloFeedGalleryAncestorNavigationController(self);
+                BOOL navigationCanAct = wantsBack
+                    ? navigationController.viewControllers.count > 1
+                    : ApolloFeedGalleryCanGoForward(navigationController);
+                if (navigationCanAct) {
+                    ApolloLog(@"[FeedGallery] handing %@ swipe to navigation (offset=%.0f)",
+                              wantsBack ? @"back" : @"forward", self.contentOffset.x);
+                    return NO;
+                }
+            }
+        }
+    }
+    return [super gestureRecognizerShouldBegin:gestureRecognizer];
 }
 
 - (void)didMoveToWindow {

--- a/src/ApolloFeedGalleryCarousel.xm
+++ b/src/ApolloFeedGalleryCarousel.xm
@@ -272,6 +272,12 @@ static UINavigationController *ApolloFeedGalleryAncestorNavigationController(UIV
     return nil;
 }
 
+// A drag that ends pulled at least this far past the first/last page commits
+// to navigation on release. UIScrollView rubber-banding roughly halves finger
+// travel in the overscroll region, so 16pt of offset is ~32pt of finger — a
+// deliberate pull, but far less than a page turn.
+static const CGFloat kApolloFeedGalleryReleaseHandOffOverscroll = 16.0;
+
 // ApolloNavigationController keeps the pages popped by swipe-back in a Swift
 // [UIViewController] ivar named poppedViewControllers; its goForward command
 // and right-side navigation pan re-push from it (RE: the class's ivar list and
@@ -332,9 +338,13 @@ static BOOL ApolloFeedGalleryCanGoForward(UINavigationController *navigationCont
             if (wantsBack || wantsForward) {
                 UINavigationController *navigationController =
                     ApolloFeedGalleryAncestorNavigationController(self);
-                BOOL navigationCanAct = wantsBack
+                // Never hand off while a transition is already running (the
+                // carousel can be asked again mid-pop as its screen animates
+                // away; a second decline would double-pop).
+                BOOL navigationCanAct = navigationController.transitionCoordinator == nil &&
+                    (wantsBack
                     ? navigationController.viewControllers.count > 1
-                    : ApolloFeedGalleryCanGoForward(navigationController);
+                    : ApolloFeedGalleryCanGoForward(navigationController));
                 if (navigationCanAct) {
                     ApolloLog(@"[FeedGallery] handing %@ swipe to navigation (offset=%.0f)",
                               wantsBack ? @"back" : @"forward", self.contentOffset.x);
@@ -403,6 +413,8 @@ static BOOL ApolloFeedGalleryCanGoForward(UINavigationController *navigationCont
 @property (nonatomic) BOOL contentIsObscured;
 @property (nonatomic) CGSize lastLayoutSize;
 @property (nonatomic) BOOL needsPageGeometry;
+@property (nonatomic) BOOL dragBeganAtLeadingEdge;
+@property (nonatomic) BOOL dragBeganAtTrailingEdge;
 - (void)configureWithItems:(NSArray<NSDictionary *> *)items
                  albumNode:(id)albumNode
                       nsfw:(BOOL)nsfw
@@ -759,6 +771,14 @@ static BOOL ApolloFeedGalleryCanGoForward(UINavigationController *navigationCont
     if (!scrollView.isDecelerating) [self apollo_loadNearIndex:index];
 }
 
+- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
+    if (scrollView != self.scrollView) return;
+    CGFloat maximumOffset = scrollView.contentSize.width - CGRectGetWidth(scrollView.bounds);
+    self.dragBeganAtLeadingEdge = maximumOffset > 0.5 && scrollView.contentOffset.x <= 0.5;
+    self.dragBeganAtTrailingEdge = maximumOffset > 0.5 &&
+        scrollView.contentOffset.x >= maximumOffset - 0.5;
+}
+
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
                      withVelocity:(CGPoint)velocity
               targetContentOffset:(inout CGPoint *)targetContentOffset {
@@ -768,8 +788,51 @@ static BOOL ApolloFeedGalleryCanGoForward(UINavigationController *navigationCont
     [self apollo_loadNearIndex:[self apollo_clampIndex:(NSInteger)llround(targetContentOffset->x / width)]];
 }
 
+// Deterministic companion to the begin-time handoff above: when that decline
+// misses (a real finger's velocity at pan-hysteresis can read as zero or
+// momentarily backwards, so the carousel takes the drag and rubber-bands),
+// releasing while still pulled past the first/last page commits to the same
+// navigation. Release-time state is unambiguous — no velocity guessing.
+- (void)apollo_navigateIfReleasedPastEdge:(UIScrollView *)scrollView {
+    if (!sFeedGalleryEdgeSwipeNav) return;
+    if (!self.dragBeganAtLeadingEdge && !self.dragBeganAtTrailingEdge) return;
+    CGFloat maximumOffset = scrollView.contentSize.width - CGRectGetWidth(scrollView.bounds);
+    if (maximumOffset <= 0.5) return;
+    CGFloat offset = scrollView.contentOffset.x;
+    BOOL pastLeading = self.dragBeganAtLeadingEdge &&
+        offset < -kApolloFeedGalleryReleaseHandOffOverscroll;
+    BOOL pastTrailing = self.dragBeganAtTrailingEdge &&
+        offset > maximumOffset + kApolloFeedGalleryReleaseHandOffOverscroll;
+    if (!pastLeading && !pastTrailing) return;
+
+    BOOL rightToLeft = self.effectiveUserInterfaceLayoutDirection ==
+        UIUserInterfaceLayoutDirectionRightToLeft;
+    BOOL wantsBack = rightToLeft ? pastTrailing : pastLeading;
+    UINavigationController *navigationController =
+        ApolloFeedGalleryAncestorNavigationController(self);
+    // A transition already in flight means an earlier gesture won this
+    // navigation; firing again would double-pop.
+    if (navigationController.transitionCoordinator) return;
+    if (wantsBack) {
+        if (navigationController.viewControllers.count <= 1) return;
+        ApolloLog(@"[FeedGallery] released past edge; navigating back (overscroll=%.0f)",
+                  pastLeading ? -offset : offset - maximumOffset);
+        [navigationController popViewControllerAnimated:YES];
+    } else {
+        if (!ApolloFeedGalleryCanGoForward(navigationController)) return;
+        if (![navigationController respondsToSelector:@selector(goForward)]) return;
+        ApolloLog(@"[FeedGallery] released past edge; navigating forward (overscroll=%.0f)",
+                  pastLeading ? -offset : offset - maximumOffset);
+        ((void (*)(id, SEL))objc_msgSend)(navigationController, @selector(goForward));
+    }
+}
+
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
-    if (scrollView == self.scrollView && !decelerate) [self apollo_finishPaging];
+    if (scrollView != self.scrollView) return;
+    [self apollo_navigateIfReleasedPastEdge:scrollView];
+    self.dragBeganAtLeadingEdge = NO;
+    self.dragBeganAtTrailingEdge = NO;
+    if (!decelerate) [self apollo_finishPaging];
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {

--- a/src/ApolloFeedGalleryCarousel.xm
+++ b/src/ApolloFeedGalleryCarousel.xm
@@ -278,6 +278,13 @@ static UINavigationController *ApolloFeedGalleryAncestorNavigationController(UIV
 // deliberate pull, but far less than a page turn.
 static const CGFloat kApolloFeedGalleryReleaseHandOffOverscroll = 16.0;
 
+// The begin-time hand-off only acts on an unambiguous velocity: below this
+// floor the hysteresis reading is jitter, and a wrong-sign blip would hand
+// the touch away and navigate — the one failure mode worse than a bounce.
+// Marginal drags simply fall through to the release-past-edge path, which
+// decides from release position and needs no velocity at all.
+static const CGFloat kApolloFeedGalleryHandOffMinimumVelocity = 150.0;
+
 // ApolloNavigationController keeps the pages popped by swipe-back in a Swift
 // [UIViewController] ivar named poppedViewControllers; its goForward command
 // and right-side navigation pan re-push from it (RE: the class's ivar list and
@@ -318,23 +325,29 @@ static BOOL ApolloFeedGalleryCanGoForward(UINavigationController *navigationCont
         // take over the same touch. Only decline when that navigation can
         // actually act; otherwise keep the native bounce.
         //
-        // Direction comes from the velocity SIGN alone: translationInView: is
-        // still zero at pan-hysteresis time, and any magnitude or axis-ratio
-        // gate here rejects slow or arced swipes (both measured during the
-        // PR #805 review).
+        // Direction comes from the velocity sign (translationInView: is still
+        // zero at pan-hysteresis time), taken only above a magnitude floor:
+        // hysteresis velocity can read as zero or momentarily backwards for
+        // real fingers, and a false hand-off navigates the user away, which
+        // is worse than a bounce. Anything below the floor falls through to
+        // the deterministic release-past-edge path in the scroll delegate.
         UIPanGestureRecognizer *pan = (UIPanGestureRecognizer *)gestureRecognizer;
         CGFloat velocityX = [pan velocityInView:self].x;
-        BOOL rightToLeft = self.effectiveUserInterfaceLayoutDirection ==
-            UIUserInterfaceLayoutDirectionRightToLeft;
-        CGFloat towardPrevious = rightToLeft ? -velocityX : velocityX;
         CGFloat maximumOffset = self.contentSize.width - CGRectGetWidth(self.bounds);
-        if (maximumOffset > 0.5 && velocityX != 0.0) {
-            BOOL atFirstPage = rightToLeft ? (self.contentOffset.x >= maximumOffset - 0.5)
-                                           : (self.contentOffset.x <= 0.5);
-            BOOL atLastPage = rightToLeft ? (self.contentOffset.x <= 0.5)
-                                          : (self.contentOffset.x >= maximumOffset - 0.5);
-            BOOL wantsBack = atFirstPage && towardPrevious > 0.0;
-            BOOL wantsForward = atLastPage && towardPrevious < 0.0;
+        if (maximumOffset > 0.5 &&
+            fabs(velocityX) >= kApolloFeedGalleryHandOffMinimumVelocity) {
+            // Pages are laid out left-to-right in every locale (see
+            // layoutSubviews), so the first image sits at offset 0 even under
+            // RTL. Only the NAVIGATION meaning of pulling past an edge
+            // mirrors with the layout direction, not the edges themselves.
+            BOOL atFirstPage = self.contentOffset.x <= 0.5;
+            BOOL atLastPage = self.contentOffset.x >= maximumOffset - 0.5;
+            BOOL pullingPastLeading = atFirstPage && velocityX > 0.0;
+            BOOL pullingPastTrailing = atLastPage && velocityX < 0.0;
+            BOOL rightToLeft = self.effectiveUserInterfaceLayoutDirection ==
+                UIUserInterfaceLayoutDirectionRightToLeft;
+            BOOL wantsBack = rightToLeft ? pullingPastTrailing : pullingPastLeading;
+            BOOL wantsForward = rightToLeft ? pullingPastLeading : pullingPastTrailing;
             if (wantsBack || wantsForward) {
                 UINavigationController *navigationController =
                     ApolloFeedGalleryAncestorNavigationController(self);

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -23,6 +23,9 @@ extern BOOL sShowRecentlyReadThumbnails;
 extern BOOL sFeedTextPostThumbnails;
 // Default-on large-feed carousel for Reddit-native multi-image galleries.
 extern BOOL sFeedGalleryCarousel;
+// Default-on: at the carousel's first/last image, swiping past the edge hands
+// the drag to Apollo's swipe-back/forward navigation instead of rubber-banding.
+extern BOOL sFeedGalleryEdgeSwipeNav;
 // Default-on fullscreen-media comments pane, opened by upward flick or button.
 extern BOOL sSwipeUpForComments;
 extern NSInteger sPreferredGIFFallbackFormat;

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -18,6 +18,7 @@ BOOL sPassiveDeletedComments = NO;
 BOOL sShowRecentlyReadThumbnails = YES;
 BOOL sFeedTextPostThumbnails = YES;
 BOOL sFeedGalleryCarousel = YES;
+BOOL sFeedGalleryEdgeSwipeNav = YES;
 BOOL sSwipeUpForComments = YES;
 NSInteger sPreferredGIFFallbackFormat = 1; // 0=GIF, 1=MP4
 

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -3420,6 +3420,7 @@ static BOOL ApolloDefaultsKeyChangesActiveAccount(NSString *key) {
                                     UDKeyShowRecentlyReadThumbnails: @YES,
                                     UDKeyFeedTextPostThumbnails: @YES,
                                     UDKeyFeedGalleryCarousel: @YES,
+                                    UDKeyFeedGalleryEdgeSwipeNav: @YES,
                                     UDKeySwipeUpForComments: @YES,
                                     UDKeySportsClipsInlineVideo: @YES,
                                     UDKeyPreferredGIFFallbackFormat: @1,
@@ -3541,6 +3542,7 @@ static BOOL ApolloDefaultsKeyChangesActiveAccount(NSString *key) {
     sShowRecentlyReadThumbnails = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowRecentlyReadThumbnails];
     sFeedTextPostThumbnails = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyFeedTextPostThumbnails];
     sFeedGalleryCarousel = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyFeedGalleryCarousel];
+    sFeedGalleryEdgeSwipeNav = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyFeedGalleryEdgeSwipeNav];
     sSwipeUpForComments = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeySwipeUpForComments];
     sPreferredGIFFallbackFormat = ([[NSUserDefaults standardUserDefaults] integerForKey:UDKeyPreferredGIFFallbackFormat] == 0) ? 0 : 1;
     sReadPostMaxCount = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyReadPostMaxCount];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -501,6 +501,13 @@ static NSString *const UDKeyFeedGalleryCarousel = @"FeedGalleryCarousel";
 // already-measured feed cells swap presentation live; the carousel's
 // layoutSpecThatFits reads the flag on each measurement.
 static NSString *const ApolloFeedGalleryCarouselChangedNotification = @"ApolloFeedGalleryCarouselChangedNotification";
+// When the feed gallery carousel sits on its first (or last) image, continuing
+// to swipe toward the edge hands the drag to Apollo's swipe-back (or
+// swipe-forward) page navigation instead of rubber-banding, but only when a
+// previous (or forward) page actually exists. Default YES. Read live at
+// gesture time, so no change notification is needed (same reasoning as
+// UDKeySwipeUpForComments below). See ApolloFeedGalleryCarousel.xm.
+static NSString *const UDKeyFeedGalleryEdgeSwipeNav = @"FeedGalleryEdgeSwipeNavigation";
 // In the fullscreen viewer for post-backed images, galleries, GIFs, and video,
 // an upward vertical flick or comments-button tap opens a media-owned comments
 // pane. The normal downward flick still dismisses when the pane is closed.

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -1635,6 +1635,13 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
                                       isOn:^BOOL { return sFeedGalleryCarousel; }
                                   onToggle:^(UISwitch *sender) { [weakSelf feedGalleryCarouselSwitchToggled:sender]; }];
 
+    ApolloSettingsRow *edgeSwipeNav =
+        [ApolloSettingsRow switchRowWithID:@"media.feedGalleryEdgeSwipeNav"
+                                     title:@"Swipe Past Gallery to Navigate"
+                                      isOn:^BOOL { return sFeedGalleryEdgeSwipeNav; }
+                                  onToggle:^(UISwitch *sender) { [weakSelf feedGalleryEdgeSwipeNavSwitchToggled:sender]; }];
+    edgeSwipeNav.visible = ^BOOL { return sFeedGalleryCarousel; };
+
     ApolloSettingsRow *swipeComments =
         [ApolloSettingsRow switchRowWithID:@"media.swipeUpComments"
                                      title:@"Swipe Up for Comments"
@@ -1642,8 +1649,8 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
                                   onToggle:^(UISwitch *sender) { [weakSelf swipeUpCommentsSwitchToggled:sender]; }];
 
     return [ApolloSettingsSection sectionWithTitle:@"Browsing"
-                                            footer:@"Swipe through Reddit image galleries without leaving the feed. In the fullscreen media viewer, swipe upward or tap the comments button to open comments over the media."
-                                              rows:@[ feedGalleries, swipeComments ]];
+                                            footer:@"Swipe through Reddit image galleries without leaving the feed. With Swipe Past Gallery to Navigate, continuing to swipe at a gallery's first or last image goes back or forward to the previous page instead of bouncing. In the fullscreen media viewer, swipe upward or tap the comments button to open comments over the media."
+                                              rows:@[ feedGalleries, edgeSwipeNav, swipeComments ]];
 }
 
 - (ApolloSettingsSection *)buildMediaPlaybackSection {
@@ -3415,6 +3422,13 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
     sFeedGalleryCarousel = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sFeedGalleryCarousel forKey:UDKeyFeedGalleryCarousel];
     [[NSNotificationCenter defaultCenter] postNotificationName:ApolloFeedGalleryCarouselChangedNotification object:nil];
+    // The edge-swipe navigation row is only shown while the carousel is on.
+    [self visibilityDidChange];
+}
+
+- (void)feedGalleryEdgeSwipeNavSwitchToggled:(UISwitch *)sender {
+    sFeedGalleryEdgeSwipeNav = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sFeedGalleryEdgeSwipeNav forKey:UDKeyFeedGalleryEdgeSwipeNav];
 }
 
 - (void)swipeUpCommentsSwitchToggled:(UISwitch *)sender {


### PR DESCRIPTION
## What

With Swipe Through Feed Galleries on, the carousel owns every horizontal drag over it, so the full-width swipe-back/forward page gestures are dead over a gallery image — at the first/last image an edge swipe just pulls and snaps back. Now, when you're on the **first image** and keep swiping back, the drag becomes an ordinary **swipe-back** to the previous screen; on the **last image**, the mirrored swipe goes **forward** to the page you previously came back from.

The handoff only happens when the navigation can actually act — at the root of the stack, or with nothing to go forward to, the gallery keeps its native rubber-band. Mid-gallery paging, taps, and vertical feed scrolling are untouched.

Behind a new **Media > Browsing** toggle **"Swipe Past Gallery to Navigate"** (default on), shown while Swipe Through Feed Galleries is enabled. OFF restores today's behavior exactly.

## How

- `ApolloFeedGalleryScrollView` now implements `gestureRecognizerShouldBegin:`: at the leading/trailing content edge with the drag heading past it, the carousel declines its own pan; the `requireGestureRecognizerToFail:` wiring from `didMoveToWindow` then releases Apollo's own navigation pans (`ApolloNavigationController`'s left/right pan recognizers) to take over the same touch. Direction comes from the velocity sign only — `translationInView:` is still zero at pan-hysteresis time, and magnitude/axis gates were the PR #805 swipe-reliability bug.
- Forward availability reads `ApolloNavigationController`'s `poppedViewControllers` ivar (the stack its goForward/right pan re-pushes from, found via RE of the class's ivar/method lists). Every failure path (different nav class, missing ivar on a future Apollo, empty stack) degrades to "keep the bounce".
- Setting follows the standard recipe: `UDKeyFeedGalleryEdgeSwipeNav` + `sFeedGalleryEdgeSwipeNav`, registered default YES, read live at gesture time (no change notification needed), conditional form row via `.visible` + `visibilityDidChange`.

## Testing (sim matrix)

Verified on Apollo-Sim3, all three legs — glass + API-key (u/iChopPryde), glass + keyless (u/RemZeroBestGirl, `[WebJSON]` confirmed), and non-glass (vtool-downgraded shell, verified by legacy tab bar pixels):

- First image + swipe back → pops to the previous screen (log `handing back swipe to navigation (offset=0)`)
- Last image + swipe forward with a forward page available → goes forward (offsets 1608/804/786 across legs)
- Last image + swipe forward with **no** forward page → rubber-bands as before
- Mid-gallery paging both directions, page counter, tap-to-viewer, vertical feed scroll over the image — all unchanged
- Toggle OFF → both directions rubber-band again at the edges
- Turning Swipe Through Feed Galleries off hides the new row (and back on restores it, state kept)

Not device-tested yet.