### PR TITLE
Comment Link Host: add Prefer Native Images auto mode

### DIFF
--- a/src/ApolloImageUploadHost.xm
+++ b/src/ApolloImageUploadHost.xm
@@ -3228,12 +3228,25 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
         }
     }
 
+    // Auto mode: the photo-button hook armed the window in NATIVE mode (the
+    // subreddit is known to allow image comments), so this comment upload takes
+    // Reddit's native media path even when the Media Upload Host is Imgur or
+    // ImgChest. Only bypasses provider SELECTION below — the keyless capability
+    // checks (synthetic bearer without a cookie lease, no captured bearer) still
+    // apply and degrade to Imgur exactly as a provider=Reddit upload would.
+    BOOL commentNativeForced = NO;
+    if (completionHandler && ApolloIsImgurImageUploadRequest(request) &&
+        !ApolloChatImageUploadPending() && ApolloCommentNativeUploadPending()) {
+        commentNativeForced = YES;
+        ApolloLog(@"[CommentLinkHost] Auto: forcing native Reddit routing for comment-editor upload (fromData)");
+    }
+
     // ImgChest host: divert Apollo's Imgur image upload to the ImgChest API
     // and answer with a synthetic Imgur response carrying the ImgChest link.
     // ImgChest uses its own API key (not Reddit's bearer), so this runs ahead of
     // the keyless Web JSON fallback below and always returns when it applies.
     if ((sImageUploadProvider == ImageUploadProviderImgChest || ApolloChatImageUploadPending() || commentLinkImgChest) &&
-        !commentLinkImgur && completionHandler && ApolloIsImgurImageUploadRequest(request)) {
+        !commentLinkImgur && !commentNativeForced && completionHandler && ApolloIsImgurImageUploadRequest(request)) {
         BOOL chestForChat = ApolloChatImageUploadPending();   // capture now; the upload completes asynchronously
         if (chestForChat) ApolloChatClearImageUpload();        // window consumed: don't let it leak to a later non-chat upload
         BOOL chestForCommentLink = commentLinkImgChest;
@@ -3314,7 +3327,7 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
         if (sImgurClientId.length == 0) ApolloWarnKeylessUploadUnavailableOnce();
         return %orig;
     }
-    if ((sImageUploadProvider != ImageUploadProviderReddit && !cookieUpload) || !completionHandler || !ApolloIsImgurImageUploadRequest(request)) {
+    if ((sImageUploadProvider != ImageUploadProviderReddit && !cookieUpload && !commentNativeForced) || !completionHandler || !ApolloIsImgurImageUploadRequest(request)) {
         if (sImageUploadProvider == ImageUploadProviderReddit && completionHandler) ApolloLogUnhandledImgurUploadRequestOnce(request, @"fromData");
         return %orig;
     }
@@ -3414,11 +3427,20 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
         }
     }
 
