### PR TITLE
Fix Share > Copy Link ignoring the Share Link Host setting

### DIFF
--- a/src/ApolloShareAsImageLink.xm
+++ b/src/ApolloShareAsImageLink.xm
@@ -506,54 +506,23 @@ static BOOL ApolloShareLinkAlreadyHasLinkSource(NSArray *items) {
 
 #pragma mark - Copy Link support
 
-// Apollo's custom Copy Link activity receives the rewritten share URL, but
-// performs its own internal copy operation. Cache the rewritten URL during
-// activity preparation, then replace the clipboard after Apollo finishes.
-static char kApolloCopyURLActivityURLKey;
-
+// Apollo's "Copy Link" share-sheet action is its own UIActivity subclass, and it
+// does NOT read the share sheet's activity items. Apollo constructs it up front as
+// `CopyURLActivity(url:)` and hands it over in `applicationActivities`; its
+// -canPerformWithActivityItems: is a bare `return YES` and -performActivity just
+// does `UIPasteboard.general.url = self.url` off that stored Swift URL property.
+//
+// So the UIActivityViewController hook above — which rewrites the *items* — never
+// reaches it: the sheet's preview and every system destination showed the selected
+// host while Copy Link still pasted the stock reddit.com link (issue #967).
+//
+// That stored property is a Swift `Foundation.URL` value laid out inline in the
+// instance, not an NSURL pointer, so reading it from ObjC is not safe across iOS
+// releases. Instead let Apollo perform its own copy and then correct the
+// pasteboard: the pasteboard is the one place the final value is observable no
+// matter how Apollo produced it, and correcting it needs no knowledge of the
+// activity's internals.
 %hook _TtC6Apollo15CopyURLActivity
-
-- (BOOL)canPerformWithActivityItems:(NSArray *)activityItems {
-    if (sShareLinkHost == ShareLinkHostDefault) return %orig;
-
-    NSURL *rewrittenURL = nil;
-
-    if ([activityItems isKindOfClass:[NSArray class]]) {
-        for (id item in activityItems) {
-            if ([item isKindOfClass:[NSURL class]]) {
-                NSURL *originalURL = (NSURL *)item;
-                NSURL *candidate = ApolloShareLinkRewriteURLForCurrentHost(originalURL);
-                if (candidate != originalURL) {
-                    rewrittenURL = candidate;
-                    break;
-                }
-            }
-
-            if ([item isKindOfClass:[NSString class]]) {
-                NSURL *originalURL = [NSURL URLWithString:(NSString *)item];
-                NSURL *candidate = ApolloShareLinkRewriteURLForCurrentHost(originalURL);
-                if (candidate != originalURL) {
-                    rewrittenURL = candidate;
-                    break;
-                }
-            }
-        }
-    }
-
-    if (rewrittenURL) {
-        objc_setAssociatedObject(self,
-                                 &kApolloCopyURLActivityURLKey,
-                                 rewrittenURL,
-                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    } else {
-        objc_setAssociatedObject(self,
-                                 &kApolloCopyURLActivityURLKey,
-                                 nil,
-                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    }
-
-    return %orig;
-}
 
 - (void)performActivity {
     if (sShareLinkHost == ShareLinkHostDefault) {
@@ -561,22 +530,26 @@ static char kApolloCopyURLActivityURLKey;
         return;
     }
 
-    NSURL *rewrittenURL =
-        objc_getAssociatedObject(self, &kApolloCopyURLActivityURLKey);
+    %orig; // Apollo copies its own URL (and shows its "Copied!" toast).
 
-    if (![rewrittenURL isKindOfClass:[NSURL class]]) {
-        ApolloLog(@"[ShareLink] CopyURLActivity had no cached URL; using stock behavior");
-        %orig;
+    UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
+    NSURL *copied = pasteboard.URL;
+    if (![copied isKindOfClass:[NSURL class]]) {
+        ApolloLog(@"[ShareLink] CopyURLActivity: pasteboard holds no URL — leaving it alone");
         return;
     }
 
-    // Preserve Apollo's normal Copy Link behavior, then correct the final
-    // pasteboard value using the URL captured from the rewritten share items.
-    %orig;
-    [UIPasteboard generalPasteboard].URL = rewrittenURL;
+    NSURL *rewritten = ApolloShareLinkRewriteURLForCurrentHost(copied);
+    if (rewritten == copied) {
+        // Not a Reddit web host (Apollo also uses this activity for e.g. YouTube
+        // links), so the selected share host does not apply — leave it as copied.
+        ApolloLog(@"[ShareLink] CopyURLActivity: copied host %@ is not a Reddit host — unchanged",
+                  copied.host ?: @"(none)");
+        return;
+    }
 
-    ApolloLog(@"[ShareLink] CopyURLActivity replaced copied URL=%@",
-              rewrittenURL.absoluteString);
+    pasteboard.URL = rewritten;
+    ApolloLog(@"[ShareLink] CopyURLActivity rewrote copied URL to %@", rewritten.absoluteString);
 }
 
 %end


### PR DESCRIPTION
Fixes #967.

Set a Share Link Host, hit Share on a post, and the sheet preview correctly shows `vxreddit.com` — then Copy Link pastes the plain `reddit.com` link anyway. Same for old.reddit and fxReddit.

### Why

Apollo's "Copy Link" is its own `UIActivity` subclass and it never looks at the share sheet's activity items. Apollo builds it up front as `CopyURLActivity(url:)` and hands it over in `applicationActivities`. From the binary:

- `-canPerformWithActivityItems:` is literally `mov w0, #1; ret` — it ignores the items entirely
- `-performActivity` is `UIPasteboard.general.url = self.url`, off a stored Swift `Foundation.URL` property, then the "Copied!" toast

So the `UIActivityViewController` hook that rewrites the outgoing *items* — the one that makes the preview and Messages/Mail/Reminders all show the right host — simply never touches Copy Link. Its URL was baked in before the sheet existed.

The existing code did try to cover this, by caching a rewritten URL during `-canPerformWithActivityItems:` and slapping it on the pasteboard after `%orig`. That never fired: by the time UIKit calls `canPerform…`, the items have *already* been rewritten by our own init hook, so the "did this URL change?" test always came back no and nothing got cached. The log said so every single time:

```
[ShareLink] rewrote outgoing share item host=2
[ShareLink] CopyURLActivity had no cached URL; using stock behavior
```

### The fix

Reading the activity's own `url` is out — it's a Swift `Foundation.URL` value laid out inline in the instance, not an `NSURL *`, and `MSHookIvar` on those is exactly the thing that breaks between iOS releases.

So instead: let Apollo do its copy, then correct the pasteboard. That's the one place the final value is observable regardless of how Apollo produced it, and it needs no knowledge of the activity's internals. Non-Reddit hosts are left alone — Apollo reuses this same activity for YouTube links, and those shouldn't be touched.

Net result is 27 lines smaller than what it replaces: the whole `canPerformWithActivityItems:` cache and its associated object are gone.

### Testing

Sim-tested on iOS 26.5, glass and non-glass shells, with an API-key account. First post in the feed, `···` → Share → Copy Link, pasteboard read back with `simctl pbpaste`:

| Setting | Glass | Non-glass |
| --- | --- | --- |
| Reddit (default) | `https://reddit.com/r/…` (untouched, hook early-returns) | `https://reddit.com/r/…` |
| old.reddit | `https://old.reddit.com/r/…` | `https://old.reddit.com/r/…` |
| vxReddit | `https://vxreddit.com/r/…` | `https://vxreddit.com/r/…` |
| fxReddit | `https://fxddit.com/r/…` | `https://fxddit.com/r/…` |

Also on glass, with vxReddit set:
- Share from the post header inside comments → rewritten
- Share on an individual **comment** → `https://vxreddit.com/r/…/comments/1vt1opk/_/p4pvf8j/?context=1`, so the comment id and `?context=1` survive
- Default host still logs nothing and copies stock, i.e. zero work when the feature is off

Device build (`make package`) compiles clean.

Not covered: the API-key-free path. Testing it needs a live web session and I didn't have one in the sim. Worth noting the fix is downstream of everything auth-related though — it reads whatever URL Apollo already put on the pasteboard and swaps the host, so it doesn't care how the link model was populated. The host allowlist it uses is the same one the already-shipping item rewrite uses, and the report itself confirms that half works.
