### PR TITLE
Fix subreddit A–Z scrubbing on non-glass builds and black section-header bands

### DIFF
--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -78,6 +78,9 @@ static NSInteger sApolloFavoriteMutationOriginalLastRow = NSNotFound;
 @property (nonatomic, strong) UISelectionFeedbackGenerator *selectionFeedbackGenerator;
 @property (nonatomic) NSInteger activeIndex;
 @property (nonatomic) NSInteger lastScrolledIndex;
+// Ancestor gesture recognisers suspended for the duration of one scrub. See
+// -apollo_suspendConflictingAncestorRecognizers.
+@property (nonatomic, strong) NSArray<UIGestureRecognizer *> *suspendedRecognizers;
 - (void)apollo_applyThemeTintToLabels;
 - (void)apollo_scheduleDeferredThemeTintRefresh;
 - (void)updateWithTableView:(UITableView *)tableView titles:(NSArray<NSString *> *)titles;
@@ -955,8 +958,67 @@ static void ApolloSubredditIndexRemoveStarProxyFromCell(UITableViewCell *cell) {
     ApolloSubredditIndexScrollToTitle(self.tableView, self.titles[index], index);
 }
 
+// The overlay tracks the scrub with raw touches on a plain view, so any gesture
+// recogniser on an ANCESTOR view also sees those touches and, once it recognises,
+// cancels ours (cancelsTouchesInView defaults to YES). The offender is UIKit's
+// _UIBarPanGestureRecognizer — the nav controller's barHideOnSwipeGestureRecognizer,
+// armed by Apollo's "auto-hide bars while scrolling". A vertical drag on the A–Z
+// strip looks exactly like the swipe it wants, so it begins on the first movement
+// and kills the scrub: the user gets the letter they pressed and nothing after it.
+//
+// This is invisible under Liquid Glass because on an iOS-26-linked binary UIKit
+// collapses the bars through the scroll-edge/morph system instead of driving
+// hidesBarsOnSwipe, so that recogniser never leaves .possible — which is exactly
+// why the A–Z strip scrubs correctly on glass builds and dies on legacy ones.
+//
+// UIKit gives a view no way to veto an ancestor's recogniser, so suspend the
+// conflicting ones for the duration of the scrub and restore them the moment it
+// ends. Toggling `enabled` is the documented way to cancel a recogniser in flight,
+// the window is one touch sequence long, and suppressing bar-hiding *while the
+// user scrubs the index* is the correct behaviour anyway.
+- (void)apollo_suspendConflictingAncestorRecognizers {
+    if (self.suspendedRecognizers.count > 0) return;
+
+    NSMutableArray<UIGestureRecognizer *> *suspended = [NSMutableArray array];
+    UIViewController *owner = ApolloSubredditIndexOwningViewController(self.tableView ?: self);
+    UINavigationController *nav = owner.navigationController;
+
+    // Exact identification via public API, rather than matching a private class name.
+    UIGestureRecognizer *barGesture = nav.barHideOnSwipeGestureRecognizer;
+    if (barGesture.isEnabled) {
+        barGesture.enabled = NO;
+        [suspended addObject:barGesture];
+    }
+
+    self.suspendedRecognizers = suspended.count > 0 ? suspended : nil;
+    if (suspended.count > 0) {
+        ApolloLogDebug(@"[SubredditIndex] scrub suspended %lu ancestor recogniser(s)",
+                       (unsigned long)suspended.count);
+    }
+}
+
+- (void)apollo_restoreConflictingAncestorRecognizers {
+    for (UIGestureRecognizer *gesture in self.suspendedRecognizers) {
+        gesture.enabled = YES;
+    }
+    self.suspendedRecognizers = nil;
+}
+
+// Safety net: if the overlay leaves the hierarchy mid-scrub (tab switch, pop,
+// enhancement toggle) no touchesEnded/Cancelled arrives, so restore here too —
+// otherwise bar-hiding would stay off until the next scrub.
+- (void)willMoveToWindow:(UIWindow *)newWindow {
+    [super willMoveToWindow:newWindow];
+    if (!newWindow) [self apollo_restoreConflictingAncestorRecognizers];
+}
+
+- (void)dealloc {
+    [self apollo_restoreConflictingAncestorRecognizers];
+}
+
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     UITouch *touch = touches.anyObject;
+    [self apollo_suspendConflictingAncestorRecognizers];
     [self.selectionFeedbackGenerator prepare];
     if (touch) [self handleTouch:touch];
 }
