### PR TITLE
Adds Apollo’s Goodbye Wallpapers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ ApolloReborn_FILES = \
     $(SRC_DIR)/settings/ApolloBackupRestore.m \
     $(SRC_DIR)/settings/ApolloThanksToViewController.m \
     $(SRC_DIR)/settings/ApolloBuyUsACoffeeViewController.m \
+    $(SRC_DIR)/settings/ApolloWallpaperViewerViewController.m \
+    $(SRC_DIR)/settings/ApolloWallpapersViewController.m \
     $(SRC_DIR)/settings/ApolloReportViewController.m \
     $(SRC_DIR)/settings/ApolloSettingsRouter.m \
     $(SRC_DIR)/settings/ApolloSettingsSearch.m \

--- a/src/settings/ApolloSettings.xm
+++ b/src/settings/ApolloSettings.xm
@@ -12,10 +12,14 @@
 #import "ApolloSettingsSearch.h"
 #import "ApolloReportViewController.h"
 #import "ApolloThemeRuntime.h"
+#import "ApolloWallpapersViewController.h"
 
 // MARK: - Settings View Controller (Custom API row injection)
 
 @interface SettingsViewController : UIViewController
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView;
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section;
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath;
 @end
 
 @interface SettingsAboutViewController : UIViewController
@@ -176,6 +180,11 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
         UIEdgeInsets indicatorInsets = tableView.verticalScrollIndicatorInsets;
         indicatorInsets.top -= 24.0;
         tableView.verticalScrollIndicatorInsets = indicatorInsets;
+
+        // Apollo 1.15.11's two-row About group is rendered below as Wallpapers,
+        // About, and Apollo Ultra. The native destinations retain their
+        // original handlers while no Apollo-owned cell is remapped.
+        ApolloLog(@"[Settings] Wallpapers row installed in native About group");
     }
 }
 
@@ -201,6 +210,7 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     if (section == 0) return 2;
+    if (section == 2) return 3;
     return %orig;
 }
 
@@ -217,7 +227,45 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
         cell.imageView.image = indexPath.row == 0
             ? (ApolloRebornOptionsSettingsIcon(29.0) ?: createSettingsIcon(@"key.fill", [UIColor systemTealColor]))
             : ApolloBuyMeACoffeeSettingsIcon(29.0);
+        cell.accessoryView = nil;
         cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+        cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+        ApolloApplyRootNativeSurface(cell, objc_getAssociatedObject(self, &kApolloRootNativeSurfaceKey));
+        return cell;
+    }
+
+    if (indexPath.section == 2) {
+        NSArray<NSString *> *titles = @[ @"Wallpapers", @"About", @"Apollo Ultra" ];
+        NSString *title = titles[indexPath.row];
+        NSString *reuseID = [@"Cell_ApolloInfoRoot_" stringByAppendingString:title];
+        UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:reuseID];
+        if (!cell) {
+            cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:reuseID];
+        }
+        cell.textLabel.text = title;
+        UIColor *primaryText = ApolloThemeRuntimeColor(ApolloThemeTokenLabel);
+        if (primaryText) cell.textLabel.textColor = primaryText;
+        cell.imageView.image = indexPath.row == 0
+            ? createSettingsIcon(@"photo.on.rectangle.angled", UIColor.systemRedColor)
+            : ApolloRootSettingsIconForTitle(title);
+        if (indexPath.row == 0) {
+            UIImageSymbolConfiguration *accessoryConfig =
+                [UIImageSymbolConfiguration configurationWithPointSize:17.0 weight:UIImageSymbolWeightRegular];
+            UIView *accessoryContainer = [[UIView alloc] initWithFrame:CGRectMake(0.0, 0.0, 24.0, 24.0)];
+            accessoryContainer.clipsToBounds = NO;
+            accessoryContainer.accessibilityElementsHidden = YES;
+            UIImageView *downloadAccessory = [[UIImageView alloc]
+                initWithImage:[UIImage systemImageNamed:@"arrow.down.to.line" withConfiguration:accessoryConfig]];
+            downloadAccessory.tintColor = UIColor.tertiaryLabelColor;
+            downloadAccessory.contentMode = UIViewContentModeCenter;
+            downloadAccessory.frame = CGRectMake(8.0, 0.0, 24.0, 24.0);
+            [accessoryContainer addSubview:downloadAccessory];
+            cell.accessoryType = UITableViewCellAccessoryNone;
+            cell.accessoryView = accessoryContainer;
+        } else {
+            cell.accessoryView = nil;
+            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+        }
         cell.selectionStyle = UITableViewCellSelectionStyleDefault;
         ApolloApplyRootNativeSurface(cell, objc_getAssociatedObject(self, &kApolloRootNativeSurfaceKey));
         return cell;
@@ -228,18 +276,6 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
     if (nativeSurface) {
         objc_setAssociatedObject(self, &kApolloRootNativeSurfaceKey, nativeSurface,
                                  OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        for (UITableViewCell *visibleCell in tableView.visibleCells) {
-            NSIndexPath *visiblePath = [tableView indexPathForCell:visibleCell];
-            if (visiblePath.section == 0) ApolloApplyRootNativeSurface(visibleCell, nativeSurface);
-        }
-        __weak UITableView *weakTable = tableView;
-        dispatch_async(dispatch_get_main_queue(), ^{
-            UITableView *liveTable = weakTable;
-            for (UITableViewCell *visibleCell in liveTable.visibleCells) {
-                NSIndexPath *visiblePath = [liveTable indexPathForCell:visibleCell];
-                if (visiblePath.section == 0) ApolloApplyRootNativeSurface(visibleCell, nativeSurface);
-            }
-        });
     }
     UIImage *normalizedIcon = ApolloRootSettingsIconForTitle(cell.textLabel.text);
     if (normalizedIcon) cell.imageView.image = normalizedIcon;
@@ -271,6 +307,21 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
             return;
         }
     }
+
+    if (indexPath.section == 2 && indexPath.row == 0) {
+        [tableView deselectRowAtIndexPath:indexPath animated:YES];
+        UITableViewCell *sourceCell = [tableView cellForRowAtIndexPath:indexPath];
+        [ApolloWallpapersViewController presentDevicePickerFromViewController:(UIViewController *)self
+                                                                   sourceView:sourceCell ?: ((UIViewController *)self).view];
+        return;
+    }
+
+    if (indexPath.section == 2 && indexPath.row > 0) {
+        NSIndexPath *nativePath = [NSIndexPath indexPathForRow:indexPath.row - 1 inSection:2];
+        %orig(tableView, nativePath);
+        return;
+    }
+
     %orig;
 }
 
@@ -286,6 +337,7 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.section == 0) return 52.0;
+    if (indexPath.section == 2) return 52.0;
     return %orig;
 }
 

--- a/src/settings/ApolloSettings.xm
+++ b/src/settings/ApolloSettings.xm
@@ -61,6 +61,13 @@ static void ApolloApplyRootNativeSurface(UITableViewCell *cell, UIColor *surface
     cell.contentView.backgroundColor = [UIColor clearColor];
 }
 
+static BOOL ApolloRootCellCopiesNativeSurface(NSIndexPath *indexPath) {
+    // Both cards are made from tweak-owned cells. They must follow a freshly
+    // themed native donor rather than retaining a resolved surface from the
+    // appearance in which they were first created.
+    return indexPath.section == 0 || indexPath.section == 2;
+}
+
 // Apollo's root Settings screen adds an Export button for its legacy settings
 // archive. Reborn owns Backup/Restore in its Data section, so two export paths
 // with different formats are ambiguous. Remove only Apollo's export action and
@@ -199,6 +206,21 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
     sApolloLastSettingsVC = (UIViewController *)self;
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    %orig;
+    UIViewController *controller = (UIViewController *)self;
+    if (!previousTraitCollection ||
+        previousTraitCollection.userInterfaceStyle == controller.traitCollection.userInterfaceStyle) return;
+
+    // The native surface captured below may be a trait-resolved color. Drop
+    // it before rebuilding so the native rows donate their new appearance,
+    // then propagate that surface back to both tweak-owned cards.
+    objc_setAssociatedObject(self, &kApolloRootNativeSurfaceKey, nil,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    UITableView *tableView = ApolloRootSettingsTableInView(controller.view);
+    [tableView reloadData];
+}
+
 // Reborn and support form one compact primary card. The cells are tweak-owned
 // because UIKit requires a cell dequeued for an index path to be returned for
 // that same path. Their surface is copied from a real native row below after
@@ -276,6 +298,25 @@ static UITableView *ApolloRootSettingsTableInView(UIView *view) {
     if (nativeSurface) {
         objc_setAssociatedObject(self, &kApolloRootNativeSurfaceKey, nativeSurface,
                                  OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        for (UITableViewCell *visibleCell in tableView.visibleCells) {
+            NSIndexPath *visiblePath = [tableView indexPathForCell:visibleCell];
+            if (ApolloRootCellCopiesNativeSurface(visiblePath)) {
+                ApolloApplyRootNativeSurface(visibleCell, nativeSurface);
+            }
+        }
+        // Apollo can finish its own cell theming later in this run-loop turn.
+        // Reassert once more after that pass so the custom cards match the
+        // final native surface during animated appearance transitions.
+        __weak UITableView *weakTable = tableView;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            UITableView *liveTable = weakTable;
+            for (UITableViewCell *visibleCell in liveTable.visibleCells) {
+                NSIndexPath *visiblePath = [liveTable indexPathForCell:visibleCell];
+                if (ApolloRootCellCopiesNativeSurface(visiblePath)) {
+                    ApolloApplyRootNativeSurface(visibleCell, nativeSurface);
+                }
+            }
+        });
     }
     UIImage *normalizedIcon = ApolloRootSettingsIconForTitle(cell.textLabel.text);
     if (normalizedIcon) cell.imageView.image = normalizedIcon;

--- a/src/settings/ApolloWallpaperViewerViewController.h
+++ b/src/settings/ApolloWallpaperViewerViewController.h
@@ -12,8 +12,11 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 // Apollo-style, full-screen wallpaper pager. Images remain remotely hosted;
-// only the current page (and UIKit's ordinary URL cache) is loaded on demand.
+// opening pages can be warmed before presentation and nearby pages are loaded
+// into a bounded shared cache as the user browses.
 @interface ApolloWallpaperViewerViewController : UIViewController
+
++ (void)preloadFirstItemFromItems:(NSArray<ApolloWallpaperItem *> *)items;
 
 - (instancetype)initWithItems:(NSArray<ApolloWallpaperItem *> *)items;
 - (instancetype)init NS_UNAVAILABLE;

--- a/src/settings/ApolloWallpaperViewerViewController.h
+++ b/src/settings/ApolloWallpaperViewerViewController.h
@@ -1,0 +1,24 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ApolloWallpaperItem : NSObject
+
++ (instancetype)itemWithURLString:(NSString *)URLString caption:(NSString *)caption;
+
+@property (nonatomic, copy, readonly) NSURL *URL;
+@property (nonatomic, copy, readonly) NSString *caption;
+
+@end
+
+// Apollo-style, full-screen wallpaper pager. Images remain remotely hosted;
+// only the current page (and UIKit's ordinary URL cache) is loaded on demand.
+@interface ApolloWallpaperViewerViewController : UIViewController
+
+- (instancetype)initWithItems:(NSArray<ApolloWallpaperItem *> *)items;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithCoder:(NSCoder *)coder NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/settings/ApolloWallpaperViewerViewController.m
+++ b/src/settings/ApolloWallpaperViewerViewController.m
@@ -3,6 +3,22 @@
 #import "ApolloCommon.h"
 #import <Photos/Photos.h>
 
