### PR TITLE
Match EAP icon row typography

### DIFF
--- a/src/ApolloLiquidGlassIconPicker.xm
+++ b/src/ApolloLiquidGlassIconPicker.xm
@@ -2861,13 +2861,13 @@ static UIImage *LGNormalizedEAPThumbnail(void) {
 
 static UITableViewCell *LGConfigureEAPCell(UITableViewCell *cell) {
     cell.textLabel.text = @"Icons Drop Test";
-    cell.detailTextLabel.text = @"EverythingApplePro";
+    cell.detailTextLabel.text = nil;
     cell.imageView.image = LGNormalizedEAPThumbnail();
     cell.imageView.contentMode = UIViewContentModeScaleAspectFit;
     cell.imageView.clipsToBounds = NO;
     BOOL selected = [UIApplication.sharedApplication.alternateIconName isEqualToString:kLGEAPIconID];
     LGSetApolloCellNativeCheckmark(cell, selected);
-    cell.accessibilityLabel = @"Icons Drop Test, EverythingApplePro";
+    cell.accessibilityLabel = @"Icons Drop Test";
     return cell;
 }
 
@@ -3088,7 +3088,7 @@ static void LGNormalizeNativeIconCellBackground(UITableViewCell *cell,
               tableView:(UITableView *)tableView
             atIndexPath:(NSIndexPath *)indexPath {
     [self apollo_applyPrimaryTextColorToCell:cell];
-    cell.detailTextLabel.textColor = UIColor.secondaryLabelColor;
+    if (_nativeTitleFont) cell.textLabel.font = _nativeTitleFont;
     cell.tintColor = ApolloThemeAccentColor() ?: tableView.tintColor;
     cell.selectedBackgroundView = nil;
     NSInteger rowCount = [self tableView:tableView numberOfRowsInSection:indexPath.section];


### PR DESCRIPTION
## Summary

Quick follow-up to #969 that makes the “Icons Drop Test” row consistent with the other Sekrit icons.

- Removes the EverythingApplePro author subtitle
- Matches the title font to Apollo’s native Sekrit rows
- Updates the accessibility label to contain only the icon title

## Preview

| Before | After |
|:---:|:---:|
| <img width="282" alt="Before" src="https://github.com/user-attachments/assets/23bf1a86-e593-44ee-b0a3-409a138582b5" /> | <img width="282" alt="After" src="https://github.com/user-attachments/assets/0218ab94-75ec-40eb-a327-d42d096df01f" /> |

## Testing

- Simulator build passes
- Tested with the Liquid Glass icon picker