@@ -967,12 +1029,14 @@ static void ApolloSubredditIndexRemoveStarProxyFromCell(UITableViewCell *cell) {
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    [self apollo_restoreConflictingAncestorRecognizers];
     self.activeIndex = NSNotFound;
     self.lastScrolledIndex = NSNotFound;
     [self applyMagnificationForIndex:NSNotFound animated:YES];
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    [self apollo_restoreConflictingAncestorRecognizers];
     self.activeIndex = NSNotFound;
     self.lastScrolledIndex = NSNotFound;
     [self applyMagnificationForIndex:NSNotFound animated:YES];

--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -27,6 +27,10 @@ static char kApolloSubredditSelectionTableKey;
 static char kApolloSubredditHeaderSeparatorKey;
 static char kApolloSubredditHeaderGradientLayerKey;
 static char kApolloSubredditHeaderLoggedKey;
+// Last background colour a real visible cell gave us for this table. Lets a header
+// styled while the table has no attached cells reuse the row colour instead of
+// falling through to the table's (darker) own background.
+static char kApolloSubredditRowSurfaceColorKey;
 // Section index this header is currently displayed for (stamped in willDisplayHeaderView)
 // plus the last pinned verdict, so the setFrame: hook only repaints on transitions.
 static char kApolloSubredditHeaderSectionKey;
@@ -131,6 +135,33 @@ static UIColor *ApolloSubredditIndexThemeListBackgroundColor(UITableView *tableV
     for (UITableViewCell *cell in tableView.visibleCells) {
         if (cell.contentView.backgroundColor) [candidates addObject:cell.contentView.backgroundColor];
         if (cell.backgroundColor) [candidates addObject:cell.backgroundColor];
+    }
+
+    // A row colour is the ONLY correct answer for a resting header: in most themes the
+    // table's own background is deliberately darker than the cells, so falling through
+    // to it paints a near-black band instead of a header that blends into the rows.
+    //
+    // UIKit re-lays out headers at moments when the table has no attached cells yet —
+    // during a fast fling, and right after reloadData — and this ran with
+    // visibleCells.count == 0, so every candidate above was missing and the chain fell
+    // through to tableView.backgroundColor. The wrong colour is opaque, so it isn't
+    // corrected by a later repaint, and it sticks until that header is restyled: the
+    // "black section header bands that show up now and then while scrolling".
+    //
+    // Remember the last colour a real cell gave us and reuse it when the table can't
+    // answer. Only used when there are no visible cells at all — if cells exist and
+    // are genuinely clear, the original fallback chain still applies, and the next
+    // pass with cells attached refreshes the cache (so a theme change re-derives).
+    for (UIColor *color in candidates) {
+        if (ApolloSubredditIndexColorIsVisible(color)) {
+            objc_setAssociatedObject(tableView, &kApolloSubredditRowSurfaceColorKey, color,
+                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            return color;
+        }
+    }
+    if (tableView.visibleCells.count == 0) {
+        UIColor *remembered = objc_getAssociatedObject(tableView, &kApolloSubredditRowSurfaceColorKey);
+        if (ApolloSubredditIndexColorIsVisible(remembered)) return remembered;
     }
 
     if (fallbackView.superview.backgroundColor) [candidates addObject:fallbackView.superview.backgroundColor];


### PR DESCRIPTION
Two independent Subreddits-list bugs, both found while investigating the first one.

---

## 1. A–Z scrubbing dies mid-drag on non-Liquid-Glass builds

Press-and-drag on the A–Z strip only ever jumped to the letter you first pressed, then went dead for the rest of the drag — you had to lift and re-press for every single letter. Glass builds scrub fine, which is what made it look cosmetic rather than a real input bug.

### Root cause

The custom A–Z overlay tracks the scrub with raw `touchesBegan/Moved` on a plain `UIView`. Gesture recognisers on **ancestor** views also see those touches, and once one recognises it cancels ours (`cancelsTouchesInView` defaults to `YES`).

The offender is UIKit's `_UIBarPanGestureRecognizer` — the nav controller's `barHideOnSwipeGestureRecognizer`, armed by Apollo's "hide bars on scroll". `-[UINavigationController setHidesBarsOnSwipe:]` attaches it to the **navigation controller's own view**, an ancestor of both the table and our overlay. A vertical drag on the strip is exactly the swipe it wants, so it begins on the first movement and cancels our touch sequence.

From the device log, non-glass, one drag:

```
AZTOUCH began n=1
selected title=★ section=1
AZTOUCH CANCELLED
AZGR active=_UIBarPanGestureRecognizer state=1 onView=UILayoutContainerView enabled=1
```

versus the same drag on glass:

```
began → moved ×7 → ★ A E J O T Y → ended
```

**Why glass is immune — this is our own doing, not a UIKit quirk:** in `ApolloAutoHideTabBar.xm` the `setHidesBarsOnSwipe:` hook takes the `ApolloSupportsNativeTabBarMinimize()` branch under Liquid Glass and calls `%orig(NO)`, hijacking the toggle into the tab bar's native `tabBarMinimizeBehavior`. With `hidesBarsOnSwipe` forced off, UIKit removes `__barSwipeHideGesture` from the nav controller's view entirely, so there is no ancestor recogniser to arbitrate against. The legacy branch passes Apollo's value straight through, so the recogniser stays attached and only legacy builds break.

It therefore only bites users who have hide-bars-on-scroll enabled. The native (non-enhanced) index was never affected — UIKit resolves this conflict internally for its own `UITableViewIndex`, which is why classic mode always worked and made this look like a styling problem.

### Fix

UIKit gives a view no way to veto an ancestor's recogniser, so the overlay suspends the conflicting one for the duration of a scrub and restores it the moment the touch ends, is cancelled, or the overlay leaves the window (plus a `dealloc` backstop, so bar-hiding can't get stranded off if the screen goes away mid-drag).

- Toggling `enabled` is the documented way to cancel a recogniser in flight, and the window is a single touch sequence.
- Not hiding the bars *while the user is scrubbing the index* is the correct behaviour anyway.
- Found via the public `barHideOnSwipeGestureRecognizer` property, not by matching the private class name.

---

## 2. Black bands behind section headers while scrolling

Section headers intermittently rendered as near-black bands instead of blending into the rows — most visible while flinging, usually several at once, and once wrong a header stayed wrong until something restyled it.

### Root cause

Resting modern headers take an opaque surface colour derived from the rows, so they fill the gap a transparent header would leave over the table's own background (#450). That colour is read from `tableView.visibleCells`.

UIKit re-lays out headers at moments when the table has **no attached cells** — during a fast fling, and right after `reloadData`. With `visibleCells` empty every cell candidate is missing, so the chain falls through to `tableView.backgroundColor`, which in most themes is deliberately darker than the cells. That's the black band, and being fully opaque nothing repaints over it.

A colour trace on the failing path, same header, two passes:

```
visCells=15  surfaceVisible=1  surface=(0.118, 0.051, 0.251)   <- row purple, correct
visCells=0   surfaceVisible=1  surface=(0.051, 0.016, 0.125)   <- table background, the black band
```

Both report `surfaceVisible=1`, so this was never a transparency problem — just the wrong opaque colour chosen when the table couldn't answer.

### Fix

Remember the last colour a real cell produced for that table and reuse it when the table can't answer. Deliberately narrow: it only applies when there are **no visible cells at all**, so a genuinely clear cell still follows the original chain, and any pass with cells refreshes the cache (a theme change re-derives on its own).

---

## Testing

Simulator, iOS 26.5, dark mode, signed-in account, glass and non-glass side by side.

A–Z scrubbing — reproduced before, fixed after:

| | non-glass before | non-glass after | glass after |
|---|---|---|---|
| Enhancements on + Modern Dividers on | 1 letter, then cancelled | full scrub, both directions | full scrub |
| Enhancements on + Modern Dividers off | 1 letter, then cancelled | full scrub | full scrub |
| Enhancements off (native index) | already worked | still works | still works |
| Enhancements on + Hide Feed Descriptions on | — | full scrub | — |

Header bands:
- Reproduced on current `main` first (black FAVORITES / MULTIREDDITS / A / B bands) with a repeatable hard fling up then down, to confirm it predates this branch. It does.
- After the change the same sequence produces no bands, through repeated stress passes, on both glass and non-glass.

Also confirmed nav bar + tab bar auto-hide on ordinary list scrolling still works after the gesture change — which is also what proves the recogniser was armed in the first place.

Both changes are confined to the subreddit list's own view code, so they're independent of API-key vs keyless mode. Device testing still pending.

Supersedes #937.