+static NSUInteger ApolloWallpaperDecodedImageCost(UIImage *image) {
+    CGImageRef CGImage = image.CGImage;
+    if (!CGImage) return 0;
+    size_t bytesPerRow = CGImageGetBytesPerRow(CGImage);
+    size_t height = CGImageGetHeight(CGImage);
+    if (height > 0 && bytesPerRow > NSUIntegerMax / height) return NSUIntegerMax;
+    return bytesPerRow * height;
+}
+
+static void ApolloWallpaperCacheImage(NSCache<NSURL *, UIImage *> *cache,
+                                      NSURL *URL,
+                                      UIImage *image) {
+    if (!cache || !URL || !image) return;
+    [cache setObject:image forKey:URL cost:ApolloWallpaperDecodedImageCost(image)];
+}
+
 @implementation ApolloWallpaperItem
 
 + (instancetype)itemWithURLString:(NSString *)URLString caption:(NSString *)caption {
@@ -190,6 +206,14 @@
     self.dataCache = dataCache;
     self.retryView.hidden = YES;
     self.imageView.image = [imageCache objectForKey:URL];
+    if (!self.imageView.image) {
+        NSData *cachedData = [dataCache objectForKey:URL];
+        UIImage *cachedImage = cachedData.length > 0 ? [UIImage imageWithData:cachedData] : nil;
+        if (cachedImage) {
+            self.imageView.image = cachedImage;
+            ApolloWallpaperCacheImage(imageCache, URL, cachedImage);
+        }
+    }
     if (self.imageView.image) {
         [self resetZoomGeometry];
         [self.spinner stopAnimating];
@@ -198,15 +222,18 @@
 
     [self.spinner startAnimating];
     __weak typeof(self) weakSelf = self;
-    self.task = [[NSURLSession sharedSession] dataTaskWithURL:URL completionHandler:^(NSData *data, __unused NSURLResponse *response, NSError *error) {
+    __weak NSURLSessionDataTask *weakTask = nil;
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:URL completionHandler:^(NSData *data, __unused NSURLResponse *response, NSError *error) {
         UIImage *image = data.length > 0 ? [UIImage imageWithData:data] : nil;
         if (image) {
-            [imageCache setObject:image forKey:URL];
+            ApolloWallpaperCacheImage(imageCache, URL, image);
             [dataCache setObject:data forKey:URL cost:data.length];
         }
         dispatch_async(dispatch_get_main_queue(), ^{
             typeof(self) strongSelf = weakSelf;
-            if (!strongSelf || ![strongSelf.representedURL isEqual:URL]) return;
+            if (!strongSelf || strongSelf.task != weakTask ||
+                ![strongSelf.representedURL isEqual:URL]) return;
+            strongSelf.task = nil;
             [strongSelf.spinner stopAnimating];
             strongSelf.imageView.image = image;
             [strongSelf resetZoomGeometry];
@@ -214,7 +241,9 @@
             if (!image) ApolloLog(@"[Wallpapers] image load failed url=%@ error=%@", URL, error.localizedDescription ?: @"decode failed");
         });
     }];
-    [self.task resume];
+    weakTask = task;
+    self.task = task;
+    [task resume];
 }
 
 - (void)retryTapped {
@@ -267,6 +296,7 @@
 @property (nonatomic) NSInteger currentIndex;
 @property (nonatomic) NSInteger savingIndex;
 @property (nonatomic) NSInteger initialIndex;
+@property (nonatomic) NSInteger prefetchDirection;
 @property (nonatomic) BOOL initialPositionApplied;
 @property (nonatomic) BOOL chromeVisible;
 @end
@@ -278,13 +308,17 @@
     if (self) {
         _items = [items copy] ?: @[];
         _imageCache = [[NSCache alloc] init];
-        _imageCache.countLimit = 3;
+        // The active page plus a direction-aware six-page preload window.
+        // NSCache can still discard these early under system memory pressure.
+        _imageCache.countLimit = 7;
+        _imageCache.totalCostLimit = 160 * 1024 * 1024;
         _dataCache = [[NSCache alloc] init];
-        _dataCache.countLimit = 3;
-        _dataCache.totalCostLimit = 32 * 1024 * 1024;
+        _dataCache.countLimit = 16;
+        _dataCache.totalCostLimit = 64 * 1024 * 1024;
         _prefetchTasks = [NSMutableDictionary dictionary];
         _initialIndex = 0;
         _savingIndex = NSNotFound;
+        _prefetchDirection = 1;
         _chromeVisible = YES;
 #if APOLLO_SIM_BUILD
         const char *previewIndex = getenv("APOLLO_OPEN_WALLPAPER_INDEX");
@@ -670,30 +704,78 @@
     self.counterLabel.text = [NSString stringWithFormat:@"%ld of %lu", (long)self.currentIndex + 1, (unsigned long)self.items.count];
     self.captionLabel.text = self.items[self.currentIndex].caption;
     if (self.savingIndex == NSNotFound) [self resetDownloadConfirmation];
-    [self prefetchAdjacentWallpapers];
+    [self prefetchNearbyWallpapers];
 }
 
-- (void)prefetchAdjacentWallpapers {
-    NSMutableSet<NSURL *> *desiredURLs = [NSMutableSet setWithCapacity:2];
-    if (self.currentIndex > 0) [desiredURLs addObject:self.items[self.currentIndex - 1].URL];
-    if (self.currentIndex + 1 < self.items.count) [desiredURLs addObject:self.items[self.currentIndex + 1].URL];
+- (void)prefetchNearbyWallpapers {
+    // Favor the direction the user is paging: four upcoming wallpapers get
+    // time to finish before rapid repeated swipes reach them, while retaining
+    // two behind for a quick reversal. Nearest URLs are created first and
+    // receive higher URLSession priority.
+    NSInteger direction = self.prefetchDirection < 0 ? -1 : 1;
+    NSMutableArray<NSURL *> *desiredURLs = [NSMutableArray arrayWithCapacity:6];
+    NSMutableSet<NSURL *> *desiredURLSet = [NSMutableSet setWithCapacity:6];
+    for (NSInteger distance = 1; distance <= 4; distance++) {
+        NSInteger primaryIndex = self.currentIndex + direction * distance;
+        if (primaryIndex >= 0 && primaryIndex < self.items.count) {
+            NSURL *URL = self.items[primaryIndex].URL;
+            if (URL && ![desiredURLSet containsObject:URL]) {
+                [desiredURLs addObject:URL];
+                [desiredURLSet addObject:URL];
+            }
+        }
+        if (distance <= 2) {
+            NSInteger reverseIndex = self.currentIndex - direction * distance;
+            if (reverseIndex >= 0 && reverseIndex < self.items.count) {
+                NSURL *URL = self.items[reverseIndex].URL;
+                if (URL && ![desiredURLSet containsObject:URL]) {
+                    [desiredURLs addObject:URL];
+                    [desiredURLSet addObject:URL];
+                }
+            }
+        }
+    }
+    // Near either end of the album one side of the preferred 4+2 window is
+    // unavailable. Fill the empty slots from the remaining direction so the
+    // opening pages can still prepare six consecutive fast swipes.
+    for (NSInteger distance = 3; desiredURLs.count < 6 && distance < self.items.count; distance++) {
+        NSInteger candidates[] = {
+            self.currentIndex + direction * distance,
+            self.currentIndex - direction * distance,
+        };
+        for (NSUInteger candidate = 0; candidate < 2 && desiredURLs.count < 6; candidate++) {
+            NSInteger index = candidates[candidate];
+            if (index < 0 || index >= self.items.count) continue;
+            NSURL *URL = self.items[index].URL;
+            if (URL && ![desiredURLSet containsObject:URL]) {
+                [desiredURLs addObject:URL];
+                [desiredURLSet addObject:URL];
+            }
+        }
+    }
+    // If the page being displayed was already prefetching, keep that task
+    // alive long enough to hand its result to the visible cell.
+    NSURL *currentURL = self.items[self.currentIndex].URL;
+    if (currentURL) [desiredURLSet addObject:currentURL];
 
-    // A page turn changes the two-item window. Cancel anything that has fallen
-    // outside it so rapid swiping cannot accumulate background downloads.
+    // Cancel only work outside the larger active window. Unlike the old
+    // previous/next strategy, consecutive fast swipes retain useful downloads
+    // instead of repeatedly cancelling the image the user is approaching.
     for (NSURL *URL in self.prefetchTasks.allKeys.copy) {
-        if ([desiredURLs containsObject:URL]) continue;
+        if ([desiredURLSet containsObject:URL]) continue;
         [self.prefetchTasks[URL] cancel];
         [self.prefetchTasks removeObjectForKey:URL];
     }
 
-    for (NSURL *URL in desiredURLs) {
+    for (NSUInteger position = 0; position < desiredURLs.count; position++) {
+        NSURL *URL = desiredURLs[position];
         if (self.prefetchTasks[URL]) continue;
         NSData *cachedData = [self.dataCache objectForKey:URL];
         UIImage *cachedImage = [self.imageCache objectForKey:URL];
         if (cachedData && cachedImage) continue;
         if (cachedData && !cachedImage) {
             UIImage *image = [UIImage imageWithData:cachedData];
-            if (image) [self.imageCache setObject:image forKey:URL];
+            if (image) ApolloWallpaperCacheImage(self.imageCache, URL, image);
             continue;
         }
 
@@ -706,10 +788,10 @@
             UIImage *image = data.length > 0 ? [UIImage imageWithData:data] : nil;
             typeof(self) strongSelf = weakSelf;
             if (image && strongSelf) {
-                [strongSelf.imageCache setObject:image forKey:URL];
+                ApolloWallpaperCacheImage(strongSelf.imageCache, URL, image);
                 [strongSelf.dataCache setObject:data forKey:URL cost:data.length];
             } else if (error.code != NSURLErrorCancelled) {
-                ApolloLog(@"[Wallpapers] adjacent preload failed url=%@ error=%@", URL,
+                ApolloLog(@"[Wallpapers] nearby preload failed url=%@ error=%@", URL,
                           error.localizedDescription ?: @"decode failed");
             }
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -717,9 +799,22 @@
                 if (mainSelf.prefetchTasks[URL] == weakTask) {
                     [mainSelf.prefetchTasks removeObjectForKey:URL];
                 }
+                if (!image || !mainSelf) return;
+                // A fast swipe may have made this prefetched URL visible while
+                // it was still downloading. Replace that cell's duplicate
+                // request immediately with the completed cached original.
+                for (UICollectionViewCell *visibleCell in mainSelf.collectionView.visibleCells) {
+                    if (![visibleCell isKindOfClass:ApolloWallpaperPageCell.class]) continue;
+                    ApolloWallpaperPageCell *pageCell = (ApolloWallpaperPageCell *)visibleCell;
+                    if ([pageCell.representedURL isEqual:URL] && !pageCell.imageView.image) {
+                        [pageCell showURL:URL imageCache:mainSelf.imageCache dataCache:mainSelf.dataCache];
+                    }
+                }
             });
         }];
         weakTask = task;
+        task.priority = position < 2 ? NSURLSessionTaskPriorityHigh
+            : (position < 4 ? NSURLSessionTaskPriorityDefault : NSURLSessionTaskPriorityLow);
         self.prefetchTasks[URL] = task;
         [task resume];
     }
@@ -742,7 +837,7 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             typeof(self) strongSelf = weakSelf;
             if (image) {
-                [strongSelf.imageCache setObject:image forKey:item.URL];
+                ApolloWallpaperCacheImage(strongSelf.imageCache, item.URL, image);
                 [strongSelf.dataCache setObject:data forKey:item.URL cost:data.length];
                 [strongSelf saveOriginalData:data atIndex:requestedIndex];
             } else {
@@ -901,9 +996,10 @@
 }
 
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
-                     withVelocity:(__unused CGPoint)velocity
+                     withVelocity:(CGPoint)velocity
               targetContentOffset:(inout CGPoint *)targetContentOffset {
     if (self.items.count == 0 || scrollView.bounds.size.width <= 0.0) return;
+    if (fabs(velocity.x) > 0.05) self.prefetchDirection = velocity.x < 0.0 ? -1 : 1;
     NSInteger targetIndex = (NSInteger)llround(targetContentOffset->x / scrollView.bounds.size.width);
     targetIndex = MAX(0, MIN(targetIndex, (NSInteger)self.items.count - 1));
     if (targetIndex == self.currentIndex) return;

--- a/src/settings/ApolloWallpaperViewerViewController.m
+++ b/src/settings/ApolloWallpaperViewerViewController.m
@@ -19,6 +19,38 @@ static void ApolloWallpaperCacheImage(NSCache<NSURL *, UIImage *> *cache,
     [cache setObject:image forKey:URL cost:ApolloWallpaperDecodedImageCost(image)];
 }
 
+// Keep decoded and original wallpaper data alive across viewer presentations.
+// Without this, choosing a different device (or reopening the same album)
+// starts from an empty per-viewer cache and its first page must visibly load.
+static NSCache<NSURL *, UIImage *> *ApolloWallpaperSharedImageCache(void) {
+    static NSCache<NSURL *, UIImage *> *cache;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        cache = [[NSCache alloc] init];
+        cache.countLimit = 7;
+        cache.totalCostLimit = 160 * 1024 * 1024;
+    });
+    return cache;
+}
+
+static NSCache<NSURL *, NSData *> *ApolloWallpaperSharedDataCache(void) {
+    static NSCache<NSURL *, NSData *> *cache;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        cache = [[NSCache alloc] init];
+        cache.countLimit = 16;
+        cache.totalCostLimit = 64 * 1024 * 1024;
+    });
+    return cache;
+}
+
+static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
+    static NSMutableSet<NSURL *> *URLs;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ URLs = [NSMutableSet set]; });
+    return URLs;
+}
+
 @implementation ApolloWallpaperItem
 
 + (instancetype)itemWithURLString:(NSString *)URLString caption:(NSString *)caption {
@@ -304,18 +336,51 @@ static void ApolloWallpaperCacheImage(NSCache<NSURL *, UIImage *> *cache,
 
 @implementation ApolloWallpaperViewerViewController
 
++ (void)preloadFirstItemFromItems:(NSArray<ApolloWallpaperItem *> *)items {
+    ApolloWallpaperItem *item = items.firstObject;
+    NSURL *URL = item.URL;
+    if (!URL || [ApolloWallpaperSharedImageCache() objectForKey:URL]) return;
+    NSData *cachedData = [ApolloWallpaperSharedDataCache() objectForKey:URL];
+    if (cachedData.length > 0) {
+        UIImage *cachedImage = [UIImage imageWithData:cachedData];
+        if (cachedImage) {
+            ApolloWallpaperCacheImage(ApolloWallpaperSharedImageCache(), URL, cachedImage);
+            return;
+        }
+    }
+
+    // Device-picker actions run on the main thread. Track these tiny, bounded
+    // three-device warmups there so repeated menu presentations cannot start
+    // duplicate requests for the same opening wallpaper.
+    NSMutableSet<NSURL *> *preloadingURLs = ApolloWallpaperInitialPreloadURLs();
+    if ([preloadingURLs containsObject:URL]) return;
+    [preloadingURLs addObject:URL];
+
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession]
+        dataTaskWithURL:URL
+      completionHandler:^(NSData *data, __unused NSURLResponse *response, NSError *error) {
+        UIImage *image = data.length > 0 ? [UIImage imageWithData:data] : nil;
+        if (image) {
+            ApolloWallpaperCacheImage(ApolloWallpaperSharedImageCache(), URL, image);
+            [ApolloWallpaperSharedDataCache() setObject:data forKey:URL cost:data.length];
+        } else if (error.code != NSURLErrorCancelled) {
+            ApolloLog(@"[Wallpapers] opening-page preload failed url=%@ error=%@", URL,
+                      error.localizedDescription ?: @"decode failed");
+        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [ApolloWallpaperInitialPreloadURLs() removeObject:URL];
+        });
+    }];
+    task.priority = NSURLSessionTaskPriorityHigh;
+    [task resume];
+}
+
 - (instancetype)initWithItems:(NSArray<ApolloWallpaperItem *> *)items {
     self = [super initWithNibName:nil bundle:nil];
     if (self) {
         _items = [items copy] ?: @[];
-        _imageCache = [[NSCache alloc] init];
-        // The active page plus a direction-aware six-page preload window.
-        // NSCache can still discard these early under system memory pressure.
-        _imageCache.countLimit = 7;
-        _imageCache.totalCostLimit = 160 * 1024 * 1024;
-        _dataCache = [[NSCache alloc] init];
-        _dataCache.countLimit = 16;
-        _dataCache.totalCostLimit = 64 * 1024 * 1024;
+        _imageCache = ApolloWallpaperSharedImageCache();
+        _dataCache = ApolloWallpaperSharedDataCache();
         _prefetchTasks = [NSMutableDictionary dictionary];
         _initialIndex = 0;
         _savingIndex = NSNotFound;

--- a/src/settings/ApolloWallpaperViewerViewController.m
+++ b/src/settings/ApolloWallpaperViewerViewController.m
@@ -44,11 +44,125 @@ static NSCache<NSURL *, NSData *> *ApolloWallpaperSharedDataCache(void) {
     return cache;
 }
 
-static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
-    static NSMutableSet<NSURL *> *URLs;
+typedef void (^ApolloWallpaperLoadCompletion)(NSData * _Nullable data,
+                                              UIImage * _Nullable image,
+                                              NSError * _Nullable error);
+
+@interface ApolloWallpaperLoadToken : NSObject
+@property (nonatomic, copy) NSURL *URL;
+@property (nonatomic, strong) NSUUID *identifier;
+@end
+
+@implementation ApolloWallpaperLoadToken
+@end
+
+@interface ApolloWallpaperLoadRecord : NSObject
+@property (nonatomic, strong) NSURLSessionDataTask *task;
+@property (nonatomic, strong) NSMutableDictionary<NSUUID *, ApolloWallpaperLoadCompletion> *completions;
+@end
+
+@implementation ApolloWallpaperLoadRecord
+@end
+
+// One broker owns all remote image transfers. A visible cell, nearby prefetch,
+// opening-page warmup, and download tap can therefore subscribe to the same
+// URL without starting parallel transfers of the original file.
+@interface ApolloWallpaperLoadBroker : NSObject
+@property (nonatomic, strong) NSMutableDictionary<NSURL *, ApolloWallpaperLoadRecord *> *records;
++ (instancetype)sharedBroker;
+- (nullable ApolloWallpaperLoadToken *)loadURL:(NSURL *)URL
+                                      priority:(float)priority
+                                    completion:(ApolloWallpaperLoadCompletion)completion;
+- (void)cancelToken:(nullable ApolloWallpaperLoadToken *)token;
+@end
+
+@implementation ApolloWallpaperLoadBroker
+
++ (instancetype)sharedBroker {
+    static ApolloWallpaperLoadBroker *broker;
     static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{ URLs = [NSMutableSet set]; });
-    return URLs;
+    dispatch_once(&onceToken, ^{
+        broker = [[self alloc] init];
+        broker.records = [NSMutableDictionary dictionary];
+    });
+    return broker;
+}
+
+- (ApolloWallpaperLoadToken *)loadURL:(NSURL *)URL
+                              priority:(float)priority
+                            completion:(ApolloWallpaperLoadCompletion)completion {
+    if (!URL || !completion) return nil;
+
+    NSData *cachedData = [ApolloWallpaperSharedDataCache() objectForKey:URL];
+    UIImage *cachedImage = [ApolloWallpaperSharedImageCache() objectForKey:URL];
+    if (cachedData.length > 0) {
+        if (!cachedImage) {
+            cachedImage = [UIImage imageWithData:cachedData];
+            if (cachedImage) ApolloWallpaperCacheImage(ApolloWallpaperSharedImageCache(), URL, cachedImage);
+        }
+        UIImage *resultImage = cachedImage;
+        dispatch_async(dispatch_get_main_queue(), ^{ completion(cachedData, resultImage, nil); });
+        return nil;
+    }
+
+    ApolloWallpaperLoadToken *token = [[ApolloWallpaperLoadToken alloc] init];
+    token.URL = URL;
+    token.identifier = [NSUUID UUID];
+
+    ApolloWallpaperLoadRecord *record = self.records[URL];
+    if (record) {
+        record.completions[token.identifier] = [completion copy];
+        record.task.priority = MAX(record.task.priority, priority);
+        return token;
+    }
+
+    record = [[ApolloWallpaperLoadRecord alloc] init];
+    record.completions = [NSMutableDictionary dictionaryWithObject:[completion copy]
+                                                             forKey:token.identifier];
+    self.records[URL] = record;
+
+    __weak typeof(self) weakSelf = self;
+    __weak ApolloWallpaperLoadRecord *weakRecord = record;
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession]
+        dataTaskWithURL:URL
+      completionHandler:^(NSData *data, __unused NSURLResponse *response, NSError *error) {
+        UIImage *image = data.length > 0 ? [UIImage imageWithData:data] : nil;
+        if (image) {
+            ApolloWallpaperCacheImage(ApolloWallpaperSharedImageCache(), URL, image);
+            [ApolloWallpaperSharedDataCache() setObject:data forKey:URL cost:data.length];
+        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            typeof(self) strongSelf = weakSelf;
+            ApolloWallpaperLoadRecord *liveRecord = strongSelf.records[URL];
+            if (!strongSelf || liveRecord != weakRecord) return;
+            [strongSelf.records removeObjectForKey:URL];
+            NSArray<ApolloWallpaperLoadCompletion> *callbacks = liveRecord.completions.allValues.copy;
+            for (ApolloWallpaperLoadCompletion callback in callbacks) callback(data, image, error);
+        });
+    }];
+    record.task = task;
+    task.priority = priority;
+    [task resume];
+    return token;
+}
+
+- (void)cancelToken:(ApolloWallpaperLoadToken *)token {
+    if (!token) return;
+    ApolloWallpaperLoadRecord *record = self.records[token.URL];
+    if (!record) return;
+    [record.completions removeObjectForKey:token.identifier];
+    if (record.completions.count > 0) return;
+    [record.task cancel];
+    [self.records removeObjectForKey:token.URL];
+}
+
+@end
+
+static NSMutableDictionary<NSURL *, ApolloWallpaperLoadToken *> *ApolloWallpaperInitialPreloadTokens(void) {
+    static NSMutableDictionary<NSURL *, ApolloWallpaperLoadToken *> *tokens;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ tokens = [NSMutableDictionary dictionary]; });
+    return tokens;
 }
 
 @implementation ApolloWallpaperItem
