### PR TITLE
Fix mojibake link previews for pages in a legacy charset (#945)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ xcrun simctl spawn "$(cat .sim/device.txt)" log show --last 2m --predicate 'subs
 | `src/Tweak.xm` / `src/Tweak.h` | Main tweak entry point and core runtime hooks |
 | `src/Apollo*.xm` | Feature-focused Logos modules; see `Makefile` for the current build list |
 | `src/ApolloCommon.{h,m}` | Shared utilities, including `ApolloLog` and helper functions |
+| `src/ApolloWebTextDecoding.{h,m}` | Charset-aware decode of bytes fetched from arbitrary third-party pages (BOM → `Content-Type` → `<meta charset>`, plus the WHATWG label upgrades). Use this instead of `initWithData:encoding:NSUTF8StringEncoding` for any *foreign* page — a UTF-8 guess mojibakes EUC-KR/Shift_JIS/GB18030/Big5 sites. Foundation-only, so the `.m` compiles straight into a host-side harness |
 | `src/ApolloState.{h,m}` | Global state, captured singletons, and feature flags |
 
 ### Settings & UI (`src/settings/`)

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ ApolloReborn_FILES = \
     $(WHATS_NEW_GEN_M) \
     $(SRC_DIR)/Tweak.xm \
     $(SRC_DIR)/ApolloCommon.m \
+    $(SRC_DIR)/ApolloWebTextDecoding.m \
     $(SRC_DIR)/ApolloMemoryDiagnostics.m \
     $(SRC_DIR)/settings/ApolloSettingsTableViewController.m \
     $(SRC_DIR)/settings/ApolloSettingsForm.m \

--- a/src/ApolloAISummary.xm
+++ b/src/ApolloAISummary.xm
@@ -26,6 +26,7 @@
 #import "ApolloCommon.h"
 #import "ApolloAISummary.h"
 #import "ApolloAICloudBridge.h"
+#import "ApolloWebTextDecoding.h"
 #import "ApolloThemeRuntime.h"
 #import "ApolloState.h"
 #import "ApolloTextureDecls.h"
@@ -1568,8 +1569,10 @@ static void ApolloAIFetchAndExtract(NSURL *url, NSString *userAgent, void (^done
             NSHTTPURLResponse *http = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
             if (!error && http && http.statusCode >= 200 && http.statusCode < 300 &&
                 data.length > 0 && data.length <= kApolloAIArticleFetchMaxBytes) {
-                html = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-                if (!html) html = [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding];
+                // Charset-aware: a Korean/Japanese/Chinese article read as
+                // Latin-1 handed the model a page of mojibake to summarise
+                // (issue #945).
+                html = ApolloWebTextFromData(data, response, NULL);
                 if (html) text = ApolloAIExtractArticleText(html);
             } else if (!error && http && (http.statusCode < 200 || http.statusCode >= 300)) {
                 outErr = [NSError errorWithDomain:@"ApolloAIArticle" code:http.statusCode userInfo:nil];

--- a/src/ApolloLinkPreviewCache.m
+++ b/src/ApolloLinkPreviewCache.m
@@ -12,6 +12,16 @@ static const NSTimeInterval ApolloLinkPreviewRedditTTL = 24.0 * 60.0 * 60.0;
 static const NSTimeInterval ApolloLinkPreviewYouTubeTTL = 30.0 * 24.0 * 60.0 * 60.0;
 static const NSTimeInterval ApolloLinkPreviewCacheDiskFlushInterval = 8.0;
 
+// Entry schema stamp. Entries written by an older schema are dropped on load
+// rather than aged out, so a fix to how previews are *produced* reaches users
+// immediately instead of hiding behind the 7-day TTL. Bumped to 2 for the
+// charset-aware HTML decode (issue #945): every preview harvested from a
+// non-UTF-8 page before that fix holds mojibake text that would otherwise
+// keep rendering for a week after updating. Bump this whenever a change
+// invalidates already-stored previews.
+static NSString *const ApolloLinkPreviewCacheSchemaKey = @"schema";
+static const NSInteger ApolloLinkPreviewCacheSchemaVersion = 2;
+
 @interface ApolloLinkPreviewCache ()
 @property (nonatomic, strong) NSMutableDictionary<NSString *, NSDictionary *> *entries;
 // Immutable point-in-time view used by layout callers after NSCache eviction.
@@ -109,7 +119,21 @@ static const NSTimeInterval ApolloLinkPreviewCacheDiskFlushInterval = 8.0;
     NSData *data = [NSData dataWithContentsOfFile:self.cachePath];
     if (!data) return nil;
     id object = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
-    return [object isKindOfClass:[NSDictionary class]] ? object : nil;
+    if (![object isKindOfClass:[NSDictionary class]]) return nil;
+
+    NSMutableDictionary *current = [NSMutableDictionary dictionaryWithCapacity:[object count]];
+    [object enumerateKeysAndObjectsUsingBlock:^(NSString *key, id entry, __unused BOOL *stop) {
+        if (![key isKindOfClass:[NSString class]] || ![entry isKindOfClass:[NSDictionary class]]) return;
+        NSNumber *schema = entry[ApolloLinkPreviewCacheSchemaKey];
+        if (![schema isKindOfClass:[NSNumber class]] || schema.integerValue != ApolloLinkPreviewCacheSchemaVersion) return;
+        current[key] = entry;
+    }];
+
+    NSUInteger dropped = [object count] - current.count;
+    if (dropped > 0) {
+        ApolloLog(@"[LinkPreviews] cache dropped %lu entr%@ from an older schema", (unsigned long)dropped, dropped == 1 ? @"y" : @"ies");
+    }
+    return current;
 }
 
 - (NSString *)cacheKeyForURL:(NSURL *)url {
@@ -223,6 +247,7 @@ static const NSTimeInterval ApolloLinkPreviewCacheDiskFlushInterval = 8.0;
     NSMutableDictionary *entry = [[preview dictionaryRepresentation] mutableCopy];
     entry[@"url"] = url.absoluteString ?: @"";
     entry[@"lastAccess"] = @([[NSDate date] timeIntervalSince1970]);
+    entry[ApolloLinkPreviewCacheSchemaKey] = @(ApolloLinkPreviewCacheSchemaVersion);
 
     [self.memoryCache setObject:preview forKey:key];
     dispatch_async(self.queue, ^{

--- a/src/ApolloLinkPreviewFetcher.m
+++ b/src/ApolloLinkPreviewFetcher.m
@@ -8,6 +8,7 @@
 #import "ApolloState.h"
 #import "ApolloSubredditInfoCache.h"
 #import "ApolloUserProfileCache.h"
+#import "ApolloWebTextDecoding.h"
 
 static const NSUInteger ApolloLinkPreviewMaxHTMLBytes = 2 * 1024 * 1024;
 
@@ -1678,9 +1679,15 @@ static NSData *ApolloLinkPreviewHeadSliceOfData(NSData *data) {
         }
 
         NSData *headSlice = ApolloLinkPreviewHeadSliceOfData(data);
-        NSString *html = [[NSString alloc] initWithData:headSlice encoding:NSUTF8StringEncoding];
-        if (html.length == 0) {
-            html = [[NSString alloc] initWithData:headSlice encoding:NSISOLatin1StringEncoding];
+        // Decode with the charset the page declares, not a UTF-8 guess: Korean
+        // (EUC-KR/CP949), Japanese (Shift_JIS) and Chinese (GB18030/Big5) news
+        // sites are not valid UTF-8, so a UTF-8-first read failed and the
+        // Latin-1 rescue turned every og: tag into mojibake (issue #945).
+        NSStringEncoding htmlEncoding = 0;
+        NSString *html = ApolloWebTextFromData(headSlice, httpResponse, &htmlEncoding);
+        if (htmlEncoding != 0 && htmlEncoding != NSUTF8StringEncoding) {
+            ApolloLog(@"[LinkPreviews] HTML decoded as %@ host=%@",
+                      ApolloWebTextNameForEncoding(htmlEncoding), ApolloLinkPreviewHost(url));
         }
 
         NSDictionary<NSString *, NSString *> *meta = [self metaValuesFromHTML:html];

--- a/src/ApolloSimDebugTap.xm
+++ b/src/ApolloSimDebugTap.xm
@@ -18,6 +18,7 @@
 #import "ApolloAccountCredentials.h"
 #import "ApolloCommentVoteInsights.h"
 #import "ApolloCommon.h"
+#import "ApolloLinkPreviewFetcher.h"
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
 #import "UIWindow+Apollo.h"
@@ -429,6 +430,23 @@ static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *
                               fullName, insight.upvotePercent, insight.reportedUpvotes,
                               error.localizedDescription ?: @"none");
                 });
+            return;
+        }
+        // "linkpreview <url>" command: run the real link-preview fetch against
+        // an arbitrary page and log what came back. Exercising the fetcher
+        // needs no Reddit account, so metadata extraction — charset handling
+        // above all (issue #945) — can be verified against live foreign-language
+        // pages on a signed-out simulator.
+        if ([contents hasPrefix:@"linkpreview "]) {
+            NSString *urlString = [[contents substringFromIndex:12] stringByTrimmingCharactersInSet:
+                NSCharacterSet.whitespaceAndNewlineCharacterSet];
+            NSURL *previewURL = urlString.length > 0 ? [NSURL URLWithString:urlString] : nil;
+            if (!previewURL) { ApolloLog(@"[SimDebugTap] malformed linkpreview url: %@", urlString); return; }
+            [ApolloLinkPreviewFetcher requestPreviewForURL:previewURL completion:^(ApolloLinkPreview *preview) {
+                ApolloLog(@"[SimDebugTap] linkpreview %@\n  site=%@\n  title=%@\n  desc=%@\n  image=%@",
+                          urlString, preview.siteName ?: @"(nil)", preview.title ?: @"(nil)",
+                          preview.desc ?: @"(nil)", preview.imageURL.absoluteString ?: @"(nil)");
+            }];
             return;
         }
         if ([contents hasPrefix:@"text "]) {

--- a/src/ApolloSimDebugTap.xm
+++ b/src/ApolloSimDebugTap.xm
@@ -19,6 +19,7 @@
 #import "ApolloCommentVoteInsights.h"
 #import "ApolloCommon.h"
 #import "ApolloLinkPreviewFetcher.h"
+#import "ApolloWebTextDecoding.h"
 #import "ApolloState.h"
 #import "UserDefaultConstants.h"
 #import "UIWindow+Apollo.h"
@@ -499,6 +500,10 @@ static void ApolloSimDebugTapNotification(CFNotificationCenterRef center, void *
     ApolloLog(@"[SimDebugTap] listening for apollofix.debugtap");
     ApolloLog(@"[CommentInsights][parser] self-tests %@",
               ApolloCommentVoteInsightsRunParserSelfTests() ? @"passed" : @"FAILED");
+    NSString *charsetFailure = nil;
+    BOOL charsetOK = ApolloWebTextDecodingRunSelfTests(&charsetFailure);
+    ApolloLog(@"[WebTextDecoding] self-tests %@", charsetOK ? @"passed"
+              : [NSString stringWithFormat:@"FAILED at \"%@\"", charsetFailure]);
 }
 
 #endif

--- a/src/ApolloWebTextDecoding.h
+++ b/src/ApolloWebTextDecoding.h
@@ -34,19 +34,30 @@ NSStringEncoding ApolloWebTextEncodingDeclaredInHTMLData(NSData *data);
 /// declares, in this order:
 ///
 ///   1. a byte-order mark, which outranks every declaration;
-///   2. UTF-8, when the bytes are valid UTF-8 *and* carry at least one
-///      multi-byte sequence (see the note in the implementation on why this
-///      sits ahead of the declared charset);
-///   3. the response's `Content-Type: …; charset=…`;
-///   4. the charset declared inside the markup;
-///   5. UTF-8, covering pure-ASCII pages and pages that declare nothing;
-///   6. Latin-1, which cannot fail and so guarantees a non-nil result for any
+///   2. the response's `Content-Type: …; charset=…`;
+///   3. the charset declared inside the markup;
+///   4. UTF-8, for pages that declare nothing usable;
+///   5. Latin-1, which cannot fail and so guarantees a non-nil result for any
 ///      non-empty input.
+///
+/// A declaration is honoured as given and is never overridden by sniffing the
+/// bytes for valid UTF-8 first — valid UTF-8 and valid legacy text overlap (see
+/// the implementation), so sniffing would decode some legacy pages to entirely
+/// the wrong characters. A declaration that fails to decode its own bytes is
+/// abandoned in favour of the next candidate.
 ///
 /// `response` may be nil. Pass a non-NULL `outEncoding` to learn which encoding
 /// won, for logging; it is left untouched when the input is empty.
 /// Returns nil only for nil/empty `data`.
 NSString *ApolloWebTextFromData(NSData *data, NSURLResponse *response, NSStringEncoding *outEncoding);
+
+/// Regression fixtures for the above, covering the label widening, the
+/// declaration sources and their precedence, and the byte sequences that are
+/// simultaneously valid UTF-8 and valid CP949/Big5/GB18030/Shift_JIS. Returns
+/// YES when every case passes; on failure `outFailedCase` (optional) receives
+/// the name of the first case that failed. Cheap and allocation-light — run
+/// from the simulator debug bridge's %ctor.
+BOOL ApolloWebTextDecodingRunSelfTests(NSString **outFailedCase);
 
 /// Human-readable name for an encoding returned above ("Korean (Windows, DOS)"),
 /// for log lines. Returns @"unknown" for 0 / unmappable values.

--- a/src/ApolloWebTextDecoding.h
+++ b/src/ApolloWebTextDecoding.h
@@ -1,0 +1,55 @@
+#import <Foundation/Foundation.h>
+
+// Charset-aware decoding for bytes fetched from arbitrary third-party web
+// pages (link-preview metadata, AI article extraction).
+//
+// Assuming UTF-8 with a Latin-1 rescue is wrong for the large slice of the web
+// that still ships legacy encodings: Korean news (EUC-KR/CP949), Japanese
+// (Shift_JIS), Chinese (GB18030/Big5), and older Western/Cyrillic pages
+// (windows-1252/1251). Their bytes are not valid UTF-8, so the UTF-8 read
+// returns nil, the Latin-1 rescue succeeds on every byte, and every og: tag
+// comes out as mojibake — issue #945, where news.nate.com's EUC-KR title
+// rendered as "¡®¾ÆÀ°´ë¡¯ ¿ÃÇØ Ãß¼®…".
+//
+// Deliberately Foundation-only and free of any tweak dependency, so it can be
+// compiled straight into a host-side harness and checked against real captured
+// pages.
+//
+// Bug: https://github.com/Apollo-Reborn/Apollo-Reborn/issues/945
+
+__BEGIN_DECLS
+
+/// Maps an IANA charset label ("euc-kr", "Shift_JIS", "windows-1251", quoted or
+/// not, any case) to the `NSStringEncoding` to decode with, or 0 when the label
+/// is empty or unrecognised.
+NSStringEncoding ApolloWebTextEncodingForCharsetLabel(NSString *label);
+
+/// Sniffs the charset an HTML byte stream declares in its own markup — either
+/// `<meta charset=…>` / `<meta http-equiv="Content-Type" content="…charset=…">`
+/// or an XHTML `<?xml … encoding="…"?>` prologue. Returns 0 when nothing usable
+/// is declared inside the scanned prefix.
+NSStringEncoding ApolloWebTextEncodingDeclaredInHTMLData(NSData *data);
+
+/// Decodes web-fetched bytes into a string using the charset the page actually
+/// declares, in this order:
+///
+///   1. a byte-order mark, which outranks every declaration;
+///   2. UTF-8, when the bytes are valid UTF-8 *and* carry at least one
+///      multi-byte sequence (see the note in the implementation on why this
+///      sits ahead of the declared charset);
+///   3. the response's `Content-Type: …; charset=…`;
+///   4. the charset declared inside the markup;
+///   5. UTF-8, covering pure-ASCII pages and pages that declare nothing;
+///   6. Latin-1, which cannot fail and so guarantees a non-nil result for any
+///      non-empty input.
+///
+/// `response` may be nil. Pass a non-NULL `outEncoding` to learn which encoding
+/// won, for logging; it is left untouched when the input is empty.
+/// Returns nil only for nil/empty `data`.
+NSString *ApolloWebTextFromData(NSData *data, NSURLResponse *response, NSStringEncoding *outEncoding);
+
+/// Human-readable name for an encoding returned above ("Korean (Windows, DOS)"),
+/// for log lines. Returns @"unknown" for 0 / unmappable values.
+NSString *ApolloWebTextNameForEncoding(NSStringEncoding encoding);
+
+__END_DECLS

--- a/src/ApolloWebTextDecoding.m
+++ b/src/ApolloWebTextDecoding.m
@@ -188,15 +188,6 @@ NSStringEncoding ApolloWebTextEncodingDeclaredInHTMLData(NSData *data) {
     return 0;
 }
 
-static BOOL ApolloWebTextDataContainsNonASCII(NSData *data) {
-    const uint8_t *bytes = data.bytes;
-    NSUInteger length = data.length;
-    for (NSUInteger index = 0; index < length; index++) {
-        if (bytes[index] & 0x80) return YES;
-    }
-    return NO;
-}
-
 #pragma mark - Decoding
 
 NSString *ApolloWebTextFromData(NSData *data, NSURLResponse *response, NSStringEncoding *outEncoding) {
@@ -213,34 +204,30 @@ NSString *ApolloWebTextFromData(NSData *data, NSURLResponse *response, NSStringE
         }
     }
 
-    // Multi-byte-bearing valid UTF-8 outranks the declared charset here, which
-    // is a deliberate departure from the spec's "HTTP header always wins".
+    // An explicit declaration is honoured as declared, and is never
+    // second-guessed by sniffing the bytes for valid UTF-8 first.
     //
-    // The spec order would regress pages that are genuinely UTF-8 but ship a
-    // stale `charset=ISO-8859-1` header (still an Apache default) — the
-    // windows-1252 read never fails, so it would win and turn working previews
-    // into mojibake. Deciding by the bytes avoids that with no ambiguity cost:
-    // legacy multi-byte text essentially cannot be mistaken for UTF-8, because
-    // EUC-KR/CP949, Shift_JIS and Big5 all lead their characters with a byte in
-    // 0x80–0xBF or 0x81–0x9F, which UTF-8 does not allow in a lead position.
-    // So "valid UTF-8 with at least one multi-byte sequence" identifies real
-    // UTF-8, and the declared charset still governs everything else.
-    BOOL hasNonASCII = ApolloWebTextDataContainsNonASCII(data);
-    NSString *utf8Decoded = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    if (hasNonASCII && utf8Decoded.length > 0) {
-        if (outEncoding) *outEncoding = NSUTF8StringEncoding;
-        return utf8Decoded;
-    }
-
-    NSMutableArray<NSNumber *> *candidates = [NSMutableArray array];
+    // Sniffing looks tempting — it would rescue a page that is really UTF-8
+    // behind a stale `charset=ISO-8859-1` header — but it is not sound, because
+    // "valid UTF-8" and "valid legacy text" are not mutually exclusive. The
+    // lead-byte ranges overlap: CP949, GB18030 and Big5 lead as high as 0xFE and
+    // CP932 as high as 0xFC, well inside UTF-8's own 0xC2–0xF4 lead range. So
+    // `C2 81` is both valid UTF-8 (U+0081) and valid CP949 (혖), and `C2 A1` is
+    // both valid UTF-8 (U+00A1) and valid Big5 (癒) / GB18030 (隆) / CP932 (ﾂ｡).
+    // A page built from those pairs would sniff clean as UTF-8 and decode to
+    // entirely the wrong characters — the very bug this file exists to fix.
+    // Trusting the declaration is also what browsers do, so a page we get
+    // "wrong" is one that renders the same way in Safari.
     NSStringEncoding headerEncoding = ApolloWebTextEncodingForCharsetLabel(response.textEncodingName);
-    if (headerEncoding != 0) [candidates addObject:@(headerEncoding)];
     NSStringEncoding markupEncoding = ApolloWebTextEncodingDeclaredInHTMLData(data);
-    if (markupEncoding != 0 && markupEncoding != headerEncoding) [candidates addObject:@(markupEncoding)];
-
-    for (NSNumber *candidate in candidates) {
-        NSStringEncoding encoding = candidate.unsignedIntegerValue;
-        if (encoding == NSUTF8StringEncoding) continue; // already tried above
+    NSStringEncoding declared[] = { headerEncoding, markupEncoding };
+    for (size_t index = 0; index < sizeof(declared) / sizeof(*declared); index++) {
+        NSStringEncoding encoding = declared[index];
+        if (encoding == 0) continue;
+        if (index > 0 && encoding == declared[0]) continue;
+        // A failed decode means the declaration was wrong about its own bytes,
+        // so fall through to the next candidate rather than honouring it into
+        // mojibake.
         NSString *decoded = [[NSString alloc] initWithData:data encoding:encoding];
         if (decoded.length > 0) {
             if (outEncoding) *outEncoding = encoding;
@@ -248,7 +235,8 @@ NSString *ApolloWebTextFromData(NSData *data, NSURLResponse *response, NSStringE
         }
     }
 
-    // Pure-ASCII documents, and documents that declared nothing usable.
+    // Nothing usable was declared (or every declaration failed to decode).
+    NSString *utf8Decoded = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     if (utf8Decoded.length > 0) {
         if (outEncoding) *outEncoding = NSUTF8StringEncoding;
         return utf8Decoded;
@@ -259,4 +247,158 @@ NSString *ApolloWebTextFromData(NSData *data, NSURLResponse *response, NSStringE
     // handing the caller nil and losing the page's metadata outright.
     if (outEncoding) *outEncoding = NSISOLatin1StringEncoding;
     return [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding];
+}
+
+#pragma mark - Self tests
+
+// Test double for the charset an NSURLResponse reports out of Content-Type.
+@interface ApolloWebTextTestResponse : NSURLResponse
+@property (nonatomic, copy) NSString *charsetName;
+@end
+@implementation ApolloWebTextTestResponse
+- (NSString *)textEncodingName { return self.charsetName; }
+@end
+
+BOOL ApolloWebTextDecodingRunSelfTests(NSString **outFailedCase) {
+    __block NSString *failure = nil;
+    void (^expect)(BOOL, NSString *) = ^(BOOL condition, NSString *name) {
+        if (!condition && !failure) failure = name;
+    };
+    NSURLResponse *(^declaring)(NSString *) = ^NSURLResponse *(NSString *charset) {
+        ApolloWebTextTestResponse *response = [ApolloWebTextTestResponse new];
+        response.charsetName = charset;
+        return response;
+    };
+    NSData *(^bytes)(const uint8_t *, NSUInteger) = ^NSData *(const uint8_t *b, NSUInteger n) {
+        return [NSData dataWithBytes:b length:n];
+    };
+
+    // --- Label mapping. euc-kr must widen to CP949: Apple's EUC-KR converter
+    // rejects the CP949-extended hangul that real "euc-kr" pages contain, and
+    // "korean" otherwise resolves to Mac OS Korean, a different encoding.
+    expect(ApolloWebTextEncodingForCharsetLabel(@"euc-kr") ==
+           CFStringConvertEncodingToNSStringEncoding(kCFStringEncodingDOSKorean), @"label euc-kr->cp949");
+    expect(ApolloWebTextEncodingForCharsetLabel(@"  \"EUC-KR\" ") ==
+           ApolloWebTextEncodingForCharsetLabel(@"euc-kr"), @"label quoted/cased/padded");
+    expect(ApolloWebTextEncodingForCharsetLabel(@"korean") ==
+           CFStringConvertEncodingToNSStringEncoding(kCFStringEncodingDOSKorean), @"label korean->cp949");
+    expect(ApolloWebTextEncodingForCharsetLabel(@"gb2312") ==
+           CFStringConvertEncodingToNSStringEncoding(kCFStringEncodingGB_18030_2000), @"label gb2312->gb18030");
+    expect(ApolloWebTextEncodingForCharsetLabel(@"iso-8859-1") ==
+           CFStringConvertEncodingToNSStringEncoding(kCFStringEncodingWindowsLatin1), @"label latin1->cp1252");
+    expect(ApolloWebTextEncodingForCharsetLabel(@"windows-1251") != 0, @"label windows-1251 resolves");
+    expect(ApolloWebTextEncodingForCharsetLabel(@"totally-bogus") == 0, @"label bogus->0");
+    expect(ApolloWebTextEncodingForCharsetLabel(nil) == 0, @"label nil->0");
+    expect(ApolloWebTextEncodingForCharsetLabel(@"") == 0, @"label empty->0");
+
+    // --- Ambiguous bytes: each of these is simultaneously well-formed UTF-8 and
+    // well-formed legacy text, so a decoder that sniffs for valid UTF-8 before
+    // reading the declaration silently returns the wrong characters. The
+    // declaration has to win.
+    const uint8_t c281[] = { 0xC2, 0x81 };  // UTF-8 U+0081 | CP949 혖
+    const uint8_t c2a1[] = { 0xC2, 0xA1 };  // UTF-8 U+00A1 | Big5 癒 | GB18030 隆 | CP932 ﾂ｡
+    expect([[NSString alloc] initWithData:bytes(c281, 2) encoding:NSUTF8StringEncoding] != nil,
+           @"fixture C2 81 really is valid UTF-8");
+    expect([[NSString alloc] initWithData:bytes(c2a1, 2) encoding:NSUTF8StringEncoding] != nil,
+           @"fixture C2 A1 really is valid UTF-8");
+    expect([ApolloWebTextFromData(bytes(c281, 2), declaring(@"euc-kr"), NULL) isEqualToString:@"혖"],
+           @"ambiguous C2 81 honours euc-kr");
+    expect([ApolloWebTextFromData(bytes(c2a1, 2), declaring(@"big5"), NULL) isEqualToString:@"癒"],
+           @"ambiguous C2 A1 honours big5");
+    expect([ApolloWebTextFromData(bytes(c2a1, 2), declaring(@"gb2312"), NULL) isEqualToString:@"隆"],
+           @"ambiguous C2 A1 honours gb2312");
+    expect([ApolloWebTextFromData(bytes(c2a1, 2), declaring(@"shift_jis"), NULL) isEqualToString:@"ﾂ｡"],
+           @"ambiguous C2 A1 honours shift_jis");
+
+    // A whole document of ambiguous pairs — the document-level version of the
+    // above, since a single pair could be dismissed as a corner case.
+    NSMutableData *ambiguousPage = [NSMutableData dataWithData:
+        [@"<html><head><title>" dataUsingEncoding:NSASCIIStringEncoding]];
+    for (int repeat = 0; repeat < 64; repeat++) [ambiguousPage appendBytes:c281 length:2];
+    [ambiguousPage appendData:[@"</title></head></html>" dataUsingEncoding:NSASCIIStringEncoding]];
+    expect([[NSString alloc] initWithData:ambiguousPage encoding:NSUTF8StringEncoding] != nil,
+           @"fixture whole ambiguous page is valid UTF-8");
+    expect([ApolloWebTextFromData(ambiguousPage, declaring(@"euc-kr"), NULL) containsString:@"혖혖"],
+           @"whole ambiguous page honours euc-kr");
+
+    // --- Declaration sources and precedence.
+    const uint8_t hangul[] = { 0xBE, 0xC6, 0xC0, 0xCC };  // 아이 in EUC-KR
+    expect([ApolloWebTextFromData(bytes(hangul, 4), declaring(@"euc-kr"), NULL) isEqualToString:@"아이"],
+           @"header charset decodes");
+
+    NSMutableData *metaOnly = [NSMutableData dataWithData:[
+        @"<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=euc-kr\"><title>"
+        dataUsingEncoding:NSASCIIStringEncoding]];
+    [metaOnly appendBytes:hangul length:4];
+    [metaOnly appendData:[@"</title></head>" dataUsingEncoding:NSASCIIStringEncoding]];
+    expect([ApolloWebTextFromData(metaOnly, nil, NULL) containsString:@"아이"], @"meta charset, nil response");
+
+    NSMutableData *xmlPrologue = [NSMutableData dataWithData:
+        [@"<?xml version=\"1.0\" encoding=\"euc-kr\"?><t>" dataUsingEncoding:NSASCIIStringEncoding]];
+    [xmlPrologue appendBytes:hangul length:4];
+    [xmlPrologue appendData:[@"</t>" dataUsingEncoding:NSASCIIStringEncoding]];
+    expect([ApolloWebTextFromData(xmlPrologue, nil, NULL) containsString:@"아이"], @"XHTML encoding prologue");
+
+    // Header outranks a contradicting markup declaration.
+    NSMutableData *headerVsMeta = [NSMutableData dataWithData:
+        [@"<html><head><meta charset=\"utf-8\"><title>" dataUsingEncoding:NSASCIIStringEncoding]];
+    [headerVsMeta appendBytes:hangul length:4];
+    [headerVsMeta appendData:[@"</title></head>" dataUsingEncoding:NSASCIIStringEncoding]];
+    expect([ApolloWebTextFromData(headerVsMeta, declaring(@"euc-kr"), NULL) containsString:@"아이"],
+           @"header outranks markup");
+
+    // A header that cannot decode its own bytes is abandoned in favour of the
+    // markup's declaration. Real shape: the server says utf-8 while serving
+    // EUC-KR, and only the page itself tells the truth.
+    NSMutableData *lyingHeader = [NSMutableData dataWithData:
+        [@"<html><head><meta charset=\"euc-kr\"><title>" dataUsingEncoding:NSASCIIStringEncoding]];
+    [lyingHeader appendBytes:hangul length:4];
+    [lyingHeader appendData:[@"</title></head>" dataUsingEncoding:NSASCIIStringEncoding]];
+    expect([[NSString alloc] initWithData:lyingHeader encoding:NSUTF8StringEncoding] == nil,
+           @"fixture lying-header body really is invalid UTF-8");
+    expect([ApolloWebTextFromData(lyingHeader, declaring(@"utf-8"), NULL) containsString:@"아이"],
+           @"undecodable header falls through to markup");
+
+    // --- BOM outranks a contradicting declaration, and is stripped.
+    NSMutableData *bom = [NSMutableData dataWithBytes:"\xEF\xBB\xBF" length:3];
+    [bom appendData:[@"<title>안녕</title>" dataUsingEncoding:NSUTF8StringEncoding]];
+    expect([ApolloWebTextFromData(bom, declaring(@"euc-kr"), NULL) isEqualToString:@"<title>안녕</title>"],
+           @"UTF-8 BOM wins and is stripped");
+
+    // --- CP949-extended hangul under a plain "euc-kr" label: nil through
+    // Apple's narrow EUC-KR converter, which is what the widening prevents.
+    const uint8_t cp949Extended[] = { 0x81, 0x41, 0xBE, 0xC6 };
+    expect([[NSString alloc] initWithData:bytes(cp949Extended, 4)
+                                 encoding:CFStringConvertEncodingToNSStringEncoding(kCFStringEncodingEUC_KR)] == nil,
+           @"fixture CP949-extended really is rejected by EUC-KR");
+    expect([ApolloWebTextFromData(bytes(cp949Extended, 4), declaring(@"euc-kr"), NULL) containsString:@"아"],
+           @"CP949-extended bytes under euc-kr label");
+
+    // --- windows-1252 punctuation under an iso-8859-1 label (0x93/0x94 are
+    // undefined C1 controls in true ISO-8859-1).
+    const uint8_t smartQuotes[] = { 'C', 'a', 'f', 0xE9, ' ', 0x93, 'h', 'i', 0x94 };
+    expect([ApolloWebTextFromData(bytes(smartQuotes, 9), declaring(@"iso-8859-1"), NULL)
+            isEqualToString:@"Café “hi”"], @"windows-1252 punctuation under iso-8859-1");
+
+    // --- Undeclared, pure ASCII, and degenerate inputs.
+    expect(ApolloWebTextFromData(bytes(hangul, 4), nil, NULL).length > 0,
+           @"undeclared non-UTF-8 never returns nil");
+    expect([ApolloWebTextFromData([@"<p>hi</p>" dataUsingEncoding:NSASCIIStringEncoding],
+                                  declaring(@"shift_jis"), NULL) isEqualToString:@"<p>hi</p>"],
+           @"pure ASCII under a legacy label");
+    expect([ApolloWebTextFromData([@"<p>Café 안녕</p>" dataUsingEncoding:NSUTF8StringEncoding], nil, NULL)
+            containsString:@"Café 안녕"], @"undeclared UTF-8");
+    expect(ApolloWebTextFromData(nil, nil, NULL) == nil, @"nil data->nil");
+    expect(ApolloWebTextFromData([NSData data], nil, NULL) == nil, @"empty data->nil");
+
+    NSStringEncoding untouched = 0xDEAD;
+    (void)ApolloWebTextFromData([NSData data], nil, &untouched);
+    expect(untouched == 0xDEAD, @"outEncoding untouched on empty input");
+
+    NSStringEncoding reported = 0;
+    (void)ApolloWebTextFromData(bytes(hangul, 4), declaring(@"euc-kr"), &reported);
+    expect([ApolloWebTextNameForEncoding(reported) isEqualToString:@"cp949"], @"reported encoding name");
+
+    if (outFailedCase) *outFailedCase = failure;
+    return failure == nil;
 }

--- a/src/ApolloWebTextDecoding.m
+++ b/src/ApolloWebTextDecoding.m
@@ -1,0 +1,262 @@
+#import "ApolloWebTextDecoding.h"
+
+// How far into the document we look for a `<meta charset>` declaration. The
+// HTML spec only obliges a page to declare inside its first 1024 bytes, but
+// plenty of real pages bury it after a pile of inline script; 64 KB covers
+// every page seen in the wild while keeping the ASCII prescan bounded on the
+// multi-megabyte documents the fetchers cap at.
+static const NSUInteger ApolloWebTextMetaPrescanBytes = 64 * 1024;
+
+#pragma mark - Charset labels
+
+// The WHATWG encoding standard exists because charset labels on the real web
+// are systematically narrower than the bytes they describe, so every browser
+// decodes these labels with a superset instead. That is not pedantry here: the
+// narrow converter *rejects* the extended bytes, and a rejected decode is
+// exactly what drops us into the Latin-1 rescue this file exists to avoid.
+//
+//   euc-kr        Apple's EUC-KR converter refuses CP949-extended hangul, which
+//                 Korean pages labelled "euc-kr" legitimately contain. CP949 is
+//                 a strict superset, so it reads both.
+//   korean        Resolves to *Mac OS* Korean through CFString — a different
+//                 encoding entirely — so it has to be overridden, not just
+//                 widened.
+//   shift_jis     Real pages carry the CP932 (windows-31j) vendor extensions.
+//   gb2312 / gbk  Superseded by GB18030, which is backward compatible.
+//   big5          Traditional Chinese pages carry HKSCS extensions.
+//   iso-8859-1    The single most mislabelled charset on the web: pages declare
+//   / us-ascii    it while using the windows-1252 smart quotes, dashes and
+//                 ellipses that live in the 0x80–0x9F control range.
+static NSStringEncoding ApolloWebTextOverrideEncodingForLabel(NSString *label) {
+    static NSDictionary<NSString *, NSNumber *> *overrides;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSNumber *korean = @(kCFStringEncodingDOSKorean);            // CP949 / UHC
+        NSNumber *japanese = @(kCFStringEncodingDOSJapanese);        // CP932 / windows-31j
+        NSNumber *simplified = @(kCFStringEncodingGB_18030_2000);
+        NSNumber *traditional = @(kCFStringEncodingBig5_HKSCS_1999);
+        NSNumber *western = @(kCFStringEncodingWindowsLatin1);       // windows-1252
+        overrides = @{
+            @"euc-kr": korean,
+            @"euckr": korean,
+            @"ks_c_5601-1987": korean,
+            @"ks_c_5601-1989": korean,
+            @"ksc5601": korean,
+            @"ksc_5601": korean,
+            @"korean": korean,
+            @"csksc56011987": korean,
+            @"iso-ir-149": korean,
+
+            @"shift_jis": japanese,
+            @"shift-jis": japanese,
+            @"sjis": japanese,
+            @"ms_kanji": japanese,
+            @"csshiftjis": japanese,
+            @"x-sjis": japanese,
+
+            @"gb2312": simplified,
+            @"gb_2312": simplified,
+            @"gb_2312-80": simplified,
+            @"chinese": simplified,
+            @"csgb2312": simplified,
+            @"gbk": simplified,
+            @"x-gbk": simplified,
+
+            @"big5": traditional,
+            @"big5-hkscs": traditional,
+            @"cn-big5": traditional,
+            @"csbig5": traditional,
+            @"x-x-big5": traditional,
+
+            @"iso-8859-1": western,
+            @"iso8859-1": western,
+            @"iso_8859-1": western,
+            @"iso_8859-1:1987": western,
+            @"latin1": western,
+            @"l1": western,
+            @"cp819": western,
+            @"ibm819": western,
+            @"ascii": western,
+            @"us-ascii": western,
+            @"ansi_x3.4-1968": western,
+        };
+    });
+
+    NSNumber *cfEncoding = overrides[label];
+    if (!cfEncoding) return 0;
+    NSStringEncoding encoding = CFStringConvertEncodingToNSStringEncoding((CFStringEncoding)cfEncoding.unsignedIntValue);
+    return encoding == kCFStringEncodingInvalidId ? 0 : encoding;
+}
+
+NSStringEncoding ApolloWebTextEncodingForCharsetLabel(NSString *label) {
+    if (![label isKindOfClass:[NSString class]] || label.length == 0) return 0;
+
+    static NSCharacterSet *trimSet;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        trimSet = [NSCharacterSet characterSetWithCharactersInString:@" \t\r\n\"';"];
+    });
+    NSString *name = [[label stringByTrimmingCharactersInSet:trimSet] lowercaseString];
+    if (name.length == 0) return 0;
+
+    NSStringEncoding override = ApolloWebTextOverrideEncodingForLabel(name);
+    if (override != 0) return override;
+
+    CFStringEncoding cfEncoding = CFStringConvertIANACharSetNameToEncoding((__bridge CFStringRef)name);
+    if (cfEncoding == kCFStringEncodingInvalidId) return 0;
+    NSStringEncoding encoding = CFStringConvertEncodingToNSStringEncoding(cfEncoding);
+    return encoding == kCFStringEncodingInvalidId ? 0 : encoding;
+}
+
+NSString *ApolloWebTextNameForEncoding(NSStringEncoding encoding) {
+    if (encoding == 0) return @"unknown";
+    CFStringEncoding cfEncoding = CFStringConvertNSStringEncodingToEncoding(encoding);
+    if (cfEncoding == kCFStringEncodingInvalidId) return @"unknown";
+    // The IANA name ("cp949", "shift_jis") rather than CFStringGetNameOfEncoding's
+    // localized prose: the prose comes back empty on iOS for exactly the legacy
+    // encodings worth logging, and a stable ASCII identifier is what a future
+    // charset report needs to be greppable anyway.
+    NSString *name = (__bridge NSString *)CFStringConvertEncodingToIANACharSetName(cfEncoding);
+    if (name.length == 0) name = (__bridge NSString *)CFStringGetNameOfEncoding(cfEncoding);
+    return name.length > 0 ? name : @"unknown";
+}
+
+#pragma mark - Sniffing
+
+// Byte-order marks outrank every other declaration, including a contradicting
+// HTTP header. Reports the BOM's own length so the caller can drop it — decoding
+// a UTF-8 BOM as UTF-8 otherwise leaves a stray U+FEFF glued to the front of the
+// document, which would ride along into a title.
+static NSStringEncoding ApolloWebTextEncodingFromBOM(NSData *data, NSUInteger *outBOMLength) {
+    const uint8_t *bytes = data.bytes;
+    if (data.length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) {
+        *outBOMLength = 3;
+        return NSUTF8StringEncoding;
+    }
+    if (data.length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF) {
+        *outBOMLength = 2;
+        return NSUTF16BigEndianStringEncoding;
+    }
+    if (data.length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE) {
+        *outBOMLength = 2;
+        return NSUTF16LittleEndianStringEncoding;
+    }
+    *outBOMLength = 0;
+    return 0;
+}
+
+NSStringEncoding ApolloWebTextEncodingDeclaredInHTMLData(NSData *data) {
+    if (data.length == 0) return 0;
+
+    // A charset declaration is itself always ASCII, and every encoding we care
+    // about is ASCII-compatible — so a Latin-1 read of the prefix (which cannot
+    // fail on any byte) is a faithful view of the declaration even though the
+    // document's real encoding is still unknown at this point.
+    NSUInteger scanLength = MIN(data.length, ApolloWebTextMetaPrescanBytes);
+    NSString *prefix = [[NSString alloc] initWithBytes:data.bytes length:scanLength encoding:NSISOLatin1StringEncoding];
+    if (prefix.length == 0) return 0;
+
+    static NSArray<NSRegularExpression *> *declarationPatterns;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSRegularExpressionOptions options = NSRegularExpressionCaseInsensitive | NSRegularExpressionDotMatchesLineSeparators;
+        // Covers both <meta charset="euc-kr"> and the http-equiv spelling
+        // <meta http-equiv="Content-Type" content="text/html; charset=euc-kr">.
+        NSRegularExpression *meta = [NSRegularExpression regularExpressionWithPattern:@"<meta\\b[^>]*?charset\\s*=\\s*[\"']?\\s*([A-Za-z0-9_.:+-]+)"
+                                                                              options:options
+                                                                                error:nil];
+        NSRegularExpression *xmlPrologue = [NSRegularExpression regularExpressionWithPattern:@"<\\?xml\\b[^>]*?encoding\\s*=\\s*[\"']\\s*([A-Za-z0-9_.:+-]+)"
+                                                                                     options:options
+                                                                                       error:nil];
+        NSMutableArray *patterns = [NSMutableArray array];
+        if (meta) [patterns addObject:meta];
+        if (xmlPrologue) [patterns addObject:xmlPrologue];
+        declarationPatterns = [patterns copy];
+    });
+
+    for (NSRegularExpression *pattern in declarationPatterns) {
+        NSArray<NSTextCheckingResult *> *matches = [pattern matchesInString:prefix options:0 range:NSMakeRange(0, prefix.length)];
+        for (NSTextCheckingResult *match in matches) {
+            if (match.numberOfRanges < 2) continue;
+            NSStringEncoding encoding = ApolloWebTextEncodingForCharsetLabel([prefix substringWithRange:[match rangeAtIndex:1]]);
+            // Keep walking past labels CFString can't resolve rather than
+            // giving up — pages sometimes carry a junk declaration ahead of the
+            // real one.
+            if (encoding != 0) return encoding;
+        }
+    }
+    return 0;
+}
+
+static BOOL ApolloWebTextDataContainsNonASCII(NSData *data) {
+    const uint8_t *bytes = data.bytes;
+    NSUInteger length = data.length;
+    for (NSUInteger index = 0; index < length; index++) {
+        if (bytes[index] & 0x80) return YES;
+    }
+    return NO;
+}
+
+#pragma mark - Decoding
+
+NSString *ApolloWebTextFromData(NSData *data, NSURLResponse *response, NSStringEncoding *outEncoding) {
+    if (![data isKindOfClass:[NSData class]] || data.length == 0) return nil;
+
+    NSUInteger bomLength = 0;
+    NSStringEncoding bomEncoding = ApolloWebTextEncodingFromBOM(data, &bomLength);
+    if (bomEncoding != 0) {
+        NSData *body = [data subdataWithRange:NSMakeRange(bomLength, data.length - bomLength)];
+        NSString *decoded = [[NSString alloc] initWithData:body encoding:bomEncoding];
+        if (decoded.length > 0) {
+            if (outEncoding) *outEncoding = bomEncoding;
+            return decoded;
+        }
+    }
+
+    // Multi-byte-bearing valid UTF-8 outranks the declared charset here, which
+    // is a deliberate departure from the spec's "HTTP header always wins".
+    //
+    // The spec order would regress pages that are genuinely UTF-8 but ship a
+    // stale `charset=ISO-8859-1` header (still an Apache default) — the
+    // windows-1252 read never fails, so it would win and turn working previews
+    // into mojibake. Deciding by the bytes avoids that with no ambiguity cost:
+    // legacy multi-byte text essentially cannot be mistaken for UTF-8, because
+    // EUC-KR/CP949, Shift_JIS and Big5 all lead their characters with a byte in
+    // 0x80–0xBF or 0x81–0x9F, which UTF-8 does not allow in a lead position.
+    // So "valid UTF-8 with at least one multi-byte sequence" identifies real
+    // UTF-8, and the declared charset still governs everything else.
+    BOOL hasNonASCII = ApolloWebTextDataContainsNonASCII(data);
+    NSString *utf8Decoded = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    if (hasNonASCII && utf8Decoded.length > 0) {
+        if (outEncoding) *outEncoding = NSUTF8StringEncoding;
+        return utf8Decoded;
+    }
+
+    NSMutableArray<NSNumber *> *candidates = [NSMutableArray array];
+    NSStringEncoding headerEncoding = ApolloWebTextEncodingForCharsetLabel(response.textEncodingName);
+    if (headerEncoding != 0) [candidates addObject:@(headerEncoding)];
+    NSStringEncoding markupEncoding = ApolloWebTextEncodingDeclaredInHTMLData(data);
+    if (markupEncoding != 0 && markupEncoding != headerEncoding) [candidates addObject:@(markupEncoding)];
+
+    for (NSNumber *candidate in candidates) {
+        NSStringEncoding encoding = candidate.unsignedIntegerValue;
+        if (encoding == NSUTF8StringEncoding) continue; // already tried above
+        NSString *decoded = [[NSString alloc] initWithData:data encoding:encoding];
+        if (decoded.length > 0) {
+            if (outEncoding) *outEncoding = encoding;
+            return decoded;
+        }
+    }
+
+    // Pure-ASCII documents, and documents that declared nothing usable.
+    if (utf8Decoded.length > 0) {
+        if (outEncoding) *outEncoding = NSUTF8StringEncoding;
+        return utf8Decoded;
+    }
+
+    // Last resort. Latin-1 maps all 256 byte values, so this always produces a
+    // string — mojibake for an undeclared non-UTF-8 page, but that still beats
+    // handing the caller nil and losing the page's metadata outright.
+    if (outEncoding) *outEncoding = NSISOLatin1StringEncoding;
+    return [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding];
+}


### PR DESCRIPTION
Closes #945

## The bug

A post linking to a Korean news article rendered the whole link card as mojibake — site name, title and description all garbage:

`¡®¾ÆÀ°´ë¡¯ ¿ÃÇØ Ãß¼® ¸ø º»´Ù¡¥MBC Ãø ¡°¾Æ½Ã¾È°ÔÀÓ ±â°£°ú °ãÃÄ¡±[°ø½ÄÀÔ…`

Nothing Korean-specific about it. `ApolloLinkPreviewFetcher` read every fetched page as UTF-8 and fell back to Latin-1:

```objc
NSString *html = [[NSString alloc] initWithData:headSlice encoding:NSUTF8StringEncoding];
if (html.length == 0) html = [[NSString alloc] initWithData:headSlice encoding:NSISOLatin1StringEncoding];
```

The linked host is `news.nate.com`, which serves `Content-Type: text/html; charset=euc-kr`. Those bytes aren't valid UTF-8, so the first read returns nil — and Latin-1 maps all 256 byte values, so it *cannot* fail and happily reinterprets every high byte as its own character. Same thing hits Shift_JIS, GB18030, Big5 and windows-125x pages.

Decoded back through EUC-KR, the reported gibberish is exactly `'아육대' 올해 추석 못 본다‥MBC 측 "아시안게임 기간과 겹쳐"[공식입장]`.

## The fix

New `src/ApolloWebTextDecoding.{h,m}` decodes by what the page actually declares: BOM → response `Content-Type` charset → `<meta charset>` / XHTML prologue → UTF-8 → Latin-1. Wired into the link-preview fetcher and the AI link-summary fetch (same bug there — it was handing the model a page of mojibake to summarise).

Three things in it are worth calling out, since they're not obvious:

**Charset labels get upgraded, and it's load-bearing.** `CFStringConvertIANACharSetNameToEncoding(@"euc-kr")` hands back Apple's *narrow* EUC-KR converter, which **rejects** the CP949-extended hangul that real "euc-kr" pages legitimately contain — so mapping the label straight through would still have failed into the mojibake path. It maps to CP949 instead. Same shape for `gb2312`/`gbk`→GB18030, `shift_jis`→CP932, `big5`→Big5-HKSCS, `iso-8859-1`/`us-ascii`→windows-1252 (that last one is the most mislabelled charset on the web — pages declare it while using the windows-1252 smart quotes in 0x80–0x9F). `"korean"` resolves through CFString to *Mac OS* Korean, a different encoding entirely, so it needs an explicit override rather than just widening.

**Declarations are honoured, never second-guessed by sniffing.** Precedence is BOM, then the response's charset, then the charset declared in the markup, then UTF-8, then Latin-1. A declaration that fails to decode its own bytes is abandoned in favour of the next candidate rather than honoured into mojibake. I originally had it prefer valid UTF-8 ahead of the declaration to rescue pages that are really UTF-8 behind a stale `charset=ISO-8859-1` header; @jordanearle correctly pointed out that this is unsound, since valid UTF-8 and valid legacy text overlap (`C2 81` is both U+0081 and CP949 `혖`; `C2 A1` is both U+00A1 and Big5 `癒` / GB18030 `隆` / CP932 `ﾂ｡`). Dropped — see the thread below.

**The header alone isn't enough.** `newsen.com` sends `Content-Type: text/html` with no charset and declares `euc-kr` only in a `<meta>` tag, so the markup gets prescanned too (as Latin-1, which never fails and is ASCII-faithful — the declaration itself is always ASCII).

## Cache invalidation

`ApolloLinkPreviewCache` entries now carry a `schema` stamp, and older-schema entries are dropped on load. Without this, anyone who already has a mojibake preview cached keeps seeing it for the rest of its 7-day TTL after updating, and the fix looks like it didn't work. Costs one lazy refetch per stored preview.

I did **not** bump `kApolloAICacheVersion` — that would wipe every user's AI summaries, which cost real model time to regenerate, to fix a rare subset. A garbage link summary generated before this stays until it ages out or the user hits Clear AI Cache.

## Testing

The simulator has no Reddit credentials, so feeds never load there and link previews couldn't be exercised at all. Added a sim-only `linkpreview <url>` debug-bridge command (same shape as the existing `insight` one, `#if APOLLO_SIM_BUILD`) that runs the real fetcher against any page and logs what it extracted:

```
echo "linkpreview https://news.nate.com/view/20260814n12161?mid=e1200" > /tmp/apollofix-tap.txt
xcrun simctl spawn <DEV> notifyutil -p apollofix.debugtap
```

Through the real fetcher in the sim:

| page | charset | before | after |
|---|---|---|---|
| news.nate.com (issue #945) | euc-kr, header + meta | `'¾ÆÀ°´ë', ¿ÃÇØ Ãß¼®…` | `'아육대', 올해 추석엔 쉬어간다…아시안 게임 편성 여파 [공식입장]` |
| newsen.com | euc-kr, **meta only** | `´º½º¿£` | `뉴스엔` |
| 2ch.sc | shift_jis | (nil → Latin-1) | `２ちゃんねる掲示板へようこそ` |
| tenasia.co.kr | utf-8 | unchanged | unchanged |

`ApolloWebTextDecodingRunSelfTests` (in `ApolloWebTextDecoding.h/.m`) carries the regression fixtures, run from the sim debug bridge's `%ctor` alongside the existing `ApolloCommentVoteInsightsRunParserSelfTests`, so a break shows up on every sim launch:

```
[ApolloFix] [CommentInsights][parser] self-tests passed
[ApolloFix] [WebTextDecoding] self-tests passed
```

It covers the byte sequences that are simultaneously valid UTF-8 and valid legacy text — `C2 81` under euc-kr, `C2 A1` under big5 / gb2312 / shift_jis, individually and as a whole document that validates as UTF-8 end to end — plus the label widening, each declaration source and their precedence, a header that lies about its own bytes falling through to the markup, BOM stripping, CP949-extended hangul, windows-1252 punctuation under an `iso-8859-1` label, and the degenerate inputs.

`ApolloWebTextDecoding.m` is Foundation-only on purpose, so it also compiles straight into a host-side harness that runs those same self-tests against the live captured pages above.

Cache purge verified by injecting 4 schema-less entries → `cache dropped 4 entries from an older schema`, 3 current ones kept.

Both `make package` (device, iOS 14 floor) and the simulator build are clean.

## Not covered

The reddit-only scrapers (`ApolloUserFlair`, `ApolloCommentVoteInsights`, ImgChest, sports clips) still read UTF-8 directly — single known hosts, all UTF-8. Easy to route through the same helper if we'd rather be uniform.

One caveat on verification: with no account in the sim I couldn't render the card on screen, only prove the decode end-to-end through the shipping fetcher. Would appreciate a device confirmation from the reporter on the actual post.

