### PR TITLE
Keep live interactive posts in the feed instead of folding them into Community Highlights

### DIFF
--- a/src/ApolloDevvitPosts.h
+++ b/src/ApolloDevvitPosts.h
@@ -1,0 +1,35 @@
+// ApolloDevvitPosts.h — detection surface shared with Community Highlights.
+//
+// A Devvit ("Developer Platform") custom post — a live match thread, a game,
+// a bracket — is only identifiable by the old-Reddit fallback text Reddit puts
+// in its selftext; there is no dedicated field anywhere in the classic JSON
+// API. Two consumers need that test, from two different data sources:
+//
+//   • ApolloDevvitPosts.xm itself, from an RDKLink (feed + comments hooks)
+//   • ApolloSubredditHighlights.xm, from a raw t3 `data` dict (the highlights
+//     REST/`api/info` fetches), so a PINNED interactive post can be left in
+//     the feed — where its live widget renders — instead of being swallowed
+//     by the Community Highlights carousel as a static card.
+//
+// Both go through the one predicate here so the two modules can never drift.
+
+#import <Foundation/Foundation.h>
+
+// Posted when either Devvit toggle changes, so Community Highlights can
+// re-decide which pinned posts the feed owns (see ApolloDevvitFeedOwns*).
+extern NSString *const ApolloDevvitFeedOwnershipChangedNotification;
+
+// The raw marker test: YES when `selfText` is Reddit's old-Reddit fallback body
+// for a custom post. Feature-flag agnostic — callers apply their own gate.
+BOOL ApolloDevvitSelfTextIsInteractive(NSString *selfText);
+
+// Same test against a t3 post's `data` dictionary (JSON API shape).
+BOOL ApolloDevvitPostDataIsInteractive(NSDictionary *postData);
+
+// YES while interactive posts render as their real live widget in FEED cards —
+// i.e. the feed, not a highlights card, is the right owner for such a post.
+BOOL ApolloDevvitFeedOwnsInteractivePosts(void);
+
+// ApolloDevvitFeedOwnsInteractivePosts() && `link` (an RDKLink) is one of them.
+// Safe to call from Texture's background layout queue.
+BOOL ApolloDevvitFeedOwnsLink(id link);

--- a/src/ApolloDevvitPosts.xm
+++ b/src/ApolloDevvitPosts.xm
@@ -64,25 +64,74 @@
 #import "ApolloTextureDecls.h"
 #import "ApolloWebSessionStore.h"
 #import "ApolloDirectChatWeb.h"
+#import "ApolloDevvitPosts.h"
 
 static void ApolloDevvitHeightDidChangeForFullName(NSString *fullName);
+
+NSString *const ApolloDevvitFeedOwnershipChangedNotification = @"ApolloDevvitFeedOwnershipChangedNotification";
 
 #pragma mark - Detection
 
 // A devvit custom post is detectable ONLY by its old-Reddit fallback body
-// (there is no dedicated field anywhere in the classic JSON). Both markers
-// must be present so an ordinary post QUOTING the fallback text is unlikely
-// to false-positive.
+// (there is no dedicated field anywhere in the classic JSON):
+//
+//   This post contains content not supported on old Reddit.
+//   [Click here to view the full post](https://sh.reddit.com/r/<sub>/comments/<id>)
+//
+// Both markers must be present AND ADJACENT. Proximity (not a length cap) is
+// what keeps a post that merely QUOTES the fallback from matching, and unlike a
+// cap it survives a rich fallback body: an app may put a full markdown post
+// ABOVE the fallback block, and r/soccer's daily discussion does exactly that —
+// 5.2KB of rules with the fallback appended at the end (markers 72 chars apart).
+// The old 4096-char cap silently failed there in COMMENTS while the shorter
+// listing copy still matched in the feed, so the widget appeared in the feed and
+// not in the thread. The bound that remains is Reddit's own selftext ceiling.
+// Exported (via ApolloDevvitPosts.h) so Community Highlights applies the exact
+// same test to its raw JSON.
+static const NSUInteger kApolloDevvitMarkerWindow = 300;
+
+BOOL ApolloDevvitSelfTextIsInteractive(NSString *body) {
+    if (body.length < 40 || body.length > 40000) return NO;
+    NSRange fallback = [body rangeOfString:@"not supported on old Reddit"
+                                   options:NSCaseInsensitiveSearch];
+    if (fallback.location == NSNotFound) return NO;
+    NSUInteger from = fallback.location > kApolloDevvitMarkerWindow
+                    ? fallback.location - kApolloDevvitMarkerWindow : 0;
+    NSUInteger to = MIN(body.length, NSMaxRange(fallback) + kApolloDevvitMarkerWindow);
+    return [body rangeOfString:@"sh.reddit.com/r/"
+                       options:0
+                         range:NSMakeRange(from, to - from)].location != NSNotFound;
+}
+
+BOOL ApolloDevvitPostDataIsInteractive(NSDictionary *postData) {
+    if (![postData isKindOfClass:[NSDictionary class]]) return NO;
+    id isSelf = postData[@"is_self"];
+    if (![isSelf respondsToSelector:@selector(boolValue)] || ![isSelf boolValue]) return NO;
+    id body = postData[@"selftext"];
+    return [body isKindOfClass:[NSString class]] && ApolloDevvitSelfTextIsInteractive(body);
+}
+
 static BOOL ApolloDevvitLinkIsInteractive(RDKLink *link) {
     if (!sDevvitInteractivePosts || !link) return NO;
     @try {
         if (![link isSelfPost]) return NO;
-        NSString *body = link.selfText;
-        if (body.length < 40 || body.length > 4096) return NO;
-        if (![body containsString:@"sh.reddit.com/r/"]) return NO;
-        return [body rangeOfString:@"not supported on old Reddit"
-                           options:NSCaseInsensitiveSearch].location != NSNotFound;
+        return ApolloDevvitSelfTextIsInteractive(link.selfText);
     } @catch (__unused id e) { return NO; }
+}
+
+// A pinned interactive post can live in EITHER the feed (as its live widget)
+// or the Community Highlights carousel (as a static card) — never usefully in
+// both. The feed wins whenever the widget is actually rendered there, which is
+// exactly the "Show in Feed" sub-toggle: the widget is the richer surface, and
+// duplicating the post as a card right above itself just wastes a row. With
+// feed widgets off, the inline post would be nothing but Reddit's fallback
+// text, so the carousel keeps owning it (unchanged pre-existing behavior).
+BOOL ApolloDevvitFeedOwnsInteractivePosts(void) {
+    return sDevvitInteractivePosts && sDevvitFeedWidgets;
+}
+
+BOOL ApolloDevvitFeedOwnsLink(id link) {
+    return ApolloDevvitFeedOwnsInteractivePosts() && ApolloDevvitLinkIsInteractive((RDKLink *)link);
 }
 
 // RDKLink.permalink is NSString on some paths and a relative NSURL on others

--- a/src/ApolloDevvitPosts.xm
+++ b/src/ApolloDevvitPosts.xm
@@ -748,6 +748,30 @@ static const NSUInteger kApolloDevvitMaxLiveWidgets = 4;
 
 #pragma mark Navigation confinement
 
+// A devvit app navigates its host page by post FULLNAME, not by the bare id
+// reddit's own permalinks use: finishing a Pixelary drawing sends the page to
+//   /r/Pixelary/comments/t3_1vp57ul
+// where a real permalink reads /r/Pixelary/comments/1vp57ul[/slug]. Apollo
+// resolves that literally, opens a post id that cannot exist, and the user is
+// left on "Error loading comments" over an endless spinner with the game gone —
+// right after posting, the worst possible moment. Strip the `t3_` so the post
+// they just made actually opens. Returns nil when there is nothing to change.
+static NSURL *ApolloDevvitNormalizedPermalink(NSURL *url) {
+    NSURLComponents *comps = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+    if (!comps) return nil;
+    NSMutableArray<NSString *> *parts = [(url.pathComponents ?: @[]) mutableCopy];
+    NSUInteger commentsIdx = [parts indexOfObject:@"comments"];
+    if (commentsIdx == NSNotFound || commentsIdx + 1 >= parts.count) return nil;
+    NSString *postID = parts[commentsIdx + 1];
+    if (![postID hasPrefix:@"t3_"] || postID.length <= 3) return nil;
+    parts[commentsIdx + 1] = [postID substringFromIndex:3];
+    // pathComponents keeps a leading "/" element; joining would double it.
+    if (parts.count && [parts.firstObject isEqualToString:@"/"]) [parts removeObjectAtIndex:0];
+    comps.path = [@"/" stringByAppendingString:[parts componentsJoinedByString:@"/"]];
+    ApolloLog(@"[Devvit] rewrote fullname permalink → %@", comps.path);
+    return comps.URL;
+}
+
 // The embed shows exactly one post. Any main-frame link activation gets
 // routed to Apollo's own browser/scheme handling instead — both to keep the
 // crop coherent and so third-party pages never inherit the seeded reddit