@@ -67,7 +181,7 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
 @property (nonatomic, strong) UIImageView *imageView;
 @property (nonatomic, strong) UIActivityIndicatorView *spinner;
 @property (nonatomic, strong) UIView *retryView;
-@property (nonatomic, strong, nullable) NSURLSessionDataTask *task;
+@property (nonatomic, strong, nullable) ApolloWallpaperLoadToken *loadToken;
 @property (nonatomic, copy, nullable) NSURL *representedURL;
 @property (nonatomic, strong, nullable) NSCache<NSURL *, UIImage *> *imageCache;
 @property (nonatomic, strong, nullable) NSCache<NSURL *, NSData *> *dataCache;
@@ -78,6 +192,7 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
 - (void)showURL:(NSURL *)URL
      imageCache:(NSCache<NSURL *, UIImage *> *)imageCache
       dataCache:(NSCache<NSURL *, NSData *> *)dataCache;
+- (void)cancelLoad;
 - (void)toggleZoomAtPoint:(CGPoint)point;
 @end
 
@@ -216,8 +331,7 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
 - (void)prepareForReuse {
     [super prepareForReuse];
     self.loadGeneration++;
-    [self.task cancel];
-    self.task = nil;
+    [self cancelLoad];
     self.representedURL = nil;
     self.imageCache = nil;
     self.dataCache = nil;
@@ -230,12 +344,18 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
     self.retryView.hidden = YES;
 }
 
+- (void)cancelLoad {
+    [[ApolloWallpaperLoadBroker sharedBroker] cancelToken:self.loadToken];
+    self.loadToken = nil;
+    [self.spinner stopAnimating];
+}
+
 - (void)showURL:(NSURL *)URL
      imageCache:(NSCache<NSURL *, UIImage *> *)imageCache
       dataCache:(NSCache<NSURL *, NSData *> *)dataCache {
     NSUInteger generation = ++self.loadGeneration;
-    [self.task cancel];
-    self.task = nil;
+    [[ApolloWallpaperLoadBroker sharedBroker] cancelToken:self.loadToken];
+    self.loadToken = nil;
     self.representedURL = URL;
     self.imageCache = imageCache;
     self.dataCache = dataCache;
@@ -257,26 +377,25 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
 
     [self.spinner startAnimating];
     __weak typeof(self) weakSelf = self;
-    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:URL completionHandler:^(NSData *data, __unused NSURLResponse *response, NSError *error) {
-        UIImage *image = data.length > 0 ? [UIImage imageWithData:data] : nil;
-        if (image) {
-            ApolloWallpaperCacheImage(imageCache, URL, image);
-            [dataCache setObject:data forKey:URL cost:data.length];
-        }
-        dispatch_async(dispatch_get_main_queue(), ^{
-            typeof(self) strongSelf = weakSelf;
-            if (!strongSelf || strongSelf.loadGeneration != generation ||
-                ![strongSelf.representedURL isEqual:URL]) return;
-            strongSelf.task = nil;
-            [strongSelf.spinner stopAnimating];
-            strongSelf.imageView.image = image;
-            [strongSelf resetZoomGeometry];
-            strongSelf.retryView.hidden = (image != nil);
-            if (!image) ApolloLog(@"[Wallpapers] image load failed url=%@ error=%@", URL, error.localizedDescription ?: @"decode failed");
-        });
+    self.loadToken = [[ApolloWallpaperLoadBroker sharedBroker]
+        loadURL:URL
+       priority:NSURLSessionTaskPriorityHigh
+     completion:^(__unused NSData *data, UIImage *image, NSError *error) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf || strongSelf.loadGeneration != generation ||
+            ![strongSelf.representedURL isEqual:URL]) return;
+        strongSelf.loadToken = nil;
+        [strongSelf.spinner stopAnimating];
+        strongSelf.imageView.image = image;
+        [strongSelf resetZoomGeometry];
+        strongSelf.retryView.hidden = (image != nil);
+        if (!image) ApolloLog(@"[Wallpapers] image load failed url=%@ error=%@", URL,
+                              error.localizedDescription ?: @"decode failed");
     }];
-    self.task = task;
-    [task resume];
+}
+
+- (void)dealloc {
+    [self cancelLoad];
 }
 
 - (void)retryTapped {
@@ -319,7 +438,8 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
 @property (nonatomic, strong) UIActivityIndicatorView *downloadSpinner;
 @property (nonatomic, strong) NSCache<NSURL *, UIImage *> *imageCache;
 @property (nonatomic, strong) NSCache<NSURL *, NSData *> *dataCache;
-@property (nonatomic, strong) NSMutableDictionary<NSURL *, NSURLSessionDataTask *> *prefetchTasks;
+@property (nonatomic, strong) NSMutableDictionary<NSURL *, ApolloWallpaperLoadToken *> *prefetchTokens;
+@property (nonatomic, strong, nullable) ApolloWallpaperLoadToken *downloadToken;
 @property (nonatomic, strong) NSMutableIndexSet *savedIndexes;
 @property (nonatomic, strong) UIPanGestureRecognizer *dismissPan;
 @property (nonatomic, strong) UITapGestureRecognizer *singleTap;
@@ -332,9 +452,19 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
 @property (nonatomic) NSInteger prefetchDirection;
 @property (nonatomic) BOOL initialPositionApplied;
 @property (nonatomic) BOOL chromeVisible;
+- (void)cancelPrefetchLoads;
+- (void)cancelOutstandingLoads;
 @end
 
 @implementation ApolloWallpaperViewerViewController
+
++ (void)cancelOpeningPreloads {
+    ApolloWallpaperLoadBroker *broker = [ApolloWallpaperLoadBroker sharedBroker];
+    for (ApolloWallpaperLoadToken *token in ApolloWallpaperInitialPreloadTokens().allValues) {
+        [broker cancelToken:token];
+    }
+    [ApolloWallpaperInitialPreloadTokens() removeAllObjects];
+}
 
 + (void)preloadFirstItemFromItems:(NSArray<ApolloWallpaperItem *> *)items {
     ApolloWallpaperItem *item = items.firstObject;
@@ -352,27 +482,23 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
     // Device-picker actions run on the main thread. Track these tiny, bounded
     // three-device warmups there so repeated menu presentations cannot start
     // duplicate requests for the same opening wallpaper.
-    NSMutableSet<NSURL *> *preloadingURLs = ApolloWallpaperInitialPreloadURLs();
-    if ([preloadingURLs containsObject:URL]) return;
-    [preloadingURLs addObject:URL];
+    NSMutableDictionary<NSURL *, ApolloWallpaperLoadToken *> *tokens = ApolloWallpaperInitialPreloadTokens();
+    if (tokens[URL]) return;
 
-    NSURLSessionDataTask *task = [[NSURLSession sharedSession]
-        dataTaskWithURL:URL
-      completionHandler:^(NSData *data, __unused NSURLResponse *response, NSError *error) {
-        UIImage *image = data.length > 0 ? [UIImage imageWithData:data] : nil;
-        if (image) {
-            ApolloWallpaperCacheImage(ApolloWallpaperSharedImageCache(), URL, image);
-            [ApolloWallpaperSharedDataCache() setObject:data forKey:URL cost:data.length];
-        } else if (error.code != NSURLErrorCancelled) {
+    __block ApolloWallpaperLoadToken *token = nil;
+    token = [[ApolloWallpaperLoadBroker sharedBroker]
+        loadURL:URL
+       priority:NSURLSessionTaskPriorityHigh
+     completion:^(__unused NSData *data, UIImage *image, NSError *error) {
+        if (!image && error.code != NSURLErrorCancelled) {
             ApolloLog(@"[Wallpapers] opening-page preload failed url=%@ error=%@", URL,
                       error.localizedDescription ?: @"decode failed");
         }
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [ApolloWallpaperInitialPreloadURLs() removeObject:URL];
-        });
+        if (ApolloWallpaperInitialPreloadTokens()[URL] == token) {
+            [ApolloWallpaperInitialPreloadTokens() removeObjectForKey:URL];
+        }
     }];
-    task.priority = NSURLSessionTaskPriorityHigh;
-    [task resume];
+    if (token) tokens[URL] = token;
 }
 
 - (instancetype)initWithItems:(NSArray<ApolloWallpaperItem *> *)items {
@@ -381,7 +507,7 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
         _items = [items copy] ?: @[];
         _imageCache = ApolloWallpaperSharedImageCache();
         _dataCache = ApolloWallpaperSharedDataCache();
-        _prefetchTasks = [NSMutableDictionary dictionary];
+        _prefetchTokens = [NSMutableDictionary dictionary];
         _savedIndexes = [NSMutableIndexSet indexSet];
         _initialIndex = 0;
         _savingIndex = NSNotFound;
@@ -419,10 +545,15 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
 
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
-    for (NSURLSessionDataTask *task in self.prefetchTasks.allValues) [task cancel];
-    [self.prefetchTasks removeAllObjects];
+    // Preserve the visible page and an in-progress user-initiated save. Only
+    // speculative work should be sacrificed in response to memory pressure.
+    [self cancelPrefetchLoads];
     [self.imageCache removeAllObjects];
     [self.dataCache removeAllObjects];
+}
+
+- (void)dealloc {
+    [self cancelOutstandingLoads];
 }
 
 - (void)viewDidLoad {
@@ -602,6 +733,7 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
 }
 
 - (void)closeTapped {
+    [self cancelOutstandingLoads];
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 
@@ -744,6 +876,7 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
             self.view.backgroundColor = UIColor.clearColor;
             [self setDismissChromeAlpha:0.0];
         } completion:^(__unused BOOL finished) {
+            [self cancelOutstandingLoads];
             [self dismissViewControllerAnimated:NO completion:nil];
         }];
     } else {
@@ -828,15 +961,16 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
     // Cancel only work outside the larger active window. Unlike the old
     // previous/next strategy, consecutive fast swipes retain useful downloads
     // instead of repeatedly cancelling the image the user is approaching.
-    for (NSURL *URL in self.prefetchTasks.allKeys.copy) {
+    ApolloWallpaperLoadBroker *broker = [ApolloWallpaperLoadBroker sharedBroker];
+    for (NSURL *URL in self.prefetchTokens.allKeys.copy) {
         if ([desiredURLSet containsObject:URL]) continue;
-        [self.prefetchTasks[URL] cancel];
-        [self.prefetchTasks removeObjectForKey:URL];
+        [broker cancelToken:self.prefetchTokens[URL]];
+        [self.prefetchTokens removeObjectForKey:URL];
     }
 
     for (NSUInteger position = 0; position < desiredURLs.count; position++) {
         NSURL *URL = desiredURLs[position];
-        if (self.prefetchTasks[URL]) continue;
+        if (self.prefetchTokens[URL]) continue;
         NSData *cachedData = [self.dataCache objectForKey:URL];
         UIImage *cachedImage = [self.imageCache objectForKey:URL];
         if (cachedData && cachedImage) continue;
@@ -846,44 +980,44 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
             continue;
         }
 
+        float priority = position < 2 ? NSURLSessionTaskPriorityHigh
+            : (position < 4 ? NSURLSessionTaskPriorityDefault : NSURLSessionTaskPriorityLow);
         __weak typeof(self) weakSelf = self;
-        __block __weak NSURLSessionDataTask *weakTask = nil;
-        NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:URL
-                                                                completionHandler:^(NSData *data,
-                                                                                    __unused NSURLResponse *response,
-                                                                                    NSError *error) {
-            UIImage *image = data.length > 0 ? [UIImage imageWithData:data] : nil;
+        __block ApolloWallpaperLoadToken *token = nil;
+        token = [broker loadURL:URL priority:priority completion:^(__unused NSData *data,
+                                                                  UIImage *image,
+                                                                  NSError *error) {
             typeof(self) strongSelf = weakSelf;
-            if (image && strongSelf) {
-                ApolloWallpaperCacheImage(strongSelf.imageCache, URL, image);
-                [strongSelf.dataCache setObject:data forKey:URL cost:data.length];
-            } else if (error.code != NSURLErrorCancelled) {
+            if (strongSelf.prefetchTokens[URL] == token) {
+                [strongSelf.prefetchTokens removeObjectForKey:URL];
+            }
+            if (!image && error.code != NSURLErrorCancelled) {
                 ApolloLog(@"[Wallpapers] nearby preload failed url=%@ error=%@", URL,
                           error.localizedDescription ?: @"decode failed");
             }
-            dispatch_async(dispatch_get_main_queue(), ^{
-                typeof(self) mainSelf = weakSelf;
-                if (mainSelf.prefetchTasks[URL] == weakTask) {
-                    [mainSelf.prefetchTasks removeObjectForKey:URL];
-                }
-                if (!image || !mainSelf) return;
-                // A fast swipe may have made this prefetched URL visible while
-                // it was still downloading. Replace that cell's duplicate
-                // request immediately with the completed cached original.
-                for (UICollectionViewCell *visibleCell in mainSelf.collectionView.visibleCells) {
-                    if (![visibleCell isKindOfClass:ApolloWallpaperPageCell.class]) continue;
-                    ApolloWallpaperPageCell *pageCell = (ApolloWallpaperPageCell *)visibleCell;
-                    if ([pageCell.representedURL isEqual:URL] && !pageCell.imageView.image) {
-                        [pageCell showURL:URL imageCache:mainSelf.imageCache dataCache:mainSelf.dataCache];
-                    }
-                }
-            });
         }];
-        weakTask = task;
-        task.priority = position < 2 ? NSURLSessionTaskPriorityHigh
-            : (position < 4 ? NSURLSessionTaskPriorityDefault : NSURLSessionTaskPriorityLow);
-        self.prefetchTasks[URL] = task;
-        [task resume];
+        if (token) self.prefetchTokens[URL] = token;
+    }
+}
+
+- (void)cancelPrefetchLoads {
+    ApolloWallpaperLoadBroker *broker = [ApolloWallpaperLoadBroker sharedBroker];
+    for (ApolloWallpaperLoadToken *token in self.prefetchTokens.allValues) {
+        [broker cancelToken:token];
+    }
+    [self.prefetchTokens removeAllObjects];
+    [ApolloWallpaperViewerViewController cancelOpeningPreloads];
+}
+
+- (void)cancelOutstandingLoads {
+    ApolloWallpaperLoadBroker *broker = [ApolloWallpaperLoadBroker sharedBroker];
+    [self cancelPrefetchLoads];
+    [broker cancelToken:self.downloadToken];
+    self.downloadToken = nil;
+    for (UICollectionViewCell *cell in self.collectionView.visibleCells) {
+        if ([cell isKindOfClass:ApolloWallpaperPageCell.class]) {
+            [(ApolloWallpaperPageCell *)cell cancelLoad];
+        }
     }
 }
 
@@ -900,22 +1034,22 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
     }
 
     __weak typeof(self) weakSelf = self;
-    [[[NSURLSession sharedSession] dataTaskWithURL:item.URL completionHandler:^(NSData *data, __unused NSURLResponse *response, NSError *error) {
-        UIImage *image = data.length > 0 ? [UIImage imageWithData:data] : nil;
-        dispatch_async(dispatch_get_main_queue(), ^{
-            typeof(self) strongSelf = weakSelf;
-            if (image) {
-                ApolloWallpaperCacheImage(strongSelf.imageCache, item.URL, image);
-                [strongSelf.dataCache setObject:data forKey:item.URL cost:data.length];
-                [strongSelf saveOriginalData:data atIndex:requestedIndex];
-            } else {
-                [strongSelf finishSavingAtIndex:requestedIndex error:error ?: [NSError errorWithDomain:@"ApolloWallpapers"
-                                                                                 code:1
-                                                                             userInfo:@{NSLocalizedDescriptionKey: @"The wallpaper could not be downloaded."}]];
-                [strongSelf showResultTitle:@"Download Failed" message:error.localizedDescription ?: @"The wallpaper could not be downloaded."];
-            }
-        });
-    }] resume];
+    self.downloadToken = [[ApolloWallpaperLoadBroker sharedBroker]
+        loadURL:item.URL
+       priority:NSURLSessionTaskPriorityHigh
+     completion:^(NSData *data, UIImage *image, NSError *error) {
+        typeof(self) strongSelf = weakSelf;
+        strongSelf.downloadToken = nil;
+        if (image && data.length > 0) {
+            [strongSelf saveOriginalData:data atIndex:requestedIndex];
+        } else {
+            NSError *resultError = error ?: [NSError errorWithDomain:@"ApolloWallpapers"
+                                                                code:1
+                                                            userInfo:@{NSLocalizedDescriptionKey: @"The wallpaper could not be downloaded."}];
+            [strongSelf finishSavingAtIndex:requestedIndex error:resultError];
+            [strongSelf showResultTitle:@"Download Failed" message:resultError.localizedDescription];
+        }
+    }];
 }
 
 - (void)beginSavingAtIndex:(NSInteger)index {

--- a/src/settings/ApolloWallpaperViewerViewController.m
+++ b/src/settings/ApolloWallpaperViewerViewController.m
@@ -320,12 +320,12 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
 @property (nonatomic, strong) NSCache<NSURL *, UIImage *> *imageCache;
 @property (nonatomic, strong) NSCache<NSURL *, NSData *> *dataCache;
 @property (nonatomic, strong) NSMutableDictionary<NSURL *, NSURLSessionDataTask *> *prefetchTasks;
+@property (nonatomic, strong) NSMutableIndexSet *savedIndexes;
 @property (nonatomic, strong) UIPanGestureRecognizer *dismissPan;
 @property (nonatomic, strong) UITapGestureRecognizer *singleTap;
 @property (nonatomic, strong) UITapGestureRecognizer *doubleTap;
 @property (nonatomic, weak) ApolloWallpaperPageCell *dismissingCell;
 @property (nonatomic, copy) NSArray<UICollectionViewCell *> *dismissHiddenCells;
-@property (nonatomic, copy, nullable) dispatch_block_t savedStateReset;
 @property (nonatomic) NSInteger currentIndex;
 @property (nonatomic) NSInteger savingIndex;
 @property (nonatomic) NSInteger initialIndex;
@@ -382,6 +382,7 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
         _imageCache = ApolloWallpaperSharedImageCache();
         _dataCache = ApolloWallpaperSharedDataCache();
         _prefetchTasks = [NSMutableDictionary dictionary];
+        _savedIndexes = [NSMutableIndexSet indexSet];
         _initialIndex = 0;
         _savingIndex = NSNotFound;
         _prefetchDirection = 1;
@@ -769,7 +770,7 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
     self.currentIndex = MAX(0, MIN(self.currentIndex, (NSInteger)self.items.count - 1));
     self.counterLabel.text = [NSString stringWithFormat:@"%ld of %lu", (long)self.currentIndex + 1, (unsigned long)self.items.count];
     self.captionLabel.text = self.items[self.currentIndex].caption;
-    if (self.savingIndex == NSNotFound) [self resetDownloadConfirmation];
+    if (self.savingIndex == NSNotFound) [self updateDownloadConfirmation];
     [self prefetchNearbyWallpapers];
 }
 
