### PR TITLE
Center subreddit index labels and tighten favorite hit target

### DIFF
--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -62,6 +62,8 @@ static void (*orig_ApolloSubredditHeaderSetFrame)(id self, SEL _cmd, CGRect fram
 static const CGFloat ApolloSubredditIndexSlotHeight = 14.0;
 static const CGFloat ApolloSubredditIndexTouchWidth = 56.0;
 static const CGFloat ApolloSubredditIndexGestureWidth = 34.0;
+static const CGFloat ApolloSubredditIndexGlyphWidth = 30.0;
+static const CGFloat ApolloSubredditIndexGlyphRightInset = 10.0;
 static const CGFloat ApolloSubredditIndexRightInset = 38.0;
 static const CGFloat ApolloSubredditStarHitWidth = 60.0;
 static const CGFloat ApolloSubredditRowBalancedLeadingMargin = 18.0;
@@ -887,11 +889,11 @@ static void ApolloSubredditIndexRemoveStarProxyFromCell(UITableViewCell *cell) {
         for (NSString *title in self.titles) {
             UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
             label.text = title;
-            label.textAlignment = NSTextAlignmentRight;
+            label.textAlignment = NSTextAlignmentCenter;
             label.font = [UIFont systemFontOfSize:11.0 weight:UIFontWeightSemibold];
             label.adjustsFontSizeToFitWidth = YES;
             label.minimumScaleFactor = 0.65;
-            label.layer.anchorPoint = CGPointMake(1.0, 0.5);
+            label.layer.anchorPoint = CGPointMake(0.5, 0.5);
             [self addSubview:label];
             [labels addObject:label];
         }
@@ -922,8 +924,8 @@ static void ApolloSubredditIndexRemoveStarProxyFromCell(UITableViewCell *cell) {
 
     [self.labels enumerateObjectsUsingBlock:^(UILabel *label, NSUInteger idx, BOOL *stop) {
         CGFloat centerY = topInset + (slotHeight * idx) + (slotHeight / 2.0);
-        label.bounds = CGRectMake(0.0, 0.0, 30.0, labelHeight);
-        label.center = CGPointMake(CGRectGetMaxX(self.bounds) - 2.0, centerY);
+        label.bounds = CGRectMake(0.0, 0.0, ApolloSubredditIndexGlyphWidth, labelHeight);
+        label.center = CGPointMake(CGRectGetMaxX(self.bounds) - ApolloSubredditIndexGlyphRightInset, centerY);
     }];
 }
 

--- a/src/ApolloSubredditIndexPolish.xm
+++ b/src/ApolloSubredditIndexPolish.xm
@@ -66,6 +66,7 @@ static const CGFloat ApolloSubredditIndexGlyphWidth = 30.0;
 static const CGFloat ApolloSubredditIndexGlyphRightInset = 10.0;
 static const CGFloat ApolloSubredditIndexRightInset = 38.0;
 static const CGFloat ApolloSubredditStarHitWidth = 60.0;
+static const CGFloat ApolloSubredditStarHitTrailingInset = 8.0;
 static const CGFloat ApolloSubredditRowBalancedLeadingMargin = 18.0;
 static const CGFloat ApolloSubredditRowIconTextGap = 12.0;
 static const CGFloat ApolloSubredditRowStandardIconTextTrim = 2.0;
@@ -740,15 +741,16 @@ static CGRect ApolloSubredditIndexProxyFrameForCell(UITableViewCell *cell, UICon
     CGFloat cellWidth = CGRectGetWidth(cell.bounds);
     CGFloat cellHeight = CGRectGetHeight(cell.bounds);
     CGFloat width = MIN(ApolloSubredditStarHitWidth, MAX(cellWidth, 0.0));
+    CGFloat visibleWidth = MAX(width - MIN(ApolloSubredditStarHitTrailingInset, width), 0.0);
 
     if (!nativeControl) {
-        return CGRectMake(MAX(cellWidth - width, 0.0), 0.0, width, cellHeight);
+        return CGRectMake(MAX(cellWidth - width, 0.0), 0.0, visibleWidth, cellHeight);
     }
 
     CGRect nativeFrame = [cell convertRect:nativeControl.bounds fromView:nativeControl];
     CGFloat minX = CGRectGetMidX(nativeFrame) - (width / 2.0);
     minX = MIN(MAX(minX, 0.0), MAX(cellWidth - width, 0.0));
-    return CGRectMake(minX, 0.0, width, cellHeight);
+    return CGRectMake(minX, 0.0, visibleWidth, cellHeight);
 }
 
 static void ApolloSubredditIndexRemoveStarProxyFromCell(UITableViewCell *cell) {


### PR DESCRIPTION
## Summary

- Center the subreddit alphabet-index labels within consistent 30-point slots.
- Use centered anchors so narrow letters and symbols align uniformly.
- Move the favorite star touch area’s right edge 8 points inward.
- Preserve the touch area’s left edge and full-row height.
 
<table>
  <tr>
    <th>BEFORE</th>
    <th>AFTER</th>
  </tr>
  <tr>
    <td>
      <img width="603" alt="Screenshot Apollo-Sim 08-20-2026 at 11 19 03 PM" src="https://github.com/user-attachments/assets/716db9f8-a15b-44f0-b09b-449b2ec1fdd8">
    </td>
    <td>
      <img width="603" alt="Screenshot Apollo-Sim 08-20-2026 at 9 52 12 PM" src="https://github.com/user-attachments/assets/b146d54c-9dfd-4f35-9f5a-f43d7593a1bf">
    </td>
  </tr>
</table>

## Testing

- Built the simulator target successfully.
- Visually verified the alphabet-index alignment in the simulator.
- Confirmed the favorite touch target remains 52 points wide and does not overlap the alphabet index.