@@ -786,7 +810,18 @@ static const NSUInteger kApolloDevvitMaxLiveWidgets = 4;
 
 - (void)routeExternally:(NSURL *)url {
     if (!url) return;
-    ApolloLog(@"[Devvit] routing external URL out of widget: %@://%@", url.scheme, url.host);
+    NSString *host = url.host.lowercaseString;
+    BOOL redditHost = host && ([host isEqualToString:@"reddit.com"] || [host hasSuffix:@".reddit.com"]);
+    NSString *path = url.path ?: @"";
+    // Log the PATH for reddit (it is the same class of identifier as the t3
+    // fullnames this module already logs, and without it a misrouted navigation
+    // is undiagnosable); host only for anywhere else.
+    if (redditHost) {
+        ApolloLog(@"[Devvit] routing reddit URL out of widget: %@", path.length ? path : @"(no path)");
+    } else {
+        ApolloLog(@"[Devvit] routing external URL out of widget: %@://%@", url.scheme, host);
+    }
+    if (redditHost) url = ApolloDevvitNormalizedPermalink(url) ?: url;
     NSURL *apolloURL = ApolloURLByConvertingResolvedURLToApolloScheme(url);
     if (apolloURL && ApolloRouteResolvedURLViaApolloScheme(apolloURL)) return;
     UIResponder *responder = self;

--- a/src/ApolloDevvitPosts.xm
+++ b/src/ApolloDevvitPosts.xm
@@ -478,6 +478,14 @@ static WKWebsiteDataStore *ApolloDevvitDataStoreForIdentity(NSString *identity, 
 @property (nonatomic) BOOL feedContext;
 // Post-reveal row-height corrections already spent (hard-capped).
 @property (nonatomic) NSInteger heightCorrections;
+// Candidate post-reveal height awaiting a quick confirm probe; a correction
+// only commits once the same value is seen twice, so a mid-animation or
+// mid-load reading can never become the cell height (or burn budget).
+@property (nonatomic) CGFloat pendingProbeHeight;
+// Budget exhausted: stop measuring until the next explicit tap re-arms it —
+// without the flag, a frozen-but-moved widget would re-confirm its unappliable
+// height on every probe forever at the confirm cadence.
+@property (nonatomic) BOOL heightFrozen;
 // Bumps every time a measured height lands; consumer re-queries the registry.
 @property (nonatomic, copy) void (^onMeasuredHeight)(NSString *fullName, CGFloat height);
 @end
@@ -594,6 +602,16 @@ static const NSUInteger kApolloDevvitMaxLiveWidgets = 4;
 
 - (void)apolloDevvitTapPoke:(UITapGestureRecognizer *)gesture {
     if (!self.revealed || !self.webView) return;
+    // An explicit tap re-arms the correction budget. The budget exists to stop
+    // a widget that resizes ITSELF forever from re-measuring the table
+    // indefinitely — but expand/collapse taps are the user asking for resizes,
+    // and configureForPermalink's same-post early return means the budget never
+    // refilled across cycles on one post: a session of playing with the same
+    // match thread drained all 12 and froze the height (device-reported).
+    // Taps are self-limiting, so a fresh budget per tap keeps both properties.
+    self.heightCorrections = 0;
+    self.heightFrozen = NO;
+    self.pendingProbeHeight = 0.0;
     // Start a fresh brisk poll loop timed for the page's expand/collapse
     // animation to have finished; bumping the generation orphans whatever idle
     // tick was pending, so loops never double up. handleProbeResult then keeps
@@ -621,6 +639,8 @@ static const NSUInteger kApolloDevvitMaxLiveWidgets = 4;
     self.failed = NO;
     self.autoRetried = NO;
     self.heightCorrections = 0;  // fresh correction budget per post
+    self.heightFrozen = NO;
+    self.pendingProbeHeight = 0.0;
     self.coverView.alpha = 1.0;
     [self.spinner startAnimating];
     self.statusLabel.text = @"Loading interactive post…";
@@ -705,6 +725,8 @@ static const NSUInteger kApolloDevvitMaxLiveWidgets = 4;
     NSInteger gen = ++self.pollGeneration;
     self.stableSamples = 0;
     self.lastProbeHeight = 0;
+    self.pendingProbeHeight = 0.0;
+    self.heightFrozen = NO;
     [self pollAfter:0.5 attempt:0 generation:gen];
 }
 
@@ -808,16 +830,38 @@ static const NSUInteger kApolloDevvitMaxLiveWidgets = 4;
     // a few times, which the old 3 could not.
     CGFloat hysteresis = (self.heightCorrections == 0) ? 8.0 : 24.0;
     BOOL changed = NO;
-    if (found && h >= kApolloDevvitMinHeight && fabs(h - self.lastProbeHeight) > hysteresis &&
-        self.heightCorrections < kApolloDevvitMaxHeightCorrections) {
-        self.heightCorrections += 1;
-        self.lastProbeHeight = h;
-        changed = YES;
-        ApolloLog(@"[Devvit] %@ height corrected to %.0fpt (%ld/%ld)", self.fullName, h,
-                  (long)self.heightCorrections, (long)kApolloDevvitMaxHeightCorrections);
-        if (ApolloDevvitStoreHeight(self.fullName, h) && self.onMeasuredHeight) {
-            self.onMeasuredHeight(self.fullName, h);
+    if (!self.heightFrozen && found && h >= kApolloDevvitMinHeight &&
+        fabs(h - self.lastProbeHeight) > hysteresis) {
+        if (self.pendingProbeHeight > 0.0 && fabs(h - self.pendingProbeHeight) <= 2.0) {
+            // Seen twice → this is a settled height, not a frame of the
+            // expand/collapse animation or a half-loaded expanded shell.
+            // (Committing first sightings was how a device ended up frozen at
+            // ~220pt: the mid-load value both became the cell height AND spent
+            // the budget's last correction.)
+            self.pendingProbeHeight = 0.0;
+            if (self.heightCorrections >= kApolloDevvitMaxHeightCorrections) {
+                self.heightFrozen = YES;
+                ApolloLog(@"[Devvit] %@ correction budget exhausted — frozen until the next tap", self.fullName);
+            } else {
+                self.heightCorrections += 1;
+                self.lastProbeHeight = h;
+                changed = YES;
+                ApolloLog(@"[Devvit] %@ height corrected to %.0fpt (%ld/%ld)", self.fullName, h,
+                          (long)self.heightCorrections, (long)kApolloDevvitMaxHeightCorrections);
+                if (ApolloDevvitStoreHeight(self.fullName, h) && self.onMeasuredHeight) {
+                    self.onMeasuredHeight(self.fullName, h);
+                }
+            }
+        } else {
+            // First sighting of a new height — confirm on a quick follow-up
+            // instead of the normal cadence, so a real change still commits
+            // well under a second after the tap.
+            self.pendingProbeHeight = h;
+            [self pollAfter:0.3 attempt:0 generation:gen];
+            return;
         }
+    } else {
+        self.pendingProbeHeight = 0.0;
     }
     // `attempt` counts consecutive still polls here; a change restarts the
     // brisk window so an expand → settle → collapse sequence stays responsive.

--- a/src/ApolloDevvitPosts.xm
+++ b/src/ApolloDevvitPosts.xm
@@ -158,20 +158,38 @@ static NSString *ApolloDevvitFullName(RDKLink *link) {
 
 #pragma mark - Measured height registry
 
-// fullName -> measured widget height. 512 (devvit "tall", what match threads
-// use) until the page reports otherwise, so the common case never re-measures.
+// fullName -> measured widget height. 512 (devvit "tall") until the page
+// reports otherwise, so the tall case measures final on the first pass.
 static const CGFloat kApolloDevvitDefaultHeight = 512.0;
+// Smallest height we accept as a real measurement. This must not sit ABOVE what
+// the probe itself treats as real (it reveals on h >= 40 held stable): devvit
+// apps size themselves, and a compact card is a legitimate layout — a finished
+// match thread renders a single ~96pt score row with an "open the full match
+// thread" footer. A 120pt floor silently REJECTED those, so the measurement was
+// discarded, the node kept the 512pt placeholder, and the card sat above ~400pt
+// of dead space in the feed and in the post alike.
+static const CGFloat kApolloDevvitMinHeight = 40.0;
+static const CGFloat kApolloDevvitMaxHeight = 900.0;
+// Post-reveal watchdog cadence: brisk while the widget is still moving (a user
+// expanding a compact card must not wait out a long tick with clipped content),
+// idle once it has held still, and a budget that stops an oscillating widget
+// from re-measuring a table forever.
+static const NSTimeInterval kApolloDevvitActivePollInterval = 1.0;
+static const NSTimeInterval kApolloDevvitIdlePollInterval = 6.0;
+static const NSInteger kApolloDevvitActivePollCount = 8;
+static const NSInteger kApolloDevvitMaxHeightCorrections = 12;
 static NSMutableDictionary<NSString *, NSNumber *> *sDevvitHeights;
 
 static CGFloat ApolloDevvitHeightForFullName(NSString *fullName) {
     if (!fullName) return kApolloDevvitDefaultHeight;
     NSNumber *n = nil;
     @synchronized (sDevvitHeights) { n = sDevvitHeights[fullName]; }
-    return n ? MAX(120.0, MIN(900.0, n.doubleValue)) : kApolloDevvitDefaultHeight;
+    return n ? MAX(kApolloDevvitMinHeight, MIN(kApolloDevvitMaxHeight, n.doubleValue))
+             : kApolloDevvitDefaultHeight;
 }
 
 static BOOL ApolloDevvitStoreHeight(NSString *fullName, CGFloat height) {
-    if (!fullName || height < 120.0 || height > 900.0) return NO;
+    if (!fullName || height < kApolloDevvitMinHeight || height > kApolloDevvitMaxHeight) return NO;
     @synchronized (sDevvitHeights) {
         NSNumber *old = sDevvitHeights[fullName];
         if (old && fabs(old.doubleValue - height) <= 4.0) return NO;
@@ -238,7 +256,38 @@ static NSString *const kApolloDevvitProbeScript = @""
 "        || document.querySelector('devvit-blocks-renderer');"
 "  if (!el) { return JSON.stringify({ found: 0, state: document.readyState, title: (document.title || '').slice(0, 40) }); }"
 "  var r = el.getBoundingClientRect();"
-"  return JSON.stringify({ found: 1, h: Math.round(r.height), w: Math.round(r.width) });"
+    /* The host element's own box is NOT the whole story. A compact match card
+       is 96pt, but tapping its "open the full match thread" control overlays
+       the expanded view on top — absolutely positioned, so it extends past the
+       host while the host's rect stays 96 and the cell clips everything below.
+       Measure the deepest painted descendant instead (shadow roots included,
+       which is where devvit renders), and take whichever is taller. The crop
+       pins the widget to top:0, so a descendant's viewport `bottom` IS its
+       height from the widget's top edge. */
+"  var deep = 0, seen = 0;"
+"  try {"
+"    (function walk(root, depth) {"
+"      if (!root || depth > 6 || seen > 2000) { return; }"
+"      var kids = root.querySelectorAll ? root.querySelectorAll('*') : [];"
+"      for (var i = 0; i < kids.length && seen < 2000; i++) {"
+"        seen++;"
+"        var k = kids[i];"
+"        var kr = k.getBoundingClientRect ? k.getBoundingClientRect() : null;"
+"        if (kr && kr.height > 0 && kr.bottom > deep && kr.bottom < 4000) { deep = kr.bottom; }"
+"        if (k.shadowRoot) { walk(k.shadowRoot, depth + 1); }"
+"      }"
+"    })(el, 0);"
+"    if (el.shadowRoot) { (function (r2) {"
+"      var kids = r2.querySelectorAll('*');"
+"      for (var i = 0; i < kids.length && seen < 2000; i++) {"
+"        seen++;"
+"        var kr = kids[i].getBoundingClientRect();"
+"        if (kr && kr.height > 0 && kr.bottom > deep && kr.bottom < 4000) { deep = kr.bottom; }"
+"      }"
+"    })(el.shadowRoot); }"
+"  } catch (e) {}"
+"  var h = Math.max(Math.round(r.height), Math.round(deep));"
+"  return JSON.stringify({ found: 1, h: h, w: Math.round(r.width) });"
 "})();";
 
 #pragma mark - Content blocker
@@ -684,7 +733,10 @@ static const NSUInteger kApolloDevvitMaxLiveWidgets = 4;
             self.lastProbeHeight = h;
             if (self.stableSamples >= 2) {
                 [self revealWithHeight:h];
-                [self pollAfter:6.0 attempt:0 generation:gen];
+                // Hand over to the watchdog in its brisk state: the moments
+                // right after reveal are exactly when someone taps a compact
+                // card open.
+                [self pollAfter:kApolloDevvitActivePollInterval attempt:0 generation:gen];
                 return;
             }
         }
@@ -692,25 +744,41 @@ static const NSUInteger kApolloDevvitMaxLiveWidgets = 4;
         return;
     }
 
-    // Post-reveal slow watchdog: track later height changes (some widgets
-    // grow when a match kicks off) and keep the crop asserted. Each report
-    // ends in a beginUpdates/endUpdates row-height re-query on every affected
-    // table, so corrections are strictly bounded: hysteresis widens sharply
-    // after the first one, and after the cap the height is frozen for this
-    // widget's lifetime — an oscillating widget must never re-measure a
-    // comments table indefinitely.
-    CGFloat hysteresis = (self.heightCorrections == 0) ? 8.0 : 32.0;
-    if (found && h >= 40.0 && fabs(h - self.lastProbeHeight) > hysteresis &&
-        self.heightCorrections < 3) {
+    // Post-reveal watchdog: track later height changes and keep the crop
+    // asserted. These are not only spontaneous (a match kicking off) — they are
+    // also USER-DRIVEN: a compact match card has an "open the full match thread"
+    // control that expands the widget several hundred points, and until the cell
+    // follows, the expanded content is clipped to the old height. So poll
+    // briskly for a while after any change and only back off once the widget has
+    // been still, rather than sitting on a fixed 6s tick where a tap appears to
+    // do nothing for several seconds.
+    //
+    // Each report ends in a beginUpdates/endUpdates row-height re-query on every
+    // affected table, so corrections stay bounded: hysteresis widens after the
+    // first one, they cannot land faster than the active poll interval, and a
+    // budget still freezes the height for a widget that oscillates forever. The
+    // budget is generous enough to absorb a user expanding and collapsing a card
+    // a few times, which the old 3 could not.
+    CGFloat hysteresis = (self.heightCorrections == 0) ? 8.0 : 24.0;
+    BOOL changed = NO;
+    if (found && h >= kApolloDevvitMinHeight && fabs(h - self.lastProbeHeight) > hysteresis &&
+        self.heightCorrections < kApolloDevvitMaxHeightCorrections) {
         self.heightCorrections += 1;
         self.lastProbeHeight = h;
-        ApolloLog(@"[Devvit] %@ height corrected to %.0fpt (%ld/3)",
-                  self.fullName, h, (long)self.heightCorrections);
+        changed = YES;
+        ApolloLog(@"[Devvit] %@ height corrected to %.0fpt (%ld/%ld)", self.fullName, h,
+                  (long)self.heightCorrections, (long)kApolloDevvitMaxHeightCorrections);
         if (ApolloDevvitStoreHeight(self.fullName, h) && self.onMeasuredHeight) {
             self.onMeasuredHeight(self.fullName, h);
         }
     }
-    [self pollAfter:6.0 attempt:0 generation:gen];
+    // `attempt` counts consecutive still polls here; a change restarts the
+    // brisk window so an expand → settle → collapse sequence stays responsive.
+    NSInteger stillPolls = changed ? 0 : attempt + 1;
+    BOOL brisk = stillPolls < kApolloDevvitActivePollCount;
+    [self pollAfter:(brisk ? kApolloDevvitActivePollInterval : kApolloDevvitIdlePollInterval)
+             attempt:stillPolls
+          generation:gen];
 }
 
 - (void)revealWithHeight:(CGFloat)height {

--- a/src/ApolloDevvitPosts.xm
+++ b/src/ApolloDevvitPosts.xm
@@ -461,7 +461,7 @@ static WKWebsiteDataStore *ApolloDevvitDataStoreForIdentity(NSString *identity, 
 // stable. One instance per on-screen devvit post; feed instances are torn
 // down when their cell leaves the preload range.
 
-@interface ApolloDevvitWidgetView : UIView <WKNavigationDelegate, WKUIDelegate>
+@interface ApolloDevvitWidgetView : UIView <WKNavigationDelegate, WKUIDelegate, UIGestureRecognizerDelegate>
 @property (nonatomic, strong) WKWebView *webView;
 @property (nonatomic, strong) UIView *coverView;
 @property (nonatomic, strong) UIActivityIndicatorView *spinner;
@@ -500,6 +500,21 @@ static const NSUInteger kApolloDevvitMaxLiveWidgets = 4;
         self.clipsToBounds = YES;
         self.backgroundColor = [UIColor clearColor];
         [self buildCover];
+        // A tap inside the widget is the moment its height is about to change —
+        // "open the full match thread" grows it several hundred points, the ✕
+        // shrinks it back — and the idle watchdog's next look can be seconds
+        // away, which reads as content clipped under the old cell height until
+        // the poll happens to land (user-reported jank). Watch the taps
+        // ourselves and probe right after each one. Passive: recognizes
+        // alongside WebKit's own gestures and never cancels the touch, so the
+        // page sees every tap exactly as before.
+        UITapGestureRecognizer *poke =
+            [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(apolloDevvitTapPoke:)];
+        poke.cancelsTouchesInView = NO;
+        poke.delaysTouchesBegan = NO;
+        poke.delaysTouchesEnded = NO;
+        poke.delegate = self;
+        [self addGestureRecognizer:poke];
         // Cap total live WEB VIEWS (not widget shells): a torn-down widget
         // stays in the weak table with webView == nil and costs nothing, so
         // both the count and the eviction must look at webView, or the cap
@@ -568,6 +583,23 @@ static const NSUInteger kApolloDevvitMaxLiveWidgets = 4;
     UITapGestureRecognizer *retry =
         [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(coverTapped)];
     [cover addGestureRecognizer:retry];
+}
+
+// Coexist with WKWebView's internal recognizers — without this the system
+// tap wins and ours never fires.
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+    shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)other {
+    return YES;
+}
+
+- (void)apolloDevvitTapPoke:(UITapGestureRecognizer *)gesture {
+    if (!self.revealed || !self.webView) return;
+    // Start a fresh brisk poll loop timed for the page's expand/collapse
+    // animation to have finished; bumping the generation orphans whatever idle
+    // tick was pending, so loops never double up. handleProbeResult then keeps
+    // polling briskly while the height is still settling.
+    NSInteger gen = ++self.pollGeneration;
+    [self pollAfter:0.35 attempt:0 generation:gen];
 }
 
 - (void)coverTapped {

--- a/src/ApolloDevvitPosts.xm
+++ b/src/ApolloDevvitPosts.xm
@@ -179,6 +179,21 @@ static const NSTimeInterval kApolloDevvitIdlePollInterval = 6.0;
 static const NSInteger kApolloDevvitActivePollCount = 8;
 static const NSInteger kApolloDevvitMaxHeightCorrections = 12;
 static NSMutableDictionary<NSString *, NSNumber *> *sDevvitHeights;
+// fullNames whose widget gave up; their rows fall back to Apollo's own rendering.
+static NSMutableSet<NSString *> *sDevvitFailedPosts;
+
+static BOOL ApolloDevvitPostFailed(NSString *fullName) {
+    if (!fullName) return NO;
+    @synchronized (sDevvitHeights) { return [sDevvitFailedPosts containsObject:fullName]; }
+}
+
+static void ApolloDevvitMarkFailed(NSString *fullName) {
+    if (!fullName) return;
+    @synchronized (sDevvitHeights) {
+        if (!sDevvitFailedPosts) sDevvitFailedPosts = [NSMutableSet set];
+        [sDevvitFailedPosts addObject:fullName];
+    }
+}
 
 static CGFloat ApolloDevvitHeightForFullName(NSString *fullName) {
     if (!fullName) return kApolloDevvitDefaultHeight;
@@ -793,10 +808,22 @@ static const NSUInteger kApolloDevvitMaxLiveWidgets = 4;
 
 - (void)showFailure {
     self.failed = YES;
-    [self.spinner stopAnimating];
-    self.statusLabel.text = @"Interactive post failed to load.\nTap to retry.";
-    self.coverView.alpha = 1.0;
+    // Reddit intermittently serves a shell that never hydrates (readyState
+    // complete, empty body). Holding the tall reservation for that left a
+    // screen-high dead box mid-feed, and a custom "failed" banner is its own
+    // problem: it has to lay out correctly at every collapsed height, and it
+    // tells the user nothing they can act on. Hand the row back instead — Apollo
+    // then renders the post exactly as it would without this feature, fallback
+    // text and its "view the full post" link included, which is both honest and
+    // useful. The mark is per-process, so a relaunch retries.
+    ApolloDevvitMarkFailed(self.fullName);
+    ApolloLog(@"[Devvit] %@ gave up — handing the row back to Apollo", self.fullName);
+    NSString *fullName = self.fullName;
+    [self teardown];
+    [self removeFromSuperview];
+    ApolloDevvitHeightDidChangeForFullName(fullName);
 }
+
 
 - (void)teardown {
     self.pollGeneration += 1;  // cancels any queued poll blocks
@@ -1106,9 +1133,60 @@ static void ApolloDevvitRefreshTableHeights(UITableView *table, NSInteger attemp
     } @catch (__unused id e) {}
 }
 
+// Invalidate the registered parent AND every node up to the enclosing cell.
+// Which node is registered differs by surface: in comments it is the cell node
+// itself (CommentsHeaderCellNode), but in the FEED it is RichMediaNode — a
+// child of the post cell. Texture serves a row's height from the CELL node's
+// cached layout, and invalidating only a descendant leaves that cache intact,
+// so begin/endUpdates below re-queried the same stale height and a compact card
+// stayed in its 512pt hole. Comments worked precisely because parent == cell,
+// which is what hid this. Stop at the cell (ASCellNode answers `owningNode`)
+// rather than walking to the root: invalidating the whole feed is needless work.
+static ASDisplayNode *ApolloDevvitInvalidateUpToCell(ASDisplayNode *node) {
+    ASDisplayNode *n = node;
+    for (NSInteger hops = 0; n && hops < 12; hops++) {
+        @try {
+            [n invalidateCalculatedLayout];
+            [n setNeedsLayout];
+            if ([n respondsToSelector:@selector(owningNode)] &&
+                ((id (*)(id, SEL))objc_msgSend)(n, @selector(owningNode))) return n; // the cell
+            n = [n supernode];
+        } @catch (__unused id e) { return nil; }
+    }
+    return nil;
+}
+
+// Invalidating a cell marks its layout dirty but nothing asks Texture to
+// re-measure it: a feed cell only re-measures when something drives it, and
+// beginUpdates/endUpdates on an ASTableView does not (it is the UITableView
+// path; Texture owns node-driven row heights). Comments got away with it
+// because that header re-measures anyway as comments stream in — the feed never
+// does, so a compact card kept the 512pt row it was first measured at.
+// transitionLayout… IS the "re-run this node's layout and publish the new size"
+// API, and it is scoped to the one cell rather than relayoutItems' whole-feed
+// pass (multi-second on a long feed — the #630 watchdog class).
+static void ApolloDevvitRemeasureCells(NSArray<ASDisplayNode *> *cells, NSInteger attempt) {
+    if (cells.count == 0 || attempt > 40) return;
+    // Never re-enter Texture's measurement while it is already measuring (#844)
+    // or mid-scroll, where a row-height change fights the scroll.
+    if (ApolloRowMeasureInProgress()) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{ ApolloDevvitRemeasureCells(cells, attempt + 1); });
+        return;
+    }
+    SEL transition = @selector(transitionLayoutWithAnimation:shouldMeasureAsync:measurementCompletion:);
+    for (ASDisplayNode *cell in cells) {
+        @try {
+            if (![cell respondsToSelector:transition]) continue;
+            ((void (*)(id, SEL, BOOL, BOOL, id))objc_msgSend)(cell, transition, NO, NO, nil);
+        } @catch (__unused id e) {}
+    }
+}
+
 static void ApolloDevvitHeightDidChangeForFullName(NSString *fullName) {
     dispatch_async(dispatch_get_main_queue(), ^{
         NSMutableSet<UITableView *> *tables = [NSMutableSet set];
+        NSMutableArray<ASDisplayNode *> *cells = [NSMutableArray array];
         for (id parent in sDevvitHostParents.allObjects) {
             RDKLink *link = nil;
             @try {
@@ -1118,11 +1196,12 @@ static void ApolloDevvitHeightDidChangeForFullName(NSString *fullName) {
             if (fullName && link && ![ApolloDevvitFullName(link) isEqualToString:fullName]) continue;
             ASDisplayNode *host = objc_getAssociatedObject(parent, kApolloDevvitHostNodeKey);
             if (host) ApolloDevvitSetNodeHeight(host, ApolloDevvitHeightForFullName(fullName));
-            [(ASDisplayNode *)parent invalidateCalculatedLayout];
-            [(ASDisplayNode *)parent setNeedsLayout];
+            ASDisplayNode *cell = ApolloDevvitInvalidateUpToCell((ASDisplayNode *)parent);
+            if (cell) [cells addObject:cell];
             UITableView *table = ApolloDevvitTableViewForNode(parent);
             if (table) [tables addObject:table];
         }
+        ApolloDevvitRemeasureCells(cells, 0);
         for (UITableView *table in tables) ApolloDevvitRefreshTableHeights(table, 0);
     });
 }
@@ -1211,6 +1290,8 @@ static id ApolloDevvitPlaceInSpec(id rootSpec, id hostSpec, NSUInteger depth) {
     @try {
         RDKLink *link = MSHookIvar<RDKLink *>(self, "link");
         if (!ApolloDevvitLinkIsInteractive(link)) return orig;
+        // Gave up on this post — let Apollo render it natively (see showFailure).
+        if (ApolloDevvitPostFailed(ApolloDevvitFullName(link))) return orig;
         ASDisplayNode *host = ApolloDevvitEnsureHostNode(self);
         if (!host) return orig;
         ApolloDevvitSetNodeHeight(host, ApolloDevvitHeightForFullName(ApolloDevvitFullName(link)));
@@ -1263,7 +1344,8 @@ static id ApolloDevvitPlaceInSpec(id rootSpec, id hostSpec, NSUInteger depth) {
         RDKLink *link = MSHookIvar<RDKLink *>(self, "link");
         // The feed sub-toggle routes through the SAME cleanup path as a
         // recycled cell, so flipping it off mid-session hides any live host.
-        if (!sDevvitFeedWidgets || !ApolloDevvitLinkIsInteractive(link)) {
+        if (!sDevvitFeedWidgets || !ApolloDevvitLinkIsInteractive(link) ||
+            ApolloDevvitPostFailed(ApolloDevvitFullName(link))) {
             // Recycled off a devvit post onto a normal one: the host node is
             // no longer in the layout, but its loaded view would linger —
             // hide it (carousel lesson #4).

--- a/src/ApolloDevvitPosts.xm
+++ b/src/ApolloDevvitPosts.xm
@@ -175,6 +175,13 @@ static const CGFloat kApolloDevvitMaxHeight = 900.0;
 // idle once it has held still, and a budget that stops an oscillating widget
 // from re-measuring a table forever.
 static const NSTimeInterval kApolloDevvitActivePollInterval = 1.0;
+// Tap-to-commit latency budget: first look right after the tap, and a quick
+// re-look to confirm stability. Devvit's expand lays out its final height
+// immediately (the animation is visual, not a height tween), so the pair
+// usually commits ~0.25s after the finger — and if a page IS mid-change, the
+// confirm just repeats until two reads agree, so speed never costs safety.
+static const NSTimeInterval kApolloDevvitTapProbeDelay = 0.12;
+static const NSTimeInterval kApolloDevvitConfirmProbeDelay = 0.15;
 static const NSTimeInterval kApolloDevvitIdlePollInterval = 6.0;
 static const NSInteger kApolloDevvitActivePollCount = 8;
 static const NSInteger kApolloDevvitMaxHeightCorrections = 12;
@@ -600,6 +607,24 @@ static const NSUInteger kApolloDevvitMaxLiveWidgets = 4;
     return YES;
 }
 
+// Coming back on screen is the other moment the cell can be out of step with
+// the page: while the user was in another thread the widget kept its DOM (an
+// expanded view stays expanded, a live match keeps growing) but off-window the
+// watchdog deliberately skips the JS probe, and Apollo's swipe-forward
+// navigation restores the SAME widget instance — budget state and all. Treat
+// re-entry like a tap: re-arm and look right away, so a revisited thread heals
+// itself instead of loading clipped until the user happens to touch it
+// (device-reported: "came back and loaded like this").
+- (void)didMoveToWindow {
+    [super didMoveToWindow];
+    if (!self.window || !self.revealed || !self.webView) return;
+    self.heightCorrections = 0;
+    self.heightFrozen = NO;
+    self.pendingProbeHeight = 0.0;
+    NSInteger gen = ++self.pollGeneration;
+    [self pollAfter:kApolloDevvitTapProbeDelay attempt:0 generation:gen];
+}
+
 - (void)apolloDevvitTapPoke:(UITapGestureRecognizer *)gesture {
     if (!self.revealed || !self.webView) return;
     // An explicit tap re-arms the correction budget. The budget exists to stop
@@ -617,7 +642,7 @@ static const NSUInteger kApolloDevvitMaxLiveWidgets = 4;
     // tick was pending, so loops never double up. handleProbeResult then keeps
     // polling briskly while the height is still settling.
     NSInteger gen = ++self.pollGeneration;
-    [self pollAfter:0.35 attempt:0 generation:gen];
+    [self pollAfter:kApolloDevvitTapProbeDelay attempt:0 generation:gen];
 }
 
 - (void)coverTapped {
@@ -857,7 +882,7 @@ static const NSUInteger kApolloDevvitMaxLiveWidgets = 4;
             // instead of the normal cadence, so a real change still commits
             // well under a second after the tap.
             self.pendingProbeHeight = h;
-            [self pollAfter:0.3 attempt:0 generation:gen];
+            [self pollAfter:kApolloDevvitConfirmProbeDelay attempt:0 generation:gen];
             return;
         }
     } else {

--- a/src/ApolloSubredditHighlights.xm
+++ b/src/ApolloSubredditHighlights.xm
@@ -33,6 +33,7 @@
 #import "ApolloCommon.h"
 #import "ApolloScrapeWebView.h"
 #import "ApolloSubredditHighlights.h"
+#import "ApolloDevvitPosts.h"
 
 #pragma mark - Minimal runtime interfaces
 
@@ -112,6 +113,7 @@ static const void *kApolloHLHeaderChangeGenKey     = &kApolloHLHeaderChangeGenKe
 static const void *kApolloHLHeaderChangePendingKey = &kApolloHLHeaderChangePendingKey; // BOOL on the table: a deferred header change awaits scroll settle
 static char kApolloHLHiddenRowsKey;            // NSMutableSet<NSNumber*> of de-duped sticky rows, per ASTableNode
 static char kApolloHLStickyCountKey;           // NSNumber (REST sticky count N) per feed ASTableNode — breaker rule
+static char kApolloHLFeedOwnedMaskKey;         // NSNumber (bitmask of sticky rows the feed keeps) per feed ASTableNode
 static char kApolloHLSwitchPendingKey;         // BOOL on the VC — an in-place-switch re-install is already scheduled
 
 #pragma mark - Subreddit detection (adapted from ApolloSubredditHeaders.xm)
@@ -289,6 +291,10 @@ static void ApolloHLReloadFeed(UIViewController *vc) {
 @property (nonatomic) long long numComments;
 @property (nonatomic, strong) NSURL *thumbnailURL;
 @property (nonatomic) BOOL isSpoiler;
+// A live Devvit custom post (match thread, game). When the feed renders those
+// as their real widget, the feed owns the post and the carousel drops it —
+// see ApolloHLFeedOwnedStickyMask / ApolloHLCarouselItems.
+@property (nonatomic) BOOL isInteractive;
 @end
 @implementation ApolloHLItem
 @end
@@ -377,11 +383,46 @@ static void ApolloHLDidCollapseRemove(NSString *sub) {
 }
 
 // Lowercased subreddit -> number of leading stickied posts the REST `hot` fetch
-// returned (= the number of inline cells we de-dup). Set ONLY from the REST parse
-// (never the web upgrade, which inflates the carousel beyond the inline stickies),
-// so the separators can keep exactly the LAST orphan as the single breaker without
-// racing the cell layout. Survives across the web upgrade.
+// returned (= the number of inline sticky ROWS the feed will show). Set ONLY from
+// the REST parse (never the web upgrade, which inflates the carousel beyond the
+// inline stickies), so the separators can keep exactly one breaker without racing
+// the cell layout. Survives across the web upgrade. NOTE: not every one of those
+// rows is necessarily de-duped — see the feed-owned mask below.
 static NSMutableDictionary<NSString *, NSNumber *> *ApolloHLStickyCount(void) {
+    static NSMutableDictionary *d; static dispatch_once_t once;
+    dispatch_once(&once, ^{ d = [NSMutableDictionary dictionary]; });
+    return d;
+}
+
+#pragma mark - Feed-owned pinned posts (live interactive posts)
+
+// A pinned post that is a live Devvit custom post — an r/soccer daily discussion
+// with its live scoreboard, a match thread, a game — is only worth anything as
+// its real widget, which renders in the FEED (large cards) and in comments. A
+// highlights card can't show a live score, and de-duping the post out of the feed
+// hid the widget entirely: turning Community Highlights on silently cost you the
+// feature. So when the feed renders those widgets, the FEED owns such a post: it
+// stays inline and the carousel drops it (no duplicate card right above itself).
+//
+// Two pieces of per-subreddit state, both derived from the one REST parse:
+//
+//  • a BITMASK over the leading sticky ROWS (bit i = sticky i stays inline),
+//    published onto the feed's ASTableNode so the breaker rule knows which
+//    trailing separators are orphaned — race-free at first measure, exactly how
+//    the sticky count N is used.
+//  • the post IDs the feed owns, so the Full-mode web set can drop them too (a
+//    DOM scrape carries no selftext to test).
+//
+// Both are only populated while ApolloDevvitFeedOwnsInteractivePosts() is on;
+// with it off every mask is 0 and the pre-existing behavior stands unchanged.
+// MAIN-QUEUE ONLY, like every other cache here (the cell-layout de-dup check
+// runs off-main but reads the link itself, never these).
+static NSMutableDictionary<NSString *, NSNumber *> *ApolloHLFeedOwnedMask(void) {
+    static NSMutableDictionary *d; static dispatch_once_t once;
+    dispatch_once(&once, ^{ d = [NSMutableDictionary dictionary]; });
+    return d;
+}
+static NSMutableDictionary<NSString *, NSSet<NSString *> *> *ApolloHLFeedOwnedIDs(void) {
     static NSMutableDictionary *d; static dispatch_once_t once;
     dispatch_once(&once, ^{ d = [NSMutableDictionary dictionary]; });
     return d;
@@ -428,6 +469,7 @@ static NSDictionary *ApolloHLItemToPlist(ApolloHLItem *it) {
     if (it.numComments) d[@"c"] = @(it.numComments);
     if (it.thumbnailURL.absoluteString) d[@"u"] = it.thumbnailURL.absoluteString;
     if (it.isSpoiler) d[@"s"] = @YES;
+    if (it.isInteractive) d[@"i"] = @YES;
     return d;
 }
 
@@ -455,6 +497,7 @@ static NSArray<ApolloHLItem *> *ApolloHLItemsFromPlist(id plist) {
         NSString *thumb = ApolloHLStringValue(d[@"u"]);
         if (thumb.length) it.thumbnailURL = [NSURL URLWithString:thumb];
         it.isSpoiler = [d[@"s"] isKindOfClass:[NSNumber class]] && [d[@"s"] boolValue];
+        it.isInteractive = [d[@"i"] isKindOfClass:[NSNumber class]] && [d[@"i"] boolValue];
         [out addObject:it];
     }
     return out;
@@ -515,6 +558,13 @@ static void ApolloHLPersistSub(NSString *subreddit) {
     entry[@"items"] = ApolloHLItemsToPlist(displayed ?: @[]);
     entry[@"rest"] = ApolloHLItemsToPlist(rest ?: @[]);
     if (ApolloHLStickyCount()[key]) entry[@"n"] = ApolloHLStickyCount()[key];
+    // Which sticky rows the feed keeps: without it a relaunch would measure the
+    // separators as if every sticky collapsed and double the breaker until the
+    // revalidating fetch lands.
+    if (ApolloHLFeedOwnedMask()[key]) entry[@"m"] = ApolloHLFeedOwnedMask()[key];
+    // Which side of the feed-ownership split this snapshot was filtered under, so
+    // a launch that disagrees revalidates instead of trusting it (see SeedFromDisk).
+    entry[@"fo"] = @(ApolloDevvitFeedOwnsInteractivePosts());
     if (ApolloHLRestSig()[key]) entry[@"sig"] = ApolloHLRestSig()[key];
     entry[@"t"] = ApolloHLFetchTime()[key] ?: [NSDate date];
     ApolloHLDiskCache()[key] = entry;
@@ -537,10 +587,25 @@ static void ApolloHLSeedFromDisk(NSString *subreddit) {
     ApolloHLCache()[key] = use;
     ApolloHLRestCache()[key] = rest;
     if ([entry[@"n"] isKindOfClass:[NSNumber class]]) ApolloHLStickyCount()[key] = entry[@"n"];
+    // Only honour a persisted feed-owned mask while the feature is still on —
+    // the toggle can have been flipped since the snapshot was written, and the
+    // revalidating fetch (always kicked for a seeded sub) republishes either way.
+    if ([entry[@"m"] isKindOfClass:[NSNumber class]] && ApolloDevvitFeedOwnsInteractivePosts()) {
+        ApolloHLFeedOwnedMask()[key] = entry[@"m"];
+    }
     if ([entry[@"sig"] isKindOfClass:[NSString class]]) ApolloHLRestSig()[key] = entry[@"sig"];
     // Keep the ORIGINAL fetch date: it is (almost always) past the freshness TTL,
     // so the very next ApolloHLMaybeRefreshStale revalidates in the background.
     ApolloHLFetchTime()[key] = [entry[@"t"] isKindOfClass:[NSDate class]] ? entry[@"t"] : [NSDate distantPast];
+    // …unless the snapshot was filtered under the OTHER feed-ownership setting: it
+    // is either missing a pinned post that now belongs in the carousel, or still
+    // carries one the feed has since taken over, and inside the freshness window
+    // nothing would refetch. Age it out so the first layout pass revalidates.
+    BOOL snapshotFeedOwned = [entry[@"fo"] isKindOfClass:[NSNumber class]] && [entry[@"fo"] boolValue];
+    if (snapshotFeedOwned != ApolloDevvitFeedOwnsInteractivePosts()) {
+        ApolloHLFetchTime()[key] = [NSDate distantPast];
+        ApolloLog(@"[Highlights] r/%@ snapshot predates the interactive-posts setting → revalidating", key);
+    }
     ApolloLog(@"[Highlights] r/%@ seeded %lu highlights from disk", key, (unsigned long)use.count);
 }
 
@@ -638,6 +703,7 @@ static ApolloHLItem *ApolloHLItemFromPostData(NSDictionary *d) {
     item.numComments = [nc isKindOfClass:[NSNumber class]] ? nc.longLongValue : 0;
     item.thumbnailURL = ApolloHLThumbnailFromPostData(d);
     item.isSpoiler = [d[@"spoiler"] respondsToSelector:@selector(boolValue)] && [d[@"spoiler"] boolValue];
+    item.isInteractive = ApolloDevvitPostDataIsInteractive(d);
     return item;
 }
 
@@ -669,6 +735,62 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
         if (item.fullName.length) map[item.fullName] = item;
     }
     return map;
+}
+
+// Bit i set = leading sticky #i is a live interactive post the feed keeps inline.
+// Capped at 32 rows (Reddit pins two; the web set tops out at six) — beyond that
+// the bit is simply not set, so the post stays de-duped as it is today.
+static NSUInteger ApolloHLFeedOwnedStickyMask(NSArray<ApolloHLItem *> *stickies) {
+    if (!ApolloDevvitFeedOwnsInteractivePosts()) return 0;
+    NSUInteger mask = 0, i = 0;
+    for (ApolloHLItem *it in stickies) {
+        if (i >= 32) break;
+        if (it.isInteractive) mask |= (1u << i);
+        i++;
+    }
+    return mask;
+}
+
+// What the carousel shows: everything the feed does not own. Returns the input
+// array untouched in the common case (nothing interactive / feature off).
+static NSArray<ApolloHLItem *> *ApolloHLCarouselItems(NSArray<ApolloHLItem *> *items) {
+    if (items.count == 0 || !ApolloDevvitFeedOwnsInteractivePosts()) return items;
+    NSMutableArray<ApolloHLItem *> *kept = [NSMutableArray arrayWithCapacity:items.count];
+    for (ApolloHLItem *it in items) {
+        if (!it.isInteractive) [kept addObject:it];
+    }
+    return kept.count == items.count ? items : kept;
+}
+
+// Post IDs of the feed-owned items, for filtering a set that can't be tested
+// directly (the web scrape has titles + permalinks, no selftext).
+static NSSet<NSString *> *ApolloHLFeedOwnedIDsFromItems(NSArray<ApolloHLItem *> *items) {
+    NSMutableSet<NSString *> *ids = [NSMutableSet set];
+    if (!ApolloDevvitFeedOwnsInteractivePosts()) return ids;
+    for (ApolloHLItem *it in items) {
+        if (!it.isInteractive) continue;
+        NSString *pid = ApolloHLPostIDFromPermalink(it.permalink);
+        if (pid.length) [ids addObject:pid];
+    }
+    return ids;
+}
+
+// Drop the subreddit's feed-owned posts from a set we can't test item-by-item.
+// Belt and braces for the Full-mode web upgrade: its own items carry the flag
+// once /api/info enrichment lands, but the pre-enrichment fast path paints
+// first, and this keeps the daily discussion from flashing into the carousel.
+static NSArray<ApolloHLItem *> *ApolloHLDropFeedOwned(NSString *sub, NSArray<ApolloHLItem *> *items) {
+    if (items.count == 0) return items;
+    if (!ApolloDevvitFeedOwnsInteractivePosts()) return items;
+    NSSet<NSString *> *owned = ApolloHLFeedOwnedIDs()[sub.lowercaseString];
+    NSMutableArray<ApolloHLItem *> *kept = [NSMutableArray arrayWithCapacity:items.count];
+    for (ApolloHLItem *it in items) {
+        if (it.isInteractive) continue;
+        NSString *pid = ApolloHLPostIDFromPermalink(it.permalink);
+        if (pid.length && [owned containsObject:pid]) continue;
+        [kept addObject:it];
+    }
+    return kept.count == items.count ? items : kept;
 }
 
 // Harvests the FULL highlights set (up to 6) via a hidden WKWebView — the only
@@ -903,9 +1025,18 @@ static void ApolloHLFetchHighlights(NSString *subredditName, BOOL force, void (^
     [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         NSInteger status = [response isKindOfClass:[NSHTTPURLResponse class]] ? ((NSHTTPURLResponse *)response).statusCode : -1;
         id json = data.length > 0 ? [NSJSONSerialization JSONObjectWithData:data options:0 error:nil] : nil;
-        NSArray<ApolloHLItem *> *items = [json isKindOfClass:[NSDictionary class]] ? ApolloHLParseListing(json) : @[];
-        ApolloLog(@"[Highlights] fetch r/%@ status=%ld stickied=%lu err=%@", subredditName,
-                  (long)status, (unsigned long)items.count, error.localizedDescription ?: @"nil");
+        // The stickies in listing order = the feed's leading rows. Split them here,
+        // before anything downstream sees them: the row COUNT and the feed-owned
+        // MASK describe those rows (the breaker rule needs both), while `items` —
+        // what the carousel shows and every cache holds — is the rest.
+        NSArray<ApolloHLItem *> *stickies = [json isKindOfClass:[NSDictionary class]] ? ApolloHLParseListing(json) : @[];
+        NSUInteger stickyRows = stickies.count;
+        NSUInteger feedOwnedMask = ApolloHLFeedOwnedStickyMask(stickies);
+        NSSet<NSString *> *feedOwnedIDs = ApolloHLFeedOwnedIDsFromItems(stickies);
+        NSArray<ApolloHLItem *> *items = ApolloHLCarouselItems(stickies);
+        ApolloLog(@"[Highlights] fetch r/%@ status=%ld stickied=%lu (feed-owned=%lu) err=%@", subredditName,
+                  (long)status, (unsigned long)stickyRows, (unsigned long)(stickyRows - items.count),
+                  error.localizedDescription ?: @"nil");
         dispatch_async(dispatch_get_main_queue(), ^{
             [ApolloHLInFlight() removeObject:key];
             // Only cache a successful response (200 / parsed). On error, leave it
@@ -927,7 +1058,12 @@ static void ApolloHLFetchHighlights(NSString *subredditName, BOOL force, void (^
             // freshness timestamp/signature for the stale-while-revalidate re-poll.
             if (status == 200) {
                 ApolloHLRestCache()[key] = items;
-                ApolloHLStickyCount()[key] = @(items.count);
+                // N counts sticky ROWS (feed-owned ones included — they still occupy
+                // a row and a trailing separator), the mask says which of those rows
+                // stay visible. Both feed the breaker rule.
+                ApolloHLStickyCount()[key] = @(stickyRows);
+                ApolloHLFeedOwnedMask()[key] = @(feedOwnedMask);
+                ApolloHLFeedOwnedIDs()[key] = feedOwnedIDs;
                 ApolloHLFetchTime()[key] = [NSDate date];
                 ApolloHLRestSig()[key] = ApolloHLItemsContentSig(items);
                 ApolloHLPersistSub(key); // keep the relaunch snapshot fresh (#909)
@@ -1922,6 +2058,9 @@ static void ApolloHLMergeMetadata(NSArray<ApolloHLItem *> *webItems,
         if (!w.flairText.length) w.flairText = info.flairText ?: api.flairText;
         if (w.numComments == 0) w.numComments = info ? info.numComments : (api ? api.numComments : 0);
         if (!w.isSpoiler) w.isSpoiler = info ? info.isSpoiler : (api ? api.isSpoiler : NO);
+        // The DOM gives no selftext, so a web item only learns it is a live
+        // interactive post from /api/info (the REST/api sets are pre-filtered).
+        if (!w.isInteractive) w.isInteractive = info ? info.isInteractive : (api ? api.isInteractive : NO);
     }
 }
 
@@ -1996,6 +2135,12 @@ static void ApolloHLMaybeWebUpgrade(NSString *subreddit) {
         // list immediately instead of blocking all extra cards on another network
         // round trip. Missing off-screen thumbnails/details arrive just below.
         ApolloHLMergeMetadata(items, apiItems, @{});
+        // A pinned interactive post the feed is rendering live must not come back
+        // as a card via the web set. The DOM scrape carries no selftext, so match
+        // by the ids the REST parse already resolved (the enrichment below then
+        // re-checks the items themselves, for a sub the REST fetch hasn't reached).
+        items = ApolloHLDropFeedOwned(sub, items);
+        if (items.count == 0) return;
         NSArray<ApolloHLItem *> *cur = ApolloHLCache()[sub];
         BOOL grew = items.count > cur.count;
         BOOL differs = ![ApolloHLItemsContentSig(items) isEqualToString:ApolloHLItemsContentSig(cur)];
@@ -2008,8 +2153,12 @@ static void ApolloHLMaybeWebUpgrade(NSString *subreddit) {
         // Enrich the already-visible list with reliable /api/info thumbnails. A
         // presentation-signature change rebuilds the cards, while an identical
         // response is a no-op and cannot cause a visible flash.
-        ApolloHLEnrichViaInfo(items, apiItems, ^(NSArray<ApolloHLItem *> *enriched) {
+        ApolloHLEnrichViaInfo(items, apiItems, ^(NSArray<ApolloHLItem *> *enrichedAll) {
             if (!sCommunityHighlights || !sCommunityHighlightsWeb) return;
+            // /api/info fills in each item's selftext-derived flag, so this is the
+            // authoritative drop of anything the feed owns.
+            NSArray<ApolloHLItem *> *enriched = ApolloHLCarouselItems(enrichedAll);
+            if (enriched.count == 0) return;
             BOOL metadataChanged = ![ApolloHLItemsPresentationSig(enriched) isEqualToString:preEnrichmentSig];
             NSArray<ApolloHLItem *> *shown = ApolloHLCache()[sub];
             BOOL setChanged = ![ApolloHLItemsContentSig(enriched) isEqualToString:ApolloHLItemsContentSig(shown)];
@@ -2108,11 +2257,18 @@ static void ApolloHLCollapseOrphanSeparators(UIViewController *vc); // defined w
 // (N already published before cells measure) never re-measure.
 static void ApolloHLApplyStickyCountToTable(UIViewController *vc, NSString *subreddit) {
     id tableNode = ApolloHLTypedIvar(vc, @"tableNode", objc_getClass("ASTableNode"));
-    NSNumber *stickyN = ApolloHLStickyCount()[subreddit.lowercaseString];
+    NSString *subKey = subreddit.lowercaseString;
+    NSNumber *stickyN = ApolloHLStickyCount()[subKey];
     if (!tableNode || !stickyN) return;
+    // The mask travels with N: both describe the same sticky run, and a change to
+    // either one changes which separators are orphaned.
+    NSNumber *ownedMask = ApolloDevvitFeedOwnsInteractivePosts() ? (ApolloHLFeedOwnedMask()[subKey] ?: @0) : @0;
     NSNumber *prev = objc_getAssociatedObject(tableNode, &kApolloHLStickyCountKey);
-    if ([prev isEqualToNumber:stickyN]) return;
+    NSNumber *prevMask = objc_getAssociatedObject(tableNode, &kApolloHLFeedOwnedMaskKey);
+    BOOL maskChanged = ![(prevMask ?: @0) isEqualToNumber:ownedMask];
+    if ([prev isEqualToNumber:stickyN] && !maskChanged) return;
     objc_setAssociatedObject(tableNode, &kApolloHLStickyCountKey, stickyN, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(tableNode, &kApolloHLFeedOwnedMaskKey, ownedMask, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     // The cold-load fallback collapses exactly the first separator (row 1) — correct
     // only for the common 2-sticky feed. When N differs (a single sticky that lost its
     // breaker, or 3+ that kept an orphan), the already-measured separators are wrong and
@@ -2125,10 +2281,12 @@ static void ApolloHLApplyStickyCountToTable(UIViewController *vc, NSString *subr
     // missing) breaker sticks until the reactive fallback pass happens to catch it.
     // Equality already early-returned above, so a non-nil prev means N genuinely
     // changed → always reload. First publish: only when N differs from the
-    // fallback's assumed 2.
-    BOOL needsReload = (prev != nil) || stickyN.integerValue != 2;
+    // fallback's assumed 2 — or when the feed keeps a sticky row visible, which
+    // the all-collapsed fallback never accounts for.
+    BOOL needsReload = (prev != nil) || stickyN.integerValue != 2 || ownedMask.unsignedIntegerValue != 0;
     if (needsReload && [tableNode respondsToSelector:@selector(reloadData)]) {
-        ApolloLog(@"[Highlights] r/%@ sticky count N=%@ (was %@) → reload to fix breaker", subreddit, stickyN, prev ?: @"unknown");
+        ApolloLog(@"[Highlights] r/%@ sticky count N=%@ (was %@) feedOwned=0x%lx → reload to fix breaker",
+                  subreddit, stickyN, prev ?: @"unknown", (unsigned long)ownedMask.unsignedIntegerValue);
         ((void (*)(id, SEL))objc_msgSend)(tableNode, @selector(reloadData));
     }
 }
@@ -2277,6 +2435,11 @@ static BOOL ApolloHLShouldHideCell(id cellNode) {
     if (!link || ![link respondsToSelector:@selector(stickied)] || !link.stickied) return NO;
     NSString *sub = link.subreddit.lowercaseString;
     if (sub.length == 0 || !ApolloHLHideSubsContains(sub)) return NO;
+    // …except a live interactive post while the feed renders those widgets: the
+    // feed owns it, so it keeps its row (the widget IS the post) and the carousel
+    // dropped it instead — no duplicate. Read straight off the link so this can
+    // never disagree with what the fetch filtered.
+    if (ApolloDevvitFeedOwnsLink(link)) return NO;
     ApolloHLDidCollapseAdd(sub);
     return YES;
 }
@@ -2298,10 +2461,6 @@ static char kApolloHLSepCollapseKey;
 
 static BOOL ApolloHLNodeIsSeparator(id node) {
     return node && [NSStringFromClass([node class]) isEqualToString:@"Apollo.ThickSeparatorCellNode"];
-}
-static BOOL ApolloHLNodeIsPostCell(id node) {
-    NSString *c = node ? NSStringFromClass([node class]) : nil;
-    return [c isEqualToString:@"Apollo.LargePostCellNode"] || [c isEqualToString:@"Apollo.CompactPostCellNode"];
 }
 
 // Zero a node's fixed style.height so an empty layoutSpec actually collapses it
@@ -2369,7 +2528,17 @@ static BOOL ApolloHLSeparatorShouldCollapse(id sepNode) {
     NSNumber *n = owning ? objc_getAssociatedObject(owning, &kApolloHLStickyCountKey) : nil;
     if (n) {
         NSInteger N = n.integerValue;
-        return N >= 1 && r < (2 * N - 1);
+        if (N < 1) return NO;
+        NSUInteger mask = [objc_getAssociatedObject(owning, &kApolloHLFeedOwnedMaskKey) unsignedIntegerValue];
+        if (mask == 0) return r < (2 * N - 1); // every sticky collapsed — keep the last
+        // Some sticky rows stay VISIBLE (a live interactive post the feed owns), so
+        // "keep the last separator" is no longer right: each visible post needs its
+        // own trailing breaker, and every separator under a collapsed post is an
+        // orphan. Separator at row r trails sticky (r-1)/2 — collapse it iff that
+        // post collapsed. At least one bit is set, so at least one breaker survives.
+        if (r >= 2 * N) return NO; // past the sticky run
+        NSInteger sticky = (r - 1) / 2;
+        return sticky >= 32 || !(mask & (1u << sticky));
     }
     // N not known yet (cold first load, before the REST fetch lands). Fall back to the
     // common 2-sticky case: collapse the first orphan (row 1) race-free. The reactive
@@ -2390,27 +2559,22 @@ static void ApolloHLCollapseOrphanSeparators(UIViewController *vc) {
     NSInteger firstRow = [tv indexPathForCell:cells.firstObject].row;
     if (firstRow != 0) return; // only when the feed top is visible
 
-    // Collect the separators in the leading run of de-duped stickies (until the first real post).
-    NSMutableArray *runSeps = [NSMutableArray array];
+    // Re-run the exact same rule the first measure used, now that N (and which of
+    // those sticky rows the feed kept) is known — the whole point of this pass is
+    // the cold load where the separators measured before the fetch landed. Rule in
+    // one place means the two paths can't disagree; flagging is one-way, and the
+    // N/mask publisher reloads (fresh nodes, no stale flags) whenever either
+    // changes, so a separator can never be stuck collapsed under a newer rule.
+    BOOL changed = NO;
     for (UITableViewCell *c in cells) {
         id node = [c respondsToSelector:@selector(node)] ? ((id (*)(id, SEL))objc_msgSend)(c, @selector(node)) : nil;
-        if (!node) continue;
-        if (ApolloHLNodeIsSeparator(node)) { [runSeps addObject:node]; continue; }
-        if (ApolloHLNodeIsPostCell(node)) {
-            if (ApolloHLShouldHideCell(node)) continue; // still a hidden sticky
-            break;                                       // first real post → run ends
-        }
-    }
-    // Keep the last separator (the breaker before the first real post); collapse the rest.
-    BOOL changed = NO;
-    for (NSUInteger i = 0; i + 1 < runSeps.count; i++) {
-        id node = runSeps[i];
-        if (![objc_getAssociatedObject(node, &kApolloHLSepCollapseKey) boolValue]) {
-            objc_setAssociatedObject(node, &kApolloHLSepCollapseKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            ApolloHLZeroNodeHeight(node);
-            if ([node respondsToSelector:@selector(setNeedsLayout)]) ((void (*)(id, SEL))objc_msgSend)(node, @selector(setNeedsLayout));
-            changed = YES;
-        }
+        if (!node || !ApolloHLNodeIsSeparator(node)) continue;
+        if ([objc_getAssociatedObject(node, &kApolloHLSepCollapseKey) boolValue]) continue; // already collapsed
+        if (!ApolloHLSeparatorShouldCollapse(node)) continue;
+        objc_setAssociatedObject(node, &kApolloHLSepCollapseKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        ApolloHLZeroNodeHeight(node);
+        if ([node respondsToSelector:@selector(setNeedsLayout)]) ((void (*)(id, SEL))objc_msgSend)(node, @selector(setNeedsLayout));
+        changed = YES;
     }
     if (changed) {
         // relayoutItems re-lays out EVERY node in the feed synchronously on main —
@@ -2648,6 +2812,30 @@ static void ApolloHLCollapseOrphanSeparators(UIViewController *vc) {
     // of a launch — which can start within a couple of seconds — is already
     // covered rather than racing the compile.
     ApolloScrapeWebViewPrewarmBlocker();
+
+    // Which pinned posts the FEED owns depends on the Devvit toggles, so a flip
+    // there changes what belongs in the carousel. Every cached set was filtered
+    // under the old setting: re-derive the sticky mask from the cached REST set
+    // (its order is the feed's row order, and it is complete whenever the feature
+    // was off), age every entry out so revisiting any sub revalidates, and
+    // refetch + reload the feeds on screen right now.
+    [[NSNotificationCenter defaultCenter] addObserverForName:ApolloDevvitFeedOwnershipChangedNotification
+                                                      object:nil
+                                                       queue:[NSOperationQueue mainQueue]
+                                                  usingBlock:^(__unused NSNotification *note) {
+        if (!sCommunityHighlights) return;
+        for (NSString *sub in ApolloHLRestCache().allKeys) {
+            ApolloHLFeedOwnedMask()[sub] = @(ApolloHLFeedOwnedStickyMask(ApolloHLRestCache()[sub]));
+        }
+        for (NSString *sub in ApolloHLCache().allKeys) ApolloHLFetchTime()[sub] = [NSDate distantPast];
+        ApolloHLForEachPostsVC(^(UIViewController *postsVC) {
+            NSString *sub = ApolloHLSubredditName(postsVC);
+            if (sub.length == 0) return;
+            ApolloHLRefreshSub(sub, NO);   // in-flight guard dedupes duplicate VCs
+            ApolloHLInstall(postsVC);      // republishes N + the new mask
+            ApolloHLReloadFeed(postsVC);   // cells measured under the old rule
+        });
+    }];
 
     [[NSNotificationCenter defaultCenter] addObserverForName:@"ApolloCommunityHighlightsToggleChangedNotification"
                                                       object:nil

--- a/src/ApolloSubredditHighlights.xm
+++ b/src/ApolloSubredditHighlights.xm
@@ -295,6 +295,10 @@ static void ApolloHLReloadFeed(UIViewController *vc) {
 // as their real widget, the feed owns the post and the carousel drops it —
 // see ApolloHLFeedOwnedStickyMask / ApolloHLCarouselItems.
 @property (nonatomic) BOOL isInteractive;
+// Pinned as a classic sticky, i.e. the post occupies one of the feed's leading
+// rows. REQUIRED for feed ownership: the Full-mode web set also carries
+// highlights that are NOT stickied, and those have no feed row to fall back to.
+@property (nonatomic) BOOL isStickied;
 @end
 @implementation ApolloHLItem
 @end
@@ -459,6 +463,11 @@ static NSString *const kApolloHLDiskCacheDefaultsKey = @"CommunityHighlightsDisk
 static NSUInteger const kApolloHLDiskCacheMaxSubs = 40;
 
 static NSString *ApolloHLStringValue(id v); // defined with the parse helpers below
+// Feed-ownership helpers, defined with the parse helpers below (the disk seed has
+// to apply the same split the fetch does).
+static NSArray<ApolloHLItem *> *ApolloHLCarouselItems(NSArray<ApolloHLItem *> *items);
+static NSUInteger ApolloHLFeedOwnedStickyMask(NSArray<ApolloHLItem *> *stickies);
+static NSSet<NSString *> *ApolloHLFeedOwnedIDsFromItems(NSArray<ApolloHLItem *> *items);
 
 static NSDictionary *ApolloHLItemToPlist(ApolloHLItem *it) {
     NSMutableDictionary *d = [NSMutableDictionary dictionary];
@@ -470,6 +479,7 @@ static NSDictionary *ApolloHLItemToPlist(ApolloHLItem *it) {
     if (it.thumbnailURL.absoluteString) d[@"u"] = it.thumbnailURL.absoluteString;
     if (it.isSpoiler) d[@"s"] = @YES;
     if (it.isInteractive) d[@"i"] = @YES;
+    if (it.isStickied) d[@"k"] = @YES;
     return d;
 }
 
@@ -498,6 +508,7 @@ static NSArray<ApolloHLItem *> *ApolloHLItemsFromPlist(id plist) {
         if (thumb.length) it.thumbnailURL = [NSURL URLWithString:thumb];
         it.isSpoiler = [d[@"s"] isKindOfClass:[NSNumber class]] && [d[@"s"] boolValue];
         it.isInteractive = [d[@"i"] isKindOfClass:[NSNumber class]] && [d[@"i"] boolValue];
+        it.isStickied = [d[@"k"] isKindOfClass:[NSNumber class]] && [d[@"k"] boolValue];
         [out addObject:it];
     }
     return out;
@@ -583,16 +594,36 @@ static void ApolloHLSeedFromDisk(NSString *subreddit) {
     NSArray<ApolloHLItem *> *displayed = ApolloHLItemsFromPlist(entry[@"items"]) ?: @[];
     // Partial mode must never resurrect a persisted Full-mode (web-upgraded) set.
     NSArray<ApolloHLItem *> *use = sCommunityHighlightsWeb ? (displayed.count ? displayed : rest) : rest;
+    // The seed has to apply the same feed-ownership split the fetch does. A
+    // snapshot written while the feed did NOT own interactive posts still holds
+    // one, and the carousel installs from this seed SYNCHRONOUSLY (that is the
+    // point of it, #909) while the feed decides live off the link — so without
+    // the filter below the post paints in both places until the revalidation
+    // lands, and stays doubled indefinitely if that fetch fails. Mask and ids are
+    // read AS STORED, before the filter removes the feed-owned posts and takes
+    // their row positions with them.
+    BOOL snapshotFeedOwned = [entry[@"fo"] isKindOfClass:[NSNumber class]] && [entry[@"fo"] boolValue];
+    NSNumber *seededMask = nil;
+    NSSet<NSString *> *seededIDs = nil;
+    if (ApolloDevvitFeedOwnsInteractivePosts()) {
+        // Same setting as the snapshot → its stored mask is authoritative (the
+        // stored set is already filtered, so it can't be re-derived). Snapshot
+        // from the other side → the stored set is still complete, so derive it.
+        seededMask = (snapshotFeedOwned && [entry[@"m"] isKindOfClass:[NSNumber class]])
+                   ? entry[@"m"] : @(ApolloHLFeedOwnedStickyMask(rest));
+        seededIDs = ApolloHLFeedOwnedIDsFromItems(rest);
+    }
+    // Items carry their own flags, so this is exact. (Nothing to undo in the
+    // other direction: a set filtered under the old setting can only be restored
+    // by the refetch the `fo` mismatch below schedules.)
+    use = ApolloHLCarouselItems(use);
+    rest = ApolloHLCarouselItems(rest);
     if (use.count == 0) return;
     ApolloHLCache()[key] = use;
     ApolloHLRestCache()[key] = rest;
     if ([entry[@"n"] isKindOfClass:[NSNumber class]]) ApolloHLStickyCount()[key] = entry[@"n"];
-    // Only honour a persisted feed-owned mask while the feature is still on —
-    // the toggle can have been flipped since the snapshot was written, and the
-    // revalidating fetch (always kicked for a seeded sub) republishes either way.
-    if ([entry[@"m"] isKindOfClass:[NSNumber class]] && ApolloDevvitFeedOwnsInteractivePosts()) {
-        ApolloHLFeedOwnedMask()[key] = entry[@"m"];
-    }
+    if (seededMask) ApolloHLFeedOwnedMask()[key] = seededMask;
+    if (seededIDs.count) ApolloHLFeedOwnedIDs()[key] = seededIDs;
     if ([entry[@"sig"] isKindOfClass:[NSString class]]) ApolloHLRestSig()[key] = entry[@"sig"];
     // Keep the ORIGINAL fetch date: it is (almost always) past the freshness TTL,
     // so the very next ApolloHLMaybeRefreshStale revalidates in the background.
@@ -601,7 +632,6 @@ static void ApolloHLSeedFromDisk(NSString *subreddit) {
     // is either missing a pinned post that now belongs in the carousel, or still
     // carries one the feed has since taken over, and inside the freshness window
     // nothing would refetch. Age it out so the first layout pass revalidates.
-    BOOL snapshotFeedOwned = [entry[@"fo"] isKindOfClass:[NSNumber class]] && [entry[@"fo"] boolValue];
     if (snapshotFeedOwned != ApolloDevvitFeedOwnsInteractivePosts()) {
         ApolloHLFetchTime()[key] = [NSDate distantPast];
         ApolloLog(@"[Highlights] r/%@ snapshot predates the interactive-posts setting → revalidating", key);
@@ -704,6 +734,7 @@ static ApolloHLItem *ApolloHLItemFromPostData(NSDictionary *d) {
     item.thumbnailURL = ApolloHLThumbnailFromPostData(d);
     item.isSpoiler = [d[@"spoiler"] respondsToSelector:@selector(boolValue)] && [d[@"spoiler"] boolValue];
     item.isInteractive = ApolloDevvitPostDataIsInteractive(d);
+    item.isStickied = [d[@"stickied"] respondsToSelector:@selector(boolValue)] && [d[@"stickied"] boolValue];
     return item;
 }
 
@@ -737,6 +768,19 @@ static NSDictionary<NSString *, ApolloHLItem *> *ApolloHLParseInfoListing(NSDict
     return map;
 }
 
+// The feed can only own a post it actually SHOWS, and the only posts it shows
+// above the fold are the leading stickies — so `stickied` is as much a part of
+// ownership as `interactive` is. In Partial mode every carousel item came from
+// the stickied-filtered REST parse and the distinction never bites, but the
+// Full-mode web set is the subreddit's whole highlights list (up to six), and
+// slots 3-6 are usually NOT classic stickies. Dropping one of those from the
+// carousel would delete it outright: nothing pins it to the top of the feed, so
+// an older highlight would only reappear if it happened to rank into the loaded
+// page. Both flags, always.
+static BOOL ApolloHLItemIsFeedOwned(ApolloHLItem *item) {
+    return item.isInteractive && item.isStickied && ApolloDevvitFeedOwnsInteractivePosts();
+}
+
 // Bit i set = leading sticky #i is a live interactive post the feed keeps inline.
 // Capped at 32 rows (Reddit pins two; the web set tops out at six) — beyond that
 // the bit is simply not set, so the post stays de-duped as it is today.
@@ -745,7 +789,7 @@ static NSUInteger ApolloHLFeedOwnedStickyMask(NSArray<ApolloHLItem *> *stickies)
     NSUInteger mask = 0, i = 0;
     for (ApolloHLItem *it in stickies) {
         if (i >= 32) break;
-        if (it.isInteractive) mask |= (1u << i);
+        if (ApolloHLItemIsFeedOwned(it)) mask |= (1u << i);
         i++;
     }
     return mask;
@@ -757,7 +801,7 @@ static NSArray<ApolloHLItem *> *ApolloHLCarouselItems(NSArray<ApolloHLItem *> *i
     if (items.count == 0 || !ApolloDevvitFeedOwnsInteractivePosts()) return items;
     NSMutableArray<ApolloHLItem *> *kept = [NSMutableArray arrayWithCapacity:items.count];
     for (ApolloHLItem *it in items) {
-        if (!it.isInteractive) [kept addObject:it];
+        if (!ApolloHLItemIsFeedOwned(it)) [kept addObject:it];
     }
     return kept.count == items.count ? items : kept;
 }
@@ -768,24 +812,27 @@ static NSSet<NSString *> *ApolloHLFeedOwnedIDsFromItems(NSArray<ApolloHLItem *> 
     NSMutableSet<NSString *> *ids = [NSMutableSet set];
     if (!ApolloDevvitFeedOwnsInteractivePosts()) return ids;
     for (ApolloHLItem *it in items) {
-        if (!it.isInteractive) continue;
+        if (!ApolloHLItemIsFeedOwned(it)) continue;
         NSString *pid = ApolloHLPostIDFromPermalink(it.permalink);
         if (pid.length) [ids addObject:pid];
     }
     return ids;
 }
 
-// Drop the subreddit's feed-owned posts from a set we can't test item-by-item.
-// Belt and braces for the Full-mode web upgrade: its own items carry the flag
-// once /api/info enrichment lands, but the pre-enrichment fast path paints
-// first, and this keeps the daily discussion from flashing into the carousel.
+// Drop the subreddit's feed-owned posts from a set whose own items can't be
+// tested yet. Belt and braces for the Full-mode web upgrade: a DOM-scraped item
+// has neither flag until /api/info enrichment lands, but the fast path paints
+// first — so match by the ids the REST sticky parse already resolved, which
+// keeps the daily discussion from flashing into the carousel. Enriched items are
+// filtered by their own flags (ApolloHLCarouselItems) instead.
 static NSArray<ApolloHLItem *> *ApolloHLDropFeedOwned(NSString *sub, NSArray<ApolloHLItem *> *items) {
     if (items.count == 0) return items;
     if (!ApolloDevvitFeedOwnsInteractivePosts()) return items;
     NSSet<NSString *> *owned = ApolloHLFeedOwnedIDs()[sub.lowercaseString];
+    if (owned.count == 0) return items;
     NSMutableArray<ApolloHLItem *> *kept = [NSMutableArray arrayWithCapacity:items.count];
     for (ApolloHLItem *it in items) {
-        if (it.isInteractive) continue;
+        if (ApolloHLItemIsFeedOwned(it)) continue;
         NSString *pid = ApolloHLPostIDFromPermalink(it.permalink);
         if (pid.length && [owned containsObject:pid]) continue;
         [kept addObject:it];
@@ -2058,9 +2105,12 @@ static void ApolloHLMergeMetadata(NSArray<ApolloHLItem *> *webItems,
         if (!w.flairText.length) w.flairText = info.flairText ?: api.flairText;
         if (w.numComments == 0) w.numComments = info ? info.numComments : (api ? api.numComments : 0);
         if (!w.isSpoiler) w.isSpoiler = info ? info.isSpoiler : (api ? api.isSpoiler : NO);
-        // The DOM gives no selftext, so a web item only learns it is a live
-        // interactive post from /api/info (the REST/api sets are pre-filtered).
+        // The DOM gives neither selftext nor pin state, so a web item only learns
+        // it is a live interactive post — and whether it is one of the classic
+        // stickies, which is what makes the feed its owner — from /api/info. (The
+        // REST/api sets are pre-filtered, so they can only ever confirm.)
         if (!w.isInteractive) w.isInteractive = info ? info.isInteractive : (api ? api.isInteractive : NO);
+        if (!w.isStickied) w.isStickied = info ? info.isStickied : (api ? api.isStickied : NO);
     }
 }
 
@@ -2101,6 +2151,8 @@ static void ApolloHLEnrichViaInfo(NSArray<ApolloHLItem *> *webItems, NSArray<Apo
 
 // If enabled, kick a one-time hidden-WebView fetch of the FULL highlights for the
 // sub and upgrade the carousel when it lands (only if it found more than the API).
+static void ApolloHLRemoveCarousel(NSString *subreddit); // defined with ApolloHLRefreshSub
+
 static void ApolloHLMaybeWebUpgrade(NSString *subreddit) {
     if (!sCommunityHighlights || !sCommunityHighlightsWeb) return;
     NSString *sub = subreddit.lowercaseString;
@@ -2155,10 +2207,30 @@ static void ApolloHLMaybeWebUpgrade(NSString *subreddit) {
         // response is a no-op and cannot cause a visible flash.
         ApolloHLEnrichViaInfo(items, apiItems, ^(NSArray<ApolloHLItem *> *enrichedAll) {
             if (!sCommunityHighlights || !sCommunityHighlightsWeb) return;
-            // /api/info fills in each item's selftext-derived flag, so this is the
-            // authoritative drop of anything the feed owns.
+            // /api/info fills in each item's selftext + pin state, so this is the
+            // authoritative drop of anything the feed owns — including a post the
+            // ids above couldn't cover because the REST fetch never landed.
             NSArray<ApolloHLItem *> *enriched = ApolloHLCarouselItems(enrichedAll);
-            if (enriched.count == 0) return;
+            if (enriched.count == 0) {
+                // Everything the scrape found belongs to the feed. Fall back to the
+                // REST set (it can still hold a pin the scrape missed); if that is
+                // empty too the sub has nothing left to show, so take the carousel
+                // the fast path painted down instead of stranding it.
+                NSArray<ApolloHLItem *> *restOnly = ApolloHLCarouselItems(ApolloHLRestCache()[sub] ?: @[]);
+                if (restOnly.count > 0) {
+                    if (![ApolloHLItemsContentSig(restOnly) isEqualToString:ApolloHLItemsContentSig(ApolloHLCache()[sub])]) {
+                        ApolloLog(@"[Highlights] r/%@ web set is all feed-owned → falling back to %lu REST highlight(s)",
+                                  sub, (unsigned long)restOnly.count);
+                        ApolloHLApplyItems(sub, restOnly);
+                    }
+                } else if (ApolloHLCache()[sub].count > 0) {
+                    ApolloLog(@"[Highlights] r/%@ every highlight is feed-owned → removing carousel", sub);
+                    ApolloHLCache()[sub] = @[];
+                    ApolloHLPersistSub(sub);
+                    ApolloHLRemoveCarousel(sub);
+                }
+                return;
+            }
             BOOL metadataChanged = ![ApolloHLItemsPresentationSig(enriched) isEqualToString:preEnrichmentSig];
             NSArray<ApolloHLItem *> *shown = ApolloHLCache()[sub];
             BOOL setChanged = ![ApolloHLItemsContentSig(enriched) isEqualToString:ApolloHLItemsContentSig(shown)];
@@ -2168,6 +2240,31 @@ static void ApolloHLMaybeWebUpgrade(NSString *subreddit) {
             }
         });
     }];
+}
+
+// Take the carousel off every live feed showing `subreddit` (both placement modes)
+// and stop de-duping it, so any inline stickies come back. Callers own the cache
+// bookkeeping — this only touches what is on screen.
+static void ApolloHLRemoveCarousel(NSString *subreddit) {
+    NSString *key = subreddit.lowercaseString;
+    ApolloHLForEachPostsVC(^(UIViewController *postsVC) {
+        if (![ApolloHLSubredditName(postsVC) isEqualToString:key]) return;
+        if (!sShowSubredditHeaders) {
+            UITableView *tv = ApolloHLFindTableView(postsVC);
+            if (tv) ApolloHLInstallCarousel(postsVC, tv, @[], subreddit); // tears down our header
+        } else {
+            ApolloHLHeaderContainerView *c = objc_getAssociatedObject(postsVC, kApolloHLContainerKey);
+            if (![c isMemberOfClass:[ApolloHLHeaderContainerView class]]) return;
+            [c installCarousel:nil];
+            UIView *wrapper = c.superview;
+            UITableView *tv = ApolloHLFindTableView(postsVC);
+            if (wrapper && tv && tv.tableHeaderView == wrapper) {
+                CGRect wf = wrapper.frame; wf.size.height = CGRectGetMaxY(c.frame); wrapper.frame = wf;
+                [tv setTableHeaderView:wrapper];
+            }
+        }
+    });
+    ApolloHLClearDeDup(subreddit);
 }
 
 // Re-fetch a subreddit's highlights and update the carousel ONLY when the pinned set
@@ -2189,24 +2286,7 @@ static void ApolloHLRefreshSub(NSString *subreddit, BOOL alwaysWeb) {
             // stop de-duping (the inline stickies, if any, return).
             if (!changed) return;
             ApolloLog(@"[Highlights] r/%@ all highlights removed → tearing down carousel", subreddit);
-            ApolloHLForEachPostsVC(^(UIViewController *postsVC) {
-                if (![ApolloHLSubredditName(postsVC) isEqualToString:key]) return;
-                if (!sShowSubredditHeaders) {
-                    UITableView *tv = ApolloHLFindTableView(postsVC);
-                    if (tv) ApolloHLInstallCarousel(postsVC, tv, @[], subreddit); // tears down our header
-                } else {
-                    ApolloHLHeaderContainerView *c = objc_getAssociatedObject(postsVC, kApolloHLContainerKey);
-                    if (![c isMemberOfClass:[ApolloHLHeaderContainerView class]]) return;
-                    [c installCarousel:nil];
-                    UIView *wrapper = c.superview;
-                    UITableView *tv = ApolloHLFindTableView(postsVC);
-                    if (wrapper && tv && tv.tableHeaderView == wrapper) {
-                        CGRect wf = wrapper.frame; wf.size.height = CGRectGetMaxY(c.frame); wrapper.frame = wf;
-                        [tv setTableHeaderView:wrapper];
-                    }
-                }
-            });
-            ApolloHLClearDeDup(subreddit);
+            ApolloHLRemoveCarousel(subreddit);
             // Negative-cache the now-empty sub. The force fetch deliberately never
             // touches the display cache, so without this the stale non-empty entry
             // survives the teardown and the very next ApolloHLInstall layout pass
@@ -2825,9 +2905,22 @@ static void ApolloHLCollapseOrphanSeparators(UIViewController *vc) {
                                                   usingBlock:^(__unused NSNotification *note) {
         if (!sCommunityHighlights) return;
         for (NSString *sub in ApolloHLRestCache().allKeys) {
-            ApolloHLFeedOwnedMask()[sub] = @(ApolloHLFeedOwnedStickyMask(ApolloHLRestCache()[sub]));
+            // Derive the mask/ids from the array AS CACHED — its order is the feed's
+            // sticky row order, and it is complete whenever the feature was off, which
+            // is exactly the direction that needs a mask. Only then filter it: turning
+            // the feature ON has to drop a post the cached set still carries, or the
+            // next visit paints it in the carousel while the feed (which decides live,
+            // off the link) already shows its widget. Turning it OFF can't be undone
+            // locally — the aged-out refetch below restores it.
+            NSArray<ApolloHLItem *> *cachedRest = ApolloHLRestCache()[sub];
+            ApolloHLFeedOwnedMask()[sub] = @(ApolloHLFeedOwnedStickyMask(cachedRest));
+            ApolloHLFeedOwnedIDs()[sub] = ApolloHLFeedOwnedIDsFromItems(cachedRest);
+            ApolloHLRestCache()[sub] = ApolloHLCarouselItems(cachedRest);
         }
-        for (NSString *sub in ApolloHLCache().allKeys) ApolloHLFetchTime()[sub] = [NSDate distantPast];
+        for (NSString *sub in ApolloHLCache().allKeys) {
+            ApolloHLCache()[sub] = ApolloHLCarouselItems(ApolloHLCache()[sub]);
+            ApolloHLFetchTime()[sub] = [NSDate distantPast];
+        }
         ApolloHLForEachPostsVC(^(UIViewController *postsVC) {
             NSString *sub = ApolloHLSubredditName(postsVC);
             if (sub.length == 0) return;

--- a/src/ApolloSubredditHighlights.xm
+++ b/src/ApolloSubredditHighlights.xm
@@ -1122,6 +1122,15 @@ static void ApolloHLFetchHighlights(NSString *subredditName, BOOL force, void (^
                 ApolloHLRestSig()[key] = ApolloHLItemsContentSig(items);
                 ApolloHLPersistSub(key); // keep the relaunch snapshot fresh (#909)
             }
+            // A failed request that parsed nothing must be indistinguishable from
+            // an in-flight dedupe, not from "this sub has no pinned posts" — every
+            // caller treats nil as "do nothing, try again later", while an empty
+            // ARRAY is a real answer that ApolloHLRefreshSub acts on by tearing the
+            // carousel down and negative-caching (dropping the disk snapshot with
+            // it). Seen live: a stale OAuth token 401s on the first launch after a
+            // couple of days away and the sub's carousel vanished until the next
+            // successful refetch. Only a 200 may report an empty listing.
+            if (status != 200 && completionItems.count == 0) completionItems = nil;
             if (completion) completion(completionItems);
         });
     }] resume];
@@ -2160,6 +2169,29 @@ static void ApolloHLEnrichViaInfo(NSArray<ApolloHLItem *> *webItems, NSArray<Apo
 // sub and upgrade the carousel when it lands (only if it found more than the API).
 static void ApolloHLRemoveCarousel(NSString *subreddit); // defined with ApolloHLRefreshSub
 
+// The web set contributed nothing the carousel may show (every scraped item is
+// feed-owned). Fall back to the REST set — it can still hold a pin the scrape
+// missed — and if that is empty too, take down whatever carousel is on display
+// (a stale disk seed, or the fast paint from this very upgrade) instead of
+// stranding it. One helper, called from BOTH zero-item exits of the web
+// upgrade: the pre-enrichment id-filter and the post-enrichment flag-filter.
+// Returning early from only one of them left the other stranded. Main queue.
+static void ApolloHLWebSetAllFeedOwned(NSString *sub) {
+    NSArray<ApolloHLItem *> *restOnly = ApolloHLCarouselItems(ApolloHLRestCache()[sub] ?: @[]);
+    if (restOnly.count > 0) {
+        if (![ApolloHLItemsContentSig(restOnly) isEqualToString:ApolloHLItemsContentSig(ApolloHLCache()[sub])]) {
+            ApolloLog(@"[Highlights] r/%@ web set is all feed-owned → falling back to %lu REST highlight(s)",
+                      sub, (unsigned long)restOnly.count);
+            ApolloHLApplyItems(sub, restOnly);
+        }
+    } else if (ApolloHLCache()[sub].count > 0) {
+        ApolloLog(@"[Highlights] r/%@ every highlight is feed-owned → removing carousel", sub);
+        ApolloHLCache()[sub] = @[];
+        ApolloHLPersistSub(sub);
+        ApolloHLRemoveCarousel(sub);
+    }
+}
+
 static void ApolloHLMaybeWebUpgrade(NSString *subreddit) {
     if (!sCommunityHighlights || !sCommunityHighlightsWeb) return;
     NSString *sub = subreddit.lowercaseString;
@@ -2199,7 +2231,7 @@ static void ApolloHLMaybeWebUpgrade(NSString *subreddit) {
         // by the ids the REST parse already resolved (the enrichment below then
         // re-checks the items themselves, for a sub the REST fetch hasn't reached).
         items = ApolloHLDropFeedOwned(sub, items);
-        if (items.count == 0) return;
+        if (items.count == 0) { ApolloHLWebSetAllFeedOwned(sub); return; }
         NSArray<ApolloHLItem *> *cur = ApolloHLCache()[sub];
         BOOL grew = items.count > cur.count;
         BOOL differs = ![ApolloHLItemsContentSig(items) isEqualToString:ApolloHLItemsContentSig(cur)];
@@ -2218,26 +2250,7 @@ static void ApolloHLMaybeWebUpgrade(NSString *subreddit) {
             // authoritative drop of anything the feed owns — including a post the
             // ids above couldn't cover because the REST fetch never landed.
             NSArray<ApolloHLItem *> *enriched = ApolloHLCarouselItems(enrichedAll);
-            if (enriched.count == 0) {
-                // Everything the scrape found belongs to the feed. Fall back to the
-                // REST set (it can still hold a pin the scrape missed); if that is
-                // empty too the sub has nothing left to show, so take the carousel
-                // the fast path painted down instead of stranding it.
-                NSArray<ApolloHLItem *> *restOnly = ApolloHLCarouselItems(ApolloHLRestCache()[sub] ?: @[]);
-                if (restOnly.count > 0) {
-                    if (![ApolloHLItemsContentSig(restOnly) isEqualToString:ApolloHLItemsContentSig(ApolloHLCache()[sub])]) {
-                        ApolloLog(@"[Highlights] r/%@ web set is all feed-owned → falling back to %lu REST highlight(s)",
-                                  sub, (unsigned long)restOnly.count);
-                        ApolloHLApplyItems(sub, restOnly);
-                    }
-                } else if (ApolloHLCache()[sub].count > 0) {
-                    ApolloLog(@"[Highlights] r/%@ every highlight is feed-owned → removing carousel", sub);
-                    ApolloHLCache()[sub] = @[];
-                    ApolloHLPersistSub(sub);
-                    ApolloHLRemoveCarousel(sub);
-                }
-                return;
-            }
+            if (enriched.count == 0) { ApolloHLWebSetAllFeedOwned(sub); return; }
             BOOL metadataChanged = ![ApolloHLItemsPresentationSig(enriched) isEqualToString:preEnrichmentSig];
             NSArray<ApolloHLItem *> *shown = ApolloHLCache()[sub];
             BOOL setChanged = ![ApolloHLItemsContentSig(enriched) isEqualToString:ApolloHLItemsContentSig(shown)];

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -10,6 +10,7 @@
 #import "InfoRowSettingsViewController.h"
 #import "ApolloWebSessionLoginViewController.h"
 #import "ApolloDirectChatWeb.h"
+#import "ApolloDevvitPosts.h"        // ApolloDevvitFeedOwnershipChangedNotification
 #import "settings/ApolloAISettingsViewController.h"
 #import "ApolloWebSessionStore.h"
 #import "ApolloAccountCredentials.h"
@@ -1337,7 +1338,7 @@ typedef NS_ENUM(NSInteger, Tag) {
     devvitFeedPosts.visible = ^BOOL { return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyDevvitInteractivePosts]; };
 
     return [ApolloSettingsSection sectionWithTitle:@"Feed"
-                                            footer:@"Small tweaks for the post list. Live Match Threads & Games shows the real live widget for Reddit's interactive posts — match scores, predictions, brackets, and community games — instead of a placeholder. Always shown in comments; Show in Feed also puts it on large-mode feed cards."
+                                            footer:@"Small tweaks for the post list. Live Match Threads & Games shows the real live widget for Reddit's interactive posts — match scores, predictions, brackets, and community games — instead of a placeholder. Always shown in comments; Show in Feed also puts it on large-mode feed cards, and keeps a pinned one (a daily discussion thread, say) in the feed rather than folding it into Community Highlights, where a card can't show live scores."
                                               rows:@[ textPostThumbnails, infoRow, blockAnnouncements, devvitPosts, devvitFeedPosts ]];
 }
 
@@ -3456,11 +3457,15 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
     sDevvitInteractivePosts = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sDevvitInteractivePosts forKey:UDKeyDevvitInteractivePosts];
     [self visibilityDidChange];  // drives the "Interactive Posts in Feed" sub-row
+    // Community Highlights hands a PINNED interactive post back to the feed while
+    // its widget renders there, so both toggles change what belongs in a carousel.
+    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloDevvitFeedOwnershipChangedNotification object:nil];
 }
 
 - (void)devvitFeedPostsSwitchToggled:(UISwitch *)sender {
     sDevvitFeedWidgets = sender.isOn;
     [[NSUserDefaults standardUserDefaults] setBool:sDevvitFeedWidgets forKey:UDKeyDevvitFeedWidgets];
+    [[NSNotificationCenter defaultCenter] postNotificationName:ApolloDevvitFeedOwnershipChangedNotification object:nil];
 }
 
 - (void)keepSearchBarInPlaceSwitchToggled:(UISwitch *)sender {

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -1321,9 +1321,14 @@ typedef NS_ENUM(NSInteger, Tag) {
                                       isOn:^BOOL { return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyBlockAnnouncements]; }
                                   onToggle:^(UISwitch *sender) { [weakSelf blockAnnouncementsSwitchToggled:sender]; }];
 
+    // Named for the whole class of Reddit Developer Platform posts, not the
+    // sports ones it was first built against: the same widget mechanism carries
+    // r/wallstreetbets' live market dashboard, brackets, polls and community
+    // games. Settings search indexes row TITLES only, so the footer below spells
+    // the range out for anyone who lands on this screen.
     ApolloSettingsRow *devvitPosts =
         [ApolloSettingsRow switchRowWithID:@"gen.devvitPosts"
-                                     title:@"Live Match Threads & Games"
+                                     title:@"Live Interactive Posts"
                                       isOn:^BOOL { return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyDevvitInteractivePosts]; }
                                   onToggle:^(UISwitch *sender) { [weakSelf devvitPostsSwitchToggled:sender]; }];
 
@@ -1338,7 +1343,7 @@ typedef NS_ENUM(NSInteger, Tag) {
     devvitFeedPosts.visible = ^BOOL { return [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyDevvitInteractivePosts]; };
 
     return [ApolloSettingsSection sectionWithTitle:@"Feed"
-                                            footer:@"Small tweaks for the post list. Live Match Threads & Games shows the real live widget for Reddit's interactive posts — match scores, predictions, brackets, and community games — instead of a placeholder. Always shown in comments; Show in Feed also puts it on large-mode feed cards, and keeps a pinned one (a daily discussion thread, say) in the feed rather than folding it into Community Highlights, where a card can't show live scores."
+                                            footer:@"Small tweaks for the post list. Live Interactive Posts shows Reddit's Developer Platform posts as their real live widget — match scores and threads, market tickers and trading dashboards, predictions, brackets, polls, and community games — instead of the placeholder text old Reddit gets. Always shown in comments; Show in Feed also puts it on large-mode feed cards, and keeps a pinned one (a subreddit's daily discussion thread, say) in the feed rather than folding it into Community Highlights, where a static card can't show live data."
                                               rows:@[ textPostThumbnails, infoRow, blockAnnouncements, devvitPosts, devvitFeedPosts ]];
 }
 


### PR DESCRIPTION
## What

Community Highlights de-dups every **stickied** post out of the feed, and a pinned Devvit post is stickied — so the carousel turned r/soccer's daily discussion into a static card and its live scoreboard never rendered. The only way to see the widget was to turn Community Highlights off entirely. Same for r/wallstreetbets' weekend thread (live tickers, sentiment, SPY chart) and r/Pixelary's pinned game.

| Before — the carousel swallows it | After — the feed renders it live |
| --- | --- |
| <img src="https://raw.githubusercontent.com/icpryde/Apollo-Reborn/pr-939-screenshots/1-before-highlights-swallows-it.png" width="330"> | <img src="https://raw.githubusercontent.com/icpryde/Apollo-Reborn/pr-939-screenshots/2-after-feed-shows-scoreboard.png" width="330"> |

Now, while the feed is actually rendering those widgets (**Live Interactive Posts** + **Show in Feed**), the FEED owns such a pinned post: it stays inline where the widget renders, and the carousel drops it rather than showing the same post as a card right above itself. Everything else pinned still goes in the carousel, so the two features coexist — r/soccer keeps its predictions-survey pin in Community Highlights and gets the daily discussion as the first feed post.

No new setting: **Show in Feed** already means "put these widgets in my feed", and Community Highlights silently defeating it was the bug. With it off, the inline post would be nothing but Reddit's fallback text, so the carousel keeps owning it and behaviour is byte-identical to today — the widget is still one tap away in the post itself. Live Interactive Posts is off by default, so nothing changes for anyone who hasn't opted in.

| Master | Show in Feed | Pinned post lives in | Widget in feed | Widget in thread |
| --- | --- | --- | --- | --- |
| Off | — | Highlights carousel | no | no (fallback text) |
| On | Off | Highlights carousel | no | **yes** |
| On | On | The feed | **yes** | yes |

## Not just sports

Detection keys on *"is this a Devvit custom post"*, not on the app, so every Developer Platform post goes through one path — which is why the rename below matters more than the sports framing suggested.

| r/wallstreetbets — live market dashboard | r/Pixelary — drawing game | The setting |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/icpryde/Apollo-Reborn/pr-939-screenshots/4-wallstreetbets-dashboard.png" width="240"> | <img src="https://raw.githubusercontent.com/icpryde/Apollo-Reborn/pr-939-screenshots/5-pixelary-game.png" width="240"> | <img src="https://raw.githubusercontent.com/icpryde/Apollo-Reborn/pr-939-screenshots/6-setting.png" width="240"> |

r/Pixelary is a good demonstration: its pinned "Welcome to Pixelary!" post is itself a Devvit post, so the split fires on a drawing game with no sports involved.

## Four bugs fixed along the way

**1. The widget didn't render in comments for r/soccer's daily discussion.** Detection (added in #920) required the old-Reddit fallback markers within a 4096-char body; that post is 5.2 KB of rules text with the fallback appended at the end, so it passed on the shorter listing copy in the feed and failed on the full one in the thread. Replaced the length cap with a proximity test — the two markers must sit within 300 chars of each other (they are 72 apart), which is what actually rules out a post that merely quotes the fallback, and it does not care how long the body is.

<img src="https://raw.githubusercontent.com/icpryde/Apollo-Reborn/pr-939-screenshots/3-thread-scoreboard.png" width="330">

**2. Posting from inside a widget dropped you on "Error loading comments".** Finishing a Pixelary drawing and tapping POST landed on an empty Comments screen over an endless spinner, with the game gone. The post *was* created; only the navigation to it was broken. A devvit app navigates its host page by post **fullname** rather than the bare id reddit's permalinks use — `/r/Pixelary/comments/t3_1vp57ul` where a real permalink reads `/r/Pixelary/comments/1vp57ul` — and Apollo resolved that literally, opening a post id that cannot exist. `routeExternally:` now strips the `t3_` prefix. Not Pixelary-specific: any interactive post that navigates to another post was affected.

| Before — POST → dead Comments screen | After — POST → your new post, widget live |
| --- | --- |
| <img src="https://raw.githubusercontent.com/icpryde/Apollo-Reborn/pr-939-screenshots/7-post-error-before.png" width="330"> | <img src="https://raw.githubusercontent.com/icpryde/Apollo-Reborn/pr-939-screenshots/8-post-opens-after.png" width="330"> |

**3. Compact widgets sat in a 512pt hole, and didn't grow when expanded.** A finished match thread renders a single ~96pt score row rather than the tall card the daily discussion uses, and it was drawn at the top of the 512pt placeholder we reserve before the page loads — in the feed and in the post alike. Two causes, both in the height path. The measurement was being *discarded*: `ApolloDevvitStoreHeight` rejected anything under 120pt as implausible, so the 96pt report never became a correction; the floor now matches what the probe itself treats as real (40pt, held stable across two samples). And the measurement *missed expansion*: tapping "open the full match thread" overlays the expanded view outside the host element's box, so its rect stayed 96pt while its descendants reached ~516pt and the cell clipped everything below. The probe now walks the widget's subtree (shadow roots included) and takes the deepest painted descendant when it is taller. The watchdog also polls at 1s while the widget is moving (was a flat 6s) and allows 12 corrections rather than 3 — an expand/collapse pair nearly exhausted the old budget on its own. And because the user's tap IS the signal, a passive tap recognizer on the widget (recognizes alongside WebKit's gestures, never cancels the touch) probes right after every tap: expand and collapse now resize the cell within ~1s of the finger, measured live on Casa Pia vs Benfica with the watchdog at its idle cadence, instead of clipping until the next idle tick.

| Before — small card, ~400pt of dead space | After — snug | After — expanded on tap |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/icpryde/Apollo-Reborn/pr-939-screenshots/9-compact-deadspace-before.png" width="240"> | <img src="https://raw.githubusercontent.com/icpryde/Apollo-Reborn/pr-939-screenshots/10-compact-snug-after.png" width="240"> | <img src="https://raw.githubusercontent.com/icpryde/Apollo-Reborn/pr-939-screenshots/11-expanded-on-tap.png" width="240"> |

Tall widgets are unaffected: the daily discussion and Pixelary's game both still measure 516pt against the 512pt they reserved.

**4. Renamed "Live Match Threads & Games" → "Live Interactive Posts".** The sports framing undersold it: the same mechanism carries market dashboards, drawing games, brackets and polls. Only the display string changes — the defaults key is untouched, so existing users keep their setting.

## How

- `src/ApolloDevvitPosts.h` (new) exports the detection predicate so `ApolloSubredditHighlights.xm` applies the *same* test to its raw JSON that the feed/comments hooks apply to an `RDKLink` — the two can't drift. Also exports `ApolloDevvitFeedOwnsInteractivePosts()` (`sDevvitInteractivePosts && sDevvitFeedWidgets`) and a notification for live toggle changes.
- Feed ownership needs **both** flags: `isInteractive && isStickied`. Only the leading stickies have a feed row, and in Full mode the web scrape returns the sub's whole highlights list (up to six) where slots 3-6 usually are not classic stickies — dropping one of those would delete it outright, since nothing pins it to the top of the feed. `stickied` is carried on `ApolloHLItem` (listing → `/api/info` for web items → persisted).
- `ApolloHLShouldHideCell` returns NO for a feed-owned link, read straight off the link so it can never disagree with what the fetch filtered.
- **Breaker rule.** Stickies occupy rows `0..2N-1` and the old rule ("collapse every separator but the last") assumed all of them collapse; with one staying visible that doubles or drops a divider. The REST parse now also publishes a bitmask of which sticky rows stay, next to the existing count N on the feed's ASTableNode, and a separator collapses iff the post above it collapsed — race-free at first measure, the same trick N already used. `mask == 0` is the old rule verbatim, so subreddits with no interactive pins are untouched. The reactive `ApolloHLCollapseOrphanSeparators` pass now re-runs that one rule instead of its own leading-run walk.
- Filtering happens at the fetch/parse split, so every downstream path (caches, signatures, empty-teardown) works unchanged. The Full-mode web set is filtered by id before the fast paint and by the items' own flags after `/api/info` enrichment; if enrichment leaves nothing, it falls back to the REST set rather than stranding what the fast path painted.
- Both zero-item exits of the Full-mode web upgrade (the pre-enrichment id-filter and the post-enrichment flag-filter) route through one fallback helper — fall back to the REST set, else take the carousel down — so an all-feed-owned scrape can never strand a stale carousel (review: @jordanearle). And a FAILED highlights fetch now reports nil ("retry later") instead of an empty listing, so a transient 401/403 on the freshness re-poll can no longer tear a carousel down and drop its disk snapshot.
- Toggle changes re-sync live (masks re-derived, cached sets re-filtered, visible feeds refetched and reloaded), and a disk snapshot written under the other setting revalidates on the next launch instead of leaving the post in neither surface. Mask and ids are always derived *before* filtering — the filter removes the very rows the mask indexes.
- Reddit URLs routed out of a widget now log their **path** rather than just `scheme://host`. The old line printed `https://reddit.com` for bug 2, which hid the malformed id and sent the first diagnosis down the wrong road.

## Testing (sim matrix)

Apollo-Sim3, glass + non-glass (vtool-downgraded shell), API-key (u/iChopPryde) + keyless (u/RemZeroBestGirl), Partial + Full highlights modes, large + compact:

- **r/soccer** (sticky #0 interactive) and **r/wallstreetbets** (sticky #1 interactive) — both mask arms: carousel drops it, feed renders the live widget, and exactly **one 8.0pt breaker** below it, measured by pixel scan and matching a normal post→post divider.
- **r/nintendo / r/formula1 / r/worldnews** (no interactive pins) — unchanged, 14pt (6pt carousel pad + one 8pt breaker), and no re-measure/reload at all in the common case.
- **r/gaming and r/movies** in Full mode — 4 web highlights each, only 2 stickied; all four stay in the carousel with `/api/info` resolving 4/4. This is the case that made ownership require `stickied`.
- **r/Pixelary** — pinned game handed to the feed and playable inline; played a full round twice (Draw → word → canvas → DONE → POST) to reproduce and then confirm bug 2.
- Comments/thread view for the soccer scoreboard and the wallstreetbets dashboard, including with **Show in Feed off** (post stays a highlight card, tapping it opens the thread with the widget).
- Toggle off → the carousel reclaims the post and the feed hides it again; toggle on → the reverse. Both at launch and flipped live in Settings.
- **Toggle matrix re-run on live data (Aug 17)**: Show in Feed ON → carousel shows only Monday Moan, the daily discussion is the first feed post with its widget; OFF → the daily discussion returns to the carousel as a card, no widget in the feed, and tapping the card opens the thread with the live widget. Forced the all-feed-owned web scrape (id filter dropping everything) to confirm the zero-item exit now reaches the fallback instead of returning early.
- **Widget sizing**: r/soccer's Charlton vs Derby match thread — 100pt snug on load, 516pt within a second of tapping expand, back to 100pt on close (2/12 corrections); r/soccer's daily discussion and r/Pixelary unchanged at 516pt.
- Snapshot written under the other setting → `snapshot predates the interactive-posts setting → revalidating`, carousel corrects on the first layout pass.

A four-lens adversarial review over the first cut raised 14 findings; 4 survived refutation and are fixed here (the `stickied` scoping above, disk-seed re-filtering, the enrichment fallback, and the toggle observer leaving cached sets filtered under the old setting).

Merged with `apollo-reborn/main` after #859 landed — it refactored `ApolloHLShouldHideCell`'s membership check and "did collapse" mark into one monitor entry, exactly where this branch adds the feed-ownership exception. Both are kept: the exception is settled before the monitor, since it reads only the link and never the shared sets.

Device build (iOS 26 SDK / iOS 14 floor) is clean. **Not device-tested yet.**

Known gap, unchanged from #920: a Devvit post that has been **crossposted** is not detected (the original is wrapped in `crosspost_parent_list[0]`).

<sub>Screenshots are hosted on the `pr-939-screenshots` branch of the fork; delete it whenever you like and only the images here go away.</sub>