@@ -889,6 +890,7 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
 - (void)downloadTapped {
     if (self.currentIndex >= self.items.count) return;
     NSInteger requestedIndex = self.currentIndex;
+    if ([self.savedIndexes containsIndex:requestedIndex]) return;
     ApolloWallpaperItem *item = self.items[self.currentIndex];
     [self beginSavingAtIndex:requestedIndex];
     NSData *cachedData = [self.dataCache objectForKey:item.URL];
@@ -917,8 +919,6 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
 }
 
 - (void)beginSavingAtIndex:(NSInteger)index {
-    if (self.savedStateReset) dispatch_block_cancel(self.savedStateReset);
-    self.savedStateReset = nil;
     self.savingIndex = index;
     self.downloadButton.enabled = NO;
     self.downloadContentStack.hidden = YES;
@@ -980,38 +980,28 @@ static NSMutableSet<NSURL *> *ApolloWallpaperInitialPreloadURLs(void) {
     self.savingIndex = NSNotFound;
     [self.downloadSpinner stopAnimating];
     self.downloadContentStack.hidden = NO;
-    self.downloadButton.enabled = YES;
 
-    if (error || self.currentIndex != index) {
-        [self resetDownloadConfirmation];
+    if (error) {
+        [self updateDownloadConfirmation];
         return;
     }
 
-    UIImageSymbolConfiguration *config = [UIImageSymbolConfiguration configurationWithPointSize:17
-                                                                                          weight:UIImageSymbolWeightSemibold];
-    self.downloadIcon.image = [UIImage systemImageNamed:@"checkmark" withConfiguration:config];
-    self.downloadTitle.text = @"Saved";
-    self.downloadButton.accessibilityLabel = @"Saved";
+    [self.savedIndexes addIndex:index];
+    [self updateDownloadConfirmation];
     UIImpactFeedbackGenerator *feedback = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
     [feedback impactOccurred];
-
-    __weak typeof(self) weakSelf = self;
-    dispatch_block_t reset = dispatch_block_create(0, ^{
-        [weakSelf resetDownloadConfirmation];
-        weakSelf.savedStateReset = nil;
-    });
-    self.savedStateReset = reset;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.4 * NSEC_PER_SEC)), dispatch_get_main_queue(), reset);
 }
 
-- (void)resetDownloadConfirmation {
-    if (self.savedStateReset) dispatch_block_cancel(self.savedStateReset);
-    self.savedStateReset = nil;
+- (void)updateDownloadConfirmation {
+    BOOL saved = self.currentIndex >= 0 && [self.savedIndexes containsIndex:self.currentIndex];
+    self.downloadButton.enabled = !saved;
     UIImageSymbolConfiguration *config = [UIImageSymbolConfiguration configurationWithPointSize:17
-                                                                                          weight:UIImageSymbolWeightMedium];
-    self.downloadIcon.image = [UIImage systemImageNamed:@"square.and.arrow.down" withConfiguration:config];
-    self.downloadTitle.text = @"Download Wallpaper";
-    self.downloadButton.accessibilityLabel = @"Download Wallpaper";
+                                                                                          weight:saved ? UIImageSymbolWeightSemibold
+                                                                                                       : UIImageSymbolWeightMedium];
+    self.downloadIcon.image = [UIImage systemImageNamed:saved ? @"checkmark" : @"square.and.arrow.down"
+                                       withConfiguration:config];
+    self.downloadTitle.text = saved ? @"Saved" : @"Download Wallpaper";
+    self.downloadButton.accessibilityLabel = self.downloadTitle.text;
 }
 
 - (void)showResultTitle:(NSString *)title message:(NSString *)message {

--- a/src/settings/ApolloWallpaperViewerViewController.m
+++ b/src/settings/ApolloWallpaperViewerViewController.m
@@ -353,6 +353,12 @@
     self.doubleTap.delegate = self;
     [self.view addGestureRecognizer:self.doubleTap];
     [self.singleTap requireGestureRecognizerToFail:self.doubleTap];
+    // A short page swipe can otherwise satisfy UIKit's tap tolerance on a
+    // physical device while the collection view's pan also succeeds. Waiting
+    // for paging to fail makes taps toggle the chrome without allowing a page
+    // turn to hide it accidentally.
+    [self.singleTap requireGestureRecognizerToFail:self.collectionView.panGestureRecognizer];
+    [self.doubleTap requireGestureRecognizerToFail:self.collectionView.panGestureRecognizer];
 
     self.dismissPan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleDismissPan:)];
     self.dismissPan.delegate = self;
@@ -560,6 +566,13 @@
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
         shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
     if (gestureRecognizer == self.dismissPan || otherGestureRecognizer == self.dismissPan) return NO;
+    BOOL involvesViewerTap = gestureRecognizer == self.singleTap || gestureRecognizer == self.doubleTap ||
+                             otherGestureRecognizer == self.singleTap || otherGestureRecognizer == self.doubleTap;
+    if (involvesViewerTap &&
+        ([gestureRecognizer isKindOfClass:UIPanGestureRecognizer.class] ||
+         [otherGestureRecognizer isKindOfClass:UIPanGestureRecognizer.class])) {
+        return NO;
+    }
     return YES;
 }
 

