### PR TITLE
Fix black bands behind subreddit section headers while scrolling

### DIFF
--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -27,6 +27,10 @@ static char kApolloSubredditSelectionTableKey;
 static char kApolloSubredditHeaderSeparatorKey;
 static char kApolloSubredditHeaderGradientLayerKey;
 static char kApolloSubredditHeaderLoggedKey;
+// Last background colour a real visible cell gave us for this table. Lets a header
+// styled while the table has no attached cells reuse the row colour instead of
+// falling through to the table's (darker) own background.
+static char kApolloSubredditRowSurfaceColorKey;
 // Section index this header is currently displayed for (stamped in willDisplayHeaderView)
 // plus the last pinned verdict, so the setFrame: hook only repaints on transitions.
 static char kApolloSubredditHeaderSectionKey;
@@ -128,6 +132,33 @@ static UIColor *ApolloSubredditIndexThemeListBackgroundColor(UITableView *tableV
     for (UITableViewCell *cell in tableView.visibleCells) {
         if (cell.contentView.backgroundColor) [candidates addObject:cell.contentView.backgroundColor];
         if (cell.backgroundColor) [candidates addObject:cell.backgroundColor];
+    }
+
+    // A row colour is the ONLY correct answer for a resting header: in most themes the
+    // table's own background is deliberately darker than the cells, so falling through
+    // to it paints a near-black band instead of a header that blends into the rows.
+    //
+    // UIKit re-lays out headers at moments when the table has no attached cells yet —
+    // during a fast fling, and right after reloadData — and this ran with
+    // visibleCells.count == 0, so every candidate above was missing and the chain fell
+    // through to tableView.backgroundColor. The wrong colour is opaque, so it isn't
+    // corrected by a later repaint, and it sticks until that header is restyled: the
+    // "black section header bands that show up now and then while scrolling".
+    //
+    // Remember the last colour a real cell gave us and reuse it when the table can't
+    // answer. Only used when there are no visible cells at all — if cells exist and
+    // are genuinely clear, the original fallback chain still applies, and the next
+    // pass with cells attached refreshes the cache (so a theme change re-derives).
+    for (UIColor *color in candidates) {
+        if (ApolloSubredditIndexColorIsVisible(color)) {
+            objc_setAssociatedObject(tableView, &kApolloSubredditRowSurfaceColorKey, color,
+                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            return color;
+        }
+    }
+    if (tableView.visibleCells.count == 0) {
+        UIColor *remembered = objc_getAssociatedObject(tableView, &kApolloSubredditRowSurfaceColorKey);
+        if (ApolloSubredditIndexColorIsVisible(remembered)) return remembered;
     }
 
     if (fallbackView.superview.backgroundColor) [candidates addObject:fallbackView.superview.backgroundColor];


### PR DESCRIPTION
Section headers on the Subreddits list intermittently render as near-black bands instead of blending into the rows. Most visible while flinging the list, and usually several headers at once — and once a header comes out wrong it stays wrong until something restyles it.

### Root cause

Resting modern headers take an opaque surface colour derived from the rows, so they fill the gap a transparent header would otherwise leave over the table's own background (#450). That colour comes from `tableView.visibleCells`.

UIKit re-lays out headers at moments when the table has **no attached cells** — during a fast fling, and right after `reloadData`. With `visibleCells` empty, every cell candidate is missing and the chain falls through to `tableView.backgroundColor`, which in most themes is deliberately darker than the cells. That's the black band. The wrong colour is fully opaque, so nothing repaints over it afterwards.

A colour trace on the failing path, same header, two passes:

```
visCells=15  surfaceVisible=1  surface=(0.118, 0.051, 0.251)   <- row purple, correct
visCells=0   surfaceVisible=1  surface=(0.051, 0.016, 0.125)   <- table background, the black band
```

Both report `surfaceVisible=1`, so this was never a transparency / showing-through problem — it's simply the wrong opaque colour being chosen when the table couldn't answer.

### Fix

Remember the last colour a real cell produced for that table and reuse it when the table can't answer. Deliberately narrow:

- Only applies when there are **no visible cells at all**. If cells exist and are genuinely clear, the original fallback chain is untouched.
- The cache refreshes on every pass that does have cells, so a theme change re-derives on its own.

### Testing

Simulator, iOS 26.5, dark mode, signed-in account.

- Reproduced on current `main` first (black FAVORITES / MULTIREDDITS / A / B bands) with a repeatable rapid up-then-down fling, to confirm it wasn't something local.
- After the change, the same fling sequence no longer produces black bands, through repeated stress passes.
- Checked both non-glass and Liquid Glass — headers correct in both (glass keeps its intended transparent-over-blur look).
- A–Z index scrubbing still works, so the header restyle path isn't disturbed.

Device testing still pending.

Independent of #936 (same file, different function) — either can merge first.