### PR TITLE
Fix two launch/feed crashes: trending-subreddits plist write and class realization

### DIFF
--- a/src/ApolloUserAvatars.xm
+++ b/src/ApolloUserAvatars.xm
@@ -4,6 +4,9 @@
 #import <objc/runtime.h>
 #import <objc/message.h>
 #import <malloc/malloc.h>
+#import <mach-o/dyld.h>
+#import <mach-o/getsect.h>
+#import <os/lock.h>
 #import <stdatomic.h>
 
 #import "ApolloCommon.h"
@@ -1454,24 +1457,63 @@ static BOOL ApolloProfileUsernameIsLoggedInAccount(NSString *username) {
     return NO;
 }
 
-// One-shot registered-class set for validating candidate isa pointers by
-// identity only (no dereference). Classes never unregister, so a single
-// snapshot is safe; classes registered later (KVO subclasses etc.) miss and
-// the probe returns nil for them — a skipped read, never a crash.
+// Registered-class set for validating candidate isa pointers by identity only
+// (no dereference), built by reading each loaded image's `__objc_classlist`
+// directly.
+//
+// It used to be built with objc_copyClassList(), which is the one thing this
+// must never do: objc_copyClassList/objc_getClassList call realizeAllClasses(),
+// realizing EVERY class in the process, and realizing a Swift class runs its
+// type-metadata accessor. Apollo weak-links frameworks that do not exist on
+// older systems, so on iOS 14.5.1 one of those accessors is bound to 0 and
+// realization jumps straight to a NULL PC — issue #961, EXC_BAD_ACCESS at 0x0
+// on the first large post cell of the session, reached through
+// ApolloWordLooksLikeObjCObject below. Stock Apollo never realizes those
+// classes, so nothing else in the process trips the weak link.
+//
+// Reading the section data touches no class: `__objc_classlist` already holds
+// the class pointers, so this stays an identity-only test. dyld replays the
+// callback for every image already loaded and calls it again for each new one,
+// so the set also stops going stale the way the old one-shot snapshot did.
+// Runtime-registered classes (KVO subclasses, objc_allocateClassPair) appear in
+// no image and still miss, which returns nil for them — a skipped read, never a
+// crash, exactly as before.
+static os_unfair_lock sKnownClassesLock = OS_UNFAIR_LOCK_INIT;
+static CFMutableSetRef sKnownClasses;   // guarded by sKnownClassesLock
+
+static void ApolloRegisterImageClasses(const struct mach_header *header, intptr_t slide) {
+    (void)slide;
+    if (!header) return;
+    const struct mach_header_64 *header64 = (const struct mach_header_64 *)header;
+    // Modern images put the class list in __DATA_CONST; older ones in __DATA.
+    static const char *const kSegments[] = { "__DATA_CONST", "__DATA" };
+    for (size_t i = 0; i < sizeof(kSegments) / sizeof(kSegments[0]); i++) {
+        unsigned long size = 0;
+        const uint8_t *section = getsectiondata(header64, kSegments[i], "__objc_classlist", &size);
+        if (!section || size < sizeof(void *)) continue;
+        const void *const *classes = (const void *const *)section;
+        os_unfair_lock_lock(&sKnownClassesLock);
+        if (!sKnownClasses) sKnownClasses = CFSetCreateMutable(NULL, 0, NULL);
+        for (unsigned long j = 0; j < size / sizeof(void *); j++) {
+            if (classes[j]) CFSetAddValue(sKnownClasses, classes[j]);
+        }
+        os_unfair_lock_unlock(&sKnownClassesLock);
+    }
+}
+
 static BOOL ApolloRuntimeKnowsClass(Class candidate) {
-    static CFSetRef sKnownClasses;
+    if (!candidate) return NO;
     static dispatch_once_t once;
     dispatch_once(&once, ^{
-        unsigned int count = 0;
-        Class *list = objc_copyClassList(&count);
-        CFMutableSetRef set = CFSetCreateMutable(NULL, count, NULL);
-        for (unsigned int i = 0; i < count; i++) {
-            CFSetAddValue(set, (__bridge const void *)list[i]);
-        }
-        free(list);
-        sKnownClasses = set;
+        // Replays every image loaded so far, then fires for each new one.
+        _dyld_register_func_for_add_image(ApolloRegisterImageClasses);
     });
-    return CFSetContainsValue(sKnownClasses, (__bridge const void *)candidate);
+    os_unfair_lock_lock(&sKnownClassesLock);
+    BOOL known = sKnownClasses
+        ? CFSetContainsValue(sKnownClasses, (__bridge const void *)candidate)
+        : NO;
+    os_unfair_lock_unlock(&sKnownClassesLock);
+    return known;
 }
 
 // Swift-class ivars carry no ObjC type encoding, so an ivar slot named e.g.