--- a/src/settings/ApolloWallpaperViewerViewController.m
+++ b/src/settings/ApolloWallpaperViewerViewController.m
@@ -1,0 +1,905 @@
+#import "settings/ApolloWallpaperViewerViewController.h"
+
+#import "ApolloCommon.h"
+#import <Photos/Photos.h>
+
+@implementation ApolloWallpaperItem
+
++ (instancetype)itemWithURLString:(NSString *)URLString caption:(NSString *)caption {
+    ApolloWallpaperItem *item = [[self alloc] init];
+    item->_URL = [NSURL URLWithString:URLString];
+    item->_caption = [caption copy] ?: @"";
+    return item;
+}
+
+@end
+
+@interface ApolloWallpaperPageCell : UICollectionViewCell <UIScrollViewDelegate>
+@property (nonatomic, strong) UIScrollView *zoomView;
+@property (nonatomic, strong) UIImageView *imageView;
+@property (nonatomic, strong) UIActivityIndicatorView *spinner;
+@property (nonatomic, strong) UIView *retryView;
+@property (nonatomic, strong, nullable) NSURLSessionDataTask *task;
+@property (nonatomic, copy, nullable) NSURL *representedURL;
+@property (nonatomic, strong, nullable) NSCache<NSURL *, UIImage *> *imageCache;
+@property (nonatomic, strong, nullable) NSCache<NSURL *, NSData *> *dataCache;
+@property (nonatomic) CGSize zoomGeometrySize;
+@property (nonatomic, readonly) BOOL isZoomed;
+@property (nonatomic, copy, nullable) void (^zoomInteractionChanged)(BOOL blocksPaging);
+- (void)showURL:(NSURL *)URL
+     imageCache:(NSCache<NSURL *, UIImage *> *)imageCache
+      dataCache:(NSCache<NSURL *, NSData *> *)dataCache;
+- (void)toggleZoomAtPoint:(CGPoint)point;
+@end
+
+@implementation ApolloWallpaperPageCell
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (!self) return nil;
+
+    // The controller owns the black backdrop. Keeping the page itself clear
+    // lets that backdrop fade away during an interactive dismissal, revealing
+    // Settings gradually instead of making it appear only after the cell is
+    // removed from the hierarchy.
+    self.backgroundColor = UIColor.clearColor;
+    self.contentView.backgroundColor = UIColor.clearColor;
+
+    _zoomView = [[UIScrollView alloc] initWithFrame:self.contentView.bounds];
+    _zoomView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    _zoomView.delegate = self;
+    _zoomView.minimumZoomScale = 1.0;
+    _zoomView.maximumZoomScale = 5.0;
+    _zoomView.showsHorizontalScrollIndicator = NO;
+    _zoomView.showsVerticalScrollIndicator = NO;
+    _zoomView.backgroundColor = UIColor.clearColor;
+    // Never rubber-band below the fitted 1x size. A zoom-out gesture should
+    // reveal only black, never shrink the page enough to expose its neighbors.
+    _zoomView.bouncesZoom = NO;
+    _zoomView.panGestureRecognizer.enabled = NO;
+    [_zoomView.pinchGestureRecognizer addTarget:self action:@selector(zoomPinchChanged:)];
+    _zoomView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+    [self.contentView addSubview:_zoomView];
+
+    _imageView = [[UIImageView alloc] initWithFrame:_zoomView.bounds];
+    _imageView.contentMode = UIViewContentModeScaleAspectFit;
+    _imageView.backgroundColor = UIColor.clearColor;
+    [_zoomView addSubview:_imageView];
+
+    _spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
+    _spinner.translatesAutoresizingMaskIntoConstraints = NO;
+    _spinner.color = UIColor.whiteColor;
+    [self.contentView addSubview:_spinner];
+
+    _retryView = [[UIView alloc] initWithFrame:CGRectZero];
+    _retryView.translatesAutoresizingMaskIntoConstraints = NO;
+    _retryView.backgroundColor = [UIColor colorWithWhite:0.08 alpha:0.78];
+    _retryView.layer.cornerRadius = 15.0;
+    _retryView.layer.cornerCurve = kCACornerCurveContinuous;
+    _retryView.hidden = YES;
+    _retryView.isAccessibilityElement = YES;
+    _retryView.accessibilityLabel = @"Wallpaper failed to load. Tap to retry.";
+    _retryView.accessibilityTraits = UIAccessibilityTraitButton;
+    [_retryView addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(retryTapped)]];
+    [self.contentView addSubview:_retryView];
+
+    UILabel *retryLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+    retryLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    retryLabel.text = @"Tap to Retry";
+    retryLabel.textColor = UIColor.whiteColor;
+    retryLabel.font = [UIFont systemFontOfSize:14.0 weight:UIFontWeightSemibold];
+    retryLabel.userInteractionEnabled = NO;
+    [_retryView addSubview:retryLabel];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [_spinner.centerXAnchor constraintEqualToAnchor:self.contentView.centerXAnchor],
+        [_spinner.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
+        [_retryView.centerXAnchor constraintEqualToAnchor:self.contentView.centerXAnchor],
+        [_retryView.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor],
+        [retryLabel.leadingAnchor constraintEqualToAnchor:_retryView.leadingAnchor constant:14.0],
+        [retryLabel.trailingAnchor constraintEqualToAnchor:_retryView.trailingAnchor constant:-14.0],
+        [retryLabel.topAnchor constraintEqualToAnchor:_retryView.topAnchor constant:8.0],
+        [retryLabel.bottomAnchor constraintEqualToAnchor:_retryView.bottomAnchor constant:-8.0],
+    ]];
+    return self;
+}
+
+- (BOOL)isZoomed {
+    return self.zoomView.zoomScale > self.zoomView.minimumZoomScale + 0.01;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    self.zoomView.frame = self.contentView.bounds;
+    if (!CGSizeEqualToSize(self.zoomGeometrySize, self.zoomView.bounds.size)) {
+        [self resetZoomGeometry];
+    }
+}
+
+// The zoomable content is the fitted wallpaper itself, not the surrounding
+// letterbox. This keeps panning clamped to the artwork at every aspect ratio.
+- (void)resetZoomGeometry {
+    CGSize bounds = self.zoomView.bounds.size;
+    if (bounds.width <= 0.0 || bounds.height <= 0.0) return;
+    self.zoomGeometrySize = bounds;
+    self.zoomView.zoomScale = self.zoomView.minimumZoomScale;
+
+    UIImage *image = self.imageView.image;
+    if (!image || image.size.width <= 0.0 || image.size.height <= 0.0) {
+        self.imageView.frame = (CGRect){ CGPointZero, bounds };
+        self.zoomView.contentSize = bounds;
+        self.zoomView.contentInset = UIEdgeInsetsZero;
+        self.zoomView.panGestureRecognizer.enabled = NO;
+        return;
+    }
+
+    CGFloat fit = MIN(bounds.width / image.size.width, bounds.height / image.size.height);
+    CGSize fitted = CGSizeMake(floor(image.size.width * fit), floor(image.size.height * fit));
+    self.imageView.frame = (CGRect){ CGPointZero, fitted };
+    self.zoomView.contentSize = fitted;
+    self.zoomView.panGestureRecognizer.enabled = NO;
+    [self centerZoomContent];
+}
+
+- (void)centerZoomContent {
+    CGSize bounds = self.zoomView.bounds.size;
+    CGSize content = self.zoomView.contentSize;
+    CGFloat vertical = MAX(0.0, (bounds.height - content.height) / 2.0);
+    CGFloat horizontal = MAX(0.0, (bounds.width - content.width) / 2.0);
+    self.zoomView.contentInset = UIEdgeInsetsMake(vertical, horizontal, vertical, horizontal);
+}
+
+- (void)toggleZoomAtPoint:(CGPoint)point {
+    if (self.isZoomed) {
+        [self.zoomView setZoomScale:self.zoomView.minimumZoomScale animated:YES];
+        return;
+    }
+    CGPoint imagePoint = [self.contentView convertPoint:point toView:self.imageView];
+    CGFloat scale = MIN(self.zoomView.maximumZoomScale, 3.0);
+    CGSize viewport = self.zoomView.bounds.size;
+    CGRect target = CGRectMake(imagePoint.x - (viewport.width / scale) / 2.0,
+                               imagePoint.y - (viewport.height / scale) / 2.0,
+                               viewport.width / scale,
+                               viewport.height / scale);
+    [self.zoomView zoomToRect:target animated:YES];
+}
+
+- (void)prepareForReuse {
+    [super prepareForReuse];
+    [self.task cancel];
+    self.task = nil;
+    self.representedURL = nil;
+    self.imageCache = nil;
+    self.dataCache = nil;
+    self.imageView.image = nil;
+    self.zoomGeometrySize = CGSizeZero;
+    self.zoomView.zoomScale = self.zoomView.minimumZoomScale;
+    self.zoomView.contentInset = UIEdgeInsetsZero;
+    self.zoomView.panGestureRecognizer.enabled = NO;
+    [self.spinner stopAnimating];
+    self.retryView.hidden = YES;
+}
+
+- (void)showURL:(NSURL *)URL
+     imageCache:(NSCache<NSURL *, UIImage *> *)imageCache
+      dataCache:(NSCache<NSURL *, NSData *> *)dataCache {
+    [self.task cancel];
+    self.task = nil;
+    self.representedURL = URL;
+    self.imageCache = imageCache;
+    self.dataCache = dataCache;
+    self.retryView.hidden = YES;
+    self.imageView.image = [imageCache objectForKey:URL];
+    if (self.imageView.image) {
+        [self resetZoomGeometry];
+        [self.spinner stopAnimating];
+        return;
+    }
+
+    [self.spinner startAnimating];
+    __weak typeof(self) weakSelf = self;
+    self.task = [[NSURLSession sharedSession] dataTaskWithURL:URL completionHandler:^(NSData *data, __unused NSURLResponse *response, NSError *error) {
+        UIImage *image = data.length > 0 ? [UIImage imageWithData:data] : nil;
+        if (image) {
+            [imageCache setObject:image forKey:URL];
+            [dataCache setObject:data forKey:URL cost:data.length];
+        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            typeof(self) strongSelf = weakSelf;
+            if (!strongSelf || ![strongSelf.representedURL isEqual:URL]) return;
+            [strongSelf.spinner stopAnimating];
+            strongSelf.imageView.image = image;
+            [strongSelf resetZoomGeometry];
+            strongSelf.retryView.hidden = (image != nil);
+            if (!image) ApolloLog(@"[Wallpapers] image load failed url=%@ error=%@", URL, error.localizedDescription ?: @"decode failed");
+        });
+    }];
+    [self.task resume];
+}
+
+- (void)retryTapped {
+    NSURL *URL = self.representedURL;
+    if (!URL || !self.imageCache || !self.dataCache) return;
+    [self showURL:URL imageCache:self.imageCache dataCache:self.dataCache];
+}
+
+- (UIView *)viewForZoomingInScrollView:(__unused UIScrollView *)scrollView {
+    return self.imageView;
+}
+
+- (void)scrollViewDidZoom:(UIScrollView *)scrollView {
+    scrollView.panGestureRecognizer.enabled = self.isZoomed;
+    [self centerZoomContent];
+    UIGestureRecognizerState pinchState = scrollView.pinchGestureRecognizer.state;
+    BOOL pinchActive = pinchState == UIGestureRecognizerStateBegan || pinchState == UIGestureRecognizerStateChanged;
+    if (self.zoomInteractionChanged) self.zoomInteractionChanged(self.isZoomed || pinchActive);
+}
+
+- (void)zoomPinchChanged:(UIPinchGestureRecognizer *)pinch {
+    BOOL active = pinch.state == UIGestureRecognizerStateBegan || pinch.state == UIGestureRecognizerStateChanged;
+    if (self.zoomInteractionChanged) self.zoomInteractionChanged(self.isZoomed || active);
+}
+
+@end
+
+@interface ApolloWallpaperViewerViewController () <UICollectionViewDataSource, UICollectionViewDelegateFlowLayout, UIGestureRecognizerDelegate>
+@property (nonatomic, copy) NSArray<ApolloWallpaperItem *> *items;
+@property (nonatomic, strong) UICollectionView *collectionView;
+@property (nonatomic, strong) UIVisualEffectView *closeBackground;
+@property (nonatomic, strong) UIButton *closeButton;
+@property (nonatomic, strong) UILabel *counterLabel;
+@property (nonatomic, strong) UILabel *captionLabel;
+@property (nonatomic, strong) UIVisualEffectView *downloadBackground;
+@property (nonatomic, strong) UIButton *downloadButton;
+@property (nonatomic, strong) UIStackView *downloadContentStack;
+@property (nonatomic, strong) UIImageView *downloadIcon;
+@property (nonatomic, strong) UILabel *downloadTitle;
+@property (nonatomic, strong) UIActivityIndicatorView *downloadSpinner;
+@property (nonatomic, strong) NSCache<NSURL *, UIImage *> *imageCache;
+@property (nonatomic, strong) NSCache<NSURL *, NSData *> *dataCache;
+@property (nonatomic, strong) NSMutableDictionary<NSURL *, NSURLSessionDataTask *> *prefetchTasks;
+@property (nonatomic, strong) UIPanGestureRecognizer *dismissPan;
+@property (nonatomic, strong) UITapGestureRecognizer *singleTap;
+@property (nonatomic, strong) UITapGestureRecognizer *doubleTap;
+@property (nonatomic, weak) ApolloWallpaperPageCell *dismissingCell;
+@property (nonatomic, copy) NSArray<UICollectionViewCell *> *dismissHiddenCells;
+@property (nonatomic, copy, nullable) dispatch_block_t savedStateReset;
+@property (nonatomic) NSInteger currentIndex;
+@property (nonatomic) NSInteger savingIndex;
+@property (nonatomic) NSInteger initialIndex;
+@property (nonatomic) BOOL initialPositionApplied;
+@property (nonatomic) BOOL chromeVisible;
+@end
+
+@implementation ApolloWallpaperViewerViewController
+
+- (instancetype)initWithItems:(NSArray<ApolloWallpaperItem *> *)items {
+    self = [super initWithNibName:nil bundle:nil];
+    if (self) {
+        _items = [items copy] ?: @[];
+        _imageCache = [[NSCache alloc] init];
+        _imageCache.countLimit = 3;
+        _dataCache = [[NSCache alloc] init];
+        _dataCache.countLimit = 3;
+        _dataCache.totalCostLimit = 32 * 1024 * 1024;
+        _prefetchTasks = [NSMutableDictionary dictionary];
+        _initialIndex = 0;
+        _savingIndex = NSNotFound;
+        _chromeVisible = YES;
+#if APOLLO_SIM_BUILD
+        const char *previewIndex = getenv("APOLLO_OPEN_WALLPAPER_INDEX");
+        if (previewIndex) _initialIndex = MAX(0, atoi(previewIndex));
+#endif
+        // Keep the presenting Settings screen alive underneath the viewer so
+        // the interactive dismissal can reveal it gradually instead of
+        // replacing the final black frame with Settings all at once.
+        self.modalPresentationStyle = UIModalPresentationOverFullScreen;
+    }
+    return self;
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    if (self.initialPositionApplied || self.items.count == 0) return;
+    // Let the collection view finish establishing its page width before live
+    // scroll tracking begins. Otherwise its first layout pass can briefly
+    // report an offset belonging to the next page and advance the caption.
+    [self.view layoutIfNeeded];
+    self.currentIndex = MIN(self.initialIndex, (NSInteger)self.items.count - 1);
+    CGFloat pageWidth = self.collectionView.bounds.size.width;
+    [self.collectionView setContentOffset:CGPointMake(self.currentIndex * pageWidth, 0.0) animated:NO];
+    self.initialPositionApplied = YES;
+    [self updateChrome];
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return UIStatusBarStyleLightContent;
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    for (NSURLSessionDataTask *task in self.prefetchTasks.allValues) [task cancel];
+    [self.prefetchTasks removeAllObjects];
+    [self.imageCache removeAllObjects];
+    [self.dataCache removeAllObjects];
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.backgroundColor = UIColor.blackColor;
+
+    UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+    layout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
+    layout.minimumLineSpacing = 0.0;
+    layout.minimumInteritemSpacing = 0.0;
+
+    self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
+    self.collectionView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.collectionView.backgroundColor = UIColor.clearColor;
+    self.collectionView.pagingEnabled = YES;
+    self.collectionView.showsHorizontalScrollIndicator = NO;
+    self.collectionView.dataSource = self;
+    self.collectionView.delegate = self;
+    self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+    [self.collectionView registerClass:ApolloWallpaperPageCell.class forCellWithReuseIdentifier:@"WallpaperPage"];
+    [self.view addSubview:self.collectionView];
+
+    [self installChrome];
+    self.singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(singleTapped:)];
+    self.singleTap.delegate = self;
+    [self.view addGestureRecognizer:self.singleTap];
+    self.doubleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(doubleTapped:)];
+    self.doubleTap.numberOfTapsRequired = 2;
+    self.doubleTap.delegate = self;
+    [self.view addGestureRecognizer:self.doubleTap];
+    [self.singleTap requireGestureRecognizerToFail:self.doubleTap];
+
+    self.dismissPan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleDismissPan:)];
+    self.dismissPan.delegate = self;
+    [self.view addGestureRecognizer:self.dismissPan];
+    // Give the vertical dismissal first refusal. For a horizontal swipe its
+    // delegate declines immediately and normal wallpaper paging proceeds; for
+    // a diagonal/vertical swipe the collection view never starts drifting to
+    // a neighboring wallpaper behind the active page.
+    [self.collectionView.panGestureRecognizer requireGestureRecognizerToFail:self.dismissPan];
+    [self updateChrome];
+}
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    UICollectionViewFlowLayout *layout = (UICollectionViewFlowLayout *)self.collectionView.collectionViewLayout;
+    if (!CGSizeEqualToSize(layout.itemSize, self.collectionView.bounds.size)) {
+        layout.itemSize = self.collectionView.bounds.size;
+        [layout invalidateLayout];
+        [self.collectionView setContentOffset:CGPointMake(self.currentIndex * self.collectionView.bounds.size.width, 0) animated:NO];
+    }
+}
+
+- (UIVisualEffectView *)neutralChromeBackgroundWithCornerRadius:(CGFloat)cornerRadius {
+    // Fixed dark chrome prevents iOS 26's adaptive glass tint from swinging
+    // between bright white and flat black as the wallpaper underneath changes.
+    UIVisualEffectView *background = [[UIVisualEffectView alloc]
+        initWithEffect:[UIBlurEffect effectWithStyle:UIBlurEffectStyleSystemChromeMaterialDark]];
+    background.translatesAutoresizingMaskIntoConstraints = NO;
+    background.layer.cornerRadius = cornerRadius;
+    background.layer.cornerCurve = kCACornerCurveContinuous;
+    background.clipsToBounds = YES;
+    background.contentView.backgroundColor = [UIColor colorWithWhite:0.16 alpha:0.42];
+    return background;
+}
+
+- (UIButton *)roundButtonWithSystemImage:(NSString *)systemImage action:(SEL)action {
+    UIImageSymbolConfiguration *symbolConfig = [UIImageSymbolConfiguration configurationWithPointSize:16 weight:UIImageSymbolWeightSemibold];
+    UIImage *image = [[UIImage systemImageNamed:systemImage withConfiguration:symbolConfig]
+        imageWithTintColor:UIColor.whiteColor
+        renderingMode:UIImageRenderingModeAlwaysOriginal];
+
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+    button.translatesAutoresizingMaskIntoConstraints = NO;
+    button.tintColor = UIColor.whiteColor;
+    button.backgroundColor = UIColor.clearColor;
+    [button setImage:image forState:UIControlStateNormal];
+    [button addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
+    return button;
+}
+
+- (void)installChrome {
+    self.closeBackground = [self neutralChromeBackgroundWithCornerRadius:22.0];
+    [self.view addSubview:self.closeBackground];
+    self.closeButton = [self roundButtonWithSystemImage:@"xmark" action:@selector(closeTapped)];
+    self.closeButton.accessibilityLabel = @"Close";
+    [self.closeBackground.contentView addSubview:self.closeButton];
+
+    self.counterLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+    self.counterLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    self.counterLabel.textColor = UIColor.whiteColor;
+    self.counterLabel.font = [UIFont systemFontOfSize:13 weight:UIFontWeightSemibold];
+    self.counterLabel.textAlignment = NSTextAlignmentCenter;
+    [self.view addSubview:self.counterLabel];
+
+    self.downloadBackground = [self neutralChromeBackgroundWithCornerRadius:14.0];
+    [self.view addSubview:self.downloadBackground];
+
+    self.downloadButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    self.downloadButton.translatesAutoresizingMaskIntoConstraints = NO;
+    self.downloadButton.accessibilityLabel = @"Download Wallpaper";
+    [self.downloadButton addTarget:self action:@selector(downloadTapped) forControlEvents:UIControlEventTouchUpInside];
+    [self.downloadBackground.contentView addSubview:self.downloadButton];
+
+    UIImageSymbolConfiguration *downloadConfig = [UIImageSymbolConfiguration configurationWithPointSize:17 weight:UIImageSymbolWeightMedium];
+    self.downloadIcon = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"square.and.arrow.down" withConfiguration:downloadConfig]];
+    self.downloadIcon.tintColor = UIColor.whiteColor;
+    self.downloadIcon.contentMode = UIViewContentModeScaleAspectFit;
+    self.downloadTitle = [[UILabel alloc] initWithFrame:CGRectZero];
+    self.downloadTitle.text = @"Download Wallpaper";
+    self.downloadTitle.textColor = UIColor.whiteColor;
+    self.downloadTitle.font = [UIFont systemFontOfSize:15 weight:UIFontWeightSemibold];
+    self.downloadContentStack = [[UIStackView alloc] initWithArrangedSubviews:@[ self.downloadIcon, self.downloadTitle ]];
+    self.downloadContentStack.translatesAutoresizingMaskIntoConstraints = NO;
+    self.downloadContentStack.axis = UILayoutConstraintAxisHorizontal;
+    self.downloadContentStack.alignment = UIStackViewAlignmentCenter;
+    self.downloadContentStack.spacing = 8.0;
+    self.downloadContentStack.userInteractionEnabled = NO;
+    [self.downloadBackground.contentView addSubview:self.downloadContentStack];
+
+    self.downloadSpinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+    self.downloadSpinner.translatesAutoresizingMaskIntoConstraints = NO;
+    self.downloadSpinner.color = UIColor.whiteColor;
+    self.downloadSpinner.hidesWhenStopped = YES;
+    [self.downloadBackground.contentView addSubview:self.downloadSpinner];
+
+    self.captionLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+    self.captionLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    self.captionLabel.textColor = UIColor.whiteColor;
+    self.captionLabel.font = [UIFont systemFontOfSize:17 weight:UIFontWeightMedium];
+    self.captionLabel.textAlignment = NSTextAlignmentCenter;
+    self.captionLabel.numberOfLines = 2;
+    self.captionLabel.layer.shadowColor = UIColor.blackColor.CGColor;
+    self.captionLabel.layer.shadowOpacity = 0.9;
+    self.captionLabel.layer.shadowRadius = 3.0;
+    [self.view addSubview:self.captionLabel];
+
+    UILayoutGuide *safe = self.view.safeAreaLayoutGuide;
+    [NSLayoutConstraint activateConstraints:@[
+        [self.collectionView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [self.collectionView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [self.collectionView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+        [self.collectionView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+        [self.closeBackground.leadingAnchor constraintEqualToAnchor:safe.leadingAnchor constant:12.0],
+        [self.closeBackground.topAnchor constraintEqualToAnchor:safe.topAnchor constant:8.0],
+        [self.closeBackground.widthAnchor constraintEqualToConstant:44.0],
+        [self.closeBackground.heightAnchor constraintEqualToConstant:44.0],
+        [self.closeButton.leadingAnchor constraintEqualToAnchor:self.closeBackground.contentView.leadingAnchor],
+        [self.closeButton.trailingAnchor constraintEqualToAnchor:self.closeBackground.contentView.trailingAnchor],
+        [self.closeButton.topAnchor constraintEqualToAnchor:self.closeBackground.contentView.topAnchor],
+        [self.closeButton.bottomAnchor constraintEqualToAnchor:self.closeBackground.contentView.bottomAnchor],
+        [self.counterLabel.centerXAnchor constraintEqualToAnchor:safe.centerXAnchor],
+        [self.counterLabel.centerYAnchor constraintEqualToAnchor:self.closeBackground.centerYAnchor],
+        [self.downloadBackground.centerXAnchor constraintEqualToAnchor:safe.centerXAnchor],
+        [self.downloadBackground.bottomAnchor constraintEqualToAnchor:self.captionLabel.topAnchor constant:-14.0],
+        [self.downloadBackground.heightAnchor constraintEqualToConstant:48.0],
+        [self.downloadBackground.widthAnchor constraintGreaterThanOrEqualToConstant:205.0],
+        [self.downloadButton.leadingAnchor constraintEqualToAnchor:self.downloadBackground.contentView.leadingAnchor constant:18.0],
+        [self.downloadButton.trailingAnchor constraintEqualToAnchor:self.downloadBackground.contentView.trailingAnchor constant:-18.0],
+        [self.downloadButton.topAnchor constraintEqualToAnchor:self.downloadBackground.contentView.topAnchor],
+        [self.downloadButton.bottomAnchor constraintEqualToAnchor:self.downloadBackground.contentView.bottomAnchor],
+        [self.downloadContentStack.centerXAnchor constraintEqualToAnchor:self.downloadBackground.contentView.centerXAnchor],
+        [self.downloadContentStack.centerYAnchor constraintEqualToAnchor:self.downloadBackground.contentView.centerYAnchor],
+        [self.downloadSpinner.centerXAnchor constraintEqualToAnchor:self.downloadBackground.contentView.centerXAnchor],
+        [self.downloadSpinner.centerYAnchor constraintEqualToAnchor:self.downloadBackground.contentView.centerYAnchor],
+        [self.captionLabel.leadingAnchor constraintGreaterThanOrEqualToAnchor:safe.leadingAnchor constant:12.0],
+        [self.captionLabel.trailingAnchor constraintLessThanOrEqualToAnchor:safe.trailingAnchor constant:-12.0],
+        [self.captionLabel.centerXAnchor constraintEqualToAnchor:safe.centerXAnchor],
+        [self.captionLabel.bottomAnchor constraintEqualToAnchor:safe.bottomAnchor constant:-8.0],
+    ]];
+}
+
+- (void)closeTapped {
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (ApolloWallpaperPageCell *)currentPageCell {
+    if (self.currentIndex < 0 || self.currentIndex >= self.items.count) return nil;
+    NSIndexPath *path = [NSIndexPath indexPathForItem:self.currentIndex inSection:0];
+    UICollectionViewCell *cell = [self.collectionView cellForItemAtIndexPath:path];
+    return [cell isKindOfClass:ApolloWallpaperPageCell.class] ? (ApolloWallpaperPageCell *)cell : nil;
+}
+
+- (void)singleTapped:(UITapGestureRecognizer *)tap {
+    if (tap.state != UIGestureRecognizerStateRecognized) return;
+    [self setChromeVisible:!self.chromeVisible animated:YES];
+}
+
+- (void)doubleTapped:(UITapGestureRecognizer *)tap {
+    if (tap.state != UIGestureRecognizerStateRecognized) return;
+    ApolloWallpaperPageCell *cell = [self currentPageCell];
+    if (!cell) return;
+    CGPoint point = [tap locationInView:cell.contentView];
+    [cell toggleZoomAtPoint:point];
+}
+
+- (void)setChromeVisible:(BOOL)visible animated:(BOOL)animated {
+    self.chromeVisible = visible;
+    CGFloat alpha = visible ? 1.0 : 0.0;
+    void (^changes)(void) = ^{
+        self.closeBackground.alpha = alpha;
+        self.counterLabel.alpha = alpha;
+        self.downloadBackground.alpha = alpha;
+        self.captionLabel.alpha = alpha;
+    };
+    self.closeButton.userInteractionEnabled = visible;
+    self.downloadButton.userInteractionEnabled = visible;
+    if (animated) {
+        [UIView animateWithDuration:0.2
+                              delay:0.0
+                            options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionAllowUserInteraction
+                         animations:changes
+                         completion:nil];
+    } else {
+        changes();
+    }
+}
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
+    if (gestureRecognizer == self.dismissPan && [self currentPageCell].isZoomed) return NO;
+    if (![gestureRecognizer isKindOfClass:UIPanGestureRecognizer.class]) return YES;
+    CGPoint velocity = [(UIPanGestureRecognizer *)gestureRecognizer velocityInView:self.view];
+    return fabs(velocity.y) > fabs(velocity.x);
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
+    if (gestureRecognizer != self.singleTap && gestureRecognizer != self.doubleTap) return YES;
+    if (!self.chromeVisible) return YES;
+    if ([touch.view isDescendantOfView:self.closeBackground] ||
+        [touch.view isDescendantOfView:self.downloadBackground]) {
+        return NO;
+    }
+    return YES;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+        shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    if (gestureRecognizer == self.dismissPan || otherGestureRecognizer == self.dismissPan) return NO;
+    return YES;
+}
+
+- (void)setDismissChromeAlpha:(CGFloat)alpha {
+    CGFloat visibleAlpha = self.chromeVisible ? alpha : 0.0;
+    self.closeBackground.alpha = visibleAlpha;
+    self.counterLabel.alpha = visibleAlpha;
+    self.downloadBackground.alpha = visibleAlpha;
+    self.captionLabel.alpha = visibleAlpha;
+}
+
+- (void)handleDismissPan:(UIPanGestureRecognizer *)gesture {
+    CGPoint translation = [gesture translationInView:self.view];
+    if (gesture.state == UIGestureRecognizerStateBegan) {
+        CGFloat pageWidth = self.collectionView.bounds.size.width;
+        [self.collectionView setContentOffset:CGPointMake(self.currentIndex * pageWidth, 0.0) animated:NO];
+        self.collectionView.scrollEnabled = NO;
+        NSIndexPath *currentPath = [NSIndexPath indexPathForItem:self.currentIndex inSection:0];
+        self.dismissingCell = (ApolloWallpaperPageCell *)[self.collectionView cellForItemAtIndexPath:currentPath];
+        NSMutableArray<UICollectionViewCell *> *hiddenCells = [NSMutableArray array];
+        for (UICollectionViewCell *cell in self.collectionView.visibleCells) {
+            if (cell == self.dismissingCell) continue;
+            cell.hidden = YES;
+            [hiddenCells addObject:cell];
+        }
+        self.dismissHiddenCells = hiddenCells;
+        return;
+    }
+    if (gesture.state == UIGestureRecognizerStateChanged) {
+        CGFloat progress = MIN(fabs(translation.y) / MAX(self.view.bounds.size.height * 0.5, 1.0), 1.0);
+        // Move only the active artwork. The controller's black root view stays
+        // fixed behind it, so a diagonal drag cannot reveal Settings or either
+        // neighboring wallpaper.
+        self.dismissingCell.imageView.transform = CGAffineTransformMakeTranslation(translation.x, translation.y);
+        self.dismissingCell.imageView.alpha = 1.0 - (progress * 0.45);
+        // Keep the presenting Settings screen subdued while the gesture is
+        // still interactive. Once dismissal commits, the completion animation
+        // below removes the remaining scrim.
+        self.view.backgroundColor = [UIColor colorWithWhite:0.0 alpha:1.0 - (progress * 0.55)];
+        [self setDismissChromeAlpha:1.0 - progress];
+        return;
+    }
+
+    if (gesture.state != UIGestureRecognizerStateEnded && gesture.state != UIGestureRecognizerStateCancelled) {
+        if (gesture.state == UIGestureRecognizerStateFailed) {
+            self.collectionView.scrollEnabled = YES;
+            self.dismissingCell.imageView.transform = CGAffineTransformIdentity;
+            self.dismissingCell.imageView.alpha = 1.0;
+            self.view.backgroundColor = UIColor.blackColor;
+            [self setDismissChromeAlpha:1.0];
+            for (UICollectionViewCell *cell in self.dismissHiddenCells) cell.hidden = NO;
+            self.dismissHiddenCells = nil;
+            self.dismissingCell = nil;
+        }
+        return;
+    }
+    self.collectionView.scrollEnabled = YES;
+    CGPoint velocity = [gesture velocityInView:self.view];
+    BOOL shouldDismiss = gesture.state == UIGestureRecognizerStateEnded &&
+        (fabs(translation.y) > 120.0 || fabs(velocity.y) > 900.0);
+    if (shouldDismiss) {
+        CGFloat direction = translation.y != 0.0 ? (translation.y > 0.0 ? 1.0 : -1.0) : (velocity.y > 0.0 ? 1.0 : -1.0);
+        CGFloat targetY = direction * self.view.bounds.size.height;
+        CGFloat targetX = translation.x + velocity.x * 0.15;
+        [UIView animateWithDuration:0.18 animations:^{
+            self.dismissingCell.imageView.transform = CGAffineTransformMakeTranslation(targetX, targetY);
+            self.dismissingCell.imageView.alpha = 0.0;
+            self.view.backgroundColor = UIColor.clearColor;
+            [self setDismissChromeAlpha:0.0];
+        } completion:^(__unused BOOL finished) {
+            [self dismissViewControllerAnimated:NO completion:nil];
+        }];
+    } else {
+        [UIView animateWithDuration:0.25
+                              delay:0.0
+             usingSpringWithDamping:0.82
+              initialSpringVelocity:0.0
+                            options:UIViewAnimationOptionCurveEaseOut
+                         animations:^{
+            self.dismissingCell.imageView.transform = CGAffineTransformIdentity;
+            self.dismissingCell.imageView.alpha = 1.0;
+            self.view.backgroundColor = UIColor.blackColor;
+            [self setDismissChromeAlpha:1.0];
+        } completion:^(__unused BOOL finished) {
+            for (UICollectionViewCell *cell in self.dismissHiddenCells) cell.hidden = NO;
+            self.dismissHiddenCells = nil;
+            self.dismissingCell = nil;
+        }];
+    }
+}
+
+- (void)updateChrome {
+    if (self.items.count == 0) return;
+    self.currentIndex = MAX(0, MIN(self.currentIndex, (NSInteger)self.items.count - 1));
+    self.counterLabel.text = [NSString stringWithFormat:@"%ld of %lu", (long)self.currentIndex + 1, (unsigned long)self.items.count];
+    self.captionLabel.text = self.items[self.currentIndex].caption;
+    if (self.savingIndex == NSNotFound) [self resetDownloadConfirmation];
+    [self prefetchAdjacentWallpapers];
+}
+
+- (void)prefetchAdjacentWallpapers {
+    NSMutableSet<NSURL *> *desiredURLs = [NSMutableSet setWithCapacity:2];
+    if (self.currentIndex > 0) [desiredURLs addObject:self.items[self.currentIndex - 1].URL];
+    if (self.currentIndex + 1 < self.items.count) [desiredURLs addObject:self.items[self.currentIndex + 1].URL];
+
+    // A page turn changes the two-item window. Cancel anything that has fallen
+    // outside it so rapid swiping cannot accumulate background downloads.
+    for (NSURL *URL in self.prefetchTasks.allKeys.copy) {
+        if ([desiredURLs containsObject:URL]) continue;
+        [self.prefetchTasks[URL] cancel];
+        [self.prefetchTasks removeObjectForKey:URL];
+    }
+
+    for (NSURL *URL in desiredURLs) {
+        if (self.prefetchTasks[URL]) continue;
+        NSData *cachedData = [self.dataCache objectForKey:URL];
+        UIImage *cachedImage = [self.imageCache objectForKey:URL];
+        if (cachedData && cachedImage) continue;
+        if (cachedData && !cachedImage) {
+            UIImage *image = [UIImage imageWithData:cachedData];
+            if (image) [self.imageCache setObject:image forKey:URL];
+            continue;
+        }
+
+        __weak typeof(self) weakSelf = self;
+        __weak NSURLSessionDataTask *weakTask = nil;
+        NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:URL
+                                                                completionHandler:^(NSData *data,
+                                                                                    __unused NSURLResponse *response,
+                                                                                    NSError *error) {
+            UIImage *image = data.length > 0 ? [UIImage imageWithData:data] : nil;
+            typeof(self) strongSelf = weakSelf;
+            if (image && strongSelf) {
+                [strongSelf.imageCache setObject:image forKey:URL];
+                [strongSelf.dataCache setObject:data forKey:URL cost:data.length];
+            } else if (error.code != NSURLErrorCancelled) {
+                ApolloLog(@"[Wallpapers] adjacent preload failed url=%@ error=%@", URL,
+                          error.localizedDescription ?: @"decode failed");
+            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                typeof(self) mainSelf = weakSelf;
+                if (mainSelf.prefetchTasks[URL] == weakTask) {
+                    [mainSelf.prefetchTasks removeObjectForKey:URL];
+                }
+            });
+        }];
+        weakTask = task;
+        self.prefetchTasks[URL] = task;
+        [task resume];
+    }
+}
+
+- (void)downloadTapped {
+    if (self.currentIndex >= self.items.count) return;
+    NSInteger requestedIndex = self.currentIndex;
+    ApolloWallpaperItem *item = self.items[self.currentIndex];
+    [self beginSavingAtIndex:requestedIndex];
+    NSData *cachedData = [self.dataCache objectForKey:item.URL];
+    if (cachedData.length > 0) {
+        [self saveOriginalData:cachedData atIndex:requestedIndex];
+        return;
+    }
+
+    __weak typeof(self) weakSelf = self;
+    [[[NSURLSession sharedSession] dataTaskWithURL:item.URL completionHandler:^(NSData *data, __unused NSURLResponse *response, NSError *error) {
+        UIImage *image = data.length > 0 ? [UIImage imageWithData:data] : nil;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            typeof(self) strongSelf = weakSelf;
+            if (image) {
+                [strongSelf.imageCache setObject:image forKey:item.URL];
+                [strongSelf.dataCache setObject:data forKey:item.URL cost:data.length];
+                [strongSelf saveOriginalData:data atIndex:requestedIndex];
+            } else {
+                [strongSelf finishSavingAtIndex:requestedIndex error:error ?: [NSError errorWithDomain:@"ApolloWallpapers"
+                                                                                 code:1
+                                                                             userInfo:@{NSLocalizedDescriptionKey: @"The wallpaper could not be downloaded."}]];
+                [strongSelf showResultTitle:@"Download Failed" message:error.localizedDescription ?: @"The wallpaper could not be downloaded."];
+            }
+        });
+    }] resume];
+}
+
+- (void)beginSavingAtIndex:(NSInteger)index {
+    if (self.savedStateReset) dispatch_block_cancel(self.savedStateReset);
+    self.savedStateReset = nil;
+    self.savingIndex = index;
+    self.downloadButton.enabled = NO;
+    self.downloadContentStack.hidden = YES;
+    [self.downloadSpinner startAnimating];
+}
+
+- (void)saveOriginalData:(NSData *)data atIndex:(NSInteger)index {
+    if (data.length == 0 || index < 0 || index >= self.items.count) return;
+    ApolloWallpaperItem *item = self.items[index];
+    __weak typeof(self) weakSelf = self;
+    void (^performSave)(void) = ^{
+        [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+            PHAssetCreationRequest *request = [PHAssetCreationRequest creationRequestForAsset];
+            PHAssetResourceCreationOptions *options = [[PHAssetResourceCreationOptions alloc] init];
+            NSString *filename = item.URL.lastPathComponent;
+            options.originalFilename = filename.length > 0 ? filename : @"Apollo-Wallpaper.jpg";
+            [request addResourceWithType:PHAssetResourceTypePhoto data:data options:options];
+        } completionHandler:^(BOOL success, NSError *error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                typeof(self) strongSelf = weakSelf;
+                NSError *resultError = success ? nil : (error ?: [NSError errorWithDomain:@"ApolloWallpapers"
+                                                                                       code:2
+                                                                                   userInfo:@{NSLocalizedDescriptionKey: @"Photos could not save the wallpaper."}]);
+                [strongSelf finishSavingAtIndex:index error:resultError];
+                if (resultError) [strongSelf showResultTitle:@"Couldn’t Save Wallpaper" message:resultError.localizedDescription];
+            });
+        }];
+    };
+
+    PHAuthorizationStatus status = [PHPhotoLibrary authorizationStatusForAccessLevel:PHAccessLevelAddOnly];
+    if (status == PHAuthorizationStatusAuthorized || status == PHAuthorizationStatusLimited) {
+        performSave();
+    } else if (status == PHAuthorizationStatusNotDetermined) {
+        [PHPhotoLibrary requestAuthorizationForAccessLevel:PHAccessLevelAddOnly handler:^(PHAuthorizationStatus newStatus) {
+            if (newStatus == PHAuthorizationStatusAuthorized || newStatus == PHAuthorizationStatusLimited) {
+                performSave();
+                return;
+            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                NSError *error = [NSError errorWithDomain:@"ApolloWallpapers"
+                                                     code:3
+                                                 userInfo:@{NSLocalizedDescriptionKey: @"Allow Apollo to add photos in Settings to save wallpapers."}];
+                typeof(self) strongSelf = weakSelf;
+                [strongSelf finishSavingAtIndex:index error:error];
+                [strongSelf showResultTitle:@"Photos Access Needed" message:error.localizedDescription];
+            });
+        }];
+    } else {
+        NSError *error = [NSError errorWithDomain:@"ApolloWallpapers"
+                                             code:3
+                                         userInfo:@{NSLocalizedDescriptionKey: @"Allow Apollo to add photos in Settings to save wallpapers."}];
+        [self finishSavingAtIndex:index error:error];
+        [self showResultTitle:@"Photos Access Needed" message:error.localizedDescription];
+    }
+}
+
+- (void)finishSavingAtIndex:(NSInteger)index error:(NSError *)error {
+    if (self.savingIndex != index) return;
+    self.savingIndex = NSNotFound;
+    [self.downloadSpinner stopAnimating];
+    self.downloadContentStack.hidden = NO;
+    self.downloadButton.enabled = YES;
+
+    if (error || self.currentIndex != index) {
+        [self resetDownloadConfirmation];
+        return;
+    }
+
+    UIImageSymbolConfiguration *config = [UIImageSymbolConfiguration configurationWithPointSize:17
+                                                                                          weight:UIImageSymbolWeightSemibold];
+    self.downloadIcon.image = [UIImage systemImageNamed:@"checkmark" withConfiguration:config];
+    self.downloadTitle.text = @"Saved";
+    self.downloadButton.accessibilityLabel = @"Saved";
+    UIImpactFeedbackGenerator *feedback = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
+    [feedback impactOccurred];
+
+    __weak typeof(self) weakSelf = self;
+    dispatch_block_t reset = dispatch_block_create(0, ^{
+        [weakSelf resetDownloadConfirmation];
+        weakSelf.savedStateReset = nil;
+    });
+    self.savedStateReset = reset;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.4 * NSEC_PER_SEC)), dispatch_get_main_queue(), reset);
+}
+
+- (void)resetDownloadConfirmation {
+    if (self.savedStateReset) dispatch_block_cancel(self.savedStateReset);
+    self.savedStateReset = nil;
+    UIImageSymbolConfiguration *config = [UIImageSymbolConfiguration configurationWithPointSize:17
+                                                                                          weight:UIImageSymbolWeightMedium];
+    self.downloadIcon.image = [UIImage systemImageNamed:@"square.and.arrow.down" withConfiguration:config];
+    self.downloadTitle.text = @"Download Wallpaper";
+    self.downloadButton.accessibilityLabel = @"Download Wallpaper";
+}
+
+- (void)showResultTitle:(NSString *)title message:(NSString *)message {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+#pragma mark - Collection view
+
+- (NSInteger)collectionView:(__unused UICollectionView *)collectionView numberOfItemsInSection:(__unused NSInteger)section {
+    return self.items.count;
+}
+
+- (__kindof UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+    ApolloWallpaperPageCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:@"WallpaperPage" forIndexPath:indexPath];
+    __weak typeof(self) weakSelf = self;
+    cell.zoomInteractionChanged = ^(BOOL blocksPaging) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        UIGestureRecognizerState dismissalState = strongSelf.dismissPan.state;
+        if (dismissalState == UIGestureRecognizerStateBegan || dismissalState == UIGestureRecognizerStateChanged) return;
+        strongSelf.collectionView.scrollEnabled = !blocksPaging;
+    };
+    [cell showURL:self.items[indexPath.item].URL imageCache:self.imageCache dataCache:self.dataCache];
+    return cell;
+}
+
+- (CGSize)collectionView:(UICollectionView *)collectionView
+                   layout:(__unused UICollectionViewLayout *)collectionViewLayout
+   sizeForItemAtIndexPath:(__unused NSIndexPath *)indexPath {
+    return collectionView.bounds.size;
+}
+
+- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
+    CGFloat width = MAX(scrollView.bounds.size.width, 1.0);
+    self.currentIndex = (NSInteger)llround(scrollView.contentOffset.x / width);
+    [self updateChrome];
+}
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
+    if (!self.initialPositionApplied || self.items.count == 0 || scrollView.bounds.size.width <= 0.0) return;
+    NSInteger nearestIndex = (NSInteger)llround(scrollView.contentOffset.x / scrollView.bounds.size.width);
+    nearestIndex = MAX(0, MIN(nearestIndex, (NSInteger)self.items.count - 1));
+    if (nearestIndex == self.currentIndex) return;
+    self.currentIndex = nearestIndex;
+    [self updateChrome];
+}
+
+- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
+                     withVelocity:(__unused CGPoint)velocity
+              targetContentOffset:(inout CGPoint *)targetContentOffset {
+    if (self.items.count == 0 || scrollView.bounds.size.width <= 0.0) return;
+    NSInteger targetIndex = (NSInteger)llround(targetContentOffset->x / scrollView.bounds.size.width);
+    targetIndex = MAX(0, MIN(targetIndex, (NSInteger)self.items.count - 1));
+    if (targetIndex == self.currentIndex) return;
+    self.currentIndex = targetIndex;
+    [self updateChrome];
+}
+
+- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView {
+    [self scrollViewDidEndDecelerating:scrollView];
+}
+
+@end