+    // Auto mode (see the fromData: hook): NATIVE-mode window forces this comment
+    // upload onto Reddit's native media path regardless of the Media Upload Host.
+    BOOL commentNativeForced = NO;
+    if (completionHandler && ApolloIsImgurImageUploadRequest(request) &&
+        !ApolloChatImageUploadPending() && ApolloCommentNativeUploadPending()) {
+        commentNativeForced = YES;
+        ApolloLog(@"[CommentLinkHost] Auto: forcing native Reddit routing for comment-editor upload (fromFile)");
+    }
+
     // ImgChest host (see the fromData: hook) — runs ahead of the keyless Web JSON
     // fallback since it authenticates with its own API key, and always returns when
     // ImgChest is the selected provider for an Imgur upload request.
     if ((sImageUploadProvider == ImageUploadProviderImgChest || ApolloChatImageUploadPending() || commentLinkImgChest) &&
-        !commentLinkImgur && completionHandler && ApolloIsImgurImageUploadRequest(request)) {
+        !commentLinkImgur && !commentNativeForced && completionHandler && ApolloIsImgurImageUploadRequest(request)) {
         BOOL chestForChat = ApolloChatImageUploadPending();   // capture now; the upload completes asynchronously
         if (chestForChat) ApolloChatClearImageUpload();        // window consumed: don't let it leak to a later non-chat upload
         BOOL chestForCommentLink = commentLinkImgChest;
@@ -3499,7 +3521,7 @@ static void ApolloCompleteRedditNativeMediaUpload(NSData *mediaData, NSURL *medi
         if (sImgurClientId.length == 0) ApolloWarnKeylessUploadUnavailableOnce();
         return %orig;
     }
-    if ((sImageUploadProvider != ImageUploadProviderReddit && !cookieUpload) || !completionHandler || !ApolloIsImgurImageUploadRequest(request)) {
+    if ((sImageUploadProvider != ImageUploadProviderReddit && !cookieUpload && !commentNativeForced) || !completionHandler || !ApolloIsImgurImageUploadRequest(request)) {
         if (sImageUploadProvider == ImageUploadProviderReddit && completionHandler) ApolloLogUnhandledImgurUploadRequestOnce(request, @"fromFile");
         return %orig;
     }

--- a/src/ApolloMarkdownToolbarGif.h
+++ b/src/ApolloMarkdownToolbarGif.h
@@ -19,6 +19,11 @@ NSRegularExpression *ApolloNativeGiphyMarkdownTokenRegex(void);
 extern "C" {
 #endif
 BOOL ApolloCommentLinkUploadPending(void);
+/// Auto mode (sCommentLinkPreferNative): the armed comment-editor window can be
+/// in NATIVE mode instead — the subreddit is known to allow image comments, so
+/// the upload is forced onto Reddit's native media path regardless of the Media
+/// Upload Host. Mutually exclusive with ApolloCommentLinkUploadPending().
+BOOL ApolloCommentNativeUploadPending(void);
 void ApolloCommentLinkClearUpload(void);
 /// Keyboard-anchored toast confirming the plain-link upload ("Uploaded to
 /// <hostName> — ..."), shown once per compose session.

--- a/src/ApolloMarkdownToolbarGif.xm
+++ b/src/ApolloMarkdownToolbarGif.xm
@@ -1446,11 +1446,23 @@ static void ApolloMarkdownGifSetActiveComposeController(UIViewController *contro
 // image button was enabled on the promise of a link.
 static double sApolloCommentLinkUploadUntil = 0.0;
 static __weak UIViewController *sApolloCommentLinkArmedComposer = nil;
+// Auto mode: the window is armed in NATIVE mode when the subreddit is known to
+// allow image comments — the upload is forced onto Reddit's native media path
+// instead of the link host. Re-decided on every photo-button tap (the cache can
+// warm mid-composer), so a single mode flag rides the one shared window.
+static BOOL sApolloCommentUploadNativeMode = NO;
 static char kApolloCommentLinkToastShownKey;
 
 static void ApolloCommentLinkMarkUpload(UIViewController *composer) {
     sApolloCommentLinkUploadUntil = [NSDate timeIntervalSinceReferenceDate] + 1800.0;   // backstop only; scope = composer lifetime
     sApolloCommentLinkArmedComposer = composer;
+    sApolloCommentUploadNativeMode = NO;
+}
+
+static void ApolloCommentNativeMarkUpload(UIViewController *composer) {
+    sApolloCommentLinkUploadUntil = [NSDate timeIntervalSinceReferenceDate] + 1800.0;
+    sApolloCommentLinkArmedComposer = composer;
+    sApolloCommentUploadNativeMode = YES;
 }
 
 #ifdef __cplusplus
@@ -1458,12 +1470,21 @@ extern "C" {
 #endif
 BOOL ApolloCommentLinkUploadPending(void) {
     return sCommentLinkHost != CommentLinkHostOff &&
+           !sApolloCommentUploadNativeMode &&
            sApolloCommentLinkArmedComposer != nil &&   // weak: dies with the arming composer
+           [NSDate timeIntervalSinceReferenceDate] < sApolloCommentLinkUploadUntil;
+}
+BOOL ApolloCommentNativeUploadPending(void) {
+    return sCommentLinkHost != CommentLinkHostOff &&   // auto only exists while a link host is set
+           sCommentLinkPreferNative &&
+           sApolloCommentUploadNativeMode &&
+           sApolloCommentLinkArmedComposer != nil &&
            [NSDate timeIntervalSinceReferenceDate] < sApolloCommentLinkUploadUntil;
 }
 void ApolloCommentLinkClearUpload(void) {
     sApolloCommentLinkUploadUntil = 0.0;
     sApolloCommentLinkArmedComposer = nil;
+    sApolloCommentUploadNativeMode = NO;
 }
 void ApolloCommentLinkShowUploadedToast(NSString *hostName) {
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -1602,9 +1623,34 @@ void ApolloMarkdownGifInstall(void) {
 - (void)cameraButtonTapped:(id)sender {
     if (sCommentLinkHost != CommentLinkHostOff) {
         UIViewController *composer = ApolloMarkdownGifActiveComposeController();
-        if (ApolloMarkdownGifResolveCommentSubreddit(composer).length > 0) {
-            ApolloCommentLinkMarkUpload(composer);
-            ApolloLog(@"[CommentLinkHost] Armed comment-editor upload window (host=%ld)", (long)sCommentLinkHost);
+        NSString *subreddit = ApolloMarkdownGifResolveCommentSubreddit(composer);
+        if (subreddit.length > 0) {
+            // Auto mode: force Reddit's native upload where the subreddit is
+            // KNOWN to allow image comments (inline images beat links); the link
+            // host handles "disallowed" and "unknown" — a plain link always
+            // posts, while a native comment in a gated subreddit is rejected at
+            // submit time. Decided per tap: the media-gating fetch fired when
+            // the composer opened, so the cache is warm in all but the very
+            // first cold-network tap, and a later tap picks up a warmed cache.
+            ApolloSubredditInfo *cached = sCommentLinkPreferNative
+                ? [[ApolloSubredditInfoCache sharedCache] cachedInfoForSubreddit:subreddit] : nil;
+            if (cached && cached.commentMediaInfoAvailable && cached.allowsImageComments) {
+                ApolloCommentNativeMarkUpload(composer);
+                ApolloLog(@"[CommentLinkHost] Auto: r/%@ allows image comments — forcing native Reddit upload", subreddit);
+            } else {
+                ApolloCommentLinkMarkUpload(composer);
+                if (sCommentLinkPreferNative) {
+                    BOOL known = cached && cached.commentMediaInfoAvailable;
+                    ApolloLog(@"[CommentLinkHost] Auto: r/%@ %@ — using link host (host=%ld)",
+                              subreddit, known ? @"disallows image comments" : @"comment media permissions unknown", (long)sCommentLinkHost);
+                    if (!known) {
+                        // Warm the cache so the next tap (or composer) can go native.
+                        [[ApolloSubredditInfoCache sharedCache] requestCommentMediaInfoForSubreddit:subreddit completion:^(__unused ApolloSubredditInfo *info) {}];
+                    }
+                } else {
+                    ApolloLog(@"[CommentLinkHost] Armed comment-editor upload window (host=%ld)", (long)sCommentLinkHost);
+                }
+            }
         } else {
             ApolloCommentLinkClearUpload();
         }

--- a/src/ApolloState.h
+++ b/src/ApolloState.h
@@ -390,6 +390,10 @@ typedef NS_ENUM(NSInteger, CommentLinkHost) {
     CommentLinkHostImgChest = 2,
 };
 extern NSInteger sCommentLinkHost;
+// Auto mode (UDKeyCommentLinkPreferNative): comment images go to Reddit's native
+// upload where the subreddit allows image comments; the link host is only the
+// fallback. Consulted at photo-button arming time in ApolloMarkdownToolbarGif.xm.
+extern BOOL sCommentLinkPreferNative;
 
 // Share Link Host: rewrites outgoing Reddit URLs in Apollo share sheets. Default
 // preserves Apollo's original reddit.com links; Old Reddit/vxReddit swap only

--- a/src/ApolloState.m
+++ b/src/ApolloState.m
@@ -100,6 +100,7 @@ NSString *sLinkPreviewCardColorHex = nil;
 uint32_t sLinkPreviewCardColorPacked = 0;
 NSInteger sImageUploadProvider = ImageUploadProviderImgur;
 NSInteger sCommentLinkHost = CommentLinkHostOff;
+BOOL sCommentLinkPreferNative = NO;
 NSInteger sShareLinkHost = ShareLinkHostDefault;
 
 NSString *ApolloShareLinkHostDomain(ShareLinkHost host) {

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -3578,6 +3578,7 @@ static BOOL ApolloDefaultsKeyChangesActiveAccount(NSString *key) {
                                     UDKeyLinkPreviewCardColor: @(ApolloLinkPreviewCardColorNeutral),
                                     UDKeyImageUploadProvider: @(ImageUploadProviderImgur),
                                     UDKeyCommentLinkHost: @(CommentLinkHostOff),
+                                    UDKeyCommentLinkPreferNative: @NO,
                                     UDKeyShareLinkHost: @(ShareLinkHostDefault),
                                     UDKeyShowUserAvatars: @NO,
                                     UDKeyUseProfileAvatarTabIcon: @NO,
@@ -3812,6 +3813,7 @@ static BOOL ApolloDefaultsKeyChangesActiveAccount(NSString *key) {
     sImageUploadProvider = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyImageUploadProvider];
     sCommentLinkHost = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyCommentLinkHost];
     if (sCommentLinkHost < CommentLinkHostOff || sCommentLinkHost > CommentLinkHostImgChest) sCommentLinkHost = CommentLinkHostOff;
+    sCommentLinkPreferNative = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyCommentLinkPreferNative];
     sShareLinkHost = [[NSUserDefaults standardUserDefaults] integerForKey:UDKeyShareLinkHost];
     if (sShareLinkHost < ShareLinkHostDefault || sShareLinkHost > ShareLinkHostFXReddit) sShareLinkHost = ShareLinkHostDefault;
     sShowUserAvatars = [[NSUserDefaults standardUserDefaults] boolForKey:UDKeyShowUserAvatars];

--- a/src/UserDefaultConstants.h
+++ b/src/UserDefaultConstants.h
@@ -119,6 +119,13 @@ static NSString *const UDKeyImageUploadProvider = @"ImageUploadProvider";
 // plain link (no native Reddit media) so they work in subreddits that disallow
 // image/GIF comments. See ApolloMarkdownToolbarGif.xm + ApolloImageUploadHost.xm.
 static NSString *const UDKeyCommentLinkHost = @"CommentLinkHost";
+// Auto mode for the Comment Link Host (default OFF). When ON, comment-editor
+// images are forced onto Reddit's NATIVE media upload (they render inline on
+// every client) wherever the subreddit allows image comments; the link host
+// above is used only where the subreddit disallows them — or when the
+// permissions aren't known yet, since a plain link always posts. Only
+// consulted while a Comment Link Host is set.
+static NSString *const UDKeyCommentLinkPreferNative = @"CommentLinkPreferNative";
 // Posted after sCommentLinkHost changes so open composers re-apply the comment
 // media-permission gating (the image button un-blocks while a link host is set).
 static NSString *const ApolloCommentLinkHostChangedNotification = @"ApolloCommentLinkHostChangedNotification";

--- a/src/settings/CustomAPIViewController.m
+++ b/src/settings/CustomAPIViewController.m
@@ -389,11 +389,18 @@ typedef NS_ENUM(NSInteger, Tag) {
     // un-blocks while a link host is set) — let it re-apply immediately.
     [[NSNotificationCenter defaultCenter] postNotificationName:ApolloCommentLinkHostChangedNotification object:nil];
     [self reloadRowWithID:@"media.commentLinkHost"];
+    // The Prefer Native Images row is only shown while a link host is set.
+    [self visibilityDidChange];
+}
+
+- (void)commentLinkPreferNativeSwitchToggled:(UISwitch *)sender {
+    sCommentLinkPreferNative = sender.isOn;
+    [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:UDKeyCommentLinkPreferNative];
 }
 
 - (void)presentCommentLinkHostSheetFromSourceView:(UIView *)sourceView {
     UIAlertController *sheet = [UIAlertController alertControllerWithTitle:@"Comment Link Host"
-                                                                   message:@"Images added to a comment or reply upload to this host and are inserted as a plain link instead of a native Reddit image — so they still work in subreddits that don't allow images or GIFs in comments. Apollo shows the linked image inline; other apps and the website show a tappable link. Posts keep using the Media Upload Host."
+                                                                   message:@"Images added to a comment or reply upload to this host and are inserted as a plain link instead of a native Reddit image — so they still work in subreddits that don't allow images or GIFs in comments. Apollo shows the linked image inline; other apps and the website show a tappable link. Posts keep using the Media Upload Host.\n\nTo use this host only where it's needed, turn on Prefer Native Images: comment images then upload to Reddit and display inline wherever the subreddit allows them."
                                                             preferredStyle:UIAlertControllerStyleActionSheet];
 
     NSString *offTitle = (sCommentLinkHost == CommentLinkHostOff) ? @"Off (Current)" : @"Off";
@@ -1842,9 +1849,20 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
         }];
     commentLinkHost.configure = disclosure;
 
+    ApolloSettingsRow *commentLinkAuto =
+        [ApolloSettingsRow switchRowWithID:@"media.commentLinkAuto"
+                                     title:@"Prefer Native Images"
+                                      isOn:^BOOL { return sCommentLinkPreferNative; }
+                                  onToggle:^(UISwitch *sender) { [weakSelf commentLinkPreferNativeSwitchToggled:sender]; }];
+    // Auto mode only means something while a link host is set (see -setCommentLinkHost:).
+    commentLinkAuto.visible = ^BOOL { return sCommentLinkHost != CommentLinkHostOff; };
+
+    // NOTE: the rendered footer for this section is the attributed one in
+    // -footerAttributedTextForSection: (matched by the "Uploads" title) — keep
+    // the two in sync when editing either.
     return [ApolloSettingsSection sectionWithTitle:@"Uploads"
                                             footer:@"Media Upload Host sets where images attached to posts and comments are uploaded. Comment Link Host uploads images in comments to Imgur or Image Chest and inserts a plain link, so they work even where images aren't allowed."
-                                              rows:@[ uploadHost, commentLinkHost ]];
+                                              rows:@[ uploadHost, commentLinkHost, commentLinkAuto ]];
 }
 
 - (ApolloSettingsSection *)buildMediaNetworkSection {
@@ -2726,7 +2744,7 @@ static NSInteger ApolloHeaderStylePickerValue(NSInteger index, BOOL blurAvailabl
             attributes:plainAttrs]];
     } else if ([sectionTitle isEqualToString:@"Uploads"]) {
         text = [[NSMutableAttributedString alloc]
-            initWithString:@"Media Upload Host selects where Apollo uploads media attached to posts and comments.\n\nComment Link Host uploads images added to a comment or reply to Imgur or Image Chest and inserts a plain link instead of a native Reddit image, so they work even in subreddits that don't allow images in comments. Apollo still shows the linked image inline.\n\nManage past uploads from Settings → General → Media → Manage Uploads."
+            initWithString:@"Media Upload Host selects where Apollo uploads media attached to posts and comments.\n\nComment Link Host uploads images added to a comment or reply to Imgur or Image Chest and inserts a plain link instead of a native Reddit image, so they work even in subreddits that don't allow images in comments. Apollo still shows the linked image inline.\n\nWith Prefer Native Images on, comment images upload to Reddit and display inline wherever the subreddit allows image comments — the link host is used only where it doesn't, or when Apollo doesn't know yet.\n\nManage past uploads from Settings → General → Media → Manage Uploads."
             attributes:plainAttrs];
     } else if ([sectionTitle isEqualToString:@"Network"]) {
         text = [[NSMutableAttributedString alloc]


### PR DESCRIPTION
## What

Adds a **Prefer Native Images** toggle under Comment Link Host (shown only while a link host is selected; default off).

Comment Link Host today is an unconditional override: with it set, *every* image added in a comment/reply editor uploads to Imgur/Image Chest and posts as a plain link — even in subreddits that allow native image comments, where the image then shows as a bare link on reddit.com and other clients instead of rendering inline. (Discovered when a comment image posted as a `cdn.imgchest.com` link in r/ApolloReborn, which allows image comments.)

With the toggle on, comment images go to **Reddit's native media upload wherever the subreddit allows image comments** — so they render inline on every client, regardless of the Media Upload Host — and the link host is used only where image comments are disallowed, or when the permissions aren't known yet (a plain link always posts; a native media comment in a gated subreddit is rejected at submit time, so unknown fails toward the link host).

## How

- The decision happens at photo-button arming time (`cameraButtonTapped:` in `ApolloMarkdownToolbarGif.xm`) using `ApolloSubredditInfoCache`'s cached `allowed_media_in_comments` — the same data the image-button gating already fetches when the composer opens, so the cache is warm by the time the user picks a photo. Unknown permissions arm the link-host window as before and kick a fetch so a later tap can go native.
- The armed window gains a NATIVE mode (`ApolloCommentNativeUploadPending()`), mutually exclusive with the existing link mode. In `ApolloImageUploadHost.xm` both upload hooks consult it: native mode bypasses provider selection (including Media Upload Host = Imgur/Image Chest) and takes the Reddit native path; the keyless capability checks (cookie lease, captured bearer) still apply and degrade exactly as a provider=Reddit upload would.
- Settings: new `switchRow` under Comment Link Host with `.visible` tied to the host being set (`visibilityDidChange` on host change); Uploads footer + picker sheet text updated. New key `CommentLinkPreferNative` registered default NO, loaded in `%ctor` (not added to the backup statics re-sync per the settings recipe).

Toggle off = existing behavior, unchanged.

## Screenshot of settings
<img width="294" height="640" alt="Simulator Screenshot - Apollo-Sim2 - 2026-08-18 at 00 52 53 Medium" src="https://github.com/user-attachments/assets/20407c44-6413-44cf-8c81-6526950bc198" />


## Testing (sim, Apollo-Sim2)

Verified glass **and** non-glass (vtool-downgraded shell), in API-key (u/iChopPryde) **and** keyless (u/remzerobestgirl) modes, against live Reddit with a throwaway test post in r/ApolloReborn (deleted after, along with all test comments):

- **Toggle off (default):** image comment in r/ApolloReborn still routes to Image Chest and posts a bare link — regression-free.
- **Toggle on, sub allows (r/ApolloReborn):** `Auto: r/ApolloReborn allows image comments — forcing native Reddit upload` → native i.redd.it upload → `/api/comment` RTJSON rewrite → comment renders as a real inline image on reddit.com. Verified with Media Upload Host = Reddit **and** = Image Chest (the force-native branch: `Auto: forcing native Reddit routing for comment-editor upload`).
- **Toggle on, keyless:** same native outcome via the account's own web-bearer media lease; comment posts through the WebJSON path and renders inline on reddit.com.
- **Toggle on, sub disallows (r/AskReddit):** `Auto: r/AskReddit disallows image comments — using link host (host=2)` — link-host fallback armed (no comment posted there).
- Settings row appears/disappears live with the Comment Link Host selection; device target builds clean (`make package`).