--- a/src/Tweak.xm
+++ b/src/Tweak.xm
@@ -2174,14 +2174,113 @@ static const char kARCompletion = '\0';
 
 %end
 
+// Apollo force-unwraps BOTH halves of its trending-subreddits load, inside
+// SearchViewController.viewDidLoad:
+//
+//     NSDictionary(contentsOfFile: Bundle.main.path(forResource: "trending-subreddits",
+//                                                   ofType: "plist")!)!
+//
+// and `-[NSBundle pathForResource:ofType:]` is implemented on top of
+// `-[NSBundle URLForResource:withExtension:]`, so the URL the hook below returns
+// IS the path Apollo force-unwraps. Handing back a URL whose file we never
+// verified turns a silent write failure into a hard launch crash: issue #964 was
+// an EXC_BREAKPOINT (`brk #1`) on the nil-dictionary arm, on every launch, once
+// the temp file stopped being writable. Nothing below may return a URL whose
+// file does not read back as a dictionary.
+
+// Today's key, built exactly the way Apollo builds it: Calendar.current's
+// year/month/day joined with "-", in ASCII digits (Swift's Int.description).
+// A fixed-format NSDateFormatter picks up the same calendar, so the year VALUE
+// agrees — but it renders digits in the current locale's numbering system
+// (Arabic-Indic, Devanagari) and `yyyy` zero-pads to four, so a Japanese-calendar
+// era year 8 comes out "0008" where Apollo writes "8". Either way the key
+// silently stops matching the one Apollo looks up.
+static NSString *ApolloTrendingTodayKey(void) {
+    NSDateComponents *components =
+        [[NSCalendar currentCalendar] components:(NSCalendarUnitYear |
+                                                  NSCalendarUnitMonth |
+                                                  NSCalendarUnitDay)
+                                        fromDate:[NSDate date]];
+    return [NSString stringWithFormat:@"%ld-%ld-%ld",
+                                      (long)components.year,
+                                      (long)components.month,
+                                      (long)components.day];
+}
+
+// Write the rewritten table somewhere Apollo can read it back, or return nil so
+// the caller falls through to Apollo's own bundled resource. NSTemporaryDirectory()
+// is neither guaranteed to exist nor to be writable — iOS purges it, and under
+// LiveContainer the guest's tmp/ is synthesised — so try a tweak-owned Caches
+// directory we create ourselves first, and read the result back through the same
+// API Apollo uses before handing the path over.
+static NSURL *ApolloWriteTrendingPlist(NSDictionary *table) {
+    if (table.count == 0) return nil;
+
+    // Serialise binary rather than letting -[NSDictionary writeToFile:] emit XML.
+    // Apollo's bundled table is 44KB of binary plist but round-trips to ~100KB of
+    // XML, and this is the launch path — the verifying read below would be
+    // re-parsing that XML on every single launch.
+    NSData *data = [NSPropertyListSerialization dataWithPropertyList:table
+                                                              format:NSPropertyListBinaryFormat_v1_0
+                                                             options:0
+                                                               error:NULL];
+    if (data.length == 0) return nil;
+
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSMutableArray<NSString *> *directories = [NSMutableArray array];
+    NSString *caches = [NSSearchPathForDirectoriesInDomains(
+        NSCachesDirectory, NSUserDomainMask, YES) firstObject];
+    if (caches.length > 0) {
+        [directories addObject:[caches stringByAppendingPathComponent:@"ApolloReborn"]];
+    }
+    NSString *temporaryDirectory = NSTemporaryDirectory();
+    if (temporaryDirectory.length > 0) {
+        [directories addObject:temporaryDirectory];
+    }
+
+    for (NSString *directory in directories) {
+        [fileManager createDirectoryAtPath:directory
+               withIntermediateDirectories:YES
+                                attributes:nil
+                                     error:NULL];
+        NSString *path =
+            [directory stringByAppendingPathComponent:@"trending-custom.plist"];
+        // No pre-delete: NSDataWritingAtomic already writes-then-renames, so
+        // unlinking first would only open a window in which a path we verified
+        // and returned has vanished. Clear the path solely to recover from a
+        // failed write — a stale directory sitting there is that case.
+        if (![data writeToFile:path options:NSDataWritingAtomic error:NULL]) {
+            [fileManager removeItemAtPath:path error:NULL];
+            if (![data writeToFile:path options:NSDataWritingAtomic error:NULL]) {
+                ApolloLog(@"[RandomSources] Trending plist write failed at %@", path);
+                continue;
+            }
+        }
+        if ([NSDictionary dictionaryWithContentsOfFile:path].count == 0) {
+            ApolloLog(@"[RandomSources] Trending plist at %@ did not read back as a "
+                      @"dictionary; discarding", path);
+            [fileManager removeItemAtPath:path error:NULL];
+            continue;
+        }
+        return [NSURL fileURLWithPath:path isDirectory:NO];
+    }
+
+    ApolloLog(@"[RandomSources] No writable location for the trending plist; "
+              @"falling back to Apollo's bundled resource");
+    return nil;
+}
+
 // Randomise the trending subreddits list
 %hook NSBundle
 -(NSURL *)URLForResource:(NSString *)name withExtension:(NSString *)ext {
     NSURL *url = %orig;
-    if ([name isEqualToString:@"trending-subreddits"] && [ext isEqualToString:@"plist"]) {
-        NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    // Scoped to the main bundle: that is where Apollo looks, and the synthesised
+    // table below must never turn another bundle's honest nil into a URL for a
+    // file we invented.
+    if ([name isEqualToString:@"trending-subreddits"] && [ext isEqualToString:@"plist"] &&
+        self == [NSBundle mainBundle]) {
         // ex: 2023-9-28 (28th September 2023)
-        [formatter setDateFormat:@"yyyy-M-d"];
+        NSString *todayKey = ApolloTrendingTodayKey();
 
         /*
             - Parse plist
@@ -2190,6 +2289,15 @@ static const char kARCompletion = '\0';
             - Return plist as a new file
         */
         NSMutableDictionary *fallbackDict = [[NSDictionary dictionaryWithContentsOfURL:url] mutableCopy];
+        if (fallbackDict.count == 0) {
+            // Apollo's own resource is missing or unreadable and Apollo
+            // force-unwraps that read, so give it an empty-but-valid table
+            // rather than the URL that would trap. Residual, unavoidable: if no
+            // candidate directory is writable either, `url` is still a trap —
+            // but returning nil instead would just trip Apollo's OTHER
+            // force-unwrap, the one on the path.
+            return ApolloWriteTrendingPlist(@{ todayKey: @[] }) ?: url;
+        }
         // Build an immediate local fallback. For a configured limit, sample
         // across Apollo's historical lists so the fallback has that many rows
         // instead of silently reverting to one native five-item day.
@@ -2198,14 +2306,13 @@ static const char kARCompletion = '\0';
         if (fallbackArray.count == 0 && sTrendingSubredditsLimit.integerValue != 0) {
             return url;
         }
-        [fallbackDict setObject:fallbackArray forKey:[formatter stringFromDate:[NSDate date]]];
+        [fallbackDict setObject:fallbackArray forKey:todayKey];
 
+        // `url` is a safe fallback here: we only reach this point after parsing
+        // the bundled plist at it, so Apollo's force-unwrapped read of it will
+        // succeed.
         NSURL * (^writeDict)(NSMutableDictionary *d) = ^(NSMutableDictionary *d){
-            // write new file
-            NSString *tempPath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"trending-custom.plist"];
-            [[NSFileManager defaultManager] removeItemAtPath:tempPath error:nil]; // remove in case it exists
-            [d writeToFile:tempPath atomically:YES];
-            return [NSURL fileURLWithPath:tempPath isDirectory:NO];
+            return ApolloWriteTrendingPlist(d) ?: url;
         };
 
         // Constructor prefetch normally has this ready. On a cold/slow network,
@@ -2238,7 +2345,7 @@ static const char kARCompletion = '\0';
         }
 
         NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-        [dict setObject:subreddits forKey:[formatter stringFromDate:[NSDate date]]];
+        [dict setObject:subreddits forKey:todayKey];
         return writeDict(dict);
     }
     return url;