--- a/src/settings/ApolloWallpaperViewerViewController.m
+++ b/src/settings/ApolloWallpaperViewerViewController.m
@@ -40,6 +40,7 @@ static void ApolloWallpaperCacheImage(NSCache<NSURL *, UIImage *> *cache,
 @property (nonatomic, strong, nullable) NSCache<NSURL *, UIImage *> *imageCache;
 @property (nonatomic, strong, nullable) NSCache<NSURL *, NSData *> *dataCache;
 @property (nonatomic) CGSize zoomGeometrySize;
+@property (nonatomic) NSUInteger loadGeneration;
 @property (nonatomic, readonly) BOOL isZoomed;
 @property (nonatomic, copy, nullable) void (^zoomInteractionChanged)(BOOL blocksPaging);
 - (void)showURL:(NSURL *)URL
@@ -182,6 +183,7 @@ static void ApolloWallpaperCacheImage(NSCache<NSURL *, UIImage *> *cache,
 
 - (void)prepareForReuse {
     [super prepareForReuse];
+    self.loadGeneration++;
     [self.task cancel];
     self.task = nil;
     self.representedURL = nil;
@@ -199,6 +201,7 @@ static void ApolloWallpaperCacheImage(NSCache<NSURL *, UIImage *> *cache,
 - (void)showURL:(NSURL *)URL
      imageCache:(NSCache<NSURL *, UIImage *> *)imageCache
       dataCache:(NSCache<NSURL *, NSData *> *)dataCache {
+    NSUInteger generation = ++self.loadGeneration;
     [self.task cancel];
     self.task = nil;
     self.representedURL = URL;
@@ -222,7 +225,6 @@ static void ApolloWallpaperCacheImage(NSCache<NSURL *, UIImage *> *cache,
 
     [self.spinner startAnimating];
     __weak typeof(self) weakSelf = self;
-    __weak NSURLSessionDataTask *weakTask = nil;
     NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:URL completionHandler:^(NSData *data, __unused NSURLResponse *response, NSError *error) {
         UIImage *image = data.length > 0 ? [UIImage imageWithData:data] : nil;
         if (image) {
@@ -231,7 +233,7 @@ static void ApolloWallpaperCacheImage(NSCache<NSURL *, UIImage *> *cache,
         }
         dispatch_async(dispatch_get_main_queue(), ^{
             typeof(self) strongSelf = weakSelf;
-            if (!strongSelf || strongSelf.task != weakTask ||
+            if (!strongSelf || strongSelf.loadGeneration != generation ||
                 ![strongSelf.representedURL isEqual:URL]) return;
             strongSelf.task = nil;
             [strongSelf.spinner stopAnimating];
@@ -241,7 +243,6 @@ static void ApolloWallpaperCacheImage(NSCache<NSURL *, UIImage *> *cache,
             if (!image) ApolloLog(@"[Wallpapers] image load failed url=%@ error=%@", URL, error.localizedDescription ?: @"decode failed");
         });
     }];
-    weakTask = task;
     self.task = task;
     [task resume];
 }
@@ -780,7 +781,7 @@ static void ApolloWallpaperCacheImage(NSCache<NSURL *, UIImage *> *cache,
         }
 
         __weak typeof(self) weakSelf = self;
-        __weak NSURLSessionDataTask *weakTask = nil;
+        __block __weak NSURLSessionDataTask *weakTask = nil;
         NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:URL
                                                                 completionHandler:^(NSData *data,
                                                                                     __unused NSURLResponse *response,

--- a/src/settings/ApolloWallpapersViewController.h
+++ b/src/settings/ApolloWallpapersViewController.h
@@ -1,0 +1,11 @@
+#import <UIKit/UIKit.h>
+
+// Hosted Goodbye Apollo wallpaper collections. Images stay off-device until
+// the user chooses a device and opens the viewer.
+@interface ApolloWallpapersViewController : NSObject
+
+// Original Apollo-style device chooser used by the native Settings row.
++ (void)presentDevicePickerFromViewController:(UIViewController *)presenter
+                                   sourceView:(UIView *)sourceView;
+
+@end

--- a/src/settings/ApolloWallpapersViewController.m
+++ b/src/settings/ApolloWallpapersViewController.m
@@ -137,6 +137,16 @@
                                    sourceView:(UIView *)sourceView {
     if (!presenter) return;
 
+    // Warm each album's opening page while the user reads and chooses from the
+    // device menu. The viewer shares these caches, so its first cell can render
+    // immediately instead of beginning its first network request on screen.
+    [ApolloWallpaperViewerViewController preloadFirstItemFromItems:
+        [self itemsWithURLs:self.goodbyeIPhoneURLs captions:self.goodbyeCaptions]];
+    [ApolloWallpaperViewerViewController preloadFirstItemFromItems:
+        [self itemsWithURLs:self.goodbyeIPadURLs captions:self.goodbyeCaptions]];
+    [ApolloWallpaperViewerViewController preloadFirstItemFromItems:
+        [self itemsWithURLs:self.goodbyeMacURLs captions:self.goodbyeMacCaptions]];
+
     UIAlertController *sheet = [UIAlertController
         alertControllerWithTitle:nil
                          message:@"Choose a device"

--- a/src/settings/ApolloWallpapersViewController.m
+++ b/src/settings/ApolloWallpapersViewController.m
@@ -1,0 +1,169 @@
+#import "settings/ApolloWallpapersViewController.h"
+
+#import "settings/ApolloWallpaperViewerViewController.h"
+
+@implementation ApolloWallpapersViewController
+
++ (NSArray<NSString *> *)goodbyeCaptions {
+    return @[
+        @"Adventures by David Lanham",
+        @"Apollo A1 by Michael Flarup",
+        @"Apollo-san by Helunky",
+        @"Apollopy by Matthew Skiles",
+        @"Argyle by Basic Apple Guy",
+        @"Bean Paradise by Beanthew Skiles",
+        @"Blast Off! by Helunky",
+        @"Stories Around the Campfire by Anthony Piraino (The Iconfactory)",
+        @"Playing Cards by Brad Ellis",
+        @"Escaping the Circus by Matthew Skiles",
+        @"Dino Spoon by Zheng3 / Christian Selig",
+        @"Ducky Buddy by Lux",
+        @"Floating by Lalit",
+        @"Hang Time by David Lanham",
+        @"Harmony by David Lanham",
+        @"Helping Hand by David Lanham",
+        @"Icarus by Michael Flarup",
+        @"Keep it Up by David Lanham",
+        @"The Masked Bot by Michael Flarup",
+        @"Mechapollo by Jorge Velez",
+        @"Neon by Candbot & Matthew Skiles",
+        @"Onwards by David Lanham",
+        @"Pixel Icons by Matthew Skiles",
+        @"Reminiscing by David Lanham",
+        @"Retirement Island by Matthew Skiles",
+        @"Scanning Space by Gavin Nelson",
+        @"Scenery by Yannick Lung",
+        @"Solara by gleptech",
+        @"Spaceman by Matthew Skiles",
+        @"Special Place by David Lanham",
+        @"Squingus by Adam Whitcroft",
+        @"Sticker Bomb by Michael Flarup",
+    ];
+}
+
++ (NSArray<NSString *> *)goodbyeIPhoneURLs {
+    return @[
+        @"https://i.imgur.com/8dY2Pp9.jpeg", @"https://i.imgur.com/AJ7WTuw.jpeg",
+        @"https://i.imgur.com/ngR7qDL.jpeg", @"https://i.imgur.com/uM4Nhls.jpeg",
+        @"https://i.imgur.com/n7W7z73.jpeg", @"https://i.imgur.com/Wzyu5Gu.jpeg",
+        @"https://i.imgur.com/a0b1Aqm.jpeg", @"https://i.imgur.com/E36nGoy.jpeg",
+        @"https://i.imgur.com/dIvbzUo.jpeg", @"https://i.imgur.com/6DETaba.jpeg",
+        @"https://i.imgur.com/A3klbfB.jpeg", @"https://i.imgur.com/bG6rLfV.jpeg",
+        @"https://i.imgur.com/8uitIJZ.jpeg", @"https://i.imgur.com/HGtCU4m.jpeg",
+        @"https://i.imgur.com/x41Gm6F.jpeg", @"https://i.imgur.com/PttkHAv.jpeg",
+        @"https://i.imgur.com/HHtNY2z.jpeg", @"https://i.imgur.com/TXH8bxS.jpeg",
+        @"https://i.imgur.com/Kc9o9G4.jpeg", @"https://i.imgur.com/P2zN82M.jpeg",
+        @"https://i.imgur.com/mGXS70i.jpeg", @"https://i.imgur.com/tnHobJA.jpeg",
+        @"https://i.imgur.com/zM0R57G.jpeg", @"https://i.imgur.com/l0YLuEo.jpeg",
+        @"https://i.imgur.com/6cVawXf.jpeg", @"https://i.imgur.com/CmyLZNG.jpeg",
+        @"https://i.imgur.com/dN9YnGc.jpeg", @"https://i.imgur.com/HlsdbJg.jpeg",
+        @"https://i.imgur.com/DDdkfh0.jpeg", @"https://i.imgur.com/cnzm9SA.jpeg",
+        @"https://i.imgur.com/RHGvhLK.jpeg", @"https://i.imgur.com/9EkRNQs.jpeg",
+    ];
+}
+
++ (NSArray<NSString *> *)goodbyeIPadURLs {
+    return @[
+        @"https://i.imgur.com/NgqQDXt.jpeg", @"https://i.imgur.com/xRgVIr5.jpeg",
+        @"https://i.imgur.com/IM7eaeT.jpeg", @"https://i.imgur.com/D4e8NRF.jpeg",
+        @"https://i.imgur.com/LGTFDZA.jpeg", @"https://i.imgur.com/9chtljy.jpeg",
+        @"https://i.imgur.com/uxL6lBI.jpeg", @"https://i.imgur.com/nbXfwlv.jpeg",
+        @"https://i.imgur.com/E1SJuDl.jpeg", @"https://i.imgur.com/gfhQEON.jpeg",
+        @"https://i.imgur.com/xPAlIbH.jpeg", @"https://i.imgur.com/RPWHHxh.jpeg",
+        @"https://i.imgur.com/XThv2A3.jpeg", @"https://i.imgur.com/YG60e02.jpeg",
+        @"https://i.imgur.com/AuMVMXF.jpeg", @"https://i.imgur.com/Eu8S2qN.jpeg",
+        @"https://i.imgur.com/SUrzm6S.jpeg", @"https://i.imgur.com/od72XYW.jpeg",
+        @"https://i.imgur.com/6AJi43x.jpeg", @"https://i.imgur.com/Rm7kGfK.jpeg",
+        @"https://i.imgur.com/4sD0stc.jpeg", @"https://i.imgur.com/ztAWzn7.jpeg",
+        @"https://i.imgur.com/ndhknT2.jpeg", @"https://i.imgur.com/sLLw9hY.jpeg",
+        @"https://i.imgur.com/DdGBYTZ.jpeg", @"https://i.imgur.com/mUcqY2r.jpeg",
+        @"https://i.imgur.com/55F1J2a.jpeg", @"https://i.imgur.com/5AH1P6E.jpeg",
+        @"https://i.imgur.com/K4CY2P1.jpeg", @"https://i.imgur.com/eM90sR4.jpeg",
+        @"https://i.imgur.com/SB6T3BR.jpeg", @"https://i.imgur.com/A4yOLxp.jpeg",
+    ];
+}
+
++ (NSArray<NSString *> *)goodbyeMacURLs {
+    return @[
+        @"https://i.imgur.com/7a6I7Vc.jpeg", @"https://i.imgur.com/urmwuDX.jpeg",
+        @"https://i.imgur.com/uC9ic9e.jpeg", @"https://i.imgur.com/pTtU94f.jpeg",
+        @"https://i.imgur.com/JG7Fu69.jpeg", @"https://i.imgur.com/vlz7AWE.jpeg",
+        @"https://i.imgur.com/LO5Txr2.jpeg", @"https://i.imgur.com/U4kwkMY.jpeg",
+        @"https://i.imgur.com/P0PhCck.jpeg", @"https://i.imgur.com/5xnWb3K.jpeg",
+        @"https://i.imgur.com/O0ZsFuV.jpeg", @"https://i.imgur.com/grc6Sqs.jpeg",
+        @"https://i.imgur.com/bAzdrvl.jpeg", @"https://i.imgur.com/5S2ohZK.jpeg",
+        @"https://i.imgur.com/VtoCvVY.jpeg", @"https://i.imgur.com/IS0Kwyj.jpeg",
+        @"https://i.imgur.com/vd3Y8jo.jpeg", @"https://i.imgur.com/uGVhjVd.jpeg",
+        @"https://i.imgur.com/zrgx7k9.jpeg", @"https://i.imgur.com/ODkLRAG.jpeg",
+        @"https://i.imgur.com/LJTH3tT.jpeg", @"https://i.imgur.com/aui8puo.jpeg",
+        @"https://i.imgur.com/V8n5KAI.jpeg", @"https://i.imgur.com/iYfrJXU.jpeg",
+        @"https://i.imgur.com/d9WQjif.jpeg", @"https://i.imgur.com/Ts28YDU.jpeg",
+        @"https://i.imgur.com/DdK4kYe.jpeg", @"https://i.imgur.com/2GxoJJ8.jpeg",
+        @"https://i.imgur.com/eK8njLL.jpeg", @"https://i.imgur.com/DAgTmmm.jpeg",
+        @"https://i.imgur.com/6x8rw7n.jpeg", @"https://i.imgur.com/Mj9Wlo9.jpeg",
+        @"https://i.imgur.com/Gldd3Ei.png", @"https://i.imgur.com/Lv6Y6oq.png",
+        @"https://i.imgur.com/Yu0nLS9.png", @"https://i.imgur.com/QS1erc3.png",
+    ];
+}
+
++ (NSArray<NSString *> *)goodbyeMacCaptions {
+    return [self.goodbyeCaptions arrayByAddingObjectsFromArray:@[
+        @"Adventures — Ultrawide",
+        @"Harmony — Ultrawide",
+        @"Adventures — Vertical",
+        @"Harmony — Vertical",
+    ]];
+}
+
++ (NSArray<ApolloWallpaperItem *> *)itemsWithURLs:(NSArray<NSString *> *)URLs captions:(NSArray<NSString *> *)captions {
+    NSMutableArray<ApolloWallpaperItem *> *items = [NSMutableArray arrayWithCapacity:URLs.count];
+    [URLs enumerateObjectsUsingBlock:^(NSString *URLString, NSUInteger index, __unused BOOL *stop) {
+        NSString *caption = index < captions.count ? captions[index] : [NSString stringWithFormat:@"Wallpaper %lu", (unsigned long)index + 1];
+        [items addObject:[ApolloWallpaperItem itemWithURLString:URLString caption:caption]];
+    }];
+    return items;
+}
+
++ (void)presentURLs:(NSArray<NSString *> *)URLs
+           captions:(NSArray<NSString *> *)captions
+ fromViewController:(UIViewController *)presenter {
+    if (!presenter) return;
+    ApolloWallpaperViewerViewController *viewer = [[ApolloWallpaperViewerViewController alloc]
+        initWithItems:[self itemsWithURLs:URLs captions:captions]];
+    [presenter presentViewController:viewer animated:YES completion:nil];
+}
+
++ (void)presentDevicePickerFromViewController:(UIViewController *)presenter
+                                   sourceView:(UIView *)sourceView {
+    if (!presenter) return;
+
+    UIAlertController *sheet = [UIAlertController
+        alertControllerWithTitle:nil
+                         message:@"Choose a device"
+                  preferredStyle:UIAlertControllerStyleActionSheet];
+    UIImpactFeedbackGenerator *deviceFeedback =
+        [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
+    [deviceFeedback prepare];
+    __weak UIViewController *weakPresenter = presenter;
+    [sheet addAction:[UIAlertAction actionWithTitle:@"iPhone" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [deviceFeedback impactOccurred];
+        [self presentURLs:self.goodbyeIPhoneURLs captions:self.goodbyeCaptions fromViewController:weakPresenter];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"iPad" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [deviceFeedback impactOccurred];
+        [self presentURLs:self.goodbyeIPadURLs captions:self.goodbyeCaptions fromViewController:weakPresenter];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Mac" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        [deviceFeedback impactOccurred];
+        [self presentURLs:self.goodbyeMacURLs captions:self.goodbyeMacCaptions fromViewController:weakPresenter];
+    }]];
+    [sheet addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+
+    UIPopoverPresentationController *popover = sheet.popoverPresentationController;
+    UIView *anchor = sourceView ?: presenter.view;
+    popover.sourceView = anchor;
+    popover.sourceRect = anchor.bounds;
+    [presenter presentViewController:sheet animated:YES completion:nil];
+}
+
+@end


### PR DESCRIPTION
## Summary

Adds Apollo’s Goodbye Wallpapers back into the app while keeping the full-resolution images hosted externally.

## What’s included

- Adds a **Wallpapers** row to Apollo’s Settings screen above **About**
- Presents a native Apollo-style device picker for:
  - iPhone
  - iPad
  - Mac
- Adds a full-screen wallpaper viewer with:
  - Horizontal paging
  - Pinch and double-tap zoom
  - Interactive vertical and diagonal dismissal
  - Tap to hide or restore all interface controls
  - Previous and next image preloading
  - Retry messaging when an image fails to load
- Downloads the original hosted image directly to Photos without re-encoding it
- Shows a temporary **Saved** confirmation and success haptic after downloading

## Preview

| Settings row and device menu | Wallpaper viewer |
|:---:|:---:|
| <img width="282" height="612" alt="Wallpapers settings row and device selection menu" src="https://github.com/user-attachments/assets/83021be7-cfda-4afa-8071-25b5a31ab567" /> | <img width="282" height="612" alt="Full-screen wallpaper viewer" src="https://github.com/user-attachments/assets/046cb049-e39b-4db8-bae5-6e9a1941d4e4" /> |

## Hosting

The wallpapers are loaded from externally hosted Imgur albums rather than bundled with Apollo. This preserves the original image quality without significantly increasing the packaged app size.

The included collections contain:

- 32 iPhone wallpapers
- 32 iPad wallpapers
- 36 Mac wallpapers

## Testing

Tested in iOS simulator and on-device, including:

- Opening each device collection
- Paging and image preloading
- Pinch and double-tap zoom
- Hiding and restoring controls
- Interactive dismissal
- Downloading original files to Photos
- Failed-load retry behavior