### PR DESCRIPTION
## Summary

Three crash reports came in with sanitized crash JSON attached (#964, #961, #956). All three are symbolicated against the release dSYMs and traced to the exact instruction. Two of them are ours and are fixed here. The third is a defect in Apollo's own binary; it is diagnosed in full below and deliberately **not** patched — see [Why #956 isn't fixed here](#why-956-isnt-fixed-here).

Closes #964
Closes #961

> Note on frame citations below: every non-leaf frame's `instruction_address` is a **return** address, so the accurate source line is `atos(addr − 1)`. Where a line number here disagrees with the raw symbolicated dump, that's why.

---

## #964 — launch crash when the trending-subreddits rewrite can't be written

`EXC_BREAKPOINT` (`brk #1`) at launch, every launch. iPad, iOS 26.0, LiveContainer, 3.5.1.

Apollo's `SearchViewController.viewDidLoad` force-unwraps **both** halves of its trending-subreddits load:

```swift
NSDictionary(contentsOfFile: Bundle.main.path(forResource: "trending-subreddits",
                                              ofType: "plist")!)!
```

`-[NSBundle pathForResource:ofType:]` is implemented on top of `-[NSBundle URLForResource:withExtension:]` — verified empirically by swizzling only the latter and watching the former return the redirected path, with no existence check afterwards. That's the method we hook to swap in a randomised table, so **the URL we return is the path Apollo force-unwraps**. And `writeDict` returned it without ever checking `writeToFile:`:

```objc
[[NSFileManager defaultManager] removeItemAtPath:tempPath error:nil]; // deletes the good file first
[d writeToFile:tempPath atomically:YES];                             // result discarded
return [NSURL fileURLWithPath:tempPath isDirectory:NO];              // returned regardless
```

One failed write is a hard launch crash.

**The PC forces this reading, it isn't inferred.** A full `__text` branch scan (2,622,469 instructions) finds that `0x100109884` has exactly one predecessor in the entire binary — the dictionary `cbz` at `0x10010973c` — and the sibling trap `0x100109880` exactly one, the path `cbz` at `0x1001096d0`. `sub_100109380` in turn has exactly one caller, `0x1002b3cdc` in `viewDidLoad`. So the path came back fine and the file behind it didn't; there is no alternate route to this PC. The `swift_once` guard before the call isn't a feature gate either — both arms reach the trending load, so it runs on every `viewDidLoad`.

The reporter is on LiveContainer, where the guest's `NSTemporaryDirectory()` resolves into LiveContainer's own container and the guest can't write there ([LiveContainer#118](https://github.com/LiveContainer/LiveContainer/issues/118)); iOS also purges `tmp/` between runs. Either one turns a single failure into a permanent brick, because the Search tab's view is loaded during UIScene connection (`scene:willConnectToSession:options:`), not on tab selection.

**Fix.** Writes go to a tweak-owned `Library/Caches/ApolloReborn` directory we create ourselves, falling back to `NSTemporaryDirectory()`. The write result is checked, and the file is read back through the same API Apollo uses before the path is handed over. If nothing is writable we return Apollo's own bundled resource instead of a URL that traps. The remaining hole — Apollo's bundled resource being itself unreadable, where the old code returned `url` into a guaranteed trap — now gets a written-and-verified empty table.

Three details worth calling out:

- **Binary, not XML.** `-[NSDictionary writeToFile:]` emits XML: the real 44 KB bundled table round-trips to ~102 KB of it, and the verifying read would then re-parse that on every launch. Serialising `NSPropertyListBinaryFormat_v1_0` keeps the written file at ~130 bytes in the normal case.
- **No pre-delete.** `NSDataWritingAtomic` already writes-then-renames, so unlinking first bought nothing and opened a window where a path we'd verified had vanished. The unlink is now only the recovery step after a failed write (the stale-directory case).
- **Scoped to the main bundle.** Without that gate the synthesised-table branch would turn *any* other bundle's honest `nil` into a URL for a file we invented. Apollo's own call is on `mainBundle`.

**Residual, stated plainly:** if Apollo's bundled plist is unreadable *and* no candidate directory is writable, `url` is still a trap. There's no safe return there — handing back `nil` would just trip the other force-unwrap, the one on the path.

Also builds today's key the way Apollo does (`Calendar.current` components, ASCII digits) instead of with an `NSDateFormatter`. The formatter picks up the same calendar so the year *value* agrees, but it renders digits in the locale's numbering system and `yyyy` zero-pads to four, so a Japanese-calendar era year 8 comes out `0008` where Apollo writes `8`. Not the crash — a silently-broken feature. (Checked that it can't *become* a crash: the function contains exactly two `brk`s, and the `dict[todayKey]` subscript path is trap-free.)

<details>
<summary>Simulator A/B, both directions</summary>

Blocking the write target with a read-only directory so both the write and the recovery unlink fail:

**Pre-fix build, `tmp/` blocked** — reproduces #964 exactly:

```
exception: EXC_BREAKPOINT  codes 0x1, 0x102625884
  0 Apollo    +1087620   (0x100109884 — the brk)
  1 Apollo    +2833632
  2 Apollo    +2834288
  3 ApolloReborn  _logos_method$..$SearchViewController$viewDidLoad
  4 UIKitCore -[UIViewController _sendViewDidLoadWithAppearanceProxyObjectTaggingEnabled]
  5 UIKitCore -[UIViewController loadViewIfRequired]
  7 Apollo    +554944 / +555932 / +534336
```

Same trap offset and the same frames 7/8/9 offsets as the user's report.

**Fixed build, _both_ locations blocked** — no crash:

```
[RandomSources] Trending plist write failed at …/Library/Caches/ApolloReborn/trending-custom.plist
[RandomSources] Trending plist write failed at …/tmp/trending-custom.plist
[RandomSources] No writable location for the trending plist; falling back to Apollo's bundled resource
```

App launches and stays up. Unblocked, it writes a 130-byte binary plist `{"2026-8-19" => [...]}` to the Caches path — key matches Apollo's `Calendar.current` computation exactly.

Caveat: the `pathForResource:` → `URLForResource:` routing was verified against macOS Foundation, not iOS 26 Foundation. Same codebase, but not directly observed on the reporter's OS — the reproduction above is what actually pins it.
</details>

---

## #961 — `objc_copyClassList` realizes every class, and one of them jumps to NULL

`EXC_BAD_ACCESS` at `0x0`. iOS 14.5.1, jailbreak .deb on stock Apollo 1.14.26. "Open app → View all posts → crash."

```
 11 ApolloReborn   LargePostCellNode didLoad hook      (ApolloUserAvatars.xm)
 10 ApolloReborn   ApolloUsernameFromCell
  9 ApolloReborn   ApolloObjectIvarValue
  6 ApolloReborn   block in ApolloRuntimeKnowsClass    ← dispatch_once
  5 libobjc        objc_copyClassList
  4 libobjc        (class realization)
  3 Apollo         type metadata accessor
  2 libswiftCore   swift_getSingletonMetadata
  1 Apollo         type metadata completion function
  0 —              0x0
```

`objc_copyClassList` calls `realizeAllClasses()`. Realizing a Swift class runs its type-metadata accessor, and Apollo weak-links **ActivityKit, WeatherKit and VisionKit** (`LC_LOAD_WEAK_DYLIB`, confirmed with `otool -l`; `nm -m -u` shows 418 undefined weak externals). On an OS that lacks them the accessor is bound to 0 and realization jumps straight to a NULL PC. Stock Apollo imports neither `objc_copyClassList` nor `objc_getClassList` (`nm -u`), so nothing else in the process ever trips that weak link — only we do.

It isn't a rare branch either: `LargePostCellNode.link` is a Swift ivar with an **empty type encoding** (confirmed by parsing the Mach-O ivar table), so `ApolloObjectIvarValue` always falls through to the Swift-word path and always reaches `ApolloRuntimeKnowsClass`. First large post cell of the session, deterministic, on any device old enough to be missing one of those frameworks.

**Fix.** The set is now built by reading each loaded image's `__objc_classlist` directly. That touches no class, so the probe stays the identity-only test it was designed to be — the property the original comment is explicit about. Registering through `_dyld_register_func_for_add_image` also retires the one-shot snapshot, so images loaded later are picked up instead of missing forever.

Measured against `objc_copyClassList` in a live process, the walk finds **9610 of 9634** classes. The 24 it misses are runtime-instantiated Swift generics (`_ContiguousArrayStorage` specialisations) — the same "registered later" category the old comment already accepted as a skipped read. Every class this path actually reads is present: `RDKLink`, `RDKComment`, `RDKUser`, `LargePostCellNode`, `CompactPostCellNode`, `CommentCellNode`, `UserCommentsViewController`.

`objc_copyClassList` no longer appears in the built dylib's imports.

---

## Why #956 isn't fixed here

Worth reading even though there's no code for it, because the diagnosis is complete and it isn't ours.

`EXC_BAD_ACCESS` on `0xce42de83f3ea0f4d`. iOS 26.6, "open a multireddit → crash." The crashed thread is a **background `ASDataController` node-allocation worker and carries no tweak frame at all.**

The chain, read out of the Apollo binary (its UUID matches our local copy 1:1, and every string literal along the way was decoded to confirm each function's identity):

```
ASDispatchApply → _allocateNodesFromElements: → -[ASCollectionElement node]
  → Apollo node block → CompactPostCellNode.init → thumbnail builder
  → URL+ContentTypes media classifier → RedGifs client
  → Array.append on the client singleton's pending-request array
  → _ContiguousArrayBuffer._consumeAndCreateNew
  → swift_bridgeObjectRelease(old buffer) → fault
```

**Six threads (2, 6, 10, 18, 19, 21) had byte-identical frames 0–3 — every one of them suspended inside that same release of the old buffer.** Ten threads in total were under `-[ASCollectionElement node]`. The append is wrapped in `swift_beginAccess` (Modify), but Swift's exclusivity enforcement keeps its active-access set thread-local, so it never sees a cross-thread conflict.

That's an unsynchronized Swift `Array` mutation on Apollo's own lazily-initialized RedGifs client, driven from AsyncDisplayKit's parallel node-allocation queue. It's a pure-Swift function with no ObjC seam, so it can't be locked or swizzled from Logos. The multireddit is incidental — the real trigger is a cold feed with several RedGifs posts and no cached RedGifs auth token, which is exactly the "a token fetch is in flight, queue this one" branch.

Two things I got wrong on a first pass and corrected under review, in case anyone reads the same stack: `_consumeAndCreateNew` releases the old buffer on **both** the unique and non-unique branches, so this is not "one thread freed a buffer the other five were writing" — all six are in the same unconditional release (frame 4, `0x100232b3c` vs `0x100232b18`, is what distinguishes which branch each took). And frames 1–2 sharing an address is **not** recursion: this repo's KSCrash inserts the link register at trace index 1 before starting the frame-pointer walk, so any frameful function that hasn't yet made a call duplicates. Two non-Swift threads in the same report (`_CFRuntimeCreateInstance`, `ASRecursiveUnfairLockLock`) show the identical duplication.

**Why no mitigation ships.** The obvious lever is a process-global lock around `-[ASCollectionElement node]`, the one hookable frame in the chain. It is both insufficient and dangerous:

- **Insufficient.** The pending-request field has **14 distinct append sites** in the binary; only one is on the node-block path. The other 13 are the client's other typed API methods. Worse, the drain function (26 call sites) opens the field with a **read-only** access token and then stores `__swiftEmptyArrayStorage` straight into it, and a second raw write carries no `swift_beginAccess` at all. Serializing node blocks kills append-vs-append and leaves append-vs-drain fully live — the same use-after-free.
- **Dangerous, provably.** Thread 22 is *inside* a node block, blocked in `__ulock_wait` after a `dispatch_sync` — under a global lock it would hold that lock while blocked off-queue, stalling every ASDK table in the app. And thread 0 is already blocked in `-[ASDataController _scheduleBlockOnMainSerialQueue:]` waiting on the very batch the lock would serialize. That's watchdog territory, not a theoretical risk.

So this wants an upstream fix (or an Apollo-side patch), not a lock bolted on from the tweak. Happy to revisit with device profiling if you disagree.

One honest note on exposure: `ApolloRedgifsSubdomainFix` widening the host regex (for #79, so `v3.redgifs.com` plays inline) routes more posts into Apollo's racy path, so it plausibly raised this user's hit rate. Stock Apollo still races on plain `redgifs.com/watch/…` URLs, so narrowing it back would regress #79 without fixing the bug. I left it alone. To be precise about our involvement: that hook *does* execute inside the classifier's own function on these very worker threads, just earlier than the crash snapshot — it's thread-safe as written (`dispatch_once` plus non-mutating `NSString` work) and its fast-reject correctly leaves the sibling streamable/gfycat patterns untouched. `ApolloThemeRuntime`'s `ThemedAttributedText` also runs on the concurrent node-allocation queue (thread 17, same node block and same cell-init function as the crashed thread) and is likewise free of shared mutable state.

---

## Testing

- Device build (`make package`, `iphone:clang:26.0:14.0`) and simulator build both clean.
- #964 verified by A/B in the simulator, both directions — pre-fix build reproduces the reported crash frame-for-frame; fixed build survives total write failure and falls back to the bundled resource. Re-run after the binary-plist / no-pre-delete / main-bundle-gate corrections.
- #961's class-set replacement validated against `objc_copyClassList` in a live process (9610/9634, every class the avatar path reads present), and `objc_copyClassList` is gone from the built dylib's imports. The iOS-14 crash itself can't be reproduced in the simulator.
- Neither change touches UI or depends on auth mode, so the usual API-key/keyless/non-glass matrix doesn't apply here.
